### PR TITLE
Refine ST_FLAG_NUMBER-related behaviours

### DIFF
--- a/common/state.c
+++ b/common/state.c
@@ -424,6 +424,11 @@ void state_setflags(st_tree_t *root, const char *var, int numflags, char **flag)
 			continue;
 		}
 
+		if (!strcasecmp(flag[i], "NUMBER")) {
+			sttmp->flags |= ST_FLAG_NUMBER;
+			continue;
+		}
+
 		upsdebugx(2, "Unrecognized flag [%s]", flag[i]);
 	}
 }

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -653,8 +653,8 @@ int dstate_addrange(const char *var, const int min, const int max)
 
 	if (ret == 1) {
 		send_to_all("ADDRANGE %s  %i %i\n", var, min, max);
-		/* Also set the "NUMBER" flag for ranges */
-		dstate_setflags(var, ST_FLAG_NUMBER);
+		/* Also add the "NUMBER" flag for ranges */
+		dstate_addflags(var, ST_FLAG_NUMBER);
 	}
 
 	return ret;

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -703,6 +703,42 @@ void dstate_setflags(const char *var, int flags)
 	send_to_all("SETFLAGS %s\n", flist);
 }
 
+void dstate_addflags(const char *var, const int addflags)
+{
+	int	flags = state_getflags(dtree_root, var);
+
+	if (flags == -1) {
+		upslogx(LOG_ERR, "%s: cannot get flags of '%s'", __func__, var);
+		return;
+	}
+
+	/* Already set */
+	if ((flags & addflags) == addflags)
+		return;
+
+	flags |= addflags;
+
+	dstate_setflags(var, flags);
+}
+
+void dstate_delflags(const char *var, const int delflags)
+{
+	int	flags = state_getflags(dtree_root, var);
+
+	if (flags == -1) {
+		upslogx(LOG_ERR, "%s: cannot get flags of '%s'", __func__, var);
+		return;
+	}
+
+	/* Already not set */
+	if (!(flags & delflags))
+		return;
+
+	flags &= ~delflags;
+
+	dstate_setflags(var, flags);
+}
+
 void dstate_setaux(const char *var, int aux)
 {
 	st_tree_t	*sttmp;

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -327,6 +327,9 @@ static int st_tree_dump_conn(st_tree_t *node, conn_t *conn)
 		if (node->flags & ST_FLAG_STRING) {
 			snprintfcat(flist, sizeof(flist), " STRING");
 		}
+		if (node->flags & ST_FLAG_NUMBER) {
+			snprintfcat(flist, sizeof(flist), " NUMBER");
+		}
 
 		if (!send_to_one(conn, "SETFLAGS %s\n", flist)) {
 			return 0;

--- a/drivers/dstate.h
+++ b/drivers/dstate.h
@@ -53,6 +53,8 @@ int dstate_addenum(const char *var, const char *fmt, ...)
 	__attribute__ ((__format__ (__printf__, 2, 3)));
 int dstate_addrange(const char *var, const int min, const int max);
 void dstate_setflags(const char *var, int flags);
+void dstate_addflags(const char *var, const int addflags);
+void dstate_delflags(const char *var, const int delflags);
 void dstate_setaux(const char *var, int aux);
 const char *dstate_getinfo(const char *var);
 void dstate_addcmd(const char *cmdname);


### PR DESCRIPTION
Follow-up to #265/#267:
- explicitly setting `ST_FLAG_NUMBER` for ranges through `dstate_setflags()` causes the elimination of previously-set flags, inducing some side effects (e.g. if a var is first set as r/w and then its range is added -> the var loses its r/w status and becomes unchangeable): this PR introduces a support function to add flags (and its counterpart to remove flags) without losing the existing ones.
- also, a couple of remaining bits were not updated for `ST_FLAG_NUMBER`.