### PR TITLE
Ippon response length fix

### DIFF
--- a/drivers/blazer_usb.c
+++ b/drivers/blazer_usb.c
@@ -28,7 +28,7 @@
 #include "blazer.h"
 
 #define DRIVER_NAME	"Megatec/Q1 protocol USB driver"
-#define DRIVER_VERSION	"0.10"
+#define DRIVER_VERSION	"0.11"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -176,7 +176,7 @@ static int phoenix_command(const char *cmd, char *buf, size_t buflen)
 static int ippon_command(const char *cmd, char *buf, size_t buflen)
 {
 	char	tmp[64];
-	int	ret;
+	int	ret, len;
 	size_t	i;
 
 	snprintf(tmp, sizeof(tmp), "%s", cmd);
@@ -207,10 +207,19 @@ static int ippon_command(const char *cmd, char *buf, size_t buflen)
 		return ret;
 	}
 
-	snprintf(buf, buflen, "%.*s", ret, tmp);
-
-	upsdebugx(3, "read: %.*s", (int)strcspn(buf, "\r"), buf);
-	return ret;
+	/*
+	 * As Ippon will always return 64 bytes in response, we have to
+	 * calculate and return length of actual response data here.
+	 * Empty response will look like 0x00 0x0D, otherwise it will be
+	 * data string terminated by 0x0D.
+	 */
+	len = (int)strcspn(tmp, "\r");
+	upsdebugx(3, "read: %.*s", len, tmp);
+	if (len > 0) {
+		len ++;
+	}
+	snprintf(buf, buflen, "%.*s", len, tmp);
+	return len;
 }
 
 

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -33,7 +33,7 @@
  *
  */
 
-#define DRIVER_VERSION	"0.03"
+#define DRIVER_VERSION	"0.04"
 
 #include "main.h"
 
@@ -537,7 +537,7 @@ static int	phoenix_command(const char *cmd, char *buf, size_t buflen)
 static int	ippon_command(const char *cmd, char *buf, size_t buflen)
 {
 	char	tmp[64];
-	int	ret;
+	int	ret, len;
 	size_t	i;
 
 	/* Send command */
@@ -565,10 +565,19 @@ static int	ippon_command(const char *cmd, char *buf, size_t buflen)
 		return ret;
 	}
 
-	snprintf(buf, buflen, "%.*s", ret, tmp);
-
-	upsdebugx(3, "read: %.*s", (int)strcspn(buf, "\r"), buf);
-	return ret;
+	/*
+	 * As Ippon will always return 64 bytes in response, we have to
+	 * calculate and return length of actual response data here.
+	 * Empty response will look like 0x00 0x0D, otherwise it will be
+	 * data string terminated by 0x0D.
+	 */
+	len = (int)strcspn(tmp, "\r");
+	upsdebugx(3, "read: %.*s", len, tmp);
+	if (len > 0) {
+		len ++;
+	}
+	snprintf(buf, buflen, "%.*s", len, tmp);
+	return len;
 }
 
 /* Krauler communication subdriver */


### PR DESCRIPTION
Ippon Back Power Pro responses are always padded to 64 bytes beyond \r payload terminator. When checking that command was successful (i.e. not echoed back) code relies on the response length reported by blazer_command which will always be 64. To fix this ippon_command should return actual payload length.
