### PR TITLE
gitlog2changelog: Date header only occurs at start of line

### DIFF
--- a/tools/gitlog2changelog.py
+++ b/tools/gitlog2changelog.py
@@ -44,13 +44,13 @@ for line in fin:
         files = ""
         continue
     # Match the author line and extract the part we want
-    elif 'Author:' in line:
+    elif line.startswith('Author:'):
         authorList = re.split(': ', line, 1)
         author = authorList[1]
         author = author[0:len(author)-1]
         authorFound = True
     # Match the date line
-    elif 'Date:' in line:
+    elif line.startswith('Date:'):
         dateList = re.split(':   ', line, 1)
         date = dateList[1]
         date = date[0:len(date)-1]


### PR DESCRIPTION
Also check for Author at the beginning of the line (since the rest of the
commit message is indented by four spaces).

Alternative to https://github.com/networkupstools/nut/pull/427