### PR TITLE
nutdrv_qx: TS Shara

### DIFF
--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -1098,6 +1098,8 @@
 "Trust"	"ups"	"2"	"UPS 1200VA Management PW-4120M"	""	"blazer_ser"
 "Trust"	"ups"	"2"	"UPS 1300VA Management PW-4130M"	""	"blazer_ser"
 
+"TS Shara"	"ups"	"4"	"(various)"	""	"nutdrv_qx"
+
 "UNITEK"	"ups"	"2"	"ALPHA 500 IC"	""	"blazer_ser"
 "UNITEK"	"ups"	"2"	"Alpha 1000is"	""	"blazer_ser"
 "UNITEK"	"ups"	"2"	"Alpha 500"	""	"blazer_ser"

--- a/docs/man/nutdrv_qx.txt
+++ b/docs/man/nutdrv_qx.txt
@@ -322,7 +322,7 @@ The argument is a regular expression that must match the bus name where the UPS 
 
 *subdriver =* 'string'::
 Select a serial-over-USB subdriver to use.
-You have a choice between *cypress*, *fabula*, *fuji*, *ippon*, *krauler* and *phoenix*.
+You have a choice between *cypress*, *fabula*, *fuji*, *ippon*, *krauler*, *phoenix* and *sgs*.
 When using this option, it is mandatory to also specify the *vendorid* and *productid*.
 
 *langid_fix =* 'value'::

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -33,7 +33,7 @@
  *
  */
 
-#define DRIVER_VERSION	"0.27"
+#define DRIVER_VERSION	"0.28"
 
 #include "main.h"
 
@@ -495,7 +495,7 @@ static int	sgs_command(const char *cmd, char *buf, size_t buflen)
 		memcpy(&tmp[1], &cmd[i], ret);
 
 		/* Write data in 8-byte chunks */
-		ret = usb_control_msg(udev, USB_ENDPOINT_OUT | USB_TYPE_CLASS | USB_RECIP_INTERFACE, 0x09, 0x200, 0, tmp, 8, 500);
+		ret = usb_control_msg(udev, USB_ENDPOINT_OUT | USB_TYPE_CLASS | USB_RECIP_INTERFACE, 0x09, 0x200, 0, tmp, 8, 5000);
 
 		if (ret <= 0) {
 			upsdebugx(3, "send: %s (%d)", ret ? usb_strerror() : "timeout", ret);
@@ -516,7 +516,7 @@ static int	sgs_command(const char *cmd, char *buf, size_t buflen)
 		memset(tmp, 0, sizeof(tmp));
 
 		/* Read data in 8-byte chunks */
-		ret = usb_interrupt_read(udev, 0x81, tmp, 8, 500);
+		ret = usb_interrupt_read(udev, 0x81, tmp, 8, 1000);
 
 		/* No error!!! */
 		if (ret == -110)

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -33,7 +33,7 @@
  *
  */
 
-#define DRIVER_VERSION	"0.26"
+#define DRIVER_VERSION	"0.27"
 
 #include "main.h"
 
@@ -530,7 +530,7 @@ static int	sgs_command(const char *cmd, char *buf, size_t buflen)
 
 		/* Every call to read returns 8 bytes
 		 * -> actually returned bytes: */
-		ret = tmp[0];
+		ret = tmp[0] <= 7 ? tmp[0] : 7;
 
 		if (ret > 0)
 			memcpy(&buf[i], &tmp[1], ret);

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -33,7 +33,7 @@
  *
  */
 
-#define DRIVER_VERSION	"0.24"
+#define DRIVER_VERSION	"0.25"
 
 #include "main.h"
 
@@ -472,6 +472,72 @@ static int	cypress_command(const char *cmd, char *buf, size_t buflen)
 	}
 
 	upsdebugx(3, "read: %.*s", (int)strcspn(buf, "\r"), buf);
+	return i;
+}
+
+/* SGS communication subdriver */
+static int	sgs_command(const char *cmd, char *buf, size_t buflen)
+{
+	char	tmp[8];
+	int	ret;
+	size_t  cmdlen, i;
+
+	/* Send command */
+	cmdlen = strlen(cmd);
+
+	for (i = 0; i < cmdlen; i += ret) {
+
+		memset(tmp, 0, 8);
+
+		ret = (cmdlen - i) < 7 ? (cmdlen - i) : 7;
+
+		tmp[0] = ret;
+		memcpy(&tmp[1], &cmd[i], ret);
+
+		/* Write data in 8-byte chunks */
+		ret = usb_control_msg(udev, USB_ENDPOINT_OUT | USB_TYPE_CLASS | USB_RECIP_INTERFACE, 0x09, 0x200, 0, tmp, 8, 500);
+
+		if (ret <= 0) {
+			upsdebugx(3, "send: %s", ret ? usb_strerror() : "timeout");
+			return ret;
+		}
+
+		ret--;
+
+	}
+
+	upsdebugx(3, "send: %s", cmd);
+
+	/* Read reply */
+	memset(buf, 0, buflen);
+
+	for (i = 0; i <= buflen - 8; i += ret) {
+
+		memset(tmp, 0, 8);
+
+		/* Read data in 8-byte chunks */
+		ret = usb_interrupt_read(udev, 0x81, tmp, 8, 500);
+
+		/* No error!!! */
+		if (ret == -110)
+			break;
+
+		/* Any errors here mean that we are unable to read a reply (which will happen after successfully writing a command to the UPS) */
+		if (ret <= 0) {
+			upsdebugx(3, "read: %s", ret ? usb_strerror() : "timeout");
+			return ret;
+		}
+
+		/* Every call to read returns 8 bytes
+		 * -> actually returned bytes: */
+		ret = tmp[0];
+
+		if (ret > 0)
+			memcpy(&buf[i], &tmp[1], ret);
+
+	}
+
+	upsdebugx(3, "read: %s", buf);
 	return i;
 }
 
@@ -944,6 +1010,12 @@ static void	*cypress_subdriver(USBDevice_t *device)
 	return NULL;
 }
 
+static void	*sgs_subdriver(USBDevice_t *device)
+{
+	subdriver_command = &sgs_command;
+	return NULL;
+}
+
 static void	*ippon_subdriver(USBDevice_t *device)
 {
 	subdriver_command = &ippon_command;
@@ -996,6 +1068,7 @@ static qx_usb_device_id_t	qx_usb_id[] = {
 	{ USB_DEVICE(0x06da, 0x0601),	NULL,		NULL,			&phoenix_subdriver },	/* Online Zinto A */
 	{ USB_DEVICE(0x0f03, 0x0001),	NULL,		NULL,			&cypress_subdriver },	/* Unitek Alpha 1200Sx */
 	{ USB_DEVICE(0x14f0, 0x00c9),	NULL,		NULL,			&phoenix_subdriver },	/* GE EP series */
+	{ USB_DEVICE(0x0483, 0x0035),	NULL,		NULL,			&sgs_subdriver },	/* TS Shara UPSes */
 	{ USB_DEVICE(0x0001, 0x0000),	"MEC",		"MEC0003",		&fabula_subdriver },	/* Fideltronik/MEC LUPUS 500 USB */
 	{ USB_DEVICE(0x0001, 0x0000),	"ATCL FOR UPS",	"ATCL FOR UPS",		&fuji_subdriver },	/* Fuji UPSes */
 	{ USB_DEVICE(0x0001, 0x0000),	NULL,		NULL,			&krauler_subdriver },	/* Krauler UP-M500VA */
@@ -1848,6 +1921,7 @@ void	upsdrv_initups(void)
 			{ "krauler", &krauler_command },
 			{ "fabula", &fabula_command },
 			{ "fuji", &fuji_command },
+			{ "sgs", &sgs_command },
 			{ NULL }
 		};
 


### PR DESCRIPTION
Let's recap:
- some time ago, TS Shara provided us with a patched version of blazer_usb, which added support for their devices,
- we then moved that code (after fixing a couple of minor bugs) to nutdrv_qx,
- over the past year, I kept it updated (meanwhile fixing another couple of small bugs).

Now, I got one user to test it: everything works as expected, but.. the shutdown/restore sequence.
What he described me (the shutdown works, but when mains returns the UPS keeps turning itself off and then on endlessly, unti he unplugs the USB cable) makes me think of a problem in the test procedure (he manually sets the FSD flag -which cannot be cleared unless you restart upsd: he told me the system running upsd is turned off, but maybe it's not really turned off but only suspended to disk - I have to investigate), but I can't tell for sure until I see the logs.

So, I'm opening this pull request but I will merge it only after that user reports back with some log: if the problem doesn't lay in the test procedure and I can't fix it, I'll disable all the `Sn`/`SnRm` commands.

Additional question: given that TS Shara provided us the code (and they even sent me a small part of their firmware, which implements the megatec commands), what support level should we use in the HCL?
- 2 -> based on fragments of publicly available protocol (which holds true for the megatec protocol), or
- 4 -> vendor provided protocol (which, conversely, holds true for the USB subdriver)?