### PR TITLE
main.c upsdrvctl.c : make debug messages a bit more useful

### DIFF
--- a/drivers/main.c
+++ b/drivers/main.c
@@ -636,7 +636,7 @@ int main(int argc, char **argv)
 				break;
 			}
 
-			upslogx(LOG_WARNING, "Duplicate driver instance detected! Terminating other driver!");
+			upslogx(LOG_WARNING, "Duplicate driver instance detected (PID file %s exists)! Terminating other driver!", buffer);
 
 			/* Allow driver some time to quit */
 			sleep(5);

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -150,13 +150,14 @@ static void stop_driver(const ups_t *ups)
 	ret = stat(pidfn, &fs);
 
 	if ((ret != 0) && (ups->port != NULL)) {
+		upslog_with_errno(LOG_ERR, "Can't open %s", pidfn);
 		snprintf(pidfn, sizeof(pidfn), "%s/%s-%s.pid", altpidpath(),
 			ups->driver, xbasename(ups->port));
 		ret = stat(pidfn, &fs);
 	}
 
 	if (ret != 0) {
-		upslog_with_errno(LOG_ERR, "Can't open %s", pidfn);
+		upslog_with_errno(LOG_ERR, "Can't open %s either", pidfn);
 		exec_error++;
 		return;
 	}


### PR DESCRIPTION
Tracing issues with service development, I found these messages are less than useful, and in case of `upsdrvctl stop` - even misleading (why does it make a pidfile with device name but look for the port name? oh, now we know).