### PR TITLE
Update mge-xml.c : Include drivers/main.h to get testvar() declared properly

### DIFF
--- a/drivers/mge-xml.c
+++ b/drivers/mge-xml.c
@@ -31,6 +31,7 @@
 
 #include "netxml-ups.h"
 #include "mge-xml.h"
+#include "main.h" /* for testvar() */
 
 #define MGE_XML_VERSION		"MGEXML/0.28"
 


### PR DESCRIPTION
Suggested by travis warnings in FTY branch