### PR TITLE
Add support for SU3000LCD2UHV

### DIFF
--- a/drivers/libhid.c
+++ b/drivers/libhid.c
@@ -276,6 +276,7 @@ void HIDDumpTree(hid_dev_handle_t udev, usage_tables_t *utab)
 #ifndef SHUT_MODE
 	/* extract the VendorId for further testing */
 	int vendorID = usb_device((struct usb_dev_handle *)udev)->descriptor.idVendor;
+	int productID = usb_device((struct usb_dev_handle *)udev)->descriptor.idProduct;
 #endif
 
 	/* Do not go further if we already know nothing will be displayed.
@@ -302,6 +303,13 @@ void HIDDumpTree(hid_dev_handle_t udev, usage_tables_t *utab)
 #else
 		if ((vendorID == 0x0463) || (vendorID == 0x047c)) {
 			if ((pData->ReportID == 254) || (pData->ReportID == 255)) {
+				continue;
+			}
+		}
+
+		/* skip report 0x54 for Tripplite SU3000LCD2UHV due to firmware bug */
+		if ((vendorID == 0x09ae) && (productID == 0x1330)) {
+			if (pData->ReportID == 0x54) {
 				continue;
 			}
 		}

--- a/drivers/tripplite-hid.c
+++ b/drivers/tripplite-hid.c
@@ -81,6 +81,8 @@ static usb_device_id_t tripplite_usb_device_table[] = {
 	{ USB_DEVICE(TRIPPLITE_VENDORID, 0x1008), battery_scale_0dot1 },
 	{ USB_DEVICE(TRIPPLITE_VENDORID, 0x1009), battery_scale_0dot1 },
 	{ USB_DEVICE(TRIPPLITE_VENDORID, 0x1010), battery_scale_0dot1 },
+	/* e.g. TrippLite SU3000LCD2UHV */
+	{ USB_DEVICE(TRIPPLITE_VENDORID, 0x1330), battery_scale_1dot0 },
 	/* e.g. TrippLite OMNI1000LCD */
 	{ USB_DEVICE(TRIPPLITE_VENDORID, 0x2005), battery_scale_0dot1 },
 	/* e.g. TrippLite OMNI900LCD */

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -1196,6 +1196,12 @@ static bool_t hid_ups_walk(walkmode_t mode)
 	double		value;
 	int		retcode;
 
+#ifndef SHUT_MODE
+	/* extract the VendorId for further testing */
+	int vendorID = usb_device((struct usb_dev_handle *)udev)->descriptor.idVendor;
+	int productID = usb_device((struct usb_dev_handle *)udev)->descriptor.idProduct;
+#endif
+
 	/* 3 modes: HU_WALKMODE_INIT, HU_WALKMODE_QUICK_UPDATE and HU_WALKMODE_FULL_UPDATE */
 
 	/* Device data walk ----------------------------- */
@@ -1275,6 +1281,15 @@ static bool_t hid_ups_walk(walkmode_t mode)
 		default:
 			fatalx(EXIT_FAILURE, "hid_ups_walk: unknown update mode!");
 		}
+
+#ifndef SHUT_MODE
+		/* skip report 0x54 for Tripplite SU3000LCD2UHV due to firmware bug */
+		if ((vendorID == 0x09ae) && (productID == 0x1330)) {
+			if (item->hiddata && (item->hiddata->ReportID == 0x54)) {
+				continue;
+			}
+		}
+#endif
 
 		retcode = HIDGetDataValue(udev, item->hiddata, &value, poll_interval);
 

--- a/scripts/upower/95-upower-hid.rules
+++ b/scripts/upower/95-upower-hid.rules
@@ -102,6 +102,7 @@ ATTRS{idVendor}=="09ae", ATTRS{idProduct}=="1007", ENV{UPOWER_BATTERY_TYPE}="ups
 ATTRS{idVendor}=="09ae", ATTRS{idProduct}=="1008", ENV{UPOWER_BATTERY_TYPE}="ups"
 ATTRS{idVendor}=="09ae", ATTRS{idProduct}=="1009", ENV{UPOWER_BATTERY_TYPE}="ups"
 ATTRS{idVendor}=="09ae", ATTRS{idProduct}=="1010", ENV{UPOWER_BATTERY_TYPE}="ups"
+ATTRS{idVendor}=="09ae", ATTRS{idProduct}=="1330", ENV{UPOWER_BATTERY_TYPE}="ups"
 ATTRS{idVendor}=="09ae", ATTRS{idProduct}=="2005", ENV{UPOWER_BATTERY_TYPE}="ups"
 ATTRS{idVendor}=="09ae", ATTRS{idProduct}=="2007", ENV{UPOWER_BATTERY_TYPE}="ups"
 ATTRS{idVendor}=="09ae", ATTRS{idProduct}=="2008", ENV{UPOWER_BATTERY_TYPE}="ups"


### PR DESCRIPTION
Note that protocol 1330 does not respond to requests for
UPS.OutletSystem.Outlet.DelayBeforeReboot, therefore those
requests needed to be bypassed in the driver.

Reported values appear correct, no further testing performed.

Signed-off-by: Timothy Pearson <kb9vqf@pearsoncomputing.net>