### PR TITLE
Add support for Eaton dual HID report descriptor

### DIFF
--- a/drivers/hidtypes.h
+++ b/drivers/hidtypes.h
@@ -5,6 +5,7 @@
  *
  * Copyright (C)
  *	1998-2003	MGE UPS SYSTEMS, Luc Descotils
+ *	2015		Eaton, Arnaud Quette (Update MAX_REPORT)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -38,11 +39,11 @@ extern "C" {
 /*
  * Constants
  * -------------------------------------------------------------------------- */
-#define PATH_SIZE		10	/* Deep max for Path					*/
-#define USAGE_TAB_SIZE		50	/* Size of usage stack					*/
-#define MAX_REPORT		300	/* Including FEATURE, INPUT and OUTPUT			*/
-#define REPORT_DSC_SIZE		6144	/* Size max of Report Descriptor			*/
-#define MAX_REPORT_TS		3	/* Max time validity of a report			*/
+#define PATH_SIZE         10   /* Deep max for Path                   */
+#define USAGE_TAB_SIZE    50   /* Size of usage stack                 */
+#define MAX_REPORT        50  /* Including FEATURE, INPUT and OUTPUT */
+#define REPORT_DSC_SIZE   6144 /* Size max of Report Descriptor       */
+#define MAX_REPORT_TS     3    /* Max time validity of a report       */
 
 /*
  * Items

--- a/drivers/hidtypes.h
+++ b/drivers/hidtypes.h
@@ -41,7 +41,7 @@ extern "C" {
  * -------------------------------------------------------------------------- */
 #define PATH_SIZE         10   /* Deep max for Path                   */
 #define USAGE_TAB_SIZE    50   /* Size of usage stack                 */
-#define MAX_REPORT        50  /* Including FEATURE, INPUT and OUTPUT */
+#define MAX_REPORT        500  /* Including FEATURE, INPUT and OUTPUT */
 #define REPORT_DSC_SIZE   6144 /* Size max of Report Descriptor       */
 #define MAX_REPORT_TS     3    /* Max time validity of a report       */
 

--- a/drivers/libhid.c
+++ b/drivers/libhid.c
@@ -287,6 +287,8 @@ void HIDDumpTree(hid_dev_handle_t udev, usage_tables_t *utab)
 		return;
 	}
 
+	upsdebugx(1, "%i HID objects found", pDesc->nitems);
+
 	for (i = 0; i < pDesc->nitems; i++)
 	{
 		double		value;

--- a/drivers/libshut.h
+++ b/drivers/libshut.h
@@ -42,12 +42,13 @@ extern upsdrv_info_t comm_upsdrv_info;
  * corresponding string did not exist or could not be retrieved.
  */
 typedef struct SHUTDevice_s {
-	uint16_t	VendorID; /*!< Device's Vendor ID */
-	uint16_t	ProductID; /*!< Device's Product ID */
-	char*		Vendor; /*!< Device's Vendor Name */
-	char*		Product; /*!< Device's Product Name */
-	char*		Serial; /* Product serial number */
-	char*		Bus;    /* Bus name, e.g. "003" */
+	uint16_t	VendorID;  /*!< Device's Vendor ID    */
+	uint16_t	ProductID; /*!< Device's Product ID   */
+	char*		Vendor;    /*!< Device's Vendor Name  */
+	char*		Product;   /*!< Device's Product Name */
+	char*		Serial;    /*!< Product serial number */
+	char*		Bus;       /*!< Bus name, e.g. "003"  */
+	uint16_t	bcdDevice; /*!< Device release number */
 } SHUTDevice_t;
 
 /*!

--- a/drivers/usb-common.h
+++ b/drivers/usb-common.h
@@ -38,12 +38,13 @@
  * corresponding string did not exist or could not be retrieved.
  */
 typedef struct USBDevice_s {
-	uint16_t	VendorID; /*!< Device's Vendor ID */
-	uint16_t	ProductID; /*!< Device's Product ID */
-	char		*Vendor; /*!< Device's Vendor Name */
-	char		*Product; /*!< Device's Product Name */
-	char		*Serial; /* Product serial number */
-	char		*Bus;    /* Bus name, e.g. "003" */
+	uint16_t	VendorID;  /*!< Device's Vendor ID    */
+	uint16_t	ProductID; /*!< Device's Product ID   */
+	char		*Vendor;   /*!< Device's Vendor Name  */
+	char		*Product;  /*!< Device's Product Name */
+	char		*Serial;   /*!< Product serial number */
+	char		*Bus;      /*!< Bus name, e.g. "003"  */
+	uint16_t	bcdDevice; /*!< Device release number */
 } USBDevice_t;
 
 /*!

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -27,7 +27,7 @@
  */
 
 #define DRIVER_NAME	"Generic HID driver"
-#define DRIVER_VERSION		"0.39"
+#define DRIVER_VERSION		"0.40"
 
 #include "main.h"
 #include "libhid.h"


### PR DESCRIPTION
All devices use HID descriptor at index 0. However, some newer
Eaton units have a light HID descriptor at index 0, and the full
version is at index 1 (in which case, bcdDevice == 0x0202). This dual
report descriptor approach is due to the fact that the main report
descriptor is now too heavy, and cause some BIOS to hang. A light
version is thus provided at the default index, solving this BIOS issues.
Also, increase the maximum number of HID objects that can be
retrieved, and add some more trace to make it easier to catch similar
issues in the future