### PR TITLE
docs: prevent smartphones from being too smart (docbook)

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -39,7 +39,8 @@ ALL_TXT_SRC = nut-names.txt $(USER_MANUAL_DEPS) $(DEVELOPER_GUIDE_DEPS) \
 
 NUT_SPELL_DICT = nut.dict
 EXTRA_DIST = $(ALL_TXT_SRC) $(SHARED_DEPS) $(IMAGE_FILES) \
- $(CABLES_IMAGES) docinfo.xml $(NUT_SPELL_DICT)
+ $(CABLES_IMAGES) docinfo.xml $(NUT_SPELL_DICT) \
+ common.xsl xhtml.xsl chunked.xsl
 
 ASCIIDOC_HTML_SINGLE = user-manual.html \
 	developer-guide.html \
@@ -97,11 +98,11 @@ A2X_COMMON_OPTS = $(ASCIIDOC_VERBOSE) --attribute icons \
     --attribute tree_version=@TREE_VERSION@ \
     -a toc -a numbered --destination-dir=.
 
-.txt.html:
-	$(A2X) $(A2X_COMMON_OPTS) --attribute=xhtml11_format --format=xhtml $<
+.txt.html: common.xsl xhtml.xsl
+	$(A2X) $(A2X_COMMON_OPTS) --attribute=xhtml11_format --format=xhtml --xsl-file=$(srcdir)/xhtml.xsl $<
 
-.txt.chunked:
-	$(A2X) $(A2X_COMMON_OPTS) --attribute=chunked_format --format=chunked $<
+.txt.chunked: common.xsl chunked.xsl
+	$(A2X) $(A2X_COMMON_OPTS) --attribute=chunked_format --format=chunked --xsl-file=$(srcdir)/chunked.xsl $<
 
 .txt.pdf: docinfo.xml
 	$(A2X) $(A2X_COMMON_OPTS) --attribute=pdf_format --format=pdf -a docinfo1 $<

--- a/docs/chunked.xsl
+++ b/docs/chunked.xsl
@@ -1,0 +1,22 @@
+<!--
+  Generates chunked XHTML documents from DocBook XML source using DocBook XSL
+  stylesheets.
+
+  NOTE: The URL reference to the current DocBook XSL stylesheets is
+  rewritten to point to the copy on the local disk drive by the XML catalog
+  rewrite directives so it doesn't need to go out to the Internet for the
+  stylesheets. This means you don't need to edit the <xsl:import> elements on
+  a machine by machine basis.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+	<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/xhtml/chunk.xsl"/>
+	<xsl:import href="common.xsl"/>
+	<xsl:param name="navig.graphics.path">images/icons/</xsl:param>
+	<xsl:param name="admon.graphics.path">images/icons/</xsl:param>
+	<xsl:param name="callout.graphics.path" select="'images/icons/callouts/'"/>
+
+	<!-- Format-detection to prevent smartphones from being too smart -->
+	<xsl:template name="user.head.content">
+		<meta name="format-detection" content="telephone=no" />
+	</xsl:template>
+</xsl:stylesheet>

--- a/docs/common.xsl
+++ b/docs/common.xsl
@@ -1,0 +1,106 @@
+<!--
+  Inlcuded in xhtml.xsl, xhtml.chunked.xsl, htmlhelp.xsl.
+  Contains common XSL stylesheets parameters.
+  Output documents styled by docbook.css.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+<xsl:param name="html.stylesheet" select="'docbook-xsl.css'"/>
+
+<xsl:param name="htmlhelp.chm" select="'htmlhelp.chm'"/>
+<xsl:param name="htmlhelp.hhc.section.depth" select="5"/>
+
+<xsl:param name="section.autolabel">
+  <xsl:choose>
+    <xsl:when test="/processing-instruction('asciidoc-numbered')">1</xsl:when>
+    <xsl:otherwise>0</xsl:otherwise>
+  </xsl:choose>
+</xsl:param>
+
+<xsl:param name="suppress.navigation" select="0"/>
+<xsl:param name="navig.graphics.extension" select="'.png'"/>
+<xsl:param name="navig.graphics" select="0"/>
+<xsl:param name="navig.graphics.path">images/icons/</xsl:param>
+<xsl:param name="navig.showtitles">0</xsl:param>
+
+<xsl:param name="shade.verbatim" select="0"/>
+<xsl:attribute-set name="shade.verbatim.style">
+  <xsl:attribute name="border">0</xsl:attribute>
+  <xsl:attribute name="background-color">#E0E0E0</xsl:attribute>
+</xsl:attribute-set>
+
+<xsl:param name="admon.graphics" select="1"/>
+<xsl:param name="admon.graphics.path">images/icons/</xsl:param>
+<xsl:param name="admon.graphics.extension" select="'.png'"/>
+<xsl:param name="admon.style">
+  <xsl:text>margin-left: 0; margin-right: 10%;</xsl:text>
+</xsl:param>
+<xsl:param name="admon.textlabel" select="1"/>
+
+<xsl:param name="callout.defaultcolumn" select="'60'"/>
+<xsl:param name="callout.graphics.extension" select="'.png'"/>
+<xsl:param name="callout.graphics" select="'1'"/>
+<xsl:param name="callout.graphics.number.limit" select="'10'"/>
+<xsl:param name="callout.graphics.path" select="'images/icons/callouts/'"/>
+<xsl:param name="callout.list.table" select="'1'"/>
+
+<!-- This does not seem to work. -->
+<xsl:param name="section.autolabel.max.depth" select="2"/>
+
+<xsl:param name="chunk.first.sections" select="1"/>
+<xsl:param name="chunk.section.depth" select="1"/>
+<xsl:param name="chunk.quietly" select="0"/>
+<xsl:param name="chunk.toc" select="''"/>
+<xsl:param name="chunk.tocs.and.lots" select="0"/>
+
+<xsl:param name="html.cellpadding" select="'4px'"/>
+<xsl:param name="html.cellspacing" select="''"/>
+
+<xsl:param name="table.borders.with.css" select="1"/>
+<xsl:param name="table.cell.border.color" select="'#527bbd'"/>
+
+<xsl:param name="table.cell.border.style" select="'solid'"/>
+<xsl:param name="table.cell.border.thickness" select="'1px'"/>
+<xsl:param name="table.footnote.number.format" select="'a'"/>
+<xsl:param name="table.footnote.number.symbols" select="''"/>
+<xsl:param name="table.frame.border.color" select="'#527bbd'"/>
+<xsl:param name="table.frame.border.style" select="'solid'"/>
+<xsl:param name="table.frame.border.thickness" select="'3px'"/>
+<xsl:param name="tablecolumns.extension" select="'1'"/>
+
+<xsl:param name="highlight.source" select="1"/>
+
+<xsl:param name="section.label.includes.component.label" select="1"/>
+
+<!--
+  Table of contents inserted by <?asciidoc-toc?> processing instruction.
+-->
+<xsl:param name="generate.toc">
+  <xsl:choose>
+    <xsl:when test="/processing-instruction('asciidoc-toc')">
+article toc,title
+book    toc,title,figure,table,example,equation
+      <!-- The only way I could find that suppressed book chapter TOCs -->
+      <xsl:if test="$generate.section.toc.level != 0">
+chapter   toc,title
+part      toc,title
+preface   toc,title
+qandadiv  toc
+qandaset  toc
+reference toc,title
+sect1     toc
+sect2     toc
+sect3     toc
+sect4     toc
+sect5     toc
+section   toc
+set       toc,title
+      </xsl:if>
+    </xsl:when>
+    <xsl:otherwise>
+article nop
+book    nop
+    </xsl:otherwise>
+  </xsl:choose>
+</xsl:param>
+
+</xsl:stylesheet>

--- a/docs/xhtml.xsl
+++ b/docs/xhtml.xsl
@@ -1,0 +1,19 @@
+<!--
+  Generates single XHTML document from DocBook XML source using DocBook XSL
+  stylesheets.
+
+  NOTE: The URL reference to the current DocBook XSL stylesheets is
+  rewritten to point to the copy on the local disk drive by the XML catalog
+  rewrite directives so it doesn't need to go out to the Internet for the
+  stylesheets. This means you don't need to edit the <xsl:import> elements on
+  a machine by machine basis.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+	<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/xhtml/docbook.xsl"/>
+	<xsl:import href="common.xsl"/>
+
+	<!-- Format-detection to prevent smartphones from being too smart -->
+	<xsl:template name="user.head.content">
+		<meta name="format-detection" content="telephone=no" />
+	</xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
Add HTML <meta> tag to not auto-create telephone number links on mobile browsers also in docbook processed documents.

Reference: https://github.com/networkupstools/nut/issues/78

XSL files source:
- https://github.com/asciidoc/asciidoc/blob/master/docbook-xsl/common.xsl
- https://github.com/asciidoc/asciidoc/blob/master/docbook-xsl/xhtml.xsl
- https://github.com/asciidoc/asciidoc/blob/master/docbook-xsl/chunked.xsl
## 

For the docbook part I had to add the xsl files: while this adds some weight to the repo, we could do nice things in future with them to personalize even further the output.
