### PR TITLE
automake: only pass net-snmp cflags to snmp-ups

### DIFF
--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -16,9 +16,6 @@ AM_CFLAGS = -I$(top_srcdir)/include
 if WITH_USB
   AM_CFLAGS += $(LIBUSB_CFLAGS)
 endif
-if WITH_SNMP
-  AM_CFLAGS += $(LIBNETSNMP_CFLAGS)
-endif
 if WITH_NEON
   AM_CFLAGS += $(LIBNEON_CFLAGS)
 endif
@@ -209,6 +206,8 @@ snmp_ups_SOURCES = snmp-ups.c apc-mib.c baytech-mib.c compaq-mib.c eaton-mib.c \
  bestpower-mib.c cyberpower-mib.c delta_ups-mib.c xppc-mib.c huawei-mib.c \
  eaton-ats16-mib.c apc-ats-mib.c raritan-px2-mib.c eaton-ats30-mib.c \
  apc-pdu-mib.c
+snmp_ups_CFLAGS = $(AM_CFLAGS)
+snmp_ups_CFLAGS += $(LIBNETSNMP_CFLAGS)
 snmp_ups_LDADD = $(LDADD_DRIVERS) $(LIBNETSNMP_LIBS)
 
 # NEON XML/HTTP


### PR DESCRIPTION
Other than formerly assumed in the makefile cflags can be more than
includes. And some of them need to be in sync in regard to CFLAGS and
LDFLAGS - for example usage of -fPIE.

This conflicts with a current assumption in the makefile "In any case,
CFLAGS are only -I options, so there is no harm".

On a Distribution where PIE is enabled by default, but disabled for
special cases (like net-snmp) the configure detection gets them as:
LIBNETSNMP_CFLAGS = -DNETSNMP_ENABLE_IPV6 -fno-strict-aliasing -g -O2
-fdebug-prefix-map=/build/net-snmp-nlMQSZ/net-snmp-5.7.3+dfsg=.
-specs=/usr/share/dpkg/no-pie-compile.specs -fstack-protector-strong
-Wformat -Werror=format-security -DNETSNMP_USE_INLINE -Ulinux
-Dlinux=linux -D_REENTRANT -D_GNU_SOURCE -DDEBIAN -fwrapv
-fno-strict-aliasing -pipe -I/usr/local/include -D_LARGEFILE_SOURCE
-D_FILE_OFFSET_BITS=64 -I/usr/lib/x86_64-linux-gnu/perl/5.26/CORE
-Wdate-time -D_FORTIFY_SOURCE=2 -I/usr/include
LIBNETSNMP_LIBS = -Wl,-Bsymbolic-functions
-specs=/usr/share/dpkg/no-pie-link.specs -Wl,-z,relro -Wl,-z,now
-L/usr/lib/x86_64-linux-gnu -lnetsnmp -lcrypto -lm

Of importance are:
-specs=/usr/share/dpkg/no-pie-compile.specs
-specs=/usr/share/dpkg/no-pie-link.specs

Now when compiling the non-snmp objects incorrectly get the
"-specs=/usr/share/dpkg/no-pie-compile.specs" due to the assumption
that it is safe to add up all CFLAGS to the global one.

LDFLAGS imported that way are only added to snmp.
snmp_ups_LDADD = $(LDADD_DRIVERS) $(LIBNETSNMP_LIBS)
[...]
snmp-ups$(EXEEXT): $(snmp_ups_OBJECTS) $(snmp_ups_DEPENDENCIES)
$(EXTRA_snmp_ups_DEPENDENCIES)
        @rm -f snmp-ups$(EXEEXT)
        $(AM_V_CCLD)$(LINK) $(snmp_ups_OBJECTS) $(snmp_ups_LDADD)
$(LIBS)

That leads to other (all non snmp_ups) objects in drivers failing to build.
They get the no-pie-compile.specs (incorrect) spec but not the
no-pie-link.specs on the link step.

Some other parts like mge_shut and nutdrv_qx already have custom
CFLAGS/LDFLAGS that are not added to the global CFLAGS. So despite the
commend in the makefile this doesn't seem to be new in general to nut.

I don't want to mess too much with your build system for now as I don't
know many of its implications. So I chose not the full drop of that
global CFLAGS merge, but a minimal patch for now which fixes the issue
described.

Thereby closes #463

Signed-off-by: Christian Ehrhardt <christian.ehrhardt@canonical.com>