### PR TITLE
snmp-ups.c : presumed typo fix : NUT var for bypass mapping is "input.bypass"

### DIFF
--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -5,6 +5,7 @@
  *  Copyright (C)
  *	2002 - 2014	Arnaud Quette <arnaud.quette@free.fr>
  *	2015 - 2016	Eaton (author: Arnaud Quette <ArnaudQuette@Eaton.com>)
+ *	2017		Eaton (author: Jim Klimov <EvgenyKlimov@Eaton.com>)
  *	2002 - 2006	Dmitry Frolov <frolov@riss-telecom.ru>
  *			J.W. Hoogervorst <jeroen@hoogervorst.net>
  *			Niels Baggesen <niels@baggesen.net>
@@ -2013,7 +2014,7 @@ int process_phase_data(const char* type, long *nb_phases, snmp_info_t *su_info_p
 		single_phase_flag = SU_OUTPUT_1;
 		three_phase_flag = SU_OUTPUT_3;
 	}
-	else if (!strncmp(type, "bypass", 6)) {
+	else if (!strncmp(type, "input.bypass", 12)) {
 		phases_flag = SU_BYPPHASES;
 		single_phase_flag = SU_BYPASS_1;
 		three_phase_flag = SU_BYPASS_3;


### PR DESCRIPTION
Checked that in `*-mib.c` tables there is no standalone "bypass" (except for a few status or config nodes):

````
$ git grep bypass drivers/*-mib.c | grep -v input.bypass
drivers/apc-mib.c:	{ "bypass.start", 0, 2, ".1.3.6.1.4.1.318.1.1.1.6.2.7.0", "", SU_TYPE_CMD | SU_FLAG_OK, NULL },
drivers/apc-mib.c:	{ "bypass.stop", 0, 3, ".1.3.6.1.4.1.318.1.1.1.6.2.7.0", "", SU_TYPE_CMD | SU_FLAG_OK, NULL },
drivers/compaq-mib.c:	{ 4, "OL BYPASS" /* bypass */ },
drivers/compaq-mib.c:	 * bypassFeed(4)
drivers/delta_ups-mib.c:    { 2, "BYPASS" },    /* bypass */
drivers/ietf-mib.c:	{ 4, "OL BYPASS" /* bypass */ },
drivers/mge-mib.c:static info_lkp_t mge_bypass_info[] = {
drivers/mge-mib.c:	{ 4, "BYPASS" /* bypass */ },
drivers/mge-mib.c:	{ "ups.status", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.705.1.7.4.0", "", SU_FLAG_OK | SU_STATUS_BATT, mge_bypass_info },
drivers/netvision-mib.c:	{ 4, "OL BYPASS" }, /* output source bypass  */
drivers/powerware-mib.c:	{   4, "BYPASS"    /* bypass */ },
drivers/powerware-mib.c:	/* FIXME: this segfaults! do we assume the same number of bypass phases as input phases?
drivers/powerware-mib.c:	{ ".1.3.6.1.4.1.534.1.7.11", "BYPASS", "On bypass!" },
drivers/powerware-mib.c:	{ ".1.3.6.1.4.1.534.1.7.44", "BYPASS", "On maintenance bypass!" },
````

Not sure if this change requires a driver version bump.