### PR TITLE
Add support for openssl-1.1.0

### DIFF
--- a/clients/upsclient.c
+++ b/clients/upsclient.c
@@ -745,7 +745,7 @@ static int upscli_sslinit(UPSCONN_t *ups, int verifycert)
 	switch(res)
 	{
 	case 1:
-		upsdebugx(3, "SSL connected");
+		upsdebugx(3, "SSL connected (%s)", SSL_get_version(ups->ssl));
 		break;
 	case 0:
 		upslog_with_errno(1, "SSL_connect do not accept handshake.");

--- a/clients/upsclient.c
+++ b/clients/upsclient.c
@@ -311,15 +311,12 @@ int upscli_init(int certverify, const char *certpath,
 	
 #ifdef WITH_OPENSSL
 
-	SSL_load_error_strings();
-	
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
+	SSL_load_error_strings();
 	SSL_library_init();
 
 	ssl_ctx = SSL_CTX_new(SSLv23_client_method());
 #else
-	OPENSSL_init_ssl(0, NULL);
-
 	ssl_ctx = SSL_CTX_new(TLS_client_method());
 #endif
 

--- a/clients/upsclient.c
+++ b/clients/upsclient.c
@@ -316,7 +316,11 @@ int upscli_init(int certverify, const char *certpath,
 	
 #ifdef WITH_OPENSSL
 	
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	SSL_library_init();
+#else
+	OPENSSL_init_ssl(0, NULL);
+#endif
 	SSL_load_error_strings();
 
 	ssl_method = TLSv1_client_method();

--- a/clients/upssched.c
+++ b/clients/upssched.c
@@ -794,7 +794,7 @@ static void parse_at(const char *ntype, const char *un, const char *cmd,
 	}
 
 	if (!strcmp(cmd, "EXECUTE")) {
-		if (ca1 == '\0') {
+		if (ca1[0] == '\0') {
 			upslogx(LOG_ERR, "Empty EXECUTE command argument");
 			return;
 		}

--- a/m4/nut_check_libopenssl.m4
+++ b/m4/nut_check_libopenssl.m4
@@ -57,9 +57,8 @@ if test -z "${nut_have_libopenssl_seen}"; then
 	AC_MSG_RESULT([${LIBS}])
 
 	dnl check if openssl is usable
-	AC_CHECK_FUNCS(OPENSSL_init_ssl, [nut_have_openssl=yes], [nut_have_openssl=no])
-	AC_CHECK_FUNCS(SSL_library_init, [nut_have_openssl=yes], [])
-	AC_CHECK_HEADERS(openssl/ssl.h, [], [nut_have_openssl=no], [AC_INCLUDES_DEFAULT])
+	AC_CHECK_HEADERS(openssl/ssl.h, [nut_have_openssl=yes], [nut_have_openssl=no], [AC_INCLUDES_DEFAULT])
+	AC_CHECK_FUNCS(SSL_CTX_new, [], [nut_have_openssl=no])
 
 	if test "${nut_have_openssl}" = "yes"; then
 		nut_with_ssl="yes"

--- a/m4/nut_check_libopenssl.m4
+++ b/m4/nut_check_libopenssl.m4
@@ -57,8 +57,9 @@ if test -z "${nut_have_libopenssl_seen}"; then
 	AC_MSG_RESULT([${LIBS}])
 
 	dnl check if openssl is usable
-	AC_CHECK_HEADERS(openssl/ssl.h, [nut_have_openssl=yes], [nut_have_openssl=no], [AC_INCLUDES_DEFAULT])
-	AC_CHECK_FUNCS(SSL_library_init, [], [nut_have_openssl=no])
+	AC_CHECK_FUNCS(OPENSSL_init_ssl, [nut_have_openssl=yes], [nut_have_openssl=no])
+	AC_CHECK_FUNCS(SSL_library_init, [nut_have_openssl=yes], [])
+	AC_CHECK_HEADERS(openssl/ssl.h, [], [nut_have_openssl=no], [AC_INCLUDES_DEFAULT])
 
 	if test "${nut_have_openssl}" = "yes"; then
 		nut_with_ssl="yes"

--- a/server/netssl.c
+++ b/server/netssl.c
@@ -275,7 +275,7 @@ void net_starttls(nut_ctype_t *client, int numarg, const char **arg)
 	{
 	case 1:
 		client->ssl_connected = 1;
-		upsdebugx(3, "SSL connected");
+		upsdebugx(3, "SSL connected (%s)", SSL_get_version(client->ssl));
 		break;
 		
 	case 0:

--- a/server/netssl.c
+++ b/server/netssl.c
@@ -381,15 +381,12 @@ void ssl_init(void)
 
 #ifdef WITH_OPENSSL
 
-	SSL_load_error_strings();
-
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
+	SSL_load_error_strings();
 	SSL_library_init();
 
 	ssl_ctx = SSL_CTX_new(SSLv23_server_method());
 #else
-	OPENSSL_init_ssl(0, NULL);
-
 	ssl_ctx = SSL_CTX_new(TLS_server_method());
 #endif
 

--- a/server/netssl.c
+++ b/server/netssl.c
@@ -388,7 +388,11 @@ void ssl_init(void)
 #ifdef WITH_OPENSSL
 
 	SSL_load_error_strings();
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	SSL_library_init();
+#else
+	OPENSSL_init_ssl(0, NULL);
+#endif
 
 	if ((ssl_method = TLSv1_server_method()) == NULL) {
 		ssl_debug();

--- a/server/netssl.c
+++ b/server/netssl.c
@@ -371,13 +371,7 @@ void ssl_init(void)
 {
 #ifdef WITH_NSS
 	SECStatus status;
-#elif defined(WITH_OPENSSL)
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
-	const SSL_METHOD	*ssl_method;
-#else
-	SSL_METHOD	*ssl_method;
-#endif
-#endif /* WITH_NSS|WITH_OPENSSL */
+#endif /* WITH_NSS */
 
 	if (!certfile) {
 		return;
@@ -388,21 +382,31 @@ void ssl_init(void)
 #ifdef WITH_OPENSSL
 
 	SSL_load_error_strings();
+
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 	SSL_library_init();
+
+	ssl_ctx = SSL_CTX_new(SSLv23_server_method());
 #else
 	OPENSSL_init_ssl(0, NULL);
+
+	ssl_ctx = SSL_CTX_new(TLS_server_method());
 #endif
 
-	if ((ssl_method = TLSv1_server_method()) == NULL) {
-		ssl_debug();
-		fatalx(EXIT_FAILURE, "TLSv1_server_method failed");
-	}
-
-	if ((ssl_ctx = SSL_CTX_new(ssl_method)) == NULL) {
+	if (!ssl_ctx) {
 		ssl_debug();
 		fatalx(EXIT_FAILURE, "SSL_CTX_new failed");
 	}
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+	/* set minimum protocol TLSv1 */
+	SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
+#else
+	if (SSL_CTX_set_min_proto_version(ssl_ctx, TLS1_VERSION) != 1) {
+		ssl_debug();
+		fatalx(EXIT_FAILURE, "SSL_CTX_set_min_proto_version(TLS1_VERSION)");
+	}
+#endif
 
 	if (SSL_CTX_use_certificate_chain_file(ssl_ctx, certfile) != 1) {
 		ssl_debug();


### PR DESCRIPTION
Tumbleweed (openSUSE) is switching to OpenSSL-1.1.0 shortly. Apply changes to server & client code and AutoConf magic to make this happen.