### PR TITLE
conf/: fix parallel install

### DIFF
--- a/conf/Makefile.am
+++ b/conf/Makefile.am
@@ -2,7 +2,7 @@
 
 INSTALL_0600 = $(INSTALL) -m 0600
 
-SECFILES = upsmon.conf.sample upsd.conf.sample upsd.users.sample
+SECFILES = upsd.conf.sample upsd.users.sample
 PUBFILES = nut.conf.sample ups.conf.sample
 CGIPUB = hosts.conf.sample upsset.conf.sample upsstats.html.sample	\
  upsstats-single.html.sample


### PR DESCRIPTION
Do not reference the upsmon.conf.sample twice, otherwise install, with
a high number of make jobs, may fail, like so:
    http://autobuild.buildroot.net/results/256/2567e13cd5bc702bc3a38a1d6fc8e34022cc7db5/build-end.log

Signed-off-by: "Yann E. MORIN" yann.morin.1998@free.fr

---

This is not a rare occurence, as my testing managed to trigger the
issue in about 1 test out of 10 on average, on a not-so-fast machine.
