### PR TITLE
Add cmdline option to run drivers not based on ups.conf.

### DIFF
--- a/docs/man/nutupsdrv.txt
+++ b/docs/man/nutupsdrv.txt
@@ -1,7 +1,7 @@
 NUTUPSDRV(8)
 ============
 
-NAME  
+NAME
 ----
 
 nutupsdrv - generic manual for unified NUT drivers
@@ -54,6 +54,14 @@ driver's author may have provided.
 Autoconfigure this driver using the 'id' section of linkman:ups.conf[5].
 *This argument is mandatory when calling the driver directly.*
 
+*-s* 'id'::
+Configure this driver only with command line arguments instead of reading
+linkman:ups.conf[5]. To be used instead of *-a* option when need to run
+a driver not present in driver configuration file. Instead, driver
+configuration have to be set with *-x* options directly in the command line.
+As the driver instance cannot be controlled by linkman:upsdrvctl[8],
+this option should be used for specific needs only.
+
 *-D*::
 Raise the debugging level.  Use this multiple times to see more details.
 Running a driver in debug mode will prevent it from backgrounding after
@@ -70,7 +78,7 @@ either too limited or too verbose to be of any use.
 Raise log level threshold.  Use this multiple times to log more details.
 +
 The debugging comment above also applies here.
- 
+
 *-i* 'interval'::
 Set the poll interval for the device.  The default value is 2 (in seconds).
 
@@ -99,7 +107,7 @@ the jail.  In fact, it is somewhat safer if you do not.
 
 *-u* 'username'::
 If started as root, the driver will setuid(2) to the user id
-associated with 'username'.  
+associated with 'username'.
 +
 If you do not specify this value and start it as root, the driver will
 switch to the default value that was compiled into the code.  This is
@@ -108,7 +116,7 @@ typically 'nobody', and is far from ideal.
 *-x* 'var'='val'::
 Define a variable called 'var' with the value of 'var' in the
 driver.  This varies from driver to driver - see the specific man pages
-for more information.  
+for more information.
 +
 This is like setting 'var'='val' in linkman:ups.conf[5], but
 *-x* overrides any settings from that file.

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -1,6 +1,8 @@
 /* main.c - Network UPS Tools driver core
 
-   Copyright (C) 1999  Russell Kroll <rkroll@exploits.org>
+   Copyright (C)
+   1999 Russell Kroll <rkroll@exploits.org>
+   2017 Eaton (author: Emilien Kia <EmilienKia@Eaton.com>)
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -87,10 +89,14 @@ static void help_msg(void)
 {
 	vartab_t	*tmp;
 
-	printf("\nusage: %s -a <id> [OPTIONS]\n", progname);
+	printf("\nusage: %s (-a <id>|-s <id>) [OPTIONS]\n", progname);
 
 	printf("  -a <id>        - autoconfig using ups.conf section <id>\n");
 	printf("                 - note: -x after -a overrides ups.conf settings\n\n");
+
+	printf("  -s <id>        - configure directly from cmd line arguments\n");
+	printf("                 - note: must specify all driver parameters with successive -x\n");
+	printf("                 - note: at least 'port' variable should be set\n\n");
 
 	printf("  -V             - print version, then exit\n");
 	printf("  -L             - print parseable list of driver variables\n");
@@ -508,7 +514,7 @@ int main(int argc, char **argv)
 	/* build the driver's extra (-x) variable table */
 	upsdrv_makevartable();
 
-	while ((i = getopt(argc, argv, "+a:kDhx:Lqr:u:Vi:")) != -1) {
+	while ((i = getopt(argc, argv, "+a:s:kDhx:Lqr:u:Vi:")) != -1) {
 		switch (i) {
 			case 'a':
 				upsname = optarg;
@@ -518,6 +524,10 @@ int main(int argc, char **argv)
 				if (!upsname_found)
 					fatalx(EXIT_FAILURE, "Error: Section %s not found in ups.conf",
 						optarg);
+				break;
+			case 's':
+				upsname = optarg;
+				upsname_found = 1;
 				break;
 			case 'D':
 				nut_debug_level++;
@@ -567,13 +577,14 @@ int main(int argc, char **argv)
 
 	if (!upsname_found) {
 		fatalx(EXIT_FAILURE,
-			"Error: specifying '-a id' is now mandatory. Try -h for help.");
+			"Error: specifying '-a id' or '-s id' is now mandatory. Try -h for help.");
 	}
 
 	/* we need to get the port from somewhere */
 	if (!device_path) {
 		fatalx(EXIT_FAILURE,
-			"Error: you must specify a port name in ups.conf. Try -h for help.");
+			"Error: you must specify a port name in ups.conf or in '-x port=...' argument.\n"
+			"Try -h for help.");
 	}
 
 	upsdebugx(1, "debug level is '%d'", nut_debug_level);


### PR DESCRIPTION
Hello,

Sometimes, some specific scenarios need to be able to run some driver instances not based on ups.conf.
For example, we could want to temporary launch a driver with specific configuration without having to modify the ups.conf file and discuss directly to it, without passing by upsd. This can be useful to validate existence of some devices, temporarily testing credentials, acquire some data, all of that without polluting upsd data.

This patch only add a specific driver option "-s" similar to existing "-a" but without reading ups.conf file.

Best regards,

Emilien