### PR TITLE
Add support for 0d9f:0001 (USB HID, Powercom)

### DIFF
--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -760,6 +760,7 @@
 "Powercom"	"ups"	"4"	"(various)"	"USB (<= 2009 models, product id: 0002)"	"powercom (requires 'usbserial' kernel module)"
 "Powercom"	"ups"	"5"	"(various)"	"USB (2009 models, product id: 00a?)"	"usbhid-ups (experimental)"
 "Powercom"	"ups"	"5"	"BNT-xxxAP"	"USB (product id: 0004)"	"usbhid-ups (experimental)"
+"Powercom"	"ups"	"1"	"BNT-xxxAP"	"USB (product id: 0001)"	"usbhid-ups (experimental)"
 
 "POWEREX"	"ups"	"2"	"VI 1000 LED"	""	"blazer_usb"
 

--- a/docs/man/usbhid-ups.txt
+++ b/docs/man/usbhid-ups.txt
@@ -31,8 +31,9 @@ At the present time, usbhid-ups supports:
  - all Dell USB models,
  - some APC models,
  - some Belkin models,
- - some Cyber Power Systems models.
- - some TrippLite models
+ - some Cyber Power Systems models,
+ - some Powercom models,
+ - some TrippLite models.
 
 For a more complete list, refer to the NUT hardware compatibility list,
 available in the source distribution as data/drivers.list, or on the
@@ -119,6 +120,14 @@ useful except for printing debugging information (typically used with
 With this option, the driver activates a tweak to workaround buggy firmware
 returning invalid HID report length. Some APC Back-UPS units are known to have
 this bug.
+
+*interruptonly*::
+If this flag is set, the driver will not poll UPS. This also implies using of
+INPUT flagged objects. Some Powercom units need this option.
+
+*interruptsize*='num'::
+Limit the number of bytes to read from interrupt pipe. For some Powercom units
+this option should be equal to 8.
 
 INSTALLATION
 ------------

--- a/drivers/libhid.c
+++ b/drivers/libhid.c
@@ -62,7 +62,6 @@ int max_report_size = 0;
 /* Tweaks for Powercom */
 int interrupt_only = 0;
 int interrupt_size = 0;
-int find_input_objects = 0;
 
 /* ---------------------------------------------------------------------- */
 /* report buffering system */
@@ -351,7 +350,7 @@ HIDData_t *HIDGetItemData(const char *hidpath, usage_tables_t *utab)
 	}
 
 	/* Get info on object (reportID, offset and size) */
-	return FindObject_with_Path(pDesc, &Path, find_input_objects ? ITEM_INPUT:ITEM_FEATURE);
+	return FindObject_with_Path(pDesc, &Path, interrupt_only ? ITEM_INPUT:ITEM_FEATURE);
 }
 
 char *HIDGetDataItem(const HIDData_t *hiddata, usage_tables_t *utab)

--- a/drivers/libhid.c
+++ b/drivers/libhid.c
@@ -59,6 +59,11 @@ static double exponent(double a, int8_t b);
 /* Tweak flag for APC Back-UPS */
 int max_report_size = 0;
 
+/* Tweaks for Powercom */
+int interrupt_only = 0;
+int interrupt_size = 0;
+int find_input_objects = 0;
+
 /* ---------------------------------------------------------------------- */
 /* report buffering system */
 
@@ -148,7 +153,7 @@ static int refresh_report_buffer(reportbuf_t *rbuf, hid_dev_handle_t udev, HIDDa
 	int	id = pData->ReportID;
 	int	r;
 
-	if (rbuf->ts[id] + age > time(NULL)) {
+	if (interrupt_only || rbuf->ts[id] + age > time(NULL)) {
 		/* buffered report is still good; nothing to do */
 		upsdebug_hex(3, "Report[buf]", rbuf->data[id], rbuf->len[id]);
 		return 0;
@@ -346,7 +351,7 @@ HIDData_t *HIDGetItemData(const char *hidpath, usage_tables_t *utab)
 	}
 
 	/* Get info on object (reportID, offset and size) */
-	return FindObject_with_Path(pDesc, &Path, ITEM_FEATURE);
+	return FindObject_with_Path(pDesc, &Path, find_input_objects ? ITEM_INPUT:ITEM_FEATURE);
 }
 
 char *HIDGetDataItem(const HIDData_t *hiddata, usage_tables_t *utab)
@@ -479,7 +484,7 @@ int HIDGetEvents(hid_dev_handle_t udev, HIDData_t **event, int eventsize)
 	HIDData_t	*pData;
 
 	/* needs libusb-0.1.8 to work => use ifdef and autoconf */
-	buflen = comm_driver->get_interrupt(udev, buf, sizeof(buf), 250);
+	buflen = comm_driver->get_interrupt(udev, buf, interrupt_size ? interrupt_size:sizeof(buf), 250);
 	if (buflen <= 0) {
 		return buflen;	/* propagate "error" or "no event" code */
 	}

--- a/drivers/libhid.h
+++ b/drivers/libhid.h
@@ -91,7 +91,6 @@ extern reportbuf_t	*reportbuf;	/* buffer for most recent reports */
 
 extern int interrupt_only;
 extern int interrupt_size;
-extern int find_input_objects;
 
 /* ---------------------------------------------------------------------- */
 

--- a/drivers/libhid.h
+++ b/drivers/libhid.h
@@ -89,6 +89,10 @@ typedef struct reportbuf_s {
 
 extern reportbuf_t	*reportbuf;	/* buffer for most recent reports */
 
+extern int interrupt_only;
+extern int interrupt_size;
+extern int find_input_objects;
+
 /* ---------------------------------------------------------------------- */
 
 /*

--- a/drivers/powercom-hid.c
+++ b/drivers/powercom-hid.c
@@ -432,11 +432,11 @@ static hid_info_t powercom_hid2nut[] = {
 
 	{ "ups.serial", 0, 0, "PowercomUPS.PowercomSerialNumber", NULL, "%s", 0, stringid_conversion },
 	{ "ups.mfr", 0, 0, "PowercomUPS.PowercomManufacturerName", NULL, "%s", 0, stringid_conversion },
-	{ "UPS.DesignCapacity", 0, 0, "PowercomUPS.PowercomDesignCapacity", NULL, "%.0f", 0, NULL },
+/*	{ "UPS.DesignCapacity", 0, 0, "PowercomUPS.PowercomDesignCapacity", NULL, "%.0f", 0, NULL }, */
 	{ "ups.mfr.date", 0, 0, "PowercomUPS.PowercomManufacturerDate", NULL, "%s", 0, date_conversion },
 	{ "battery.temperature", 0, 0, "PowercomUPS.PowercomBatterySystem.PowercomTemperature", NULL, "%.0f", 0, NULL },
 	{ "battery.charge", 0, 0, "PowercomUPS.PowercomBatterySystem.PowercomVoltage", NULL, "%.0f", 0, NULL },
-	{ "UPS.BatterySystem.SpecificationInfo", 0, 0, "PowercomUPS.PowercomBatterySystem.PowercomSpecificationInfo", NULL, "%.0f", 0, NULL },
+/*	{ "UPS.BatterySystem.SpecificationInfo", 0, 0, "PowercomUPS.PowercomBatterySystem.PowercomSpecificationInfo", NULL, "%.0f", 0, NULL }, */
 	{ "input.frequency", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomInput.PowercomFrequency", NULL, "%.0f", 0, NULL },
 	{ "input.voltage", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomInput.PowercomVoltage", NULL, "%.0f", 0, powercom_voltage_conversion },
 	{ "output.voltage", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomVoltage", NULL, "%.0f", 0, powercom_voltage_conversion },
@@ -451,7 +451,7 @@ static hid_info_t powercom_hid2nut[] = {
 	 * bit 6  Disable NO LOAD SHUTDOWN (1 = ACTIVE)
 	 * bit 7  0
 	 */
-	{ "UPS.PowerConverter.Output.InternalChargeController", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomInternalChargeController", NULL, "%.0f", 0, NULL },
+/*	{ "UPS.PowerConverter.Output.InternalChargeController", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomInternalChargeController", NULL, "%.0f", 0, NULL }, */
 	{ "BOOL", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomInternalChargeController", NULL, NULL, HU_FLAG_QUICK_POLL, powercom_upsfail_conversion },
 	{ "BOOL", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomInternalChargeController", NULL, NULL, HU_FLAG_QUICK_POLL, powercom_replacebatt_conversion },
 	{ "BOOL", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomInternalChargeController", NULL, NULL, HU_FLAG_QUICK_POLL, powercom_test_conversion },
@@ -467,7 +467,7 @@ static hid_info_t powercom_hid2nut[] = {
 	 * bit 6  X
 	 * bit 7  SD mode display
 	 */
-	{ "UPS.PowerConverter.Output.PrimaryBatterySupport", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomPrimaryBatterySupport", NULL, "%.0f", 0, NULL },
+/*	{ "UPS.PowerConverter.Output.PrimaryBatterySupport", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomPrimaryBatterySupport", NULL, "%.0f", 0, NULL }, */
 	{ "BOOL", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomPrimaryBatterySupport", NULL, NULL, HU_FLAG_QUICK_POLL, powercom_online_conversion },
 	{ "BOOL", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomPrimaryBatterySupport", NULL, NULL, HU_FLAG_QUICK_POLL, powercom_lowbatt_conversion },
 	{ "BOOL", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomPrimaryBatterySupport", NULL, NULL, HU_FLAG_QUICK_POLL, powercom_trim_conversion },
@@ -475,7 +475,7 @@ static hid_info_t powercom_hid2nut[] = {
 	{ "BOOL", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomPrimaryBatterySupport", NULL, NULL, HU_FLAG_QUICK_POLL, powercom_overload_conversion },
 	{ "output.frequency", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomFrequency", NULL, "%.0f", 0, NULL },
 	{ "ups.test.result", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomTest", NULL, "%s", 0, test_read_info },
-	{ "UPS.PowerConverter.ShutdownRequested", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomShutdownRequested", NULL, "%.0f", 0, NULL },
+/*	{ "UPS.PowerConverter.ShutdownRequested", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomShutdownRequested", NULL, "%.0f", 0, NULL }, */
 	{ "ups.delay.shutdown", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomDelayBeforeShutdown", NULL, "%.0f", 0, NULL },
 	{ "ups.delay.start", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomDelayBeforeStartup", NULL, "%.0f", 0, NULL },
 	{ "load.off", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomDelayBeforeShutdown", NULL, "0", HU_TYPE_CMD, NULL },

--- a/drivers/powercom-hid.c
+++ b/drivers/powercom-hid.c
@@ -25,7 +25,7 @@
 #include "powercom-hid.h"
 #include "usb-common.h"
 
-#define POWERCOM_HID_VERSION	"PowerCOM HID 0.4"
+#define POWERCOM_HID_VERSION	"PowerCOM HID 0.5"
 /* FIXME: experimental flag to be put in upsdrv_info */
 
 /* PowerCOM */

--- a/drivers/powercom-hid.c
+++ b/drivers/powercom-hid.c
@@ -508,7 +508,6 @@ static int powercom_claim(HIDDevice_t *hd)
 		if (hd->ProductID == 0x0001) {
 			interrupt_only = 1;
 			interrupt_size = 8;
-			find_input_objects = 1;
 		}
 		return 1;
 

--- a/drivers/powercom-hid.c
+++ b/drivers/powercom-hid.c
@@ -181,19 +181,6 @@ static info_lkp_t powercom_test_conversion[] = {
 	{ 0, NULL, powercom_test_conversion_fun }
 };
 
-static const char *powercom_discharging_conversion_fun(double value)
-{
-	if ((long)value & 0x0008) {
-		return "dischrg";
-	} else {
-		return "!dischrg";
-	}
-}
-
-static info_lkp_t powercom_discharging_conversion[] = {
-	{ 0, NULL, powercom_discharging_conversion_fun }
-};
-
 static const char *powercom_shutdownimm_conversion_fun(double value)
 {
 	if ((long)value & 0x0010) {
@@ -441,7 +428,7 @@ static hid_info_t powercom_hid2nut[] = {
 	{ "input.voltage", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomInput.PowercomVoltage", NULL, "%.0f", 0, powercom_voltage_conversion },
 	{ "output.voltage", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomVoltage", NULL, "%.0f", 0, powercom_voltage_conversion },
 	{ "ups.load", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomPercentLoad", NULL, "%.0f", 0, NULL },
-	/* flags: 4 - Testing, 8 - Discharging
+	/* flags: 4 - Testing
 	 * bit 0  UPS fault  (1 = FAILT)
 	 * bit 1  Battery status (1 = BAD, 0 = NORMAL)
 	 * bit 2  Test  mode  (1 = TEST, 0 = NORMAL)
@@ -455,9 +442,8 @@ static hid_info_t powercom_hid2nut[] = {
 	{ "BOOL", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomInternalChargeController", NULL, NULL, HU_FLAG_QUICK_POLL, powercom_upsfail_conversion },
 	{ "BOOL", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomInternalChargeController", NULL, NULL, HU_FLAG_QUICK_POLL, powercom_replacebatt_conversion },
 	{ "BOOL", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomInternalChargeController", NULL, NULL, HU_FLAG_QUICK_POLL, powercom_test_conversion },
-	{ "BOOL", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomInternalChargeController", NULL, NULL, HU_FLAG_QUICK_POLL, powercom_discharging_conversion },
 	{ "BOOL", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomInternalChargeController", NULL, NULL, HU_FLAG_QUICK_POLL, powercom_shutdownimm_conversion },
-	/* flags: 1 - On battery, 2 - Low Battery, 4 - ?, 8 - Trim, 8+16 - Boost
+	/* flags: 1 - On battery, 2 - Low Battery, 8 - Trim, 8+16 - Boost
 	 * bit 0  is line fail (1 = INV, 0 = LINE)
 	 * bit 1  is low battery (1 = BAT_ LOW, 0 = NORMAL)
 	 * bit 2  X

--- a/drivers/powercom-hid.c
+++ b/drivers/powercom-hid.c
@@ -45,6 +45,7 @@ static usb_device_id_t powercom_usb_device_table[] = {
 	{ USB_DEVICE(POWERCOM_VENDORID, 0x00a6), NULL },
 	/* PowerCOM Vanguard and BNT-xxxAP */
 	{ USB_DEVICE(POWERCOM_VENDORID, 0x0004), NULL },
+	{ USB_DEVICE(POWERCOM_VENDORID, 0x0001), NULL },
 
 	/* Terminating entry */
 	{ -1, -1, NULL }
@@ -130,12 +131,173 @@ static info_lkp_t powercom_beeper_info[] = {
 	{ 0, NULL, NULL }
 };
 
+static const char *powercom_voltage_conversion_fun(double value)
+{
+	static char buf[20];
+	snprintf(buf, sizeof(buf), "%0.0f", value * 4);
+	return buf;
+}
+
+static info_lkp_t powercom_voltage_conversion[] = {
+	{ 0, NULL, powercom_voltage_conversion_fun }
+};
+
+static const char *powercom_upsfail_conversion_fun(double value)
+{
+	if ((long)value & 0x0001) {
+		return "fanfail";
+	} else {
+		return "!fanfail";
+	}
+}
+
+static info_lkp_t powercom_upsfail_conversion[] = {
+	{ 0, NULL, powercom_upsfail_conversion_fun }
+};
+
+static const char *powercom_replacebatt_conversion_fun(double value)
+{
+	if ((long)value & 0x0002) {
+		return "replacebatt";
+	} else {
+		return "!replacebatt";
+	}
+}
+
+static info_lkp_t powercom_replacebatt_conversion[] = {
+	{ 0, NULL, powercom_replacebatt_conversion_fun }
+};
+
+static const char *powercom_test_conversion_fun(double value)
+{
+	if ((long)value & 0x0004) {
+		return "cal";
+	} else {
+		return "!cal";
+	}
+}
+
+static info_lkp_t powercom_test_conversion[] = {
+	{ 0, NULL, powercom_test_conversion_fun }
+};
+
+static const char *powercom_discharging_conversion_fun(double value)
+{
+	if ((long)value & 0x0008) {
+		return "dischrg";
+	} else {
+		return "!dischrg";
+	}
+}
+
+static info_lkp_t powercom_discharging_conversion[] = {
+	{ 0, NULL, powercom_discharging_conversion_fun }
+};
+
+static const char *powercom_shutdownimm_conversion_fun(double value)
+{
+	if ((long)value & 0x0010) {
+		return "shutdownimm";
+	} else {
+		return "!shutdownimm";
+	}
+}
+
+static info_lkp_t powercom_shutdownimm_conversion[] = {
+	{ 0, NULL, powercom_shutdownimm_conversion_fun }
+};
+
+static const char *powercom_online_conversion_fun(double value)
+{
+	if ((long)value & 0x0001) {
+		return "!online";
+	} else {
+		return "online";
+	}
+}
+
+static info_lkp_t powercom_online_conversion[] = {
+	{ 0, NULL, powercom_online_conversion_fun }
+};
+
+static const char *powercom_lowbatt_conversion_fun(double value)
+{
+	if ((long)value & 0x0002) {
+		return "lowbatt";
+	} else {
+		return "!lowbatt";
+	}
+}
+
+static info_lkp_t powercom_lowbatt_conversion[] = {
+	{ 0, NULL, powercom_lowbatt_conversion_fun }
+};
+
+static const char *powercom_trim_conversion_fun(double value)
+{
+	if (((long)value & 0x0018) == 0x0008) {
+		return "trim";
+	} else {
+		return "!trim";
+	}
+}
+
+static info_lkp_t powercom_trim_conversion[] = {
+	{ 0, NULL, powercom_trim_conversion_fun }
+};
+
+static const char *powercom_boost_conversion_fun(double value)
+{
+	if (((long)value & 0x0018) == 0x0018) {
+		return "boost";
+	} else {
+		return "!boost";
+	}
+}
+
+static info_lkp_t powercom_boost_conversion[] = {
+	{ 0, NULL, powercom_boost_conversion_fun }
+};
+
+static const char *powercom_overload_conversion_fun(double value)
+{
+	if ((long)value & 0x0020) {
+		return "overload";
+	} else {
+		return "!overload";
+	}
+}
+
+static info_lkp_t powercom_overload_conversion[] = {
+	{ 0, NULL, powercom_overload_conversion_fun }
+};
+
 /* --------------------------------------------------------------- */
 /* Vendor-specific usage table */
 /* --------------------------------------------------------------- */
 
 /* POWERCOM usage table */
 static usage_lkp_t powercom_usage_lkp[] = {
+	{ "PowercomUPS",                      0x00020004 },
+	{ "PowercomBatterySystem",            0x00020010 },
+	{ "PowercomPowerConverter",           0x00020016 },
+	{ "PowercomInput",                    0x0002001a },
+	{ "PowercomOutput",                   0x0002001c },
+	{ "PowercomVoltage",                  0x00020030 },
+	{ "PowercomFrequency",                0x00020032 },
+	{ "PowercomPercentLoad",              0x00020035 },
+	{ "PowercomTemperature",              0x00020036 },
+	{ "PowercomDelayBeforeStartup",       0x00020056 },
+	{ "PowercomDelayBeforeShutdown",      0x00020057 },
+	{ "PowercomTest",                     0x00020058 },
+	{ "PowercomShutdownRequested",        0x00020068 },
+	{ "PowercomInternalChargeController", 0x00020081 },
+	{ "PowercomPrimaryBatterySupport",    0x00020082 },
+	{ "PowercomDesignCapacity",           0x00020083 },
+	{ "PowercomSpecificationInfo",        0x00020084 },
+	{ "PowercomManufacturerDate",         0x00020085 },
+	{ "PowercomSerialNumber",             0x00020086 },
+	{ "PowercomManufacturerName",         0x00020087 },
 	{ "POWERCOM1",	0x0084002f },
 	{ "POWERCOM2",	0xff860060 },
 	{ "POWERCOM3",	0xff860080 },
@@ -268,6 +430,56 @@ static hid_info_t powercom_hid2nut[] = {
 	{ "shutdown.return", 0, 0, "UPS.PowerSummary.PCMDelayBeforeShutdown", NULL, NULL, HU_TYPE_CMD, powercom_shutdown_info },
 	{ "shutdown.stayoff", 0, 0, "UPS.PowerSummary.PCMDelayBeforeShutdown", NULL, NULL, HU_TYPE_CMD, powercom_stayoff_info },
 
+	{ "ups.serial", 0, 0, "PowercomUPS.PowercomSerialNumber", NULL, "%s", 0, stringid_conversion },
+	{ "ups.mfr", 0, 0, "PowercomUPS.PowercomManufacturerName", NULL, "%s", 0, stringid_conversion },
+	{ "UPS.DesignCapacity", 0, 0, "PowercomUPS.PowercomDesignCapacity", NULL, "%.0f", 0, NULL },
+	{ "ups.mfr.date", 0, 0, "PowercomUPS.PowercomManufacturerDate", NULL, "%s", 0, date_conversion },
+	{ "battery.temperature", 0, 0, "PowercomUPS.PowercomBatterySystem.PowercomTemperature", NULL, "%.0f", 0, NULL },
+	{ "battery.charge", 0, 0, "PowercomUPS.PowercomBatterySystem.PowercomVoltage", NULL, "%.0f", 0, NULL },
+	{ "UPS.BatterySystem.SpecificationInfo", 0, 0, "PowercomUPS.PowercomBatterySystem.PowercomSpecificationInfo", NULL, "%.0f", 0, NULL },
+	{ "input.frequency", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomInput.PowercomFrequency", NULL, "%.0f", 0, NULL },
+	{ "input.voltage", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomInput.PowercomVoltage", NULL, "%.0f", 0, powercom_voltage_conversion },
+	{ "output.voltage", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomVoltage", NULL, "%.0f", 0, powercom_voltage_conversion },
+	{ "ups.load", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomPercentLoad", NULL, "%.0f", 0, NULL },
+	/* flags: 4 - Testing, 8 - Discharging
+	 * bit 0  UPS fault  (1 = FAILT)
+	 * bit 1  Battery status (1 = BAD, 0 = NORMAL)
+	 * bit 2  Test  mode  (1 = TEST, 0 = NORMAL)
+	 * bit 3  X
+	 * bit 4  Pre-SD count mode (1 = ACTIVE)
+	 * bit 5  Schedule count mode (1 = ACTIVE)
+	 * bit 6  Disable NO LOAD SHUTDOWN (1 = ACTIVE)
+	 * bit 7  0
+	 */
+	{ "UPS.PowerConverter.Output.InternalChargeController", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomInternalChargeController", NULL, "%.0f", 0, NULL },
+	{ "BOOL", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomInternalChargeController", NULL, NULL, HU_FLAG_QUICK_POLL, powercom_upsfail_conversion },
+	{ "BOOL", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomInternalChargeController", NULL, NULL, HU_FLAG_QUICK_POLL, powercom_replacebatt_conversion },
+	{ "BOOL", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomInternalChargeController", NULL, NULL, HU_FLAG_QUICK_POLL, powercom_test_conversion },
+	{ "BOOL", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomInternalChargeController", NULL, NULL, HU_FLAG_QUICK_POLL, powercom_discharging_conversion },
+	{ "BOOL", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomInternalChargeController", NULL, NULL, HU_FLAG_QUICK_POLL, powercom_shutdownimm_conversion },
+	/* flags: 1 - On battery, 2 - Low Battery, 4 - ?, 8 - Trim, 8+16 - Boost
+	 * bit 0  is line fail (1 = INV, 0 = LINE)
+	 * bit 1  is low battery (1 = BAT_ LOW, 0 = NORMAL)
+	 * bit 2  X
+	 * bit 3  AVR status (1 = AVR, 0 = NO_AVR)
+	 * bit 4  AVR mode (1 = BOOST, 0 = BUCK)
+	 * bit 5  Load status (1 = OVER LOAD, 0 = NORMAL)
+	 * bit 6  X
+	 * bit 7  SD mode display
+	 */
+	{ "UPS.PowerConverter.Output.PrimaryBatterySupport", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomPrimaryBatterySupport", NULL, "%.0f", 0, NULL },
+	{ "BOOL", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomPrimaryBatterySupport", NULL, NULL, HU_FLAG_QUICK_POLL, powercom_online_conversion },
+	{ "BOOL", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomPrimaryBatterySupport", NULL, NULL, HU_FLAG_QUICK_POLL, powercom_lowbatt_conversion },
+	{ "BOOL", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomPrimaryBatterySupport", NULL, NULL, HU_FLAG_QUICK_POLL, powercom_trim_conversion },
+	{ "BOOL", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomPrimaryBatterySupport", NULL, NULL, HU_FLAG_QUICK_POLL, powercom_boost_conversion },
+	{ "BOOL", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomPrimaryBatterySupport", NULL, NULL, HU_FLAG_QUICK_POLL, powercom_overload_conversion },
+	{ "output.frequency", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomFrequency", NULL, "%.0f", 0, NULL },
+	{ "ups.test.result", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomTest", NULL, "%s", 0, test_read_info },
+	{ "UPS.PowerConverter.ShutdownRequested", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomShutdownRequested", NULL, "%.0f", 0, NULL },
+	{ "ups.delay.shutdown", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomDelayBeforeShutdown", NULL, "%.0f", 0, NULL },
+	{ "ups.delay.start", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomDelayBeforeStartup", NULL, "%.0f", 0, NULL },
+	{ "load.off", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomDelayBeforeShutdown", NULL, "0", HU_TYPE_CMD, NULL },
+
 	/* end of structure. */
 	{ NULL, 0, 0, NULL, NULL, NULL, 0, NULL }
 };
@@ -307,6 +519,11 @@ static int powercom_claim(HIDDevice_t *hd)
 		return 0;
 
 	case SUPPORTED:
+		if (hd->ProductID == 0x0001) {
+			interrupt_only = 1;
+			interrupt_size = 8;
+			find_input_objects = 1;
+		}
 		return 1;
 
 	case NOT_SUPPORTED:

--- a/drivers/powercom-hid.c
+++ b/drivers/powercom-hid.c
@@ -419,7 +419,7 @@ static hid_info_t powercom_hid2nut[] = {
 
 	{ "ups.serial", 0, 0, "PowercomUPS.PowercomSerialNumber", NULL, "%s", 0, stringid_conversion },
 	{ "ups.mfr", 0, 0, "PowercomUPS.PowercomManufacturerName", NULL, "%s", 0, stringid_conversion },
-/*	{ "UPS.DesignCapacity", 0, 0, "PowercomUPS.PowercomDesignCapacity", NULL, "%.0f", 0, NULL }, */
+/*	{ "UPS.DesignCapacity", 0, 0, "PowercomUPS.PowercomDesignCapacity", NULL, "%.0f", 0, NULL }, is always 255 */
 	{ "ups.mfr.date", 0, 0, "PowercomUPS.PowercomManufacturerDate", NULL, "%s", 0, date_conversion },
 	{ "battery.temperature", 0, 0, "PowercomUPS.PowercomBatterySystem.PowercomTemperature", NULL, "%.0f", 0, NULL },
 	{ "battery.charge", 0, 0, "PowercomUPS.PowercomBatterySystem.PowercomVoltage", NULL, "%.0f", 0, NULL },
@@ -428,7 +428,7 @@ static hid_info_t powercom_hid2nut[] = {
 	{ "input.voltage", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomInput.PowercomVoltage", NULL, "%.0f", 0, powercom_voltage_conversion },
 	{ "output.voltage", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomVoltage", NULL, "%.0f", 0, powercom_voltage_conversion },
 	{ "ups.load", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomPercentLoad", NULL, "%.0f", 0, NULL },
-	/* flags: 4 - Testing
+	/* flags: 4 - Testing, 8 - Probably mute (it's set on battery with muted beeper and sometimes during ups test)
 	 * bit 0  UPS fault  (1 = FAILT)
 	 * bit 1  Battery status (1 = BAD, 0 = NORMAL)
 	 * bit 2  Test  mode  (1 = TEST, 0 = NORMAL)
@@ -455,6 +455,7 @@ static hid_info_t powercom_hid2nut[] = {
 	 */
 /*	{ "UPS.PowerConverter.Output.PrimaryBatterySupport", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomPrimaryBatterySupport", NULL, "%.0f", 0, NULL }, */
 	{ "BOOL", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomPrimaryBatterySupport", NULL, NULL, HU_FLAG_QUICK_POLL, powercom_online_conversion },
+	/* Low battery status may not work */
 	{ "BOOL", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomPrimaryBatterySupport", NULL, NULL, HU_FLAG_QUICK_POLL, powercom_lowbatt_conversion },
 	{ "BOOL", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomPrimaryBatterySupport", NULL, NULL, HU_FLAG_QUICK_POLL, powercom_trim_conversion },
 	{ "BOOL", 0, 0, "PowercomUPS.PowercomPowerConverter.PowercomOutput.PowercomPrimaryBatterySupport", NULL, NULL, HU_FLAG_QUICK_POLL, powercom_boost_conversion },

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -970,9 +970,9 @@ void upsdrv_initups(void)
 	if (testvar("interruptonly")) {
 		interrupt_only = 1;
 	}
-	char *interruptsize = getval("interruptsize");
-	if (interruptsize != NULL) {
-		interrupt_size = atoi(interruptsize);
+	val = getval("interruptsize");
+	if (val) {
+		interrupt_size = atoi(val);
 	}
 
 	if (hid_ups_walk(HU_WALKMODE_INIT) == FALSE) {

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -747,7 +747,6 @@ void upsdrv_makevartable(void)
 	addvar(VAR_FLAG, "maxreport", "Activate tweak for buggy APC Back-UPS firmware");
 	addvar(VAR_FLAG, "interruptonly", "Don't use polling, only use interrupt pipe");
 	addvar(VAR_VALUE, "interruptsize", "Number of bytes to read from interrupt pipe");
-	addvar(VAR_FLAG, "findinputobjects", "Read input objects instead of feature ones");
 #else
 	addvar(VAR_VALUE, "notification", "Set notification type, (ignored, only for backward compatibility)");
 #endif
@@ -815,7 +814,7 @@ void upsdrv_updateinfo(void)
 		}
 
 		/* Skip Input reports, if we don't use the Feature report */
-		item = find_hid_info(FindObject_with_Path(pDesc, &(event[i]->Path), find_input_objects ? ITEM_INPUT:ITEM_FEATURE));
+		item = find_hid_info(FindObject_with_Path(pDesc, &(event[i]->Path), interrupt_only ? ITEM_INPUT:ITEM_FEATURE));
 		if (!item) {
 			upsdebugx(3, "NUT doesn't use this HID object");
 			continue;
@@ -958,9 +957,6 @@ void upsdrv_initups(void)
 	char *interruptsize = getval("interruptsize");
 	if (interruptsize != NULL) {
 		interrupt_size = atoi(interruptsize);
-	}
-	if (testvar("findinputobjects")) {
-		find_input_objects = 1;
 	}
 
 	if (hid_ups_walk(HU_WALKMODE_INIT) == FALSE) {

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -27,7 +27,7 @@
  */
 
 #define DRIVER_NAME	"Generic HID driver"
-#define DRIVER_VERSION		"0.38"
+#define DRIVER_VERSION		"0.39"
 
 #include "main.h"
 #include "libhid.h"

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -794,7 +794,6 @@ void upsdrv_updateinfo(void)
 	/* Get HID notifications on Interrupt pipe first */
 	if (use_interrupt_pipe == TRUE) {
 		evtCount = HIDGetEvents(udev, event, MAX_EVENT_NUM);
-		upsdebugx(1, "Got %i HID objects...", (evtCount >= 0) ? evtCount : 0);
 		switch (evtCount)
 		{
 		case -EBUSY:		/* Device or resource busy */
@@ -808,6 +807,9 @@ void upsdrv_updateinfo(void)
 			/* Uh oh, got to reconnect! */
 			hd = NULL;
 			return;
+		default:
+			upsdebugx(1, "Got %i HID objects...", (evtCount >= 0) ? evtCount : 0);
+			break;
 		}
 	} else {
 		evtCount = 0;

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -795,6 +795,20 @@ void upsdrv_updateinfo(void)
 	if (use_interrupt_pipe == TRUE) {
 		evtCount = HIDGetEvents(udev, event, MAX_EVENT_NUM);
 		upsdebugx(1, "Got %i HID objects...", (evtCount >= 0) ? evtCount : 0);
+		switch (evtCount)
+		{
+		case -EBUSY:		/* Device or resource busy */
+			upslog_with_errno(LOG_CRIT, "Got disconnected by another driver");
+		case -EPERM:		/* Operation not permitted */
+		case -ENODEV:		/* No such device */
+		case -EACCES:		/* Permission denied */
+		case -EIO:		/* I/O error */
+		case -ENXIO:		/* No such device or address */
+		case -ENOENT:		/* No such file or directory */
+			/* Uh oh, got to reconnect! */
+			hd = NULL;
+			return;
+		}
 	} else {
 		evtCount = 0;
 		upsdebugx(1, "Not using interrupt pipe...");


### PR DESCRIPTION
Tested with BNT-1000AР (old model). Confirmed values: battery.charge, input.frequency (0 on battery, 50 on AC), input.voltage, output.voltage, ups.load and likely output.frequency (always 50); statuses: online, cal (ups test), dischrg, trim.

Key changes:
* Read exactly 8 bytes on interrupt.
* Get values of input objects. Getting both will be better since there are some feature objects during init.
* Avoid comm_driver->get_report since it often returns corrupt data (0 values).