### PR TITLE
Prefix structures in eaton-atsXY-mib.c files with an eaton_atsXY…

### DIFF
--- a/drivers/eaton-ats16-mib.c
+++ b/drivers/eaton-ats16-mib.c
@@ -29,7 +29,7 @@
 #define EATON_ATS16_SYSOID       ".1.3.6.1.4.1.534.10"
 #define EATON_ATS16_MODEL        ".1.3.6.1.4.1.534.10.2.1.2.0"
 
-static info_lkp_t ats16_source_info[] = {
+static info_lkp_t eaton_ats16_source_info[] = {
 	{ 1, "init" },
 	{ 2, "diagnosis" },
 	{ 3, "off" },
@@ -40,20 +40,20 @@ static info_lkp_t ats16_source_info[] = {
 	{ 0, NULL }
 };
 
-static info_lkp_t ats16_sensitivity_info[] = {
+static info_lkp_t eaton_ats16_sensitivity_info[] = {
 	{ 1, "normal" },
 	{ 2, "high" },
 	{ 3, "low" },
 	{ 0, NULL }
 };
 
-static info_lkp_t ats16_input_frequency_status_info[] = {
+static info_lkp_t eaton_ats16_input_frequency_status_info[] = {
 	{ 1, "good" },          /* No threshold triggered */
 	{ 2, "out-of-range" },  /* Frequency out of range triggered */
 	{ 0, NULL }
 };
 
-static info_lkp_t ats16_input_voltage_status_info[] = {
+static info_lkp_t eaton_ats16_input_voltage_status_info[] = {
 	{ 1, "good" },          /* No threshold triggered */
 	{ 2, "derated-range" }, /* Voltage derated */
 	{ 3, "out-of-range" },  /* Voltage out of range triggered */
@@ -61,7 +61,7 @@ static info_lkp_t ats16_input_voltage_status_info[] = {
 	{ 0, NULL }
 };
 
-static info_lkp_t ats16_test_result_info[] = {
+static info_lkp_t eaton_ats16_test_result_info[] = {
 	{ 1, "done and passed" },
 	{ 2, "done and warning" },
 	{ 3, "done and error" },
@@ -71,7 +71,7 @@ static info_lkp_t ats16_test_result_info[] = {
 	{ 0, NULL }
 };
 
-static info_lkp_t ats16_output_status_info[] = {
+static info_lkp_t eaton_ats16_output_status_info[] = {
 	{ 1, "OFF" }, /* Output not powered */
 	{ 2, "OL" },  /* Output powered */
 	{ 0, NULL }
@@ -111,21 +111,21 @@ static snmp_info_t eaton_ats16_mib[] = {
 	/* ats2InputVoltage.source2 = INTEGER: 2432 0.1 V */
 	{ "input.2.voltage", 0, 0.1, ".1.3.6.1.4.1.534.10.2.2.2.1.2.2", NULL, SU_FLAG_OK, NULL, NULL },
 	/* ats2InputStatusVoltage.source1 = INTEGER: normalRange(1) */
-	{ "input.1.voltage.status", ST_FLAG_STRING, 1, ".1.3.6.1.4.1.534.10.2.3.2.1.5.1", NULL, SU_FLAG_OK, ats16_input_voltage_status_info, NULL },
+	{ "input.1.voltage.status", ST_FLAG_STRING, 1, ".1.3.6.1.4.1.534.10.2.3.2.1.5.1", NULL, SU_FLAG_OK, eaton_ats16_input_voltage_status_info, NULL },
 	/* ats2InputStatusVoltage.source2 = INTEGER: normalRange(1) */
-	{ "input.2.voltage.status", ST_FLAG_STRING, 1, ".1.3.6.1.4.1.534.10.2.3.2.1.5.2", NULL, SU_FLAG_OK, ats16_input_voltage_status_info, NULL },
+	{ "input.2.voltage.status", ST_FLAG_STRING, 1, ".1.3.6.1.4.1.534.10.2.3.2.1.5.2", NULL, SU_FLAG_OK, eaton_ats16_input_voltage_status_info, NULL },
 	/* ats2InputFrequency.source1 = INTEGER: 500 0.1 Hz */
 	{ "input.1.frequency", 0, 0.1, ".1.3.6.1.4.1.534.10.2.2.2.1.3.1", NULL, SU_FLAG_OK, NULL, NULL },
 	/* ats2InputFrequency.source2 = INTEGER: 500 0.1 Hz */
 	{ "input.2.frequency", 0, 0.1, ".1.3.6.1.4.1.534.10.2.2.2.1.3.2", NULL, SU_FLAG_OK, NULL, NULL },
 	/* ats2InputStatusFrequency.source1 = INTEGER: good(1) */
-	{ "input.1.frequency.status", ST_FLAG_STRING, 1, ".1.3.6.1.4.1.534.10.2.3.2.1.2.1", NULL, SU_FLAG_OK, ats16_input_frequency_status_info, NULL },
+	{ "input.1.frequency.status", ST_FLAG_STRING, 1, ".1.3.6.1.4.1.534.10.2.3.2.1.2.1", NULL, SU_FLAG_OK, eaton_ats16_input_frequency_status_info, NULL },
 	/* ats2InputStatusFrequency.source2 = INTEGER: good(1) */
-	{ "input.2.frequency.status", ST_FLAG_STRING, 1, ".1.3.6.1.4.1.534.10.2.3.2.1.2.2", NULL, SU_FLAG_OK, ats16_input_frequency_status_info, NULL },
+	{ "input.2.frequency.status", ST_FLAG_STRING, 1, ".1.3.6.1.4.1.534.10.2.3.2.1.2.2", NULL, SU_FLAG_OK, eaton_ats16_input_frequency_status_info, NULL },
 	/* ats2ConfigSensitivity.0 = INTEGER: normal(1) */
-	{ "input.sensitivity", ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.4.1.534.10.2.4.6.0", NULL, SU_FLAG_OK, &ats16_sensitivity_info[0], NULL },
+	{ "input.sensitivity", ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.4.1.534.10.2.4.6.0", NULL, SU_FLAG_OK, &eaton_ats16_sensitivity_info[0], NULL },
 	/* ats2OperationMode.0 = INTEGER: source1(4) */
-	{ "input.source", ST_FLAG_STRING, 1, ".1.3.6.1.4.1.534.10.2.2.4.0", NULL, SU_FLAG_OK, ats16_source_info, NULL },
+	{ "input.source", ST_FLAG_STRING, 1, ".1.3.6.1.4.1.534.10.2.2.4.0", NULL, SU_FLAG_OK, eaton_ats16_source_info, NULL },
 	/* ats2ConfigPreferred.0 = INTEGER: source1(1) */
 	{ "input.source.preferred", ST_FLAG_RW, 1, ".1.3.6.1.4.1.534.10.2.4.5.0", NULL, SU_FLAG_OK, NULL, NULL },
 
@@ -140,10 +140,10 @@ static snmp_info_t eaton_ats16_mib[] = {
 	/* UPS collection */
 	/* FIXME: RFC for device.test.result! */
 	/* ats2ConfigTransferTest.0 = INTEGER: noTestInitiated(6) */
-	{ "ups.test.result", 0, 1, ".1.3.6.1.4.1.534.10.2.4.8.0", NULL, SU_FLAG_OK, ats16_test_result_info, NULL },
+	{ "ups.test.result", 0, 1, ".1.3.6.1.4.1.534.10.2.4.8.0", NULL, SU_FLAG_OK, eaton_ats16_test_result_info, NULL },
 	/* FIXME: RFC for device.status! */
 	/* ats2StatusOutput.0 = INTEGER: outputPowered(2) */
-	{ "ups.status", 0, 1, ".1.3.6.1.4.1.534.10.2.3.3.2.0", NULL, SU_FLAG_OK, ats16_output_status_info, NULL },
+	{ "ups.status", 0, 1, ".1.3.6.1.4.1.534.10.2.3.3.2.0", NULL, SU_FLAG_OK, eaton_ats16_output_status_info, NULL },
 
 	/* Ambient collection */
 	/* ats2EnvRemoteTemp.0 = INTEGER: 0 degrees Centigrade */

--- a/drivers/eaton-ats30-mib.c
+++ b/drivers/eaton-ats30-mib.c
@@ -54,35 +54,35 @@ static info_lkp_t eaton_ats30_input_sensitivity[] = {
  * 4 atsFailureOverTemperature N/A
  */
 static info_lkp_t eaton_ats30_status_info[] = {
-    { 0, "OL" },
-    { 1, "OL" }, /* SwitchFault */
-    { 2, "OFF" }, /* NoOutput */
-    { 3, "OFF" }, /* SwitchFault + NoOutput */
-    { 4, "OL OVER" }, /* OutputOC */
-    { 5, "OL OVER" }, /* OutputOC + SwitchFault */
-    { 6, "OFF OVER" }, /* OutputOC + NoOutput */
-    { 7, "OFF OVER" }, /* OutputOC + SwitchFault + NoOutput */
-    { 8, "OL" }, /* OverTemperature */
-    { 9, "OL" }, /* OverTemperature + SwitchFault */
-    { 10, "OFF" }, /* OverTemperature + NoOutput */
-    { 11, "OFF" }, /* OverTemperature + SwitchFault + NoOutput */
-    { 12, "OL OVER" }, /* OverTemperature + OutputOC */
-    { 13, "OL OVER" }, /* OverTemperature + OutputOC + SwitchFault */
-    { 14, "OFF OVER" }, /* OverTemperature + OutputOC + NoOutput */
-    { 15, "OFF OVER" }, /* OverTemperature + OutputOC + SwitchFault + NoOutput */
+	{ 0, "OL" },
+	{ 1, "OL" }, /* SwitchFault */
+	{ 2, "OFF" }, /* NoOutput */
+	{ 3, "OFF" }, /* SwitchFault + NoOutput */
+	{ 4, "OL OVER" }, /* OutputOC */
+	{ 5, "OL OVER" }, /* OutputOC + SwitchFault */
+	{ 6, "OFF OVER" }, /* OutputOC + NoOutput */
+	{ 7, "OFF OVER" }, /* OutputOC + SwitchFault + NoOutput */
+	{ 8, "OL" }, /* OverTemperature */
+	{ 9, "OL" }, /* OverTemperature + SwitchFault */
+	{ 10, "OFF" }, /* OverTemperature + NoOutput */
+	{ 11, "OFF" }, /* OverTemperature + SwitchFault + NoOutput */
+	{ 12, "OL OVER" }, /* OverTemperature + OutputOC */
+	{ 13, "OL OVER" }, /* OverTemperature + OutputOC + SwitchFault */
+	{ 14, "OFF OVER" }, /* OverTemperature + OutputOC + NoOutput */
+	{ 15, "OFF OVER" }, /* OverTemperature + OutputOC + SwitchFault + NoOutput */
 	{ 0, NULL }
 };
 
 /* EATON_ATS30 Snmp2NUT lookup table */
 static snmp_info_t eaton_ats30_mib[] = {
-    /* device type: ats */
+	/* device type: ats */
 	{ "device.type", ST_FLAG_STRING, SU_INFOSIZE, NULL, "ats", SU_FLAG_STATIC | SU_FLAG_ABSENT | SU_FLAG_OK, NULL, NULL },
-    
-    /* standard MIB items */
+
+	/* standard MIB items */
 	{ "device.description", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.1.0", NULL, SU_FLAG_OK, NULL, NULL },
 	{ "device.contact", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.4.0", NULL, SU_FLAG_OK, NULL, NULL },
 	{ "device.location", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.6.0", NULL, SU_FLAG_OK, NULL, NULL },
-    
+
 	/* enterprises.534.10.1.1.1.0 = STRING: "Eaton" */
 	{ "device.mfr", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.534.10.1.1.1.0", NULL, SU_FLAG_STATIC | SU_FLAG_OK, NULL, NULL },
 	/* enterprises.534.10.1.1.2.0 = STRING: "01.12.13b" -- SNMP agent version */
@@ -99,9 +99,9 @@ static snmp_info_t eaton_ats30_mib[] = {
 	{ "device.serial", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.534.10.1.2.4.0", NULL, SU_FLAG_OK, NULL, NULL },
 	/* enterprises.534.10.1.2.5.0 = STRING: "                    " -- Device ID codes */
 	/* { "unmapped.enterprises", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.534.10.1.2.5.0", NULL, SU_FLAG_OK, NULL, NULL }, */
-    
-    /* ats measure */
-    /* =========== */
+
+	/* ats measure */
+	/* =========== */
 	/* enterprises.534.10.1.3.1.1.1.1 = INTEGER: 1 */
 	{ "input.1.id", 0, 1, ".1.3.6.1.4.1.534.10.1.3.1.1.1.1", NULL, SU_FLAG_OK, NULL, NULL },
 	/* enterprises.534.10.1.3.1.1.1.2 = INTEGER: 2 */
@@ -128,9 +128,9 @@ static snmp_info_t eaton_ats30_mib[] = {
 	/* { "unmapped.atsMessureTransferedTimes", 0, 1, ".1.3.6.1.4.1.534.10.1.3.6.0", NULL, SU_FLAG_OK, NULL, NULL }, */
 	/* enterprises.534.10.1.3.7.0 = INTEGER: 4 */
 	{ "input.source", 0, 1, ".1.3.6.1.4.1.534.10.1.3.7.0", NULL, SU_FLAG_OK, eaton_ats30_source_info, NULL },
-    
-    /* atsStatus */
-    /* ========= */
+
+	/* atsStatus */
+	/* ========= */
 #if 0
 	/* NOTE: Unused OIDs are left as comments for potential future improvements */
 	/* enterprises.534.10.1.4.1.0 = INTEGER: 7 */
@@ -212,12 +212,12 @@ static snmp_info_t eaton_ats30_mib[] = {
 	/* enterprises.534.10.1.4.6.4.0 = INTEGER: 2 */
 	{ "unmapped.enterprises", 0, 1, ".1.3.6.1.4.1.534.10.1.4.6.4.0", NULL, SU_FLAG_OK, NULL, NULL },
 #endif /* 0 */
-    
-    /* atsLog */
-    /* ====== */
+
+	/* atsLog */
+	/* ====== */
 #if 0
-    /* We are not interested for log */
-    /* enterprises.534.10.1.5.1.0 = INTEGER: 272 */
+	/* We are not interested in log */
+	/* enterprises.534.10.1.5.1.0 = INTEGER: 272 */
 	{ "unmapped.enterprises", 0, 1, ".1.3.6.1.4.1.534.10.1.5.1.0", NULL, SU_FLAG_OK, NULL, NULL },
 	/* enterprises.534.10.1.5.2.1.1.1 = INTEGER: 1 */
 	{ "unmapped.enterprises", 0, 1, ".1.3.6.1.4.1.534.10.1.5.2.1.1.1", NULL, SU_FLAG_OK, NULL, NULL },
@@ -300,9 +300,9 @@ static snmp_info_t eaton_ats30_mib[] = {
 	/* enterprises.534.10.1.5.2.1.4.10 = STRING: "07:31:28 05/12/2016" */
 	{ "unmapped.enterprises", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.534.10.1.5.2.1.4.10", NULL, SU_FLAG_OK, NULL, NULL },
 #endif /* 0 */
-    
-    /* atsConfig */
-    /* ========= */
+
+	/* atsConfig */
+	/* ========= */
 #if 0
 	/* enterprises.534.10.1.6.1.1.0 = INTEGER: 538562409 */
 	{ "unmapped.enterprises", 0, 1, ".1.3.6.1.4.1.534.10.1.6.1.1.0", NULL, SU_FLAG_OK, NULL, NULL },
@@ -352,18 +352,18 @@ static snmp_info_t eaton_ats30_mib[] = {
 	/* enterprises.534.10.1.6.7.0 = INTEGER: 2 */
 	/* { "unmapped.atsConfigTest", 0, 1, ".1.3.6.1.4.1.534.10.1.6.7.0", NULL, SU_FLAG_OK, NULL, NULL }, */
 
-    /* atsUpgrade */
-    /* ========== */
+	/* atsUpgrade */
+	/* ========== */
 #if 0
-    /* We are not interested in atsUpgrade */
+	/* We are not interested in atsUpgrade */
 	/* enterprises.534.10.1.7.1.0 = INTEGER: 1 */
-    /* { "unmapped.enterprises", 0, 1, ".1.3.6.1.4.1.534.10.1.7.1.0", NULL, SU_FLAG_OK, NULL, NULL }, */
+	/* { "unmapped.enterprises", 0, 1, ".1.3.6.1.4.1.534.10.1.7.1.0", NULL, SU_FLAG_OK, NULL, NULL }, */
 	/* enterprises.534.10.1.7.2.0 = INTEGER: 1 */
 	/* { "unmapped.enterprises", 0, 1, ".1.3.6.1.4.1.534.10.1.7.2.0", NULL, SU_FLAG_OK, NULL, NULL }, */
 	/* enterprises.534.10.1.7.3.0 = INTEGER: 0 */
 	/* { "unmapped.enterprises", 0, 1, ".1.3.6.1.4.1.534.10.1.7.3.0", NULL, SU_FLAG_OK, NULL, NULL }, */
 #endif /* 0 */
-    
+
 	/* end of structure. */
 	{ NULL, 0, 0, NULL, NULL, 0, NULL }
 };

--- a/drivers/eaton-ats30-mib.c
+++ b/drivers/eaton-ats30-mib.c
@@ -28,7 +28,7 @@
 #define EATON_ATS30_SYSOID       ".1.3.6.1.4.1.534.10.1"
 #define EATON_ATS30_MODEL        ".1.3.6.1.4.1.534.10.1.2.1.0"
 
-static info_lkp_t ats30_source_info[] = {
+static info_lkp_t eaton_ats30_source_info[] = {
 	{ 1, "init" },
 	{ 2, "diagnosis" },
 	{ 3, "off" },
@@ -39,7 +39,7 @@ static info_lkp_t ats30_source_info[] = {
 	{ 0, NULL }
 };
 
-static info_lkp_t ats30_input_sensitivity[] = {
+static info_lkp_t eaton_ats30_input_sensitivity[] = {
 	{ 1, "high" },
 	{ 2, "low" },
 	{ 0, NULL }
@@ -53,7 +53,7 @@ static info_lkp_t ats30_input_sensitivity[] = {
  * 3 atsFailureOutputOC OVER
  * 4 atsFailureOverTemperature N/A
  */
-static info_lkp_t ats30_status_info[] = {
+static info_lkp_t eaton_ats30_status_info[] = {
     { 0, "OL" },
     { 1, "OL" }, /* SwitchFault */
     { 2, "OFF" }, /* NoOutput */
@@ -127,7 +127,7 @@ static snmp_info_t eaton_ats30_mib[] = {
 	/* enterprises.534.10.1.3.6.0 = INTEGER: 284 */
 	/* { "unmapped.atsMessureTransferedTimes", 0, 1, ".1.3.6.1.4.1.534.10.1.3.6.0", NULL, SU_FLAG_OK, NULL, NULL }, */
 	/* enterprises.534.10.1.3.7.0 = INTEGER: 4 */
-	{ "input.source", 0, 1, ".1.3.6.1.4.1.534.10.1.3.7.0", NULL, SU_FLAG_OK, ats30_source_info, NULL },
+	{ "input.source", 0, 1, ".1.3.6.1.4.1.534.10.1.3.7.0", NULL, SU_FLAG_OK, eaton_ats30_source_info, NULL },
     
     /* atsStatus */
     /* ========= */
@@ -200,7 +200,7 @@ static snmp_info_t eaton_ats30_mib[] = {
 #endif /* 0 */
 
 	/* enterprises.atsFailureIndicator = INTEGER: 0 */
-	{ "ups.status", 0, 1, ".1.3.6.1.4.1.534.10.1.4.5.0", NULL, SU_FLAG_OK, ats30_status_info, NULL },
+	{ "ups.status", 0, 1, ".1.3.6.1.4.1.534.10.1.4.5.0", NULL, SU_FLAG_OK, eaton_ats30_status_info, NULL },
 
 #if 0
 	/* enterprises.534.10.1.4.6.1.0 = INTEGER: 2 -- atsFailure start */
@@ -347,7 +347,7 @@ static snmp_info_t eaton_ats30_mib[] = {
 	/* enterprises.534.10.1.6.5.0 = INTEGER: 1 */
 	{ "input.source.preferred", ST_FLAG_RW, 1, ".1.3.6.1.4.1.534.10.1.6.5.0", NULL, SU_FLAG_OK, NULL, NULL },
 	/* enterprises.534.10.1.6.6.0 = INTEGER: 2 */
-	{ "input.sensitivity", ST_FLAG_RW, 1, ".1.3.6.1.4.1.534.10.1.6.6.0", NULL, SU_FLAG_OK, ats30_input_sensitivity, NULL },
+	{ "input.sensitivity", ST_FLAG_RW, 1, ".1.3.6.1.4.1.534.10.1.6.6.0", NULL, SU_FLAG_OK, eaton_ats30_input_sensitivity, NULL },
 
 	/* enterprises.534.10.1.6.7.0 = INTEGER: 2 */
 	/* { "unmapped.atsConfigTest", 0, 1, ".1.3.6.1.4.1.534.10.1.6.7.0", NULL, SU_FLAG_OK, NULL, NULL }, */


### PR DESCRIPTION
…rather than just atsXY

This is a moderate improvement in current upstream, but rather critical for DMF work (where internal structures are exposed in the DMF tree, so naming collisions are a concern).