### PR TITLE
Add a product ID for APC AP9584 USB kit.

### DIFF
--- a/drivers/apc-hid.c
+++ b/drivers/apc-hid.c
@@ -79,6 +79,8 @@ static void *general_apc_check(USBDevice_t *device)
 
 /* USB IDs device table */
 static usb_device_id_t apc_usb_device_table[] = {
+	/* APC AP9584 Serial->USB kit */
+	{ USB_DEVICE(APC_VENDORID, 0x0000), NULL },
 	/* various models */
 	{ USB_DEVICE(APC_VENDORID, 0x0002), general_apc_check },
 	/* various 5G models */

--- a/scripts/upower/95-upower-hid.rules
+++ b/scripts/upower/95-upower-hid.rules
@@ -65,6 +65,7 @@ ATTRS{idVendor}=="050d", ATTRS{idProduct}=="0f51", ENV{UPOWER_BATTERY_TYPE}="ups
 ATTRS{idVendor}=="050d", ATTRS{idProduct}=="1100", ENV{UPOWER_BATTERY_TYPE}="ups"
 
 # APC
+ATTRS{idVendor}=="051d", ATTRS{idProduct}=="0000", ENV{UPOWER_BATTERY_TYPE}="ups"
 ATTRS{idVendor}=="051d", ATTRS{idProduct}=="0002", ENV{UPOWER_BATTERY_TYPE}="ups"
 ATTRS{idVendor}=="051d", ATTRS{idProduct}=="0003", ENV{UPOWER_BATTERY_TYPE}="ups"
 


### PR DESCRIPTION
Add a product ID for APC AP9584 USB kit.