### PR TITLE
Travis CI matrix builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.l[oa]
 .deps/
 .libs/
+.inst/
 Makefile
 Makefile.in
 ## Parent directory only

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ matrix:
         - libltdl-dev
         - libneon27-dev
         - libfreeipmi-dev
+        - libfreeipmi16
         - libusb-dev
         - libpowerman0-dev
         - libavahi-common-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
   matrix:
     - BUILD_TYPE=default
     - BUILD_TYPE=default-nodoc
+    - BUILD_TYPE=default-withdoc
 
 # Builds with customized setups
 matrix:
@@ -43,17 +44,17 @@ matrix:
         - libavahi-common-dev
         - libavahi-core-dev
         - libavahi-client-dev
-  - env: BUILD_TYPE=default-withdoc
-    os: linux
-    addons:
-      apt:
-        packages:
-        - asciidoc
-        - xsltproc
-        - libxml2-utils
-        - dblatex
-        - docbook-xsl
-        - docbook-xsl-ns
+#  - env: BUILD_TYPE=default-withdoc
+#    os: linux
+#    addons:
+#      apt:
+#        packages:
+#        - asciidoc
+#        - xsltproc
+#        - libxml2-utils
+#        - dblatex
+#        - docbook-xsl
+#        - docbook-xsl-ns
 #  - env: BUILD_TYPE=valgrind
 #    os: linux
 #    dist: trusty
@@ -64,11 +65,20 @@ matrix:
 #        - valgrind
 
 # Common required packages for all scenarios
+# TODO: Remove doc-generation packages from common set and uncomment the
+# BUILD_TYPE=default-withdoc matrix settings above after integrating the
+# support for --with-doc=skip which allows distcheck to pass
 addons:
   apt:
     packages:
     - git
     - ccache
+    - asciidoc
+    - xsltproc
+    - libxml2-utils
+    - dblatex
+    - docbook-xsl
+    - docbook-xsl-ns
 
 before_install:
 - if [ $TRAVIS_OS_NAME == "osx" ] ; then brew update; brew install binutils asciidoc docbook-xsl ; XML_CATALOG_FILES=/usr/local/etc/xml/catalog ; export XML_CATALOG_FILES ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
         - libavahi-common-dev
         - libavahi-core-dev
         - libavahi-client-dev
-        - libgd-dev
+        - libgd2-xpm-dev
         - libpng-dev
         - libjpeg-dev
         - libfreetype6-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ matrix:
         - libipmimonitoring-dev
         - libipmimonitoring4
         - libusb-dev
+        - linux-libc-dev
         - libpowerman0-dev
         - libavahi-common-dev
         - libavahi-core-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,28 @@ env:
     - CI_TIME=true
     - CI_TRACE=false
   matrix:
+    - BUILD_TYPE=default-nodoc
     - BUILD_TYPE=default
+    - BUILD_TYPE=default-alldrv
+
+matrix:
+  include:
+  - env: BUILD_TYPE=default-alldrv
+    os: linux
+    dist: trusty
+    sudo: required
+    addons:
+      apt:
+        packages:
+        - libsnmp-dev
+        - libltdl-dev
+        - libneon27-dev
+        - libfreeipmi-dev
+        - libusb-dev
+        - libpowerman0-dev
+        - libavahi-common-dev
+        - libavahi-core-dev
+        - libavahi-client-dev
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+# Travis CI script
+################################################################################
+# This file is based on a template used by zproject, but isn't auto-generated. #
+################################################################################
+
+language: c
+
+cache: ccache
+
+os:
+- linux
+
+sudo: false
+
+services:
+- docker
+
+env:
+  global:
+    - CI_TIME=true
+    - CI_TRACE=false
+  matrix:
+    - BUILD_TYPE=default
+
+addons:
+  apt:
+    packages:
+    - git
+    - ccache
+    - asciidoc
+    - xsltproc
+    - libxml2-utils
+    - dblatex
+    - docbook-xsl
+    - docbook-xsl-ns
+
+before_install:
+- if [ $TRAVIS_OS_NAME == "osx" ] ; then brew update; brew install binutils asciidoc docbook-xsl ; XML_CATALOG_FILES=/usr/local/etc/xml/catalog ; export XML_CATALOG_FILES ; fi
+
+# Hand off to generated script for each BUILD_TYPE
+script: ./ci_build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
         - libltdl-dev
         - libneon27-dev
         - libfreeipmi-dev
-        - libfreeipmi16
+        - libfreeipmi10
         - libusb-dev
         - libpowerman0-dev
         - libavahi-common-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ env:
   matrix:
     - BUILD_TYPE=default-nodoc
     - BUILD_TYPE=default
-    - BUILD_TYPE=default-alldrv
 
+# Builds with customized setups
 matrix:
   include:
   - env: BUILD_TYPE=default-alldrv

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,11 @@ matrix:
         - libavahi-common-dev
         - libavahi-core-dev
         - libavahi-client-dev
+        - libgd-dev
+        - libpng-dev
+        - libjpeg-dev
+        - libfreetype6-dev
+        - libxpm-dev
 #  - env: BUILD_TYPE=default-withdoc
 #    os: linux
 #    addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ matrix:
         - libneon27-dev
         - libfreeipmi-dev
         - libfreeipmi10
+        - libipmimonitoring-dev
+        - libipmimonitoring4
         - libusb-dev
         - libpowerman0-dev
         - libavahi-common-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,16 +20,14 @@ env:
     - CI_TIME=true
     - CI_TRACE=false
   matrix:
-    - BUILD_TYPE=default-nodoc
     - BUILD_TYPE=default
+    - BUILD_TYPE=default-nodoc
 
 # Builds with customized setups
 matrix:
   include:
   - env: BUILD_TYPE=default-alldrv
     os: linux
-    dist: trusty
-    sudo: required
     addons:
       apt:
         packages:
@@ -42,18 +40,32 @@ matrix:
         - libavahi-common-dev
         - libavahi-core-dev
         - libavahi-client-dev
+  - env: BUILD_TYPE=default-withdoc
+    os: linux
+    addons:
+      apt:
+        packages:
+        - asciidoc
+        - xsltproc
+        - libxml2-utils
+        - dblatex
+        - docbook-xsl
+        - docbook-xsl-ns
+#  - env: BUILD_TYPE=valgrind
+#    os: linux
+#    dist: trusty
+#    sudo: required
+#    addons:
+#      apt:
+#        packages:
+#        - valgrind
 
+# Common required packages for all scenarios
 addons:
   apt:
     packages:
     - git
     - ccache
-    - asciidoc
-    - xsltproc
-    - libxml2-utils
-    - dblatex
-    - docbook-xsl
-    - docbook-xsl-ns
 
 before_install:
 - if [ $TRAVIS_OS_NAME == "osx" ] ; then brew update; brew install binutils asciidoc docbook-xsl ; XML_CATALOG_FILES=/usr/local/etc/xml/catalog ; export XML_CATALOG_FILES ; fi

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -24,7 +24,7 @@ case "$CI_TRACE" in
         set -x ;;
 esac
 
-if [ "$BUILD_TYPE" == "default" ] ||  [ "$BUILD_TYPE" == "default-alldrv" ] || [ "$BUILD_TYPE" == "default-nodoc" ] ; then
+if [ "$BUILD_TYPE" == "default" ] ||  [ "$BUILD_TYPE" == "default-alldrv" ] || [ "$BUILD_TYPE" == "default-nodoc" ] || [ "$BUILD_TYPE" == "default-withdoc" ] ; then
     LANG=C
     LC_ALL=C
     export LANG LC_ALL
@@ -103,12 +103,16 @@ if [ "$BUILD_TYPE" == "default" ] ||  [ "$BUILD_TYPE" == "default-alldrv" ] || [
         "default-nodoc")
             CONFIG_OPTS+=("--with-doc=no")
             ;;
+        "default-withdoc")
+            CONFIG_OPTS+=("--with-doc=yes")
+            ;;
         "default-alldrv")
             CONFIG_OPTS+=("--with-doc=skip")
             CONFIG_OPTS+=("--with-all=yes")
             ;;
         "default"|*)
-            CONFIG_OPTS+=("--with-doc=yes")
+            # Do not build the docs and tell distcheck it is okay
+            CONFIG_OPTS+=("--with-doc=skip")
             ;;
     esac
 

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -99,18 +99,27 @@ if [ "$BUILD_TYPE" == "default" ] ||  [ "$BUILD_TYPE" == "default-alldrv" ] || [
     CONFIG_OPTS+=("LDFLAGS=-L${BUILD_PREFIX}/lib")
     CONFIG_OPTS+=("PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig")
     CONFIG_OPTS+=("--prefix=${BUILD_PREFIX}")
+
+    DO_DISTCHECK=yes
     case "$BUILD_TYPE" in
         "default-nodoc")
             CONFIG_OPTS+=("--with-doc=no")
+            DO_DISTCHECK=no
             ;;
         "default-withdoc")
             CONFIG_OPTS+=("--with-doc=yes")
             ;;
         "default-alldrv")
-            # Do not build the docs and do not distcheckbelow
+            # Do not build the docs and do not distcheck below
             # TODO: "skip" will work after its PR is integrated
             #CONFIG_OPTS+=("--with-doc=skip")
             CONFIG_OPTS+=("--with-doc=no")
+            # TODO: can enable distcheck for alldrv but not sure it brings
+            # extra value for the consumed time; this may change e.g. after
+            # DMF integration which can regenerate the *.dmf files and redist
+            # those products. And also distcheck requires either skipped or
+            # generated manpages.
+            DO_DISTCHECK=no
             CONFIG_OPTS+=("--with-all=yes")
             ;;
         "default"|*)
@@ -190,10 +199,7 @@ if [ "$BUILD_TYPE" == "default" ] ||  [ "$BUILD_TYPE" == "default-alldrv" ] || [
     [ -z "$CI_TIME" ] || echo "`date`: Trying to install the currently tested project into the custom DESTDIR..."
     $CI_TIME make VERBOSE=1 DESTDIR="$INST_PREFIX" install
 
-    # TODO: can enable distcheck alldrv but not sure it brings extra value
-    # for the consumed time; this may change e.g. after DMF integration
-    # which can regenerate the *.dmf files and redist those products.
-    if [ "$BUILD_TYPE" == "default-nodoc" ] || [ "$BUILD_TYPE" == "default-alldrv" ] ; then
+    if [ "$DO_DISTCHECK" == "no" ] ; then
         echo "Skipping distcheck (doc generation is disabled, it would fail)"
     else
         [ -z "$CI_TIME" ] || echo "`date`: Starting distcheck of currently tested project..."

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -99,6 +99,10 @@ if [ "$BUILD_TYPE" == "default" ] ||  [ "$BUILD_TYPE" == "default-alldrv" ] || [
     CONFIG_OPTS+=("LDFLAGS=-L${BUILD_PREFIX}/lib")
     CONFIG_OPTS+=("PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig")
     CONFIG_OPTS+=("--prefix=${BUILD_PREFIX}")
+    CONFIG_OPTS+=("--sysconfdir=${BUILD_PREFIX}/etc/nut")
+    CONFIG_OPTS+=("--with-udev-dir=${BUILD_PREFIX}/etc/udev")
+    CONFIG_OPTS+=("--with-devd-dir=${BUILD_PREFIX}/etc/devd")
+    CONFIG_OPTS+=("--with-hotplug-dir=${BUILD_PREFIX}/etc/hotplug")
 
     DO_DISTCHECK=yes
     case "$BUILD_TYPE" in

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -204,6 +204,8 @@ if [ "$BUILD_TYPE" == "default" ] ||  [ "$BUILD_TYPE" == "default-alldrv" ] || [
 
     [ -z "$CI_TIME" ] || echo "`date`: Trying to install the currently tested project into the custom DESTDIR..."
     $CI_TIME make VERBOSE=1 DESTDIR="$INST_PREFIX" install
+    [ -n "$CI_TIME" ] && echo "`date`: listing files installed into the custom DESTDIR..." && \
+        find "$INST_PREFIX" -ls || true
 
     if [ "$DO_DISTCHECK" == "no" ] ; then
         echo "Skipping distcheck (doc generation is disabled, it would fail)"

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -107,12 +107,17 @@ if [ "$BUILD_TYPE" == "default" ] ||  [ "$BUILD_TYPE" == "default-alldrv" ] || [
             CONFIG_OPTS+=("--with-doc=yes")
             ;;
         "default-alldrv")
-            CONFIG_OPTS+=("--with-doc=all=skip")
+            # Do not build the docs and do not distcheckbelow
+            # TODO: "skip" will work after its PR is integrated
+            #CONFIG_OPTS+=("--with-doc=skip")
+            CONFIG_OPTS+=("--with-doc=no")
             CONFIG_OPTS+=("--with-all=yes")
             ;;
         "default"|*)
             # Do not build the docs and tell distcheck it is okay
-            CONFIG_OPTS+=("--with-doc=all=skip")
+            # TODO: "skip" will work after its PR is integrated
+            #CONFIG_OPTS+=("--with-doc=skip")
+            CONFIG_OPTS+=("--with-doc=man")
             ;;
     esac
 

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -107,12 +107,12 @@ if [ "$BUILD_TYPE" == "default" ] ||  [ "$BUILD_TYPE" == "default-alldrv" ] || [
             CONFIG_OPTS+=("--with-doc=yes")
             ;;
         "default-alldrv")
-            CONFIG_OPTS+=("--with-doc=skip")
+            CONFIG_OPTS+=("--with-doc=all=skip")
             CONFIG_OPTS+=("--with-all=yes")
             ;;
         "default"|*)
             # Do not build the docs and tell distcheck it is okay
-            CONFIG_OPTS+=("--with-doc=skip")
+            CONFIG_OPTS+=("--with-doc=all=skip")
             ;;
     esac
 

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -120,6 +120,8 @@ if [ "$BUILD_TYPE" == "default" ] ||  [ "$BUILD_TYPE" == "default-alldrv" ] || [
             # those products. And also distcheck requires either skipped or
             # generated manpages.
             DO_DISTCHECK=no
+            # NOTE: At this time the required i2c routines are not found in
+            # the system headers, and configure skips that optional driver.
             CONFIG_OPTS+=("--with-all=yes")
             ;;
         "default"|*)

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -178,7 +178,10 @@ if [ "$BUILD_TYPE" == "default" ] ||  [ "$BUILD_TYPE" == "default-alldrv" ] || [
     export CCACHE_BASEDIR
     $CI_TIME ./autogen.sh 2> /dev/null
     $CI_TIME ./configure "${CONFIG_OPTS[@]}"
-    $CI_TIME make VERBOSE=1 all
+    ( echo "`date`: Starting the parallel build attempt..."; \
+      $CI_TIME make VERBOSE=1 -k -j8 all; ) || \
+    ( echo "`date`: Starting the sequential build attempt..."; \
+      $CI_TIME make VERBOSE=1 all )
 
     echo "=== Are GitIgnores good after 'make all'? (should have no output below)"
     git status -s || true

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+
+################################################################################
+# This file is based on a template used by zproject, but isn't auto-generated. #
+################################################################################
+
+set -e
+
+# Set this to enable verbose profiling
+[ -n "${CI_TIME-}" ] || CI_TIME=""
+case "$CI_TIME" in
+    [Yy][Ee][Ss]|[Oo][Nn]|[Tt][Rr][Uu][Ee])
+        CI_TIME="time -p " ;;
+    [Nn][Oo]|[Oo][Ff][Ff]|[Ff][Aa][Ll][Ss][Ee])
+        CI_TIME="" ;;
+esac
+
+# Set this to enable verbose tracing
+[ -n "${CI_TRACE-}" ] || CI_TRACE="no"
+case "$CI_TRACE" in
+    [Nn][Oo]|[Oo][Ff][Ff]|[Ff][Aa][Ll][Ss][Ee])
+        set +x ;;
+    [Yy][Ee][Ss]|[Oo][Nn]|[Tt][Rr][Uu][Ee])
+        set -x ;;
+esac
+
+if [ "$BUILD_TYPE" == "default" ] ; then
+    LANG=C
+    LC_ALL=C
+    export LANG LC_ALL
+
+    if [ -d "./tmp" ]; then
+        rm -rf ./tmp
+    fi
+    if [ -d "./.inst" ]; then
+        rm -rf ./.inst
+    fi
+    mkdir -p tmp .inst
+    BUILD_PREFIX=$PWD/tmp
+    INST_PREFIX=$PWD/.inst
+
+    PATH="`echo "$PATH" | sed -e 's,^/usr/lib/ccache/?:,,' -e 's,:/usr/lib/ccache/?:,,' -e 's,:/usr/lib/ccache/?$,,' -e 's,^/usr/lib/ccache/?$,,'2`"
+    CCACHE_PATH="$PATH"
+    CCACHE_DIR="${HOME}/.ccache"
+    export CCACHE_PATH CCACHE_DIR PATH
+    HAVE_CCACHE=no
+    if which ccache && ls -la /usr/lib/ccache ; then
+        HAVE_CCACHE=yes
+    fi
+
+    if [ "$HAVE_CCACHE" = yes ] && [ -d "$CCACHE_DIR" ]; then
+        echo "CCache stats before build:"
+        ccache -s || true
+    fi
+    mkdir -p "${HOME}/.ccache"
+
+    CONFIG_OPTS=()
+    COMMON_CFLAGS=""
+    EXTRA_CFLAGS=""
+    EXTRA_CPPFLAGS=""
+    EXTRA_CXXFLAGS=""
+
+    is_gnucc() {
+        if [ -n "$1" ] && "$1" --version 2>&1 | grep 'Free Software Foundation' > /dev/null ; then true ; else false ; fi
+    }
+
+    COMPILER_FAMILY=""
+    if [ -n "$CC" -a -n "$CXX" ]; then
+        if is_gnucc "$CC" && is_gnucc "$CXX" ; then
+            COMPILER_FAMILY="GCC"
+            export CC CXX
+        fi
+    else
+        if is_gnucc "gcc" && is_gnucc "g++" ; then
+            # Autoconf would pick this by default
+            COMPILER_FAMILY="GCC"
+            [ -n "$CC" ] || CC=gcc
+            [ -n "$CXX" ] || CXX=g++
+            export CC CXX
+        elif is_gnucc "cc" && is_gnucc "c++" ; then
+            COMPILER_FAMILY="GCC"
+            [ -n "$CC" ] || CC=cc
+            [ -n "$CXX" ] || CXX=c++
+            export CC CXX
+        fi
+    fi
+
+    if [ -n "$CPP" ] ; then
+        [ -x "$CPP" ] && export CPP
+    else
+        if is_gnucc "cpp" ; then
+            CPP=cpp && export CPP
+        fi
+    fi
+
+    CONFIG_OPTS+=("CFLAGS=-I${BUILD_PREFIX}/include")
+    CONFIG_OPTS+=("CPPFLAGS=-I${BUILD_PREFIX}/include")
+    CONFIG_OPTS+=("CXXFLAGS=-I${BUILD_PREFIX}/include")
+    CONFIG_OPTS+=("LDFLAGS=-L${BUILD_PREFIX}/lib")
+    CONFIG_OPTS+=("PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig")
+    CONFIG_OPTS+=("--prefix=${BUILD_PREFIX}")
+    CONFIG_OPTS+=("--with-doc=yes")
+
+    if [ "$HAVE_CCACHE" = yes ] && [ "${COMPILER_FAMILY}" = GCC ]; then
+        PATH="/usr/lib/ccache:$PATH"
+        export PATH
+        if [ -n "$CC" ] && [ -x "/usr/lib/ccache/`basename "$CC"`" ]; then
+            case "$CC" in
+                *ccache*) ;;
+                */*) DIR_CC="`dirname "$CC"`" && [ -n "$DIR_CC" ] && DIR_CC="`cd "$DIR_CC" && pwd `" && [ -n "$DIR_CC" ] && [ -d "$DIR_CC" ] || DIR_CC=""
+                    [ -z "$CCACHE_PATH" ] && CCACHE_PATH="$DIR_CC" || \
+                    if echo "$CCACHE_PATH" | egrep '(^'"$DIR_CC"':.*|^'"$DIR_CC"'$|:'"$DIR_CC"':|:'"$DIR_CC"'$)' ; then
+                        CCACHE_PATH="$DIR_CC:$CCACHE_PATH"
+                    fi
+                    ;;
+            esac
+            CC="/usr/lib/ccache/`basename "$CC"`"
+        else
+            : # CC="ccache $CC"
+        fi
+        if [ -n "$CXX" ] && [ -x "/usr/lib/ccache/`basename "$CXX"`" ]; then
+            case "$CXX" in
+                *ccache*) ;;
+                */*) DIR_CXX="`dirname "$CXX"`" && [ -n "$DIR_CXX" ] && DIR_CXX="`cd "$DIR_CXX" && pwd `" && [ -n "$DIR_CXX" ] && [ -d "$DIR_CXX" ] || DIR_CXX=""
+                    [ -z "$CCACHE_PATH" ] && CCACHE_PATH="$DIR_CXX" || \
+                    if echo "$CCACHE_PATH" | egrep '(^'"$DIR_CXX"':.*|^'"$DIR_CXX"'$|:'"$DIR_CXX"':|:'"$DIR_CXX"'$)' ; then
+                        CCACHE_PATH="$DIR_CXX:$CCACHE_PATH"
+                    fi
+                    ;;
+            esac
+            CXX="/usr/lib/ccache/`basename "$CXX"`"
+        else
+            : # CXX="ccache $CXX"
+        fi
+        if [ -n "$CPP" ] && [ -x "/usr/lib/ccache/`basename "$CPP"`" ]; then
+            case "$CPP" in
+                *ccache*) ;;
+                */*) DIR_CPP="`dirname "$CPP"`" && [ -n "$DIR_CPP" ] && DIR_CPP="`cd "$DIR_CPP" && pwd `" && [ -n "$DIR_CPP" ] && [ -d "$DIR_CPP" ] || DIR_CPP=""
+                    [ -z "$CCACHE_PATH" ] && CCACHE_PATH="$DIR_CPP" || \
+                    if echo "$CCACHE_PATH" | egrep '(^'"$DIR_CPP"':.*|^'"$DIR_CPP"'$|:'"$DIR_CPP"':|:'"$DIR_CPP"'$)' ; then
+                        CCACHE_PATH="$DIR_CPP:$CCACHE_PATH"
+                    fi
+                    ;;
+            esac
+            CPP="/usr/lib/ccache/`basename "$CPP"`"
+        else
+            : # CPP="ccache $CPP"
+        fi
+
+        CONFIG_OPTS+=("CC=${CC}")
+        CONFIG_OPTS+=("CXX=${CXX}")
+        CONFIG_OPTS+=("CPP=${CPP}")
+    fi
+
+    # Build and check this project; note that zprojects always have an autogen.sh
+    [ -z "$CI_TIME" ] || echo "`date`: Starting build of currently tested project..."
+    CCACHE_BASEDIR=${PWD}
+    export CCACHE_BASEDIR
+    $CI_TIME ./autogen.sh 2> /dev/null
+    $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+    $CI_TIME make VERBOSE=1 all
+
+    echo "=== Are GitIgnores good after 'make all'? (should have no output below)"
+    git status -s || true
+    echo "==="
+
+    [ -z "$CI_TIME" ] || echo "`date`: Trying to install the currently tested project into the custom DESTDIR..."
+    $CI_TIME make VERBOSE=1 DESTDIR="$INST_PREFIX" install
+
+    [ -z "$CI_TIME" ] || echo "`date`: Starting distcheck of currently tested project..."
+    (
+        export DISTCHECK_CONFIGURE_FLAGS="${CONFIG_OPTS[@]}"
+        $CI_TIME make VERBOSE=1 DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS" distcheck
+
+        echo "=== Are GitIgnores good after 'make distcheck'? (should have no output below)"
+        git status -s || true
+        echo "==="
+    )
+
+    if [ "$HAVE_CCACHE" = yes ]; then
+        echo "CCache stats after build:"
+        ccache -s
+    fi
+
+elif [ "$BUILD_TYPE" == "bindings" ]; then
+    pushd "./bindings/${BINDING}" && ./ci_build.sh
+else
+    pushd "./builds/${BUILD_TYPE}" && REPO_DIR="$(dirs -l +1)" ./ci_build.sh
+fi

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -12,7 +12,7 @@ IMAGE_FILES = images/asciidoc.png \
 	images/old-cgi.png
 
 # Only track here the local deps
-SHARED_DEPS = nut-names.txt daisychain.txt asciidoc.conf
+SHARED_DEPS = nut-names.txt daisychain.txt asciidoc.conf asciidoc.txt
 
 USER_MANUAL_DEPS = acknowledgements.txt cables.txt config-notes.txt	\
  configure.txt download.txt documentation.txt features.txt history.txt	\


### PR DESCRIPTION
This extends the basics of PR #351 and defines several build scenarios that would run in parallel - and provides a template for future similar customized tests. As detailed in issue #338 this adds several build scenarios to quickly see if a coding/Makefile error breaks the repo:
* a "default-nodoc" build takes about a minute (just build and install - no docs, no distcheck)
* a "default" build (just manpages and a distcheck) is over 2 minutes
* a "default-withdoc" (all formats and distcheck) is over 5 minutes
* a "default-alldrv" (no doc => no distcheck, but otherwise `--with-all`) is just a bit longer than "default-nodoc"

These times might be improved by integrating the changesets (PR #353) which added support for `--with-doc=skip` so that a (limited) `make distcheck` can still be done and uncommenting the prepared lines; some of the benefit will come from not building even the manpages, and some will come from not installing the doc-processing packages in builds that don't care about them.

After this is integrated, development in branches will have an easy way to define tests for features brought by the branch (e.g. some custom scenarios for DMF that are not relevant in codebases that do not have it yet).