### PR TITLE
usbhid-ups input vs feature

### DIFF
--- a/drivers/tripplite-hid.c
+++ b/drivers/tripplite-hid.c
@@ -29,7 +29,7 @@
 #include "tripplite-hid.h"
 #include "usb-common.h"
 
-#define TRIPPLITE_HID_VERSION "TrippLite HID 0.81"
+#define TRIPPLITE_HID_VERSION "TrippLite HID 0.82"
 /* FIXME: experimental flag to be put in upsdrv_info */
 
 
@@ -279,7 +279,7 @@ static hid_info_t tripplite_hid2nut[] = {
 #endif /* USBHID_UPS_TRIPPLITE_DEBUG */
 
 	/* Device page */
-	{ "device.part", 0, 0, "UPS.TLCustom.[1].iUPSPartNumber", NULL, "%.0f", 0, stringid_conversion },
+	{ "device.part", 0, 0, "UPS.TLCustom.[1].iUPSPartNumber", NULL, "%s", HU_FLAG_STATIC, stringid_conversion },
 
 	/* Battery page */
 	{ "battery.charge", 0, 0, "UPS.PowerSummary.RemainingCapacity", NULL, "%.0f", 0, NULL },

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -27,7 +27,7 @@
  */
 
 #define DRIVER_NAME	"Generic HID driver"
-#define DRIVER_VERSION		"0.39"
+#define DRIVER_VERSION		"0.40"
 
 #include "main.h"
 #include "libhid.h"
@@ -753,7 +753,7 @@ void upsdrv_makevartable(void)
 void upsdrv_updateinfo(void)
 {
 	hid_info_t	*item;
-	HIDData_t	*event[MAX_EVENT_NUM];
+	HIDData_t	*event[MAX_EVENT_NUM], *found_data;
 	int		i, evtCount;
 	double		value;
 	time_t		now;
@@ -826,7 +826,15 @@ void upsdrv_updateinfo(void)
 		}
 
 		/* Skip Input reports, if we don't use the Feature report */
-		item = find_hid_info(FindObject_with_Path(pDesc, &(event[i]->Path), interrupt_only ? ITEM_INPUT:ITEM_FEATURE));
+		found_data = FindObject_with_Path(pDesc, &(event[i]->Path), interrupt_only ? ITEM_INPUT:ITEM_FEATURE);
+                if(!found_data && !interrupt_only) {
+			found_data = FindObject_with_Path(pDesc, &(event[i]->Path), ITEM_INPUT);
+		}
+		if(!found_data) {
+			upsdebugx(2, "Could not find event as either ITEM_INPUT or ITEM_FEATURE?");
+			continue;
+		}
+		item = find_hid_info(found_data);
 		if (!item) {
 			upsdebugx(3, "NUT doesn't use this HID object");
 			continue;
@@ -1480,6 +1488,11 @@ static hid_info_t *find_nut_info(const char *varname)
 static hid_info_t *find_hid_info(const HIDData_t *hiddata)
 {
 	hid_info_t *hidups_item;
+
+	if(!hiddata) {
+		upsdebugx(2, "%s: hiddata == NULL", __func__);
+		return NULL;
+	}
 
 	for (hidups_item = subdriver->hid2nut; hidups_item->info_type != NULL ; hidups_item++) {
 


### PR DESCRIPTION
See http://thread.gmane.org/gmane.comp.monitoring.nut.devel/6961 for details.

Basically, `FindObject_with_Path()` was returning NULL on events from the interrupt pipe, and `find_hid_info()` was matching the first entry in `tripplite_hid2nut[]` (which was not present on the Tripp Lite UPS in question).

This patch allows the interrupt code to match either `TYPE_INPUT` or `TYPE_FEATURE` items.