### PR TITLE
Problem: nutscan_init() called before debug is enabled

### DIFF
--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -246,8 +246,6 @@ int main(int argc, char *argv[])
 	xml_sec.usec_timeout = -1; /* Override with the "timeout" common setting later */
 	xml_sec.peername = NULL;
 
-	nutscan_init();
-
 	display_func = nutscan_display_ups_conf;
 
 	/* Note: the getopts print an error message about unknown arguments
@@ -467,6 +465,12 @@ display_help:
 		allow_ipmi = 1;
 		/* BEWARE: allow_all does not include allow_eaton_serial! */
 	}
+
+	/* TODO: nutscan_init() should consider (via args? shared global vars?)
+	 * which scan types we desire at this run, and not try to load irrelevant
+	 * libraries.
+	 */
+	nutscan_init();
 
 /* TODO/discuss : Should the #else...#endif code below for lack of pthreads
  * during build also serve as a fallback for pthread failure at runtime?


### PR DESCRIPTION
Solution: Move the call to this stateless function to the point after we parse arguments and just before we'd start the actual scans. Later this can be extended to also consider which scans were requested and so which libs to load.

Thanks to @clepple for research in https://github.com/networkupstools/nut/issues/500

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>