### PR TITLE
configure.ac: Fix systemd shutdown directory detection

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,6 +23,7 @@ DISTCHECK_VALGRIND_FLAGS = --with-all=auto --with-ssl=auto --with-doc=skip --wit
 
 DISTCHECK_CONFIGURE_FLAGS = ${DISTCHECK_FLAGS}		\
  --with-systemdsystemunitdir='$${prefix}/lib/systemd/system' \
+ --with-systemdshutdowndir='$${prefix}/lib/systemd/system-shutdown' \
  --with-augeas-lenses-dir='$${prefix}/usr/share/augeas/lenses'		\
  --with-hotplug-dir='$${prefix}/etc/hotplug'		\
  --with-udev-dir='$${prefix}/etc/udev'			\

--- a/configure.ac
+++ b/configure.ac
@@ -1197,16 +1197,24 @@ AC_ARG_WITH([systemdsystemunitdir],
 		;;
 	esac
 ], [])
-dnl Override installation directory, with the local installation
-dnl prefix. This is needed for 'distcheck*' targets, otherwise
-dnl files will try to get intalled to the actual system directories
 if test -n "${systemdsystemunitdir}"; then
-	systemdsystemshutdowndir="${libdir}/systemd/system-shutdown"
 	AC_MSG_RESULT(using ${systemdsystemunitdir})
 else
 	AC_MSG_RESULT(no)
 fi
 AM_CONDITIONAL(HAVE_SYSTEMD, test "$systemdsystemunitdir" != "")
+dnl This option is only provided so that make distcheck can override it,
+dnl otherwise we ask pkg-config whenever --with-systemdsystemunitdir is
+dnl given
+AC_ARG_WITH([systemdshutdowndir],
+	AS_HELP_STRING([--with-systemdshutdowndir=DIR], [Directory for systemd shutdown scripts (auto)]),
+	[systemdshutdowndir=${withval}])
+if test -n "${systemdsystemunitdir}"; then
+	case "${systemdshutdowndir}" in
+	yes|auto|"")
+		systemdshutdowndir=`$PKG_CONFIG --variable=systemdshutdowndir systemd`
+	esac
+fi
 
 dnl
 dnl Tests for CppUnit availability and usability (will be built if we can,
@@ -1582,7 +1590,7 @@ AC_SUBST(driverexecdir)
 AC_SUBST(htmldir)
 AC_SUBST(pkgconfigdir)
 AC_SUBST(systemdsystemunitdir)
-AC_SUBST(systemdsystemshutdowndir)
+AC_SUBST(systemdshutdowndir)
 AC_SUBST(auglensdir)
 AC_SUBST(hotplugdir)
 AC_SUBST(udevdir)

--- a/scripts/systemd/Makefile.am
+++ b/scripts/systemd/Makefile.am
@@ -7,7 +7,7 @@ systemdsystemunit_DATA = \
         nut-monitor.service \
         nut-server.service
 
-systemdsystemshutdown_SCRIPTS = nutshutdown
+systemdshutdown_SCRIPTS = nutshutdown
 
 else
 EXTRA_DIST += nut-driver.service.in nut-monitor.service.in \


### PR DESCRIPTION
The configure script assumes that systemd is installed below ${libdir},
which is not true on many biarch Linux distros with /lib64. Instead of
guessing, use pkg-config to find the path and provide a
--with-systemdshutdowndir option so that make distcheck can override it.
Also, rename the internal varable to systemdshutdowndir to rhyme with
the respective systemd.pc variable.

Signed-off-by: Michal Marek <MichalMarek1@eaton.com>