### PR TITLE
configure.ac: Fix ${systemdsystemshutdowndir} detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1197,11 +1197,8 @@ AC_ARG_WITH([systemdsystemunitdir],
 		;;
 	esac
 ], [])
-dnl Override installation directory, with the local installation
-dnl prefix. This is needed for 'distcheck*' targets, otherwise
-dnl files will try to get intalled to the actual system directories
 if test -n "${systemdsystemunitdir}"; then
-	systemdsystemshutdowndir="${libdir}/systemd/system-shutdown"
+	systemdsystemshutdowndir=`dirname "${systemdsystemunitdir}"`/system-shutdown
 	AC_MSG_RESULT(using ${systemdsystemunitdir})
 else
 	AC_MSG_RESULT(no)


### PR DESCRIPTION
On non-Debian systems, ${libdir} is /usr/lib64, but systemd files are
installed below /usr/lib/systemd. Instead of assuming that the shutdown
directory is below ${libdir}, assume that it has the same parent
directory as ${systemdsystemunitdir}, which we already detect properly
using pkg-config. The proper fix would be a --with option for the
shutdown directory, but that would be an overkill.

Signed-off-by: Michal Marek <MichalMarek1@eaton.com>