### PR TITLE
Define bool_t correctly if TRUE is defined

### DIFF
--- a/drivers/nutdrv_qx.h
+++ b/drivers/nutdrv_qx.h
@@ -45,7 +45,11 @@
 #define DEFAULT_OFFDELAY	"30"	/* Delay before power off, in seconds */
 #define DEFAULT_POLLFREQ	30	/* Polling interval between full updates, in seconds; the driver will do quick polls in the meantime */
 
+#ifndef TRUE
 typedef enum { FALSE, TRUE } bool_t;
+#else
+typedef int bool_t;
+#endif
 
 /* Structure for rw vars */
 typedef struct {


### PR DESCRIPTION
Detect if TRUE (and FALSE) are already defined and define bool_t accordingly.

Fix #108
