### PR TITLE
liebert-esp2 changes: Correct battery V scaling, update docs, implement split-phase unit support

### DIFF
--- a/docs/man/liebert-esp2.txt
+++ b/docs/man/liebert-esp2.txt
@@ -41,7 +41,7 @@ Set the speed of the serial connection - 1200, 2400 (default), 4800, 9600 or 192
 
 AUTHOR
 ------
-Richard Gregory <R.Gregory at liverpool.ac.uk>, Arjen de Korte <adkorte-guest at alioth.debian.org>
+Richard Gregory <R.Gregory at liverpool.ac.uk>, Arjen de Korte <adkorte-guest at alioth.debian.org>, Nash Kaminski <nashkaminski at kaminski.io>
 
 SEE ALSO
 --------

--- a/docs/man/liebert-esp2.txt
+++ b/docs/man/liebert-esp2.txt
@@ -12,9 +12,24 @@ This man page only documents the hardware-specific features of the
 liebert-esp2 driver.  For information about the core driver, see  
 linkman:nutupsdrv[8].
 
+SPECIAL CABLING NOTE
+--------------------
+Be aware that an RS-232 cable with ONLY the RX, TX and ground pin
+must be used when interfacing with GXT2 series UPS units (and possibly others),
+since the handshaking lines are used for purposes other than RS-232 flow control.
+Use of a standard RS-232 cable with full handshaking may result in
+undesired operation and/or shutdown. It is therefore advisable to confirm
+the proper cable/wiring with the diagram provided in the manual with your UPS.
+
 SUPPORTED HARDWARE
 ------------------
+Tested to work on the following units:
+Liebert GXT2-6000RT208
+
 This is an experimental driver.  You have been warned.
+
+This driver currently does not support modification of configuration parameters,
+such as the low battery warning time and automatic restart policy.
 
 EXTRA ARGUMENTS
 ---------------

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -437,6 +437,7 @@ KNutClient
 KNutSetting
 KOLFF
 KRT
+Kaminski
 Kain
 Kanji
 Kazutoshi
@@ -617,6 +618,7 @@ NVA
 NX
 Nadav
 Nagios
+Nash
 NaturalDocs
 Necedah
 NetBSD
@@ -1816,6 +1818,7 @@ myupsname
 nabcd
 namespace
 nanosleep
+nashkaminski
 natively
 nb
 nbr

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1655,6 +1655,7 @@ jpgraph
 json
 kVA
 kadets
+kaminski
 kde
 keyclick
 keyout


### PR DESCRIPTION
• Refactor output format of liebert-esp2 driver to follow that of other drivers to fix the nut-cgi interface as well as for overall consistency. 

• Implement proper support for "2 phase" i.e. split phase input Liebert GXT2 series units. Existing driver treats these units as 3 phase which results in a large number of unpopulated/zero values being returned by the driver.

• Correct battery voltage scaling for GXT2 series units.

• Include notes in liebert-esp2 man page that the DB9 cable used to interface a GXT2 series UPS to its host system must not connect and handshaking/flow control lines since these are used for other features such as non "smart" shutdown and power loss notification. Using a DB9 cable with full handshaking with a GXT2-6000RT208 UPS is confirmed to cause an unintended shutdown due to the RTS line being connected to the "shutdown on battery" input of the UPS.