### PR TITLE
Undo ${systemdsystemunitdir} mangling.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1063,7 +1063,6 @@ dnl files will try to get intalled to the actual system directories
 if test -n "${systemdsystemunitdir}"; then
 	systemdsystemshutdowndir="${libdir}/systemd/system-shutdown"
 	AC_MSG_RESULT(using ${systemdsystemunitdir})
-	systemdsystemunitdir="`echo ${systemdsystemunitdir} | sed 's/\/lib/\${libdir}/'`"
 else
 	AC_MSG_RESULT(no)
 fi


### PR DESCRIPTION
Running sed 's/\/lib/\${libdir}/' destroys any ${systemdsystemunitdir}
values that don't start with '/lib' e.g. '/usr/lib64/systemd/system'
becomes '/usr/usr/lib6464/systemd/system'.

If a local installation prefix is needed use appropriately prefixed
--with-systemdsystemunitdir='' parameter instead.