### PR TITLE
Allow to customize path to gdlib-config and net-snmp-config programs

### DIFF
--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -23,6 +23,13 @@ Note that you need to install the libusb development package or files.
 Build and install the SNMP drivers (default: auto-detect)
 Note that you need to install libsnmp development package or files.
 
+	--with-net-snmp-config
+
+In addition to the `--with-snmp` option above, this one allows to provide
+a custom program name (in `PATH`) or complete pathname to `net-snmp-config`.
+This may be needed on build systems which support multiple architectures,
+or in cases where your distribution names this program differently.
+
 	--with-neon
 
 Build and install the XML drivers (default: auto-detect)
@@ -334,6 +341,13 @@ proper -L and -l flags to make it work.  See LIBS= in gd's Makefile.
 NOTE: the --with-gd switches are not necessary if you have gd 2.0.8
 or higher installed properly.  The gdlib-config script will be 
 detected and used by default in that situation.
+
+	--with-gdlib-config
+
+This option allows to provide a custom program name (in `PATH`) or
+a complete pathname to `gdlib-config`. This may be needed on build
+systems which support multiple architectures, or in cases where your
+distribution names this program differently.
 
 	--with-ssl-includes, --with-usb-includes, --with-snmp-includes,
 	--with-neon-includes, --with-libltdl-includes,

--- a/m4/nut_check_libgd.m4
+++ b/m4/nut_check_libgd.m4
@@ -19,8 +19,25 @@ if test -z "${nut_have_libgd_seen}"; then
 	LDFLAGS="-L/usr/X11R6/lib"
 	LIBS="-lgd -lpng -lz -ljpeg -lfreetype -lm -lXpm -lX11"
 
-	AC_MSG_CHECKING(for gd version via gdlib-config)
-	GD_VERSION=`gdlib-config --version 2>/dev/null`
+	dnl By default seek in PATH
+	GDLIB_CONFIG=gdlib-config
+	AC_ARG_WITH(gdlib-config,
+		AS_HELP_STRING([@<:@--with-gdlib-config=/path/to/gdlib-config@:>@],
+			[path to program that reports GDLIB configuration]),
+	[
+		case "${withval}" in
+		"") ;;
+		yes|no)
+			AC_MSG_ERROR(invalid option --with(out)-gdlib-config - see docs/configure.txt)
+			;;
+		*)
+			GDLIB_CONFIG="${withval}"
+			;;
+		esac
+	])
+
+	AC_MSG_CHECKING(for gd version via ${GDLIB_CONFIG})
+	GD_VERSION=`${GDLIB_CONFIG} --version 2>/dev/null`
 	if test "$?" != "0" -o -z "${GD_VERSION}"; then
 		GD_VERSION="none"
 	fi
@@ -30,13 +47,13 @@ if test -z "${nut_have_libgd_seen}"; then
 	none)
 		;;
 	2.0.5 | 2.0.6 | 2.0.7)
-		AC_MSG_WARN([[gd ${GD_VERSION} detected, unable to use gdlib-config script]])
+		AC_MSG_WARN([[gd ${GD_VERSION} detected, unable to use ${GDLIB_CONFIG} script]])
 		AC_MSG_WARN([[If gd detection fails, upgrade gd or use --with-gd-includes and --with-gd-libs]])
 		;;
 	*)
-		CFLAGS="`gdlib-config --includes 2>/dev/null`"
-		LDFLAGS="`gdlib-config --ldflags 2>/dev/null`"
-		LIBS="`gdlib-config --libs 2>/dev/null`"
+		CFLAGS="`${GDLIB_CONFIG} --includes 2>/dev/null`"
+		LDFLAGS="`${GDLIB_CONFIG} --ldflags 2>/dev/null`"
+		LIBS="`${GDLIB_CONFIG} --libs 2>/dev/null`"
 		;;
 	esac
 

--- a/m4/nut_check_libnetsnmp.m4
+++ b/m4/nut_check_libnetsnmp.m4
@@ -13,9 +13,26 @@ if test -z "${nut_have_libnetsnmp_seen}"; then
 	CFLAGS_ORIG="${CFLAGS}"
 	LIBS_ORIG="${LIBS}"
 
+	dnl By default seek in PATH
+	NET_SNMP_CONFIG=net-snmp-config
+	AC_ARG_WITH(net-snmp-config,
+		AS_HELP_STRING([@<:@--with-net-snmp-config=/path/to/net-snmp-config@:>@],
+			[path to program that reports Net-SNMP configuration]),
+	[
+		case "${withval}" in
+		"") ;;
+		yes|no)
+			AC_MSG_ERROR(invalid option --with(out)-net-snmp-config - see docs/configure.txt)
+			;;
+		*)
+			NET_SNMP_CONFIG="${withval}"
+			;;
+		esac
+	])
+
 	dnl See which version of the Net-SNMP library (if any) is installed
-	AC_MSG_CHECKING(for Net-SNMP version via net-snmp-config)
-	SNMP_VERSION=`net-snmp-config --version 2>/dev/null`
+	AC_MSG_CHECKING(for Net-SNMP version via ${NET_SNMP_CONFIG})
+	SNMP_VERSION=`${NET_SNMP_CONFIG} --version 2>/dev/null`
 	if test "$?" != "0" -o -z "${SNMP_VERSION}"; then
 		SNMP_VERSION="none"
 	fi
@@ -33,7 +50,7 @@ if test -z "${nut_have_libnetsnmp_seen}"; then
 			CFLAGS="${withval}"
 			;;
 		esac
-	], [CFLAGS="`net-snmp-config --base-cflags 2>/dev/null`"])
+	], [CFLAGS="`${NET_SNMP_CONFIG} --base-cflags 2>/dev/null`"])
 	AC_MSG_RESULT([${CFLAGS}])
 
 	AC_MSG_CHECKING(for Net-SNMP libs)
@@ -48,7 +65,7 @@ if test -z "${nut_have_libnetsnmp_seen}"; then
 			LIBS="${withval}"
 			;;
 		esac
-	], [LIBS="`net-snmp-config --libs 2>/dev/null`"])
+	], [LIBS="`${NET_SNMP_CONFIG} --libs 2>/dev/null`"])
 	AC_MSG_RESULT([${LIBS}])
 
 	dnl Check if the Net-SNMP library is usable


### PR DESCRIPTION
Current m4 scripts assume a fixed program name to be in PATH. This is not always the case, e.g. in Solarish oi-userland we have /usr/bin/net-snmp-config-{32,64} and /usr/bin{,/$(MACH64)}/gdlib-config