### PR TITLE
Enhancement for netxml driver (by Vaclav Krpec)

### DIFF
--- a/docs/man/netxml-ups.txt
+++ b/docs/man/netxml-ups.txt
@@ -43,6 +43,10 @@ This value *must never* be higher than half the MAXAGE value specified in
 linkman:upsd.conf[5], otherwise you run the risk that linkman:upsd[8] declares
 the driver stale while it is waiting for a connection to timeout.
 
+*subscribe*::
+Connect to the NMC in subscribed mode. This allows to receive notifications
+and alarms more quickly, beside from the standard polling requests.
+
 *login*='value'::
 Set the login value for authenticated mode. This feature also needs the
 *password* argument, and allows value settings in the card.
@@ -51,6 +55,16 @@ This feature is not used yet.
 *password*='value'::
 Set the password value, needed with the login for authenticated mode.
 This feature is not used yet.
+
+*shutdown_duration*='value'::
+Set the shutdown duration of the operating system, in seconds. This
+represents the amount of time needed by the system to operate a clean
+shutdown. Defaults to 120 seconds.
+
+*shutdown_timer*='value'::
+Set the shutdown timer, in seconds. After 'value' seconds running on battery,
+the local system will receive a notification to shutdown.
+Defaults to "none" (disabled).
 
 IMPLEMENTATION
 --------------

--- a/drivers/mge-xml.c
+++ b/drivers/mge-xml.c
@@ -38,12 +38,16 @@
 #define ST_FLAG_RW		0x0001
 #define ST_FLAG_STATIC		0x0002
 
+extern int 	shutdown_duration;
+
 static int	mge_ambient_value = 0;
 
 static char	mge_scratch_buf[256];
 
 static char	var[128];
 static char	val[128];
+
+static int	mge_shutdown_pending = 0;
 
 typedef enum {
 	ROOTPARENT = NE_XML_STATEROOT,
@@ -125,6 +129,10 @@ static const char *discharging_info(const char *val)
 {
 	if (val[0] == '1') {
 		STATUS_SET(DISCHRG);
+		/* Workaround NMC bug: both charging and discharging set to 1 */
+		if(STATUS_BIT(CHRG)) {
+			STATUS_CLR(CHRG);
+		}
 	} else {
 		STATUS_CLR(DISCHRG);
 	}
@@ -255,7 +263,8 @@ static const char *fanfail_info(const char *val)
 
 	return NULL;
 }
-/*
+
+#if 0
 static const char *shutdownimm_info(const char *val)
 {
 	if (val[0] == '1') {
@@ -266,7 +275,8 @@ static const char *shutdownimm_info(const char *val)
 
 	return NULL;
 }
- */
+#endif
+
 static const char *overheat_info(const char *val)
 {
 	if (val[0] == '1') {
@@ -524,24 +534,328 @@ static const char *mge_ambient_info(const char *val)
 	}
 }
 
-static const char *mge_timer_shutdown(const char *val)
+static const char *mge_timer_shutdown(const char *delay_before_shutoff)
 {
-	const char	*delay = dstate_getinfo("ups.delay.shutdown");
-
-	if ((delay) && (atoi(val) > -1) && (atoi(val) < atoi(delay))) {
+	if (atoi(delay_before_shutoff) > -1 ) {
 		STATUS_SET(SHUTDOWNIMM);
+		mge_shutdown_pending = 1;
+
+		if( atoi(delay_before_shutoff) > shutdown_duration ) {
+			STATUS_CLR(SHUTDOWNIMM);
+			mge_shutdown_pending = 0;
+		}
 	} else {
 		STATUS_CLR(SHUTDOWNIMM);
+		mge_shutdown_pending = 0;
 	}
 
 	return val;
 }
 
+static const char *mge_shutdown_imminent(const char *val)
+{
+	const int shutdown_delay = atoi(val);
+
+	/* shutdown is already managed by mge_timer_shutdown, give up */
+	if(mge_shutdown_pending) {
+		return NULL;
+	}
+
+	/* We may have "NONE" or "-1" or ?? as value
+	 * We also double check both the string and numeric values to be zero!*/
+	if ((val) && (val[0] == '0') && (shutdown_delay == 0)) {
+		STATUS_SET(SHUTDOWNIMM);
+	} else {
+		STATUS_CLR(SHUTDOWNIMM);
+	}
+
+	return NULL;
+}
+
 static xml_info_t mge_xml2nut[] = {
+	/* NMC configuration (mapped 1:1 for now) */
+	{ "device.contact", ST_FLAG_RW, 0, "System.Contact", 0, 0, NULL },
+	{ "device.location", ST_FLAG_RW, 0, "System.Location", 0, 0, NULL },
+	/* Not used for now; might however be used in future for history & stats collection
+	{ "System.History.Log.Interval", ST_FLAG_RW, 0, "System.History.Log.Interval", 0, 0, NULL },
+	*/
+	{ "System.Environment.Log.Interval", ST_FLAG_RW, 0, "System.Environment.Log.Interval", 0, 0, NULL },
+	{ "System.Outlet[1].iName", ST_FLAG_RW, 0, "System.Outlet[1].iName", 0, 0, NULL },
+	/* Mapped as ups.delay.shutdown
+	{ "System.ShutdownDuration", ST_FLAG_RW, 0, "System.ShutdownDuration", 0, 0, NULL },
+	*/
+	{ "System.ShutdownTimerSelected", ST_FLAG_RW, 0, "System.ShutdownTimerSelected", 0, 0, NULL },
+	{ "System.ShutdownTimer", ST_FLAG_RW, 0, "System.ShutdownTimer", 0, 0, NULL },
+	/* Mapped as battery.runtime.low
+	{ "System.RunTimeToEmptyLimit", ST_FLAG_RW, 0, "System.RunTimeToEmptyLimit", 0, 0, NULL },
+	*/
+	{ "System.RemainingCapacityLimit", ST_FLAG_RW, 0, "System.RemainingCapacityLimit", 0, 0, NULL },
+	{ "System.RestartLevel", ST_FLAG_RW, 0, "System.RestartLevel", 0, 0, NULL },
+	{ "System.Outlet[2].iName", ST_FLAG_RW, 0, "System.Outlet[2].iName", 0, 0, NULL },
+	/* Mapped as outlet.1.delay.shutdown
+	{ "System.Outlet[2].ShutdownDuration", ST_FLAG_RW, 0, "System.Outlet[2].ShutdownDuration", 0, 0, NULL },
+	*/
+	{ "System.Outlet[2].ShutdownTimer", ST_FLAG_RW, 0, "System.Outlet[2].ShutdownTimer", 0, 0, NULL },
+	{ "System.Outlet[2].StartupTimer", ST_FLAG_RW, 0, "System.Outlet[2].StartupTimer", 0, 0, NULL },
+	{ "System.Outlet[2].RemainingCapacityLimit", ST_FLAG_RW, 0, "System.Outlet[2].RemainingCapacityLimit", 0, 0, NULL },
+	/* For future extension, and support of shutdown on load segment
+	 * { "System.Outlet[2].RunTimeToShutdown", ST_FLAG_RW, 0, "System.Outlet[2].RunTimeToShutdown", 0, 0, NULL }, */
+	{ "System.Outlet[3].iName", ST_FLAG_RW, 0, "System.Outlet[3].iName", 0, 0, NULL },
+	/* Mapped as outlet.2.delay.shutdown
+	{ "System.Outlet[3].ShutdownDuration", ST_FLAG_RW, 0, "System.Outlet[3].ShutdownDuration", 0, 0, NULL },
+	*/
+	{ "System.Outlet[3].ShutdownTimer", ST_FLAG_RW, 0, "System.Outlet[3].ShutdownTimer", 0, 0, NULL },
+	{ "System.Outlet[3].StartupTimer", ST_FLAG_RW, 0, "System.Outlet[3].StartupTimer", 0, 0, NULL },
+	{ "System.Outlet[3].RemainingCapacityLimit", ST_FLAG_RW, 0, "System.Outlet[3].RemainingCapacityLimit", 0, 0, NULL },
+	/* For future extension, and support of shutdown on load segment
+	 * { "System.Outlet[3].RunTimeToShutdown", ST_FLAG_RW, 0, "System.Outlet[3].RunTimeToShutdown", 0, 0, NULL }, */
+	{ "System.Outlet[1].OffDelay", ST_FLAG_RW, 0, "System.Outlet[1].OffDelay", 0, 0, NULL },
+	{ "System.Outlet[1].Toggle", ST_FLAG_RW, 0, "System.Outlet[1].Toggle", 0, 0, NULL },
+	{ "System.Outlet[1].OnDelay", ST_FLAG_RW, 0, "System.Outlet[1].OnDelay", 0, 0, NULL },
+	{ "System.Outlet[2].OffDelay", ST_FLAG_RW, 0, "System.Outlet[2].OffDelay", 0, 0, NULL },
+	{ "System.Outlet[2].Toggle", ST_FLAG_RW, 0, "System.Outlet[2].Toggle", 0, 0, NULL },
+	{ "System.Outlet[2].OnDelay", ST_FLAG_RW, 0, "System.Outlet[2].OnDelay", 0, 0, NULL },
+	{ "System.Outlet[3].OffDelay", ST_FLAG_RW, 0, "System.Outlet[3].OffDelay", 0, 0, NULL },
+	{ "System.Outlet[3].Toggle", ST_FLAG_RW, 0, "System.Outlet[3].Toggle", 0, 0, NULL },
+	{ "System.Outlet[3].OnDelay", ST_FLAG_RW, 0, "System.Outlet[3].OnDelay", 0, 0, NULL },
+	{ "System.Login", ST_FLAG_RW, 0, "System.Login", 0, 0, NULL },
+	{ "System.Password", ST_FLAG_RW, 0, "System.Password", 0, 0, NULL },
+	{ "System.Security", ST_FLAG_RW, 0, "System.Security", 0, 0, NULL },
+	{ "System.FirmwareUpgrade", ST_FLAG_RW, 0, "System.FirmwareUpgrade", 0, 0, NULL },
+#if (0)  /* not interresting for NUT */
+	{ "System.Network.SNMP.ReadCommunity", ST_FLAG_RW, 0, "System.Network.SNMP.ReadCommunity", 0, 0, NULL },
+	{ "System.Network.SNMP.ReadCommunityName", 0, 0, "System.Network.SNMP.ReadCommunityName", 0, 0, NULL },
+	{ "System.Network.SNMP.ReadCommunitySecurityLevel", 0, 0, "System.Network.SNMP.ReadCommunitySecurityLevel", 0, 0, NULL },
+	{ "System.Network.SNMP.ReadCommunitySecurityRight", 0, 0, "System.Network.SNMP.ReadCommunitySecurityRight", 0, 0, NULL },
+	{ "System.Network.SNMP.WriteCommunity", ST_FLAG_RW, 0, "System.Network.SNMP.WriteCommunity", 0, 0, NULL },
+	{ "System.Network.SNMP.WriteCommunityName", 0, 0, "System.Network.SNMP.WriteCommunityName", 0, 0, NULL },
+	{ "System.Network.SNMP.WriteCommunitySecurityLevel", 0, 0, "System.Network.SNMP.WriteCommunitySecurityLevel", 0, 0, NULL },
+	{ "System.Network.SNMP.WriteCommunitySecurityRight", ST_FLAG_RW, 0, "System.Network.SNMP.WriteCommunitySecurityRight", 0, 0, NULL },
+	{ "System.Network.SNMP.Admin", ST_FLAG_RW, 0, "System.Network.SNMP.Admin", 0, 0, NULL },
+	{ "System.Network.SNMP.AdminPassword", ST_FLAG_RW, 0, "System.Network.SNMP.AdminPassword", 0, 0, NULL },
+	{ "System.Network.SNMP.AdminSecurityLevel", ST_FLAG_RW, 0, "System.Network.SNMP.AdminSecurityLevel", 0, 0, NULL },
+	{ "System.Network.SNMP.AdminSecurityRight", 0, 0, "System.Network.SNMP.AdminSecurityRight", 0, 0, NULL },
+	{ "System.Network.SNMP.User", ST_FLAG_RW, 0, "System.Network.SNMP.User", 0, 0, NULL },
+	{ "System.Network.SNMP.UserPassword", ST_FLAG_RW, 0, "System.Network.SNMP.UserPassword", 0, 0, NULL },
+	{ "System.Network.SNMP.UserSecurityLevel", ST_FLAG_RW, 0, "System.Network.SNMP.UserSecurityLevel", 0, 0, NULL },
+	{ "System.Network.SNMP.UserSecurityRight", 0, 0, "System.Network.SNMP.UserSecurityRight", 0, 0, NULL },
+	{ "System.Network.SNMP.NotificationUserName", ST_FLAG_RW, 0, "System.Network.SNMP.NotificationUserName", 0, 0, NULL },
+	{ "System.Network.SNMP.snmpVersion", ST_FLAG_RW, 0, "System.Network.SNMP.snmpVersion", 0, 0, NULL },
+	{ "System.Network.SNMP.engineBoots", 0, 0, "System.Network.SNMP.engineBoots", 0, 0, NULL },
+	{ "System.Network.Telnet.Access", ST_FLAG_RW, 0, "System.Network.Telnet.Access", 0, 0, NULL },
+	{ "System.Network.Telnet.Security", ST_FLAG_RW, 0, "System.Network.Telnet.Security", 0, 0, NULL },
+	{ "System.Network.Telnet.Console", ST_FLAG_RW, 0, "System.Network.Telnet.Console", 0, 0, NULL },
+	{ "System.Email.Sender", ST_FLAG_RW, 0, "System.Email.Sender", 0, 0, NULL },
+	{ "System.Email.Subject", ST_FLAG_RW, 0, "System.Email.Subject", 0, 0, NULL },
+	{ "System.Email.UPSName", ST_FLAG_RW, 0, "System.Email.UPSName", 0, 0, NULL },
+	{ "System.Email.Message", ST_FLAG_RW, 0, "System.Email.Message", 0, 0, NULL },
+	{ "System.Email.Localization", ST_FLAG_RW, 0, "System.Email.Localization", 0, 0, NULL },
+	{ "System.Email.EventName", ST_FLAG_RW, 0, "System.Email.EventName", 0, 0, NULL },
+	{ "System.Email[0].Recipient", ST_FLAG_RW, 0, "System.Email[0].Recipient", 0, 0, NULL },
+	{ "System.Email[0].Selected", ST_FLAG_RW, 0, "System.Email[0].Selected", 0, 0, NULL },
+	{ "System.Email[0].Enotify", ST_FLAG_RW, 0, "System.Email[0].Enotify", 0, 0, NULL },
+	{ "System.Email[0].Measures.Log", ST_FLAG_RW, 0, "System.Email[0].Measures.Log", 0, 0, NULL },
+	{ "System.Email[0].Events.Log", ST_FLAG_RW, 0, "System.Email[0].Events.Log", 0, 0, NULL },
+	{ "System.Email[0].SystemEvents.Log", ST_FLAG_RW, 0, "System.Email[0].SystemEvents.Log", 0, 0, NULL },
+	{ "System.Email[0].Environment.Log", ST_FLAG_RW, 0, "System.Email[0].Environment.Log", 0, 0, NULL },
+	{ "System.Email[0].Report.Periodicity", ST_FLAG_RW, 0, "System.Email[0].Report.Periodicity", 0, 0, NULL },
+	{ "System.Email[0].Report.Hour", ST_FLAG_RW, 0, "System.Email[0].Report.Hour", 0, 0, NULL },
+	{ "System.Email[0].Report.Next", ST_FLAG_RW, 0, "System.Email[0].Report.Next", 0, 0, NULL },
+	{ "System.Email[0].EventList.Discharging", ST_FLAG_RW, 0, "System.Email[0].EventList.Discharging", 0, 0, NULL },
+	{ "System.Email[0].EventList.ACPresent", ST_FLAG_RW, 0, "System.Email[0].EventList.ACPresent", 0, 0, NULL },
+	{ "System.Email[0].EventList.RunTimeToShutdown", ST_FLAG_RW, 0, "System.Email[0].EventList.RunTimeToShutdown", 0, 0, NULL },
+	{ "System.Email[0].EventList.BelowRemainingCapacityLimit", ST_FLAG_RW, 0, "System.Email[0].EventList.BelowRemainingCapacityLimit", 0, 0, NULL },
+	{ "System.Email[0].EventList.NeedReplacement.1", ST_FLAG_RW, 0, "System.Email[0].EventList.NeedReplacement.1", 0, 0, NULL },
+	{ "System.Email[0].EventList.NeedReplacement.0", ST_FLAG_RW, 0, "System.Email[0].EventList.NeedReplacement.0", 0, 0, NULL },
+	{ "System.Email[0].EventList.Overload.1", ST_FLAG_RW, 0, "System.Email[0].EventList.Overload.1", 0, 0, NULL },
+	{ "System.Email[0].EventList.Overload.0", ST_FLAG_RW, 0, "System.Email[0].EventList.Overload.0", 0, 0, NULL },
+	{ "System.Email[0].EventList.InternalFailure.1", ST_FLAG_RW, 0, "System.Email[0].EventList.InternalFailure.1", 0, 0, NULL },
+	{ "System.Email[0].EventList.InternalFailure.0", ST_FLAG_RW, 0, "System.Email[0].EventList.InternalFailure.0", 0, 0, NULL },
+	{ "System.Email[0].EventList.CommunicationLost.1", ST_FLAG_RW, 0, "System.Email[0].EventList.CommunicationLost.1", 0, 0, NULL },
+	{ "System.Email[0].EventList.CommunicationLost.0", ST_FLAG_RW, 0, "System.Email[0].EventList.CommunicationLost.0", 0, 0, NULL },
+	{ "System.Email[0].EventList.Charger.InternalFailure", ST_FLAG_RW, 0, "System.Email[0].EventList.Charger.InternalFailure", 0, 0, NULL },
+	{ "System.Email[0].EventList.Input[2].Used.1", ST_FLAG_RW, 0, "System.Email[0].EventList.Input[2].Used.1", 0, 0, NULL },
+	{ "System.Email[0].EventList.Input[2].Used.0", ST_FLAG_RW, 0, "System.Email[0].EventList.Input[2].Used.0", 0, 0, NULL },
+	{ "System.Email[0].EventList.PowerModule.RedundancyLost.1", ST_FLAG_RW, 0, "System.Email[0].EventList.PowerModule.RedundancyLost.1", 0, 0, NULL },
+	{ "System.Email[0].EventList.PowerModule.RedundancyLost.0", ST_FLAG_RW, 0, "System.Email[0].EventList.PowerModule.RedundancyLost.0", 0, 0, NULL },
+	{ "System.Email[0].EventList.PowerModule.ProtectionLost.1", ST_FLAG_RW, 0, "System.Email[0].EventList.PowerModule.ProtectionLost.1", 0, 0, NULL },
+	{ "System.Email[0].EventList.PowerModule.ProtectionLost.0", ST_FLAG_RW, 0, "System.Email[0].EventList.PowerModule.ProtectionLost.0", 0, 0, NULL },
+	{ "System.Email[0].EventList.FirmwareUpgrade", ST_FLAG_RW, 0, "System.Email[0].EventList.FirmwareUpgrade", 0, 0, NULL },
+	{ "System.Email[0].EventList.Environment.CommunicationLost", ST_FLAG_RW, 0, "System.Email[0].EventList.Environment.CommunicationLost", 0, 0, NULL },
+	{ "System.Email[0].EventList.Environment.Notify", ST_FLAG_RW, 0, "System.Email[0].EventList.Environment.Notify", 0, 0, NULL },
+	{ "System.Email[1].Recipient", ST_FLAG_RW, 0, "System.Email[1].Recipient", 0, 0, NULL },
+	{ "System.Email[1].Selected", ST_FLAG_RW, 0, "System.Email[1].Selected", 0, 0, NULL },
+	{ "System.Email[1].Enotify", ST_FLAG_RW, 0, "System.Email[1].Enotify", 0, 0, NULL },
+	{ "System.Email[1].Measures.Log", ST_FLAG_RW, 0, "System.Email[1].Measures.Log", 0, 0, NULL },
+	{ "System.Email[1].Events.Log", ST_FLAG_RW, 0, "System.Email[1].Events.Log", 0, 0, NULL },
+	{ "System.Email[1].SystemEvents.Log", ST_FLAG_RW, 0, "System.Email[1].SystemEvents.Log", 0, 0, NULL },
+	{ "System.Email[1].Environment.Log", ST_FLAG_RW, 0, "System.Email[1].Environment.Log", 0, 0, NULL },
+	{ "System.Email[1].Report.Periodicity", ST_FLAG_RW, 0, "System.Email[1].Report.Periodicity", 0, 0, NULL },
+	{ "System.Email[1].Report.Hour", ST_FLAG_RW, 0, "System.Email[1].Report.Hour", 0, 0, NULL },
+	{ "System.Email[1].Report.Next", ST_FLAG_RW, 0, "System.Email[1].Report.Next", 0, 0, NULL },
+	{ "System.Email[1].EventList.Discharging", ST_FLAG_RW, 0, "System.Email[1].EventList.Discharging", 0, 0, NULL },
+	{ "System.Email[1].EventList.ACPresent", ST_FLAG_RW, 0, "System.Email[1].EventList.ACPresent", 0, 0, NULL },
+	{ "System.Email[1].EventList.RunTimeToShutdown", ST_FLAG_RW, 0, "System.Email[1].EventList.RunTimeToShutdown", 0, 0, NULL },
+	{ "System.Email[1].EventList.BelowRemainingCapacityLimit", ST_FLAG_RW, 0, "System.Email[1].EventList.BelowRemainingCapacityLimit", 0, 0, NULL },
+	{ "System.Email[1].EventList.NeedReplacement.1", ST_FLAG_RW, 0, "System.Email[1].EventList.NeedReplacement.1", 0, 0, NULL },
+	{ "System.Email[1].EventList.NeedReplacement.0", ST_FLAG_RW, 0, "System.Email[1].EventList.NeedReplacement.0", 0, 0, NULL },
+	{ "System.Email[1].EventList.Overload.1", ST_FLAG_RW, 0, "System.Email[1].EventList.Overload.1", 0, 0, NULL },
+	{ "System.Email[1].EventList.Overload.0", ST_FLAG_RW, 0, "System.Email[1].EventList.Overload.0", 0, 0, NULL },
+	{ "System.Email[1].EventList.InternalFailure.1", ST_FLAG_RW, 0, "System.Email[1].EventList.InternalFailure.1", 0, 0, NULL },
+	{ "System.Email[1].EventList.InternalFailure.0", ST_FLAG_RW, 0, "System.Email[1].EventList.InternalFailure.0", 0, 0, NULL },
+	{ "System.Email[1].EventList.CommunicationLost.1", ST_FLAG_RW, 0, "System.Email[1].EventList.CommunicationLost.1", 0, 0, NULL },
+	{ "System.Email[1].EventList.CommunicationLost.0", ST_FLAG_RW, 0, "System.Email[1].EventList.CommunicationLost.0", 0, 0, NULL },
+	{ "System.Email[1].EventList.Charger.InternalFailure", ST_FLAG_RW, 0, "System.Email[1].EventList.Charger.InternalFailure", 0, 0, NULL },
+	{ "System.Email[1].EventList.Input[2].Used.1", ST_FLAG_RW, 0, "System.Email[1].EventList.Input[2].Used.1", 0, 0, NULL },
+	{ "System.Email[1].EventList.Input[2].Used.0", ST_FLAG_RW, 0, "System.Email[1].EventList.Input[2].Used.0", 0, 0, NULL },
+	{ "System.Email[1].EventList.PowerModule.RedundancyLost.1", ST_FLAG_RW, 0, "System.Email[1].EventList.PowerModule.RedundancyLost.1", 0, 0, NULL },
+	{ "System.Email[1].EventList.PowerModule.RedundancyLost.0", ST_FLAG_RW, 0, "System.Email[1].EventList.PowerModule.RedundancyLost.0", 0, 0, NULL },
+	{ "System.Email[1].EventList.PowerModule.ProtectionLost.1", ST_FLAG_RW, 0, "System.Email[1].EventList.PowerModule.ProtectionLost.1", 0, 0, NULL },
+	{ "System.Email[1].EventList.PowerModule.ProtectionLost.0", ST_FLAG_RW, 0, "System.Email[1].EventList.PowerModule.ProtectionLost.0", 0, 0, NULL },
+	{ "System.Email[1].EventList.FirmwareUpgrade", ST_FLAG_RW, 0, "System.Email[1].EventList.FirmwareUpgrade", 0, 0, NULL },
+	{ "System.Email[1].EventList.Environment.CommunicationLost", ST_FLAG_RW, 0, "System.Email[1].EventList.Environment.CommunicationLost", 0, 0, NULL },
+	{ "System.Email[1].EventList.Environment.Notify", ST_FLAG_RW, 0, "System.Email[1].EventList.Environment.Notify", 0, 0, NULL },
+	{ "System.Email[2].Recipient", ST_FLAG_RW, 0, "System.Email[2].Recipient", 0, 0, NULL },
+	{ "System.Email[2].Selected", ST_FLAG_RW, 0, "System.Email[2].Selected", 0, 0, NULL },
+	{ "System.Email[2].Enotify", ST_FLAG_RW, 0, "System.Email[2].Enotify", 0, 0, NULL },
+	{ "System.Email[2].Measures.Log", ST_FLAG_RW, 0, "System.Email[2].Measures.Log", 0, 0, NULL },
+	{ "System.Email[2].Events.Log", ST_FLAG_RW, 0, "System.Email[2].Events.Log", 0, 0, NULL },
+	{ "System.Email[2].SystemEvents.Log", ST_FLAG_RW, 0, "System.Email[2].SystemEvents.Log", 0, 0, NULL },
+	{ "System.Email[2].Environment.Log", ST_FLAG_RW, 0, "System.Email[2].Environment.Log", 0, 0, NULL },
+	{ "System.Email[2].Report.Periodicity", ST_FLAG_RW, 0, "System.Email[2].Report.Periodicity", 0, 0, NULL },
+	{ "System.Email[2].Report.Hour", ST_FLAG_RW, 0, "System.Email[2].Report.Hour", 0, 0, NULL },
+	{ "System.Email[2].Report.Next", ST_FLAG_RW, 0, "System.Email[2].Report.Next", 0, 0, NULL },
+	{ "System.Email[2].EventList.Discharging", ST_FLAG_RW, 0, "System.Email[2].EventList.Discharging", 0, 0, NULL },
+	{ "System.Email[2].EventList.ACPresent", ST_FLAG_RW, 0, "System.Email[2].EventList.ACPresent", 0, 0, NULL },
+	{ "System.Email[2].EventList.RunTimeToShutdown", ST_FLAG_RW, 0, "System.Email[2].EventList.RunTimeToShutdown", 0, 0, NULL },
+	{ "System.Email[2].EventList.BelowRemainingCapacityLimit", ST_FLAG_RW, 0, "System.Email[2].EventList.BelowRemainingCapacityLimit", 0, 0, NULL },
+	{ "System.Email[2].EventList.NeedReplacement.1", ST_FLAG_RW, 0, "System.Email[2].EventList.NeedReplacement.1", 0, 0, NULL },
+	{ "System.Email[2].EventList.NeedReplacement.0", ST_FLAG_RW, 0, "System.Email[2].EventList.NeedReplacement.0", 0, 0, NULL },
+	{ "System.Email[2].EventList.Overload.1", ST_FLAG_RW, 0, "System.Email[2].EventList.Overload.1", 0, 0, NULL },
+	{ "System.Email[2].EventList.Overload.0", ST_FLAG_RW, 0, "System.Email[2].EventList.Overload.0", 0, 0, NULL },
+	{ "System.Email[2].EventList.InternalFailure.1", ST_FLAG_RW, 0, "System.Email[2].EventList.InternalFailure.1", 0, 0, NULL },
+	{ "System.Email[2].EventList.InternalFailure.0", ST_FLAG_RW, 0, "System.Email[2].EventList.InternalFailure.0", 0, 0, NULL },
+	{ "System.Email[2].EventList.CommunicationLost.1", ST_FLAG_RW, 0, "System.Email[2].EventList.CommunicationLost.1", 0, 0, NULL },
+	{ "System.Email[2].EventList.CommunicationLost.0", ST_FLAG_RW, 0, "System.Email[2].EventList.CommunicationLost.0", 0, 0, NULL },
+	{ "System.Email[2].EventList.Charger.InternalFailure", ST_FLAG_RW, 0, "System.Email[2].EventList.Charger.InternalFailure", 0, 0, NULL },
+	{ "System.Email[2].EventList.Input[2].Used.1", ST_FLAG_RW, 0, "System.Email[2].EventList.Input[2].Used.1", 0, 0, NULL },
+	{ "System.Email[2].EventList.Input[2].Used.0", ST_FLAG_RW, 0, "System.Email[2].EventList.Input[2].Used.0", 0, 0, NULL },
+	{ "System.Email[2].EventList.PowerModule.RedundancyLost.1", ST_FLAG_RW, 0, "System.Email[2].EventList.PowerModule.RedundancyLost.1", 0, 0, NULL },
+	{ "System.Email[2].EventList.PowerModule.RedundancyLost.0", ST_FLAG_RW, 0, "System.Email[2].EventList.PowerModule.RedundancyLost.0", 0, 0, NULL },
+	{ "System.Email[2].EventList.PowerModule.ProtectionLost.1", ST_FLAG_RW, 0, "System.Email[2].EventList.PowerModule.ProtectionLost.1", 0, 0, NULL },
+	{ "System.Email[2].EventList.PowerModule.ProtectionLost.0", ST_FLAG_RW, 0, "System.Email[2].EventList.PowerModule.ProtectionLost.0", 0, 0, NULL },
+	{ "System.Email[2].EventList.FirmwareUpgrade", ST_FLAG_RW, 0, "System.Email[2].EventList.FirmwareUpgrade", 0, 0, NULL },
+	{ "System.Email[2].EventList.Environment.CommunicationLost", ST_FLAG_RW, 0, "System.Email[2].EventList.Environment.CommunicationLost", 0, 0, NULL },
+	{ "System.Email[2].EventList.Environment.Notify", ST_FLAG_RW, 0, "System.Email[2].EventList.Environment.Notify", 0, 0, NULL },
+	{ "System.Email[3].Recipient", ST_FLAG_RW, 0, "System.Email[3].Recipient", 0, 0, NULL },
+	{ "System.Email[3].Selected", ST_FLAG_RW, 0, "System.Email[3].Selected", 0, 0, NULL },
+	{ "System.Email[3].Enotify", ST_FLAG_RW, 0, "System.Email[3].Enotify", 0, 0, NULL },
+	{ "System.Email[3].Measures.Log", ST_FLAG_RW, 0, "System.Email[3].Measures.Log", 0, 0, NULL },
+	{ "System.Email[3].Events.Log", ST_FLAG_RW, 0, "System.Email[3].Events.Log", 0, 0, NULL },
+	{ "System.Email[3].SystemEvents.Log", ST_FLAG_RW, 0, "System.Email[3].SystemEvents.Log", 0, 0, NULL },
+	{ "System.Email[3].Environment.Log", ST_FLAG_RW, 0, "System.Email[3].Environment.Log", 0, 0, NULL },
+	{ "System.Email[3].Report.Periodicity", ST_FLAG_RW, 0, "System.Email[3].Report.Periodicity", 0, 0, NULL },
+	{ "System.Email[3].Report.Hour", ST_FLAG_RW, 0, "System.Email[3].Report.Hour", 0, 0, NULL },
+	{ "System.Email[3].Report.Next", ST_FLAG_RW, 0, "System.Email[3].Report.Next", 0, 0, NULL },
+	{ "System.Email[3].EventList.Discharging", ST_FLAG_RW, 0, "System.Email[3].EventList.Discharging", 0, 0, NULL },
+	{ "System.Email[3].EventList.ACPresent", ST_FLAG_RW, 0, "System.Email[3].EventList.ACPresent", 0, 0, NULL },
+	{ "System.Email[3].EventList.RunTimeToShutdown", ST_FLAG_RW, 0, "System.Email[3].EventList.RunTimeToShutdown", 0, 0, NULL },
+	{ "System.Email[3].EventList.BelowRemainingCapacityLimit", ST_FLAG_RW, 0, "System.Email[3].EventList.BelowRemainingCapacityLimit", 0, 0, NULL },
+	{ "System.Email[3].EventList.NeedReplacement.1", ST_FLAG_RW, 0, "System.Email[3].EventList.NeedReplacement.1", 0, 0, NULL },
+	{ "System.Email[3].EventList.NeedReplacement.0", ST_FLAG_RW, 0, "System.Email[3].EventList.NeedReplacement.0", 0, 0, NULL },
+	{ "System.Email[3].EventList.Overload.1", ST_FLAG_RW, 0, "System.Email[3].EventList.Overload.1", 0, 0, NULL },
+	{ "System.Email[3].EventList.Overload.0", ST_FLAG_RW, 0, "System.Email[3].EventList.Overload.0", 0, 0, NULL },
+	{ "System.Email[3].EventList.InternalFailure.1", ST_FLAG_RW, 0, "System.Email[3].EventList.InternalFailure.1", 0, 0, NULL },
+	{ "System.Email[3].EventList.InternalFailure.0", ST_FLAG_RW, 0, "System.Email[3].EventList.InternalFailure.0", 0, 0, NULL },
+	{ "System.Email[3].EventList.CommunicationLost.1", ST_FLAG_RW, 0, "System.Email[3].EventList.CommunicationLost.1", 0, 0, NULL },
+	{ "System.Email[3].EventList.CommunicationLost.0", ST_FLAG_RW, 0, "System.Email[3].EventList.CommunicationLost.0", 0, 0, NULL },
+	{ "System.Email[3].EventList.Charger.InternalFailure", ST_FLAG_RW, 0, "System.Email[3].EventList.Charger.InternalFailure", 0, 0, NULL },
+	{ "System.Email[3].EventList.Input[2].Used.1", ST_FLAG_RW, 0, "System.Email[3].EventList.Input[2].Used.1", 0, 0, NULL },
+	{ "System.Email[3].EventList.Input[2].Used.0", ST_FLAG_RW, 0, "System.Email[3].EventList.Input[2].Used.0", 0, 0, NULL },
+	{ "System.Email[3].EventList.PowerModule.RedundancyLost.1", ST_FLAG_RW, 0, "System.Email[3].EventList.PowerModule.RedundancyLost.1", 0, 0, NULL },
+	{ "System.Email[3].EventList.PowerModule.RedundancyLost.0", ST_FLAG_RW, 0, "System.Email[3].EventList.PowerModule.RedundancyLost.0", 0, 0, NULL },
+	{ "System.Email[3].EventList.PowerModule.ProtectionLost.1", ST_FLAG_RW, 0, "System.Email[3].EventList.PowerModule.ProtectionLost.1", 0, 0, NULL },
+	{ "System.Email[3].EventList.PowerModule.ProtectionLost.0", ST_FLAG_RW, 0, "System.Email[3].EventList.PowerModule.ProtectionLost.0", 0, 0, NULL },
+	{ "System.Email[3].EventList.FirmwareUpgrade", ST_FLAG_RW, 0, "System.Email[3].EventList.FirmwareUpgrade", 0, 0, NULL },
+	{ "System.Email[3].EventList.Environment.CommunicationLost", ST_FLAG_RW, 0, "System.Email[3].EventList.Environment.CommunicationLost", 0, 0, NULL },
+	{ "System.Email[3].EventList.Environment.Notify", ST_FLAG_RW, 0, "System.Email[3].EventList.Environment.Notify", 0, 0, NULL },
+	{ "System.Schedule[0].Off", ST_FLAG_RW, 0, "System.Schedule[0].Off", 0, 0, NULL },
+	{ "System.Schedule[0].On", ST_FLAG_RW, 0, "System.Schedule[0].On", 0, 0, NULL },
+	{ "System.Schedule[1].Off", ST_FLAG_RW, 0, "System.Schedule[1].Off", 0, 0, NULL },
+	{ "System.Schedule[1].On", ST_FLAG_RW, 0, "System.Schedule[1].On", 0, 0, NULL },
+	{ "System.Schedule[2].Off", ST_FLAG_RW, 0, "System.Schedule[2].Off", 0, 0, NULL },
+	{ "System.Schedule[2].On", ST_FLAG_RW, 0, "System.Schedule[2].On", 0, 0, NULL },
+	{ "System.Schedule[3].Off", ST_FLAG_RW, 0, "System.Schedule[3].Off", 0, 0, NULL },
+	{ "System.Schedule[3].On", ST_FLAG_RW, 0, "System.Schedule[3].On", 0, 0, NULL },
+	{ "System.Schedule[4].Off", ST_FLAG_RW, 0, "System.Schedule[4].Off", 0, 0, NULL },
+	{ "System.Schedule[4].On", ST_FLAG_RW, 0, "System.Schedule[4].On", 0, 0, NULL },
+	{ "System.Schedule[5].Off", ST_FLAG_RW, 0, "System.Schedule[5].Off", 0, 0, NULL },
+	{ "System.Schedule[5].On", ST_FLAG_RW, 0, "System.Schedule[5].On", 0, 0, NULL },
+	{ "System.Schedule[6].Off", ST_FLAG_RW, 0, "System.Schedule[6].Off", 0, 0, NULL },
+	{ "System.Schedule[6].On", ST_FLAG_RW, 0, "System.Schedule[6].On", 0, 0, NULL },
+	{ "System.NetworkManagementSystem[0].Name", ST_FLAG_RW, 0, "System.NetworkManagementSystem[0].Name", 0, 0, NULL },
+	{ "System.NetworkManagementSystem[0].HostName", ST_FLAG_RW, 0, "System.NetworkManagementSystem[0].HostName", 0, 0, NULL },
+	{ "System.NetworkManagementSystem[0].TrapCommunity", ST_FLAG_RW, 0, "System.NetworkManagementSystem[0].TrapCommunity", 0, 0, NULL },
+	{ "System.NetworkManagementSystem[0].TrapSnmpVersion", ST_FLAG_RW, 0, "System.NetworkManagementSystem[0].TrapSnmpVersion", 0, 0, NULL },
+	{ "System.NetworkManagementSystem[0].TrapSelectedMibs", ST_FLAG_RW, 0, "System.NetworkManagementSystem[0].TrapSelectedMibs", 0, 0, NULL },
+	{ "System.NetworkManagementSystem[1].Name", ST_FLAG_RW, 0, "System.NetworkManagementSystem[1].Name", 0, 0, NULL },
+	{ "System.NetworkManagementSystem[1].HostName", ST_FLAG_RW, 0, "System.NetworkManagementSystem[1].HostName", 0, 0, NULL },
+	{ "System.NetworkManagementSystem[1].TrapCommunity", ST_FLAG_RW, 0, "System.NetworkManagementSystem[1].TrapCommunity", 0, 0, NULL },
+	{ "System.NetworkManagementSystem[1].TrapSnmpVersion", ST_FLAG_RW, 0, "System.NetworkManagementSystem[1].TrapSnmpVersion", 0, 0, NULL },
+	{ "System.NetworkManagementSystem[1].TrapSelectedMibs", ST_FLAG_RW, 0, "System.NetworkManagementSystem[1].TrapSelectedMibs", 0, 0, NULL },
+	{ "System.NetworkManagementSystem[2].Name", ST_FLAG_RW, 0, "System.NetworkManagementSystem[2].Name", 0, 0, NULL },
+	{ "System.NetworkManagementSystem[2].HostName", ST_FLAG_RW, 0, "System.NetworkManagementSystem[2].HostName", 0, 0, NULL },
+	{ "System.NetworkManagementSystem[2].TrapCommunity", ST_FLAG_RW, 0, "System.NetworkManagementSystem[2].TrapCommunity", 0, 0, NULL },
+	{ "System.NetworkManagementSystem[2].TrapSnmpVersion", ST_FLAG_RW, 0, "System.NetworkManagementSystem[2].TrapSnmpVersion", 0, 0, NULL },
+	{ "System.NetworkManagementSystem[2].TrapSelectedMibs", ST_FLAG_RW, 0, "System.NetworkManagementSystem[2].TrapSelectedMibs", 0, 0, NULL },
+	{ "System.ClientCfg.ShutdownTimer.Select", ST_FLAG_RW, 0, "System.ClientCfg.ShutdownTimer.Select", 0, 0, NULL },
+	{ "System.ClientCfg.ShutdownTimer", ST_FLAG_RW, 0, "System.ClientCfg.ShutdownTimer", 0, 0, NULL },
+	{ "System.ClientCfg.ShutdownDuration", ST_FLAG_RW, 0, "System.ClientCfg.ShutdownDuration", 0, 0, NULL },
+	{ "System.ClientCfg.BroadcastAdmins", ST_FLAG_RW, 0, "System.ClientCfg.BroadcastAdmins", 0, 0, NULL },
+	{ "System.ClientCfg.BroadcastUsers", ST_FLAG_RW, 0, "System.ClientCfg.BroadcastUsers", 0, 0, NULL },
+#endif  /* not interresting for NUT */
+	{ "Environment.iName", ST_FLAG_RW, 0, "Environment.iName", 0, 0, NULL },
+	{ "Environment.Temperature.Unit", ST_FLAG_RW, 0, "Environment.Temperature.Unit", 0, 0, NULL },
+	{ "Environment.Temperature.HighThreshold", ST_FLAG_RW, 0, "Environment.Temperature.HighThreshold", 0, 0, NULL },
+	{ "Environment.Temperature.LowThreshold", ST_FLAG_RW, 0, "Environment.Temperature.LowThreshold", 0, 0, NULL },
+	{ "Environment.Temperature.Hysteresis", ST_FLAG_RW, 0, "Environment.Temperature.Hysteresis", 0, 0, NULL },
+	{ "Environment.Temperature.Offset", ST_FLAG_RW, 0, "Environment.Temperature.Offset", 0, 0, NULL },
+	{ "Environment.Temperature.HighNotify", ST_FLAG_RW, 0, "Environment.Temperature.HighNotify", 0, 0, NULL },
+	{ "Environment.Temperature.LowNotify", ST_FLAG_RW, 0, "Environment.Temperature.LowNotify", 0, 0, NULL },
+	{ "Environment.Temperature.HighShutdown", ST_FLAG_RW, 0, "Environment.Temperature.HighShutdown", 0, 0, NULL },
+	{ "Environment.Temperature.LowShutdown", ST_FLAG_RW, 0, "Environment.Temperature.LowShutdown", 0, 0, NULL },
+	{ "Environment.Humidity.HighThreshold", ST_FLAG_RW, 0, "Environment.Humidity.HighThreshold", 0, 0, NULL },
+	{ "Environment.Humidity.LowThreshold", ST_FLAG_RW, 0, "Environment.Humidity.LowThreshold", 0, 0, NULL },
+	{ "Environment.Humidity.Hysteresis", ST_FLAG_RW, 0, "Environment.Humidity.Hysteresis", 0, 0, NULL },
+	{ "Environment.Humidity.Offset", ST_FLAG_RW, 0, "Environment.Humidity.Offset", 0, 0, NULL },
+	{ "Environment.Humidity.HighNotify", ST_FLAG_RW, 0, "Environment.Humidity.HighNotify", 0, 0, NULL },
+	{ "Environment.Humidity.LowNotify", ST_FLAG_RW, 0, "Environment.Humidity.LowNotify", 0, 0, NULL },
+	{ "Environment.Humidity.HighShutdown", ST_FLAG_RW, 0, "Environment.Humidity.HighShutdown", 0, 0, NULL },
+	{ "Environment.Humidity.LowShutdown", ST_FLAG_RW, 0, "Environment.Humidity.LowShutdown", 0, 0, NULL },
+	{ "Environment.Input[1].iName", ST_FLAG_RW, 0, "Environment.Input[1].iName", 0, 0, NULL },
+	{ "Environment.Input[1].State[0].Description", ST_FLAG_RW, 0, "Environment.Input[1].State[0].Description", 0, 0, NULL },
+	{ "Environment.Input[1].State[0].Notify", ST_FLAG_RW, 0, "Environment.Input[1].State[0].Notify", 0, 0, NULL },
+	{ "Environment.Input[1].State[0].Shutdown", ST_FLAG_RW, 0, "Environment.Input[1].State[0].Shutdown", 0, 0, NULL },
+	{ "Environment.Input[1].State[1].Description", ST_FLAG_RW, 0, "Environment.Input[1].State[1].Description", 0, 0, NULL },
+	{ "Environment.Input[1].State[1].Notify", ST_FLAG_RW, 0, "Environment.Input[1].State[1].Notify", 0, 0, NULL },
+	{ "Environment.Input[1].State[1].Shutdown", ST_FLAG_RW, 0, "Environment.Input[1].State[1].Shutdown", 0, 0, NULL },
+	{ "Environment.Input[2].iName", ST_FLAG_RW, 0, "Environment.Input[2].iName", 0, 0, NULL },
+	{ "Environment.Input[2].State[0].Description", ST_FLAG_RW, 0, "Environment.Input[2].State[0].Description", 0, 0, NULL },
+	{ "Environment.Input[2].State[0].Notify", ST_FLAG_RW, 0, "Environment.Input[2].State[0].Notify", 0, 0, NULL },
+	{ "Environment.Input[2].State[0].Shutdown", ST_FLAG_RW, 0, "Environment.Input[2].State[0].Shutdown", 0, 0, NULL },
+	{ "Environment.Input[2].State[1].Description", ST_FLAG_RW, 0, "Environment.Input[2].State[1].Description", 0, 0, NULL },
+	{ "Environment.Input[2].State[1].Notify", ST_FLAG_RW, 0, "Environment.Input[2].State[1].Notify", 0, 0, NULL },
+	{ "Environment.Input[2].State[1].Shutdown", ST_FLAG_RW, 0, "Environment.Input[2].State[1].Shutdown", 0, 0, NULL },
+	{ "System.TimeSync", ST_FLAG_RW, 0, "System.TimeSync", 0, 0, NULL },
+	{ "System.TimeNtp", ST_FLAG_RW, 0, "System.TimeNtp", 0, 0, NULL },
+	{ "System.TimeZone", ST_FLAG_RW, 0, "System.TimeZone", 0, 0, NULL },
+	{ "System.TimeDaylight", ST_FLAG_RW, 0, "System.TimeDaylight", 0, 0, NULL },
+
 	/* Special case: boolean values that are mapped to ups.status and ups.alarm */
 	{ NULL, 0, 0, "UPS.PowerSummary.PresentStatus.ACPresent", 0, 0, online_info },
-	{ NULL, 0, 0, "UPS.PowerSummary.PresentStatus.Discharging", 0, 0, discharging_info },
 	{ NULL, 0, 0, "UPS.PowerSummary.PresentStatus.Charging", 0, 0, charging_info },
+	/* NMC bug: keep discharging test AFTER charging test */
+	{ NULL, 0, 0, "UPS.PowerSummary.PresentStatus.Discharging", 0, 0, discharging_info },
 	{ NULL, 0, 0, "UPS.PowerSummary.PresentStatus.BelowRemainingCapacityLimit", 0, 0, lowbatt_info },
 	{ NULL, 0, 0, "UPS.PowerSummary.PresentStatus.Overload", 0, 0, overload_info },
 	{ NULL, 0, 0, "UPS.PowerSummary.PresentStatus.NeedReplacement", 0, 0, replacebatt_info },
@@ -573,7 +887,7 @@ static xml_info_t mge_xml2nut[] = {
 	{ "battery.charge.restart", 0, 0, "UPS.PowerSummary.RestartLevel", 0, 0, NULL },
 	{ "battery.capacity", 0, 0, "UPS.BatterySystem.Battery.DesignCapacity", 0, 0, mge_battery_capacity }, /* conversion needed from As to Ah */
 	{ "battery.runtime", 0, 0, "UPS.PowerSummary.RunTimeToEmpty", 0, 0, NULL },
-	{ "battery.runtime.low", 0, 0, "System.RunTimeToEmptyLimit", 0, 0, NULL },
+	{ "battery.runtime.low", ST_FLAG_RW, 0, "System.RunTimeToEmptyLimit", 0, 0, NULL },
 	{ "battery.temperature", 0, 0, "UPS.BatterySystem.Battery.Temperature", 0, 0, NULL },
 	{ "battery.type", ST_FLAG_STATIC, 0, "UPS.PowerSummary.iDeviceChemistry", 0, 0, NULL },
 	{ "battery.type", ST_FLAG_STATIC, 0, "UPS.PowerSummary.iDeviceChemistery", 0, 0, NULL }, /* [sic] */
@@ -598,9 +912,12 @@ static xml_info_t mge_xml2nut[] = {
 	{ "ups.firmware", ST_FLAG_STATIC, 0, "UPS.PowerSummary.iVersion", 0, 0, NULL },
 	{ "ups.load", 0, 0, "UPS.PowerSummary.PercentLoad", 0, 0, NULL },
 	{ "ups.load.high", 0, 0, "UPS.Flow[4].ConfigPercentLoad", 0, 0, NULL },
-	{ "ups.delay.shutdown", 0, 0, "System.ShutdownDuration", 0, 0, NULL },
-	{ "ups.timer.start", 0, 0, "UPS.PowerSummary.DelayBeforeStartup", 0, 0, NULL},
-	{ "ups.timer.shutdown", 0, 0, "UPS.PowerSummary.DelayBeforeShutdown", 0, 0, mge_timer_shutdown },
+	{ "ups.delay.shutdown", ST_FLAG_RW, 0, "System.ShutdownDuration", 0, 0, NULL },
+	{ "ups.timer.start", ST_FLAG_RW, 0, "UPS.PowerSummary.DelayBeforeStartup", 0, 0, NULL},
+	{ "ups.timer.shutdown", ST_FLAG_RW, 0, "UPS.PowerSummary.DelayBeforeShutdown", 0, 0, mge_timer_shutdown },
+	/* Catch shutdown imminent criteria, keep it after 
+	UPS.PowerSummary.DelayBeforeShutdown managment */
+	{ NULL, 0, 0, "System.RunTimeToShutdown", 0, 0, mge_shutdown_imminent },
 	{ "ups.timer.reboot", 0, 0, "UPS.PowerSummary.DelayBeforeReboot", 0, 0, NULL },
 	{ "ups.test.result", 0, 0, "UPS.BatterySystem.Battery.Test", 0, 0, mge_test_result_info },
 	{ "ups.test.interval", 0, 0, "UPS.BatterySystem.Battery.TestPeriod", 0, 0, NULL },
@@ -722,7 +1039,7 @@ static xml_info_t mge_xml2nut[] = {
 	{ "outlet.1.timer.shutdown", 0, 0, "UPS.OutletSystem.Outlet[2].DelayBeforeShutdown", 0, 0, NULL },
 	{ "outlet.1.delay.start", 0, 0, "UPS.OutletSystem.Outlet[2].StartupTimer", 0, 0, NULL },
 	/* { "outlet.1.delay.shutdown", 0, 0, "UPS.OutletSystem.Outlet[2].ShutdownTimer", 0, 0, NULL }, */
-	{ "outlet.1.delay.shutdown", 0, 0, "System.Outlet[2].ShutdownDuration", 0, 0, NULL },
+	{ "outlet.1.delay.shutdown", ST_FLAG_RW, 0, "System.Outlet[2].ShutdownDuration", 0, 0, NULL },
 
 	{ "outlet.2.id", 0, 0, "UPS.OutletSystem.Outlet[3].OutletID", 0, 0, NULL },
 	{ "outlet.2.desc", 0, 0, "UPS.OutletSystem.Outlet[3].iName", 0, 0, NULL },
@@ -733,7 +1050,7 @@ static xml_info_t mge_xml2nut[] = {
 	{ "outlet.2.timer.shutdown", 0, 0, "UPS.OutletSystem.Outlet[3].DelayBeforeShutdown", 0, 0, NULL },
 	{ "outlet.2.delay.start", 0, 0, "UPS.OutletSystem.Outlet[3].StartupTimer", 0, 0, NULL },
 	/* { "outlet.2.delay.shutdown", 0, 0, "UPS.OutletSystem.Outlet[3].ShutdownTimer", 0, 0, NULL }, */
-	{ "outlet.2.delay.shutdown", 0, 0, "System.Outlet[3].ShutdownDuration", 0, 0, NULL },
+	{ "outlet.2.delay.shutdown", ST_FLAG_RW, 0, "System.Outlet[3].ShutdownDuration", 0, 0, NULL },
 
 	/* For newer ePDU Monitored */
 	{ "outlet.1.desc", 0, 0, "PDU.OutletSystem.Outlet[1].iName", 0, 0, NULL },
@@ -1118,3 +1435,83 @@ subdriver_t mge_xml_subdriver = {
 	mge_xml_cdata_cb,
 	mge_xml_endelm_cb,
 };
+
+const char *vname_nut2mge_xml(const char *name) {
+	assert(NULL != name);
+
+	size_t i = 0;
+
+	for (; i < sizeof(mge_xml2nut) / sizeof(xml_info_t); ++i) {
+		xml_info_t *info = mge_xml2nut + i;
+
+		if (NULL != info->nutname)
+			if (0 == strcasecmp(name, info->nutname))
+				return info->xmlname;
+	}
+
+	return NULL;
+}
+
+const char *vname_mge_xml2nut(const char *name) {
+	assert(NULL != name);
+
+	size_t i = 0;
+
+	for (; i < sizeof(mge_xml2nut) / sizeof(xml_info_t); ++i) {
+		xml_info_t *info = mge_xml2nut + i;
+
+		if (NULL != info->xmlname)
+			if (0 == strcasecmp(name, info->xmlname))
+				return info->nutname;
+	}
+
+	return NULL;
+}
+
+char *vvalue_mge_xml2nut(const char *name, const char *value, size_t len) {
+	assert(NULL != name);
+
+	size_t i = 0;
+
+	for (; i < sizeof(mge_xml2nut) / sizeof(xml_info_t); ++i) {
+		xml_info_t *info = mge_xml2nut + i;
+
+		if (NULL != info->nutname)
+			if (0 == strcasecmp(name, info->nutname)) {
+				/* Copy value */
+				char *vcpy = (char *)malloc((len + 1) * sizeof(char));
+
+				if (NULL == vcpy)
+					return vcpy;
+
+				memcpy(vcpy, value, len * sizeof(char));
+				vcpy[len] = '\0';
+
+				/* Convert */
+				if (NULL != info->convert) {
+					char *vconv = info->convert(vcpy);
+
+					free(vcpy);
+
+					return vconv;
+				}
+				else
+					return vcpy;
+			}
+	}
+
+	return NULL;
+}
+
+void vname_register_rw(void) {
+	size_t i = 0;
+
+	for (; i < sizeof(mge_xml2nut) / sizeof(xml_info_t); ++i) {
+		xml_info_t *info = mge_xml2nut + i;
+
+		if (NULL != info->nutname && info->nutflags & ST_FLAG_RW) {
+			dstate_setinfo(info->nutname, "");
+			dstate_setflags(info->nutname, ST_FLAG_RW);
+		}
+	}
+}

--- a/drivers/mge-xml.h
+++ b/drivers/mge-xml.h
@@ -25,4 +25,41 @@
 
 extern subdriver_t	mge_xml_subdriver;
 
+/**
+ *  \brief  Convert NUT variable name to MGE XML
+ *
+ *  \param  name  NUT variable name
+ *
+ *  \return MGE XML variable name
+ */
+const char *vname_nut2mge_xml(const char *name);
+
+/**
+ *  \brief  Convert MGE XML variable name to NUT
+ *
+ *  \param  name  MGE XML variable name
+ *
+ *  \return NUT variable name
+ */
+const char * vname_mge_xml2nut(const char *name);
+
+/**
+ *  \brief  Convert MGE XML variable value to NUT value
+ *
+ *  The function produces a newly created C-string that should
+ *  be destroyed using \c free.
+ *
+ *  \param  name   NUT variable name
+ *  \param  value  MGE XML variable value
+ *  \param  len    MGE XML variable value length (in characters)
+ *
+ *  \return NUT variable value
+ */
+char *vvalue_mge_xml2nut(const char *name, const char *value, size_t len);
+
+/**
+ *  \brief  Register set of R/W variables
+ */
+void vname_register_rw(void);
+
 #endif /* MGE_XML_H */

--- a/drivers/netxml-ups.c
+++ b/drivers/netxml-ups.c
@@ -2,6 +2,7 @@
 
    Copyright (C)
 	2008-2009	Arjen de Korte <adkorte-guest@alioth.debian.org>
+	2013		Vaclav Krpec <VaclavKrpec@Eaton.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -21,6 +22,7 @@
 #include "main.h"
 #include "netxml-ups.h"
 #include "mge-xml.h"
+#include "dstate.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -38,16 +40,187 @@
 #include <ne_socket.h>
 
 #define DRIVER_NAME	"network XML UPS"
-#define DRIVER_VERSION	"0.31"
+#define DRIVER_VERSION	"0.40"
+
+/** *_OBJECT query multi-part body boundary */
+#define FORM_POST_BOUNDARY "NUT-NETXML-UPS-OBJECTS"
 
 /* driver description structure */
 upsdrv_info_t	upsdrv_info = {
 	DRIVER_NAME,
 	DRIVER_VERSION,
-	"Arjen de Korte <adkorte-guest@alioth.debian.org>",
+	"Arjen de Korte <adkorte-guest@alioth.debian.org>" \
+	"Vaclav Krpec <VaclavKrpec@Eaton.com>",
 	DRV_EXPERIMENTAL,
 	{ NULL }
 };
+
+
+/** *_OBJECT query status */
+typedef enum {
+	OBJECT_OK = 0,       /**< OK            */
+	OBJECT_PARSE_ERROR,  /**< Parse error   */
+	OBJECT_ERROR,        /**< Generic error */
+} object_query_status_t;  /* end of typedef enum */
+
+
+/** *_OBJECT entry type */
+typedef enum {
+	SET_OBJECT_REQUEST,   /**< SET_OBJECT request  */
+	SET_OBJECT_RESPONSE,  /**< SET_OBJECT response */
+} object_query_type_t;  /* end of typedef enum */
+
+
+/** *_OBJECT POST request mode */
+typedef enum {
+	RAW_POST,   /**< RAW POST mode  */
+	FORM_POST,  /**< FORM POST mode */
+} object_post_mode_t;  /* end of typedef enum */
+
+
+typedef struct set_object_req   set_object_req_t;    /**< SET_OBJECT request  carrier */
+typedef struct set_object_resp  set_object_resp_t;   /**< SET_OBJECT response carrier */
+typedef struct object_entry     object_entry_t;      /**< *_OBJECT entry      carrier */
+typedef struct object_query     object_query_t;      /**< *_OBJECT query      handle  */
+
+
+/** SET_OBJECT request carrier */
+struct set_object_req {
+	char *name;   /**< OBJECT name  */
+	char *value;  /**< OBJECT value */
+};  /* end of struct set_object_req */
+
+
+/** SET_OBJECT response carrier */
+struct set_object_resp {
+	char *name;    /**< OBJECT name   */
+	char *unit;    /**< OBJECT unit   */
+	char *access;  /**< OBJECT access */
+	char *value;   /**< OBJECT value  */
+};  /* end of struct set_object_resp */
+
+
+/** *_OBJECT query entry */
+struct object_entry {
+	/** Payload */
+	union {
+		set_object_req_t  req;   /**< Request  entry */
+		set_object_resp_t resp;  /**< Response entry */
+	} payld;
+
+	/* Metadata */
+	object_entry_t *next;  /**< Next     entry */
+	object_entry_t *prev;  /**< Previous entry */
+};  /* end of struct object_entry */
+
+
+/** *_OBJECT query handle */
+struct object_query {
+	object_query_status_t  status;  /**< Query status      */
+	object_query_type_t    type;    /**< List entries type */
+	object_post_mode_t     mode;    /**< POST request mode */
+	size_t                 cnt;     /**< Count of entries  */
+	object_entry_t        *head;    /**< List head         */
+	object_entry_t        *tail;    /**< List tail         */
+};  /* end of struct object_query */
+
+
+/**
+ *  \brief  *_OBJECT query constructor
+ *
+ *  \param  type  Query type
+ *  \param  mode  Query mode
+ *
+ *  \return *_OBJECT query handle or \c NULL in case of memory error
+ */
+static object_query_t *object_query_create(
+	object_query_type_t type,
+	object_post_mode_t  mode);
+
+
+/**
+ *  \brief  Number of *_OBJECT query entries
+ *
+ *  \param  handle  Query handle
+ *
+ *  \return NUmber of entries
+ */
+static size_t object_query_size(object_query_t *handle);
+
+
+/**
+ *  \brief  *_OBJECT query destructor
+ *
+ *  \param  handle  Query handle
+ */
+static void object_query_destroy(object_query_t *handle);
+
+
+/**
+ *  \brief  SET_OBJECT: add request query entry
+ *
+ *  \param  handle  Request query handle
+ *  \param  name    OBJECT name
+ *  \param  value   OBJECT value
+ *
+ *  \return Query entry or \c NULL in case of memory error
+ */
+static object_entry_t *set_object_add(
+	object_query_t *handle,
+	const char     *name,
+	const char     *value);
+
+
+/**
+ *  \brief  SET_OBJECT: RAW POST mode implementation
+ *
+ *  \brief  req  SET_OBJECT request
+ *
+ *  \return Response to the request
+ */
+static object_query_t *set_object_raw(object_query_t *req);
+
+
+/**
+ *  \brief  SET_OBJECT: FORM POST mode implementation
+ *
+ *  \brief  req  SET_OBJECT request
+ *
+ *  \return \c NULL (FORM POST mode resp. is ignored by specification)
+ */
+static object_query_t *set_object_form(object_query_t *req);
+
+
+/**
+ *  \brief  SET_OBJECT: implementation
+ *
+ *  \brief  req  SET_OBJECT request
+ *
+ *  \return Response to the request
+ */
+static object_query_t *set_object(object_query_t *req);
+
+
+/**
+ *  \brief  SET_OBJECT: RAW POST mode request serialisation
+ *
+ *  \param  handle  Request query handle
+ *
+ *  \return POST request body
+ */
+static ne_buffer *set_object_serialise_raw(object_query_t *handle);
+
+
+/**
+ *  \brief  SET_OBJECT: FORM POST mode request serialisation
+ *
+ *  \param  handle  Request query handle
+ *
+ *  \return POST request body
+ */
+static ne_buffer *set_object_serialise_form(object_query_t *handle);
+
+
 /* FIXME:
  * "built with neon library %s" LIBNEON_VERSION 
  * subdrivers (limited to MGE only ATM) */
@@ -55,6 +228,8 @@ upsdrv_info_t	upsdrv_info = {
 /* Global vars */
 uint32_t		ups_status = 0;
 static int		timeout = 5;
+int			shutdown_duration = 120;
+static int		shutdown_timer = 0;
 static time_t		lastheard = 0;
 static subdriver_t	*subdriver = &mge_xml_subdriver;
 static ne_session	*session = NULL;
@@ -67,6 +242,9 @@ static void netxml_status_set(void);
 static int netxml_authenticate(void *userdata, const char *realm, int attempt, char *username, char *password);
 static int netxml_dispatch_request(ne_request *request, ne_xml_parser *parser);
 static int netxml_get_page(const char *page);
+
+static int instcmd(const char *cmdname, const char *extra);
+static int setvar(const char *varname, const char *val);
 
 static int netxml_alarm_subscribe(const char *page);
 
@@ -98,6 +276,13 @@ void upsdrv_initinfo(void)
 			extrafd = ne_sock_fd(sock);
 			time(&lastheard);
 		}
+
+		/* Register r/w variables */
+		vname_register_rw();
+
+		/* Set UPS driver handler callbacks */
+		upsh.setvar  = &setvar;
+		upsh.instcmd = &instcmd;
 
 		return;
 	}
@@ -182,15 +367,14 @@ void upsdrv_updateinfo(void)
 	dstate_dataok();
 }
 
-void upsdrv_shutdown(void)
-{
+void upsdrv_shutdown(void) {
 	/* tell the UPS to shut down, then return - DO NOT SLEEP HERE */
 
 	/* maybe try to detect the UPS here, but try a shutdown even if
 	   it doesn't respond at first if possible */
 
 	/* replace with a proper shutdown function */
-	fatalx(EXIT_FAILURE, "shutdown not supported");
+	/* fatalx(EXIT_FAILURE, "shutdown not supported"); */
 
 	/* you may have to check the line status since the commands
 	   for toggling power are frequently different for OL vs. OB */
@@ -198,33 +382,109 @@ void upsdrv_shutdown(void)
 	/* OL: this must power cycle the load if possible */
 
 	/* OB: the load must remain off until the power returns */
+
+	int status = STAT_SET_FAILED;  /* pessimistic assumption */
+
+	object_query_t *resp = NULL;
+	object_query_t *req  = NULL;
+
+	/* Pragmatic do { ... } while (0) loop allowing break to cleanup */
+	do {
+		/* Create SET_OBJECT request */
+		req = object_query_create(SET_OBJECT_REQUEST, FORM_POST);
+
+		if (NULL == req)
+			break;
+
+		if (NULL == set_object_add(req, "battery.runtime.low", "999999999"))
+			break;
+
+		/* Send SET_OBJECT request */
+		resp = set_object(req);
+
+#if (0)  /* FORM_POST method response is ignored, we can only hope it worked... */
+		if (NULL == resp)
+			break;
+
+		/* Check if setting was done */
+		if (1 > object_query_size(resp)) {
+			status = STAT_SET_UNKNOWN;
+
+			break;
+		}
+#endif  /* end of code removal */
+
+		status = STAT_SET_HANDLED;  /* success */
+
+	} while (0);  /* end of pragmatic loop, break target */
+
+	/* Cleanup */
+	if (NULL != req)
+		object_query_destroy(req);
+
+	if (NULL != resp)
+		object_query_destroy(resp);
+
+	if (STAT_SET_HANDLED != status)
+		fatalx(EXIT_FAILURE, "Shutdown failed: %d", status);
 }
 
-/*
 static int instcmd(const char *cmdname, const char *extra)
 {
+/*
 	if (!strcasecmp(cmdname, "test.battery.stop")) {
 		ser_send_buf(upsfd, ...);
 		return STAT_INSTCMD_HANDLED;
 	}
 
+*/
 	upslogx(LOG_NOTICE, "%s: unknown command [%s]", __func__, cmdname);
 	return STAT_INSTCMD_UNKNOWN;
 }
-*/
 
-/*
-static int setvar(const char *varname, const char *val)
-{
-	if (!strcasecmp(varname, "ups.test.interval")) {
-		ser_send_buf(upsfd, ...);
-		return STAT_SET_HANDLED;
-	}
+static int setvar(const char *varname, const char *val) {
+	int status = STAT_SET_FAILED;  /* pessimistic assumption */
 
-	upslogx(LOG_NOTICE, "%s: unknown variable [%s]", __func__, varname);
-	return STAT_SET_UNKNOWN;
+	object_query_t *resp = NULL;
+	object_query_t *req  = NULL;
+
+	/* Pragmatic do { ... } while (0) loop allowing break to cleanup */
+	do {
+		/* Create SET_OBJECT request */
+		req = object_query_create(SET_OBJECT_REQUEST, FORM_POST);
+
+		if (NULL == req)
+			break;
+
+		if (NULL == set_object_add(req, varname, val))
+			break;
+
+		/* Send SET_OBJECT request */
+		resp = set_object(req);
+
+		if (NULL == resp)
+			break;
+
+		/* Check if setting was done */
+		if (1 > object_query_size(resp)) {
+			status = STAT_SET_UNKNOWN;
+
+			break;
+		}
+
+		status = STAT_SET_HANDLED;  /* success */
+
+	} while (0);  /* end of pragmatic loop, break target */
+
+	/* Cleanup */
+	if (NULL != req)
+		object_query_destroy(req);
+
+	if (NULL != resp)
+		object_query_destroy(resp);
+
+	return status;
 }
-*/
 
 void upsdrv_help(void)
 {
@@ -238,10 +498,21 @@ void upsdrv_makevartable(void)
 	snprintf(buf, sizeof(buf), "network timeout (default: %d seconds)", timeout);
 	addvar(VAR_VALUE, "timeout", buf);
 
-	addvar(VAR_FLAG, "subscribe", "NSM subscribe to NMC");
+	addvar(VAR_FLAG, "subscribe", "authenticated subscription on NMC");
 
 	addvar(VAR_VALUE | VAR_SENSITIVE, "login", "login value for authenticated mode");
 	addvar(VAR_VALUE | VAR_SENSITIVE, "password", "password value for authenticated mode");
+
+	snprintf(buf, sizeof(buf), "shutdown duration in second (default: %d seconds)", shutdown_duration);
+	addvar(VAR_VALUE, "shutdown_duration", buf);
+
+	if( shutdown_timer > 0 ) {
+		snprintf(buf, sizeof(buf), "shutdown timer in second (default: %d seconds)", shutdown_timer);
+	}
+	else {
+		snprintf(buf, sizeof(buf), "shutdown timer in second (default: none)");
+	}
+	addvar(VAR_VALUE, "shutdown_timer", buf);
 }
 
 void upsdrv_initups(void)
@@ -268,6 +539,24 @@ void upsdrv_initups(void)
 
 		if (timeout < 1) {
 			fatalx(EXIT_FAILURE, "timeout must be greater than 0");
+		}
+	}
+
+	val = getval("shutdown_duration");
+	if (val) {
+		shutdown_duration = atoi(val);
+
+		if (shutdown_duration < 0) {
+			fatalx(EXIT_FAILURE, "shutdown duration must be greater than or equal to 0");
+		}
+	}
+
+	val = getval("shutdown_timer");
+	if (val) {
+		shutdown_timer = atoi(val);
+
+		if (shutdown_timer < 0) {
+			fatalx(EXIT_FAILURE, "shutdwon timer must be greater than or equal to 0");
 		}
 	}
 
@@ -398,6 +687,10 @@ static int netxml_alarm_subscribe(const char *page)
 	ne_request	*request;
 	ne_sock_addr	*addr;
 	const ne_inet_addr	*ai;
+	char	resp_buf[LARGEBUF];
+
+	/* Clear response buffer */
+	memset(resp_buf, 0, sizeof(resp_buf));
 
 	upsdebugx(2, "%s: %s", __func__, page);
 
@@ -416,18 +709,23 @@ static int netxml_alarm_subscribe(const char *page)
 
 	netxml_get_page(subdriver->configure);
 
-	snprintf(buf, sizeof(buf),	"<?xml version=\"1.0\">\n");
+	snprintf(buf, sizeof(buf),	"<?xml version=\"1.0\"?>\n");
 	snprintfcat(buf, sizeof(buf),	"<Subscribe>\n");
 	snprintfcat(buf, sizeof(buf),		"<Class>%s v%s</Class>\n", progname, DRIVER_VERSION);
 	snprintfcat(buf, sizeof(buf),		"<Type>connected socket</Type>\n");
 	snprintfcat(buf, sizeof(buf),		"<HostName>%s</HostName>\n", dstate_getinfo("driver.hostname"));
 	snprintfcat(buf, sizeof(buf),		"<XMLClientParameters>\n");
-	snprintfcat(buf, sizeof(buf),			"<ShutdownDuration>%s</ShutdownDuration>\n", dstate_getinfo("driver.delay.shutdown"));
-	snprintfcat(buf, sizeof(buf),			"<ShutdownTimer>%s</ShutdownTimer>\n", dstate_getinfo("driver.timer.shutdown"));
-	snprintfcat(buf, sizeof(buf),			"<AutoConfig>CENTRALIZED</AutoConfig>\n");
+	snprintfcat(buf, sizeof(buf),		"<ShutdownDuration>%d</ShutdownDuration>\n", shutdown_duration);
+	if( shutdown_timer > 0 ) {
+		snprintfcat(buf, sizeof(buf),	"<ShutdownTimer>%d</ShutdownTimer>\r\n", shutdown_timer);
+	}
+	else {
+		snprintfcat(buf, sizeof(buf),	"<ShutdownTimer>NONE</ShutdownTimer>\n");
+	}
+	snprintfcat(buf, sizeof(buf),			"<AutoConfig>LOCAL</AutoConfig>\n");
 	snprintfcat(buf, sizeof(buf),			"<OutletGroup>1</OutletGroup>\n");
 	snprintfcat(buf, sizeof(buf),		"</XMLClientParameters>\n");
-/*	snprintfcat(buf, sizeof(buf),		"<Warning>NUT driver</Warning>\n"); */
+	snprintfcat(buf, sizeof(buf),		"<Warning></Warning>\n");
 	snprintfcat(buf, sizeof(buf),	"</Subscribe>\n");
 
 	/* now send subscription message setting all the proper flags */
@@ -448,7 +746,7 @@ static int netxml_alarm_subscribe(const char *page)
 			break;
 		}
 
-		ret = ne_read_response_block(request, buf, sizeof buf);
+		ret = ne_read_response_block(request, resp_buf, sizeof(resp_buf));
 
 		if (ret == NE_OK) {
 			ret = ne_end_request(request);
@@ -460,7 +758,7 @@ static int netxml_alarm_subscribe(const char *page)
 
 	/* due to different formats used by the various NMCs, we need to\
 	   break up the reply in lines and parse each one separately */
-	for (s = strtok(buf, "\r\n"); s != NULL; s = strtok(NULL, "\r\n")) {
+	for (s = strtok(resp_buf, "\r\n"); s != NULL; s = strtok(NULL, "\r\n")) {
 		upsdebugx(2, "%s: parsing %s", __func__, s);
 
 		if (!strncasecmp(s, "<Port>", 6) && (sscanf(s+6, "%u", &port) != 1)) {
@@ -515,8 +813,8 @@ static int netxml_alarm_subscribe(const char *page)
 		return NE_RETRY;
 	}
 
-	snprintf(buf, sizeof(buf), "<Subscription Identification=\"%u\"></Subscription>\n", secret);
-	ret = ne_sock_fullwrite(sock, buf, strlen(buf));
+	snprintf(buf, sizeof(buf), "<Subscription Identification=\"%u\"></Subscription>", secret);
+	ret = ne_sock_fullwrite(sock, buf, strlen(buf) + 1);
 
 	if (ret != NE_OK) {
 		upsdebugx(2, "%s: send failed: %s", __func__, ne_sock_error(sock));
@@ -684,3 +982,769 @@ static void netxml_status_set(void)
 	}
 }
 
+
+/*
+ * *_OBJECT interface implementation
+ */
+
+static object_query_t *object_query_create(
+	object_query_type_t type,
+	object_post_mode_t  mode)
+{
+	object_query_t *handle = (object_query_t *)calloc(1,
+		sizeof(object_query_t));
+
+	if (NULL == handle)
+		return NULL;
+
+	handle->type = type;
+	handle->mode = mode;
+
+	return handle;
+}
+
+
+static size_t object_query_size(object_query_t *handle) {
+	assert(NULL != handle);
+
+	return handle->cnt;
+}
+
+
+/**
+ *  \brief  SET_OBJECT request list entry destructor
+ *
+ *  \param  req  SET_OBJECT request list entry
+ */
+static void set_object_req_destroy(set_object_req_t *req) {
+	assert(NULL != req);
+
+	if (NULL != req->name)
+		free(req->name);
+
+	if (NULL != req->value)
+		free(req->value);
+}
+
+
+/**
+ *  \brief  SET_OBJECT response list entry destructor
+ *
+ *  \param  req  SET_OBJECT response list entry
+ */
+static void set_object_resp_destroy(set_object_resp_t *resp) {
+	assert(NULL != resp);
+
+	if (NULL != resp->name)
+		free(resp->name);
+
+	if (NULL != resp->unit)
+		free(resp->unit);
+
+	if (NULL != resp->access)
+		free(resp->access);
+
+	if (NULL != resp->value)
+		free(resp->value);
+}
+
+
+/**
+ *  \brief  *_OBJECT query entry destructor
+ *
+ *  \param  handle  SET_OBJECT query handle
+ *  \param  entry   SET_OBJECT query entry
+ */
+static void object_entry_destroy(object_query_t *handle, object_entry_t *entry) {
+	assert(NULL != handle);
+	assert(NULL != entry);
+
+	/* Sanity checks */
+	assert(0 < handle->cnt);
+
+	/* Relink list */
+	if (entry == handle->head) {
+		handle->head = entry->next;
+	}
+	else {
+		assert(NULL != entry->prev);
+
+		entry->prev->next = entry->next;
+	}
+
+	if (entry == handle->tail) {
+		handle->tail = entry->prev;
+	}
+	else {
+		assert(NULL != entry->next);
+
+		entry->next->prev = entry->prev;
+	}
+
+	--handle->cnt;
+
+	/* Destroy payload */
+	switch (handle->type) {
+		case SET_OBJECT_REQUEST:
+			set_object_req_destroy(&entry->payld.req);
+
+			break;
+
+		case SET_OBJECT_RESPONSE:
+			set_object_resp_destroy(&entry->payld.resp);
+
+			break;
+	}
+
+	/* Destroy entry */
+	free(entry);
+}
+
+
+static void object_query_destroy(object_query_t *handle) {
+	assert(NULL != handle);
+
+	/* Destroy entries */
+	while (handle->cnt)
+		object_entry_destroy(handle, handle->head);
+
+	/* Destroy handle */
+	free(handle);
+}
+
+
+/**
+ *  \brief  Add *_OBJECT list entry (at list end)
+ *
+ *  \param  handle  Entry list handle
+ *  \param  entry   Entry
+ */
+static void object_add_entry(object_query_t *handle, object_entry_t *entry) {
+	assert(NULL != handle);
+	assert(NULL != entry);
+
+	/* Sanity checks */
+	assert(SET_OBJECT_REQUEST == handle->type);
+
+	/* Add entry at end of bi-directional list */
+	if (handle->cnt) {
+		assert(NULL != handle->tail);
+		assert(NULL == handle->tail->next);
+
+		handle->tail->next = entry;
+		entry->prev = handle->tail;
+	}
+
+	/* Add the very first entry */
+	else {
+		handle->head = entry;
+		entry->prev  = NULL;
+	}
+
+	handle->tail = entry;
+	entry->next  = NULL;
+
+	++handle->cnt;
+}
+
+
+static object_entry_t *set_object_add(
+	object_query_t *handle,
+	const char     *name,
+	const char     *value)
+{
+	char *name_cpy;
+	char *value_cpy;
+
+	assert(NULL != name);
+	assert(NULL != value);
+
+	object_entry_t *entry = (object_entry_t *)calloc(1,
+		sizeof(object_entry_t));
+
+	if (NULL == entry)
+		return NULL;
+
+	/* Copy payload data */
+	name_cpy  = strdup(name);
+	value_cpy = strdup(value);
+
+	/* Cleanup in case of memory error */
+	if (NULL == name_cpy || NULL == value_cpy) {
+		if (NULL != name_cpy)
+			free(name_cpy);
+
+		if (NULL != value_cpy)
+			free(value_cpy);
+
+		free(entry);
+
+		return NULL;
+	}
+
+	/* Set payload */
+	entry->payld.req.name  = name_cpy;
+	entry->payld.req.value = value_cpy;
+
+	/* Enlist */
+	object_add_entry(handle, entry);
+
+	return entry;
+}
+
+
+/**
+ *  \brief  Common SET_OBJECT entries serialiser
+ *
+ *  \param  buff   Buffer
+ *  \param  entry  SET_OBJECT request entry
+ *
+ *  \retval OBJECT_OK    on success
+ *  \retval OBJECT_ERROR otherwise
+ */
+static object_query_status_t set_object_serialise_entries(ne_buffer *buff, object_entry_t *entry) {
+	object_query_status_t status = OBJECT_OK;
+
+	assert(NULL != buff);
+
+	ne_buffer_zappend(buff, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n");
+	ne_buffer_zappend(buff, "<SET_OBJECT>\r\n");
+
+	for (; NULL != entry; entry = entry->next) {
+		const char *vname = vname_nut2mge_xml(entry->payld.req.name);
+
+		/* Serialise one object */
+		if (NULL != vname) {
+			ne_buffer_zappend(buff, "  <OBJECT name=\"");
+			ne_buffer_zappend(buff, vname);
+			ne_buffer_zappend(buff, "\">");
+			ne_buffer_zappend(buff, entry->payld.req.value);
+			ne_buffer_zappend(buff, "</OBJECT>\r\n");
+		}
+
+		/* Var. name resolution error */
+		else
+			status = OBJECT_ERROR;
+	}
+
+	ne_buffer_zappend(buff, "</SET_OBJECT>\r\n");
+
+	return status;
+}
+
+
+static ne_buffer *set_object_serialise_raw(object_query_t *handle) {
+	assert(NULL != handle);
+
+	/* Sanity checks */
+	assert(SET_OBJECT_REQUEST == handle->type);
+
+	/* Create buffer */
+	ne_buffer *buff = ne_buffer_create();
+
+	/* neon API ref. states that the function always succeeds */
+	assert(NULL != buff);
+
+	/* Serialise all entries */
+	set_object_serialise_entries(buff, handle->head);
+
+	return buff;
+}
+
+
+static ne_buffer *set_object_serialise_form(object_query_t *handle) {
+	const char *vname = NULL;
+
+	assert(NULL != handle);
+
+	/* Sanity checks */
+	assert(SET_OBJECT_REQUEST == handle->type);
+
+	/* Create buffer */
+	ne_buffer *buff = ne_buffer_create();
+
+	/* neon API ref. states that the function always succeeds */
+	assert(NULL != buff);
+
+	/* Simple request */
+	if (1 == object_query_size(handle)) {
+		assert(NULL != handle->head);
+
+		/* TODO: Simple req. doesn't seem to work
+		vname = vname_nut2mge_xml(handle->head->payld.req.name);
+		*/
+	}
+	if (NULL != vname) {
+		assert(NULL != handle->head);
+
+		ne_buffer_zappend(buff, "objectName=");
+		ne_buffer_zappend(buff, vname);
+		ne_buffer_zappend(buff, "&objectValue=");
+		ne_buffer_zappend(buff, handle->head->payld.req.value);
+	}
+
+	/* Multi set request (or empty request) */
+	else {
+		/* Add request prologue */
+		ne_buffer_zappend(buff, "--" FORM_POST_BOUNDARY "\r\n");
+		ne_buffer_zappend(buff, "Content-Disposition: form-data; name=\"file\"; "
+					"filename=\"Configuration.xml\"\r\n");
+		ne_buffer_zappend(buff, "Content-Type: application/octet-stream\r\n");
+		ne_buffer_zappend(buff, "\r\n");
+
+		/* Serialise all entries */
+		set_object_serialise_entries(buff, handle->head);
+
+		/* Add request epilogue */
+		ne_buffer_zappend(buff, "--" FORM_POST_BOUNDARY "--\r\n");
+	}
+
+	return buff;
+}
+
+
+/**
+ *  \brief  neon callback for SET_OBJECT RAW POST mode response element start
+ *
+ *  \param  userdata  Obfuscated SET_OBJECT_RESPONSE query handle
+ *  \param  parent    Element parent
+ *  \param  nspace    Element namespace (empty)
+ *  \param  name      Element name
+ *  \param  attrs     Element attributes
+ *
+ *  \return \c NE_XML_STATEROOT + distance of the element from root
+ */
+static int set_object_raw_resp_start_element(
+	void        *userdata,
+	int          parent,
+	const char  *nspace,
+	const char  *name,
+	const char **attrs)
+{
+	object_query_t *handle = (object_query_t *)userdata;
+
+	assert(NULL != handle);
+
+	/* Sanity checks */
+	assert(SET_OBJECT_RESPONSE == handle->type);
+
+	/* Check that namespace is empty */
+	if (NULL != nspace && '\0' != *nspace) {
+		handle->status = OBJECT_PARSE_ERROR;
+
+		return NE_XML_STATEROOT;
+	}
+
+	/* OBJECT (as a SET_OBJECT child) */
+	if (NE_XML_STATEROOT + 1 == parent && 0 == strcasecmp(name, "OBJECT")) {
+		size_t i;
+
+		object_entry_t *entry = (object_entry_t *)calloc(1,
+			sizeof(object_entry_t));
+
+		/* Memory error */
+		if (NULL == entry) {
+			handle->status = OBJECT_ERROR;
+
+			return NE_XML_STATEROOT;
+		}
+
+		/* Set attributes */
+		for (i = 0; NULL != attrs[i] && NULL != attrs[i + 1]; i += 2) {
+			char       **attr = NULL;
+			const char  *aval = NULL;
+
+			/* Skip unset attribute name and/or value (useless) */
+			if (NULL == attrs[i] || NULL == attrs[i + 1])
+				continue;
+
+			/* Obviously, the following holds, now */
+			assert(NULL != attrs[i]);
+			assert(NULL != attrs[i + 1]);
+
+			/* name */
+			if (0 == strcasecmp(attrs[i], "name")) {
+				attr = &entry->payld.resp.name;
+				aval = vname_mge_xml2nut(attrs[i + 1]);
+			}
+
+			/* unit */
+			else if (0 == strcasecmp(attrs[i], "unit")) {
+				attr = &entry->payld.resp.unit;
+				aval = attrs[i + 1];
+			}
+
+			/* access */
+			else if (0 == strcasecmp(attrs[i], "access")) {
+				attr = &entry->payld.resp.access;
+				aval = attrs[i + 1];
+			}
+
+			/* Set known attribute */
+			if (NULL != attr) {
+				/* Copy value */
+				if (NULL != aval) {
+					*attr = strdup(aval);
+
+					if (NULL == *attr)
+						handle->status = OBJECT_ERROR;
+				}
+
+				/* Value resolution error */
+				else
+					handle->status = OBJECT_ERROR;
+			}
+		}
+
+		object_add_entry(handle, entry);
+
+		return NE_XML_STATEROOT + 2;  /* signal to cdata callback */
+	}
+
+	/* SET_OBJECT (as the root child) */
+	if (NE_XML_STATEROOT == parent && 0 == strcasecmp(name, "SET_OBJECT"))
+		return NE_XML_STATEROOT + 1;
+
+	/* Unknown element (as a SET_OBJECT child) */
+	if (NE_XML_STATEROOT + 1 == parent)
+		return NE_XML_STATEROOT + 1;
+
+	/* Ignore any other root children */
+	return NE_XML_STATEROOT;
+}
+
+
+/**
+ *  \brief  neon callback for SET_OBJECT RAW POST mode response data start
+ *
+ *  The callback is used to set OBJECT element value.
+ *  This is done for state \c NE_XML_STATEROOT + 2
+ *  (see \ref set_object_raw_resp_start_element).
+ *
+ *  \param  userdata  Obfuscated SET_OBJECT_RESPONSE query handle
+ *  \param  state     Element distance from root
+ *  \param  cdata     Character data
+ *  \param  len       Character data length
+ *
+ *  \return state
+ */
+static int set_object_raw_resp_cdata(
+	void       *userdata,
+	int         state,
+	const char *cdata,
+	size_t      len)
+{
+	object_query_t *handle = (object_query_t *)userdata;
+
+	assert(NULL != handle);
+
+	/* Sanity checks */
+	assert(SET_OBJECT_RESPONSE == handle->type);
+
+	/* Ignore any element except OBJECT */
+	if (NE_XML_STATEROOT + 2 != state)
+		return state;
+
+	if (OBJECT_OK == handle->status) {
+		char *value;
+
+		/* Set last object value */
+		assert(NULL != handle->tail);
+		assert(NULL != handle->tail->payld.resp.name);
+
+		value = vvalue_mge_xml2nut(handle->tail->payld.resp.name, cdata, len);
+
+		handle->tail->payld.resp.value = value;
+
+		if (NULL == handle->tail->payld.resp.value)
+			handle->status = OBJECT_ERROR;
+	}
+
+	return state;
+}
+
+
+/**
+ *  \brief  neon callback for SET_OBJECT RAW POST mode response element start
+ *
+ *  \param  userdata  Obfuscated SET_OBJECT_RESPONSE query handle
+ *  \param  state     Element distance from root
+ *  \param  nspace    Element namespace (empty)
+ *  \param  name      Element name
+ *
+ *  \return \c NE_XML_STATEROOT + distance of the element from root
+ */
+static int set_object_raw_resp_end_element(
+	void       *userdata,
+	int         state,
+	const char *nspace,
+	const char *name)
+{
+	/* OBJECT (as a SET_OBJECT child) */
+	if (NE_XML_STATEROOT + 2 == state) {
+		assert(0 == strcasecmp(name, "OBJECT"));
+
+		return NE_XML_STATEROOT + 1;
+	}
+
+	/*
+	 * Otherwise, state is either NE_XML_STATEROOT or NE_XML_STATEROOT + 1
+	 * In any case, we return NE_XML_STATEROOT
+	 */
+	return NE_XML_STATEROOT;
+}
+
+
+static object_query_t *set_object_deserialise_raw(ne_buffer *buff) {
+	int ne_status;
+
+	assert(NULL != buff);
+
+	/* Create SET_OBJECT query response */
+	object_query_t *handle = object_query_create(SET_OBJECT_RESPONSE, RAW_POST);
+
+	if (NULL == handle)
+		return NULL;
+
+	/* Create XML parser */
+	ne_xml_parser *parser = ne_xml_create();
+
+	/* neon API ref. states that the function always succeeds */
+	assert(NULL != parser);
+
+	/* Set element & data handlers */
+	ne_xml_push_handler(
+		parser,
+		set_object_raw_resp_start_element,
+		set_object_raw_resp_cdata,
+		set_object_raw_resp_end_element,
+		handle);
+
+	/* Parse the response */
+	ne_status = ne_xml_parse(parser, buff->data, buff->used);
+
+	if (NE_OK != ne_status)
+		handle->status = OBJECT_PARSE_ERROR;
+
+	/* Destroy parser */
+	ne_xml_destroy(parser);
+
+	return handle;
+}
+
+
+/**
+ *  \brief  Send HTTP request over a session
+ *
+ *  The function creates HTTP request, sends it and reads-out the response.
+ *
+ *  \param[in]   session    HTTP session
+ *  \param[in]   method     Request method
+ *  \param[in]   uri        Request URI
+ *  \param[in]   ct         Request content type (optional, \c NULL accepted)
+ *  \param[in]   req_body   Request body (optional, \c NULL is accepted)
+ *  \param[out]  resp_body  Response body (optional, \c NULL is accepted)
+ *
+ *  \return HTTP status code if response was sent, 0 on send error
+ */
+static int send_http_request(
+	ne_session *session,
+	const char *method,
+	const char *uri,
+	const char *ct,
+	ne_buffer  *req_body,
+	ne_buffer  *resp_body)
+{
+	int resp_code = 0;
+
+	ne_request *req = NULL;
+
+	/* Create request */
+	req = ne_request_create(session, method, uri);
+
+	/* Neon claims that request creation is always successful */
+	assert(NULL != req);
+
+	do {  /* Pragmatic do ... while (0) loop allowing breaks on error */
+		const ne_status *req_st;
+
+		/* Set Content-Type */
+		if (NULL != ct)
+			ne_add_request_header(req, "Content-Type", ct);
+
+		/* Set request body */
+		if (NULL != req_body)
+			/* BEWARE: The terminating '\0' byte is "used", too */
+			ne_set_request_body_buffer(req,
+				req_body->data, req_body->used - 1);
+
+		/* Send request */
+		int status = ne_begin_request(req);
+
+		if (NE_OK != status) {
+			break;
+		}
+
+		/* Read response */
+		assert(NE_OK == status);
+
+		for (;;) {
+			char buff[512];
+
+			ssize_t read;
+
+			read = ne_read_response_block(req, buff, sizeof(buff));
+
+			/* Read failure */
+			if (0 > read) {
+				status = NE_ERROR;
+
+				break;
+			}
+
+			if (0 == read)
+				break;
+
+			if (NULL != resp_body)
+				ne_buffer_append(resp_body, buff, read);
+		}
+
+		if (NE_OK != status) {
+			break;
+		}
+
+		/* Request served */
+		ne_end_request(req);
+
+		/* Get response code */
+		req_st = ne_get_status(req);
+
+		assert(NULL != req_st);
+
+		resp_code = req_st->code;
+
+	} while (0);  /* end of do ... while (0) pragmatic loop */
+
+	if (NULL != req)
+		ne_request_destroy(req);
+
+	return resp_code;
+}
+
+
+static object_query_t *set_object_raw(object_query_t *req) {
+	int             resp_code;
+	object_query_t *resp      = NULL;
+	ne_buffer      *req_body  = NULL;
+	ne_buffer      *resp_body = NULL;
+
+	assert(NULL != req);
+
+	/* Sanity check */
+	assert(SET_OBJECT_REQUEST == req->type);
+	assert(RAW_POST           == req->mode);
+
+	/* Serialise request POST data */
+	req_body = set_object_serialise_raw(req);
+
+	/* Send request */
+	resp_body = ne_buffer_create();
+
+	assert(NULL != resp_body);
+
+	resp_code = send_http_request(session,
+		"POST", "/set_obj.htm", NULL, req_body, resp_body);
+
+	/*
+	 * Repeat in case of 401 - Unauthorised
+	 *
+	 * Note that this is a WA of NMC sending Connection: close
+	 * header in the 401 response, in which case neon closes
+	 * connection (quite rightfully).
+	 */
+	if (401 == resp_code)
+		resp_code = send_http_request(session,
+			"POST", "/set_obj.htm", NULL, req_body, resp_body);
+
+	/* Deserialise response */
+	if (200 == resp_code)
+		resp = set_object_deserialise_raw(resp_body);
+
+	/* Cleanup */
+	if (NULL != req_body)
+		ne_buffer_destroy(req_body);
+
+	if (NULL != resp_body)
+		ne_buffer_destroy(resp_body);
+
+	return resp;
+}
+
+
+static object_query_t *set_object_form(object_query_t *req) {
+	int       resp_code;
+	ne_buffer *req_body = NULL;
+
+	const char *ct = "multipart/form-data; boundary=" FORM_POST_BOUNDARY;
+
+	/* TODO: Single request doesn't seem to work
+	if (1 == object_query_size(req))
+		ct = "application/x-form-urlencoded";
+	*/
+
+	assert(NULL != req);
+
+	/* Sanity check */
+	assert(SET_OBJECT_REQUEST == req->type);
+	assert(FORM_POST          == req->mode);
+
+	/* Serialise request POST data */
+	req_body = set_object_serialise_form(req);
+
+	/* Send request (response is ignored by the proto. spec v3) */
+	resp_code = send_http_request(session,
+		"POST", "/Forms/set_obj_2", ct, req_body, NULL);
+
+	/*
+	 * Repeat in case of 401 - Unauthorised
+	 *
+	 * Note that this is a WA of NMC sending Connection: close
+	 * header in the 401 response, in which case neon closes
+	 * connection (quite rightfully).
+	 */
+	if (401 == resp_code) {
+		resp_code = send_http_request(session,
+			"POST", "/Forms/set_obj_2", ct, req_body, NULL);
+	}
+
+	/* Cleanup */
+	if (NULL != req_body)
+		ne_buffer_destroy(req_body);
+
+	return NULL;
+}
+
+
+static object_query_t *set_object(object_query_t *req) {
+	object_query_t *resp = NULL;
+
+	assert(NULL != req);
+
+	/* Sanity checks */
+	assert(SET_OBJECT_REQUEST == req->type);
+
+	/* Select implementation by POST request mode */
+	switch (req->mode) {
+		case RAW_POST:
+			resp = set_object_raw(req);
+
+			break;
+
+		case FORM_POST:
+			resp = set_object_form(req);
+
+			break;
+	}
+
+	return resp;
+}


### PR DESCRIPTION
Fixed bugs in resolution of FSD condition and computation of shutdown duration.
Added System.\* UPS variables.
Enabled RW access to appropriate UPS variables.
Added UPS veriables value convertors.
Added support for XML protocol v3 {GET|SET}_OBJECT query implementing getvar and setvar routines.
netxml driver man page updated to include info about the driver-specific configuration parameters.
