### PR TITLE
mge-xml.c : calculate (input|input.bypass|output).phases number (1 or 3)…

### DIFF
--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -1058,7 +1058,7 @@ int dstate_detect_phasecount(
 		           *v1n, *v2n, *v3n,
 		           *v12, *v23, *v31,
 		           *c1,  *c2,  *c3,  *c0;
-		char buf[80]; /* For concatenation of "xput_prefix" with items we want to query */
+		char buf[MAX_STRING_SIZE]; /* For concatenation of "xput_prefix" with items we want to query */
 		size_t xput_prefix_len;
 		int bufrw_max;
 		char *bufrw_ptr = NULL;
@@ -1080,6 +1080,7 @@ int dstate_detect_phasecount(
 			upsdebugx(0, "%s(): Bad xput_prefix was passed: it is too long - function skipped", __func__);
 			return -1;
 		}
+		memset(buf, 0, sizeof(buf));
 		strncpy(buf, xput_prefix, sizeof(buf));
 		bufrw_ptr = buf + xput_prefix_len ;
 

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -1048,25 +1048,29 @@ int dstate_detect_phasecount(
 		           *v12, *v23, *v31,
 		           *c1,  *c2,  *c3,  *c0;
 		char buf[80]; /* For concatenation of "xput_prefix" with items we want to query */
+		size_t xput_prefix_len;
+		int bufrw_max;
+		char *bufrw_ptr = NULL;
+
 		if (!xput_prefix) {
 			upsdebugx(0, "%s(): Bad xput_prefix was passed: it is NULL - function skipped", __func__);
 			return -1;
 		}
 
-		size_t xput_prefix_len = strlen(xput_prefix);
+		xput_prefix_len = strlen(xput_prefix);
 		if (xput_prefix_len < 1) {
 			upsdebugx(0, "%s(): Bad xput_prefix was passed: it is empty - function skipped", __func__);
 			return -1;
 		}
 
-		int bufrw_max = sizeof(buf) - xput_prefix_len;
+		bufrw_max = sizeof(buf) - xput_prefix_len;
 		if (bufrw_max <= 15) {
 			/* We need to append max ~13 chars per below, so far */
 			upsdebugx(0, "%s(): Bad xput_prefix was passed: it is too long - function skipped", __func__);
 			return -1;
 		}
 		strncpy(buf, xput_prefix, sizeof(buf));
-		char *bufrw_ptr = buf + xput_prefix_len ;
+		bufrw_ptr = buf + xput_prefix_len ;
 
 		/* We either have defined and non-zero (numeric) values below, or NULLs */
 		strncpy(bufrw_ptr, "L1.voltage", bufrw_max);

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -1077,34 +1077,30 @@ int dstate_detect_phasecount(
 		bufrw_ptr = buf + xput_prefix_len ;
 
 		/* We either have defined and non-zero (numeric) values below, or NULLs */
-		strncpy(bufrw_ptr, "L1.voltage", bufrw_max);
-		if ((v1 = dstate_getinfo(buf)))    { if (v1[0]  == '0') { v1  = NULL; } }
-		strncpy(bufrw_ptr, "L2.voltage", bufrw_max);
-		if ((v2 = dstate_getinfo(buf)))    { if (v2[0]  == '0') { v2  = NULL; } }
-		strncpy(bufrw_ptr, "L3.voltage", bufrw_max);
-		if ((v3 = dstate_getinfo(buf)))    { if (v3[0]  == '0') { v3  = NULL; } }
-		strncpy(bufrw_ptr, "L1-N.voltage", bufrw_max);
-		if ((v1n = dstate_getinfo(buf)))   { if (v1n[0] == '0') { v1n = NULL; } }
-		strncpy(bufrw_ptr, "L2-N.voltage", bufrw_max);
-		if ((v2n = dstate_getinfo(buf)))   { if (v2n[0] == '0') { v2n = NULL; } }
-		strncpy(bufrw_ptr, "L3-N.voltage", bufrw_max);
-		if ((v3n = dstate_getinfo(buf)))   { if (v3n[0] == '0') { v3n = NULL; } }
-		strncpy(bufrw_ptr, "L1-L2.voltage", bufrw_max);
-		if ((v12 = dstate_getinfo(buf)))   { if (v12[0] == '0') { v12 = NULL; } }
-		strncpy(bufrw_ptr, "L2-L3.voltage", bufrw_max);
-		if ((v23 = dstate_getinfo(buf)))   { if (v23[0] == '0') { v23 = NULL; } }
-		strncpy(bufrw_ptr, "L3-L1.voltage", bufrw_max);
-		if ((v31 = dstate_getinfo(buf)))   { if (v31[0] == '0') { v31 = NULL; } }
-		strncpy(bufrw_ptr, "L1.current", bufrw_max);
-		if ((c1 = dstate_getinfo(buf)))    { if (c1[0]  == '0') { c1  = NULL; } }
-		strncpy(bufrw_ptr, "L2.current", bufrw_max);
-		if ((c2 = dstate_getinfo(buf)))    { if (c2[0]  == '0') { c2  = NULL; } }
-		strncpy(bufrw_ptr, "L3.current", bufrw_max);
-		if ((c3 = dstate_getinfo(buf)))    { if (c3[0]  == '0') { c3  = NULL; } }
-		strncpy(bufrw_ptr, "voltage", bufrw_max);
-		if ((v0 = dstate_getinfo(buf)))    { if (v0[0]  == '0') { v0  = NULL; } }
-		strncpy(bufrw_ptr, "current", bufrw_max);
-		if ((c0 = dstate_getinfo(buf)))    { if (c0[0]  == '0') { c0  = NULL; } }
+#define dstate_getinfo_nonzero(var, suffix) \
+		{ strncpy(bufrw_ptr, suffix, bufrw_max); \
+		  if ( (var = dstate_getinfo(buf)) ) { \
+		    if (var[0] == '0') { \
+		      var = NULL; \
+		    } \
+		  } \
+		} ;
+
+		dstate_getinfo_nonzero(v1,  "L1.voltage");
+		dstate_getinfo_nonzero(v2,  "L2.voltage");
+		dstate_getinfo_nonzero(v3,  "L3.voltage");
+		dstate_getinfo_nonzero(v1n, "L1-N.voltage");
+		dstate_getinfo_nonzero(v2n, "L2-N.voltage");
+		dstate_getinfo_nonzero(v3n, "L3-N.voltage");
+		dstate_getinfo_nonzero(v1n, "L1-N.voltage");
+		dstate_getinfo_nonzero(v12, "L1-L2.voltage");
+		dstate_getinfo_nonzero(v23, "L2-L3.voltage");
+		dstate_getinfo_nonzero(v31, "L3-L1.voltage");
+		dstate_getinfo_nonzero(c1,  "L1.current");
+		dstate_getinfo_nonzero(c2,  "L2.current");
+		dstate_getinfo_nonzero(c3,  "L3.current");
+		dstate_getinfo_nonzero(v0,  "voltage");
+		dstate_getinfo_nonzero(c0,  "current");
 
 		if ( (v1 && v2 && v3) ||
 		     (v1n && v2n && v3n) ||

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -1076,11 +1076,21 @@ int dstate_detect_phasecount(
 		strncpy(buf, xput_prefix, sizeof(buf));
 		bufrw_ptr = buf + xput_prefix_len ;
 
-		/* We either have defined and non-zero (numeric) values below, or NULLs */
+		/* We either have defined and non-zero (numeric) values below, or NULLs.
+		 * Note that as "zero" we should expect any valid numeric representation
+		 * of a zero value as some drivers may save strangely formatted values.
+		 * For now, we limit the level of paranoia with missing dstate entries,
+		 * empty entries, and actual single zero character as contents of the
+		 * string. Other obscure cases (string of multiple zeroes, a floating
+		 * point zero, surrounding whitespace etc. may be solved if the need
+		 * does arise in the future. Arguably, drivers' translation/mapping
+		 * tables should take care of this with converion routine and numeric
+		 * data type flags. */
 #define dstate_getinfo_nonzero(var, suffix) \
 		{ strncpy(bufrw_ptr, suffix, bufrw_max); \
 		  if ( (var = dstate_getinfo(buf)) ) { \
-		    if (var[0] == '0') { \
+		    if ( (var[0] == '0' && var[1] == '\0') || \
+		         (var[0] == '\0') ) { \
 		      var = NULL; \
 		    } \
 		  } \

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -1004,9 +1004,13 @@ void device_alarm_commit(const int device_number)
 }
 
 /* For devices where we do not have phase-count info (no mapping provided
- * above), nor in the XML, we can guesstimate and report a value. This may
- * also replace an existing value, if we've found new data, hence the bools
- * "may_reevaluate" and the readonly flag "may_change_dstate".
+ * in the tables), nor in the device data/protocol, we can still guesstimate
+ * and report a value. This routine may also replace an existing value, e.g.
+ * if we've found new data disproving old one (e.g. if the 3-phase UPS was
+ * disbalanced when the driver was started, so we thought it is 1-phase in
+ * practice, and then the additional lines came up loaded, hence the bools
+ * "may_reevaluate" and the readonly flag "may_change_dstate" (so the caller
+ * can query the current apparent situation, without changing any dstates).
  * It is up to callers to decide if they already have data they want to keep.
  * The "xput_prefix" is e.g. "input." or "input.bypass." or "output." with
  * the trailing dot where applicable - we use this string verbatim below.

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -1017,6 +1017,13 @@ void device_alarm_commit(const int device_number)
  * The "inited_phaseinfo" and "num_phases" are addresses of caller's own
  * variables to store the flag (if we have successfully inited) and the
  * discovered amount of phases, or NULL if caller does not want to track it.
+ *
+ * NOTE: At this time the code below, like elsewhere in the NUT codebase,
+ * assumes there are either 1 or 3 phases, when/if it has to guess (rather
+ * than use a value reported by the device). There was recently a discussion
+ * in NUT issues that 2-phase devices (aka "split phase") exist on the market,
+ * so (TODO) support for these may have to be added at some point.
+ *
  * Returns:
  *   -1     Runtime/input error (non fatal, but routine was skipped)
  *    0     Nothing changed: could not determine a value

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -1039,7 +1039,7 @@ int dstate_detect_phasecount(
 		num_phases = &local_num_phases;
 	old_num_phases = *num_phases;
 
-	upsdebugx(3, "Entering set_phasecount('%s', %i, %i, %i, %i)",
+	upsdebugx(3, "Entering %s('%s', %i, %i, %i, %i)", __func__,
 		xput_prefix, may_change_dstate, *inited_phaseinfo, *num_phases, may_reevaluate);
 
 	if (!(*inited_phaseinfo) || may_reevaluate) {
@@ -1049,20 +1049,20 @@ int dstate_detect_phasecount(
 		           *c1,  *c2,  *c3,  *c0;
 		char buf[80]; /* For concatenation of "xput_prefix" with items we want to query */
 		if (!xput_prefix) {
-			upsdebugx(0, "set_phasecount(): Bad xput_prefix was passed: it is NULL - function skipped");
+			upsdebugx(0, "%s(): Bad xput_prefix was passed: it is NULL - function skipped", __func__);
 			return -1;
 		}
 
 		size_t xput_prefix_len = strlen(xput_prefix);
 		if (xput_prefix_len < 1) {
-			upsdebugx(0, "set_phasecount(): Bad xput_prefix was passed: it is empty - function skipped");
+			upsdebugx(0, "%s(): Bad xput_prefix was passed: it is empty - function skipped", __func__);
 			return -1;
 		}
 
 		int bufrw_max = sizeof(buf) - xput_prefix_len;
 		if (bufrw_max <= 15) {
 			/* We need to append max ~13 chars per below, so far */
-			upsdebugx(0, "set_phasecount(): Bad xput_prefix was passed: it is too long - function skipped");
+			upsdebugx(0, "%s(): Bad xput_prefix was passed: it is too long - function skipped", __func__);
 			return -1;
 		}
 		strncpy(buf, xput_prefix, sizeof(buf));
@@ -1104,7 +1104,7 @@ int dstate_detect_phasecount(
 		     (c2 && (c1 || c3)) ||
 		     (c3 && (c1 || c2)) ||
 		     v12 || v23 || v31 ) {
-			upsdebugx(5, "set_phasecount(): determined a 3-phase case");
+			upsdebugx(5, "%s(): determined a 3-phase case", __func__);
 			*num_phases = 3;
 			*inited_phaseinfo = 1;
 			detected_phaseinfo = 1;
@@ -1124,9 +1124,9 @@ int dstate_detect_phasecount(
 			*num_phases = 1;
 			*inited_phaseinfo = 1;
 			detected_phaseinfo = 1;
-			upsdebugx(5, "set_phasecount(): determined a 1-phase case");
-		} else{
-			upsdebugx(5, "set_phasecount(): could not determine the phase case");
+			upsdebugx(5, "%s(): determined a 1-phase case", __func__);
+		} else {
+			upsdebugx(5, "%s(): could not determine the phase case", __func__);
 		}
 
 		if (detected_phaseinfo) {
@@ -1137,7 +1137,8 @@ int dstate_detect_phasecount(
 			if (oldphases) {
 				if (atoi(oldphases) == *num_phases) {
 					/* Technically, a bit has changed: we have set the flag which may have been missing before */
-					upsdebugx(5, "set_phasecount(): Nothing changed, with a valid reason; dstate already published with the same value: %s=%s (detected %d)", buf, oldphases, *num_phases);
+					upsdebugx(5, "%s(): Nothing changed, with a valid reason; dstate already published with the same value: %s=%s (detected %d)",
+						__func__, buf, oldphases, *num_phases);
 					return 3;
 				}
 			}
@@ -1155,10 +1156,10 @@ int dstate_detect_phasecount(
 			}
 		}
 
-		upsdebugx(5, "set_phasecount(): Nothing changed: could not determine a value");
+		upsdebugx(5, "%s(): Nothing changed: could not determine a value", __func__);
 		return 0;
 	}
 
-	upsdebugx(5, "set_phasecount(): Nothing changed, with a valid reason; already inited");
+	upsdebugx(5, "%s(): Nothing changed, with a valid reason; already inited", __func__);
 	return 2;
 }

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -1095,7 +1095,7 @@ int dstate_detect_phasecount(
 		if ((v23 = dstate_getinfo(buf)))   { if (v23[0] == '0') { v23 = NULL; } }
 		strncpy(bufrw_ptr, "L3-L1.voltage", bufrw_max);
 		if ((v31 = dstate_getinfo(buf)))   { if (v31[0] == '0') { v31 = NULL; } }
-		strncpy(bufrw_ptr, "L3.current", bufrw_max);
+		strncpy(bufrw_ptr, "L1.current", bufrw_max);
 		if ((c1 = dstate_getinfo(buf)))    { if (c1[0]  == '0') { c1  = NULL; } }
 		strncpy(bufrw_ptr, "L2.current", bufrw_max);
 		if ((c2 = dstate_getinfo(buf)))    { if (c2[0]  == '0') { c2  = NULL; } }

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -1150,11 +1150,11 @@ int dstate_detect_phasecount(
 			if ( (*num_phases != old_num_phases) || (!oldphases) ) {
 				if (may_change_dstate) {
 					dstate_setinfo(buf, "%d", *num_phases);
-					upsdebugx(3, "-> calculated non-XML value for NUT variable %s was set to %d",
-						buf, *num_phases);
+					upsdebugx(3, "%s(): calculated non-XML value for NUT variable %s was set to %d",
+						__func__, buf, *num_phases);
 				} else {
-					upsdebugx(3, "-> calculated non-XML value for NUT variable %s=%d but did not set its dstate (read-only request)",
-						buf, *num_phases);
+					upsdebugx(3, "%s(): calculated non-XML value for NUT variable %s=%d but did not set its dstate (read-only request)",
+						__func__, buf, *num_phases);
 				}
 				return 1;
 			}

--- a/drivers/dstate.h
+++ b/drivers/dstate.h
@@ -31,6 +31,10 @@
 #define DS_LISTEN_BACKLOG 16
 #define DS_MAX_READ 256		/* don't read forever from upsd */
 
+#ifndef MAX_STRING_SIZE
+#define MAX_STRING_SIZE	128
+#endif
+
 /* track client connections */
 typedef struct conn_s {
 	int     fd;

--- a/drivers/dstate.h
+++ b/drivers/dstate.h
@@ -87,4 +87,10 @@ void alarm_commit(void);
 void device_alarm_init(void);
 void device_alarm_commit(const int device_number);
 
+int dstate_detect_phasecount(
+        const char *xput_prefix,
+        int *inited_phaseinfo,
+        int *num_phases,
+        const int maychange);
+
 #endif	/* DSTATE_H_SEEN */

--- a/drivers/dstate.h
+++ b/drivers/dstate.h
@@ -89,8 +89,9 @@ void device_alarm_commit(const int device_number);
 
 int dstate_detect_phasecount(
         const char *xput_prefix,
+        const int may_change_dstate,
         int *inited_phaseinfo,
         int *num_phases,
-        const int maychange);
+        const int may_reevaluate);
 
 #endif	/* DSTATE_H_SEEN */

--- a/drivers/mge-xml.c
+++ b/drivers/mge-xml.c
@@ -1446,7 +1446,8 @@ static int mge_xml_endelm_cb(void *userdata, int state, const char *nspace, cons
 		if (!inited_phaseinfo_in) {
 			const char *v1,  *v2, *v3,
 			           *v1n, *v2n, *v3n,
-			           *v12, *v23, *v31;
+			           *v12, *v23, *v31,
+			           *c1,  *c2,  *c3;
 
 			/* We either have defined and non-zero (numeric) values below, or NULLs */
 			if ((v1 = dstate_getinfo("input.L1.voltage")))      { if (v1[0]  == '0') { v1  = NULL; } }
@@ -1458,14 +1459,23 @@ static int mge_xml_endelm_cb(void *userdata, int state, const char *nspace, cons
 			if ((v12 = dstate_getinfo("input.L1-L2.voltage")))  { if (v12[0] == '0') { v12 = NULL; } }
 			if ((v23 = dstate_getinfo("input.L2-L3.voltage")))  { if (v23[0] == '0') { v23 = NULL; } }
 			if ((v31 = dstate_getinfo("input.L3-L1.voltage")))  { if (v31[0] == '0') { v31 = NULL; } }
+			if ((c1 = dstate_getinfo("input.L1.current")))      { if (c1[0]  == '0') { c1  = NULL; } }
+			if ((c2 = dstate_getinfo("input.L2.current")))      { if (c2[0]  == '0') { c2  = NULL; } }
+			if ((c3 = dstate_getinfo("input.L3.current")))      { if (c3[0]  == '0') { c3  = NULL; } }
 
 			if ( (v1 && v2 && v3) ||
 			     (v1n && v2n && v3n) ||
+			     (c1 && (c2 || c3)) ||
+			     (c2 && (c1 || c3)) ||
+			     (c3 && (c1 || c2)) ||
 			     v12 || v23 || v31 ) {
 				num_inphases = 3;
 				inited_phaseinfo_in = 1;
 			} else if ( /* We definitely have only one non-zero line */
 			     !v12 && !v23 && !v31 && (
+			     (c1 && !c2 && !c3) ||
+			     (!c1 && c2 && !c3) ||
+			     (!c1 && !c2 && c3) ||
 			     (v1 && !v2 && !v3) ||
 			     (!v1 && v2 && !v3) ||
 			     (!v1 && !v2 && v3) ||
@@ -1486,7 +1496,8 @@ static int mge_xml_endelm_cb(void *userdata, int state, const char *nspace, cons
 		if (!inited_phaseinfo_bypass) {
 			const char *v1,  *v2, *v3,
 			           *v1n, *v2n, *v3n,
-			           *v12, *v23, *v31;
+			           *v12, *v23, *v31,
+			           *c1,  *c2,  *c3;
 
 			/* We either have defined and non-zero (numeric) values below, or NULLs */
 			if ((v1 = dstate_getinfo("bypass.L1.voltage")))      { if (v1[0]  == '0') { v1  = NULL; } }
@@ -1498,14 +1509,23 @@ static int mge_xml_endelm_cb(void *userdata, int state, const char *nspace, cons
 			if ((v12 = dstate_getinfo("bypass.L1-L2.voltage")))  { if (v12[0] == '0') { v12 = NULL; } }
 			if ((v23 = dstate_getinfo("bypass.L2-L3.voltage")))  { if (v23[0] == '0') { v23 = NULL; } }
 			if ((v31 = dstate_getinfo("bypass.L3-L1.voltage")))  { if (v31[0] == '0') { v31 = NULL; } }
+			if ((c1 = dstate_getinfo("bypass.L1.current")))      { if (c1[0]  == '0') { c1  = NULL; } }
+			if ((c2 = dstate_getinfo("bypass.L2.current")))      { if (c2[0]  == '0') { c2  = NULL; } }
+			if ((c3 = dstate_getinfo("bypass.L3.current")))      { if (c3[0]  == '0') { c3  = NULL; } }
 
 			if ( (v1 && v2 && v3) ||
 			     (v1n && v2n && v3n) ||
+			     (c1 && (c2 || c3)) ||
+			     (c2 && (c1 || c3)) ||
+			     (c3 && (c1 || c2)) ||
 			     v12 || v23 || v31 ) {
 				num_bypassphases = 3;
 				inited_phaseinfo_bypass = 1;
 			} else if ( /* We definitely have only one non-zero line */
 			     !v12 && !v23 && !v31 && (
+			     (c1 && !c2 && !c3) ||
+			     (!c1 && c2 && !c3) ||
+			     (!c1 && !c2 && c3) ||
 			     (v1 && !v2 && !v3) ||
 			     (!v1 && v2 && !v3) ||
 			     (!v1 && !v2 && v3) ||
@@ -1528,7 +1548,8 @@ static int mge_xml_endelm_cb(void *userdata, int state, const char *nspace, cons
 		if (!inited_phaseinfo_out) {
 			const char *v1,  *v2, *v3,
 			           *v1n, *v2n, *v3n,
-			           *v12, *v23, *v31;
+			           *v12, *v23, *v31,
+			           *c1,  *c2,  *c3;
 
 			/* We either have defined and non-zero (numeric) values below, or NULLs */
 			if ((v1 = dstate_getinfo("output.L1.voltage")))      { if (v1[0]  == '0') { v1  = NULL; } }
@@ -1540,14 +1561,23 @@ static int mge_xml_endelm_cb(void *userdata, int state, const char *nspace, cons
 			if ((v12 = dstate_getinfo("output.L1-L2.voltage")))  { if (v12[0] == '0') { v12 = NULL; } }
 			if ((v23 = dstate_getinfo("output.L2-L3.voltage")))  { if (v23[0] == '0') { v23 = NULL; } }
 			if ((v31 = dstate_getinfo("output.L3-L1.voltage")))  { if (v31[0] == '0') { v31 = NULL; } }
+			if ((c1 = dstate_getinfo("output.L1.current")))      { if (c1[0]  == '0') { c1  = NULL; } }
+			if ((c2 = dstate_getinfo("output.L2.current")))      { if (c2[0]  == '0') { c2  = NULL; } }
+			if ((c3 = dstate_getinfo("output.L3.current")))      { if (c3[0]  == '0') { c3  = NULL; } }
 
 			if ( (v1 && v2 && v3) ||
 			     (v1n && v2n && v3n) ||
+			     (c1 && (c2 || c3)) ||
+			     (c2 && (c1 || c3)) ||
+			     (c3 && (c1 || c2)) ||
 			     v12 || v23 || v31 ) {
 				num_outphases = 3;
 				inited_phaseinfo_out = 1;
 			} else if ( /* We definitely have only one non-zero line */
 			     !v12 && !v23 && !v31 && (
+			     (c1 && !c2 && !c3) ||
+			     (!c1 && c2 && !c3) ||
+			     (!c1 && !c2 && c3) ||
 			     (v1 && !v2 && !v3) ||
 			     (!v1 && v2 && !v3) ||
 			     (!v1 && !v2 && v3) ||

--- a/drivers/mge-xml.c
+++ b/drivers/mge-xml.c
@@ -1544,7 +1544,6 @@ static int mge_xml_endelm_cb(void *userdata, int state, const char *nspace, cons
 				inited_phaseinfo_bypass = 1;
 			}
 
-
 			if (inited_phaseinfo_bypass) {
 				dstate_setinfo("input.bypass.phases", "%d", num_bypassphases);
 				upsdebugx(3, "-> calculated non-XML value for NUT variable %s was set to %d",

--- a/drivers/mge-xml.c
+++ b/drivers/mge-xml.c
@@ -1504,20 +1504,20 @@ static int mge_xml_endelm_cb(void *userdata, int state, const char *nspace, cons
 			           *c1,  *c2,  *c3,  *c0;
 
 			/* We either have defined and non-zero (numeric) values below, or NULLs */
-			if ((v1 = dstate_getinfo("bypass.L1.voltage")))      { if (v1[0]  == '0') { v1  = NULL; } }
-			if ((v2 = dstate_getinfo("bypass.L2.voltage")))      { if (v2[0]  == '0') { v2  = NULL; } }
-			if ((v3 = dstate_getinfo("bypass.L3.voltage")))      { if (v3[0]  == '0') { v3  = NULL; } }
-			if ((v1n = dstate_getinfo("bypass.L1-N.voltage")))   { if (v1n[0] == '0') { v1n = NULL; } }
-			if ((v2n = dstate_getinfo("bypass.L2-N.voltage")))   { if (v2n[0] == '0') { v2n = NULL; } }
-			if ((v3n = dstate_getinfo("bypass.L3-N.voltage")))   { if (v3n[0] == '0') { v3n = NULL; } }
-			if ((v12 = dstate_getinfo("bypass.L1-L2.voltage")))  { if (v12[0] == '0') { v12 = NULL; } }
-			if ((v23 = dstate_getinfo("bypass.L2-L3.voltage")))  { if (v23[0] == '0') { v23 = NULL; } }
-			if ((v31 = dstate_getinfo("bypass.L3-L1.voltage")))  { if (v31[0] == '0') { v31 = NULL; } }
-			if ((c1 = dstate_getinfo("bypass.L1.current")))      { if (c1[0]  == '0') { c1  = NULL; } }
-			if ((c2 = dstate_getinfo("bypass.L2.current")))      { if (c2[0]  == '0') { c2  = NULL; } }
-			if ((c3 = dstate_getinfo("bypass.L3.current")))      { if (c3[0]  == '0') { c3  = NULL; } }
-			if ((v0 = dstate_getinfo("bypass.voltage")))         { if (v0[0]  == '0') { v0  = NULL; } }
-			if ((c0 = dstate_getinfo("bypass.current")))         { if (c0[0]  == '0') { c0  = NULL; } }
+			if ((v1 = dstate_getinfo("input.bypass.L1.voltage")))      { if (v1[0]  == '0') { v1  = NULL; } }
+			if ((v2 = dstate_getinfo("input.bypass.L2.voltage")))      { if (v2[0]  == '0') { v2  = NULL; } }
+			if ((v3 = dstate_getinfo("input.bypass.L3.voltage")))      { if (v3[0]  == '0') { v3  = NULL; } }
+			if ((v1n = dstate_getinfo("input.bypass.L1-N.voltage")))   { if (v1n[0] == '0') { v1n = NULL; } }
+			if ((v2n = dstate_getinfo("input.bypass.L2-N.voltage")))   { if (v2n[0] == '0') { v2n = NULL; } }
+			if ((v3n = dstate_getinfo("input.bypass.L3-N.voltage")))   { if (v3n[0] == '0') { v3n = NULL; } }
+			if ((v12 = dstate_getinfo("input.bypass.L1-L2.voltage")))  { if (v12[0] == '0') { v12 = NULL; } }
+			if ((v23 = dstate_getinfo("input.bypass.L2-L3.voltage")))  { if (v23[0] == '0') { v23 = NULL; } }
+			if ((v31 = dstate_getinfo("input.bypass.L3-L1.voltage")))  { if (v31[0] == '0') { v31 = NULL; } }
+			if ((c1 = dstate_getinfo("input.bypass.L1.current")))      { if (c1[0]  == '0') { c1  = NULL; } }
+			if ((c2 = dstate_getinfo("input.bypass.L2.current")))      { if (c2[0]  == '0') { c2  = NULL; } }
+			if ((c3 = dstate_getinfo("input.bypass.L3.current")))      { if (c3[0]  == '0') { c3  = NULL; } }
+			if ((v0 = dstate_getinfo("input.bypass.voltage")))         { if (v0[0]  == '0') { v0  = NULL; } }
+			if ((c0 = dstate_getinfo("input.bypass.current")))         { if (c0[0]  == '0') { c0  = NULL; } }
 
 			if ( (v1 && v2 && v3) ||
 			     (v1n && v2n && v3n) ||
@@ -1546,9 +1546,9 @@ static int mge_xml_endelm_cb(void *userdata, int state, const char *nspace, cons
 
 
 			if (inited_phaseinfo_bypass) {
-				dstate_setinfo("bypass.phases", "%d", num_bypassphases);
+				dstate_setinfo("input.bypass.phases", "%d", num_bypassphases);
 				upsdebugx(3, "-> calculated non-XML value for NUT variable %s was set to %d",
-					"bypass.phases", num_bypassphases);
+					"input.bypass.phases", num_bypassphases);
 			}
 
 		}

--- a/drivers/mge-xml.c
+++ b/drivers/mge-xml.c
@@ -1444,11 +1444,11 @@ static int mge_xml_endelm_cb(void *userdata, int state, const char *nspace, cons
 		 * it stays this way for the rest of the driver run/life-time. */
 		/* To change this behavior just flip the maychange flag to "1" */
 
-		dstate_detect_phasecount("input.",
+		dstate_detect_phasecount("input.", 1,
 			&inited_phaseinfo_in, &num_inphases, 0);
-		dstate_detect_phasecount("input.bypass.",
+		dstate_detect_phasecount("input.bypass.", 1,
 			&inited_phaseinfo_bypass, &num_bypassphases, 0);
-		dstate_detect_phasecount("output.",
+		dstate_detect_phasecount("output.", 1,
 			&inited_phaseinfo_out, &num_outphases, 0);
 
 		break;

--- a/drivers/mge-xml.c
+++ b/drivers/mge-xml.c
@@ -1444,10 +1444,10 @@ static int mge_xml_endelm_cb(void *userdata, int state, const char *nspace, cons
 		 * it stays this way for the rest of the driver run/life-time. */
 
 		if (!inited_phaseinfo_in) {
-			const char *v1,  *v2, *v3,
+			const char *v1,  *v2,  *v3,  *v0,
 			           *v1n, *v2n, *v3n,
 			           *v12, *v23, *v31,
-			           *c1,  *c2,  *c3;
+			           *c1,  *c2,  *c3,  *c0;
 
 			/* We either have defined and non-zero (numeric) values below, or NULLs */
 			if ((v1 = dstate_getinfo("input.L1.voltage")))      { if (v1[0]  == '0') { v1  = NULL; } }
@@ -1462,6 +1462,8 @@ static int mge_xml_endelm_cb(void *userdata, int state, const char *nspace, cons
 			if ((c1 = dstate_getinfo("input.L1.current")))      { if (c1[0]  == '0') { c1  = NULL; } }
 			if ((c2 = dstate_getinfo("input.L2.current")))      { if (c2[0]  == '0') { c2  = NULL; } }
 			if ((c3 = dstate_getinfo("input.L3.current")))      { if (c3[0]  == '0') { c3  = NULL; } }
+			if ((v0 = dstate_getinfo("input.voltage")))         { if (v0[0]  == '0') { v0  = NULL; } }
+			if ((c0 = dstate_getinfo("input.current")))         { if (c0[0]  == '0') { c0  = NULL; } }
 
 			if ( (v1 && v2 && v3) ||
 			     (v1n && v2n && v3n) ||
@@ -1473,6 +1475,8 @@ static int mge_xml_endelm_cb(void *userdata, int state, const char *nspace, cons
 				inited_phaseinfo_in = 1;
 			} else if ( /* We definitely have only one non-zero line */
 			     !v12 && !v23 && !v31 && (
+			     (c0 && !c1 && !c2 && !c3) ||
+			     (v0 && !v1 && !v2 && !v3) ||
 			     (c1 && !c2 && !c3) ||
 			     (!c1 && c2 && !c3) ||
 			     (!c1 && !c2 && c3) ||
@@ -1494,10 +1498,10 @@ static int mge_xml_endelm_cb(void *userdata, int state, const char *nspace, cons
 		}
 
 		if (!inited_phaseinfo_bypass) {
-			const char *v1,  *v2, *v3,
+			const char *v1,  *v2,  *v3,  *v0,
 			           *v1n, *v2n, *v3n,
 			           *v12, *v23, *v31,
-			           *c1,  *c2,  *c3;
+			           *c1,  *c2,  *c3,  *c0;
 
 			/* We either have defined and non-zero (numeric) values below, or NULLs */
 			if ((v1 = dstate_getinfo("bypass.L1.voltage")))      { if (v1[0]  == '0') { v1  = NULL; } }
@@ -1512,6 +1516,8 @@ static int mge_xml_endelm_cb(void *userdata, int state, const char *nspace, cons
 			if ((c1 = dstate_getinfo("bypass.L1.current")))      { if (c1[0]  == '0') { c1  = NULL; } }
 			if ((c2 = dstate_getinfo("bypass.L2.current")))      { if (c2[0]  == '0') { c2  = NULL; } }
 			if ((c3 = dstate_getinfo("bypass.L3.current")))      { if (c3[0]  == '0') { c3  = NULL; } }
+			if ((v0 = dstate_getinfo("bypass.voltage")))         { if (v0[0]  == '0') { v0  = NULL; } }
+			if ((c0 = dstate_getinfo("bypass.current")))         { if (c0[0]  == '0') { c0  = NULL; } }
 
 			if ( (v1 && v2 && v3) ||
 			     (v1n && v2n && v3n) ||
@@ -1523,6 +1529,8 @@ static int mge_xml_endelm_cb(void *userdata, int state, const char *nspace, cons
 				inited_phaseinfo_bypass = 1;
 			} else if ( /* We definitely have only one non-zero line */
 			     !v12 && !v23 && !v31 && (
+			     (c0 && !c1 && !c2 && !c3) ||
+			     (v0 && !v1 && !v2 && !v3) ||
 			     (c1 && !c2 && !c3) ||
 			     (!c1 && c2 && !c3) ||
 			     (!c1 && !c2 && c3) ||
@@ -1546,10 +1554,10 @@ static int mge_xml_endelm_cb(void *userdata, int state, const char *nspace, cons
 		}
 
 		if (!inited_phaseinfo_out) {
-			const char *v1,  *v2, *v3,
+			const char *v1,  *v2,  *v3,  *v0,
 			           *v1n, *v2n, *v3n,
 			           *v12, *v23, *v31,
-			           *c1,  *c2,  *c3;
+			           *c1,  *c2,  *c3,  *c0;
 
 			/* We either have defined and non-zero (numeric) values below, or NULLs */
 			if ((v1 = dstate_getinfo("output.L1.voltage")))      { if (v1[0]  == '0') { v1  = NULL; } }
@@ -1564,6 +1572,8 @@ static int mge_xml_endelm_cb(void *userdata, int state, const char *nspace, cons
 			if ((c1 = dstate_getinfo("output.L1.current")))      { if (c1[0]  == '0') { c1  = NULL; } }
 			if ((c2 = dstate_getinfo("output.L2.current")))      { if (c2[0]  == '0') { c2  = NULL; } }
 			if ((c3 = dstate_getinfo("output.L3.current")))      { if (c3[0]  == '0') { c3  = NULL; } }
+			if ((v0 = dstate_getinfo("output.voltage")))         { if (v0[0]  == '0') { v0  = NULL; } }
+			if ((c0 = dstate_getinfo("output.current")))         { if (c0[0]  == '0') { c0  = NULL; } }
 
 			if ( (v1 && v2 && v3) ||
 			     (v1n && v2n && v3n) ||
@@ -1575,6 +1585,8 @@ static int mge_xml_endelm_cb(void *userdata, int state, const char *nspace, cons
 				inited_phaseinfo_out = 1;
 			} else if ( /* We definitely have only one non-zero line */
 			     !v12 && !v23 && !v31 && (
+			     (c0 && !c1 && !c2 && !c3) ||
+			     (v0 && !v1 && !v2 && !v3) ||
 			     (c1 && !c2 && !c3) ||
 			     (!c1 && c2 && !c3) ||
 			     (!c1 && !c2 && c3) ||

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -2148,7 +2148,7 @@ bool_t snmp_ups_walk(int mode)
 		if (devices_count > 1)
 			device_alarm_init();
 
-		/* Loop through all mapping entries */
+		/* Loop through all mapping entries for the current_device_number */
 		for (su_info_p = &snmp_info[0]; su_info_p->info_type != NULL ; su_info_p++) {
 
 			// FIXME:
@@ -2175,6 +2175,7 @@ bool_t snmp_ups_walk(int mode)
 			}
 
 // FIXME: daisychain-whole, what to do?
+// Note that when addressing the FIXME above, if (current_device_number == 0 && daisychain_enabled == FALSE) then we'd skip it still (unitary device is at current_device_number == 1)...
 			/* skip the whole-daisychain for now */
 			if (current_device_number == 0) {
 				upsdebugx(1, "Skipping daisychain device.0 for now...");

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -2051,7 +2051,7 @@ int process_phase_data(const char* type, long *nb_phases, snmp_info_t *su_info_p
 				/* Daisychain specific: we may have a template (including
 				 * formatting string) that needs to be adapted! */
 				if (strchr(tmp_info_p->OID, '%') != NULL) {
-					upsdebugx(2, "Found template, need to be adapted");										
+					upsdebugx(2, "Found template, need to be adapted");
 					snprintf((char*)tmpOID, SU_INFOSIZE, tmp_info_p->OID, current_device_number - 1);
 				}
 				else {

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -2163,8 +2163,10 @@ bool_t snmp_ups_walk(int mode)
 			}
 
 			/* Check if we are asked to stop (reactivity++) */
-			if (exit_flag != 0)
+			if (exit_flag != 0) {
+				upsdebugx(1, "%s: aborting because exit_flag was set", __func__);
 				return TRUE;
+			}
 
 			/* Skip daisychain data count */
 			if (mode == SU_WALKMODE_INIT &&

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -1687,7 +1687,7 @@ bool_t process_template(int mode, const char* type, snmp_info_t *su_info_p)
 			 * whole daisychain ("device.0") */
 			if (!strncmp(type, "device", 6))
 			{
-				/* Device(s) 2-N (master + slave(s)) need to append 'device.x' */
+				/* Device(s) 1-N (master + slave(s)) need to append 'device.x' */
 				if (current_device_number > 0) {
 					char *ptr = NULL;
 					/* Another special processing for daisychain

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -2137,6 +2137,9 @@ bool_t snmp_ups_walk(int mode)
 	 * some proprietary link not visible from the outside) and represented
 	 * through the master - the slaves are not addressable directly. If the
 	 * master dies/reboots, connection to the whole chain is interrupted.
+	 * The dstate string names for daisychained sub-devices have the prefix
+	 * "device." and number embedded (e.g. "device.3.input.phases") except
+	 * for the whole (#0) virtual device, so it *seems* similar to unitary.
 	 */
 
 	for (current_device_number = 0 ; current_device_number <= devices_count ; current_device_number++)

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -107,8 +107,8 @@ int g_pwr_battery;
 int pollfreq; /* polling frequency */
 /* Number of device(s): standard is "1", but daisychain means more than 1 */
 long devices_count = 1;
-int current_device_number = 0;      /* to handle daisychain iterations */
-bool_t daisychain_enabled = FALSE;
+int current_device_number = 0;      /* global var to handle daisychain iterations - changed by loops in snmp_ups_walk() and su_addcmd() */
+bool_t daisychain_enabled = FALSE;  /* global var to handle daisychain iterations */
 daisychain_info_t **daisychain_info = NULL;
 
 /* pointer to the Snmp2Nut lookup table */

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -2124,6 +2124,21 @@ bool_t snmp_ups_walk(int mode)
 	bool_t status = FALSE;
 
 	/* Loop through all device(s) */
+	/* Note: considering "unitary" and "daisy-chained" devices, we have
+	 * several variables (and their values) that can come into play:
+	 *  devices_count == 1 (default) AND daisychain_enabled == FALSE => unitary
+	 *  devices_count > 1 (AND/OR?) daisychain_enabled == TRUE => a daisy-chain
+	 * The current_device_number == 0 in context of daisy-chain means the
+	 * "whole device" with composite or summary values that refer to the
+	 * chain as a virtual power device (e.g. might be a sum of outlet counts).
+	 * If daisychain_enabled == TRUE and current_device_number == 1 then we
+	 * are looking at the "master" device (one that we have direct/networked
+	 * connectivity to; the current_device_number > 1 is a slave (chained by
+	 * some proprietary link not visible from the outside) and represented
+	 * through the master - the slaves are not addressable directly. If the
+	 * master dies/reboots, connection to the whole chain is interrupted.
+	 */
+
 	for (current_device_number = 0 ; current_device_number <= devices_count ; current_device_number++)
 	{
 		/* reinit the alarm buffer, before */

--- a/drivers/usbhid-ups.h
+++ b/drivers/usbhid-ups.h
@@ -52,7 +52,9 @@ extern bool_t	 	use_interrupt_pipe;	/* Set to FALSE if interrupt reports should 
 					/* The driver will wait for Interrupt */
 					/* and do "light poll" in the meantime */
 
-#define MAX_STRING_SIZE    	128
+#ifndef MAX_STRING_SIZE
+#define MAX_STRING_SIZE	128
+#endif
 
 
 /* --------------------------------------------------------------- */


### PR DESCRIPTION
…based on available non-zero measurements

NOTE: The NetXML specs for XMLv3 and XMLv4 do not mention a separate value for "phases" and devices do just return the per-line values (non-zero voltages compared to neutral and among lines, as well as an overall input Voltage value), and currents (value depends on actually connected loads).

Comments and questions to reviewers and testers:

As seen in the patch, the added logic is to wait until we've completed parsing a `GET_OBJECT` response (where we have dstate's set for all discovered values), and set states for the `(input|bypass|output).phases` based on querying the per-line data and getting non-zero numeric replies (and in fact any replies at all).

In effect this can mean that a device claiming (or really having) 3 phases but running with input or load connected on just one phase vs. neutral at the moment of driver startup, would be considered and remembered as a 1-phase device until the driver restart. On the other hand, some UPSes might support both 1- and 3-phase connectivity, so their firmware would expose 3 but practical usage will be for 1...

TODO: Maybe this should be occasionally reconsidered during driver run-time (e.g. if we remember 1 phase, still do check if we get data proving that we became 3-phase)?

Also, no definite dstate value is published for these items until we have definitely decided that at some point in time there was proof of either 1- or 3-phase usecase, This is a conscious choice - as it is better so than publishing e.g. hardcoded 1 phase from the start, and then connecting to the actual device and changing the mind (and reported value) after a minute or so.

Tested with both 1- and 3-phase devices:

````
$ make && sudo ./drivers/netxml-ups -a 93pm1 -u root -DDDDD 2>&1 | ggrep 'calculated non-XML value for NUT '
...
   0.747425	[D3] -> calculated non-XML value for NUT variable input.phases was set to 3
   0.757701	[D3] -> calculated non-XML value for NUT variable input.bypass.phases was set to 3
   0.747523	[D3] -> calculated non-XML value for NUT variable output.phases was set to 3
````

````
$ make && sudo ./drivers/netxml-ups -a 9px -u root -DDDDD 2>&1 | ggrep 'calculated non-XML value for NUT '
...
   1.045194	[D3] -> calculated non-XML value for NUT variable input.phases was set to 1
   1.045274	[D3] -> calculated non-XML value for NUT variable input.bypass.phases was set to 1
   1.046301	[D3] -> calculated non-XML value for NUT variable output.phases was set to 1
````

Another note: I saw that many drivers implement something of this sort, often with quirks like "this additional logic applies to this device model". So, refactoring to share some of the code and logic makes sense, but is out of scope for this PR :)