### PR TITLE
Configure : allow to fully toggle generation of manpages among other docs, and do not ALWAYS blindly attempt systemd setup

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1053,13 +1053,13 @@ fi
 AM_CONDITIONAL(WITH_PKG_CONFIG, test -n "${pkgconfigdir}")
 
 PKG_PROG_PKG_CONFIG
-systemdsystemunitdir=`$PKG_CONFIG --variable=systemdsystemunitdir systemd`
 AC_MSG_CHECKING(whether to install systemd files)
 AC_ARG_WITH([systemdsystemunitdir],
 	AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files (auto)]),
 [
 	case "${withval}" in
-	yes|auto)
+	yes|auto|"")
+		systemdsystemunitdir=`$PKG_CONFIG --variable=systemdsystemunitdir systemd`
 		;;
 	no)
 		systemdsystemunitdir=""

--- a/configure.ac
+++ b/configure.ac
@@ -202,7 +202,7 @@ AC_CHECK_DECLS(__func__, [], [
 		AC_DEFINE(__func__, __LINE__, [Replace missing  __func__ declaration])
 	], [AC_INCLUDES_DEFAULT])
 ], [AC_INCLUDES_DEFAULT])
-	      
+
 dnl Solaris compatibility - check for -lnsl and -lsocket
 AC_SEARCH_LIBS(gethostbyname, nsl)
 AC_SEARCH_LIBS(connect, socket)
@@ -210,7 +210,7 @@ AC_SEARCH_LIBS(connect, socket)
 AC_HEADER_TIME
 AC_CHECK_HEADERS(sys/modem.h stdarg.h varargs.h sys/termios.h sys/time.h, [], [], [AC_INCLUDES_DEFAULT])
 
-# pthread related checks
+dnl pthread related checks
 AC_SEARCH_LIBS([pthread_create], [pthread],
        [AC_DEFINE(HAVE_PTHREAD, 1, [Define to enable pthread support code])],
        [])
@@ -629,81 +629,6 @@ dnl Always check for AsciiDoc prerequisites, since even if --with-doc
 dnl is set to 'no', we may still want to build some doc targets manually
 NUT_CHECK_ASCIIDOC
 
-case "${nut_with_doc}" in
-	yes|all)
-		nut_doc_build_list="html-single html-chunked pdf"
-		;;
-	auto)
-		nut_doc_build_list="html-single=auto html-chunked=auto pdf=auto"
-		nut_with_doc=auto
-		;;
-	no|"")
-		nut_doc_build_list=""
-		;;
-	*)
-		nut_doc_build_list="`echo ${nut_with_doc} | sed 's/,/ /g'`"
-		;;
-esac
-
-for nut_doc_build_target in ${nut_doc_build_list}; do
-	case "${nut_doc_build_target}" in
-	html-single*)
-		AC_MSG_CHECKING([if asciidoc version can build ${nut_doc_build_target} (minimum required 8.6.3)])
-		AX_COMPARE_VERSION([${ASCIIDOC_VERSION}], [ge], [8.6.3], [
-			AC_MSG_RESULT(yes)
-			DOC_BUILD_LIST="${DOC_BUILD_LIST} `basename ${nut_doc_build_target} =auto`"
-		], [
-			case "${nut_doc_build_target}" in *=auto) ;; *) AC_MSG_ERROR([Unable to build ${nut_doc_build_target} documentation which you requested]) ;; esac
-			AC_MSG_RESULT(no)
-			DOC_NOBUILD_LIST="${DOC_NOBUILD_LIST} `basename ${nut_doc_build_target} =auto`"
-		])
-		;;
-
-	html-chunked*)
-		AC_MSG_CHECKING([if a2x version can build ${nut_doc_build_target} (minimum required 8.6.3)])
-		AX_COMPARE_VERSION([${A2X_VERSION}], [ge], [8.6.3], [
-			AC_MSG_RESULT(yes)
-			DOC_BUILD_LIST="${DOC_BUILD_LIST} `basename ${nut_doc_build_target} =auto`"
-		], [
-			case "${nut_doc_build_target}" in *=auto) ;; *) AC_MSG_ERROR([Unable to build ${nut_doc_build_target} documentation which you requested]) ;; esac
-			AC_MSG_RESULT(no)
-			DOC_NOBUILD_LIST="${DOC_NOBUILD_LIST} `basename ${nut_doc_build_target} =auto`"
-		])
-		;;
-
-	pdf*)
-		AC_MSG_CHECKING([if dblatex version can build ${nut_doc_build_target} (minimum required 0.2.5)])
-		AX_COMPARE_VERSION([${DBLATEX_VERSION}], [ge], [0.2.5], [
-			AC_MSG_RESULT(yes)
-			DOC_BUILD_LIST="${DOC_BUILD_LIST} `basename ${nut_doc_build_target} =auto`"
-		], [
-			case "${nut_doc_build_target}" in *=auto) ;; *) AC_MSG_ERROR([Unable to build ${nut_doc_build_target} documentation which you requested]) ;; esac
-			AC_MSG_RESULT(no)
-			DOC_NOBUILD_LIST="${DOC_NOBUILD_LIST} `basename ${nut_doc_build_target} =auto`"
-		])
-		;;
-	esac
-done
-
-case "${nut_with_doc}" in
-auto)
-	if test -n "${DOC_BUILD_LIST}"; then
-		nut_with_doc="yes"
-	else
-		nut_with_doc="no"
-	fi
-	;;	
-no)
-	;;
-*)
-	if test -z "${DOC_NOBUILD_LIST}"; then
-		nut_with_doc="yes"
-	else
-		AC_MSG_ERROR(["Unable to build ${DOC_NOBUILD_LIST} documentation (check for 'no' results above)"])
-	fi
-	;;
-esac
-
 AC_MSG_CHECKING([if asciidoc version can build manpages (minimum required 8.6.3)])
 AX_COMPARE_VERSION([${ASCIIDOC_VERSION}], [ge], [8.6.3], [
 	AC_MSG_RESULT(yes)
@@ -753,9 +678,156 @@ dnl Notes: we also keep HAVE_ASCIIDOC for implicit targets, such as manpage
 dnl building
 AM_CONDITIONAL([HAVE_ASCIIDOC], [test "${nut_have_asciidoc}" = "yes"])
 
-if test "${nut_with_doc}" = "yes"; then
-	NUT_REPORT([only build specific documentation format], [${DOC_BUILD_LIST}])
+
+case "${nut_with_doc}" in
+	yes|all)
+		nut_doc_build_list="man html-single html-chunked pdf"
+		;;
+	auto)
+		nut_doc_build_list="man=auto html-single=auto html-chunked=auto pdf=auto"
+		;;
+	no)
+		nut_doc_build_list=""
+		;;
+dnl If user passed --with-doc='' they they want nothing, right?
+	"")
+		nut_doc_build_list=""
+		AC_MSG_NOTICE([Got explicit empty list of document formats to build; nothing will be generated])
+		;;
+	*)
+		nut_doc_build_list="`echo ${nut_with_doc} | sed 's/,/ /g'`"
+		AC_MSG_NOTICE([Got explicit list of document formats to build or not: ${nut_doc_build_list}; formats not listed will be silently skipped])
+		;;
+esac
+
+dnl Note: Do not cover ${nut_doc_build_list} in braces or quotes here,
+dnl to ensure that it is processed as several space-separated tokens
+for nut_doc_build_target in $nut_doc_build_list; do
+	case "${nut_doc_build_target}" in
+	*=*=*) AC_MSG_ERROR([Invalid documentation format option: ${nut_doc_build_target}]) ;;
+	*=*)
+		nut_doc_build_target_base="`echo "${nut_doc_build_target}" | sed 's,=.*$,,'`"
+		nut_doc_build_target_flag="`echo "${nut_doc_build_target}" | sed 's,^.*=,,'`"
+		;;
+	*)
+		nut_doc_build_target_base="${nut_doc_build_target}"
+		nut_doc_build_target_flag="yes"
+		;;
+	esac
+	case "${nut_doc_build_target_flag}" in
+	yes|no|auto|skip) ;;
+	"") nut_doc_build_target_flag="yes" ;;
+	*)  AC_MSG_ERROR([Invalid documentation format option: ${nut_doc_build_target}]) ;;
+	esac
+	AC_MSG_CHECKING([desire and ability to build ${nut_doc_build_target_base} documentation])
+	AC_MSG_RESULT([${nut_doc_build_target_flag}])
+
+	case "${nut_doc_build_target}" in
+	*=no|*=skip)
+		DOC_SKIPBUILD_LIST="${DOC_SKIPBUILD_LIST} ${nut_doc_build_target_base}"
+		;;
+
+dnl Notes: Document options below assume either no flag value (which
+dnl by default means "yes"), "yes" which is a requirement, or "auto"
+dnl to detect if we can build the wanted documentation format and yet
+dnl not fail if we have no tools to generate it.
+
+	html-single*)
+		AC_MSG_CHECKING([if asciidoc version can build ${nut_doc_build_target_base} (minimum required 8.6.3)])
+		AX_COMPARE_VERSION([${ASCIIDOC_VERSION}], [ge], [8.6.3], [
+			AC_MSG_RESULT(yes)
+			DOC_BUILD_LIST="${DOC_BUILD_LIST} ${nut_doc_build_target_base}"
+		], [
+			AC_MSG_RESULT(no)
+			if test "${nut_doc_build_target}" = "yes" ; then
+				AC_MSG_ERROR([Unable to build ${nut_doc_build_target_base} documentation which you requested])
+			fi
+			DOC_CANNOTBUILD_LIST="${DOC_CANNOTBUILD_LIST} ${nut_doc_build_target_base}"
+		])
+		;;
+
+	html-chunked*)
+		AC_MSG_CHECKING([if a2x version can build ${nut_doc_build_target_base} (minimum required 8.6.3)])
+		AX_COMPARE_VERSION([${A2X_VERSION}], [ge], [8.6.3], [
+			AC_MSG_RESULT(yes)
+			DOC_BUILD_LIST="${DOC_BUILD_LIST} ${nut_doc_build_target_base}"
+		], [
+			AC_MSG_RESULT(no)
+			if test "${nut_doc_build_target}" = "yes" ; then
+				AC_MSG_ERROR([Unable to build ${nut_doc_build_target_base} documentation which you requested])
+			fi
+			DOC_CANNOTBUILD_LIST="${DOC_CANNOTBUILD_LIST} ${nut_doc_build_target_base}"
+		])
+		;;
+
+	pdf*)
+		AC_MSG_CHECKING([if dblatex version can build ${nut_doc_build_target_base} (minimum required 0.2.5)])
+		AX_COMPARE_VERSION([${DBLATEX_VERSION}], [ge], [0.2.5], [
+			AC_MSG_RESULT(yes)
+			DOC_BUILD_LIST="${DOC_BUILD_LIST} ${nut_doc_build_target_base}"
+		], [
+			AC_MSG_RESULT(no)
+			if test "${nut_doc_build_target}" = "yes" ; then
+				AC_MSG_ERROR([Unable to build ${nut_doc_build_target_base} documentation which you requested])
+			fi
+			DOC_CANNOTBUILD_LIST="${DOC_CANNOTBUILD_LIST} ${nut_doc_build_target_base}"
+		])
+		;;
+
+	man*)
+		AC_MSG_CHECKING([if we can build ${nut_doc_build_target_base}])
+		if test "${nut_have_asciidoc}" = yes ; then
+			AC_MSG_RESULT(yes)
+			DOC_BUILD_LIST="${DOC_BUILD_LIST} ${nut_doc_build_target_base}"
+		else
+			AC_MSG_RESULT(no)
+			if test "${nut_doc_build_target}" = "yes" ; then
+				AC_MSG_ERROR([Unable to build ${nut_doc_build_target_base} documentation which you requested])
+			fi
+			DOC_CANNOTBUILD_LIST="${DOC_CANNOTBUILD_LIST} ${nut_doc_build_target_base}"
+		fi
+		;;
+
+	*) AC_MSG_ERROR([--with-doc option refers to unknown documentation format: $nut_doc_build_target]) ;;
+
+	esac
+done
+
+case "${nut_with_doc}" in
+auto)
+	if test -n "${DOC_BUILD_LIST}"; then
+		nut_with_doc="yes"
+	else
+		nut_with_doc="no"
+	fi
+	;;
+no)
+	;;
+*)
+	if test -n "${DOC_CANNOTBUILD_LIST}"; then
+		AC_MSG_ERROR([Unable to build${DOC_CANNOTBUILD_LIST} documentation (check for 'no' results above)])
+	fi
+
+	if test -n "${DOC_SKIPBUILD_LIST}"; then
+		AC_MSG_NOTICE([Skipping build of${DOC_SKIPBUILD_LIST} documentation (check for 'skip' results above)])
+	fi
+
+	if test -n "${DOC_BUILD_LIST}"; then
+		nut_with_doc="yes"
+	else
+		nut_with_doc="no"
+	fi
+	;;
+esac
+
+NUT_REPORT_FEATURE([build specific documentation format(s)], [${nut_with_doc}], [${DOC_BUILD_LIST}],
+					[WITH_DOCS], [Define to enable overall documentation generation])
+
+WITH_MANS=no
+if echo "${DOC_BUILD_LIST}" | grep -w "man" >/dev/null ; then
+	WITH_MANS=yes
 fi
+AM_CONDITIONAL(WITH_MANS, test "${WITH_MANS}" = "yes")
 
 dnl ----------------------------------------------------------------------
 dnl checks related to --with-dev
@@ -1000,17 +1072,22 @@ if test "${DRIVER_BUILD_LIST}" != "all"; then
 fi
 
 AC_MSG_CHECKING(which driver man pages to install)
-if test "${DRIVER_BUILD_LIST}" = "all"; then
-	DRIVER_MAN_LIST=all
-	AC_MSG_RESULT(all available)
+if test "${WITH_MANS}" = "yes"; then
+	if test "${DRIVER_BUILD_LIST}" = "all"; then
+		DRIVER_MAN_LIST=all
+		AC_MSG_RESULT(all available)
+	else
+		DRIVER_MAN_LIST=""
+		for i in ${DRIVER_BUILD_LIST}; do
+			if test -f ${srcdir}/docs/man/$i.8; then
+				DRIVER_MAN_LIST="${DRIVER_MAN_LIST} $i.8"
+			fi
+		done
+		AC_MSG_RESULT(${DRIVER_MAN_LIST})
+	fi
 else
 	DRIVER_MAN_LIST=""
-	for i in ${DRIVER_BUILD_LIST}; do
-		if test -f ${srcdir}/docs/man/$i.8; then
-			DRIVER_MAN_LIST="${DRIVER_MAN_LIST} $i.8"
-		fi
-	done
-	AC_MSG_RESULT(${DRIVER_MAN_LIST})
+	AC_MSG_RESULT([none (manpages disabled)])
 fi
 
 AC_MSG_CHECKING(whether to strip debug symbols)

--- a/configure.ac
+++ b/configure.ac
@@ -254,7 +254,7 @@ dnl they are listed near the top by "./configure --help"
 NUT_ARG_WITH([dev], [build and install the development files], [no])
 NUT_ARG_WITH([serial], [build and install serial drivers], [yes])
 NUT_ARG_WITH([usb], [build and install USB drivers], [auto])
-NUT_ARG_WITH([doc], [build and install documentation], [no])
+NUT_ARG_WITH([doc], [build and install documentation], [man=yes])
 NUT_ARG_WITH([avahi], [build and install Avahi support], [auto])
 
 dnl ----------------------------------------------------------------------

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -99,13 +99,13 @@ A2X_COMMON_OPTS = $(ASCIIDOC_VERBOSE) --attribute icons \
     --attribute=badges \
     --attribute=external_title \
     --attribute tree_version=@TREE_VERSION@ \
-    -a toc -a numbered --destination-dir=.
+    -a toc -a numbered
 
 .txt.html: common.xsl xhtml.xsl
-	$(A2X) $(A2X_COMMON_OPTS) --attribute=xhtml11_format --format=xhtml --xsl-file=$(srcdir)/xhtml.xsl $<
+	$(A2X) $(A2X_COMMON_OPTS) --destination-dir=. --attribute=xhtml11_format --format=xhtml --xsl-file=$(srcdir)/xhtml.xsl $<
 
 .txt.chunked: common.xsl chunked.xsl
-	$(A2X) $(A2X_COMMON_OPTS) --attribute=chunked_format --format=chunked --xsl-file=$(srcdir)/chunked.xsl $<
+	$(A2X) $(A2X_COMMON_OPTS) --destination-dir=. --attribute=chunked_format --format=chunked --xsl-file=$(srcdir)/chunked.xsl $<
 
 .txt.pdf: docinfo.xml
 	$(A2X) $(A2X_COMMON_OPTS) --attribute=pdf_format --format=pdf -a docinfo1 $<

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -99,13 +99,13 @@ A2X_COMMON_OPTS = $(ASCIIDOC_VERBOSE) --attribute icons \
     --attribute=badges \
     --attribute=external_title \
     --attribute tree_version=@TREE_VERSION@ \
-    -a toc -a numbered
+    -a toc -a numbered --destination-dir=.
 
 .txt.html: common.xsl xhtml.xsl
-	$(A2X) $(A2X_COMMON_OPTS) --destination-dir=. --attribute=xhtml11_format --format=xhtml --xsl-file=$(srcdir)/xhtml.xsl $<
+	$(A2X) $(A2X_COMMON_OPTS) --attribute=xhtml11_format --format=xhtml --xsl-file=$(srcdir)/xhtml.xsl $<
 
 .txt.chunked: common.xsl chunked.xsl
-	$(A2X) $(A2X_COMMON_OPTS) --destination-dir=. --attribute=chunked_format --format=chunked --xsl-file=$(srcdir)/chunked.xsl $<
+	$(A2X) $(A2X_COMMON_OPTS) --attribute=chunked_format --format=chunked --xsl-file=$(srcdir)/chunked.xsl $<
 
 .txt.pdf: docinfo.xml
 	$(A2X) $(A2X_COMMON_OPTS) --attribute=pdf_format --format=pdf -a docinfo1 $<

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -89,13 +89,39 @@ information on how to set up CGI programs.
 	--with-doc=<output-format(s)>  (default: no)
 
 Build and install NUT documentation file(s).
+
 The possible values are "html-single" for single page HTML, "html-chunked"
-for multi pages HTML, "pdf" for a PDF file or "auto" to build all the
-possible previous documentation formats.  Multiple values can be specified,
-separated with comma.
+for multi pages HTML, "pdf" for a PDF file, and "man" for the usual manpages.
+
+If the "--with-doc" argument is passed without a list, or lists just "=yes"
+or "=all", it enables all supported formats with a "=yes".
+
+An (explicit!) "--with-doc=auto" argument tries to enable all supported
+formats with an "=auto".
+
+A "--with-doc=no" quietly skips generation of all types of documentation,
+including manpages.
+
+Multiple documentation format values can be specified, separated with comma.
+Each such value can be suffixed with "=yes" to require building of the this
+documentation format (abort configuration if tools are missing), "=auto" to
+detect and enable if we can build it on this system (and not abort if we
+can not), and "=no" (or "=skip") to explicitly skip generation of this
+document format even if we do have the tools to build it.
+
+If a document format is mentioned in the list without a suffix, then it is
+treated as a "=yes" requirement.
+
 Verbose output can be enabled using: ASCIIDOC_VERBOSE=-v make
 
 This feature requires AsciiDoc 8.6.3 (http://www.methods.co.nz/asciidoc).
+
+Example valid formats of this flag:
+* `--with-doc`
+* `--with-doc=` is a valid empty list, effectively same as `--with-doc=no`
+* `--with-doc=auto`
+* `--with-doc=pdf,html-chunked`
+* `--with-doc=man=no,pdf=auto,html-single`
 
 	--with-dev (default: no)
 

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -300,6 +300,16 @@ override this option.
 
 Use --without-udev-dir to disable this feature altogether. 
 
+	--with-systemdsystemunitdir=PATH
+
+Where to install Linux systemd unit definitions. Useless and harmless
+on other OSes, including Linux distributions without systemd, just adding
+a little noise to configure script output.
+
+Use --with-systemdsystemunitdir to detect the settings using pkg-config.
+
+Use --with-systemdsystemunitdir=no to disable this feature altogether.
+
 
 Directories used by NUT at run-time
 -----------------------------------

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -637,7 +637,8 @@ A2X_MANPAGE_OPTS = --doctype manpage --format manpage \
 	--xsltproc-opts "--nonet" \
 	--attribute mansource="Network UPS Tools" \
 	--attribute manversion="@PACKAGE_VERSION@" \
-	--attribute manmanual="NUT Manual"
+	--attribute manmanual="NUT Manual" \
+	--destination-dir=.
 
 .txt.1:
 	$(A2X) $(A2X_MANPAGE_OPTS) $<

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -637,8 +637,7 @@ A2X_MANPAGE_OPTS = --doctype manpage --format manpage \
 	--xsltproc-opts "--nonet" \
 	--attribute mansource="Network UPS Tools" \
 	--attribute manversion="@PACKAGE_VERSION@" \
-	--attribute manmanual="NUT Manual" \
-	--destination-dir=.
+	--attribute manmanual="NUT Manual"
 
 .txt.1:
 	$(A2X) $(A2X_MANPAGE_OPTS) $<

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -21,6 +21,7 @@ SRC_CONF_PAGES = \
 	upsmon.conf.txt \
 	upssched.conf.txt
 
+if WITH_MANS
 MAN_CONF_PAGES = \
 	nut.conf.5 \
 	ups.conf.5 \
@@ -28,6 +29,7 @@ MAN_CONF_PAGES = \
 	upsd.users.5 \
 	upsmon.conf.5 \
 	upssched.conf.5
+endif
 
 man5_MANS = $(MAN_CONF_PAGES)
 
@@ -50,6 +52,7 @@ SRC_CLIENT_PAGES = \
 	upsrw.txt \
 	upssched.txt
 
+if WITH_MANS
 MAN_CLIENT_PAGES = \
 	nutupsdrv.8 \
 	upsc.8 \
@@ -60,6 +63,7 @@ MAN_CLIENT_PAGES = \
 	upsmon.8 \
 	upsrw.8 \
 	upssched.8
+endif
 
 man8_MANS = $(MAN_CLIENT_PAGES)
 
@@ -76,7 +80,9 @@ HTML_CLIENT_MANS = \
 
 SRC_TOOL_PAGES = nut-scanner.txt nut-recorder.txt
 
+if WITH_MANS
 MAN_TOOL_PAGES = nut-scanner.8 nut-recorder.8
+endif
 
 man8_MANS += $(MAN_TOOL_PAGES)
 
@@ -91,6 +97,7 @@ SRC_CGI_PAGES = \
 	upsstats.cgi.txt \
 	upsimage.cgi.txt
 
+if WITH_MANS
 MAN5_CGI_PAGES = \
 	hosts.conf.5 \
 	upsset.conf.5 \
@@ -100,6 +107,7 @@ MAN8_CGI_PAGES = \
 	upsset.cgi.8 \
 	upsstats.cgi.8 \
 	upsimage.cgi.8
+endif
 
 if WITH_CGI
  man5_MANS += $(MAN5_CGI_PAGES)
@@ -162,6 +170,7 @@ SRC_DEV_PAGES = \
 	libupsclient-config.txt \
 	skel.txt
 
+if WITH_MANS
 # NOTE: nutclient_*.3 has no source counterpart (libnutclient_*.txt)
 MAN3_DEV_PAGES = \
 	upsclient.3 \
@@ -235,6 +244,7 @@ MAN3_DEV_PAGES = \
 
 MAN1_DEV_PAGES = \
 	libupsclient-config.1
+endif
 
 if WITH_DEV
  man3_MANS = $(MAN3_DEV_PAGES)
@@ -343,6 +353,7 @@ SRC_SERIAL_PAGES = \
 	victronups.txt	\
 	apcupsd-ups.txt
 
+if WITH_MANS
 MAN_SERIAL_PAGES = \
 	al175.8	\
 	apcsmart.8	\
@@ -384,6 +395,7 @@ MAN_SERIAL_PAGES = \
 	upscode2.8	\
 	victronups.8	\
 	apcupsd-ups.8
+endif
 
 if WITH_SERIAL
   man8_MANS +=  $(MAN_SERIAL_PAGES)
@@ -433,7 +445,9 @@ HTML_SERIAL_MANS = \
 
 # (--with-snmp)
 SRC_SNMP_PAGES = snmp-ups.txt
+if WITH_MANS
 MAN_SNMP_PAGES = snmp-ups.8
+endif
 
 if WITH_SNMP
   man8_MANS += $(MAN_SNMP_PAGES)
@@ -453,6 +467,7 @@ SRC_USB_LIBUSB_PAGES = \
 	tripplite_usb.txt \
 	usbhid-ups.txt
 
+if WITH_MANS
 MAN_USB_LIBUSB_PAGES = \
 	bcmxcp_usb.8 \
 	blazer_usb.8 \
@@ -462,6 +477,7 @@ MAN_USB_LIBUSB_PAGES = \
 	riello_usb.8	\
 	tripplite_usb.8 \
 	usbhid-ups.8
+endif
 
 if WITH_USB
  man8_MANS += $(MAN_USB_LIBUSB_PAGES)
@@ -479,7 +495,9 @@ HTML_USB_LIBUSB_MANS = \
 
 # (--with-neon)
 SRC_NETXML_PAGES = netxml-ups.txt
+if WITH_MANS
 MAN_NETXML_PAGES = netxml-ups.8
+endif
 
 if WITH_NEON
    man8_MANS += $(MAN_NETXML_PAGES)
@@ -489,7 +507,9 @@ HTML_NETXML_MANS = netxml-ups.html
 
 # (--with-powerman)
 SRC_POWERMAN_PAGES = powerman-pdu.txt
+if WITH_MANS
 MAN_POWERMAN_PAGES = powerman-pdu.8
+endif
 
 if WITH_LIBPOWERMAN
    man8_MANS += $(MAN_POWERMAN_PAGES)
@@ -499,7 +519,9 @@ HTML_POWERMAN_MANS = powerman-pdu.html
 
 # (--with-ipmi)
 SRC_IPMIPSU_PAGES = nut-ipmipsu.txt
+if WITH_MANS
 MAN_IPMIPSU_PAGES = nut-ipmipsu.8
+endif
 
 if WITH_IPMI
    man8_MANS += $(MAN_IPMIPSU_PAGES)
@@ -508,7 +530,9 @@ endif
 HTML_IPMIPSU_MANS = nut-ipmipsu.html
 
 SRC_MACOSX_PAGES = macosx-ups.txt
+if WITH_MANS
 MAN_MACOSX_PAGES = macosx-ups.8
+endif
 
 if WITH_MACOSX
    man8_MANS += $(MAN_MACOSX_PAGES)
@@ -517,7 +541,9 @@ endif
 HTML_MACOSX_MANS = macosx-ups.html
 
 SRC_LINUX_I2C_PAGES = asem.txt
+if WITH_MANS
 MAN_LINUX_I2C_PAGES = asem.8
+endif
 
 if WITH_LINUX_I2C
    man8_MANS += $(LINUX_I2C_PAGES)
@@ -528,7 +554,9 @@ HTML_LINUX_I2C_MANS = asem.html
 # SOME_DRIVERS
 endif
 
-MAN_MANS = \
+MAN_MANS =
+if WITH_MANS
+MAN_MANS += \
 	$(MAN_CONF_PAGES) \
 	$(MAN_CLIENT_PAGES) \
 	$(MAN_TOOL_PAGES) \
@@ -544,6 +572,7 @@ MAN_MANS = \
 	$(MAN_IPMIPSU_PAGES) \
 	$(MAN_MACOSX_PAGES) \
 	$(MAN_LINUX_I2C_PAGES)
+endif
 
 # distribute everything, even those not installed by default
 # Note that 'dist' target requires AsciiDoc!
@@ -563,6 +592,13 @@ EXTRA_DIST = \
 	$(SRC_LINUX_I2C_PAGES) \
 	$(MAN_MANS) \
 	asciidoc.conf
+
+if ! WITH_MANS
+# Cause "make dist" to fail
+EXTRA_DIST += dist
+dist:
+	@echo "ERROR: Manpage building was disabled by configure script, and these pages are required for our proper 'make dist'" >&2 ; false
+endif
 
 HTML_MANS = \
 	$(HTML_CONF_MANS) \


### PR DESCRIPTION
Rationale: on a build-host that prepares packaging for multiple architectures in empty workspaces, it suffices to build the docs just once, including manpages (should the buildhost recipe define so). Now this can be done indeed.

Note: disabled manpage generation explicitly causes "make dist" to fail, in order to avoid dist'able tarballs not conforming to spec and expectations.

Also this PR reduces noise about systemd on OSes or builds that are not relevant for it.