### PR TITLE
Fix creation of documentation from libnutclient_misc.txt

### DIFF
--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -246,7 +246,7 @@ MAN3_DEV_PAGES = \
 	nutscan_get_serial_ports_list.3 \
 	nutscan_init.3
 
-$(LIBNUTCLIENT_MISC_DEPS): libnutclient_misc.3:
+$(LIBNUTCLIENT_MISC_DEPS): libnutclient_misc.3
 	touch $@
 
 MAN1_DEV_PAGES = \

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -172,6 +172,15 @@ SRC_DEV_PAGES = \
 
 if WITH_MANS
 # NOTE: nutclient_*.3 has no source counterpart (libnutclient_*.txt)
+
+LIBNUTCLIENT_MISC_DEPS=
+	nutclient_authenticate.3 \
+	nutclient_logout.3 \
+	nutclient_device_login.3 \
+	nutclient_get_device_num_logins.3 \
+	nutclient_device_master.3 \
+	nutclient_device_forced_shutdown.3
+
 MAN3_DEV_PAGES = \
 	upsclient.3 \
 	upscli_add_host_cert.3 \
@@ -197,16 +206,12 @@ MAN3_DEV_PAGES = \
 	libnutclient_misc.3 \
 	libnutclient_tcp.3 \
 	libnutclient_variables.3 \
-	nutclient_authenticate.3 \
+	$(LIBNUTCLIENT_MISC_DEPS)
 	nutclient_destroy.3 \
-	nutclient_device_forced_shutdown.3 \
-	nutclient_device_login.3 \
-	nutclient_device_master.3 \
 	nutclient_execute_device_command.3 \
 	nutclient_get_device_command_description.3 \
 	nutclient_get_device_commands.3 \
 	nutclient_get_device_description.3 \
-	nutclient_get_device_num_logins.3 \
 	nutclient_get_device_rw_variables.3 \
 	nutclient_get_devices.3 \
 	nutclient_get_device_variable_description.3 \
@@ -215,7 +220,6 @@ MAN3_DEV_PAGES = \
 	nutclient_has_device.3 \
 	nutclient_has_device_command.3 \
 	nutclient_has_device_variable.3 \
-	nutclient_logout.3 \
 	nutclient_set_device_variable_value.3 \
 	nutclient_set_device_variable_values.3 \
 	nutclient_tcp_create_client.3 \
@@ -241,6 +245,9 @@ MAN3_DEV_PAGES = \
 	nutscan_add_device_to_device.3 \
 	nutscan_get_serial_ports_list.3 \
 	nutscan_init.3
+
+$(LIBNUTCLIENT_MISC_DEPS): libnutclient_misc.3:
+	touch $@
 
 MAN1_DEV_PAGES = \
 	libupsclient-config.1


### PR DESCRIPTION
A parallel build of a fresh git checkout of the libusb-1.0 branch fails.

A simple .txt.3 rule doesn't understand that libnutclient_misc.txt
creates a bunch of .3.

A parallel build, say 'make -j 10' results in make trying to figure out
how to build nutclient_authenticate.3 before building libnutclient_misc.3,
and without a corresponding .txt in sight it gives up.

Signed-off-by: Sam Varshavchik <mrsam@courier-mta.com>