### PR TITLE
Update OpenWRT package information

### DIFF
--- a/docs/download.txt
+++ b/docs/download.txt
@@ -109,7 +109,7 @@ link:http://packages.gentoo.org/package/sys-power/nut[Gentoo Linux],
 Mandriva,
 link:https://apps.fedoraproject.org/packages/nut[Red Hat / Fedora],
 link:http://software.opensuse.org/package/nut[Novell Suse / openSUSE],
-link:https://forum.openwrt.org/viewtopic.php?id=26269[OpenWrt],
+link:https://github.com/openwrt/packages/tree/master/net/nut[OpenWrt],
 link:http://packages.ubuntu.com/nut[Ubuntu],
 link:https://github.com/voidlinux/xbps-packages/blob/master/srcpkgs/network-ups-tools/template[Void Linux].
 


### PR DESCRIPTION
The previous link is over 5 years old, nut is now maintained in the packages repository on GitHub.