### PR TITLE
Enhance Upsdebugx with the message's debug-level tag

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -404,8 +404,6 @@ void upslogx(int priority, const char *fmt, ...)
 	va_end(va);
 }
 
-// FIXME: Find equivalent code number for MSVC (if applicable at all)
-DISABLE_WARNING(varargs,varargs,42)
 void upsdebug_with_errno(int level, const char *fmt, ...)
 {
 	va_list va;
@@ -418,30 +416,23 @@ void upsdebug_with_errno(int level, const char *fmt, ...)
 // of logging info he needs to see at the moment. Using '-DDDDD' all the time
 // is too brutal and needed high-level overview can be lost. This [D#] prefix
 // can help limit this debug stream quicker, than experimentally picking ;)
-// Normally this code rightfully warns that we might pass a bad formatting
-// string (we know we don't); so we quiesce this with e.g. GCC pragmas below.
-//  warning: second parameter of 'va_start' not last named argument [-Wvarargs]
-	const char *fmtUse = fmt;
+	char fmt2[LARGEBUF];
 	if (level > 0) {
 		int ret;
-		char fmt2[LARGEBUF];
 		ret = snprintf(fmt2, sizeof(fmt2), "[D%d] %s", level, fmt);
 		if ((ret < 0) || (ret >= (int) sizeof(fmt2))) {
 			syslog(LOG_WARNING, "upsdebug_with_errno: snprintf needed more than %d bytes",
 				LARGEBUF);
 		} else {
-			fmtUse = (const char *)fmt2;
+			fmt = (const char *)fmt2;
 		}
 	}
 
-	va_start(va, fmtUse);
-	vupslog(LOG_DEBUG, fmtUse, va, 1);
+	va_start(va, fmt);
+	vupslog(LOG_DEBUG, fmt, va, 1);
 	va_end(va);
 }
-ENABLE_WARNING(varargs,varargs,42)
 
-// FIXME: Find equivalent code number for MSVC (if applicable at all)
-DISABLE_WARNING(varargs,varargs,42)
 void upsdebugx(int level, const char *fmt, ...)
 {
 	va_list va;
@@ -450,24 +441,22 @@ void upsdebugx(int level, const char *fmt, ...)
 		return;
 
 // See comments above in upsdebug_with_errno() - they apply here too.
-	const char *fmtUse = fmt;
+	char fmt2[LARGEBUF];
 	if (level > 0) {
 		int ret;
-		char fmt2[LARGEBUF];
 		ret = snprintf(fmt2, sizeof(fmt2), "[D%d] %s", level, fmt);
 		if ((ret < 0) || (ret >= (int) sizeof(fmt2))) {
 			syslog(LOG_WARNING, "upsdebugx: snprintf needed more than %d bytes",
 				LARGEBUF);
 		} else {
-			fmtUse = (const char *)fmt2;
+			fmt = (const char *)fmt2;
 		}
 	}
 
-	va_start(va, fmtUse);
-	vupslog(LOG_DEBUG, fmtUse, va, 0);
+	va_start(va, fmt);
+	vupslog(LOG_DEBUG, fmt, va, 0);
 	va_end(va);
 }
-ENABLE_WARNING(varargs,varargs,42)
 
 /* dump message msg and len bytes from buf to upsdebugx(level) in
    hexadecimal. (This function replaces Philippe Marzouk's original

--- a/common/common.c
+++ b/common/common.c
@@ -51,7 +51,7 @@ static int xbit_test(int val, int flag)
 	return ((val & flag) == flag);
 }
 
-/* enable writing upslog_with_errno() and upslogx() type messages to 
+/* enable writing upslog_with_errno() and upslogx() type messages to
    the syslog */
 void syslogbit_set(void)
 {
@@ -126,7 +126,7 @@ void background(void)
 	close(1);
 	close(2);
 
-	if (pid != 0) 
+	if (pid != 0)
 		_exit(EXIT_SUCCESS);		/* parent */
 
 	/* child */
@@ -163,7 +163,7 @@ struct passwd *get_user_pwent(const char *name)
 		fatalx(EXIT_FAILURE, "user %s not found", name);
 	else
 		fatal_with_errno(EXIT_FAILURE, "getpwnam(%s)", name);
-		
+
 	return NULL;  /* to make the compiler happy */
 }
 
@@ -246,7 +246,7 @@ int sendsignalfn(const char *pidfn, int sig)
 		upslogx(LOG_NOTICE, "Failed to read pid from %s", pidfn);
 		fclose(pidf);
 		return -1;
-	}	
+	}
 
 	pid = strtol(buf, (char **)NULL, 10);
 
@@ -331,18 +331,18 @@ static void vupslog(int priority, const char *fmt, va_list va, int use_strerror)
 	if (nut_debug_level > 0) {
 		static struct timeval	start = { 0 };
 		struct timeval		now;
-	
+
 		gettimeofday(&now, NULL);
-	
+
 		if (start.tv_sec == 0) {
 			start = now;
 		}
-	
+
 		if (start.tv_usec > now.tv_usec) {
 			now.tv_usec += 1000000;
 			now.tv_sec -= 1;
 		}
-	
+
 		fprintf(stderr, "%4.0f.%06ld\t", difftime(now.tv_sec, start.tv_sec), (long)(now.tv_usec - start.tv_usec));
 	}
 
@@ -353,7 +353,7 @@ static void vupslog(int priority, const char *fmt, va_list va, int use_strerror)
 }
 
 /* Return the default path for the directory containing configuration files */
-const char * confpath(void) 
+const char * confpath(void)
 {
 	const char * path;
 
@@ -364,7 +364,7 @@ const char * confpath(void)
 }
 
 /* Return the default path for the directory containing state files */
-const char * dflt_statepath(void) 
+const char * dflt_statepath(void)
 {
 	const char * path;
 
@@ -375,7 +375,7 @@ const char * dflt_statepath(void)
 }
 
 /* Return the alternate path for pid files */
-const char * altpidpath(void) 
+const char * altpidpath(void)
 {
 #ifdef ALTPIDPATH
 	return ALTPIDPATH;
@@ -407,7 +407,7 @@ void upslogx(int priority, const char *fmt, ...)
 void upsdebug_with_errno(int level, const char *fmt, ...)
 {
 	va_list va;
-	
+
 	if (nut_debug_level < level)
 		return;
 
@@ -419,7 +419,7 @@ void upsdebug_with_errno(int level, const char *fmt, ...)
 void upsdebugx(int level, const char *fmt, ...)
 {
 	va_list va;
-	
+
 	if (nut_debug_level < level)
 		return;
 
@@ -437,7 +437,7 @@ void upsdebug_hex(int level, const char *msg, const void *buf, int len)
 	int n;	/* number of characters currently in line */
 	int i;	/* number of bytes output from buffer */
 
-	n = snprintf(line, sizeof(line), "%s: (%d bytes) =>", msg, len); 
+	n = snprintf(line, sizeof(line), "%s: (%d bytes) =>", msg, len);
 
 	for (i = 0; i < len; i++) {
 

--- a/common/common.c
+++ b/common/common.c
@@ -404,6 +404,8 @@ void upslogx(int priority, const char *fmt, ...)
 	va_end(va);
 }
 
+// FIXME: Find equivalent code number for MSVC (if applicable at all)
+DISABLE_WARNING(varargs,varargs,42)
 void upsdebug_with_errno(int level, const char *fmt, ...)
 {
 	va_list va;
@@ -432,14 +434,14 @@ void upsdebug_with_errno(int level, const char *fmt, ...)
 		}
 	}
 
-// FIXME: Find equivalent code number for MSVC (if applicable at all)
-DISABLE_WARNING(varargs,varargs,42)
 	va_start(va, fmtUse);
 	vupslog(LOG_DEBUG, fmtUse, va, 1);
 	va_end(va);
-ENABLE_WARNING(varargs,varargs,42)
 }
+ENABLE_WARNING(varargs,varargs,42)
 
+// FIXME: Find equivalent code number for MSVC (if applicable at all)
+DISABLE_WARNING(varargs,varargs,42)
 void upsdebugx(int level, const char *fmt, ...)
 {
 	va_list va;
@@ -461,13 +463,11 @@ void upsdebugx(int level, const char *fmt, ...)
 		}
 	}
 
-// FIXME: Find equivalent code number for MSVC (if applicable at all)
-DISABLE_WARNING(varargs,varargs,42)
 	va_start(va, fmtUse);
 	vupslog(LOG_DEBUG, fmtUse, va, 0);
 	va_end(va);
-ENABLE_WARNING(varargs,varargs,42)
 }
+ENABLE_WARNING(varargs,varargs,42)
 
 /* dump message msg and len bytes from buf to upsdebugx(level) in
    hexadecimal. (This function replaces Philippe Marzouk's original

--- a/common/common.c
+++ b/common/common.c
@@ -420,14 +420,16 @@ void upsdebug_with_errno(int level, const char *fmt, ...)
 // string (we know we don't); so we quiesce this with e.g. GCC pragmas below.
 //  warning: second parameter of 'va_start' not last named argument [-Wvarargs]
 	const char *fmtUse = fmt;
-	int ret;
-	char fmt2[LARGEBUF];
-	ret = snprintf(fmt2, sizeof(fmt2), "[D%d] %s", level, fmt);
-	if ((ret < 0) || (ret >= (int) sizeof(fmt2))) {
-		syslog(LOG_WARNING, "upsdebug_with_errno: snprintf needed more than %d bytes",
-			LARGEBUF);
-	} else {
-		fmtUse = (const char *)fmt2;
+	if (level > 0) {
+		int ret;
+		char fmt2[LARGEBUF];
+		ret = snprintf(fmt2, sizeof(fmt2), "[D%d] %s", level, fmt);
+		if ((ret < 0) || (ret >= (int) sizeof(fmt2))) {
+			syslog(LOG_WARNING, "upsdebug_with_errno: snprintf needed more than %d bytes",
+				LARGEBUF);
+		} else {
+			fmtUse = (const char *)fmt2;
+		}
 	}
 
 // FIXME: Find equivalent code number for MSVC (if applicable at all)
@@ -447,14 +449,16 @@ void upsdebugx(int level, const char *fmt, ...)
 
 // See comments above in upsdebug_with_errno() - they apply here too.
 	const char *fmtUse = fmt;
-	int ret;
-	char fmt2[LARGEBUF];
-	ret = snprintf(fmt2, sizeof(fmt2), "[D%d] %s", level, fmt);
-	if ((ret < 0) || (ret >= (int) sizeof(fmt2))) {
-		syslog(LOG_WARNING, "upsdebugx: snprintf needed more than %d bytes",
-			LARGEBUF);
-	} else {
-		fmtUse = (const char *)fmt2;
+	if (level > 0) {
+		int ret;
+		char fmt2[LARGEBUF];
+		ret = snprintf(fmt2, sizeof(fmt2), "[D%d] %s", level, fmt);
+		if ((ret < 0) || (ret >= (int) sizeof(fmt2))) {
+			syslog(LOG_WARNING, "upsdebugx: snprintf needed more than %d bytes",
+				LARGEBUF);
+		} else {
+			fmtUse = (const char *)fmt2;
+		}
 	}
 
 // FIXME: Find equivalent code number for MSVC (if applicable at all)

--- a/include/common.h
+++ b/include/common.h
@@ -149,57 +149,6 @@ extern int optind;
 #	define setegid(x) setresgid(-1,x,-1)    /* Works for HP-UX 10.20 */
 #endif
 
-/* This pragmatic code is courtesy of Martin Gerhardy posted on the web at
- *   http://stackoverflow.com/questions/3378560/how-to-disable-gcc-warnings-for-a-few-lines-of-code
- * and further integrated to NUT by Jim Klimov. From original post comments:
- * ...This should do the trick for gcc, clang and msvc
- * Can be called with e.g.:
-DISABLE_WARNING(unused-variable,unused-variable,42)
-[.... some code with warnings in here ....]
-ENABLE_WARNING(unused-variable,unused-variable,42)
- * see https://gcc.gnu.org/onlinedocs/cpp/Pragmas.html
- * and http://clang.llvm.org/docs/UsersManual.html#controlling-diagnostics-via-pragmas
- * and https://msdn.microsoft.com/de-DE/library/d9x1s805.aspx for more details
- * You need at least version 4.02 to use these kind of pragmas for gcc,
- * not sure about msvc and clang about the versions.
- */
-#if defined(__clang__) || defined(__GNUC__) || defined(_MSC_VER)
-# define DIAG_STR(s) #s
-# define DIAG_JOINSTR(x,y) DIAG_STR(x ## y)
-# ifdef _MSC_VER
-#  define DIAG_DO_PRAGMA(x) __pragma (#x)
-#  define DIAG_PRAGMA(compiler,x) DIAG_DO_PRAGMA(warning(x))
-# else
-#  define DIAG_DO_PRAGMA(x) _Pragma (#x)
-#  define DIAG_PRAGMA(compiler,x) DIAG_DO_PRAGMA(compiler diagnostic x)
-# endif
-#else
-# define DIAG_STR(S)
-# define DIAG_JOINSTR(x,y)
-# define DIAG_DO_PRAGMA(x)
-# define DIAG_PRAGMA(compiler,x)
-#endif
-
-#if defined(__clang__)
-# define DISABLE_WARNING(gcc_unused,clang_option,msvc_unused) DIAG_PRAGMA(clang,push) DIAG_PRAGMA(clang,ignored DIAG_JOINSTR(-W,clang_option))
-# define ENABLE_WARNING(gcc_unused,clang_option,msvc_unused) DIAG_PRAGMA(clang,pop)
-#elif defined(_MSC_VER)
-# define DISABLE_WARNING(gcc_unused,clang_unused,msvc_errorcode) DIAG_PRAGMA(msvc,push) DIAG_DO_PRAGMA(warning(disable:##msvc_errorcode))
-# define ENABLE_WARNING(gcc_unused,clang_unused,msvc_errorcode) DIAG_PRAGMA(msvc,pop)
-#elif defined(__GNUC__)
-# if ((__GNUC__ * 100) + __GNUC_MINOR__) >= 406
-#  define DISABLE_WARNING(gcc_option,clang_unused,msvc_unused) DIAG_PRAGMA(GCC,push) DIAG_PRAGMA(GCC,ignored DIAG_JOINSTR(-W,gcc_option))
-#  define ENABLE_WARNING(gcc_option,clang_unused,msvc_unused) DIAG_PRAGMA(GCC,pop)
-# else
-#  define DISABLE_WARNING(gcc_option,clang_unused,msvc_unused) DIAG_PRAGMA(GCC,ignored DIAG_JOINSTR(-W,gcc_option))
-#  define ENABLE_WARNING(gcc_option,clang_option,msvc_unused) DIAG_PRAGMA(GCC,warning DIAG_JOINSTR(-W,gcc_option))
-# endif
-#else
-# define DISABLE_WARNING(gcc_option,clang_unused,msvc_unused) /* DISABLE_WARNING not supported for this compiler */
-# define ENABLE_WARNING(gcc_option,clang_unused,msvc_unused)  /* ENABLE_WARNING not supported for this compiler */
-#endif
-
-
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 }

--- a/include/common.h
+++ b/include/common.h
@@ -149,6 +149,44 @@ extern int optind;
 #	define setegid(x) setresgid(-1,x,-1)    /* Works for HP-UX 10.20 */
 #endif
 
+/* This pragmatic code is courtesy of Martin Gerhardy posted on the web at
+ * http://stackoverflow.com/questions/3378560/how-to-disable-gcc-warnings-for-a-few-lines-of-code
+ * ...This should do the trick for gcc, clang and msvc
+ * Can be called with e.g.:
+DISABLE_WARNING(unused-variable,unused-variable,42)
+[.... some code with warnings in here ....]
+ENABLE_WARNING(unused-variable,unused-variable,42)
+ * see https://gcc.gnu.org/onlinedocs/cpp/Pragmas.html
+ * and http://clang.llvm.org/docs/UsersManual.html#controlling-diagnostics-via-pragmas
+ * and https://msdn.microsoft.com/de-DE/library/d9x1s805.aspx for more details
+ * You need at least version 4.02 to use these kind of pragmas for gcc,
+ * not sure about msvc and clang about the versions.
+ */
+#define DIAG_STR(s) #s
+#define DIAG_JOINSTR(x,y) DIAG_STR(x ## y)
+#ifdef _MSC_VER
+# define DIAG_DO_PRAGMA(x) __pragma (#x)
+# define DIAG_PRAGMA(compiler,x) DIAG_DO_PRAGMA(warning(x))
+#else
+# define DIAG_DO_PRAGMA(x) _Pragma (#x)
+# define DIAG_PRAGMA(compiler,x) DIAG_DO_PRAGMA(compiler diagnostic x)
+#endif
+#if defined(__clang__)
+# define DISABLE_WARNING(gcc_unused,clang_option,msvc_unused) DIAG_PRAGMA(clang,push) DIAG_PRAGMA(clang,ignored DIAG_JOINSTR(-W,clang_option))
+# define ENABLE_WARNING(gcc_unused,clang_option,msvc_unused) DIAG_PRAGMA(clang,pop)
+#elif defined(_MSC_VER)
+# define DISABLE_WARNING(gcc_unused,clang_unused,msvc_errorcode) DIAG_PRAGMA(msvc,push) DIAG_DO_PRAGMA(warning(disable:##msvc_errorcode))
+# define ENABLE_WARNING(gcc_unused,clang_unused,msvc_errorcode) DIAG_PRAGMA(msvc,pop)
+#elif defined(__GNUC__)
+#if ((__GNUC__ * 100) + __GNUC_MINOR__) >= 406
+# define DISABLE_WARNING(gcc_option,clang_unused,msvc_unused) DIAG_PRAGMA(GCC,push) DIAG_PRAGMA(GCC,ignored DIAG_JOINSTR(-W,gcc_option))
+# define ENABLE_WARNING(gcc_option,clang_unused,msvc_unused) DIAG_PRAGMA(GCC,pop)
+#else
+# define DISABLE_WARNING(gcc_option,clang_unused,msvc_unused) DIAG_PRAGMA(GCC,ignored DIAG_JOINSTR(-W,gcc_option))
+# define ENABLE_WARNING(gcc_option,clang_option,msvc_unused) DIAG_PRAGMA(GCC,warning DIAG_JOINSTR(-W,gcc_option))
+#endif
+#endif
+
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 }


### PR DESCRIPTION
For debugging output, we want to prepend the debug level so the user can e.g. more easily lower the level (less -D's on command line) to retain just the amount of logging info he needs to see at the moment. Using '-DDDDD' all the time is too brutal and needed high-level overview can be lost. This [D#] prefix can help limit this debug stream quicker, than experimentally picking ;)

Example screenshot (testing code in screenshot is not part of this commit, a copy for reference is just below in the comment):
````
$ ./snmp-ups -DDDDDDDD -a x
Network UPS Tools - Generic SNMP UPS driver 0.99 (2.7.4-109-g0059555)
   0.000000	[D2] Processing CLI option  1 'D' : '(null)'
   0.000018	[D2] Processing CLI option  1 'D' : '(null)'
   0.000025	[D2] Processing CLI option  1 'D' : '(null)'
   0.000033	[D2] Processing CLI option  1 'D' : '(null)'
   0.000103	[D2] Processing CLI option  1 'D' : '(null)'
   0.000110	[D2] Processing CLI option  2 'D' : '(null)'
   0.000117	[D2] Processing CLI option  4 'a' : 'x'
   0.000133	Can't open /usr/local/ups/etc/ups.conf: Can't open /usr/local/ups/etc/ups.conf: No such file or directory
````

The quick-test code was to debug-print something somewhere before we fail because NUT is not installed and set up on the workstation ;)
````
diff --git a/drivers/main.c b/drivers/main.c
index f63d54a..d85cf35 100644
--- a/drivers/main.c
+++ b/drivers/main.c
@@ -509,6 +509,7 @@ int main(int argc, char **argv)
 	upsdrv_makevartable();
 
 	while ((i = getopt(argc, argv, "+a:kDhx:Lqr:u:Vi:")) != -1) {
+		upsdebugx(2,"Processing CLI option %2d '%c' : '%s'",optind, i, optarg);
 		switch (i) {
 			case 'a':
 				upsname = optarg;
````
