### PR TITLE
[WIP - DO NOT MERGE] Cppcheck improvements

### DIFF
--- a/clients/upsclient.c
+++ b/clients/upsclient.c
@@ -570,7 +570,7 @@ static int upscli_select_read(const int fd, void *buf, const size_t buflen, cons
 /* internal: abstract the SSL calls for the other functions */
 static int net_read(UPSCONN_t *ups, char *buf, size_t buflen)
 {
-	int	ret;
+	int	ret = -1;
 
 #ifdef WITH_SSL
 	if (ups->ssl) {
@@ -631,7 +631,7 @@ static int upscli_select_write(const int fd, const void *buf, const size_t bufle
 /* internal: abstract the SSL calls for the other functions */
 static int net_write(UPSCONN_t *ups, const char *buf, size_t buflen)
 {
-	int	ret;
+	int	ret = -1;
 
 #ifdef WITH_SSL
 	if (ups->ssl) {

--- a/drivers/gamatronic.c
+++ b/drivers/gamatronic.c
@@ -66,6 +66,7 @@ int sec_upsrecv (char *buf)
 		return(0);
 		case SEC_DATAMSG:
 		strncpy(lenbuf,buf+2,3);
+		lenbuf[3] = '\0';
 		ret = atoi(lenbuf);
 		if (ret > 0){
 		strcpy(buf,buf+5);

--- a/drivers/gamatronic.c
+++ b/drivers/gamatronic.c
@@ -359,11 +359,12 @@ void setup_serial(const char *port)
     if (i == 5) {
 	printf("Can't talk to UPS on port %s!\n",port);
 	printf("Check the cabling and portname and try again\n");
-	printf("Please note that this driver only support UPS Models with SEC Protorol\n");
+	printf("Please note that this driver only support UPS Models with SEC Protocol\n");
 	ser_close(upsfd, device_path);
 	exit (1);
     }
-printf("Connected to UPS on %s baudrate: %d\n",port, baud_rates[i].name);
+    else
+      printf("Connected to UPS on %s baudrate: %d\n",port, baud_rates[i].name);
 }
 
 void upsdrv_initups(void)

--- a/drivers/openups-hid.c
+++ b/drivers/openups-hid.c
@@ -236,7 +236,7 @@ static const char *openups_scale_cdischarge_fun(double value)
 static const char *openups_temperature_fun(double value)
 {
 	int i;
-	int pos = -1;
+	int pos = 0;
 	unsigned int thermistor = value * 100;
 
 	if (thermistor <= therm_tbl[0]) {

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -2576,6 +2576,7 @@ int su_setOID(int mode, const char *varname, const char *val)
 	if ((daisychain_enabled == TRUE) && (devices_count > 1) && (daisychain_device_number == 0)) {
 		upsdebugx(2, "daisychain %s for device.0 are not yet supported!",
 			(mode==SU_MODE_INSTCMD)?"command":"setting");
+		free(tmp_varname);
 		return STAT_SET_INVALID;
 	}
 

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -705,7 +705,14 @@ struct snmp_pdu **nut_snmp_walk(const char *OID, int max_iteration)
 
 		nb_iteration++;
 		/* +1 is for the terminating NULL */
-		ret_array = realloc(ret_array,sizeof(struct snmp_pdu*)*(nb_iteration+1));
+		struct snmp_pdu ** new_ret_array = realloc(ret_array,sizeof(struct snmp_pdu*)*(nb_iteration+1));
+		if (new_ret_array == NULL) {
+			upsdebugx(1, "%s: Failed to realloc thread", __func__);
+			break;
+		}
+		else {
+			ret_array = new_ret_array;
+		}
 		ret_array[nb_iteration-1] = response;
 		ret_array[nb_iteration]=NULL;
 

--- a/server/netssl.c
+++ b/server/netssl.c
@@ -240,10 +240,11 @@ void net_starttls(nut_ctype_t *client, int numarg, const char **arg)
 	}
 	
 #ifdef WITH_OPENSSL	
-	if (!ssl_ctx) {
+	if (!ssl_ctx)
 #elif defined(WITH_NSS) /* WITH_OPENSSL */
-	if (!NSS_IsInitialized()) {
+	if (!NSS_IsInitialized())
 #endif /* WITH_OPENSSL | WITH_NSS */
+	{
 		send_err(client, NUT_ERR_FEATURE_NOT_CONFIGURED);
 		ssl_initialized = 0;
 		return;

--- a/tools/nut-scanner/nutscan-ip.c
+++ b/tools/nut-scanner/nutscan-ip.c
@@ -230,14 +230,15 @@ int nutscan_cidr_to_ip(const char * cidr, char ** start_ip, char ** stop_ip)
 
 	cidr_tok = strdup(cidr);
 	first_ip = strdup(strtok_r(cidr_tok,"/",&saveptr));
+	free(cidr_tok);
 	if( first_ip == NULL) {
 		return 0;
 	}
 	mask = strtok_r(NULL,"/",&saveptr);
 	if( mask == NULL ) {
+		free (first_ip);
 		return 0;
 	}
-	free(cidr_tok);
 
 	mask_val = atoi(mask);
 

--- a/tools/nut-scanner/nutscan-serial.c
+++ b/tools/nut-scanner/nutscan-serial.c
@@ -27,6 +27,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include "nut_platform.h"
+#include "common.h"
 
 #ifdef WIN32
 /* Windows: all serial port names start with "COM" */
@@ -102,7 +103,8 @@ static char ** add_port(char ** list, char * port)
 	/*+1 for the terminal NULL */
 	res = realloc(list,(count+1+1)*sizeof(char*));
 	if( res == NULL ) {
-		return NULL;
+		upsdebugx(1, "%s: Failed to realloc port list", __func__);
+		return list;
 	}
 	res[count] = strdup(port);
 	res[count+1] = NULL;

--- a/tools/nut-scanner/scan_eaton_serial.c
+++ b/tools/nut-scanner/scan_eaton_serial.c
@@ -410,8 +410,15 @@ nutscan_device_t * nutscan_scan_eaton_serial(const char* ports_range)
 #ifdef HAVE_PTHREAD
 		if (pthread_create(&thread, NULL, nutscan_scan_eaton_serial_device, (void*)current_port_name) == 0){
 			thread_count++;
-			thread_array = realloc(thread_array,
-					thread_count*sizeof(pthread_t));
+			pthread_t *new_thread_array = realloc(thread_array,
+						thread_count*sizeof(pthread_t));
+			if (new_thread_array == NULL) {
+				upsdebugx(1, "%s: Failed to realloc thread", __func__);
+				break;
+			}
+			else {
+				thread_array = new_thread_array;
+			}
 			thread_array[thread_count-1] = thread;
 		}
 #else

--- a/tools/nut-scanner/scan_nut.c
+++ b/tools/nut-scanner/scan_nut.c
@@ -264,8 +264,15 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 #ifdef HAVE_PTHREAD
 		if (pthread_create(&thread,NULL,list_nut_devices,(void*)nut_arg)==0){
 			thread_count++;
-			thread_array = realloc(thread_array,
-					thread_count*sizeof(pthread_t));
+			pthread_t *new_thread_array = realloc(thread_array,
+						thread_count*sizeof(pthread_t));
+			if (new_thread_array == NULL) {
+				upsdebugx(1, "%s: Failed to realloc thread", __func__);
+				break;
+			}
+			else {
+				thread_array = new_thread_array;
+			}
 			thread_array[thread_count-1] = thread;
 		}
 #else

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -700,8 +700,15 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 #ifdef HAVE_PTHREAD
 		if (pthread_create(&thread,NULL,try_SysOID,(void*)tmp_sec)==0){
 			thread_count++;
-			thread_array = realloc(thread_array,
+			pthread_t *new_thread_array = realloc(thread_array,
 						thread_count*sizeof(pthread_t));
+			if (new_thread_array == NULL) {
+				upsdebugx(1, "%s: Failed to realloc thread", __func__);
+				break;
+			}
+			else {
+				thread_array = new_thread_array;
+			}
 			thread_array[thread_count-1] = thread;
 		}
 #else

--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -414,11 +414,13 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 			};
 
 #ifdef HAVE_PTHREAD
-			for ( i=0; i < thread_count ; i++) {
-				pthread_join(thread_array[i],NULL);
+			if (thread_array != NULL) {
+				for ( i=0; i < thread_count ; i++) {
+						pthread_join(thread_array[i],NULL);
+				}
+				free(thread_array);
 			}
 			pthread_mutex_destroy(&dev_mutex);
-			free(thread_array);
 #endif
 			result = nutscan_rewind_device(dev_ret);
 			dev_ret = NULL;

--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -394,8 +394,15 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 #ifdef HAVE_PTHREAD
 				if (pthread_create(&thread,NULL,nutscan_scan_xml_http_generic, (void *)tmp_sec)==0){
 					thread_count++;
-					thread_array = realloc(thread_array,
+					pthread_t *new_thread_array = realloc(thread_array,
 								thread_count*sizeof(pthread_t));
+					if (new_thread_array == NULL) {
+						upsdebugx(1, "%s: Failed to realloc thread", __func__);
+						break;
+					}
+					else {
+						thread_array = new_thread_array;
+					}
 					thread_array[thread_count-1] = thread;
 				}
 #else


### PR DESCRIPTION
This is another attempt to improve the code through static code analysis, using Cppcheck
Command line: `cppcheck --inconclusive --std=c89 --force .`

1rst iteration, limited to errors and using c89 as the standard.

Errors list:
* [x] [clients/upsclient.c:583]: (error) Uninitialized variable: ret
* [x] [clients/upsclient.c:644]: (error) Uninitialized variable: ret
* [x] [drivers/gamatronic.c:365]: (error) Array 'baud_rates[5]' accessed at index 5, which is out of bounds.
* [x] [drivers/gamatronic.c:69]: (error) Dangerous usage of 'lenbuf' (strncpy doesn't always null-terminate it).
* [ ] [drivers/mge-shut.c:759]: (error) Uninitialized struct member: SHUTRequest.bChecksum
* [x] [drivers/openups-hid.c:255]: (error) Array index -1 is out of bounds.
* [x] [drivers/snmp-ups.c:708]: (error) Common realloc mistake: 'ret_array' nulled but not freed upon failure
* [x] [drivers/snmp-ups.c:2579]: (error) Memory leak: tmp_varname
* [x] [server/netssl.c:367]: (error) Invalid number of character ({) when these macros are defined: 'WITH_SSL'.
* [x] [tools/nut-scanner/nutscan-ip.c:238]: (error) Memory leak: first_ip
* [x] [tools/nut-scanner/nutscan-serial.c:163]: (error) Memory leak: ports_list
* [x] [tools/nut-scanner/scan_eaton_serial.c:413]: (error) Common realloc mistake: 'thread_array' nulled but not freed upon failure
* [x] [tools/nut-scanner/scan_nut.c:267]: (error) Common realloc mistake: 'thread_array' nulled but not freed upon failure
* [x] [tools/nut-scanner/scan_snmp.c:703]: (error) Common realloc mistake: 'thread_array' nulled but not freed upon failure
* [x] [tools/nut-scanner/scan_xml_http.c:411]: (error) Possible null pointer dereference: thread_array
* [x] [tools/nut-scanner/scan_xml_http.c:397]: (error) Common realloc mistake: 'thread_array' nulled but not freed upon failure

Notes:
* warnings on common/snprintf.c can be fixed by refreshing with https://github.com/weiss/c99-snprintf
