### PR TITLE
Update solis.c to force ScanReceivePack()

### DIFF
--- a/drivers/solis.c
+++ b/drivers/solis.c
@@ -760,6 +760,7 @@ CommReceive(const char *bufptr,  int size)
 			default:
 			{
 				printf( M_UNKN );
+				ScanReceivePack(); // Scan anyway.
 				break;
 			}
 		}


### PR DESCRIPTION
Hello,

MicroSol have released new APC nobreaks, that do not fit the numbers there.
So the idea is force the scanreceivePack() for every request.
