### PR TITLE
nutclient library socket reading

### DIFF
--- a/clients/nutclient.cpp
+++ b/clients/nutclient.cpp
@@ -374,6 +374,11 @@ std::string Socket::read()throw(nut::IOException)
 
 		// Read new buffer
 		size_t sz = read(&buff, 256);
+		if(sz==0)
+		{
+			disconnect();
+			throw nut::IOException("Server closed connection unexpectedly");
+		}
 		_buffer.assign(buff, sz);
 	}
 }


### PR DESCRIPTION
Problem: nutclient library sometimes reads socket closed by server. Causes 100% CPU utilization.
Solution: proper ::read() return value evaluation

read returns -1 only if socket option O_NONBLOCK is set. But this option is explicitly avoided in connect method. When there is reading problem 0 is returned.  