### PR TITLE
Support builds and installs on systems without suitable asciidoc (fix issue #448)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -742,9 +742,9 @@ dnl to detect if we can build the wanted documentation format and yet
 dnl not fail if we have no tools to generate it (so add to SKIP list).
 
 	html-single*)
-		AC_MSG_CHECKING([if asciidoc version can build ${nut_doc_build_target_base} (minimum required 8.6.3)])
+		AC_MSG_CHECKING([if asciidoc version can build ${nut_doc_build_target_base} (minimum required ${ASCIIDOC_MIN_VERSION})])
 		can_build_doc_html_single=no
-		AX_COMPARE_VERSION([${ASCIIDOC_VERSION}], [ge], [8.6.3], [
+		AX_COMPARE_VERSION([${ASCIIDOC_VERSION}], [ge], [${ASCIIDOC_MIN_VERSION}], [
 			( cd "$DOCTESTDIR" && ${A2X} --attribute=xhtml11_format --format=xhtml --xsl-file="${abs_srcdir}"/docs/xhtml.xsl --destination-dir=. "${abs_srcdir}"/docs/asciidoc.txt && test -s asciidoc.html ) && can_build_doc_html_single=yes
 			rm -f "$DOCTESTDIR"/asciidoc*.htm*
 		], [])
@@ -763,9 +763,9 @@ dnl not fail if we have no tools to generate it (so add to SKIP list).
 		;;
 
 	html-chunked*)
-		AC_MSG_CHECKING([if a2x version can build ${nut_doc_build_target_base} (minimum required 8.6.3)])
+		AC_MSG_CHECKING([if a2x version can build ${nut_doc_build_target_base} (minimum required ${ASCIIDOC_MIN_VERSION})])
 		can_build_doc_html_chunked=no
-		AX_COMPARE_VERSION([${A2X_VERSION}], [ge], [8.6.3], [
+		AX_COMPARE_VERSION([${A2X_VERSION}], [ge], [${ASCIIDOC_MIN_VERSION}], [
 			( cd "$DOCTESTDIR" && ${A2X} --attribute=chunked_format --format=chunked --xsl-file="${abs_srcdir}"/docs/chunked.xsl --destination-dir=. "${abs_srcdir}"/docs/FAQ.txt && test -s FAQ.chunked/index.html ) && can_build_doc_html_chunked=yes
 			rm -rf "${DOCTESTDIR}"/FAQ*.chunked*
 		], [])
@@ -784,9 +784,9 @@ dnl not fail if we have no tools to generate it (so add to SKIP list).
 		;;
 
 	pdf*)
-		AC_MSG_CHECKING([if dblatex version can build ${nut_doc_build_target_base} (minimum required 0.2.5)])
+		AC_MSG_CHECKING([if dblatex version can build ${nut_doc_build_target_base} (minimum required ${DBLATEX_MIN_VERSION})])
 		can_build_doc_pdf=no
-		AX_COMPARE_VERSION([${DBLATEX_VERSION}], [ge], [0.2.5], [
+		AX_COMPARE_VERSION([${DBLATEX_VERSION}], [ge], [${DBLATEX_MIN_VERSION}], [
 			( cd "$DOCTESTDIR" && ${A2X} --format=pdf --destination-dir=. "${abs_srcdir}"/docs/asciidoc.txt && test -s asciidoc.pdf ) && can_build_doc_pdf=yes
 			rm -f "${DOCTESTDIR}"/asciidoc.pdf
 		], [])

--- a/configure.ac
+++ b/configure.ac
@@ -696,8 +696,6 @@ dnl If user passed --with-doc='' they they want nothing, right?
 		;;
 esac
 
-dnl Note: Do not cover ${nut_doc_build_list} in braces or quotes here,
-dnl to ensure that it is processed as several space-separated tokens
 if test -z "${abs_srcdir}" ; then
 	case "${srcdir}" in
 		/*) abs_srcdir="${srcdir}";;
@@ -707,6 +705,9 @@ if test -z "${abs_srcdir}" ; then
 fi
 DOCTESTDIR="$(mktemp -d configure-test.docbuild.$$.XXXXXXX)" && \
 DOCTESTDIR="$(cd "$DOCTESTDIR" && pwd)"
+
+dnl Note: Do not cover ${nut_doc_build_list} in braces or quotes here,
+dnl to ensure that it is processed as several space-separated tokens
 for nut_doc_build_target in $nut_doc_build_list; do
 	case "${nut_doc_build_target}" in
 	*=*=*)	rm -rf "${DOCTESTDIR}"

--- a/configure.ac
+++ b/configure.ac
@@ -673,6 +673,8 @@ NUT_CHECK_ASCIIDOC
 NUT_REPORT_FEATURE([build and install documentation], [${nut_with_doc}], [],
 					[WITH_ASCIIDOC], [Define to enable Asciidoc support])
 
+DOC_INSTALL_DISTED_MANS=no
+
 case "${nut_with_doc}" in
 	yes|all)
 		nut_doc_build_list="man html-single html-chunked pdf"
@@ -821,6 +823,15 @@ dnl not fail if we have no tools to generate it (so add to SKIP list).
 				AC_MSG_WARN([Unable to build ${nut_doc_build_target_base} documentation which you requested])
 			else
 				DOC_SKIPBUILD_LIST="${DOC_SKIPBUILD_LIST} ${nut_doc_build_target_base}"
+				if test "${nut_doc_build_target_flag}" = "auto" ; then
+dnl Test that groff files exist (building from dist'ed tarball, not git repo)
+					if test -s "${abs_srcdir}"/docs/man/snmp-ups.8 ; then
+						AC_MSG_WARN([Unable to build ${nut_doc_build_target_base} documentation, but can install pre-built dist'ed copies])
+						DOC_INSTALL_DISTED_MANS="yes"
+					else
+						AC_MSG_WARN([Unable to build ${nut_doc_build_target_base} documentation, and unable to install pre-built dist'ed copies because they are absent])
+					fi
+				fi  # Other variants include "no", "skip"...
 			fi
 		fi
 		;;
@@ -864,7 +875,7 @@ NUT_REPORT_FEATURE([build specific documentation format(s)], [${nut_with_doc}], 
 
 WITH_MANS=no
 SKIP_MANS=no
-if echo "${DOC_BUILD_LIST}" | grep -w "man" >/dev/null ; then
+if echo "${DOC_BUILD_LIST}" | grep -w "man" >/dev/null || test "${DOC_INSTALL_DISTED_MANS}" = "yes" ; then
 	WITH_MANS=yes
 fi
 if echo "${DOC_SKIPBUILD_LIST}" | grep -w "man" >/dev/null ; then
@@ -877,6 +888,7 @@ dnl just mans) instead. Note that for WITH_MANS=yes the SKIP_MANS value
 dnl is effectively ignored by docs/man/Makefile.am at this time.
 AM_CONDITIONAL(WITH_MANS, test "${WITH_MANS}" = "yes")
 AM_CONDITIONAL(SKIP_MANS, test "${SKIP_MANS}" = "yes")
+AM_CONDITIONAL(DOC_INSTALL_DISTED_MANS, test "${DOC_INSTALL_DISTED_MANS}" = "yes")
 
 dnl ----------------------------------------------------------------------
 dnl checks related to --with-dev

--- a/configure.ac
+++ b/configure.ac
@@ -291,8 +291,9 @@ dnl a second-class citizen (if both are set, the old option name wins).
 dnl Also note that the legacy default was "man=yes" due to requirements
 dnl of the "make distcheck", but it was reduced to "man=auto" so that
 dnl the usual builds can pass by default on systems without asciidoc.
+nut_with_docs="man=auto"
 NUT_ARG_WITH([docs], [build and install documentation (alias to --with-doc)], [man=auto])
-NUT_ARG_WITH([doc], [build and install documentation], [${nut_with_docs}])
+NUT_ARG_WITH([doc], [build and install documentation (see docs/configure.txt for many variants of the option)], [${nut_with_docs}])
 
 dnl ----------------------------------------------------------------------
 dnl Check for presence and compiler flags of various libraries

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -113,12 +113,15 @@ A2X_COMMON_OPTS = $(ASCIIDOC_VERBOSE) --attribute icons \
 # and do not forget to fix up docs/man/Makefile.am too ;)
 
 .txt.html: common.xsl xhtml.xsl
+	@if test -s "${builddir}/docbook-xsl.css" && test -r "${builddir}/docbook-xsl.css" && ! test -w "${builddir}/docbook-xsl.css" ; then chmod +w "${builddir}/docbook-xsl.css" ; fi
 	$(A2X) $(A2X_COMMON_OPTS) --attribute=xhtml11_format --format=xhtml --xsl-file=$(srcdir)/xhtml.xsl $<
 
 .txt.chunked: common.xsl chunked.xsl
+	@if test -s "${builddir}/docbook-xsl.css" && test -r "${builddir}/docbook-xsl.css" && ! test -w "${builddir}/docbook-xsl.css" ; then chmod +w "${builddir}/docbook-xsl.css" ; fi
 	$(A2X) $(A2X_COMMON_OPTS) --attribute=chunked_format --format=chunked --xsl-file=$(srcdir)/chunked.xsl $<
 
 .txt.pdf: docinfo.xml
+	@if test -s "${builddir}/docbook-xsl.css" && test -r "${builddir}/docbook-xsl.css" && ! test -w "${builddir}/docbook-xsl.css" ; then chmod +w "${builddir}/docbook-xsl.css" ; fi
 	$(A2X) $(A2X_COMMON_OPTS) --attribute=pdf_format --format=pdf -a docinfo1 $<
 
 if HAVE_ASPELL

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -623,6 +623,16 @@ dist:
 endif
 endif
 
+if ! DOC_INSTALL_DISTED_MANS
+# For builds done from dist'ed sources, there may be a conflict of timestamps
+# between original *.txt files and pre-built manpages etc. leading to skipping
+# of manpage re-generation even if that activity is possible and requested.
+# Possibly a cleaner, but less portable, solution would be to touch the
+# generated files to long ago. Current solution assumes good valid clocks :)
+dist-hook:
+	@echo "Fix up manpage source timestamps" && cd $(distdir) && touch $(SRC_ALL_PAGES)
+endif
+
 HTML_MANS = \
 	$(HTML_CONF_MANS) \
 	$(HTML_CLIENT_MANS) \

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -680,7 +680,7 @@ A2X_MANPAGE_OPTS = --doctype manpage --format manpage \
 else !HAVE_ASCIIDOC
 
 .txt.html:
-	@if [ -r "$@" ]; then \
+	@if [ -r "$@" ] || [ -r "$(srcdir)/`basename $@`" ]; then \
 		echo "Not (re)building $@ manual page, since 'asciidoc', 'xmllint' or 'xsltproc' were not found." ; \
 	else \
 		echo "Could not find prebuilt $@ manual page." ; \
@@ -689,7 +689,7 @@ else !HAVE_ASCIIDOC
 	fi
 
 .txt.1:
-	@if [ -r "$@" ]; then \
+	@if [ -r "$@" ] || [ -r "$(srcdir)/`basename $@`" ]; then \
 		echo "Not (re)building $@ manual page, since 'asciidoc', 'xmllint' or 'xsltproc' were not found." ; \
 	else \
 		echo "Could not find prebuilt $@ manual page." ; \
@@ -698,7 +698,7 @@ else !HAVE_ASCIIDOC
 	fi
 
 .txt.3:
-	@if [ -r "$@" ]; then \
+	@if [ -r "$@" ] || [ -r "$(srcdir)/`basename $@`" ]; then \
 		echo "Not (re)building $@ manual page, since 'asciidoc', 'xmllint' or 'xsltproc' were not found." ; \
 	else \
 		echo "Could not find prebuilt $@ manual page." ; \
@@ -707,7 +707,7 @@ else !HAVE_ASCIIDOC
 	fi
 
 .txt.5:
-	@if [ -r "$@" ]; then \
+	@if [ -r "$@" ] || [ -r "$(srcdir)/`basename $@`" ]; then \
 		echo "Not (re)building $@ manual page, since 'asciidoc', 'xmllint' or 'xsltproc' were not found." ; \
 	else \
 		echo "Could not find prebuilt $@ manual page." ; \
@@ -716,7 +716,7 @@ else !HAVE_ASCIIDOC
 	fi
 
 .txt.8:
-	@if [ -r "$@" ]; then \
+	@if [ -r "$@" ] || [ -r "$(srcdir)/`basename $@`" ]; then \
 		echo "Not (re)building $@ manual page, since 'asciidoc', 'xmllint' or 'xsltproc' were not found." ; \
 	else \
 		echo "Could not find prebuilt $@ manual page." ; \

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -655,6 +655,16 @@ CLEANFILES = *.xml *.html
 
 SUFFIXES = .txt .html .1 .3 .5 .8
 
+# For builds with allowed installation of prebuild man pages, check that
+# they exist in sources (make would pull them automatically as a fallback
+# from failed lookup in build products). For builds that require rebuild
+# of man pages, abort with error if build product is missing.
+if DOC_INSTALL_DISTED_MANS
+SRC_PREBUILT_CLAUSE=|| [ -r "$(srcdir)/`basename $@`" ]
+else
+SRC_PREBUILT_CLAUSE=
+endif
+
 if HAVE_ASCIIDOC
 
 .txt.html:
@@ -688,7 +698,7 @@ A2X_MANPAGE_OPTS = --doctype manpage --format manpage \
 else !HAVE_ASCIIDOC
 
 .txt.html:
-	@if [ -r "$@" ] || [ -r "$(srcdir)/`basename $@`" ]; then \
+	@if [ -r "$@" ] $(SRC_PREBUILT_CLAUSE); then \
 		echo "Not (re)building $@ manual page, since 'asciidoc', 'xmllint' or 'xsltproc' were not found." ; \
 	else \
 		echo "Could not find prebuilt $@ manual page." ; \
@@ -697,7 +707,7 @@ else !HAVE_ASCIIDOC
 	fi
 
 .txt.1:
-	@if [ -r "$@" ] || [ -r "$(srcdir)/`basename $@`" ]; then \
+	@if [ -r "$@" ] $(SRC_PREBUILT_CLAUSE); then \
 		echo "Not (re)building $@ manual page, since 'asciidoc', 'xmllint' or 'xsltproc' were not found." ; \
 	else \
 		echo "Could not find prebuilt $@ manual page." ; \
@@ -706,7 +716,7 @@ else !HAVE_ASCIIDOC
 	fi
 
 .txt.3:
-	@if [ -r "$@" ] || [ -r "$(srcdir)/`basename $@`" ]; then \
+	@if [ -r "$@" ] $(SRC_PREBUILT_CLAUSE); then \
 		echo "Not (re)building $@ manual page, since 'asciidoc', 'xmllint' or 'xsltproc' were not found." ; \
 	else \
 		echo "Could not find prebuilt $@ manual page." ; \
@@ -715,7 +725,7 @@ else !HAVE_ASCIIDOC
 	fi
 
 .txt.5:
-	@if [ -r "$@" ] || [ -r "$(srcdir)/`basename $@`" ]; then \
+	@if [ -r "$@" ] $(SRC_PREBUILT_CLAUSE); then \
 		echo "Not (re)building $@ manual page, since 'asciidoc', 'xmllint' or 'xsltproc' were not found." ; \
 	else \
 		echo "Could not find prebuilt $@ manual page." ; \
@@ -724,7 +734,7 @@ else !HAVE_ASCIIDOC
 	fi
 
 .txt.8:
-	@if [ -r "$@" ] || [ -r "$(srcdir)/`basename $@`" ]; then \
+	@if [ -r "$@" ] $(SRC_PREBUILT_CLAUSE); then \
 		echo "Not (re)building $@ manual page, since 'asciidoc', 'xmllint' or 'xsltproc' were not found." ; \
 	else \
 		echo "Could not find prebuilt $@ manual page." ; \

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -612,7 +612,7 @@ EXTRA_DIST = \
 if ! WITH_MANS
 if ! SKIP_MANS
 # Cause "make dist" to fail, unless caller (like the stack of distcheck-dmf)
-# runs ./configure --with-doc=skip (or --with-man=skip specifically)
+# runs ./configure --with-doc=skip (or --with-doc=man=skip specifically)
 EXTRA_DIST += dist
 dist:
 	echo "ERROR: Manpage building was disabled by configure script, and these pages are required for our proper 'make dist'" >&2 ; false

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -623,7 +623,6 @@ dist:
 endif
 endif
 
-if ! DOC_INSTALL_DISTED_MANS
 # For builds done from dist'ed sources, there may be a conflict of timestamps
 # between original *.txt files and pre-built manpages etc. leading to skipping
 # of manpage re-generation even if that activity is possible and requested.
@@ -631,7 +630,6 @@ if ! DOC_INSTALL_DISTED_MANS
 # generated files to long ago. Current solution assumes good valid clocks :)
 dist-hook:
 	@echo "Fix up manpage source timestamps" && cd $(distdir) && touch $(SRC_ALL_PAGES)
-endif
 
 HTML_MANS = \
 	$(HTML_CONF_MANS) \

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -4,13 +4,17 @@
 # Notes:
 # - sources (.txt) and groff formats are both distributed,
 # - only sources are versioned ; groff files are generated at worst
-#   during 'make dist'
+#   during 'make dist' (while preparing a release tarball)
 # - HTML files are built upon request, if AsciiDoc is available,
 # - groff update will only happen if AsciiDoc is available too,
 # - all this can probably (and hopefully) be improved, but I've not
 #   found a way to do pattern replacement on the fly for target deps!
 #   FIXME: investigate an autogen.sh hook
 # - Ref: http://www.gnu.org/software/hello/manual/automake/Man-pages.html
+# - WITH_MANS can be enabled if either we are building man-pages, or if
+#   the --with-doc=man=auto detected an inability to build the man-pages
+#   but enabled the DOC_INSTALL_DISTED_MANS toggle so we deliver disted
+#   files from source tree
 
 # Base configuration and client manpages, always installed
 SRC_CONF_PAGES = \

--- a/m4/nut_check_asciidoc.m4
+++ b/m4/nut_check_asciidoc.m4
@@ -15,6 +15,10 @@ AC_DEFUN([NUT_CHECK_ASCIIDOC],
 [
 if test -z "${nut_have_asciidoc_seen}"; then
 	nut_have_asciidoc_seen=yes
+	# Note: this is for both asciidoc and a2x at this time
+	ASCIIDOC_MIN_VERSION="8.6.3"
+	# Note: this is checked in the configure script if PDF is of interest at all
+	DBLATEX_MIN_VERSION="0.2.5"
 
 	AC_PATH_PROGS([ASCIIDOC], [asciidoc])
 	if test -n "${ASCIIDOC}"; then
@@ -79,8 +83,8 @@ if test -z "${nut_have_asciidoc_seen}"; then
 	dnl Note that a common "nut_have_asciidoc" variable is in fact a flag
 	dnl that we have several tools needed for the documentation generation
 	dnl TODO? Rename the script variable and makefile flags to reflect this?
-	AC_MSG_CHECKING([if asciidoc version can build manpages (minimum required 8.6.3)])
-	AX_COMPARE_VERSION([${ASCIIDOC_VERSION}], [ge], [8.6.3], [
+	AC_MSG_CHECKING([if asciidoc version can build manpages (minimum required ${ASCIIDOC_MIN_VERSION})])
+	AX_COMPARE_VERSION([${ASCIIDOC_VERSION}], [ge], [${ASCIIDOC_MIN_VERSION}], [
 		AC_MSG_RESULT(yes)
 		nut_have_asciidoc="yes"
 	], [
@@ -88,8 +92,8 @@ if test -z "${nut_have_asciidoc_seen}"; then
 		nut_have_asciidoc="no"
 	])
 
-	AC_MSG_CHECKING([if a2x version can build manpages (minimum required 8.6.3)])
-	AX_COMPARE_VERSION([${A2X_VERSION}], [ge], [8.6.3], [
+	AC_MSG_CHECKING([if a2x version can build manpages (minimum required ${ASCIIDOC_MIN_VERSION})])
+	AX_COMPARE_VERSION([${A2X_VERSION}], [ge], [${ASCIIDOC_MIN_VERSION}], [
 		AC_MSG_RESULT(yes)
 	], [
 		AC_MSG_RESULT(no)


### PR DESCRIPTION
As reaction to issue #448 this PR changes handling of `--with-doc=man=auto` (which is the default behavior if no `--with-doc` is specified on command-line) to fall back to installation of pre-built docs (currently just manpages) that can be available in either build or source dir, for tarball distributions.

Tested with `./configure --with-all=no && make distcheck-light` by requiring a non-existently large minimal version of ASCIIDOC in m4 in one case, and leaving the correct version in the other - so both codepaths seem to install the manpages correctly.