### PR TITLE
HCL: Change Riello IDG/IPG support level to 4

### DIFF
--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -898,8 +898,8 @@
 
 "Riello"	"ups"	"3"	"Riello Sentinel SDL 6000-7"	"Netman Plus 102 SNMP Card"	"snmp-ups"
 "Riello"	"ups"	"3"	"Riello Sentinel Dual SDH 1000-7"	"Netman Plus 102 SNMP Card"	"snmp-ups"
-"Riello"	"ups"	"5"	"IDG 400/600/800/1200/1600"	""	"riello_usb"
-"Riello"	"ups"	"5"	"IPG 600/800"	""	"riello_usb"
+"Riello"	"ups"	"4"	"IDG 400/600/800/1200/1600"	""	"riello_usb"
+"Riello"	"ups"	"4"	"IPG 600/800"	""	"riello_usb"
 "Riello"	"ups"	"5"	"WPG 400/600/800"	""	"riello_usb"
 "Riello"	"ups"	"5"	"NPW 600/800/1000/1500/2000"	""	"riello_usb"
 "Riello"	"ups"	"5"	"NDG 800/1000/1500/2000"	""	"riello_usb"


### PR DESCRIPTION
The IDG and IPG models were not included in the protocol documentation provided
to the NUT project. Some values are also returned as 0xFF/0xFFF/0xFFFF - see
the HCL for details.

Source: http://lists.alioth.debian.org/pipermail/nut-upsdev/2017-November/007357.html