### PR TITLE
tripplitesu: Fix initialization after UART power cycle when tripplite firmware is buggy

### DIFF
--- a/drivers/tripplitesu.c
+++ b/drivers/tripplitesu.c
@@ -125,7 +125,7 @@
 #include "serial.h"
 
 #define DRIVER_NAME		"Tripp Lite SmartOnline driver"
-#define DRIVER_VERSION	"0.03"
+#define DRIVER_VERSION	"0.04"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -552,6 +552,11 @@ static int init_comm(void)
 	char response[MAX_RESPONSE_LENGTH];
 
 	ups.commands_available = 0;
+	//Repeat enumerate command 2x, firmware bug on some units garbles 1st response
+	if (do_command(POLL, AVAILABLE, "", response) <= 0){
+		upslogx(LOG_NOTICE, "init_comm: Initial response malformed, retrying in 300ms");
+		usleep(3E5);
+	}
 	if (do_command(POLL, AVAILABLE, "", response) <= 0)
 		return 0;
 	i = strlen(response);


### PR DESCRIPTION
With some Tripplite SU1000RT2U (and possibly more) UPS's, a firmware bug causes a malformed response to the very first command that is sent after the serial port is opened following a warm or cold boot of the system. My theory is that this related to either the RS232 data lines or handshaking lines being pulled high once the server's UART is powered however I have not determined precisely if this is related to the data lines or the handshaking lines. However, I have been able to consistently reproduce the issue where the tripplitesu driver fails to start on the first attempt after a cold/warm boot across 3 different machines and 2 SU1000RT2U UPS's. To workaround this, the initial enumeration is repeated a 2nd time after 300ms(to allow all garbage data to arrive) if the first attempt fails, which allows the driver to consistently startup successfully on the 1st attempt.