### PR TITLE
nut-scanner: fix scan_usb to remove trailing spaces from output strings

### DIFF
--- a/tools/nut-scanner/Makefile.am
+++ b/tools/nut-scanner/Makefile.am
@@ -21,7 +21,7 @@ libnutscan_la_CFLAGS = -I$(top_srcdir)/clients -I$(top_srcdir)/include $(LIBLTDL
 
 nut_scanner_SOURCES = nut-scanner.c
 nut_scanner_CFLAGS = -I$(top_srcdir)/clients -I$(top_srcdir)/include
-nut_scanner_LDADD = libnutscan.la
+nut_scanner_LDADD = libnutscan.la ../../common/libcommon.la
 
 if WITH_SSL
   libnutscan_la_CFLAGS += $(LIBSSL_CFLAGS)

--- a/tools/nut-scanner/scan_usb.c
+++ b/tools/nut-scanner/scan_usb.c
@@ -177,7 +177,7 @@ nutscan_device_t * nutscan_scan_usb()
 						dev->descriptor.iSerialNumber,
 						string, sizeof(string));
 					if (ret > 0) {
-						serialnumber = strdup(string);
+						serialnumber = strdup(rtrim(string, ' '));
 					}
 				}
 				/* get product name */
@@ -186,7 +186,7 @@ nutscan_device_t * nutscan_scan_usb()
 						dev->descriptor.iProduct,
 						string, sizeof(string));
 					if (ret > 0) {
-						device_name = strdup(string);
+						device_name = strdup(rtrim(string, ' '));
 					}
 				}
 
@@ -196,7 +196,7 @@ nutscan_device_t * nutscan_scan_usb()
 						dev->descriptor.iManufacturer, 
 						string, sizeof(string));
 					if (ret > 0) {
-						vendor_name = strdup(string);
+						vendor_name = strdup(rtrim(string, ' '));
 					}
 				}
 


### PR DESCRIPTION
This patch uses rtrim() from libcommon to remove trailing spaces from
serialnumber, device_name and vendor_name.

see: https://github.com/networkupstools/nut/issues/26
