### PR TITLE
snmp-ups: add sysContact and sysLocation support

### DIFF
--- a/docs/documentation.txt
+++ b/docs/documentation.txt
@@ -63,6 +63,17 @@ or as a pull request against the
 link:https://github.com/networkupstools/nut-ddl[NUT Devices Dumps Library]
 following the naming and other rules described in the DDL documentation page.
 
+Data dumps collected by the tools above, or by `upsc` client, or by drivers
+in exploratory data-dumping mode (with `-d 1` argument), can be compared by
+ifdef::website[]
+link:https://raw.githubusercontent.com/networkupstools/nut/master/tools/nut-dumpdiff.sh[`tools/nut-dumpdiff.sh`]
+endif::website[]
+ifndef::website[]
+`./tools/nut-dumpdiff.sh`
+endif::website[]
+script from the main NUT codebase, which strips away lines with only numeric
+values (aiming to minimize the risk of losing meaningful changes like counters).
+
 Offsite Links
 -------------
 

--- a/drivers/apc-ats-mib.c
+++ b/drivers/apc-ats-mib.c
@@ -24,7 +24,7 @@
 
 #include "apc-ats-mib.h"
 
-#define APC_ATS_MIB_VERSION  "0.5"
+#define APC_ATS_MIB_VERSION  "0.6"
 
 #define APC_ATS_SYSOID       ".1.3.6.1.4.1.318.1.3.11"
 #define APC_ATS_OID_MODEL_NAME ".1.3.6.1.4.1.318.1.1.8.1.5.0"
@@ -58,6 +58,11 @@ static info_lkp_t apc_ats_outletgroups_status_info[] = {
 
 /* APC ATS Snmp2NUT lookup table */
 static snmp_info_t apc_ats_mib[] = {
+
+	/* standard MIB items */
+	{ "device.description", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.1.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.contact", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.4.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.location", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.6.0", NULL, SU_FLAG_OK, NULL },
 
 	/* Device collection */
 	{ "device.type", ST_FLAG_STRING, SU_INFOSIZE, NULL, "ats", SU_FLAG_STATIC | SU_FLAG_ABSENT | SU_FLAG_OK, NULL },

--- a/drivers/apc-mib.c
+++ b/drivers/apc-mib.c
@@ -192,7 +192,7 @@ static snmp_info_t apcc_mib[] = {
 	{ "input.frequency", 0, 1, ".1.3.6.1.4.1.318.1.1.1.3.2.4.0", "", SU_FLAG_OK, NULL },
 	{ "input.transfer.low", ST_FLAG_STRING | ST_FLAG_RW, 3, ".1.3.6.1.4.1.318.1.1.1.5.2.3.0", "", SU_TYPE_INT | SU_FLAG_OK, NULL },
 	{ "input.transfer.high", ST_FLAG_STRING | ST_FLAG_RW, 3, ".1.3.6.1.4.1.318.1.1.1.5.2.2.0", "", SU_TYPE_INT | SU_FLAG_OK, NULL },
-    { "input.transfer.reason", ST_FLAG_STRING, 1, APCC_OID_TRANSFERREASON, "", SU_TYPE_INT | SU_FLAG_OK, apcc_transfer_reasons },
+	{ "input.transfer.reason", ST_FLAG_STRING, 1, APCC_OID_TRANSFERREASON, "", SU_TYPE_INT | SU_FLAG_OK, apcc_transfer_reasons },
 	{ "input.sensitivity", ST_FLAG_STRING | ST_FLAG_RW, 1, APCC_OID_SENSITIVITY, "", SU_TYPE_INT | SU_FLAG_OK, apcc_sensitivity_modes },
 	{ "ups.power", 0, 1, ".1.3.6.1.4.1.318.1.1.1.4.2.9.0", "", SU_FLAG_OK, NULL },
 	{ "ups.realpower", 0, 1, ".1.3.6.1.4.1.318.1.1.1.4.2.8.0", "", SU_FLAG_OK, NULL },

--- a/drivers/apc-mib.c
+++ b/drivers/apc-mib.c
@@ -26,7 +26,7 @@
 
 #include "apc-mib.h"
 
-#define APCC_MIB_VERSION	"1.5"
+#define APCC_MIB_VERSION	"1.6"
 
 #define APC_UPS_DEVICE_MODEL	".1.3.6.1.4.1.318.1.1.1.1.1.1.0"
 /* FIXME: Find a better oid_auto_check vs sysOID for this one? */
@@ -150,6 +150,11 @@ static info_lkp_t apcc_transfer_reasons[] = {
 
 
 static snmp_info_t apcc_mib[] = {
+
+	/* standard MIB items */
+	{ "device.description", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.1.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.contact", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.4.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.location", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.6.0", NULL, SU_FLAG_OK, NULL },
 
 	/* info elements. */
 	{ "ups.mfr", ST_FLAG_STRING, SU_INFOSIZE, NULL, "APC",

--- a/drivers/baytech-mib.c
+++ b/drivers/baytech-mib.c
@@ -24,7 +24,7 @@
 #include "baytech-mib.h"
 
 /* NOTE: last badly versioned release was "4032" but should be "X.Y[Z]"! */
-#define BAYTECH_MIB_VERSION	"0.4033"
+#define BAYTECH_MIB_VERSION	"0.4034"
 
 /* Baytech MIB */
 #define BAYTECH_OID_MIB			".1.3.6.1.4.1.4779"
@@ -40,6 +40,12 @@ static info_lkp_t baytech_outlet_status_info[] = {
 
 /* Snmp2NUT lookup table for BayTech MIBs */
 static snmp_info_t baytech_mib[] = {
+
+	/* standard MIB items */
+	{ "device.description", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.1.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.contact", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.4.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.location", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.6.0", NULL, SU_FLAG_OK, NULL },
+
 	/* Device page */
 	{ "device.mfr", ST_FLAG_STRING, SU_INFOSIZE, NULL, "BayTech",
 		SU_FLAG_STATIC | SU_FLAG_ABSENT | SU_FLAG_OK, NULL },

--- a/drivers/bestpower-mib.c
+++ b/drivers/bestpower-mib.c
@@ -22,7 +22,7 @@
 
 #include "bestpower-mib.h"
 
-#define BESTPOWER_MIB_VERSION		"0.3"
+#define BESTPOWER_MIB_VERSION		"0.4"
 #define BESTPOWER_OID_MODEL_NAME	".1.3.6.1.4.1.2947.1.1.2.0"
 
 /*
@@ -42,6 +42,12 @@ static info_lkp_t bestpower_power_status[] = {
 
 /* Snmp2NUT lookup table for Best Power MIB */
 static snmp_info_t bestpower_mib[] = {
+
+	/* standard MIB items */
+	{ "device.description", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.1.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.contact", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.4.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.location", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.6.0", NULL, SU_FLAG_OK, NULL },
+
 	/* Device page */
 	{ "device.type", ST_FLAG_STRING, SU_INFOSIZE, NULL, "ups",
 		SU_FLAG_STATIC | SU_FLAG_ABSENT | SU_FLAG_OK, NULL },

--- a/drivers/compaq-mib.c
+++ b/drivers/compaq-mib.c
@@ -30,7 +30,7 @@
 
 #include "compaq-mib.h"
 
-#define CPQPOWER_MIB_VERSION	"1.65"
+#define CPQPOWER_MIB_VERSION	"1.66"
 
 #define DEFAULT_ONDELAY		"30"
 #define DEFAULT_OFFDELAY	"20"
@@ -173,6 +173,12 @@ static info_lkp_t cpqpower_outlet_switchability_info[] = {
 /* Snmp2NUT lookup table */
 
 static snmp_info_t cpqpower_mib[] = {
+
+	/* standard MIB items */
+	{ "device.description", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.1.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.contact", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.4.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.location", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.6.0", NULL, SU_FLAG_OK, NULL },
+
 	/* UPS page */
 	/* info_type, info_flags, info_len, OID, dfl, flags, oid2info, setvar */
 	{ "ups.mfr", ST_FLAG_STRING, SU_INFOSIZE, CPQPOWER_OID_MFR_NAME, "HP/Compaq", SU_FLAG_STATIC, NULL },

--- a/drivers/cyberpower-mib.c
+++ b/drivers/cyberpower-mib.c
@@ -24,7 +24,7 @@
 
 #include "cyberpower-mib.h"
 
-#define CYBERPOWER_MIB_VERSION		"0.4"
+#define CYBERPOWER_MIB_VERSION		"0.5"
 #define CYBERPOWER_OID_MODEL_NAME	".1.3.6.1.4.1.3808.1.1.1.1.1.1.0"
 
 /* CPS-MIB::ups */
@@ -63,6 +63,12 @@ static info_lkp_t cyberpower_battrepl_status[] = {
 
 /* Snmp2NUT lookup table for CyberPower MIB */
 static snmp_info_t cyberpower_mib[] = {
+
+	/* standard MIB items */
+	{ "device.description", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.1.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.contact", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.4.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.location", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.6.0", NULL, SU_FLAG_OK, NULL },
+
 	/* Device page */
 	{ "device.type", ST_FLAG_STRING, SU_INFOSIZE, NULL, "ups",
 		SU_FLAG_STATIC | SU_FLAG_ABSENT | SU_FLAG_OK, NULL },

--- a/drivers/delta_ups-mib.c
+++ b/drivers/delta_ups-mib.c
@@ -25,7 +25,7 @@
 
 #include "delta_ups-mib.h"
 
-#define DELTA_UPS_MIB_VERSION  "0.4"
+#define DELTA_UPS_MIB_VERSION  "0.5"
 
 #define DELTA_UPS_SYSOID       ".1.3.6.1.4.1.2254.2.4"
 
@@ -86,6 +86,11 @@ static snmp_info_t delta_ups_mib[] = {
 	 * 	{ 0, NULL }
 	 * };
 	 */
+
+	/* standard MIB items */
+	{ "device.description", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.1.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.contact", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.4.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.location", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.6.0", NULL, SU_FLAG_OK, NULL },
 
 	/* dupsIdentManufacturer.0 = STRING: "Socomec" */
 	{ "ups.mfr", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.2254.2.4.1.1.0", NULL, SU_FLAG_OK, NULL },

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -261,7 +261,7 @@ static int send_to_one(conn_t *conn, const char *fmt, ...)
 	if (ret <= INT_MAX)
 		upsdebugx(5, "%s: %.*s", __func__, (int)(ret-1), buf);
 
-	ret = write(conn->fd, buf, strlen(buf));
+	ret = write(conn->fd, buf, buflen);
 
 	if ((ret < 1) || (ret != (ssize_t)buflen)) {
 		upsdebugx(1, "%s: write %zd bytes to socket %d failed "

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -213,7 +213,10 @@ static void send_to_all(const char *fmt, ...)
 		ret = write(conn->fd, buf, buflen);
 
 		if ((ret < 1) || (ret != (ssize_t)buflen)) {
-			upsdebugx(1, "write %zd bytes to socket %d failed", buflen, conn->fd);
+			upsdebugx(1, "%s: write %zd bytes to socket %d failed "
+				"(ret=%zd): %s",
+				__func__, buflen, conn->fd, ret, strerror(errno));
+			upsdebugx(6, "failed write: %s", buf);
 			sock_disconnect(conn);
 		}
 	}
@@ -261,7 +264,10 @@ static int send_to_one(conn_t *conn, const char *fmt, ...)
 	ret = write(conn->fd, buf, strlen(buf));
 
 	if ((ret < 1) || (ret != (ssize_t)buflen)) {
-		upsdebugx(1, "write %zd bytes to socket %d failed", buflen, conn->fd);
+		upsdebugx(1, "%s: write %zd bytes to socket %d failed "
+			"(ret=%zd): %s",
+			__func__, buflen, conn->fd, ret, strerror(errno));
+		upsdebugx(6, "failed write: %s", buf);
 		sock_disconnect(conn);
 		return 0;	/* failed */
 	}

--- a/drivers/eaton-ats16-nm2-mib.c
+++ b/drivers/eaton-ats16-nm2-mib.c
@@ -25,7 +25,7 @@
 
 #include "eaton-ats16-nm2-mib.h"
 
-#define EATON_ATS16_NM2_MIB_VERSION  "0.20"
+#define EATON_ATS16_NM2_MIB_VERSION  "0.21"
 
 #define EATON_ATS16_NM2_SYSOID  ".1.3.6.1.4.1.534.10.2" /* newer Network-M2 */
 #define EATON_ATS16_NM2_MODEL   ".1.3.6.1.4.1.534.10.2.1.2.0"
@@ -80,6 +80,11 @@ static info_lkp_t eaton_ats16_nm2_output_status_info[] = {
 
 /* EATON_ATS Snmp2NUT lookup table */
 static snmp_info_t eaton_ats16_nm2_mib[] = {
+
+	/* standard MIB items */
+	{ "device.description", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.1.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.contact", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.4.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.location", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.6.0", NULL, SU_FLAG_OK, NULL },
 
 	/* Device collection */
 	{ "device.type", ST_FLAG_STRING, SU_INFOSIZE, NULL, "ats", SU_FLAG_STATIC | SU_FLAG_ABSENT | SU_FLAG_OK, NULL },

--- a/drivers/eaton-ats16-nmc-mib.c
+++ b/drivers/eaton-ats16-nmc-mib.c
@@ -25,7 +25,7 @@
 
 #include "eaton-ats16-nmc-mib.h"
 
-#define EATON_ATS16_NMC_MIB_VERSION  "0.19"
+#define EATON_ATS16_NMC_MIB_VERSION  "0.20"
 
 #define EATON_ATS16_NMC_SYSOID  ".1.3.6.1.4.1.705.1"    /* legacy NMC */
 #define EATON_ATS16_NMC_MODEL   ".1.3.6.1.4.1.534.10.2.1.2.0"
@@ -80,6 +80,11 @@ static info_lkp_t eaton_ats16_nmc_output_status_info[] = {
 
 /* EATON_ATS_NMC Snmp2NUT lookup table */
 static snmp_info_t eaton_ats16_nmc_mib[] = {
+
+	/* standard MIB items */
+	{ "device.description", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.1.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.contact", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.4.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.location", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.6.0", NULL, SU_FLAG_OK, NULL },
 
 	/* Device collection */
 	{ "device.type", ST_FLAG_STRING, SU_INFOSIZE, NULL, "ats", SU_FLAG_STATIC | SU_FLAG_ABSENT | SU_FLAG_OK, NULL },

--- a/drivers/eaton-pdu-genesis2-mib.c
+++ b/drivers/eaton-pdu-genesis2-mib.c
@@ -29,7 +29,7 @@
 
 #include "eaton-pdu-genesis2-mib.h"
 
-#define EATON_APHEL_GENESIS2_MIB_VERSION	"0.51"
+#define EATON_APHEL_GENESIS2_MIB_VERSION	"0.52"
 
 /* APHEL-GENESIS-II-MIB (monitored ePDU)
  * *************************************
@@ -48,6 +48,12 @@
 
 /* Snmp2NUT lookup table for GenesisII MIB */
 static snmp_info_t eaton_aphel_genesisII_mib[] = {
+
+	/* standard MIB items */
+	{ "device.description", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.1.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.contact", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.4.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.location", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.6.0", NULL, SU_FLAG_OK, NULL },
+
 	/* Device page */
 	{ "device.mfr", ST_FLAG_STRING, SU_INFOSIZE, NULL, "EATON | Powerware",
 		SU_FLAG_STATIC | SU_FLAG_ABSENT | SU_FLAG_OK, NULL },

--- a/drivers/eaton-pdu-marlin-mib.c
+++ b/drivers/eaton-pdu-marlin-mib.c
@@ -34,7 +34,7 @@
 /* Eaton PDU-MIB - Marlin MIB
  * ************************** */
 
-#define EATON_MARLIN_MIB_VERSION	"0.58"
+#define EATON_MARLIN_MIB_VERSION	"0.59"
 #define EATON_MARLIN_SYSOID			".1.3.6.1.4.1.534.6.6.7"
 #define EATON_MARLIN_OID_MODEL_NAME	".1.3.6.1.4.1.534.6.6.7.1.2.1.2.0"
 
@@ -231,6 +231,11 @@ static info_lkp_t marlin_outlet_group_phase_info[] = {
 
 /* Snmp2NUT lookup table for Eaton Marlin MIB */
 static snmp_info_t eaton_marlin_mib[] = {
+
+	/* standard MIB items */
+	{ "device.description", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.1.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.contact", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.4.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.location", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.6.0", NULL, SU_FLAG_OK, NULL },
 
 	/* Device collection */
 	{ "device.mfr", ST_FLAG_STRING, SU_INFOSIZE, NULL, "EATON",

--- a/drivers/eaton-pdu-marlin-mib.c
+++ b/drivers/eaton-pdu-marlin-mib.c
@@ -217,7 +217,7 @@ static const char *marlin_outlet_group_phase_fun(void *raw_outlet_group_nb)
 			snprintf(marlin_scratch_buf, sizeof(marlin_scratch_buf), "L%i", phases_nb);
 			if (phases_nb < 1 || phases_nb > 3)
 				upsdebugx(3, "WARNING: %s got %i phases which is an unexpected amount",
-				        __func__, phases_nb);
+					__func__, phases_nb);
 
 			return marlin_scratch_buf;
 		}

--- a/drivers/eaton-pdu-pulizzi-mib.c
+++ b/drivers/eaton-pdu-pulizzi-mib.c
@@ -42,7 +42,7 @@
 
 /* Pulizzi Switched ePDU */
 
-#define EATON_PULIZZI_SW_MIB_VERSION	"0.4"
+#define EATON_PULIZZI_SW_MIB_VERSION	"0.5"
 
 #define PULIZZI_SW_OID_MIB			".1.3.6.1.4.1.20677.3.1.1"
 #define PULIZZI_SW_OID_MODEL_NAME		".1.3.6.1.4.1.20677.2.1.1.0"
@@ -67,6 +67,12 @@ static info_lkp_t pulizzi_sw_outlet_switchability_info[] = {
 
 /* Snmp2NUT lookup table for Eaton Pulizzi Switched ePDU MIB */
 static snmp_info_t eaton_pulizzi_switched_mib[] = {
+
+	/* standard MIB items */
+	{ "device.description", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.1.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.contact", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.4.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.location", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.6.0", NULL, SU_FLAG_OK, NULL },
+
 	/* Device page */
 	{ "device.mfr", ST_FLAG_STRING, SU_INFOSIZE, NULL, "EATON | Powerware",
 		SU_FLAG_STATIC | SU_FLAG_ABSENT | SU_FLAG_OK, NULL },

--- a/drivers/eaton-pdu-revelation-mib.c
+++ b/drivers/eaton-pdu-revelation-mib.c
@@ -29,7 +29,7 @@
 
 #include "eaton-pdu-revelation-mib.h"
 
-#define EATON_APHEL_REVELATION_MIB_VERSION	"0.51"
+#define EATON_APHEL_REVELATION_MIB_VERSION	"0.52"
 
 /* APHEL PDU-MIB - Revelation MIB (Managed ePDU)
  * ********************************************* */
@@ -86,6 +86,12 @@ static info_lkp_t revelation_outlet_switchability_info[] = {
 
 /* Snmp2NUT lookup table for Eaton Revelation MIB */
 static snmp_info_t eaton_aphel_revelation_mib[] = {
+
+	/* standard MIB items */
+	{ "device.description", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.1.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.contact", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.4.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.location", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.6.0", NULL, SU_FLAG_OK, NULL },
+
 	/* Device collection */
 	{ "device.mfr", ST_FLAG_STRING, SU_INFOSIZE, NULL, "EATON | Powerware",
 		SU_FLAG_STATIC | SU_FLAG_ABSENT | SU_FLAG_OK, NULL },

--- a/drivers/emerson-avocent-pdu-mib.c
+++ b/drivers/emerson-avocent-pdu-mib.c
@@ -25,16 +25,16 @@
 
 #include "emerson-avocent-pdu-mib.h"
 
-#define EMERSON_AVOCENT_MIB_VERSION		"1.2"
+#define EMERSON_AVOCENT_MIB_VERSION		"1.3"
 #define EMERSON_AVOCENT_SYSOID			".1.3.6.1.4.1.10418.17.1.7"
 #define EMERSON_AVOCENT_OID_MODEL_NAME	".1.3.6.1.4.1.10418.17.2.1.2.0"
 
 /* FIXME: Avocent PM's seem to have 3 temperature sensors (index 1, 2, 3)
  * for the embedded temperature (equivalent to ups.temperature) */
-#define AVOCENT_OID_UNIT_TEMPERATURE ".1.3.6.1.4.1.10418.17.2.5.3.1.17.1.1"
+#define AVOCENT_OID_UNIT_TEMPERATURE	".1.3.6.1.4.1.10418.17.2.5.3.1.17.1.1"
 
 /* Same as above for humidity... */
-#define AVOCENT_OID_UNIT_HUMIDITY ".1.3.6.1.4.1.10418.17.2.5.3.1.24.1"
+#define AVOCENT_OID_UNIT_HUMIDITY	".1.3.6.1.4.1.10418.17.2.5.3.1.24.1"
 
 #define AVOCENT_OID_OUTLET_COUNT	".1.3.6.1.4.1.10418.17.2.5.3.1.8.%i.%i"
 
@@ -42,7 +42,7 @@
 #define AVOCENT_OID_UNIT_CURRENT	".1.3.6.1.4.1.10418.17.2.5.3.1.10.1.1"
 /* FIXME: This is actually pmPowerMgmtPDUTableVoltage1Value */
 #define AVOCENT_OID_UNIT_VOLTAGE	".1.3.6.1.4.1.10418.17.2.5.3.1.31.1.1"
-#define AVOCENT_OID_UNIT_MACADDR        ".1.3.6.1.2.1.2.2.1.6.1"
+#define AVOCENT_OID_UNIT_MACADDR	".1.3.6.1.2.1.2.2.1.6.1"
 
 #ifdef OPENGEAR_MULTIPLE_BANKS
 #define AVOCENT_OID_OUTLET_ID		".1.3.6.1.4.1.10418.17.2.5.5.1.3"

--- a/drivers/emerson-avocent-pdu-mib.c
+++ b/drivers/emerson-avocent-pdu-mib.c
@@ -76,6 +76,12 @@ static info_lkp_t avocent_outlet_status_info[] = {
 };
 
 static snmp_info_t emerson_avocent_pdu_mib[] = {
+
+	/* standard MIB items */
+	{ "device.description", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.1.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.contact", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.4.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.location", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.6.0", NULL, SU_FLAG_OK, NULL },
+
 	/* Device page */
 	{ "device.mfr", ST_FLAG_STRING, SU_INFOSIZE, NULL, "Avocent",
 		SU_FLAG_STATIC | SU_FLAG_ABSENT | SU_FLAG_OK, NULL },

--- a/drivers/hpe-pdu-mib.c
+++ b/drivers/hpe-pdu-mib.c
@@ -24,7 +24,7 @@
 #include "hpe-pdu-mib.h"
 #include "dstate.h"
 
-#define HPE_EPDU_MIB_VERSION      "0.32"
+#define HPE_EPDU_MIB_VERSION      "0.33"
 #define HPE_EPDU_MIB_SYSOID       ".1.3.6.1.4.1.232.165.7"
 #define HPE_EPDU_OID_MODEL_NAME	".1.3.6.1.4.1.232.165.7.1.2.1.3.0"
 
@@ -175,6 +175,11 @@ static info_lkp_t hpe_pdu_outlet_group_phase_info[] = {
 
 /* Snmp2NUT lookup table for HPE PDU MIB */
 static snmp_info_t hpe_pdu_mib[] = {
+
+	/* standard MIB items */
+	{ "device.description", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.1.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.contact", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.4.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.location", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.6.0", NULL, SU_FLAG_OK, NULL },
 
 	/* Device collection */
 	{ "device.mfr", ST_FLAG_STRING, SU_INFOSIZE, NULL, "HPE",

--- a/drivers/huawei-mib.c
+++ b/drivers/huawei-mib.c
@@ -21,7 +21,7 @@
 
 #include "huawei-mib.h"
 
-#define HUAWEI_MIB_VERSION  "0.3"
+#define HUAWEI_MIB_VERSION  "0.4"
 
 #define HUAWEI_SYSOID       ".1.3.6.1.4.1.8072.3.2.10"
 #define HUAWEI_UPSMIB       ".1.3.6.1.4.1.2011"
@@ -140,6 +140,11 @@ static snmp_info_t huawei_mib[] = {
 	 * 	{ 0, NULL }
 	 * };
 	 */
+
+	/* standard MIB items */
+	{ "device.description", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.1.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.contact", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.4.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.location", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.6.0", NULL, SU_FLAG_OK, NULL },
 
 	/* UPS page */
 

--- a/drivers/ietf-mib.c
+++ b/drivers/ietf-mib.c
@@ -26,7 +26,7 @@
 
 #include "ietf-mib.h"
 
-#define IETF_MIB_VERSION	"1.53"
+#define IETF_MIB_VERSION	"1.54"
 
 /* SNMP OIDs set */
 #define IETF_OID_UPS_MIB	"1.3.6.1.2.1.33.1."
@@ -111,6 +111,12 @@ static info_lkp_t ietf_beeper_status_info[] = {
 
 /* Snmp2NUT lookup table info_type, info_flags, info_len, OID, dfl, flags, oid2info, setvar */
 static snmp_info_t ietf_mib[] = {
+
+	/* standard MIB items */
+	{ "device.description", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.1.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.contact", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.4.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.location", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.6.0", NULL, SU_FLAG_OK, NULL },
+
 	/* The Device Identification group */
 	{ "ups.mfr", ST_FLAG_STRING, SU_INFOSIZE, IETF_OID_UPS_MIB "1.1.0", "Generic", SU_FLAG_STATIC, NULL }, /* upsIdentManufacturer */
 	{ "ups.model", ST_FLAG_STRING, SU_INFOSIZE, IETF_OID_UPS_MIB "1.2.0", "Generic SNMP UPS", SU_FLAG_STATIC, NULL }, /* upsIdentModel */

--- a/drivers/mge-mib.c
+++ b/drivers/mge-mib.c
@@ -27,7 +27,7 @@
 
 #include "mge-mib.h"
 
-#define MGE_MIB_VERSION	"0.53"
+#define MGE_MIB_VERSION	"0.54"
 
 /* TODO:
  * - MGE PDU MIB and sysOID (".1.3.6.1.4.1.705.2") */
@@ -146,6 +146,11 @@ static info_lkp_t mge_power_source_info[] = {
 
 /* Snmp2NUT lookup table */
 static snmp_info_t mge_mib[] = {
+
+	/* standard MIB items */
+	{ "device.description", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.1.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.contact", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.4.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.location", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.6.0", NULL, SU_FLAG_OK, NULL },
 
 	/* UPS page */
 	{ "ups.mfr", ST_FLAG_STRING, SU_INFOSIZE, NULL, "Eaton", SU_FLAG_STATIC | SU_FLAG_ABSENT | SU_FLAG_OK, NULL },

--- a/drivers/netvision-mib.c
+++ b/drivers/netvision-mib.c
@@ -25,7 +25,7 @@
 
 #include "netvision-mib.h"
 
-#define NETVISION_MIB_VERSION			"0.43"
+#define NETVISION_MIB_VERSION			"0.44"
 
 #define NETVISION_SYSOID				".1.3.6.1.4.1.4555.1.1.1"
 
@@ -115,6 +115,12 @@ static info_lkp_t netvision_output_info[] = {
 
 /* Snmp2NUT lookup table */
 static snmp_info_t netvision_mib[] = {
+
+	/* standard MIB items */
+	{ "device.description", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.1.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.contact", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.4.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.location", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.6.0", NULL, SU_FLAG_OK, NULL },
+
 	{ "ups.mfr", ST_FLAG_STRING, SU_INFOSIZE, NETVISION_OID_UPSIDENTAGENTSWVERSION, "SOCOMEC SICON UPS",
 		SU_FLAG_STATIC | SU_FLAG_OK, NULL },
 	{ "ups.model", ST_FLAG_STRING, SU_INFOSIZE, NETVISION_OID_UPSIDENTMODEL,

--- a/drivers/powerware-mib.c
+++ b/drivers/powerware-mib.c
@@ -25,7 +25,7 @@
 
 #include "powerware-mib.h"
 
-#define PW_MIB_VERSION "0.94"
+#define PW_MIB_VERSION "0.95"
 
 /* TODO: more sysOID and MIBs support:
  *
@@ -197,6 +197,12 @@ static info_lkp_t pw_yes_no_info[] = {
 /* Snmp2NUT lookup table */
 
 static snmp_info_t pw_mib[] = {
+
+	/* standard MIB items */
+	{ "device.description", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.1.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.contact", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.4.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.location", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.6.0", NULL, SU_FLAG_OK, NULL },
+
 	/* FIXME: miss device page! */
 	/* UPS page */
 	/* info_type, info_flags, info_len, OID, dfl, flags, oid2info, setvar */

--- a/drivers/raritan-pdu-mib.c
+++ b/drivers/raritan-pdu-mib.c
@@ -25,7 +25,7 @@
 
 #include "raritan-pdu-mib.h"
 
-#define RARITAN_MIB_VERSION	"0.7"
+#define RARITAN_MIB_VERSION	"0.8"
 
 /* Raritan MIB
  * this one uses the same MIB as Eaton Revelation,
@@ -48,6 +48,12 @@ static info_lkp_t raritan_pdu_outlet_status_info[] = {
 
 /* Snmp2NUT lookup table for Raritan MIB */
 static snmp_info_t raritan_mib[] = {
+
+	/* standard MIB items */
+	{ "device.description", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.1.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.contact", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.4.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.location", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.6.0", NULL, SU_FLAG_OK, NULL },
+
 	/* Device page */
 	{ "device.mfr", ST_FLAG_STRING, SU_INFOSIZE, NULL, "Raritan",
 		SU_FLAG_STATIC | SU_FLAG_ABSENT | SU_FLAG_OK, NULL },

--- a/drivers/raritan-px2-mib.c
+++ b/drivers/raritan-px2-mib.c
@@ -23,7 +23,7 @@
 
 #include "raritan-px2-mib.h"
 
-#define RARITAN_PX2_MIB_VERSION  "0.3"
+#define RARITAN_PX2_MIB_VERSION  "0.4"
 
 #define RARITAN_PX2_MIB_SYSOID     ".1.3.6.1.4.1.13742.6"
 #define RARITAN_PX2_OID_MODEL_NAME ".1.3.6.1.4.1.13742.6.3.2.1.1.3.1"
@@ -66,6 +66,11 @@ static info_lkp_t raritanpx2_outlet_switchability_info[] = {
 
 /* PDU2-MIB Snmp2NUT lookup table */
 static snmp_info_t raritan_px2_mib[] = {
+
+	/* standard MIB items */
+	{ "device.description", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.1.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.contact", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.4.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.location", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.6.0", NULL, SU_FLAG_OK, NULL },
 
 	/* pduManufacturer.1 = STRING: Raritan */
 	{ "device.mfr", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.13742.6.3.2.1.1.2.1",

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -680,7 +680,9 @@ void upsdrv_initups(void)
 	 * tables (note: for lack of better knowledge, defined as read-only
 	 * entries here, and also read-once - not updated during driver uptime) */
 
-	if (NULL == dstate_getinfo("device.description")) {
+	if (NULL == dstate_getinfo("device.description")
+	&&  NULL == dstate_getinfo("device.1.description")
+	) {
 		/* sysDescr.0 */
 		if (nut_snmp_get_str(".1.3.6.1.2.1.1.1.0", model, sizeof(model), NULL) == TRUE) {
 			upsdebugx(2, "Using IETF-MIB default to get and publish sysDescr for device.description (once)");
@@ -690,7 +692,9 @@ void upsdrv_initups(void)
 		}
 	}
 
-	if (NULL == dstate_getinfo("device.contact")) {
+	if (NULL == dstate_getinfo("device.contact")
+	&&  NULL == dstate_getinfo("device.1.contact")
+	) {
 		/* sysContact.0 */
 		if (nut_snmp_get_str(".1.3.6.1.2.1.1.4.0", model, sizeof(model), NULL) == TRUE) {
 			upsdebugx(2, "Using IETF-MIB default to get and publish sysContact for device.contact (once)");
@@ -700,7 +704,9 @@ void upsdrv_initups(void)
 		}
 	}
 
-	if (NULL == dstate_getinfo("device.location")) {
+	if (NULL == dstate_getinfo("device.location")
+	&&  NULL == dstate_getinfo("device.1.location")
+	) {
 		/* sysLocation.0 */
 		if (nut_snmp_get_str(".1.3.6.1.2.1.1.6.0", model, sizeof(model), NULL) == TRUE) {
 			upsdebugx(2, "Using IETF-MIB default to get and publish sysLocation for device.location (once)");

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -675,18 +675,30 @@ void upsdrv_initups(void)
 		dstate_addcmd("shutdown.stayoff");
 	}
 
-	/* Publish sysContact and sysLocation for all subdrivers */
-	/* sysContact.0 */
-	if (nut_snmp_get_str(".1.3.6.1.2.1.1.4.0", model, sizeof(model), NULL) == TRUE)
-		dstate_setinfo("device.contact", "%s", model);
-	else
-		upsdebugx(2, "Can't get and publish sysContact for device.contact");
+	/* Publish sysContact and sysLocation (from IETF standard paths)
+	 * for all subdrivers that do not have one defined in their mapping
+	 * tables (note: for lack of better knowledge, defined as read-only
+	 * entries here) */
 
-	/* sysLocation.0 */
-	if (nut_snmp_get_str(".1.3.6.1.2.1.1.6.0", model, sizeof(model), NULL) == TRUE)
-		dstate_setinfo("device.location", "%s", model);
-	else
-		upsdebugx(2, "Can't get and publish sysLocation for device.location");
+	if (NULL == dstate_getinfo("device.contact")) {
+		/* sysContact.0 */
+		if (nut_snmp_get_str(".1.3.6.1.2.1.1.4.0", model, sizeof(model), NULL) == TRUE) {
+			upsdebugx(2, "Using IETF-MIB default to get and publish sysContact for device.contact");
+			dstate_setinfo("device.contact", "%s", model);
+		} else {
+			upsdebugx(2, "Can't get and publish sysContact for device.contact");
+		}
+	}
+
+	if (NULL == dstate_getinfo("device.location")) {
+		/* sysLocation.0 */
+		if (nut_snmp_get_str(".1.3.6.1.2.1.1.6.0", model, sizeof(model), NULL) == TRUE) {
+			upsdebugx(2, "Using IETF-MIB default to get and publish sysLocation for device.location");
+			dstate_setinfo("device.location", "%s", model);
+		} else {
+			upsdebugx(2, "Can't get and publish sysLocation for device.location");
+		}
+	}
 
 	/* set shutdown and autostart delay */
 	set_delays();

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -3382,18 +3382,32 @@ static int su_setOID(int mode, const char *varname, const char *val)
 					__func__, daisychain_device_number, devices_count);
 		}
 		else {
-			/* TODO: Ideally, check if "OID" contains ".%i" template text like:
-			 *   (su_info_p->OID == NULL || strstr(su_info_p->OID, ".%i") != NULL)
+			/* Note: below we check if "OID" contains ".%i" template text
 			 * like we do in su_setinfo(); eventually we might get vendor
 			 * MIBs that do expose device.contact/location/description
 			 * for each link in the chain...
 			 */
 			if (daisychain_enabled == TRUE) {
-				daisychain_device_number = 1;
+				/* Is the original "device.varname" backed by a templated
+				 * OID string, so we can commonly set e.g. device.contact
+				 * for everything in the chain?
+				 */
+				su_info_p = su_find_info(varname);
+				if (su_info_p
+				&&  (su_info_p->OID == NULL || strstr(su_info_p->OID, ".%i") != NULL)
+				) {
+					/* is templated or defaulted */
+					daisychain_device_number = 0;
+				} else {
+					daisychain_device_number = 1;
+				}
+
 				upsdebugx(2, "%s: got an un-numbered daisychain %s (%s), "
-					"directing it to 'master' device %i",
+					"directing it to %s",
 					__func__, (mode==SU_MODE_INSTCMD)?"command":"setting",
-					varname, daisychain_device_number);
+					varname,
+					(daisychain_device_number==1)?"'master' device":"all devices"
+					);
 			} else {
 				/* No daisy, no poppy */
 				daisychain_device_number = 0;

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -150,7 +150,7 @@ static const char *mibname;
 static const char *mibvers;
 
 #define DRIVER_NAME	"Generic SNMP UPS driver"
-#define DRIVER_VERSION		"1.18"
+#define DRIVER_VERSION		"1.19"
 
 /* driver description structure */
 upsdrv_info_t	upsdrv_info = {
@@ -674,6 +674,19 @@ void upsdrv_initups(void)
 		dstate_addcmd("shutdown.return");
 		dstate_addcmd("shutdown.stayoff");
 	}
+
+	/* Publish sysContact and sysLocation for all subdrivers */
+	/* sysContact.0 */
+	if (nut_snmp_get_str(".1.3.6.1.2.1.1.4.0", model, sizeof(model), NULL) == TRUE)
+		dstate_setinfo("device.contact", "%s", model);
+	else
+		upsdebugx(2, "Can't get and publish sysContact for device.contact");
+
+	/* sysLocation.0 */
+	if (nut_snmp_get_str(".1.3.6.1.2.1.1.6.0", model, sizeof(model), NULL) == TRUE)
+		dstate_setinfo("device.location", "%s", model);
+	else
+		upsdebugx(2, "Can't get and publish sysLocation for device.location");
 
 	/* set shutdown and autostart delay */
 	set_delays();

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -273,9 +273,11 @@ void upsdrv_updateinfo(void)
 
 		/* update all dynamic info fields */
 		if (snmp_ups_walk(SU_WALKMODE_UPDATE)) {
+			upsdebugx(1, "%s: pollfreq: Data OK", __func__);
 			dstate_dataok();
 		}
 		else {
+			upsdebugx(1, "%s: pollfreq: Data STALE", __func__);
 			dstate_datastale();
 		}
 

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -1527,7 +1527,8 @@ void su_setinfo(snmp_info_t *su_info_p, const char *value)
 	char info_type[128]; /* We tweak incoming "su_info_p->info_type" value in some cases */
 
 /* FIXME: Replace hardcoded 128 with a macro above (use {SU_}LARGEBUF?),
- *and same macro or sizeof(info_type) below? */
+ * and same macro or sizeof(info_type) below (also more 128 cases below)?
+ */
 
 	upsdebugx(1, "entering %s(%s, %s)", __func__, su_info_p->info_type, (value)?value:"");
 

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -678,12 +678,12 @@ void upsdrv_initups(void)
 	/* Publish sysDescr, sysContact and sysLocation (from IETF standard paths)
 	 * for all subdrivers that do not have one defined in their mapping
 	 * tables (note: for lack of better knowledge, defined as read-only
-	 * entries here) */
+	 * entries here, and also read-once - not updated during driver uptime) */
 
 	if (NULL == dstate_getinfo("device.description")) {
 		/* sysDescr.0 */
 		if (nut_snmp_get_str(".1.3.6.1.2.1.1.1.0", model, sizeof(model), NULL) == TRUE) {
-			upsdebugx(2, "Using IETF-MIB default to get and publish sysDescr for device.description");
+			upsdebugx(2, "Using IETF-MIB default to get and publish sysDescr for device.description (once)");
 			dstate_setinfo("device.description", "%s", model);
 		} else {
 			upsdebugx(2, "Can't get and publish sysDescr for device.description");
@@ -693,7 +693,7 @@ void upsdrv_initups(void)
 	if (NULL == dstate_getinfo("device.contact")) {
 		/* sysContact.0 */
 		if (nut_snmp_get_str(".1.3.6.1.2.1.1.4.0", model, sizeof(model), NULL) == TRUE) {
-			upsdebugx(2, "Using IETF-MIB default to get and publish sysContact for device.contact");
+			upsdebugx(2, "Using IETF-MIB default to get and publish sysContact for device.contact (once)");
 			dstate_setinfo("device.contact", "%s", model);
 		} else {
 			upsdebugx(2, "Can't get and publish sysContact for device.contact");
@@ -703,7 +703,7 @@ void upsdrv_initups(void)
 	if (NULL == dstate_getinfo("device.location")) {
 		/* sysLocation.0 */
 		if (nut_snmp_get_str(".1.3.6.1.2.1.1.6.0", model, sizeof(model), NULL) == TRUE) {
-			upsdebugx(2, "Using IETF-MIB default to get and publish sysLocation for device.location");
+			upsdebugx(2, "Using IETF-MIB default to get and publish sysLocation for device.location (once)");
 			dstate_setinfo("device.location", "%s", model);
 		} else {
 			upsdebugx(2, "Can't get and publish sysLocation for device.location");

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -2173,7 +2173,8 @@ static bool_t is_multiple_template(const char *OID_template)
  * Note: remember to adapt info_type, OID and optionaly dfl */
 static snmp_info_t *instantiate_info(snmp_info_t *info_template, snmp_info_t *new_instance)
 {
-	upsdebugx(1, "%s(%s)", __func__, info_template ? info_template->info_type : "n/a");
+	upsdebugx(1, "%s(%s)", __func__,
+		info_template ? info_template->info_type : "n/a");
 
 	/* sanity check */
 	if (info_template == NULL)
@@ -2181,6 +2182,8 @@ static snmp_info_t *instantiate_info(snmp_info_t *info_template, snmp_info_t *ne
 
 	if (new_instance == NULL)
 		new_instance = (snmp_info_t *)xmalloc(sizeof(snmp_info_t));
+	/* TOTHINK: Should there be an "else" to free()
+	 * the fields which we (re-)allocate below? */
 
 	new_instance->info_type = (char *)xmalloc(SU_INFOSIZE);
 	if (new_instance->info_type)
@@ -2190,8 +2193,10 @@ static snmp_info_t *instantiate_info(snmp_info_t *info_template, snmp_info_t *ne
 		if (new_instance->OID)
 			memset((char *)new_instance->OID, 0, SU_INFOSIZE);
 	}
-	else
+	else {
 		new_instance->OID = NULL;
+	}
+
 	new_instance->info_flags = info_template->info_flags;
 	new_instance->info_len = info_template->info_len;
 	/* FIXME: check if we need to adapt this one... */
@@ -2636,7 +2641,8 @@ bool_t get_and_process_data(int mode, snmp_info_t *su_info_p)
 {
 	bool_t status = FALSE;
 
-	upsdebugx(1, "%s: %s (%s)", __func__, su_info_p->info_type, su_info_p->OID);
+	upsdebugx(1, "%s: %s (%s)", __func__,
+		su_info_p->info_type, su_info_p->OID);
 
 	/* ok, update this element. */
 	status = su_ups_get(su_info_p);
@@ -3162,7 +3168,9 @@ bool_t su_ups_get(snmp_info_t *su_info_p)
 
 			/* adapt info_type */
 			if (su_info_p->info_type != NULL) {
-				snprintf((char *)tmp_info_p->info_type, SU_INFOSIZE, "%s", su_info_p->info_type);
+				snprintf((char *)tmp_info_p->info_type,
+					SU_INFOSIZE, "%s",
+					su_info_p->info_type);
 			}
 			else {
 				free_info(tmp_info_p);
@@ -3299,7 +3307,8 @@ bool_t su_ups_get(snmp_info_t *su_info_p)
 	}
 
 	if (su_info_p->info_flags & ST_FLAG_STRING) {
-		status = nut_snmp_get_str(su_info_p->OID, buf, sizeof(buf), su_info_p->oid2info);
+		status = nut_snmp_get_str(su_info_p->OID, buf,
+			sizeof(buf), su_info_p->oid2info);
 		if (status == TRUE) {
 			if (quirk_symmetra_threephase) {
 				if (!strcasecmp(su_info_p->info_type, "input.transfer.low")
@@ -3351,8 +3360,9 @@ bool_t su_ups_get(snmp_info_t *su_info_p)
 		su_setinfo(su_info_p, buf);
 		upsdebugx(2, "=> value: %s", buf);
 	}
-	else
+	else {
 		upsdebugx(2, "=> Failed");
+	}
 
 	free_info(tmp_info_p);
 	return status;

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -2646,6 +2646,7 @@ bool_t get_and_process_data(int mode, snmp_info_t *su_info_p)
 
 	/* ok, update this element. */
 	status = su_ups_get(su_info_p);
+	upsdebugx(4, "%s: su_ups_get returned %d", __func__, status);
 
 	/* set stale flag if data is stale, clear if not. */
 	if (status == TRUE) {
@@ -2656,6 +2657,7 @@ bool_t get_and_process_data(int mode, snmp_info_t *su_info_p)
 		}
 		if(su_info_p->flags & SU_FLAG_UNIQUE) {
 			/* We should be the only provider of this */
+			upsdebugx(4, "%s: unique flag", __func__);
 			disable_competition(su_info_p);
 			su_info_p->flags &= ~SU_FLAG_UNIQUE;
 		}
@@ -3142,8 +3144,13 @@ bool_t su_ups_get(snmp_info_t *su_info_p)
 
 	/* Check if this is a daisychain template */
 	if ((format_char = strchr(su_info_p->OID, '%')) != NULL) {
+		upsdebugx(3, "%s: calling instantiate_info() for "
+			"daisy-chain template", __func__);
 		tmp_info_p = instantiate_info(su_info_p, tmp_info_p);
 		if (tmp_info_p != NULL) {
+			upsdebugx(3, "%s: instantiate_info() returned "
+				"non-null OID: %s",
+				__func__, tmp_info_p->OID);
 			/* adapt the OID */
 			if (su_info_p->OID != NULL) {
 #ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_NONLITERAL
@@ -3160,6 +3167,9 @@ bool_t su_ups_get(snmp_info_t *su_info_p)
 #ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_NONLITERAL
 #pragma GCC diagnostic pop
 #endif
+				upsdebugx(3, "%s: OID %s adapted into %s",
+					__func__, su_info_p->OID,
+					tmp_info_p->OID);
 			}
 			else {
 				free_info(tmp_info_p);
@@ -3187,6 +3197,9 @@ bool_t su_ups_get(snmp_info_t *su_info_p)
 
 	if (!strcasecmp(su_info_p->info_type, "ups.status")) {
 /* FIXME: daisychain status support! */
+		upsdebugx(2, "%s: requesting nut_snmp_get_int() for "
+			"ups.status, with%s daisy template originally",
+			__func__, (format_char!=NULL ? "" : "out"));
 		status = nut_snmp_get_int(su_info_p->OID, &value);
 		if (status == TRUE)
 		{
@@ -3207,6 +3220,9 @@ bool_t su_ups_get(snmp_info_t *su_info_p)
 		upsdebugx(2, "Processing alarm: %s", su_info_p->info_type);
 
 /* FIXME: daisychain alarms support! */
+		upsdebugx(2, "%s: requesting nut_snmp_get_int() for "
+			"some alarm, with%s daisy template originally",
+			__func__, (format_char!=NULL ? "" : "out"));
 		status = nut_snmp_get_int(su_info_p->OID, &value);
 		if (status == TRUE)
 		{
@@ -3224,6 +3240,9 @@ bool_t su_ups_get(snmp_info_t *su_info_p)
 	 * present, this means that the alarm condition is TRUE.
 	 * Only present in powerware-mib.c for now */
 	if (!strcasecmp(su_info_p->info_type, "ups.alarms")) {
+		upsdebugx(2, "%s: requesting nut_snmp_get_int() for "
+			"ups.alarms, with%s daisy template originally",
+			__func__, (format_char!=NULL ? "" : "out"));
 		status = nut_snmp_get_int(su_info_p->OID, &value);
 		if (status == TRUE) {
 			upsdebugx(2, "=> %ld alarms present", value);
@@ -3275,6 +3294,9 @@ bool_t su_ups_get(snmp_info_t *su_info_p)
 	if (!strcasecmp(su_info_p->info_type, "ambient.temperature")) {
 		float temp=0;
 
+		upsdebugx(2, "%s: requesting nut_snmp_get_int() for "
+			"ambient.temperature, with%s daisy template originally",
+			__func__, (format_char!=NULL ? "" : "out"));
 		status = nut_snmp_get_int(su_info_p->OID, &value);
 
 		if(status != TRUE) {
@@ -3307,6 +3329,9 @@ bool_t su_ups_get(snmp_info_t *su_info_p)
 	}
 
 	if (su_info_p->info_flags & ST_FLAG_STRING) {
+		upsdebugx(2, "%s: requesting nut_snmp_get_str(), "
+			"with%s daisy template originally",
+			__func__, (format_char!=NULL ? "" : "out"));
 		status = nut_snmp_get_str(su_info_p->OID, buf,
 			sizeof(buf), su_info_p->oid2info);
 		if (status == TRUE) {
@@ -3326,6 +3351,9 @@ bool_t su_ups_get(snmp_info_t *su_info_p)
 			}
 		}
 	} else {
+		upsdebugx(2, "%s: requesting nut_snmp_get_int(), "
+			"with%s daisy template originally",
+			__func__, (format_char!=NULL ? "" : "out"));
 		status = nut_snmp_get_int(su_info_p->OID, &value);
 		if (status == TRUE) {
 			if ((su_info_p->flags&SU_FLAG_NEGINVALID && value<0)

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -675,10 +675,20 @@ void upsdrv_initups(void)
 		dstate_addcmd("shutdown.stayoff");
 	}
 
-	/* Publish sysContact and sysLocation (from IETF standard paths)
+	/* Publish sysDescr, sysContact and sysLocation (from IETF standard paths)
 	 * for all subdrivers that do not have one defined in their mapping
 	 * tables (note: for lack of better knowledge, defined as read-only
 	 * entries here) */
+
+	if (NULL == dstate_getinfo("device.description")) {
+		/* sysDescr.0 */
+		if (nut_snmp_get_str(".1.3.6.1.2.1.1.1.0", model, sizeof(model), NULL) == TRUE) {
+			upsdebugx(2, "Using IETF-MIB default to get and publish sysDescr for device.description");
+			dstate_setinfo("device.description", "%s", model);
+		} else {
+			upsdebugx(2, "Can't get and publish sysDescr for device.description");
+		}
+	}
 
 	if (NULL == dstate_getinfo("device.contact")) {
 		/* sysContact.0 */

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -3349,9 +3349,15 @@ static int su_setOID(int mode, const char *varname, const char *val)
 	memset(setOID, 0, SU_INFOSIZE);
 	memset(template_count_var, 0, SU_BUFSIZE);
 
-	/* Check if it's a daisychain setting */
-	if (!strncmp(varname, "device", 6)) {
-		/* Extract the device number */
+	/* Check if it's a daisychain setting (device.x.varname) */
+	if (!strncmp(varname, "device", 6)
+	&&  varname[7] >= '0'
+	&&  varname[7] <= '9'
+	) {
+		/* Extract the (single-digit) device number
+		 * TODO: use strtol() or similar to support multi-digit
+		 * chains and offset tmp_varname inside varname properly
+		 */
 		daisychain_device_number = atoi(&varname[7]);
 		/* Point at the command, without the "device.x" prefix */
 		tmp_varname = strdup(&varname[9]);

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -3555,16 +3555,36 @@ static int su_setOID(int mode, const char *varname, const char *val)
 	if (strncmp(tmp_varname, "outlet", 6)) {
 		su_info_p = su_find_info(tmp_varname);
 		/* what if e.g. "device.x.contact" is not found as a "contact"? */
-/*
 		if (!su_info_p && strcmp(tmp_varname, varname)) {
 			upsdebugx(2,
 				"%s: did not find info for daisychained entry %s, "
 				"retrying with original varname %s",
 				__func__, tmp_varname, varname);
 			su_info_p = su_find_info(varname);
+
+			/* Still nothing? Try to revert from "device.1."
+			 * as a daisychain master? */
+			if (!su_info_p
+			&&  daisychain_enabled == TRUE
+			&&  devices_count > 1
+			&&  daisychain_device_number == 1
+			&&  !strncmp(varname, "device.1.", 9)
+			) {
+				char tmp_buf[SU_INFOSIZE];
+				snprintf(tmp_buf, sizeof(tmp_buf),
+					"device.%s", (varname + 9));
+				su_info_p = su_find_info(tmp_buf);
+				if (su_info_p) {
+					upsdebugx(2, "%s: finally found "
+						"as daisy master revert %s",
+						__func__, tmp_buf);
+					free(tmp_varname);
+					tmp_varname = strdup(tmp_buf);
+				}
+			}
 		}
-*/
 	} else {
+		/* is indeed an outlet.* or device.x.outlet.* */
 		snmp_info_t *tmp_info_p;
 		/* Point the outlet or outlet group number in the string */
 		const char *item_number_ptr = NULL;

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -1565,19 +1565,39 @@ void su_setinfo(snmp_info_t *su_info_p, const char *value)
 			/* Special case: we remove "device" from the device collection not to
 			 * get "device.X.device.<something>", but "device.X.<something>" */
 			if (!strncmp(su_info_p->info_type, "device.", 7)) {
+				upsdebugx(6, "%s: in a daisy-chained device, "
+					"OID %s: TRIM 'device.' from type %s (value %s)",
+					__func__, su_info_p->OID,
+					su_info_p->info_type, (value)?value:"");
 				snprintf(info_type, 128, "device.%i.%s",
 					current_device_number, su_info_p->info_type + 7);
 			}
 			else {
+				upsdebugx(6, "%s: in a daisy-chained device, "
+					"OID %s is templated: for type %s (value %s)",
+					__func__, su_info_p->OID,
+					su_info_p->info_type, (value)?value:"");
 				snprintf(info_type, 128, "device.%i.%s",
 					current_device_number, su_info_p->info_type);
 			}
 		}
-		else
+		else {
+			upsdebugx(6, "%s: in a daisy-chained device, "
+				"OID %s: for type %s (value %s) "
+				"device %d is not positive or type already "
+				"contains the prepared expectation: %s",
+				__func__, su_info_p->OID,
+				su_info_p->info_type, (value)?value:"",
+				current_device_number,
+				info_type
+				);
 			snprintf(info_type, 128, "%s", su_info_p->info_type);
+		}
 	}
-	else
+	else {
+		upsdebugx(6, "%s: NOT in a daisy-chained device", __func__);
 		snprintf(info_type, 128, "%s", su_info_p->info_type);
+	}
 
 	upsdebugx(1, "%s: using info_type '%s'", __func__, info_type);
 

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -3416,9 +3416,19 @@ static int su_setOID(int mode, const char *varname, const char *val)
 	}
 
 	/* Check if it is outlet / outlet.group, or standard variable */
-	if (strncmp(tmp_varname, "outlet", 6))
+	if (strncmp(tmp_varname, "outlet", 6)) {
 		su_info_p = su_find_info(tmp_varname);
-	else {
+		/* what if e.g. "device.x.contact" is not found as a "contact"? */
+/*
+		if (!su_info_p && strcmp(tmp_varname, varname)) {
+			upsdebugx(2,
+				"%s: did not find info for daisychained entry %s, "
+				"retrying with original varname %s",
+				__func__, tmp_varname, varname);
+			su_info_p = su_find_info(varname);
+		}
+*/
+	} else {
 		snmp_info_t *tmp_info_p;
 		/* Point the outlet or outlet group number in the string */
 		const char *item_number_ptr = NULL;

--- a/drivers/snmp-ups.h
+++ b/drivers/snmp-ups.h
@@ -30,7 +30,6 @@
  */
 
 /* TODO list:
-- add syscontact/location (to all mib.h or centralized?)
 - complete shutdown
 - add enum values to OIDs.
 - optimize network flow by:

--- a/drivers/xppc-mib.c
+++ b/drivers/xppc-mib.c
@@ -24,7 +24,7 @@
 
 #include "xppc-mib.h"
 
-#define XPPC_MIB_VERSION  "0.3"
+#define XPPC_MIB_VERSION  "0.4"
 
 #define XPPC_SYSOID       ".1.3.6.1.4.1.935"
 
@@ -98,6 +98,12 @@ static snmp_info_t xppc_mib[] = {
 	 * 	{ 0, NULL }
 	 * };
 	 */
+
+	/* standard MIB items */
+	{ "device.description", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.1.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.contact", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.4.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.location", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.6.0", NULL, SU_FLAG_OK, NULL },
+
         { "ups.mfr", ST_FLAG_STRING, SU_INFOSIZE, NULL, "Tripp Lite / Phoenixtec",
                 SU_FLAG_STATIC | SU_FLAG_ABSENT | SU_FLAG_OK, NULL },
 

--- a/drivers/xppc-mib.c
+++ b/drivers/xppc-mib.c
@@ -104,8 +104,8 @@ static snmp_info_t xppc_mib[] = {
 	{ "device.contact", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.4.0", NULL, SU_FLAG_OK, NULL },
 	{ "device.location", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.6.0", NULL, SU_FLAG_OK, NULL },
 
-        { "ups.mfr", ST_FLAG_STRING, SU_INFOSIZE, NULL, "Tripp Lite / Phoenixtec",
-                SU_FLAG_STATIC | SU_FLAG_ABSENT | SU_FLAG_OK, NULL },
+	{ "ups.mfr", ST_FLAG_STRING, SU_INFOSIZE, NULL, "Tripp Lite / Phoenixtec",
+		SU_FLAG_STATIC | SU_FLAG_ABSENT | SU_FLAG_OK, NULL },
 
 	/* upsBaseIdentModel.0 = STRING: "Intelligent" */
 	{ "ups.model", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.935.1.1.1.1.1.1.0", "Generic Phoenixtec SNMP device", SU_FLAG_OK, NULL },

--- a/scripts/subdriver/gen-snmp-subdriver.sh
+++ b/scripts/subdriver/gen-snmp-subdriver.sh
@@ -241,6 +241,13 @@ generate_C() {
 		 * 	{ 0, NULL }
 		 * };
 		 */
+
+		/* standard MIB items; if the vendor MIB contains better OIDs for
+		 * this (e.g. with daisy-chain support), consider adding those here
+		 */
+		{ "device.description", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.1.0", NULL, SU_FLAG_OK, NULL },
+		{ "device.contact", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.4.0", NULL, SU_FLAG_OK, NULL },
+		{ "device.location", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.6.0", NULL, SU_FLAG_OK, NULL },
 	EOF
 
 	# extract OID string paths, one by one

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -669,6 +669,9 @@ static void driver_free(void)
 	upstype_t	*ups, *unext;
 
 	for (ups = firstups; ups; ups = unext) {
+		upsdebugx(1, "%s: forgetting UPS [%s] (FD %d)",
+			__func__, ups->name, ups->sock_fd);
+
 		unext = ups->next;
 
 		if (ups->sock_fd != -1) {
@@ -985,7 +988,11 @@ static void mainloop(void)
 
 		/* see if we need to (re)connect to the socket */
 		if (ups->sock_fd < 0) {
+			upsdebugx(1, "%s: UPS [%s] is not currently connected",
+				__func__, ups->name);
 			ups->sock_fd = sstate_connect(ups);
+			upsdebugx(1, "%s: UPS [%s] is now connected as FD %d",
+				__func__, ups->name, ups->sock_fd);
 			continue;
 		}
 

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -13,7 +13,7 @@ SUBDIRS = . nut-scanner
 
 PYTHON = @PYTHON@
 
-EXTRA_DIST = nut-usbinfo.pl nut-recorder.sh nut-ddl-dump.sh \
+EXTRA_DIST = nut-usbinfo.pl nut-recorder.sh nut-ddl-dump.sh nut-dumpdiff.sh \
   gitlog2changelog.py.in nut-snmpinfo.py.in driver-list-format.sh
 
 GENERATED_SNMP_FILES = nut-scanner/nutscan-snmp.h

--- a/tools/nut-dumpdiff.sh
+++ b/tools/nut-dumpdiff.sh
@@ -23,6 +23,11 @@ fi
 DATA1="`sort -n < "$1"`"
 DATA2="`sort -n < "$2"`"
 
+# Strip away same-context lines,
+# and lines with values that are decimal numbers,
+# and lines with multi-digit numbers without a decimal point
+# (assuming differences in shorter counters may be important)
 diff -bu <(echo "$DATA1") <(echo "$DATA2") \
 | grep -E '^[+-][^+-]' \
-| grep -vE '^[^:]*: [0-9][0-9.]*$'
+| grep -vE '^[^:]*: [0-9][0-9]*\.[0-9][0-9]*$' \
+| grep -vE '^[^:]*: [0-9][0-9]*$'

--- a/tools/nut-dumpdiff.sh
+++ b/tools/nut-dumpdiff.sh
@@ -24,10 +24,9 @@ DATA1="`sort -n < "$1"`"
 DATA2="`sort -n < "$2"`"
 
 # Strip away same-context lines,
-# and lines with values that are decimal numbers,
-# and lines with multi-digit numbers without a decimal point
-# (assuming differences in shorter counters may be important)
+# and lines with measurements that are either decimal numbers
+# or multi-digit numbers without a decimal point (assuming
+# differences in shorter numbers or counters may be important)
 diff -bu <(echo "$DATA1") <(echo "$DATA2") \
 | grep -E '^[+-][^+-]' \
-| grep -vE '^[^:]*: [0-9][0-9]*\.[0-9][0-9]*$' \
-| grep -vE '^[^:]*: [0-9][0-9]*$'
+| grep -vE '^[^:]*(power|voltage|current): ([0-9][0-9]*|[0-9][0-9]*\.[0-9][0-9]*)$'

--- a/tools/nut-dumpdiff.sh
+++ b/tools/nut-dumpdiff.sh
@@ -29,7 +29,7 @@ DATA2="`sort -n < "$2"`"
 # differences in shorter numbers or counters may be important)
 diff -bu <(echo "$DATA1") <(echo "$DATA2") \
 | grep -E '^[+-][^+-]' \
-| grep -vE '^[^:]*(power|load|voltage|current|temperature|humidity): ([0-9][0-9]*|[0-9][0-9]*\.[0-9][0-9]*)$'
+| grep -vE '^[^:]*(power|load|voltage|current|frequency|temperature|humidity): ([0-9][0-9]*|[0-9][0-9]*\.[0-9][0-9]*)$'
 
 # Note: up to user to post-filter, "^driver.version.*:"
 # may be deemed irrelevant as well

--- a/tools/nut-dumpdiff.sh
+++ b/tools/nut-dumpdiff.sh
@@ -29,4 +29,7 @@ DATA2="`sort -n < "$2"`"
 # differences in shorter numbers or counters may be important)
 diff -bu <(echo "$DATA1") <(echo "$DATA2") \
 | grep -E '^[+-][^+-]' \
-| grep -vE '^[^:]*(power|voltage|current): ([0-9][0-9]*|[0-9][0-9]*\.[0-9][0-9]*)$'
+| grep -vE '^[^:]*(power|load|voltage|current|temperature|humidity): ([0-9][0-9]*|[0-9][0-9]*\.[0-9][0-9]*)$'
+
+# Note: up to user to post-filter, "^driver.version.*:"
+# may be deemed irrelevant as well

--- a/tools/nut-dumpdiff.sh
+++ b/tools/nut-dumpdiff.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# This script is intended to simplify comparison of NUT data dumps,
+# such as those collected by drivers with `-d 1` argument, or by
+# the `upsc` client, ignoring irrelevant variations (e.g. numbers).
+#
+# TODO: Make more portable than bash and GNU toolkits
+#
+# Subject to same license as the NUT Project.
+#
+# Copyright (C)
+#	2022 Jim Klimov <jimklimov+nut@gmail.com>
+#
+
+if [ $# = 2 ] && [ -s "$1" ] && [ -s "$2" ]; then
+    echo "=== $0: comparing '$1' (-) vs '$2' (+)" >&2
+else
+    echo "=== $0: aborting: requires two filenames to compare as arguments" >&2
+    exit 1
+fi
+
+# Pre-sort just in case:
+DATA1="`sort -n < "$1"`"
+DATA2="`sort -n < "$2"`"
+
+diff -bu <(echo "$DATA1") <(echo "$DATA2") \
+| grep -E '^[+-][^+-]' \
+| grep -vE '^[^:]*: [0-9][0-9.]*$'


### PR DESCRIPTION
The generic MIB-2 provides system contact and location information that are now
publish respectively as device.contact and device.location
