### PR TITLE
client/ups: add missing include

### DIFF
--- a/clients/upsclient.c
+++ b/clients/upsclient.c
@@ -37,6 +37,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <fcntl.h>
+#include <sys/time.h>
 
 #include "upsclient.h"
 #include "common.h"


### PR DESCRIPTION
struct timeval is declared in sys/time.h, so we need to #include it.

Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>