### PR TITLE
Problem: configure fails on system without pkg-config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,9 +128,19 @@ matrix:
       apt:
         packages:
         - *deps_driverlibs
+  - env:
+    - BUILD_TYPE=default-tgt:distcheck-light
+    - NO_PKG_CONFIG=true
+    os: linux
+    sudo: true
+    addons:
+      apt:
+        packages:
+        - *deps_driverlibs
 
 before_install:
 - if [ $TRAVIS_OS_NAME == "osx" ] ; then brew update; brew install binutils asciidoc docbook-xsl ; XML_CATALOG_FILES=/usr/local/etc/xml/catalog ; export XML_CATALOG_FILES ; fi
+- if [ "$NO_PKG_CONFIG" == "true" ] ; then echo "BUTCHER pkg-config for this test case" >&2; sudo dpkg -r --force all pkg-config ; fi
 
 # Hand off to generated script for each BUILD_TYPE
 script: ./ci_build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -140,7 +140,6 @@ matrix:
 
 before_install:
 - if [ $TRAVIS_OS_NAME == "osx" ] ; then brew update; brew install binutils asciidoc docbook-xsl ; XML_CATALOG_FILES=/usr/local/etc/xml/catalog ; export XML_CATALOG_FILES ; fi
-- if [ "$NO_PKG_CONFIG" == "true" ] ; then echo "BUTCHER pkg-config for this test case" >&2; sudo dpkg -r --force all pkg-config ; fi
 
 # Hand off to generated script for each BUILD_TYPE
 script: ./ci_build.sh

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -186,7 +186,18 @@ default|default-alldrv|default-spellcheck|default-nodoc|default-withdoc|"default
     [ -z "$CI_TIME" ] || echo "`date`: Starting build of currently tested project..."
     CCACHE_BASEDIR=${PWD}
     export CCACHE_BASEDIR
+
+    # Note: modern auto(re)conf requires pkg-config to generate the configure
+    # script, so to stage the situation of building without one (as if on an
+    # older system) we have to remove it when we already have the script.
+    # This matches the use-case of distro-building from release tarballs that
+    # include all needed pre-generated files to rely less on OS facilities.
     $CI_TIME ./autogen.sh 2> /dev/null
+    if [ "$NO_PKG_CONFIG" == "true" ] ; then
+        echo "NO_PKG_CONFIG==true : BUTCHER pkg-config for this test case" >&2
+        sudo dpkg -r --force all pkg-config
+    fi
+
     $CI_TIME ./configure "${CONFIG_OPTS[@]}"
 
     case "$BUILD_TYPE" in

--- a/configure.ac
+++ b/configure.ac
@@ -27,7 +27,24 @@ dnl Use "./configure --enable-maintainer-mode" to keep Makefile.in and Makefile
 dnl in sync after Git updates.
 AM_MAINTAINER_MODE
 
-dnl PKG_PROG_PKG_CONFIG
+dnl Some systems have older autotools without direct macro support for PKG_CONF*
+have_PKG_CONFIG=yes
+AC_PATH_PROG(dummy_PKG_CONFIG, pkg-config)
+AS_IF([test x"$dummy_PKG_CONFIG" = xno || test -z "$dummy_PKG_CONFIG"],
+    [have_PKG_CONFIG=no],
+    [AC_MSG_CHECKING([for autoconf macro support of pkg-config])
+     PKG_PROG_PKG_CONFIG
+     dummy_RES=$?
+     AS_IF([test $dummy_RES = 0],
+        [AC_MSG_RESULT(ok)
+         AC_MSG_CHECKING([for autoconf macro support of pkg-config module checker])
+         PKG_CHECK_MODULES([dummy_PKG_CONFIG], [pkg-config],
+            [AC_MSG_RESULT([ok])], [have_PKG_CONFIG=no])
+        ], [have_PKG_CONFIG=no])]
+)
+AS_IF([test x"$have_PKG_CONFIG" = xno],
+    [AC_MSG_WARN([pkg-config is needed to look for further dependencies (will be skipped)])])
+
 
 dnl Various version related processing
 dnl ----------------------------------
@@ -1180,7 +1197,6 @@ else
 fi
 AM_CONDITIONAL(WITH_PKG_CONFIG, test -n "${pkgconfigdir}")
 
-PKG_PROG_PKG_CONFIG
 AC_MSG_CHECKING(whether to install systemd files)
 AC_ARG_WITH([systemdsystemunitdir],
 	AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files (auto)]),
@@ -1254,14 +1270,20 @@ AC_LANG_POP([C++])
 
 have_cppunit="no"
 CPPUNIT_NUT_CXXFLAGS=""
-AS_IF([test "${HAVE_CXX11}" = 1],
-    [PKG_CHECK_MODULES(CPPUNIT, cppunit, have_cppunit=yes, have_cppunit=no)
-     if test "${have_cppunit}" != "yes" ; then
-        AC_MSG_WARN([libcppunit not found - those C++ tests will not be built.])
-     else
-     AS_IF([test -n "$CXX"],[AS_IF([$CXX --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
-        [CPPUNIT_NUT_CXXFLAGS="-g -O0"])])
-     fi])
+AS_IF([test x"$have_PKG_CONFIG" = xyes],
+    [AS_IF([test "${HAVE_CXX11}" = 1],
+        [PKG_CHECK_MODULES(CPPUNIT, cppunit, have_cppunit=yes, have_cppunit=no)
+         AS_IF([test "${have_cppunit}" != "yes"],
+            [AC_MSG_WARN([libcppunit not found - those C++ tests will not be built.])
+             have_cppunit=no],
+            [AS_IF([test -n "$CXX"],
+                [AS_IF([$CXX --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+                    [CPPUNIT_NUT_CXXFLAGS="-g -O0"])])
+            ])
+        ])
+    ], [AC_MSG_WARN([pkg-config not found, can not look properly for libcppunit - those C++ tests will not be built.])
+        have_cppunit=no]
+)
 AM_CONDITIONAL(HAVE_CPPUNIT, test "${have_cppunit}" = "yes")
 AC_DEFINE_UNQUOTED(CPPUNIT_NUT_CXXFLAGS, $CPPUNIT_NUT_CXXFLAGS, [Compiler flags for cppunit tests])
 


### PR DESCRIPTION
Solution: detect presence and usability of pkg-config program
and autotools macros (they end up as unexpanded tokens if
pkg-config is not installed), and use this knowledge to
proceed with search for libcppunit - or not. When the test is
optional, we should not kill the build if we can not make it
due to missing tools.