### PR TITLE
mge-xml: fix compile-time warnings, versioning

### DIFF
--- a/drivers/mge-xml.c
+++ b/drivers/mge-xml.c
@@ -31,7 +31,7 @@
 #include "netxml-ups.h"
 #include "mge-xml.h"
 
-#define MGE_XML_VERSION		"MGEXML/0.22"
+#define MGE_XML_VERSION		"MGEXML/0.23"
 #define MGE_XML_INITUPS		"/"
 #define MGE_XML_INITINFO	"/mgeups/product.xml /product.xml /ws/product.xml"
 
@@ -1489,7 +1489,7 @@ char *vvalue_mge_xml2nut(const char *name, const char *value, size_t len) {
 
 				/* Convert */
 				if (NULL != info->convert) {
-					char *vconv = info->convert(vcpy);
+					char *vconv = (char *)info->convert(vcpy);
 
 					free(vcpy);
 
@@ -1510,7 +1510,7 @@ void vname_register_rw(void) {
 		xml_info_t *info = mge_xml2nut + i;
 
 		if (NULL != info->nutname && info->nutflags & ST_FLAG_RW) {
-			dstate_setinfo(info->nutname, "");
+			dstate_setinfo(info->nutname, "%s", "");
 			dstate_setflags(info->nutname, ST_FLAG_RW);
 		}
 	}


### PR DESCRIPTION
```
../../drivers/mge-xml.c: In function ‘vvalue_mge_xml2nut’:
../../drivers/mge-xml.c:1492:20: warning: initialization discards ‘const’ qualifier from pointer target type [enabled by default]
      char *vconv = info->convert(vcpy);
                    ^
../../drivers/mge-xml.c: In function ‘vname_register_rw’:
../../drivers/mge-xml.c:1513:4: warning: zero-length gnu_printf format string [-Wformat-zero-length]
    dstate_setinfo(info->nutname, "");
    ^
```

..as we are now taking care of these things (https://github.com/networkupstools/nut/commit/2cc43bda48e27a81782db6a848389bc722790053 & https://github.com/networkupstools/nut/commit/7daa0feb6ed4f1c29bfe14c8e491ba198a4ba643)
