### PR TITLE
snmp-ups: add support for input.phase.shift

### DIFF
--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -221,6 +221,7 @@
 "Cyber Power Systems"	"ups"	"3"	"CP1500EPFCLCD"	"USB"	"usbhid-ups"	# http://www.cyberpower-eu.com/products/ups_systems/pfc-sinewave/cp1500epfclcd.htm
 "Cyber Power Systems"	"ups"	"3"	"CP825AVR-G / LE825G"	"USB"	"usbhid-ups"	# http://www.cyberpowersystems.com/products/ups-systems/retail-products/LE825G.html
 "Cyber Power Systems"	"ups"	"3"	"EC350G"	"USB"	"usbhid-ups"	# https://www.cyberpowersystems.com/products/ups/ecologic/ec350g
+"Cyber Power Systems"	"ups"	"3"	"EC750G"	"USB"	"usbhid-ups"	# https://www.cyberpowersystems.com/products/ups/desktop/ec750g
 "Cyber Power Systems"	"ups"	"3"	"OR2200LCDRM2U"	"USB"	"usbhid-ups"
 "Cyber Power Systems"	"ups"	"3"	"OR700LCDRM1U"	"USB"	"usbhid-ups"
 "Cyber Power Systems"	"ups"	"3"	"PR6000LCDRTXL5U"	"USB"	"usbhid-ups"

--- a/docs/nut-names.txt
+++ b/docs/nut-names.txt
@@ -194,7 +194,9 @@ input: Incoming line/power information
 | input.power                 | Current sum value of all (ePDU)
                                 phases apparent power (VA)        | 500
 | input.source                | The current input power source    | 1
-| input.source.preferred      | The preferred power source         | 1
+| input.source.preferred      | The preferred power source        | 1
+| input.phase.shift           | Voltage dephasing between input 
+                                sources (degrees)                 | 181
 |=================================================================================
 
 output: Outgoing power/inverter information

--- a/drivers/eaton-ats16-mib.c
+++ b/drivers/eaton-ats16-mib.c
@@ -24,7 +24,7 @@
 
 #include "eaton-ats16-mib.h"
 
-#define EATON_ATS16_MIB_VERSION  "0.13"
+#define EATON_ATS16_MIB_VERSION  "0.14"
 
 #define EATON_ATS16_SYSOID       ".1.3.6.1.4.1.534.10"
 #define EATON_ATS16_MODEL        ".1.3.6.1.4.1.534.10.2.1.2.0"
@@ -128,6 +128,8 @@ static snmp_info_t eaton_ats16_mib[] = {
 	{ "input.source", ST_FLAG_STRING, 1, ".1.3.6.1.4.1.534.10.2.2.4.0", NULL, SU_FLAG_OK, eaton_ats16_source_info, NULL },
 	/* ats2ConfigPreferred.0 = INTEGER: source1(1) */
 	{ "input.source.preferred", ST_FLAG_RW, 1, ".1.3.6.1.4.1.534.10.2.4.5.0", NULL, SU_FLAG_OK, NULL, NULL },
+	/* ats2InputDephasing = INTEGER: 181 */
+	{ "input.phase.shift", 0, 1, ".1.3.6.1.4.1.534.10.2.2.1.1.0", NULL, SU_FLAG_OK, NULL, NULL },
 
 	/* Output collection */
 	/* ats2OutputVoltage.0 = INTEGER: 2304 0.1 V */


### PR DESCRIPTION
ATS can now publish the electrical dephasing between input sources

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>