### PR TITLE
Default to type NUMBER for variables

### DIFF
--- a/clients/upsrw.c
+++ b/clients/upsrw.c
@@ -366,6 +366,11 @@ static void do_type(const char *varname)
 
 		}
 
+		if (!strcasecmp(answer[i], "NUMERIC")) {
+			printf("Type: NUMERIC\n");
+			return;
+		}
+
 		/* ignore this one */
 		if (!strcasecmp(answer[i], "RW")) {
 			continue;

--- a/clients/upsrw.c
+++ b/clients/upsrw.c
@@ -366,8 +366,8 @@ static void do_type(const char *varname)
 
 		}
 
-		if (!strcasecmp(answer[i], "NUMERIC")) {
-			printf("Type: NUMERIC\n");
+		if (!strcasecmp(answer[i], "NUMBER")) {
+			printf("Type: NUMBER\n");
 			return;
 		}
 

--- a/docs/man/upsrw.txt
+++ b/docs/man/upsrw.txt
@@ -84,6 +84,13 @@ username and password.  If you get "access denied" errors, make sure
 that your linkman:upsd.users[5] has an entry for you, and that the
 username you are using has permissions to SET variables.
 
+VALUE FORMAT
+------------
+
+When using *upsrw* to modify a numeric float value, that values must be given
+using decimal english-based representation, so using a dot. For example: "10.20"
+and not "10,20".
+
 HISTORY
 -------
 

--- a/docs/man/upsrw.txt
+++ b/docs/man/upsrw.txt
@@ -88,8 +88,10 @@ VALUE FORMAT
 ------------
 
 When using *upsrw* to modify a numeric float value, that values must be given
-using decimal english-based representation, so using a dot. For example: "10.20"
-and not "10,20".
+using decimal (base 10) english-based representation, so using a dot, in
+non-scientific notation.  So hexadecimal, exponents, and comma for thousands
+separator are forbiden.
+For example: "1200.20" is valid, while "1,200.20" and "1200,20" are invalid.
 
 HISTORY
 -------

--- a/docs/net-protocol.txt
+++ b/docs/net-protocol.txt
@@ -133,7 +133,7 @@ Response:
 - 'ENUM': an enumerated type, which supports a few specific values
 - 'STRING:n': this is a string of maximum length n
 - 'RANGE': this is an numeric, either integer or float, comprised in the range (see LIST RANGE)
-- 'NUMERIC': this is a simple numeric value, either integer or float
+- 'NUMBER': this is a simple numeric value, either integer or float
 
 ENUM, STRING and RANGE are usually associated with RW, but not always.
 The default <type>, when omitted, is numeric, so either integer or float.  Each

--- a/docs/net-protocol.txt
+++ b/docs/net-protocol.txt
@@ -132,10 +132,12 @@ Response:
 - 'RW': this variable may be set to another value with SET
 - 'ENUM': an enumerated type, which supports a few specific values
 - 'STRING:n': this is a string of maximum length n
-- 'RANGE': this is an integer, comprised in the range (see LIST RANGE)
+- 'RANGE': this is an numeric, either integer or float, comprised in the range (see LIST RANGE)
+- 'NUMERIC': this is a simple numeric value, either integer or float
 
 ENUM, STRING and RANGE are usually associated with RW, but not always.
-The default <type>, when omitted, is integer.
+The default <type>, when omitted, is numeric, so either integer or float.  Each
+driver is then responsible for handling values as either integer or float.
 
 This replaces the old "VARTYPE" command.
 

--- a/docs/net-protocol.txt
+++ b/docs/net-protocol.txt
@@ -139,6 +139,9 @@ ENUM, STRING and RANGE are usually associated with RW, but not always.
 The default <type>, when omitted, is numeric, so either integer or float.  Each
 driver is then responsible for handling values as either integer or float.
 
+Note that float values are expressed using decimal english-based representation,
+so using a dot. For example: "10.20" and not "10,20".
+
 This replaces the old "VARTYPE" command.
 
 

--- a/docs/net-protocol.txt
+++ b/docs/net-protocol.txt
@@ -139,8 +139,11 @@ ENUM, STRING and RANGE are usually associated with RW, but not always.
 The default <type>, when omitted, is numeric, so either integer or float.  Each
 driver is then responsible for handling values as either integer or float.
 
-Note that float values are expressed using decimal english-based representation,
-so using a dot. For example: "10.20" and not "10,20".
+Note that float values are expressed using decimal (base 10) english-based
+representation, so using a dot, in non-scientific notation.  So hexadecimal,
+exponents, and comma for thousands separator are forbiden.
+For example: "1200.20" is valid, while "1,200.20" and "1200,20" are invalid.
+
 
 This replaces the old "VARTYPE" command.
 

--- a/server/netget.c
+++ b/server/netget.c
@@ -159,7 +159,7 @@ static void get_type(nut_ctype_t *client, const char *upsname, const char *var)
 	/* Any variable that is not string | range | enum is just a simple
 	 * numeric value */
 
-	sendback(client, "TYPE %s %s NUMERIC\n", upsname, var);
+	sendback(client, "TYPE %s %s NUMBER\n", upsname, var);
 }		
 
 static void get_var_server(nut_ctype_t *client, const char *upsname, const char *var)

--- a/server/netget.c
+++ b/server/netget.c
@@ -156,9 +156,10 @@ static void get_type(nut_ctype_t *client, const char *upsname, const char *var)
 		return;
 	}
 
-	/* hmm... */
+	/* Any variable that is not string | range | enum is just a simple
+	 * numeric value */
 
-	sendback(client, "TYPE %s %s UNKNOWN\n", upsname, var);
+	sendback(client, "TYPE %s %s NUMERIC\n", upsname, var);
 }		
 
 static void get_var_server(nut_ctype_t *client, const char *upsname, const char *var)


### PR DESCRIPTION
Any variable that is not STRING, RANGE or ENUM is just a simple numeric value.
The protocol documentation (net-protocol.txt) was previously stating that "The
default <type>, when omitted, is integer." which was not fully true, since a
variable could also be a float.  Hence, the wording was changed to advertise
this, and that each driver is then responsible for handling values as either
integer or float.  Moreover, instead of returning a TYPE "UNKNOWN", return
"NUMERIC", which is more suitable, and aligned with the NUT protocol
specification