### PR TITLE
Provide retry options for upsdrvctl and driver(s)

### DIFF
--- a/docs/man/ups.conf.txt
+++ b/docs/man/ups.conf.txt
@@ -58,6 +58,21 @@ directory, which is often /usr/local/ups/bin.
 Optional.  Same as the UPS field of the same name, but this is the
 default for UPSes that don't have the field.
 
+*maxretry*::
+Optional.  Specify the number of attempts to start the driver(s), in case of
+failure, before giving up. A delay of 'retrydelay' is inserted between each
+attempt. Caution should be taken when using this option, since it can
+impact the time taken by your system to start.
++
+The default is 1 attempt.
+
+*retrydelay*::
+Optional.  Specify the delay between each restart attempt of the driver(s),
+as specified by 'maxretry'. Caution should be taken when using this option,
+since it can impact the time taken by your system to start.
++
+The default is 5 seconds.
+
 *pollinterval*::
 
 Optional.  The status of the UPS will be refreshed after a maximum

--- a/docs/man/upsdrvctl.txt
+++ b/docs/man/upsdrvctl.txt
@@ -63,7 +63,8 @@ Without that argument, they operate on every UPS that is currently
 configured.
 
 *start*::
-Start the UPS driver(s).
+Start the UPS driver(s). In case of failure, further attempts may be executed
+by using the 'maxretry' and 'retrydelay' options - see linkman:ups.conf[5].
 
 *stop*::
 Stop the UPS driver(s).


### PR DESCRIPTION
As recently seen in Debian (bugs #694717 and #677143), it may be required to
have upsdrvctl retrying to start the driver in case of failure.  More
specifically, a mix of init system (V and systemd), udev and USB device(s) can
result in the /dev entry not being available at driver startup, thus resulting
in a general failure to start NUT.  This commit provides at least a way to
overcome this issue. A more suitable  solution will require more work on NUT
design.

This patch if based on Arnaud Quette proposal
