### PR TITLE
scan_xml_http.c : do not suggest NetXML support for ePDUs

### DIFF
--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -270,7 +270,7 @@ nutscan_device_t * nutscan_scan_xml_http(long usec_timeout)
 				}
 				else
 				{
-					fprintf(stderr,"Device replied with NetXML but was not deemed compatible\n");
+					fprintf(stderr,"Device at IP %s replied with NetXML but was not deemed compatible with 'netxml-ups' driver (unsupported protocol version, etc.)\n", string);
 					continue; // skip this device; note that for broadcast scan there may be more in the loop's queue
 				}
 

--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -271,7 +271,7 @@ nutscan_device_t * nutscan_scan_xml_http(long usec_timeout)
 				else
 				{
 					fprintf(stderr,"Device replied with NetXML but was not deemed compatible\n");
-					return NULL;
+					continue; // skip this device; note that for broadcast scan there may be more in the loop's queue
 				}
 
 			}

--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -47,6 +47,7 @@ static void (*nut_ne_xml_push_handler)(ne_xml_parser *p,
                          ne_xml_endelm_cb *endelm,
                          void *userdata);
 static void (*nut_ne_xml_destroy)(ne_xml_parser *p);
+static int (*nut_ne_xml_failed)(ne_xml_parser *p);
 static ne_xml_parser * (*nut_ne_xml_create)(void);
 static int (*nut_ne_xml_parse)(ne_xml_parser *p, const char *block, size_t len);
 
@@ -100,6 +101,11 @@ int nutscan_load_neon_library(const char *libname_path)
 		goto err;
 	}
 
+	*(void **) (&nut_ne_xml_failed) = lt_dlsym(dl_handle,"ne_xml_failed");
+	if ((dl_error = lt_dlerror()) != NULL)  {
+		goto err;
+	}
+
 	return 1;
 err:
 	fprintf(stderr, "Cannot load XML library (%s) : %s. XML search disabled.\n", libname, dl_error);
@@ -108,19 +114,49 @@ err:
 	return 0;
 }
 
+/* A start-element callback for element with given namespace/name. */
 static int startelm_cb(void *userdata, int parent, const char *nspace, const char *name, const char **atts) {
 	nutscan_device_t * dev = (nutscan_device_t *)userdata;
 	char buf[SMALLBUF];
 	int i = 0;
+	int result = -1;
 	while( atts[i] != NULL ) {
+		/* netxml-ups currently only supports XML version 3 (for UPS),
+		 * and not version 4 (for UPS and PDU)! */
+		upsdebugx(5,"startelm_cb() : parent=%d nspace='%s' name='%s' atts[%d]='%s' atts[%d]='%s'",
+			parent, nspace, name, i, atts[i], (i+1), atts[i+1]);
+// This test from mge-xml.c works when parsing a product.xml file.
+// Unfortunately, different products serve it over different URIs
+// and over HTTP, so porting its support here would be complicated.
+// As an indirect way to detect the version, the XMLv4 devices serve
+// the "/product.xml" with protocol version in it, and XMLv3 ones
+// serve the "/mgeups/product.xml" without protocol info, by spec...
+/*
+		if (parent == NE_XML_STATEROOT && !strcasecmp(name, "PRODUCT_INFO") && !strcasecmp(atts[i], "protocol")) {
+			if (!strcasecmp(atts[i+1], "XML.V4")) {
+				fprintf(stderr, "ERROR: XML v4 protocol is not supported by current NUT drivers, skipping device!\n");
+				return -1;
+			}
+		}
+*/
+// The Eaton/MGE ePDUs almost exclusively support only XMLv4 protocol
+// (only the very first generation of G2/G3 NMCs supported an older
+// protocol, but all should have been FW upgraded by now), which NUT
+// drivers don't yet support. To avoid failing drivers later, the
+// nut-scanner should not suggest netxml-ups configuration for ePDUs
+// at this time.
+		if(strcmp(atts[i],"class") == 0 && strcmp(atts[i+1],"DEV.PDU") == 0 ) {
+			upsdebugx(1, "XML v4 protocol is not supported by current NUT drivers, skipping device!");
+			return -1;
+		}
 		if(strcmp(atts[i],"type") == 0) {
 			snprintf(buf,sizeof(buf),"%s",atts[i+1]);
 			nutscan_add_option_to_device(dev,"desc",buf);
-			return 0;
+			result = 0;
 		}
 		i=i+2;
 	}
-	return 0;
+	return result;
 }
 
 nutscan_device_t * nutscan_scan_xml_http(long usec_timeout)
@@ -221,14 +257,22 @@ nutscan_device_t * nutscan_scan_xml_http(long usec_timeout)
 				(*nut_ne_xml_push_handler)(parser, startelm_cb,
 							NULL, NULL, nut_dev);
 				(*nut_ne_xml_parse)(parser, buf, recv_size);
+				int parserFailed = (*nut_ne_xml_failed)(parser); // 0 = ok, nonzero = fail
 				(*nut_ne_xml_destroy)(parser);
 
-				nut_dev->driver = strdup("netxml-ups");
-				sprintf(buf,"http://%s",string);
-				nut_dev->port = strdup(buf);
+				if (parserFailed == 0) {
+					nut_dev->driver = strdup("netxml-ups");
+					sprintf(buf,"http://%s",string);
+					nut_dev->port = strdup(buf);
 
-				current_nut_dev = nutscan_add_device_to_device(
+					current_nut_dev = nutscan_add_device_to_device(
 						current_nut_dev,nut_dev);
+				}
+				else
+				{
+					fprintf(stderr,"Device replied with NetXML but was not deemed compatible\n");
+					return NULL;
+				}
 
 			}
 		}


### PR DESCRIPTION
(almost exclusively they are XMLv4 and do not work with current NUT)