### PR TITLE
nutdrv_qx: fix 'megatec/old' and 'mustek' subdrivers' claim functions

### DIFF
--- a/docs/man/nutdrv_qx.txt
+++ b/docs/man/nutdrv_qx.txt
@@ -50,7 +50,9 @@ If you set stayoff in linkman:ups.conf[5] when FSD arises the UPS will call a *s
 
 *protocol =* 'string'::
 Skip autodetection of the protocol to use and only use the one specified.
-Supported values 'mecer', 'megatec', 'megatec/old', 'mustek', 'q1', 'voltronic' and 'zinto'.
+Supported values: 'mecer', 'megatec', 'megatec/old', 'mustek', 'q1', 'voltronic' and 'zinto'.
++
+Note that if you end up using the 'q1' protocol, you may want to give a try to the 'mecer', 'megatec' and 'zinto' ones setting the <<old-blazer-protocols-options,*novendor*/*norating* flags>> (only one, or both).
 
 *pollfreq =* 'value'::
 Set polling frequency, in seconds, to reduce the data flow.
@@ -99,6 +101,7 @@ If not specified, the driver defaults to 10%.
 Only used if *runtimecal* is also specified.
 
 
+[[old-blazer-protocols-options]]
 MECER, MEGATAEC, MEGATEC/OLD, MUSTEK, ZINTO PROTOCOLS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -33,7 +33,7 @@
  *
  */
 
-#define DRIVER_VERSION	"0.02"
+#define DRIVER_VERSION	"0.03"
 
 #include "main.h"
 

--- a/drivers/nutdrv_qx_blazer-common.c
+++ b/drivers/nutdrv_qx_blazer-common.c
@@ -88,6 +88,30 @@ int	blazer_claim(void) {
 
 }
 
+/* This function allows the subdriver to "claim" a device: return 1 if the device is supported by this subdriver, else 0.
+ * NOTE: this 'light' version only checks for status (Q1/QS/D/..) */
+int	blazer_claim_light(void) {
+
+	/* To tell whether the UPS is supported or not, we'll check just status (Q1/QS/D/..). */
+
+	item_t	*item = find_nut_info("input.voltage", 0, 0);
+
+	/* Don't know what happened */
+	if (!item)
+		return 0;
+
+	/* No reply/Unable to get value */
+	if (qx_process(item, NULL))
+		return 0;
+
+	/* Unable to process value */
+	if (ups_infoval_set(item) != 1)
+		return 0;
+
+	return 1;
+
+}
+
 /* Subdriver-specific flags/vars */
 void	blazer_makevartable(void)
 {

--- a/drivers/nutdrv_qx_blazer-common.h
+++ b/drivers/nutdrv_qx_blazer-common.h
@@ -28,6 +28,7 @@
 void	blazer_makevartable(void);
 void	blazer_initups(item_t *qx2nut);
 int	blazer_claim(void);
+int	blazer_claim_light(void);
 
 /* Preprocess functions */
 int	blazer_process_command(item_t *item, char *value, size_t valuelen);

--- a/drivers/nutdrv_qx_megatec-old.c
+++ b/drivers/nutdrv_qx_megatec-old.c
@@ -25,7 +25,7 @@
 
 #include "nutdrv_qx_megatec-old.h"
 
-#define MEGATEC_OLD_VERSION "Megatec/old 0.01"
+#define MEGATEC_OLD_VERSION "Megatec/old 0.02"
 
 /* qx2nut lookup table */
 static item_t	megatec_old_qx2nut[] = {
@@ -128,7 +128,7 @@ static void	megatec_old_initups(void)
 /* Subdriver interface */
 subdriver_t	megatec_old_subdriver = {
 	MEGATEC_OLD_VERSION,
-	blazer_claim,
+	blazer_claim_light,
 	megatec_old_qx2nut,
 	megatec_old_initups,
 	NULL,

--- a/drivers/nutdrv_qx_mustek.c
+++ b/drivers/nutdrv_qx_mustek.c
@@ -25,7 +25,7 @@
 
 #include "nutdrv_qx_mustek.h"
 
-#define MUSTEK_VERSION "Mustek 0.01"
+#define MUSTEK_VERSION "Mustek 0.02"
 
 /* qx2nut lookup table */
 static item_t	mustek_qx2nut[] = {
@@ -128,7 +128,7 @@ static void	mustek_initups(void)
 /* Subdriver interface */
 subdriver_t	mustek_subdriver = {
 	MUSTEK_VERSION,
-	blazer_claim,
+	blazer_claim_light,
 	mustek_qx2nut,
 	mustek_initups,
 	NULL,

--- a/drivers/nutdrv_qx_q1.c
+++ b/drivers/nutdrv_qx_q1.c
@@ -35,7 +35,7 @@
 
 #include "nutdrv_qx_q1.h"
 
-#define Q1_VERSION "Q1 0.01"
+#define Q1_VERSION "Q1 0.02"
 
 /* qx2nut lookup table */
 static item_t	q1_qx2nut[] = {
@@ -102,34 +102,10 @@ static testing_t	q1_testing[] = {
 };
 #endif	/* TESTING */
 
-
-/* This function allows the subdriver to "claim" a device: return 1 if the device is supported by this subdriver, else 0. */
-int	q1_claim(void) {
-
-	/* To tell whether the UPS is supported or not, we'll check just status (Q1). */
-
-	item_t	*item = find_nut_info("input.voltage", 0, 0);
-
-	/* Don't know what happened */
-	if (!item)
-		return 0;
-
-	/* No reply/Unable to get value */
-	if (qx_process(item, NULL))
-		return 0;
-
-	/* Unable to process value */
-	if (ups_infoval_set(item) != 1)
-		return 0;
-
-	return 1;
-
-}
-
 /* Subdriver interface */
 subdriver_t	q1_subdriver = {
 	Q1_VERSION,
-	q1_claim,
+	blazer_claim_light,
 	q1_qx2nut,
 	NULL,
 	NULL,


### PR DESCRIPTION
Address, for 'megatec/old' and 'mustek' subdrivers, the same problem fixed in commit 720975f4de910b270ba705a7f2981c2ee33ca2eb for Q1-based ones (pull request #72):
- Make the claim function of 'megatec/old' and 'mustek' subdrivers not poll the UPS for 'vendor' informations as they are not really needed to set these protocols apart from the other ones (i.e. the 'status' poll is specific enough, at the time of writing).
- Move common 'light' claim function to nutdrv_qx_blazer-common.{c,h}.
- Update manual.
- Versioning.

This is, in my opinion, a better way to address the same problem than the one of #75, as it doesn't add a bunch of pretty useless subdrivers.
