### PR TITLE
Fix wrong errno reported by connect on Solaris

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -136,6 +136,10 @@ then
 fi
 
 case ${target_os} in
+   solaris2.1* )
+      dnl On Solaris 10/11 this allow errno to use thread local storage
+      CFLAGS="${CFLAGS} -D_REENTRANT"
+      ;;
    hpux11* )
       dnl It seems like the thread safe string functions will not be included
       dnl on 64 bit HP-UX unless we define _REENTRANT


### PR DESCRIPTION
_REENTRANT allows errno to use thread local storage, so that correct errno value are reported by connect in multi-threaded environnement (nut-scanner).
