### PR TITLE
Sort input file list

### DIFF
--- a/tools/nut-snmpinfo.py
+++ b/tools/nut-snmpinfo.py
@@ -80,7 +80,7 @@ output_file.write( "\n" )
 output_file.write( "/* SNMP IDs device table */\n" )
 output_file.write( "static snmp_device_id_t snmp_device_table[] = {\n" )
 
-for filename in glob.glob('../drivers/*-mib.c'):
+for filename in sorted(glob.glob('../drivers/*-mib.c')):
 	list_of_line = open(filename,'r').read().split(';')
 	for line in list_of_line:
 		if "mib2nut_info_t" in line:

--- a/tools/nut-usbinfo.pl
+++ b/tools/nut-usbinfo.pl
@@ -76,7 +76,7 @@ my %vendorName;
 
 ################# MAIN #################
 
-find(\&find_usbdevs,$scanPath);
+find({wanted=>\&find_usbdevs, preprocess=>sub{sort @_}}, $scanPath);
 &gen_usb_files;
 
 ################# SUB METHOD #################


### PR DESCRIPTION
so that nut builds in a reproducible way
in spite of indeterministic filesystem readdir order
and http://bugs.python.org/issue30461

See https://reproducible-builds.org/ for why this is good.