### PR TITLE
 Disable mge-xml.c::convert_deci() that was needed a decade ago 

### DIFF
--- a/docs/man/netxml-ups.txt
+++ b/docs/man/netxml-ups.txt
@@ -66,6 +66,14 @@ Set the shutdown timer, in seconds. After 'value' seconds running on battery,
 the local system will receive a notification to shutdown.
 Defaults to "none" (disabled).
 
+*do_convert_deci*='value'::
+Set this flag value as a Boolean (yes|no or true|false or on|off or 1|0) if
+you have a very old MGE UPS (or rather an old network management card firmware)
+which serves certain measurements 10x too big in the XML markup. Originally
+such measurements were decimated by the driver -- but this is wrong for newer
+more sane devices, so this behavior was deprecated and is disabled by default.
+Enabling this flag restores the old behavior for those measurements.
+
 IMPLEMENTATION
 --------------
 The hostname of the UPS is specified with the "port" value in

--- a/docs/man/netxml-ups.txt
+++ b/docs/man/netxml-ups.txt
@@ -66,13 +66,14 @@ Set the shutdown timer, in seconds. After 'value' seconds running on battery,
 the local system will receive a notification to shutdown.
 Defaults to "none" (disabled).
 
-*do_convert_deci*='value'::
-Set this flag value as a Boolean (yes|no or true|false or on|off or 1|0) if
-you have a very old MGE UPS (or rather an old network management card firmware)
-which serves certain measurements 10x too big in the XML markup. Originally
-such measurements were decimated by the driver -- but this is wrong for newer
-more sane devices, so this behavior was deprecated and is disabled by default.
-Enabling this flag restores the old behavior for those measurements.
+*do_convert_deci*::
+If this flag value is present, the driver assumes you have a very old
+MGE networked UPS (or rather an old network management card firmware)
+which serves certain measurements spelled 10x too big in the XML markup.
+Originally such measurements were decimated by the driver -- but this is
+wrong for newer, more sane, devices -- so this behavior was deprecated
+and is now disabled by default. Enabling this flag in configuration of a
+particular driver instance restores the old behavior for those measurements.
 
 IMPLEMENTATION
 --------------

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 1770 utf-8
+personal_ws-1.1 en 1771 utf-8
 ACFAIL
 ACFREQ
 ACK
@@ -992,6 +992,7 @@ de
 deUNV
 debian
 debouncing
+deci
 decrypt
 defun
 dep

--- a/drivers/mge-xml.c
+++ b/drivers/mge-xml.c
@@ -32,7 +32,7 @@
 #include "netxml-ups.h"
 #include "mge-xml.h"
 
-#define MGE_XML_VERSION		"MGEXML/0.26"
+#define MGE_XML_VERSION		"MGEXML/0.28"
 #define MGE_XML_INITUPS		"/"
 #define MGE_XML_INITINFO	"/mgeups/product.xml /product.xml /ws/product.xml"
 

--- a/drivers/mge-xml.c
+++ b/drivers/mge-xml.c
@@ -406,9 +406,22 @@ static const char *on_off_info(const char *val)
 
 static const char *convert_deci(const char *val)
 {
+	/* Note: this routine was needed for original MGE devices, before the company
+	 * was bought out and split in 200x's. Those firmwares apparently served 10x
+	 * the measured values. Not sure if any are in service now (and with same FW).
+	 * For currently known NetXML servers, the value served is good without more
+	 * conversions. If older devices pop up in the field, we can add an estimation
+	 * by e.g. reported voltage and amps (to be an order of magnitude for power).
+	 * Alternately we can look at model names and/or firmware versions or release
+	 * dates, if we get those and if we know enough to map them to either logic. */
+	return val;
+
+/* Old code for old devices: */
+/*
 	snprintf(mge_scratch_buf, sizeof(mge_scratch_buf), "%.1f", 0.1 * (float)atoi(val));
 
 	return mge_scratch_buf;
+*/
 }
 
 /* Ignore a zero value if the UPS is not switched off */

--- a/drivers/mge-xml.c
+++ b/drivers/mge-xml.c
@@ -3,6 +3,7 @@
    Copyright (C)
 	2008-2009	Arjen de Korte <adkorte-guest@alioth.debian.org>
 	2009		Arnaud Quette <ArnaudQuette@Eaton.com>
+	2017		Jim Klimov <EvgenyKlimov@Eaton.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/drivers/mge-xml.c
+++ b/drivers/mge-xml.c
@@ -411,8 +411,10 @@ static const char *on_off_info(const char *val)
 static const char *convert_deci(const char *val)
 {
 	/* Note: this routine was needed for original MGE devices, before the company
-	 * was bought out and split in 200x's. Those firmwares apparently served 10x
-	 * the measured values. Not sure if any are in service now (and with same FW).
+	 * was bought out and split in 2007 between Eaton (1ph devices) and Schneider
+	 * (3ph devices). Those firmwares back when the driver was written apparently
+	 * served 10x the measured values. Not sure if any such units are in service
+	 * now (with same FW, and with no upgrade path). Reign of XML/PDC is waning.
 	 * For currently known NetXML servers, the value served is good without more
 	 * conversions. If older devices pop up in the field, we can add an estimation
 	 * by e.g. reported voltage and amps (to be an order of magnitude for power).

--- a/drivers/mge-xml.c
+++ b/drivers/mge-xml.c
@@ -39,7 +39,8 @@
 #define ST_FLAG_RW		0x0001
 #define ST_FLAG_STATIC		0x0002
 
-extern int 	shutdown_duration;
+extern int	shutdown_duration;
+extern int	do_convert_deci;
 
 static int	mge_ambient_value = 0;
 
@@ -420,19 +421,23 @@ static const char *convert_deci(const char *val)
 	 * by e.g. reported voltage and amps (to be an order of magnitude for power).
 	 * Alternately we can look at model names and/or firmware versions or release
 	 * dates, if we get those and if we know enough to map them to either logic. */
+
+	if (do_convert_deci == 1) {
+		/* Old code for old devices: */
+		if (mge_report_deprecation__convert_deci) {
+			upslogx(LOG_NOTICE, "%s() is now deprecated, so values from XML are normally not decimated. This driver instance has however configured do_convert_deci=1 in your ups.conf, so behavior for old MGE NetXML-capable devices is preserved.", __func__);
+			mge_report_deprecation__convert_deci = 0;
+		}
+		snprintf(mge_scratch_buf, sizeof(mge_scratch_buf), "%.1f", 0.1 * (float)atoi(val));
+		return mge_scratch_buf;
+	}
+
 	if (mge_report_deprecation__convert_deci) {
-		upslogx(LOG_NOTICE, "%s() is now deprecated, so values from XML are not decimated. If you happen to have an old MGE NetXML-capable device that now shows measurements 10x too big, and a firmware update does not solve this, please inform NUT devs via the issue tracker at %s with details about your hardware and firmware versions.", __func__, PACKAGE_BUGREPORT );
+		upslogx(LOG_NOTICE, "%s() is now deprecated, so values from XML are not decimated. If you happen to have an old MGE NetXML-capable device that now shows measurements 10x too big, and a firmware update does not solve this, please inform NUT devs via the issue tracker at %s with details about your hardware and firmware versions. Also try to enable do_convert_deci=1 in your ups.conf", __func__, PACKAGE_BUGREPORT );
 		mge_report_deprecation__convert_deci = 0;
 	}
 	upsdebugx(5, "%s() is now deprecated, so value '%s' is not decimated. If this change broke your setup, please see details logged above.", __func__, val);
 	return val;
-
-/* Old code for old devices: */
-/*
-	snprintf(mge_scratch_buf, sizeof(mge_scratch_buf), "%.1f", 0.1 * (float)atoi(val));
-
-	return mge_scratch_buf;
-*/
 }
 
 /* Ignore a zero value if the UPS is not switched off */

--- a/drivers/mge-xml.c
+++ b/drivers/mge-xml.c
@@ -50,6 +50,9 @@ static char	val[128];
 
 static int	mge_shutdown_pending = 0;
 
+/* This flag flips to 0 when/if we post the detailed deprecation message */
+static int	mge_report_deprecation__convert_deci = 1;
+
 typedef enum {
 	ROOTPARENT = NE_XML_STATEROOT,
 
@@ -415,7 +418,11 @@ static const char *convert_deci(const char *val)
 	 * by e.g. reported voltage and amps (to be an order of magnitude for power).
 	 * Alternately we can look at model names and/or firmware versions or release
 	 * dates, if we get those and if we know enough to map them to either logic. */
-	upsdebugx(5, "%s() is now deprecated, so value '%s' is not decimated. If you happen to have an old MGE NetXML-capable device that now shows measurements 10x too big, and a firmware update does not solve this, please inform NUT devs via the GitHub issue tracker with details about your hardware and firmware versions", __func__, val);
+	if (mge_report_deprecation__convert_deci) {
+		upslogx(LOG_NOTICE, "%s() is now deprecated, so values from XML are not decimated. If you happen to have an old MGE NetXML-capable device that now shows measurements 10x too big, and a firmware update does not solve this, please inform NUT devs via the issue tracker at %s with details about your hardware and firmware versions.", __func__, PACKAGE_BUGREPORT );
+		mge_report_deprecation__convert_deci = 0;
+	}
+	upsdebugx(5, "%s() is now deprecated, so value '%s' is not decimated. If this change broke your setup, please see details logged above.", __func__, val);
 	return val;
 
 /* Old code for old devices: */

--- a/drivers/mge-xml.c
+++ b/drivers/mge-xml.c
@@ -1437,6 +1437,7 @@ static int mge_xml_endelm_cb(void *userdata, int state, const char *nspace, cons
 
 			if (info->convert) {
 				value = info->convert(val);
+				upsdebugx(4, "-> XML variable %s [%s] which maps to NUT variable %s was converted to value %s for the NUT driver state", var, val, info->nutname, value);
 			} else {
 				value = val;
 			}

--- a/drivers/mge-xml.c
+++ b/drivers/mge-xml.c
@@ -415,6 +415,7 @@ static const char *convert_deci(const char *val)
 	 * by e.g. reported voltage and amps (to be an order of magnitude for power).
 	 * Alternately we can look at model names and/or firmware versions or release
 	 * dates, if we get those and if we know enough to map them to either logic. */
+	upsdebugx(5, "%s() is now deprecated, so value '%s' is not decimated. If you happen to have an old MGE NetXML-capable device that now shows measurements 10x too big, and a firmware update does not solve this, please inform NUT devs via the GitHub issue tracker with details about your hardware and firmware versions", __func__, val);
 	return val;
 
 /* Old code for old devices: */

--- a/drivers/mge-xml.c
+++ b/drivers/mge-xml.c
@@ -40,7 +40,6 @@
 #define ST_FLAG_STATIC		0x0002
 
 extern int	shutdown_duration;
-extern int	do_convert_deci;
 
 static int	mge_ambient_value = 0;
 
@@ -422,10 +421,10 @@ static const char *convert_deci(const char *val)
 	 * Alternately we can look at model names and/or firmware versions or release
 	 * dates, if we get those and if we know enough to map them to either logic. */
 
-	if (do_convert_deci == 1) {
+	if (testvar("do_convert_deci")) {
 		/* Old code for old devices: */
 		if (mge_report_deprecation__convert_deci) {
-			upslogx(LOG_NOTICE, "%s() is now deprecated, so values from XML are normally not decimated. This driver instance has however configured do_convert_deci=1 in your ups.conf, so behavior for old MGE NetXML-capable devices is preserved.", __func__);
+			upslogx(LOG_NOTICE, "%s() is now deprecated, so values from XML are normally not decimated. This driver instance has however configured do_convert_deci in your ups.conf, so this behavior for old MGE NetXML-capable devices is preserved.", __func__);
 			mge_report_deprecation__convert_deci = 0;
 		}
 		snprintf(mge_scratch_buf, sizeof(mge_scratch_buf), "%.1f", 0.1 * (float)atoi(val));
@@ -433,7 +432,7 @@ static const char *convert_deci(const char *val)
 	}
 
 	if (mge_report_deprecation__convert_deci) {
-		upslogx(LOG_NOTICE, "%s() is now deprecated, so values from XML are not decimated. If you happen to have an old MGE NetXML-capable device that now shows measurements 10x too big, and a firmware update does not solve this, please inform NUT devs via the issue tracker at %s with details about your hardware and firmware versions. Also try to enable do_convert_deci=1 in your ups.conf", __func__, PACKAGE_BUGREPORT );
+		upslogx(LOG_NOTICE, "%s() is now deprecated, so values from XML are not decimated. If you happen to have an old MGE NetXML-capable device that now shows measurements 10x too big, and a firmware update does not solve this, please inform NUT devs via the issue tracker at %s with details about your hardware and firmware versions. Also try to enable do_convert_deci in your ups.conf", __func__, PACKAGE_BUGREPORT );
 		mge_report_deprecation__convert_deci = 0;
 	}
 	upsdebugx(5, "%s() is now deprecated, so value '%s' is not decimated. If this change broke your setup, please see details logged above.", __func__, val);

--- a/drivers/netxml-ups.c
+++ b/drivers/netxml-ups.c
@@ -230,6 +230,7 @@ uint32_t		ups_status = 0;
 static int		timeout = 5;
 int			shutdown_duration = 120;
 static int		shutdown_timer = 0;
+int			do_convert_deci = 0; /* Legacy MGE-XML conversion from 2000's, not needed in modern firmwares */
 static time_t		lastheard = 0;
 static subdriver_t	*subdriver = &mge_xml_subdriver;
 static ne_session	*session = NULL;
@@ -513,6 +514,9 @@ void upsdrv_makevartable(void)
 		snprintf(buf, sizeof(buf), "shutdown timer in second (default: none)");
 	}
 	addvar(VAR_VALUE, "shutdown_timer", buf);
+
+	snprintf(buf, sizeof(buf), "enable legacy convert_deci() for certain measurements 10x too large (default: %d)", do_convert_deci);
+	addvar(VAR_VALUE, "do_convert_deci", buf);
 }
 
 void upsdrv_initups(void)
@@ -558,6 +562,27 @@ void upsdrv_initups(void)
 		if (shutdown_timer < 0) {
 			fatalx(EXIT_FAILURE, "shutdwon timer must be greater than or equal to 0");
 		}
+	}
+
+	val = getval("do_convert_deci");
+	upsdebugx(5, "incoming do_convert_deci = '%s'", val?val:"<null>");
+	if (val) {
+		do_convert_deci = -1;
+		if ( strcasecmp(val, "on") == 0 || strcasecmp(val, "true") == 0 || strcasecmp(val, "yes") == 0 ) {
+			do_convert_deci = 1;
+		} else if ( strcasecmp(val, "off") == 0 || strcasecmp(val, "false") == 0 || strcasecmp(val, "no") == 0 ) {
+			do_convert_deci = 0;
+		} else {
+			do_convert_deci = atoi(val);
+		}
+
+		if (do_convert_deci < 0) {
+			fatalx(EXIT_FAILURE, "do_convert_deci must be a boolean (no|yes / false|true / off|on) or numeric (0|1) value");
+		}
+		if (do_convert_deci > 1)
+			do_convert_deci = 1;
+
+		upsdebugx(5, "resulting do_convert_deci = '%d'", do_convert_deci);
 	}
 
 	if (nut_debug_level > 5) {

--- a/drivers/netxml-ups.c
+++ b/drivers/netxml-ups.c
@@ -230,7 +230,6 @@ uint32_t		ups_status = 0;
 static int		timeout = 5;
 int			shutdown_duration = 120;
 static int		shutdown_timer = 0;
-int			do_convert_deci = 0; /* Legacy MGE-XML conversion from 2000's, not needed in modern firmwares */
 static time_t		lastheard = 0;
 static subdriver_t	*subdriver = &mge_xml_subdriver;
 static ne_session	*session = NULL;
@@ -515,8 +514,8 @@ void upsdrv_makevartable(void)
 	}
 	addvar(VAR_VALUE, "shutdown_timer", buf);
 
-	snprintf(buf, sizeof(buf), "enable legacy convert_deci() for certain measurements 10x too large (default: %d)", do_convert_deci);
-	addvar(VAR_VALUE, "do_convert_deci", buf);
+	/* Legacy MGE-XML conversion from 2000's, not needed in modern firmwares */
+	addvar(VAR_FLAG, "do_convert_deci", "enable legacy convert_deci() for certain measurements 10x too large");
 }
 
 void upsdrv_initups(void)
@@ -562,27 +561,6 @@ void upsdrv_initups(void)
 		if (shutdown_timer < 0) {
 			fatalx(EXIT_FAILURE, "shutdwon timer must be greater than or equal to 0");
 		}
-	}
-
-	val = getval("do_convert_deci");
-	upsdebugx(5, "incoming do_convert_deci = '%s'", val?val:"<null>");
-	if (val) {
-		do_convert_deci = -1;
-		if ( strcasecmp(val, "on") == 0 || strcasecmp(val, "true") == 0 || strcasecmp(val, "yes") == 0 ) {
-			do_convert_deci = 1;
-		} else if ( strcasecmp(val, "off") == 0 || strcasecmp(val, "false") == 0 || strcasecmp(val, "no") == 0 ) {
-			do_convert_deci = 0;
-		} else {
-			do_convert_deci = atoi(val);
-		}
-
-		if (do_convert_deci < 0) {
-			fatalx(EXIT_FAILURE, "do_convert_deci must be a boolean (no|yes / false|true / off|on) or numeric (0|1) value");
-		}
-		if (do_convert_deci > 1)
-			do_convert_deci = 1;
-
-		upsdebugx(5, "resulting do_convert_deci = '%d'", do_convert_deci);
 	}
 
 	if (nut_debug_level > 5) {


### PR DESCRIPTION
Made a debug level 5 notice for end-users, and bumped subdriver version for clarity.

Note: version bump from 0.26 to 0.28 accounts for another recent PR against this file that bumps it to 0.27.