### PR TITLE
Support envvar for ALTPIDPATH

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -375,13 +375,27 @@ const char * dflt_statepath(void)
 	return path;
 }
 
-/* Return the alternate path for pid files */
+/* Return the alternate path for pid files, for processes running as non-root
+ * Per documentation and configure script, the fallback value is the
+ * state-file path as the daemon and drivers can write there too.
+ * Note that this differs from PIDPATH that higher-privileged daemons, such
+ * as upsmon, tend to use.
+ */
 const char * altpidpath(void)
 {
+	const char * path;
+
+	if ((path = getenv("NUT_ALTPIDPATH")) == NULL)
+		path = getenv("NUT_STATEPATH");
+
+	if (path != NULL)
+		return path;
+
 #ifdef ALTPIDPATH
 	return ALTPIDPATH;
 #else
-	return dflt_statepath();
+/* We assume, here and elsewhere, that at least STATEPATH is always defined */
+	return STATEPATH;
 #endif
 }
 

--- a/common/common.c
+++ b/common/common.c
@@ -369,7 +369,8 @@ const char * dflt_statepath(void)
 {
 	const char * path;
 
-	if ((path = getenv("NUT_STATEPATH")) == NULL)
+	path = getenv("NUT_STATEPATH");
+	if ( (path == NULL) || (*path == '\0') )
 		path = STATEPATH;
 
 	return path;
@@ -385,10 +386,11 @@ const char * altpidpath(void)
 {
 	const char * path;
 
-	if ((path = getenv("NUT_ALTPIDPATH")) == NULL)
+	path = getenv("NUT_ALTPIDPATH");
+	if ( (path == NULL) || (*path == '\0') )
 		path = getenv("NUT_STATEPATH");
 
-	if (path != NULL)
+	if ( (path != NULL) && (*path != '\0') )
 		return path;
 
 #ifdef ALTPIDPATH

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -98,7 +98,11 @@ static void help_msg(void)
 
 	printf("  -s <id>        - configure directly from cmd line arguments\n");
 	printf("                 - note: must specify all driver parameters with successive -x\n");
-	printf("                 - note: at least 'port' variable should be set\n\n");
+	printf("                 - note: at least 'port' variable should be set\n");
+	printf("                 - note: to explore the current values on a device from an\n");
+	printf("                   unprivileged user account (with sufficient media access in\n");
+	printf("                   the OS - e.g. to query networked devices), you can specify\n");
+	printf("                   '-d 1' argument and `export NUT_STATEPATH=/tmp` beforehand\n\n");
 
 	printf("  -V             - print version, then exit\n");
 	printf("  -L             - print parseable list of driver variables\n");


### PR DESCRIPTION
The `STATEPATH` defined during build can be overridden via envvar `NUT_STATEPATH` during run-time, which is useful to e.g. run the recently added "dump" + "cmd line defined" mode of drivers with an otherwise unprivileged account (not `nut`, not `root`). Such execution however claims errors saving the PID file of the driver - because that still uses strictly the macro value of `ALTPIDPATH` if it is defined (and per the `configure` script, it is always defined - either by user-provided value, or as fallback to `STATEPATH` value).

This PR adds the same level of flexibility to `ALTPIDPATH`, allowing it to use `NUT_ALTPIDPATH` or `NUT_STATEPATH` envvars if defined, and only then fall back to the built-in macros (`ALTPIDPATH` if defined - which is always in practice, or `STATEPATH` otherwise) to match the old, expected and documented behavior.

Also this PR adds handling of empty values for these envvars as if they are not defined (otherwise the combined PID file paths effectively resolve to filesystem-root-based paths which is not what the user may have wanted - and for a `root` user this can cause unexpected actual writes; the user is still free to define the envvar == `"/"` explicitly.

Screenshot from before the PR: the state path can be overridden so the process at least starts, but it complains about the inability to save the PID file:
````
jim@jimoi:~/nut$ NUT_STATEPATH=/tmp ./drivers/snmp-ups -s testsnmp -x port=10.10.10.10 -d 1
Network UPS Tools - Generic SNMP UPS driver 1.02 (2.7.4-1672-gf1b4343c)
writepid: fopen /var/state/ups/snmp-ups-dmf-testsnmp.pid: Permission denied
Detected Eaton 9PX on host 10.10.10.10 (mib: mge 0.51)

ambient.humidity: 0
ambient.temperature: 0.0
...
````

Screenshots with this PR in place:

* Both values defined and empty:
````
$ NUT_ALTPIDPATH="" NUT_STATEPATH="" ./drivers/snmp-ups -s testsnmp -x port=10.10.10.10 -d 1
Network UPS Tools - Generic SNMP UPS driver 1.02 (2.7.4-422-gd7c728c4)
Can't chdir to /var/state/ups: Permission denied
````

* NUT_ALTPIDPATH empty, NUT_STATEPATH value defined - so it is the fallback for PID too:
````
$ NUT_ALTPIDPATH="" NUT_STATEPATH="/tmp/nut" ./drivers/snmp-ups -s testsnmp -x port=10.10.10.10 -d 1
Network UPS Tools - Generic SNMP UPS driver 1.02 (2.7.4-422-gd7c728c4)
Detected Eaton 9PX on host 10.10.10.10 (mib: mge 0.51)
^Z

$ find /tmp/nut \! -type d -ls
2173496361    4 -rw-r--r--   1 jim      jim             6 Sep  6 08:36 /tmp/nut/snmp-ups-testsnmp.pid
3025529069    0 srw-rw----   1 jim      jim             0 Sep  6 08:36 /tmp/nut/snmp-ups-testsnmp
````

* ... same as when NUT_ALTPIDPATH is not defined at all:
````
$ NUT_STATEPATH="/tmp/nut" ./drivers/snmp-ups -s testsnmp -x port=10.10.10.10 -d 1
Network UPS Tools - Generic SNMP UPS driver 1.02 (2.7.4-422-gd7c728c4)
Detected Eaton 9PX on host 10.10.10.10 (mib: mge 0.51)
^Z

$ find /tmp/nut \! -type d -ls
3025529069    4 -rw-r--r--   1 jim      jim             6 Sep  6 08:37 /tmp/nut/snmp-ups-testsnmp.pid
3025508985    0 srw-rw----   1 jim      jim             0 Sep  6 08:37 /tmp/nut/snmp-ups-testsnmp
````

* Both defined and different:
````
$ NUT_ALTPIDPATH="/tmp/nut/pid" NUT_STATEPATH="/tmp/nut/state" ./drivers/snmp-ups -s testsnmp -x port=10.10.10.10 -d 1
Network UPS Tools - Generic SNMP UPS driver 1.02 (2.7.4-422-gd7c728c4)
Detected Eaton 9PX on host 10.10.10.10 (mib: mge 0.51)
^Z

$ find /tmp/nut \! -type d -ls
2184524222    0 srw-rw----   1 jim      jim             0 Sep  6 08:40 /tmp/nut/state/snmp-ups-testsnmp
3025511200    4 -rw-r--r--   1 jim      jim             6 Sep  6 08:40 /tmp/nut/pid/snmp-ups-testsnmp.pid
````

Interim screenshot - before adding support for empty envvars same as undefined:
````
$ NUT_ALTPIDPATH="" NUT_STATEPATH=/tmp ./drivers/snmp-ups -s testsnmp -x port=10.10.10.10 -d 1
Network UPS Tools - Generic SNMP UPS driver 1.02 (2.7.4-422-gd7c728c4)
writepid: fopen /snmp-ups-testsnmp.pid: Permission denied
Detected Eaton 9PX on host 10.10.10.10 (mib: mge 0.51)

````