### PR TITLE
Add mib2nut listing (this should help set up snmp-ups driver)

### DIFF
--- a/docs/man/snmp-ups.txt
+++ b/docs/man/snmp-ups.txt
@@ -59,6 +59,8 @@ Cyberpower RMCARD201. Should also support RMCARD100 (net version), RMCARD202 and
 *huawei*::
 Huawei UPS5000-E, perhaps others
 
+For a more up-to-date listing, you can query the driver by passing the *mibs=--list* argument (see below).
+
 EXTRA ARGUMENTS
 ---------------
 
@@ -68,6 +70,13 @@ linkman:ups.conf[5]:
 *port*='hostname[:port]'::
 Set SNMP hostname, or IP address, and port number of the peer SNMP agent.
 There is no default for the hostname, but the default port is 161.
+
+*mibs*='--list'::
+A special option which allows to list the currently known MIB-to-NUT mappings
+and exit the driver binary, intended for command-line usage like this:
+----
+$ snmp-ups -a snmp-test -x mibs=--list
+----
 
 *mibs*='name'::
 Set MIB compliance (default=auto, allowed entries: refer to SUPPORTED HARDWARE above).

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -304,7 +304,7 @@ void upsdrv_initups(void)
 	mibs = testvar(SU_VAR_MIBS) ? getval(SU_VAR_MIBS) : "auto";
 	if (!strcmp(mibs, "--list")) {
 		printf("The 'mibs' argument is '%s', so just listing the mappings this driver knows,\n"
-		       "and for 'mibs=auto'these mappings will be tried in the following order until\n"
+		       "and for 'mibs=auto' these mappings will be tried in the following order until\n"
 		       "the first one matches your device\n\n", mibs);
 		int i;
 		printf("%7s\t%-23s\t%-7s\t%-31s\t%-s\n",

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -262,6 +262,7 @@ void upsdrv_makevartable(void)
 	upsdebugx(1, "entering %s()", __func__);
 
 	addvar(VAR_VALUE, SU_VAR_MIBS,
+		"NOTE: You can run the driver binary with '-x mibs=--list' for an up to date listing)\n"
 		"Set MIB compliance (default=ietf, allowed: mge,apcc,netvision,pw,cpqpower,...)");
 	addvar(VAR_VALUE | VAR_SENSITIVE, SU_VAR_COMMUNITY,
 		"Set community name (default=public)");
@@ -301,6 +302,24 @@ void upsdrv_initups(void)
 
 	/* Retrieve user's parameters */
 	mibs = testvar(SU_VAR_MIBS) ? getval(SU_VAR_MIBS) : "auto";
+	if (!strcmp(mibs, "--list")) {
+		printf("The 'mibs' argument is '%s', so just listing the mappings this driver knows,\n"
+		       "and for 'mibs=auto'these mappings will be tried in the following order until\n"
+		       "the first one matches your device\n\n", mibs);
+		int i;
+		printf("%7s\t%-23s\t%-7s\t%-31s\t%-s\n",
+			"NUMBER", "MAPPING NAME", "VERSION",
+			"ENTRY POINT OID", "AUTO CHECK OID");
+		for (i=0; mib2nut[i] != NULL; i++) {
+			printf(" %4d \t%-23s\t%7s\t%-31s\t%-s\n", (i+1),
+				mib2nut[i]->mib_name		? mib2nut[i]->mib_name : "<NULL>" ,
+				mib2nut[i]->mib_version 	? mib2nut[i]->mib_version : "<NULL>" ,
+				mib2nut[i]->sysOID  		? mib2nut[i]->sysOID : "<NULL>" ,
+				mib2nut[i]->oid_auto_check	? mib2nut[i]->oid_auto_check : "<NULL>" );
+		}
+		printf("\nOverall this driver has loaded %d MIB-to-NUT mapping tables\n", i);
+		fatalx(EXIT_FAILURE, "Marking the exit code as failure since the driver is not started now");
+	}
 
 	/* init SNMP library, etc... */
 	nut_snmp_init(progname, device_path);

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -88,7 +88,7 @@ static mib2nut_info_t *mib2nut[] = {
 	/*
 	 * Prepend vendor specific MIB mappings before IETF, so that
 	 * if a device supports both IETF and vendor specific MIB,
-	 * the vendor specific one takes precedence (when mib=auto)
+	 * the vendor specific one takes precedence (when mibs=auto)
 	 */
 	&ietf,
 	/* end of structure. */


### PR DESCRIPTION
Review on PR #314 mentioned that the snmp-ups manpage does not reflect all built-in MIBs. Indeed... and I found no easy way to list them in a pretty manner. So now here is one ;)