### PR TITLE
Phoenixcontact modbus driver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ addons:
     - libfreetype6-dev
     - libxpm-dev
     - libxml2-utils
+    - libmodbus-dev
 
 env:
   global:

--- a/configure.ac
+++ b/configure.ac
@@ -253,7 +253,7 @@ dnl check for --with-all (or --without-all, or --with-all=auto) flag
 
 AC_MSG_CHECKING(for --with-all)
 AC_ARG_WITH(all,
-	AS_HELP_STRING([--with-all], [enable serial, usb, snmp, neon, ipmi, powerman, cgi, dev, avahi, linux_i2c]),
+	AS_HELP_STRING([--with-all], [enable serial, usb, snmp, neon, ipmi, powerman, modbus, cgi, dev, avahi, linux_i2c]),
 [
 	if test -n "${withval}"; then
 		dnl Note: we allow "no" as a positive value, because
@@ -263,6 +263,7 @@ AC_ARG_WITH(all,
 		if test -z "${with_snmp}"; then with_snmp="${withval}"; fi
 		if test -z "${with_neon}"; then with_neon="${withval}"; fi
 		if test -z "${with_powerman}"; then with_powerman="${withval}"; fi
+		if test -z "${with_modbus}"; then with_modbus="${withval}"; fi
 		if test -z "${with_cgi}"; then with_cgi="${withval}"; fi
 		if test -z "${with_dev}"; then with_dev="${withval}"; fi
 		if test -z "${with_avahi}"; then with_avahi="${withval}"; fi
@@ -308,6 +309,8 @@ NUT_ARG_WITH([neon], [build and install neon based XML/HTTP driver], [auto])
 NUT_CHECK_LIBNEON
 NUT_ARG_WITH([powerman], [build and install Powerman PDU client driver], [auto])
 NUT_CHECK_LIBPOWERMAN
+NUT_ARG_WITH([modbus], [build and install modbus drivers], [auto])
+NUT_CHECK_LIBMODBUS
 NUT_CHECK_LIBAVAHI
 
 dnl ----------------------------------------------------------------------
@@ -403,6 +406,20 @@ fi
 NUT_REPORT_FEATURE([build Powerman PDU client driver], [${nut_with_powerman}], [],
 					[WITH_LIBPOWERMAN], [Define to enable Powerman PDU support])
 
+dnl ----------------------------------------------------------------------
+dnl checks related to --with-modbus
+
+dnl ${nut_with_modbus}: any value except "yes" or "no" is treated as "auto".
+if test "${nut_with_modbus}" = "yes" -a "${nut_have_libmodbus}" != "yes"; then
+   AC_MSG_ERROR(["modbus library not found, required for Modbus driver"])
+fi
+
+if test "${nut_with_modbus}" != "no"; then
+   nut_with_modbus="${nut_have_libmodbus}"
+fi
+
+NUT_REPORT_FEATURE([build Modbus driver], [${nut_with_modbus}], [],
+                                       [WITH_MODBUS], [Define to enable Modbus support])
 dnl ----------------------------------------------------------------------
 dnl Check for with-ipmi, and --with-freeipmi (or --with-openipmi)
 dnl Only one can be enabled at a time, with a preference for FreeIPMI
@@ -1465,6 +1482,8 @@ AC_SUBST(LIBAVAHI_CFLAGS)
 AC_SUBST(LIBAVAHI_LIBS)
 AC_SUBST(LIBPOWERMAN_CFLAGS)
 AC_SUBST(LIBPOWERMAN_LIBS)
+AC_SUBST(LIBMODBUS_CFLAGS)
+AC_SUBST(LIBMODBUS_LIBS)
 AC_SUBST(LIBIPMI_CFLAGS)
 AC_SUBST(LIBIPMI_LIBS)
 AC_SUBST(DOC_BUILD_LIST)

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -794,6 +794,8 @@
 
 "Phasak"	"ups"	"2"	"400VA / 600VA"	""	"blazer_ser"
 
+"PhoenixContact"	"ups"	"4"	"QUINT-UPS/24DC"	"2320461"	"phoenixcontact_modbus" #https://www.phoenixcontact.com/online/portal/us?uri=pxc-oc-itemdetail:pid=2320461
+
 "Plexus"	"ups"	"2"	"500VA"	"USB"	"blazer_usb"
 "Plexus"	"ups"	"2"	"1000VA Pro"	"USB"	"blazer_usb"
 "Plexus"	"ups"	"1"	"800 VA"	"USB"	"nutdrv_atcl_usb"

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -341,6 +341,7 @@ SRC_SERIAL_PAGES = \
 	microdowell.txt	\
 	nutdrv_qx.txt	\
 	optiups.txt	\
+	phoenixcontact_modbus.txt \
 	powercom.txt 	\
 	powerpanel.txt	\
 	rhino.txt		\
@@ -386,6 +387,7 @@ MAN_SERIAL_PAGES = \
 	optiups.8	\
 	powercom.8 	\
 	powerpanel.8	\
+	phoenixcontact_modbus.8 \
 	rhino.8		\
 	riello_ser.8	\
 	safenet.8	\
@@ -433,6 +435,7 @@ HTML_SERIAL_MANS = \
 	optiups.html	\
 	powercom.html 	\
 	powerpanel.html	\
+	phoenixcontact_modbus.html	\
 	rhino.html		\
 	riello_ser.html	\
 	safenet.html	\

--- a/docs/man/phoenixcontact_modbus.txt
+++ b/docs/man/phoenixcontact_modbus.txt
@@ -30,7 +30,7 @@ How to configure the UPS
 
 Note: this UPS and its manual refers to Low-Batt as "Shutdown Event".
 
-You need the IFS-RS232-DATACABLE to communicate with the UPS in linux as the IFS-USB cable doesn't seem to be supported.
+You need the IFS-RS232-DATACABLE to communicate with the UPS in linux as the IFS-USB cable doesn't seem to be supported. FYI communication parameters are: 115200,E,8,1.
 You also need the UPS-CONF windows software (free, download from their site), to configure the UPS signals and timers. 
 1) Run the UPS-CONF
 2) Go to Settings->Time Setting

--- a/docs/man/phoenixcontact_modbus.txt
+++ b/docs/man/phoenixcontact_modbus.txt
@@ -25,6 +25,29 @@ More information about this UPS can be found here: https://www.phoenixcontact.co
 
 phoenixcontact_modbus uses the libmodbus project, for Modbus implementation.
 
+How to configure the UPS
+------------------------
+
+Note: this UPS and its manual refers to Low-Batt as "Shutdown Event".
+
+You need the IFS-RS232-DATACABLE to communicate with the UPS in linux as the IFS-USB cable doesn't seem to be supported.
+You also need the UPS-CONF windows software (free, download from their site), to configure the UPS signals and timers. 
+1) Run the UPS-CONF
+2) Go to Settings->Time Setting
+3) Choose "state of charge shutdown delay"
+4) Choose Remote starts PC-Shutdown in Mains and Battery mode
+5) On the PC-Shutdown enter the maximum value (5 minutes)
+6) On the PC-Restart delay enter the time you want the ups to leave the output power off before restarting (e.g. 60 seconds), after mains power is restored.
+7) On the UPS, turn the screw to the "PC-MODE" position
+
+Configuring the above way ensures that:
+* When power is lost ups constantly calculates remaining battery time
+* When remaining bat. time is <= 5 minutes (PC-Shutdown setting), it will raise the "Shutdown" event (seen as LOW-BATT in NUT)
+* From that moment even if input power is restored, the UPS will cut the output power to its load after 5 minutes
+* When the input power is restored, the ups will restore output power after 60 seconds (PC-RESTART delay setting).
+
+Unfortunately 5 minutes is the max, and 60 seconds also the max setting it can accept. It would be beneficial to raise PC-Restart to say 5 minutes to allow the UPS battery to charge.
+
 
 EXTRA ARGUMENTS
 ---------------

--- a/docs/man/phoenixcontact_modbus.txt
+++ b/docs/man/phoenixcontact_modbus.txt
@@ -1,9 +1,8 @@
 PHOENIXCONTACT_MODBUS(8)
-================
+========================
 
 NAME
 ----
-
 phoenixcontact_modbus - Driver for Phoenix Contact
 
 SYNOPSIS
@@ -32,21 +31,24 @@ Note: this UPS and its manual refers to Low-Batt as "Shutdown Event".
 
 You need the IFS-RS232-DATACABLE to communicate with the UPS in linux as the IFS-USB cable doesn't seem to be supported. FYI communication parameters are: 115200,E,8,1.
 You also need the UPS-CONF windows software (free, download from their site), to configure the UPS signals and timers. 
-1) Run the UPS-CONF
-2) Go to Settings->Time Setting
-3) Choose "state of charge shutdown delay"
-4) Choose Remote starts PC-Shutdown in Mains and Battery mode
-5) On the PC-Shutdown enter the maximum value (5 minutes)
-6) On the PC-Restart delay enter the time you want the ups to leave the output power off before restarting (e.g. 60 seconds), after mains power is restored.
-7) On the UPS, turn the screw to the "PC-MODE" position
 
-Configuring the above way ensures that:
-* When power is lost ups constantly calculates remaining battery time
-* When remaining bat. time is <= 5 minutes (PC-Shutdown setting), it will raise the "Shutdown" event (seen as LOW-BATT in NUT)
-* From that moment even if input power is restored, the UPS will cut the output power to its load after 5 minutes
-* When the input power is restored, the ups will restore output power after 60 seconds (PC-RESTART delay setting).
+1. Run the UPS-CONF
+2. Go to Settings->Time Setting
+3. Choose "state of charge shutdown delay"
+4. Choose Remote starts PC-Shutdown in Mains and Battery mode
+5. On the PC-Shutdown enter the maximum value (5 minutes)
+6. On the PC-Restart delay enter the time you want the ups to leave the output power off before restarting (e.g. 60 seconds), after mains power is restored.
+7. On the UPS, turn the screw to the "PC-MODE" position
 
-Unfortunately 5 minutes is the max, and 60 seconds also the max setting it can accept. It would be beneficial to raise PC-Restart to say 5 minutes to allow the UPS battery to charge.
+.Configuring the above way ensures that:
+ * When power is lost ups constantly calculates remaining battery time
+ * When remaining bat. time is <= 5 minutes (PC-Shutdown setting), it will raise the "Shutdown" event (seen as LOW-BATT in NUT)
+ * From that moment even if input power is restored, the UPS will cut the output power to its load after 5 minutes
+ * When the input power is restored, the ups will restore output power after 60 seconds (PC-RESTART delay setting).
+
+.Meaning of settings:
+ * PC-Shutdown: How long before output cutoff the ups will raise the "shutdown event" signal. Max value for this is 5 minutes. So PC should be able to shutdown within 5 minutes.
+ * PC-Restart: How long to delay output power after power is restored. Max is 60 seconds.
 
 
 EXTRA ARGUMENTS
@@ -67,9 +69,6 @@ INSTANT COMMANDS
 ----------------
 
 This driver doesn't support any instant commands.
-
-IMPLEMENTATION
---------------
 
 
 AUTHOR

--- a/docs/man/phoenixcontact_modbus.txt
+++ b/docs/man/phoenixcontact_modbus.txt
@@ -1,0 +1,66 @@
+PHOENIXCONTACT_MODBUS(8)
+================
+
+NAME
+----
+
+phoenixcontact_modbus - Driver for Phoenix Contact
+
+SYNOPSIS
+--------
+
+*phoenixcontact_modbus* -h
+
+*phoenixcontact_modbus* -a 'DEVICE_NAME' ['OPTIONS']
+
+NOTE: This man page only documents the hardware-specific features of the
+phoenixcontact_modbus  driver.  For information about the core driver, see
+linkman:nutupsdrv[8].
+
+SUPPORTED HARDWARE
+------------------
+
+This driver should support the PhoenixContact QUINT-UPS industrial DC UPS, model 2320461 and all compatible models.
+More information about this UPS can be found here: https://www.phoenixcontact.com/online/portal/us?uri=pxc-oc-itemdetail:pid=2320461
+
+phoenixcontact_modbus uses the libmodbus project, for Modbus implementation.
+
+
+EXTRA ARGUMENTS
+---------------
+
+This driver doesn't support any optional settings.
+
+INSTALLATION
+------------
+
+This driver is not built by default.  You can build it by using
+"configure --with-modbus=yes".
+
+You also need to give proper permissions on the local serial device file
+(/dev/ttyS0 for example) to allow the NUT user to access it.
+
+INSTANT COMMANDS
+----------------
+
+This driver doesn't support any instant commands.
+
+IMPLEMENTATION
+--------------
+
+
+AUTHOR
+------
+Spiros Ioannou <sivann@gmail.com>
+
+SEE ALSO
+--------
+The core driver:
+~~~~~~~~~~~~~~~~
+linkman:nutupsdrv[8]
+
+Internet resources:
+~~~~~~~~~~~~~~~~~~~
+The NUT (Network UPS Tools) home page: http://www.networkupstools.org/
+
+libmodbus home page: http://libmodbus.org

--- a/docs/man/phoenixcontact_modbus.txt
+++ b/docs/man/phoenixcontact_modbus.txt
@@ -29,7 +29,7 @@ How to configure the UPS
 
 Note: this UPS and its manual refers to Low-Batt as "Shutdown Event".
 
-You need the IFS-RS232-DATACABLE to communicate with the UPS in linux as the IFS-USB cable doesn't seem to be supported. FYI communication parameters are: 115200,E,8,1.
+You need the "IFS-RS232-DATACABLE" to communicate with the UPS in linux as the IFS-USB cable doesn't seem to be supported. FYI communication parameters are: 115200,E,8,1.
 You also need the UPS-CONF windows software (free, download from their site), to configure the UPS signals and timers. 
 
 1. Run the UPS-CONF

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -2403,3 +2403,8 @@ zwfa
 zzz
 Åstrand
 Ørpetveit
+modbus
+phoenixcontact
+PhoenixContact
+libmodbus
+DATACABLE

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -386,9 +386,9 @@ Hough
 Hurd
 Håvard
 IANA
+ID's
 IDEN
 IDentifiers
-ID's
 IFBETWEEN
 IFSUPP
 IGN
@@ -427,8 +427,8 @@ JW
 Jageson
 Jarosch
 Jasuny
-Javadoc
 JavaScript
+Javadoc
 Javascript
 Joon
 Jumpered

--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -28,6 +28,9 @@ endif
 if WITH_IPMI
   AM_CFLAGS += $(LIBIPMI_CFLAGS)
 endif
+if WITH_MODBUS
+  AM_CFLAGS += $(LIBMODBUS_CFLAGS)
+endif
 
 SERIAL_DRIVERLIST = al175 bcmxcp belkin belkinunv bestfcom	\
  bestfortress bestuferrups bestups dummy-ups etapro everups 	\
@@ -44,6 +47,7 @@ USB_LIBUSB_DRIVERLIST = usbhid-ups bcmxcp_usb tripplite_usb \
 USB_DRIVERLIST = $(USB_LIBUSB_DRIVERLIST)
 NEONXML_DRIVERLIST = netxml-ups
 MACOSX_DRIVERLIST = macosx-ups
+MODBUS_DRIVERLIST = phoenixcontact_modbus
 LINUX_I2C_DRIVERLIST = asem
 
 # distribute all drivers, even ones that are not built by default
@@ -77,6 +81,9 @@ if WITH_MACOSX
 endif
 if WITH_LINUX_I2C
    driverexec_PROGRAMS += $(LINUX_I2C_DRIVERLIST)
+endif
+if WITH_MODBUS
+  driverexec_PROGRAMS += $(MODBUS_DRIVERLIST)
 endif
 else
    driverexec_PROGRAMS += skel
@@ -224,6 +231,10 @@ nut_ipmipsu_LDADD = $(LDADD) $(LIBIPMI_LIBS)
 macosx_ups_LDADD = $(LDADD_DRIVERS)
 macosx_ups_LDFLAGS = $(LDFLAGS) -framework IOKit -framework CoreFoundation
 macosx_ups_SOURCES = macosx-ups.c
+
+# Modbus driver
+phoenixcontact_modbus_SOURCES = phoenixcontact_modbus.c
+phoenixcontact_modbus_LDADD = $(LDADD_DRIVERS) $(LIBMODBUS_LIBS)
 
 # Asem
 asem_LDADD = $(LDADD_DRIVERS)

--- a/drivers/phoenixcontact_modbus.c
+++ b/drivers/phoenixcontact_modbus.c
@@ -192,7 +192,7 @@ int mrir(modbus_t *ctx, int addr, int nb, uint16_t *dest) {
     int r;
     r =  modbus_read_input_registers(ctx, addr, nb, dest);
     if (r == -1) {
-        upslogx(LOG_ERR, "mrir: modbus_read_input_registers: %s", modbus_strerror(errno));
+        upslogx(LOG_ERR, "mrir: modbus_read_input_registers(addr:%d, count:%d): %s (%s)", addr,nb,modbus_strerror(errno),device_path);
         errcount ++;
     }
     errcount = 0;

--- a/drivers/phoenixcontact_modbus.c
+++ b/drivers/phoenixcontact_modbus.c
@@ -1,0 +1,220 @@
+/*  phoenixcontact_modbus.c - Driver for PhoenixContact-QUINT UPS 
+ *
+ *  Copyright (C)
+ *    2017  Spiros Ioannou <sivann@inaccess.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * TODO list:
+ * - everything...
+ * - create the format for the "NUT Modbus definition file"
+ * - complete initups
+ * - create initinfo
+ * - create updateinfo
+ * 
+ * "NUT Modbus definition file"		xxx.modbus
+ * # A comment header may contain information such as
+ * # - author and device information
+ * # - default communication settings (baudrate, parity, data_bit, stop_bit)
+ * device.type: <ups,meter,...>
+ * [device.mfr: <Manufacturer name>]
+ * [device.model: <Model name>]
+ * <nut varname>: <modbus address>, <modbus register>, ..., <convertion function name>
+ */
+
+#include "main.h"
+#include <modbus.h>
+
+#define DRIVER_NAME	"NUT Modbus driver"
+#define DRIVER_VERSION	"0.01"
+
+/* Variables */
+modbus_t *ctx = NULL;
+
+/* driver description structure */
+upsdrv_info_t upsdrv_info = {
+	DRIVER_NAME,
+	DRIVER_VERSION,
+	"Arnaud Quette <arnaud.quette@gmail.com>\n",
+	DRV_EXPERIMENTAL,
+	{ NULL }
+};
+
+void upsdrv_initinfo(void)
+{
+	upsdebugx(2, "upsdrv_initinfo");
+
+	/* try to detect the device here - call fatal_with_errno(EXIT_FAILURE, ) if it fails */
+
+	/* 1/ Open the NUT Modbus definition file and load the data
+	 * 2/ Iterate through these data and call dstate_setinfo */
+
+	/* dstate_setinfo("device.mfr", "skel manufacturer"); */
+	/* dstate_setinfo("device.model", "longrun 15000"); */
+	/* dstate_setinfo("device.type", "longrun 15000"); */
+	/* ... */
+
+	/* upsh.instcmd = instcmd; */
+	/* upsh.setvar = setvar; */
+}
+
+void upsdrv_updateinfo(void)
+{
+	upsdebugx(2, "upsdrv_updateinfo");
+
+	/* int flags; */
+	/* char temp[256]; */
+
+	/* ser_sendchar(upsfd, 'A'); */
+	/* ser_send(upsfd, "foo%d", 1234); */
+	/* ser_send_buf(upsfd, bincmd, 12); */
+
+	/* 
+	 * ret = ser_get_line(upsfd, temp, sizeof(temp), ENDCHAR, IGNCHARS);
+	 *
+	 * if (ret < STATUS_LEN) {
+	 * 	upslogx(LOG_ERR, "Short read from UPS");
+	 *	dstate_datastale();
+	 *	return;
+	 * }
+	 */
+
+	/* dstate_setinfo("var.name", ""); */
+
+	/* if (ioctl(upsfd, TIOCMGET, &flags)) {
+	 *	upslog_with_errno(LOG_ERR, "TIOCMGET");
+	 *	dstate_datastale();
+	 *	return;
+	 * }
+	 */
+
+	/* status_init();
+	 *
+	 * if (ol)
+	 * 	status_set("OL");
+	 * else
+	 * 	status_set("OB");
+	 * ...
+	 *
+	 * status_commit();
+	 *
+	 * dstate_dataok();
+	 */
+
+	/*
+	 * poll_interval = 2;
+	 */
+}
+
+void upsdrv_shutdown(void)
+{
+	/* tell the UPS to shut down, then return - DO NOT SLEEP HERE */
+
+	/* maybe try to detect the UPS here, but try a shutdown even if
+	   it doesn't respond at first if possible */
+
+	/* replace with a proper shutdown function */
+	fatalx(EXIT_FAILURE, "shutdown not supported");
+
+	/* you may have to check the line status since the commands
+	   for toggling power are frequently different for OL vs. OB */
+
+	/* OL: this must power cycle the load if possible */
+
+	/* OB: the load must remain off until the power returns */
+}
+
+/*
+static int instcmd(const char *cmdname, const char *extra)
+{
+	if (!strcasecmp(cmdname, "test.battery.stop")) {
+		ser_send_buf(upsfd, ...);
+		return STAT_INSTCMD_HANDLED;
+	}
+
+	upslogx(LOG_NOTICE, "instcmd: unknown command [%s]", cmdname);
+	return STAT_INSTCMD_UNKNOWN;
+}
+*/
+
+/*
+static int setvar(const char *varname, const char *val)
+{
+	if (!strcasecmp(varname, "ups.test.interval")) {
+		ser_send_buf(upsfd, ...);
+		return STAT_SET_HANDLED;
+	}
+
+	upslogx(LOG_NOTICE, "setvar: unknown variable [%s]", varname);
+	return STAT_SET_UNKNOWN;
+}
+*/
+
+void upsdrv_help(void)
+{
+}
+
+/* list flags and values that you want to receive via -x */
+void upsdrv_makevartable(void)
+{
+	/* allow '-x xyzzy' */
+	/* addvar(VAR_FLAG, "xyzzy", "Enable xyzzy mode"); */
+
+	/* allow '-x foo=<some value>' */
+	/* addvar(VAR_VALUE, "foo", "Override foo setting"); */
+}
+
+void upsdrv_initups(void)
+{
+	upsdebugx(2, "upsdrv_initups");
+
+	/* Determine if it's a RTU (serial) or ethernet (TCP) connection */
+	/* FIXME: need to address windows COM port too!
+	 * || !strncmp(device_path[0], "COM", 3) */
+	if (device_path[0] == '/') {
+		upsdebugx(2, "upsdrv_initups: RTU (serial) device");
+
+		/* FIXME: handle serial comm. params (params in ups.conf
+		 * and/or definition file) */
+		ctx = modbus_new_rtu(device_path, 115200, 'N', 8, 1);
+		if (ctx == NULL)
+			fatalx(EXIT_FAILURE, "Unable to create the libmodbus context");
+	}
+	/* else {
+		 * upscli_splitaddr(device_path[0] ? device_path[0] : "localhost", &hostname, &port
+		upsdebugx(2, "upsdrv_initups: TCP (network) device");
+		ctx = modbus_new_tcp(device_path, 1502); 
+		if (ctx == NULL)
+			fatalx(EXIT_FAILURE, "Unable to create the libmodbus context");
+
+		if (modbus_connect(ctx) == -1) {
+			modbus_free(ctx);
+			fatalx(EXIT_FAILURE, "Connection failed: %s\n", modbus_strerror(errno));
+		}
+	}
+	*/
+
+	/* don't try to detect the device here */
+}
+
+void upsdrv_cleanup(void)
+{
+	/* free(dynamic_mem); */
+	if (ctx != NULL) {
+		modbus_close(ctx);
+		modbus_free(ctx);
+	}
+}

--- a/drivers/phoenixcontact_modbus.c
+++ b/drivers/phoenixcontact_modbus.c
@@ -27,6 +27,7 @@
 #define DRIVER_VERSION	"0.01"
 
 #define CHECK_BIT(var,pos) ((var) & (1<<(pos)))
+#define MODBUS_SLAVE_ID 192
 
 /* Variables */
 modbus_t *ctx = NULL;
@@ -145,10 +146,10 @@ void upsdrv_initups(void)
 	if (ctx == NULL)
 		fatalx(EXIT_FAILURE, "Unable to create the libmodbus context");
 
-	r = modbus_set_slave(ctx, 192);	/* slave ID */
+	r = modbus_set_slave(ctx, MODBUS_SLAVE_ID);	/* slave ID */
 	if (r < 0) {
 		modbus_free(ctx);
-		fatalx(EXIT_FAILURE, "Invalid slave ID 192");
+		fatalx(EXIT_FAILURE, "Invalid slave ID %d",MODBUS_SLAVE_ID);
 	}
 
 	if (modbus_connect(ctx) == -1) {

--- a/m4/nut_check_libmodbus.m4
+++ b/m4/nut_check_libmodbus.m4
@@ -1,0 +1,71 @@
+dnl Check for LIBMODBUS compiler flags. On success, set nut_have_libmodbus="yes"
+dnl and set LIBMODBUS_CFLAGS and LIBMODBUS_LIBS. On failure, set
+dnl nut_have_libmodbus="no". This macro can be run multiple times, but will
+dnl do the checking only once.
+
+AC_DEFUN([NUT_CHECK_LIBMODBUS],
+[
+if test -z "${nut_have_libmodbus_seen}"; then
+	nut_have_libmodbus_seen=yes
+
+	dnl save CFLAGS and LIBS
+	CFLAGS_ORIG="${CFLAGS}"
+	LIBS_ORIG="${LIBS}"
+
+	AC_MSG_CHECKING(for libmodbus version via pkg-config)
+	LIBMODBUS_VERSION="`pkg-config --silence-errors --modversion libmodbus 2>/dev/null`"
+	if test "$?" = "0" -a -n "${LIBMODBUS_VERSION}"; then
+		CFLAGS="`pkg-config --silence-errors --cflags libmodbus 2>/dev/null`"
+		LIBS="`pkg-config --silence-errors --libs libmodbus 2>/dev/null`"
+	else
+		LIBMODBUS_VERSION="none"
+		CFLAGS="-I/usr/include/modbus"
+		LIBS="-lmodbus"
+	fi
+	AC_MSG_RESULT(${LIBMODBUS_VERSION} found)
+
+	AC_MSG_CHECKING(for libmodbus cflags)
+	AC_ARG_WITH(modbus-includes,
+		AS_HELP_STRING([@<:@--with-modbus-includes=CFLAGS@:>@], [include flags for the libmodbus library]),
+	[
+		case "${withval}" in
+		yes|no)
+			AC_MSG_ERROR(invalid option --with(out)-modbus-includes - see docs/configure.txt)
+			;;
+		*)
+			CFLAGS="${withval}"
+			;;
+		esac
+	], [])
+	AC_MSG_RESULT([${CFLAGS}])
+
+	AC_MSG_CHECKING(for libmodbus ldflags)
+	AC_ARG_WITH(modbus-libs,
+		AS_HELP_STRING([@<:@--with-modbus-libs=LIBS@:>@], [linker flags for the libmodbus library]),
+	[
+		case "${withval}" in
+		yes|no)
+			AC_MSG_ERROR(invalid option --with(out)-modbus-libs - see docs/configure.txt)
+			;;
+		*)
+			LIBS="${withval}"
+			;;
+		esac
+	], [])
+	AC_MSG_RESULT([${LIBS}])
+
+	dnl check if libmodbus is usable
+	AC_CHECK_HEADERS(modbus.h, [nut_have_libmodbus=yes], [nut_have_libmodbus=no], [AC_INCLUDES_DEFAULT])
+	AC_CHECK_FUNCS(modbus_new_rtu, [], [nut_have_libmodbus=no])
+	AC_CHECK_FUNCS(modbus_new_tcp, [], [nut_have_libmodbus=no])
+
+	if test "${nut_have_libmodbus}" = "yes"; then
+		LIBMODBUS_CFLAGS="${CFLAGS}"
+		LIBMODBUS_LIBS="${LIBS}"
+	fi
+
+	dnl restore original CFLAGS and LIBS
+	CFLAGS="${CFLAGS_ORIG}"
+	LIBS="${LIBS_ORIG}"
+fi
+])


### PR DESCRIPTION
This is a modbus driver (the first?) for the Phoenix Contact QUINT-UPS model 2320461. The driver has been tested and works as expected. 
The custom IFS-RS-232 modbus cable is required (about 72$!), and UPS must be setup via its windows software to work correctly with NUT. All that is documented on the manual page of the driver.

This includes all skeleton modbus driver changes for building with libmodbus.

The ups on the web: https://www.phoenixcontact.com/online/portal/us?uri=pxc-oc-itemdetail:pid=2320461

Best Regards,
-Spiros