### PR TITLE
Nut-scanner debugging revision and NetXML scanning support for IP addresses

### DIFF
--- a/tools/nut-scanner/nut-scan.h
+++ b/tools/nut-scanner/nut-scan.h
@@ -2,6 +2,7 @@
  *  Copyright (C)
  *    2011 - EATON
  *    2012 - Arnaud Quette <arnaud.quette@free.fr>
+ *    2016 - EATON - IP addressed XML scan
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -22,6 +23,8 @@
     \brief general header for nut-scanner
     \author Frederic Bohe <fredericbohe@eaton.com>
     \author Arnaud Quette <arnaud.quette@free.fr>
+    \author Michal Vyskocil <MichalVyskocil@eaton.com>
+    \author Jim Klimov <EvgenyKlimov@eaton.com>
 */
 
 #ifndef NUT_SCAN_H
@@ -84,12 +87,22 @@ typedef struct nutscan_ipmi {
 #define IPMI_1_5		1
 #define IPMI_2_0		0
 
+/* XML HTTP structure */
+typedef struct nutscan_xml {
+	int port_http;		/* Port for xml http (tcp) */
+	int port_udp;		/* Port for xml udp */
+	long usec_timeout;	/* Wait this long for a response */
+	char *peername;		/* Hostname or NULL for broadcast mode */
+} nutscan_xml_t;
+
 /* Scanning */
 nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip, long usec_timeout, nutscan_snmp_t * sec);
 
 nutscan_device_t * nutscan_scan_usb();
 
-nutscan_device_t * nutscan_scan_xml_http(long usec_timeout);
+/* If "ip" == NULL, do a broadcast scan */
+/* If sec->usec_timeout < 0 then the common usec_timeout arg overrides it */
+nutscan_device_t * nutscan_scan_xml_http_range(const char *start_ip, const char *end_ip, long usec_timeout, nutscan_xml_t * sec);
 
 nutscan_device_t * nutscan_scan_nut(const char * startIP, const char * stopIP, const char * port, long usec_timeout);
 

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -1,5 +1,6 @@
 /*
  *  Copyright (C) 2011 - 2012  Arnaud Quette <arnaud.quette@free.fr>
+ *  Copyright (C) 2016 Michal Vyskocil <MichalVyskocil@eaton.com>
  *  Copyright (C) 2016 Jim Klimov <EvgenyKlimov@eaton.com>
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -20,6 +21,7 @@
 /*! \file nut-scanner.c
     \brief A tool to detect NUT supported devices
     \author Arnaud Quette <arnaud.quette@free.fr>
+    \author Michal Vyskocil <MichalVyskocil@eaton.com>
     \author Jim Klimov <EvgenyKlimov@eaton.com>
 */
 
@@ -108,7 +110,9 @@ static void * run_snmp(void * arg)
 
 static void * run_xml(void * arg)
 {
-	dev[TYPE_XML] = nutscan_scan_xml_http(timeout);
+	nutscan_xml_t * sec = (nutscan_xml_t *)arg;
+
+	dev[TYPE_XML] = nutscan_scan_xml_http_range(start_ip, end_ip, timeout, sec);
 	return NULL;
 }
 
@@ -215,6 +219,7 @@ int main(int argc, char *argv[])
 {
 	nutscan_snmp_t snmp_sec;
 	nutscan_ipmi_t ipmi_sec;
+	nutscan_xml_t  xml_sec;
 	int opt_ret;
 	char *	cidr = NULL;
 	int allow_all = 0;
@@ -231,11 +236,19 @@ int main(int argc, char *argv[])
 
 	memset(&snmp_sec, 0, sizeof(snmp_sec));
 	memset(&ipmi_sec, 0, sizeof(ipmi_sec));
+	memset(&xml_sec, 0, sizeof(xml_sec));
+
 	/* Set the default values for IPMI */
 	ipmi_sec.authentication_type = IPMI_AUTHENTICATION_TYPE_MD5;
 	ipmi_sec.ipmi_version = IPMI_1_5; /* default to IPMI 1.5, if not otherwise specified */
 	ipmi_sec.cipher_suite_id = 3; /* default to HMAC-SHA1; HMAC-SHA1-96; AES-CBC-128 */
 	ipmi_sec.privilege_level = IPMI_PRIVILEGE_LEVEL_ADMIN; /* should be sufficient */
+
+	/* Set the default values for XML HTTP (run_xml()) */
+	xml_sec.port_http = 80;
+	xml_sec.port_udp = 4679;
+	xml_sec.usec_timeout = -1; /* Override with the "timeout" common setting later */
+	xml_sec.peername = NULL;
 
 	nutscan_init();
 
@@ -507,15 +520,16 @@ display_help:
 
 	if( allow_xml && nutscan_avail_xml_http) {
 		upsdebugx(quiet,"Scanning XML/HTTP bus.");
+		xml_sec.usec_timeout = timeout;
 #ifdef HAVE_PTHREAD
 		upsdebugx(1,"XML/HTTP SCAN: starting pthread_create with run_xml...");
-		if(pthread_create(&thread[TYPE_XML],NULL,run_xml,NULL)) {
+		if(pthread_create(&thread[TYPE_XML],NULL,run_xml,&xml_sec)) {
 			upsdebugx(1,"pthread_create returned an error; disabling this scan mode");
 			nutscan_avail_xml_http = 0;
 		}
 #else
-		upsdebugx(1,"XML/HTTP SCAN: no pthread support, starting nutscan_scan_xml_http()...");
-		dev[TYPE_XML] = nutscan_scan_xml_http(timeout);
+		upsdebugx(1,"XML/HTTP SCAN: no pthread support, starting nutscan_scan_xml_http_range()...");
+		dev[TYPE_XML] = nutscan_scan_xml_http_range(start_ip, end_ip, timeout, &xml_sec);
 #endif /* HAVE_PTHREAD */
 	} else {
 		upsdebugx(1,"XML/HTTP SCAN: not requested, SKIPPED");

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -472,11 +472,15 @@ display_help:
 		upsdebugx(quiet,"Scanning USB bus.");
 #ifdef HAVE_PTHREAD
 		if(pthread_create(&thread[TYPE_USB],NULL,run_usb,NULL)) {
+			upsdebugx(1,"pthread_create returned an error; disabling this scan mode");
 			nutscan_avail_usb = 0;
 		}
 #else
+		upsdebugx(1,"USB SCAN: no pthread support, starting nutscan_scan_usb...");
 		dev[TYPE_USB] = nutscan_scan_usb();
 #endif /* HAVE_PTHREAD */
+	} else {
+		upsdebugx(1,"USB SCAN: not requested, SKIPPED");
 	}
 
 	if( allow_snmp && nutscan_avail_snmp ) {
@@ -487,24 +491,34 @@ display_help:
 		else {
 			upsdebugx(quiet,"Scanning SNMP bus.");
 #ifdef HAVE_PTHREAD
+			upsdebugx(1,"SNMP SCAN: starting pthread_create with run_snmp...");
 			if( pthread_create(&thread[TYPE_SNMP],NULL,run_snmp,&snmp_sec)) {
+				upsdebugx(1,"pthread_create returned an error; disabling this scan mode");
 				nutscan_avail_snmp = 0;
 			}
 #else
+			upsdebugx(1,"SNMP SCAN: no pthread support, starting nutscan_scan_snmp...");
 			dev[TYPE_SNMP] = nutscan_scan_snmp(start_ip,end_ip,timeout,&snmp_sec);
 #endif /* HAVE_PTHREAD */
 		}
+	} else {
+		upsdebugx(1,"SNMP SCAN: not requested, SKIPPED");
 	}
 
 	if( allow_xml && nutscan_avail_xml_http) {
 		upsdebugx(quiet,"Scanning XML/HTTP bus.");
 #ifdef HAVE_PTHREAD
+		upsdebugx(1,"XML/HTTP SCAN: starting pthread_create with run_xml...");
 		if(pthread_create(&thread[TYPE_XML],NULL,run_xml,NULL)) {
+			upsdebugx(1,"pthread_create returned an error; disabling this scan mode");
 			nutscan_avail_xml_http = 0;
 		}
 #else
+		upsdebugx(1,"XML/HTTP SCAN: no pthread support, starting nutscan_scan_xml_http()...");
 		dev[TYPE_XML] = nutscan_scan_xml_http(timeout);
 #endif /* HAVE_PTHREAD */
+	} else {
+		upsdebugx(1,"XML/HTTP SCAN: not requested, SKIPPED");
 	}
 
 	if( allow_oldnut && nutscan_avail_nut) {
@@ -515,94 +529,140 @@ display_help:
 		else {
 			upsdebugx(quiet,"Scanning NUT bus (old connect method).");
 #ifdef HAVE_PTHREAD
+			upsdebugx(1,"NUT bus (old) SCAN: starting pthread_create with run_nut_old...");
 			if(pthread_create(&thread[TYPE_NUT],NULL,run_nut_old,NULL)) {
+				upsdebugx(1,"pthread_create returned an error; disabling this scan mode");
 				nutscan_avail_nut = 0;
 			}
 #else
+			upsdebugx(1,"NUT bus (old) SCAN: no pthread support, starting nutscan_scan_nut...");
 			dev[TYPE_NUT] = nutscan_scan_nut(start_ip,end_ip,port,timeout);
 #endif /* HAVE_PTHREAD */
 		}
+	} else {
+		upsdebugx(1,"NUT bus (old) SCAN: not requested, SKIPPED");
 	}
 
 	if( allow_avahi && nutscan_avail_avahi) {
 		upsdebugx(quiet,"Scanning NUT bus (avahi method).");
 #ifdef HAVE_PTHREAD
+		upsdebugx(1,"NUT bus (avahi) SCAN: starting pthread_create with run_avahi...");
 		if(pthread_create(&thread[TYPE_AVAHI],NULL,run_avahi,NULL)) {
+			upsdebugx(1,"pthread_create returned an error; disabling this scan mode");
 			nutscan_avail_avahi = 0;
 		}
 #else
+		upsdebugx(1,"NUT bus (avahi) SCAN: no pthread support, starting nutscan_scan_avahi...");
 		dev[TYPE_AVAHI] = nutscan_scan_avahi(timeout);
 #endif /* HAVE_PTHREAD */
+	} else {
+		upsdebugx(1,"NUT bus (avahi) SCAN: not requested, SKIPPED");
 	}
 
 	if( allow_ipmi  && nutscan_avail_ipmi) {
 		upsdebugx(quiet,"Scanning IPMI bus.");
 #ifdef HAVE_PTHREAD
+		upsdebugx(1,"IPMI SCAN: starting pthread_create with run_ipmi...");
 		if(pthread_create(&thread[TYPE_IPMI],NULL,run_ipmi,&ipmi_sec)) {
+			upsdebugx(1,"pthread_create returned an error; disabling this scan mode");
 			nutscan_avail_ipmi = 0;
 		}
 #else
+		upsdebugx(1,"IPMI SCAN: no pthread support, starting nutscan_scan_ipmi...");
 		dev[TYPE_IPMI] = nutscan_scan_ipmi(start_ip,end_ip,&ipmi_sec);
 #endif /* HAVE_PTHREAD */
+	} else {
+		upsdebugx(1,"IPMI SCAN: not requested, SKIPPED");
 	}
 
 	/* Eaton serial scan */
 	if (allow_eaton_serial) {
 		upsdebugx(quiet,"Scanning serial bus for Eaton devices.");
 #ifdef HAVE_PTHREAD
+		upsdebugx(1,"SERIAL SCAN: starting pthread_create with run_eaton_serial (return not checked!)...");
 		pthread_create(&thread[TYPE_EATON_SERIAL], NULL, run_eaton_serial, serial_ports);
 		/* FIXME: check return code */
+		/* upsdebugx(1,"pthread_create returned an error; disabling this scan mode"); */
+		/* nutscan_avail_eaton_serial(?) = 0; */
 #else
+		upsdebugx(1,"SERIAL SCAN: no pthread support, starting nutscan_scan_eaton_serial...");
 		dev[TYPE_EATON_SERIAL] = nutscan_scan_eaton_serial (serial_ports);
 #endif /* HAVE_PTHREAD */
+	} else {
+		upsdebugx(1,"SERIAL SCAN: not requested, SKIPPED");
 	}
 
 #ifdef HAVE_PTHREAD
 	if( allow_usb && nutscan_avail_usb && thread[TYPE_USB]) {
+		upsdebugx(1,"USB SCAN: join back the pthread");
 		pthread_join(thread[TYPE_USB], NULL);
 	}
 	if( allow_snmp && nutscan_avail_snmp && thread[TYPE_SNMP]) {
+		upsdebugx(1,"SNMP SCAN: join back the pthread");
 		pthread_join(thread[TYPE_SNMP], NULL);
 	}
 	if( allow_xml && nutscan_avail_xml_http && thread[TYPE_XML]) {
+		upsdebugx(1,"XML/HTTP SCAN: join back the pthread");
 		pthread_join(thread[TYPE_XML], NULL);
 	}
 	if( allow_oldnut && nutscan_avail_nut && thread[TYPE_NUT]) {
+		upsdebugx(1,"NUT bus (old) SCAN: join back the pthread");
 		pthread_join(thread[TYPE_NUT], NULL);
 	}
 	if( allow_avahi && nutscan_avail_avahi && thread[TYPE_AVAHI]) {
+		upsdebugx(1,"NUT bus (avahi) SCAN: join back the pthread");
 		pthread_join(thread[TYPE_AVAHI], NULL);
 	}
 	if( allow_ipmi && nutscan_avail_ipmi && thread[TYPE_IPMI]) {
+		upsdebugx(1,"IPMI SCAN: join back the pthread");
 		pthread_join(thread[TYPE_IPMI], NULL);
 	}
 	if (allow_eaton_serial && thread[TYPE_EATON_SERIAL]) {
+		upsdebugx(1,"SERIAL SCAN: join back the pthread");
 		pthread_join(thread[TYPE_EATON_SERIAL], NULL);
 	}
 #endif /* HAVE_PTHREAD */
 
+	upsdebugx(1,"SCANS DONE: display results");
+
+	upsdebugx(1,"SCANS DONE: display results: USB");
 	display_func(dev[TYPE_USB]);
+	upsdebugx(1,"SCANS DONE: free resources: USB");
 	nutscan_free_device(dev[TYPE_USB]);
 
+	upsdebugx(1,"SCANS DONE: display results: SNMP");
 	display_func(dev[TYPE_SNMP]);
+	upsdebugx(1,"SCANS DONE: free resources: SNMP");
 	nutscan_free_device(dev[TYPE_SNMP]);
 
+	upsdebugx(1,"SCANS DONE: display results: XML/HTTP");
 	display_func(dev[TYPE_XML]);
+	upsdebugx(1,"SCANS DONE: free resources: XML/HTTP");
 	nutscan_free_device(dev[TYPE_XML]);
 
+	upsdebugx(1,"SCANS DONE: display results: NUT bus (old)");
 	display_func(dev[TYPE_NUT]);
+	upsdebugx(1,"SCANS DONE: free resources: NUT bus (old)");
 	nutscan_free_device(dev[TYPE_NUT]);
 
+	upsdebugx(1,"SCANS DONE: display results: NUT bus (avahi)");
 	display_func(dev[TYPE_AVAHI]);
+	upsdebugx(1,"SCANS DONE: free resources: NUT bus (avahi)");
 	nutscan_free_device(dev[TYPE_AVAHI]);
 
+	upsdebugx(1,"SCANS DONE: display results: IPMI");
 	display_func(dev[TYPE_IPMI]);
+	upsdebugx(1,"SCANS DONE: free resources: IPMI");
 	nutscan_free_device(dev[TYPE_IPMI]);
 
+	upsdebugx(1,"SCANS DONE: display results: SERIAL");
 	display_func(dev[TYPE_EATON_SERIAL]);
+	upsdebugx(1,"SCANS DONE: free resources: SERIAL");
 	nutscan_free_device(dev[TYPE_EATON_SERIAL]);
 
+	upsdebugx(1,"SCANS DONE: free common scanner resources");
 	nutscan_free();
 
+	upsdebugx(1,"SCANS DONE: EXIT_SUCCESS");
 	return EXIT_SUCCESS;
 }

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -116,12 +116,12 @@ int nutscan_load_snmp_library(const char *libname_path)
 	}
 
 	if (libname_path == NULL) {
-		fprintf(stderr, "SNMP library not found. SNMP search disabled.\n");
+		upsdebugx(1, "SNMP library not found. SNMP search disabled");
 		return 0;
 	}
 
 	if( lt_dlinit() != 0 ) {
-		fprintf(stderr, "Error initializing lt_init\n");
+		upsdebugx(1, "Error initializing lt_init");
 		return 0;
 	}
 

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -319,8 +319,8 @@ static void scan_snmp_add_device(nutscan_snmp_t * sec, struct snmp_pdu *response
 
 static struct snmp_pdu * scan_snmp_get_manufacturer(char* oid_str,void* handle)
 {
-        size_t name_len;
-        oid name[MAX_OID_LEN];
+	size_t name_len;
+	oid name[MAX_OID_LEN];
 	struct snmp_pdu *pdu, *response = NULL;
 	int status;
 	int index = 0;
@@ -432,31 +432,31 @@ static int init_session(struct snmp_session * snmp_sess, nutscan_snmp_t * sec)
 		}
 
 		/* Process mandatory fields, based on the security level */
-                switch (snmp_sess->securityLevel) {
-                        case SNMP_SEC_LEVEL_AUTHNOPRIV:
-                                if (sec->authPassword == NULL) {
-                                        fprintf(stderr,
+		switch (snmp_sess->securityLevel) {
+			case SNMP_SEC_LEVEL_AUTHNOPRIV:
+				if (sec->authPassword == NULL) {
+					fprintf(stderr,
 			"authPassword is required for SNMPv3 in %s mode\n",
 						sec->secLevel);
 					return 0;
 				}
 				break;
-                        case SNMP_SEC_LEVEL_AUTHPRIV:
-                                if ((sec->authPassword == NULL) ||
+			case SNMP_SEC_LEVEL_AUTHPRIV:
+				if ((sec->authPassword == NULL) ||
 					(sec->privPassword == NULL)) {
-                                        fprintf(stderr,
+					fprintf(stderr,
 	"authPassword and privPassword are required for SNMPv3 in %s mode\n",
 						sec->secLevel);
 					return 0;
 				}
 				break;
-                        default:
-                                /* nothing else needed */
-                                break;
-                }
+			default:
+				/* nothing else needed */
+				break;
+		}
 
-                /* Process authentication protocol and key */
-               	snmp_sess->securityAuthKeyLen = USM_AUTH_KU_LEN;
+		/* Process authentication protocol and key */
+		snmp_sess->securityAuthKeyLen = USM_AUTH_KU_LEN;
 
 		/* default to MD5 */
 		snmp_sess->securityAuthProto = (*nut_usmHMACMD5AuthProtocol);
@@ -549,8 +549,8 @@ static void * try_SysOID(void * arg)
 	struct snmp_session snmp_sess;
 	void * handle;
 	struct snmp_pdu *pdu, *response = NULL, *resp = NULL;
-        oid name[MAX_OID_LEN];
-        size_t name_len = MAX_OID_LEN;
+	oid name[MAX_OID_LEN];
+	size_t name_len = MAX_OID_LEN;
 	nutscan_snmp_t * sec = (nutscan_snmp_t *)arg;
 	int index = 0;
 	int sysoid_found = 0;
@@ -667,10 +667,9 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 	pthread_mutex_init(&dev_mutex,NULL);
 #endif
 
-        if( !nutscan_avail_snmp ) {
-                return NULL;
-        }
-
+	if( !nutscan_avail_snmp ) {
+		return NULL;
+	}
 
 	g_usec_timeout = usec_timeout;
 

--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -1,5 +1,6 @@
 /*
  *  Copyright (C) 2011 - EATON
+ *  Copyright (C) 2016 - EATON - IP addressed XML scan
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -19,6 +20,8 @@
 /*! \file scan_xml_http.c
     \brief detect NUT supported XML HTTP devices
     \author Frederic Bohe <fredericbohe@eaton.com>
+    \author Michal Vyskocil <MichalVyskocil@eaton.com>
+    \author Jim Klimov <EvgenyKlimov@eaton.com>
 */
 
 #include "common.h"
@@ -36,8 +39,12 @@
 #include <ne_xml.h>
 #include <ltdl.h>
 
+#ifdef HAVE_PTHREAD
+#include <pthread.h>
+#endif
+
 /* dynamic link library stuff */
-static char * libname = "libneon";
+static char * libname = "libneon"; /* Note: this is for info messages, not the SONAME */
 static lt_dlhandle dl_handle = NULL;
 static const char *dl_error = NULL;
 
@@ -47,8 +54,15 @@ static void (*nut_ne_xml_push_handler)(ne_xml_parser *p,
                          ne_xml_endelm_cb *endelm,
                          void *userdata);
 static void (*nut_ne_xml_destroy)(ne_xml_parser *p);
+static int (*nut_ne_xml_failed)(ne_xml_parser *p);
 static ne_xml_parser * (*nut_ne_xml_create)(void);
 static int (*nut_ne_xml_parse)(ne_xml_parser *p, const char *block, size_t len);
+
+static nutscan_device_t * dev_ret = NULL;
+#ifdef HAVE_PTHREAD
+static pthread_mutex_t dev_mutex;
+#endif
+long g_usec_timeout ;
 
 /* return 0 on error */
 int nutscan_load_neon_library(const char *libname_path)
@@ -100,6 +114,11 @@ int nutscan_load_neon_library(const char *libname_path)
 		goto err;
 	}
 
+	*(void **) (&nut_ne_xml_failed) = lt_dlsym(dl_handle,"ne_xml_failed");
+	if ((dl_error = lt_dlerror()) != NULL)  {
+		goto err;
+	}
+
 	return 1;
 err:
 	fprintf(stderr, "Cannot load XML library (%s) : %s. XML search disabled.\n", libname, dl_error);
@@ -108,70 +127,123 @@ err:
 	return 0;
 }
 
+/* A start-element callback for element with given namespace/name. */
 static int startelm_cb(void *userdata, int parent, const char *nspace, const char *name, const char **atts) {
 	nutscan_device_t * dev = (nutscan_device_t *)userdata;
 	char buf[SMALLBUF];
 	int i = 0;
+	int result = -1;
 	while( atts[i] != NULL ) {
+		upsdebugx(5,"startelm_cb() : parent=%d nspace='%s' name='%s' atts[%d]='%s' atts[%d]='%s'",
+			parent, nspace, name, i, atts[i], (i+1), atts[i+1]);
+// The Eaton/MGE ePDUs almost exclusively support only XMLv4 protocol
+// (only the very first generation of G2/G3 NMCs supported an older
+// protocol, but all should have been FW upgraded by now), which NUT
+// drivers don't yet support. To avoid failing drivers later, the
+// nut-scanner should not suggest netxml-ups configuration for ePDUs
+// at this time.
+		if(strcmp(atts[i],"class") == 0 && strcmp(atts[i+1],"DEV.PDU") == 0 ) {
+			upsdebugx(3, "startelm_cb() : XML v4 protocol is not supported by current NUT drivers, skipping device!");
+			/* netxml-ups currently only supports XML version 3 (for UPS),
+			 * and not version 4 (for UPS and PDU)! */
+			return -1;
+		}
 		if(strcmp(atts[i],"type") == 0) {
 			snprintf(buf,sizeof(buf),"%s",atts[i+1]);
 			nutscan_add_option_to_device(dev,"desc",buf);
-			return 0;
+			result = 0;
 		}
 		i=i+2;
 	}
-	return 0;
+	return result;
 }
 
-nutscan_device_t * nutscan_scan_xml_http(long usec_timeout)
+static void * nutscan_scan_xml_http_generic(void * arg)
 {
+	nutscan_xml_t * sec = (nutscan_xml_t *)arg;
 	char *scanMsg = "<SCAN_REQUEST/>";
-	int port = 4679;
+/* Note: at this time the HTTP/XML scan is in fact not implemented - just the UDP part */
+//	int port_http = 80;
+	int port_udp = 4679;
+/* A NULL "ip" causes a broadcast scan; otherwise the single ip address is queried directly */
+	char *ip = NULL;
+	long usec_timeout = -1;
 	int peerSocket;
 	int sockopt_on = 1;
-	struct sockaddr_in sockAddress;
-	socklen_t sockAddressLength = sizeof(sockAddress);
-	memset(&sockAddress, 0, sizeof(sockAddress));
+	struct sockaddr_in sockAddress_udp;
+	socklen_t sockAddressLength = sizeof(sockAddress_udp);
+	memset(&sockAddress_udp, 0, sizeof(sockAddress_udp));
 	fd_set fds;
 	struct timeval timeout;
 	int ret;
 	char buf[SMALLBUF];
 	char string[SMALLBUF];
 	ssize_t recv_size;
+	int i;
 
 	nutscan_device_t * nut_dev = NULL;
-	nutscan_device_t * current_nut_dev = NULL;
+	if(sec != NULL) {
+//		if (sec->port_http > 0 && sec->port_http <= 65534)
+//			port_http = sec->port_http;
+		if (sec->port_udp > 0 && sec->port_udp <= 65534)
+			port_udp = sec->port_udp;
+		if (sec->usec_timeout > 0)
+			usec_timeout = sec->usec_timeout;
+		ip = sec->peername; /* NULL or not... */
+	}
 
-        if( !nutscan_avail_xml_http ) {
-                return NULL;
-        }
+	if (usec_timeout <= 0)
+		usec_timeout = 5000000; /* Driver default : 5sec */
 
-	if((peerSocket = socket(AF_INET, SOCK_DGRAM, 0)) != -1)
-	{
+	if( !nutscan_avail_xml_http ) {
+		return NULL;
+	}
+
+	if((peerSocket = socket(AF_INET, SOCK_DGRAM, 0)) == -1) {
+		fprintf(stderr,"Error creating socket\n");
+		return NULL;
+	}
+
+// FIXME : Per http://stackoverflow.com/questions/683624/udp-broadcast-on-all-interfaces
+// A single sendto() generates a single packet, so one must iterate all known interfaces...
+#define MAX_RETRIES 3
+	for (i = 0; i != MAX_RETRIES ; i++) {
 		/* Initialize socket */
-		sockAddress.sin_family = AF_INET;
-		sockAddress.sin_addr.s_addr = INADDR_BROADCAST;
-		sockAddress.sin_port = htons(port);
-		setsockopt(peerSocket, SOL_SOCKET, SO_BROADCAST, &sockopt_on,
+		sockAddress_udp.sin_family = AF_INET;
+		if (ip == NULL) {
+			upsdebugx(2, "nutscan_scan_xml_http_generic() : scanning connected network segment(s) with a broadcast, attempt %d of %d with a timeout of %ld usec", (i+1), MAX_RETRIES, usec_timeout);
+			sockAddress_udp.sin_addr.s_addr = INADDR_BROADCAST;
+			setsockopt(peerSocket, SOL_SOCKET, SO_BROADCAST, &sockopt_on,
 				sizeof(sockopt_on));
+		} else {
+			upsdebugx(2, "nutscan_scan_xml_http_generic() : scanning IP '%s' with a unicast, attempt %d of %d with a timeout of %ld usec", ip, (i+1), MAX_RETRIES, usec_timeout);
+			inet_pton(AF_INET, ip, &(sockAddress_udp.sin_addr));
+		}
+		sockAddress_udp.sin_port = htons(port_udp);
 
 		/* Send scan request */
 		if(sendto(peerSocket, scanMsg, strlen(scanMsg), 0,
-					(struct sockaddr *)&sockAddress,
+					(struct sockaddr *)&sockAddress_udp,
 					sockAddressLength) <= 0)
 		{
-			fprintf(stderr,"Error sending Eaton <SCAN_REQUEST/>\n");
+			fprintf(stderr,"Error sending Eaton <SCAN_REQUEST/> to %s, #%d/%d\n", ip ? ip : "<broadcast>", (i+1), MAX_RETRIES);
+			usleep(usec_timeout);
+			continue;
 		}
 		else
 		{
+			int retNum = 0;
 			FD_ZERO(&fds);
 			FD_SET(peerSocket,&fds);
 
 			timeout.tv_sec = usec_timeout / 1000000;
 			timeout.tv_usec = usec_timeout % 1000000;
 
+			upsdebugx(5, "nutscan_scan_xml_http_generic() : sent request to %s, loop #%d/%d, waiting for responses", ip ? ip : "<broadcast>", (i+1), MAX_RETRIES);
 			while ((ret=select(peerSocket+1,&fds,NULL,NULL,
 						&timeout) )) {
+				retNum ++;
+				upsdebugx(5, "nutscan_scan_xml_http_generic() : request to %s, loop #%d/%d, response #%d", ip ? ip : "<broadcast>", (i+1), MAX_RETRIES, retNum);
 
 				timeout.tv_sec = usec_timeout / 1000000;
 				timeout.tv_usec = usec_timeout % 1000000;
@@ -186,63 +258,190 @@ nutscan_device_t * nutscan_scan_xml_http(long usec_timeout)
 				sockAddressLength = sizeof(struct sockaddr_in);
 				recv_size = recvfrom(peerSocket,buf,
 						sizeof(buf),0,
-						(struct sockaddr *)&sockAddress,
+						(struct sockaddr *)&sockAddress_udp,
 						&sockAddressLength);
 
 				if(recv_size==-1) {
 					fprintf(stderr,
 						"Error reading \
-						socket: %d\n",errno);
+						socket: %d, #%d/%d\n",errno, (i+1), MAX_RETRIES);
+					usleep(usec_timeout);
 					continue;
 				}
 
-			        if( getnameinfo(
-					(struct sockaddr *)&sockAddress,
-                               		sizeof(struct sockaddr_in),string,
-	                                sizeof(string),NULL,0,
+				if( getnameinfo(
+					(struct sockaddr *)&sockAddress_udp,
+									sizeof(struct sockaddr_in),string,
+									sizeof(string),NULL,0,
 					NI_NUMERICHOST) != 0) {
 
 					fprintf(stderr,
-						"Error converting IP address \
-						: %d\n",errno);
+						"Error converting IP address: %d\n",errno);
+					usleep(usec_timeout);
 					continue;
 				}
 
-                                nut_dev = nutscan_new_device();
-                                if(nut_dev == NULL) {
-                                        fprintf(stderr,"Memory allocation \
-					error\n");
-                                        return NULL;
-                                }
+				nut_dev = nutscan_new_device();
+				if(nut_dev == NULL) {
+					fprintf(stderr,"Memory allocation \
+						error\n");
+					goto end_abort; //return NULL;
+				}
 
-                                nut_dev->type = TYPE_XML;
+#ifdef HAVE_PTHREAD
+				pthread_mutex_lock(&dev_mutex);
+#endif
+				upsdebugx(5, "Some host at IP %s replied to NetXML UDP request on port %d, inspecting the response...", string, port_udp);
+				nut_dev->type = TYPE_XML;
 				/* Try to read device type */
 				ne_xml_parser *parser = (*nut_ne_xml_create)();
 				(*nut_ne_xml_push_handler)(parser, startelm_cb,
 							NULL, NULL, nut_dev);
 				(*nut_ne_xml_parse)(parser, buf, recv_size);
+				int parserFailed = (*nut_ne_xml_failed)(parser); // 0 = ok, nonzero = fail
 				(*nut_ne_xml_destroy)(parser);
 
-				nut_dev->driver = strdup("netxml-ups");
-				sprintf(buf,"http://%s",string);
-				nut_dev->port = strdup(buf);
+				if (parserFailed == 0) {
+					nut_dev->driver = strdup("netxml-ups");
+					sprintf(buf,"http://%s",string);
+					nut_dev->port = strdup(buf);
+					upsdebugx(3,"nutscan_scan_xml_http_generic(): Added configuration for driver='%s' port='%s'", nut_dev->driver, nut_dev->port);
+					dev_ret = nutscan_add_device_to_device(
+						dev_ret,nut_dev);
+#ifdef HAVE_PTHREAD
+					pthread_mutex_unlock(&dev_mutex);
+#endif
+				}
+				else
+				{
+					fprintf(stderr,"Device at IP %s replied with NetXML but was not deemed compatible with 'netxml-ups' driver (unsupported protocol version, etc.)\n", string);
+					nutscan_free_device(nut_dev);
+					nut_dev = NULL;
+#ifdef HAVE_PTHREAD
+					pthread_mutex_unlock(&dev_mutex);
+#endif
+					if (ip == NULL)
+						continue; // skip this device; note that for broadcast scan there may be more in the loop's queue
+				}
 
-				current_nut_dev = nutscan_add_device_to_device(
-						current_nut_dev,nut_dev);
-
+				if (ip != NULL) {
+					upsdebugx(2,"nutscan_scan_xml_http_generic(): we collected one reply to unicast for %s (repsponse from %s), done", ip, string);
+					goto end;
+				}
+			} // while select() responses
+			if (ip == NULL && dev_ret != NULL) {
+				upsdebugx(2,"nutscan_scan_xml_http_generic(): we collected one round of replies to broadcast with no errors, done");
+				goto end;
 			}
 		}
 	}
-	else
-	{
-		fprintf(stderr,"Error creating socket\n");
+	upsdebugx(2,"nutscan_scan_xml_http_generic(): no replies collected for %s, done", ip ? ip : "<broadcast>");
+	goto end;
+
+end_abort:
+	upsdebugx(1,"Had to abort nutscan_scan_xml_http_generic() for %s, see fatal details above", ip ? ip : "<broadcast>");
+end:
+	if (ip != NULL) /* do not free "ip", it comes from caller */
+		close(peerSocket);
+	return NULL;
+}
+
+nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char * end_ip, long usec_timeout, nutscan_xml_t * sec)
+{
+	nutscan_xml_t * tmp_sec = NULL;
+	nutscan_device_t * result = NULL;
+	int i;
+
+	if( !nutscan_avail_xml_http ) {
+		return NULL;
 	}
 
+	if (start_ip == NULL && end_ip != NULL) {
+		start_ip = end_ip;
+	}
 
-	return nutscan_rewind_device(current_nut_dev);
+	if (start_ip == NULL ) {
+		upsdebugx(1,"Scanning XML/HTTP bus using broadcast.");
+	} else {
+		if ( (start_ip == end_ip) || (end_ip == NULL) || (strncmp(start_ip,end_ip,128)==0) ) {
+			upsdebugx(1,"Scanning XML/HTTP bus for single IP (%s).", start_ip);
+		} else {
+			// Iterate the range of IPs to scan
+			nutscan_ip_iter_t ip;
+			char * ip_str = NULL;
+#ifdef HAVE_PTHREAD
+			pthread_t thread;
+			pthread_t * thread_array = NULL;
+			int thread_count = 0;
+
+			pthread_mutex_init(&dev_mutex,NULL);
+#endif
+
+			g_usec_timeout = usec_timeout;
+
+			ip_str = nutscan_ip_iter_init(&ip, start_ip, end_ip);
+
+			while(ip_str != NULL) {
+				tmp_sec = malloc(sizeof(nutscan_xml_t));
+				if (tmp_sec == NULL) {
+					fprintf(stderr,"Memory allocation \
+						error\n");
+					return NULL;
+				}
+				memcpy(tmp_sec, sec, sizeof(nutscan_xml_t));
+				tmp_sec->peername = ip_str;
+				if (tmp_sec->usec_timeout < 0) tmp_sec->usec_timeout = usec_timeout;
+
+#ifdef HAVE_PTHREAD
+				if (pthread_create(&thread,NULL,nutscan_scan_xml_http_generic, (void *)tmp_sec)==0){
+					thread_count++;
+					thread_array = realloc(thread_array,
+								thread_count*sizeof(pthread_t));
+					thread_array[thread_count-1] = thread;
+				}
+#else
+				nutscan_scan_xml_http_generic((void *)tmp_sec);
+#endif
+//				free(ip_str); // One of these free()s seems to cause a double-free
+				ip_str = nutscan_ip_iter_inc(&ip);
+//				free(tmp_sec);
+			};
+
+#ifdef HAVE_PTHREAD
+			for ( i=0; i < thread_count ; i++) {
+				pthread_join(thread_array[i],NULL);
+			}
+			pthread_mutex_destroy(&dev_mutex);
+			free(thread_array);
+#endif
+			result = nutscan_rewind_device(dev_ret);
+			dev_ret = NULL;
+			return result;
+		}
+	}
+
+	tmp_sec = malloc(sizeof(nutscan_xml_t));
+	if (tmp_sec == NULL) {
+		fprintf(stderr,"Memory allocation \
+			error\n");
+		return NULL;
+	}
+
+	memcpy(tmp_sec, sec, sizeof(nutscan_xml_t));
+	if (start_ip == NULL) {
+		tmp_sec->peername = NULL;
+	} else {
+		tmp_sec->peername = strdup(start_ip);
+	}
+	if (tmp_sec->usec_timeout < 0) tmp_sec->usec_timeout = usec_timeout;
+	nutscan_scan_xml_http_generic(tmp_sec);
+	result = nutscan_rewind_device(dev_ret);
+	dev_ret = NULL;
+	free(tmp_sec);
+	return result;
 }
 #else /* WITH_NEON */
-nutscan_device_t * nutscan_scan_xml_http(long usec_timeout)
+nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char * end_ip, long usec_timeout, nutscan_xml_t * sec)
 {
 	return NULL;
 }


### PR DESCRIPTION
These are two somewhat separate, but quite interwoven pieces of work which are easier to push together than to untangle backwards:
* revision of nut-scanner code structure for logging approaches common with other NUT programs (e.g. use `upsdebugx()` and `-D` flag) and push the help-text printer out of common loop into a separate routine,
* enhance netxml(udp) scanning to do not only broadcasts on a connected segment as before (if no target IP is provided), but also be able to scan single IP (`-s` alone), range of IPs (`-s` + `-e`) and subnets (`-m`) instead
* this includes a more evolved variant of not-suggesting XMLv4 devices mistakenly as if they were netxml-supported (so this code supersedes PR #324)

Work by Jim Klimov and Michal Vyskocil (@vyskocilm).