### PR TITLE
nutscanner: get debug level early (for nutscan_init()) and restore options

### DIFF
--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -246,10 +246,22 @@ int main(int argc, char *argv[])
 	xml_sec.usec_timeout = -1; /* Override with the "timeout" common setting later */
 	xml_sec.peername = NULL;
 
+	/* Parse command line options -- First loop: only get debug level */
+	/* Suppress error messages, for now -- leave them to the second loop. */
+	opterr = 0;
+	while((opt_ret = getopt_long(argc, argv, optstring, longopts, NULL)) != -1)
+		if (opt_ret == 'D')
+			nut_debug_level++;
+
 	nutscan_init();
 
 	display_func = nutscan_display_ups_conf;
 
+	/* Parse command line options -- Second loop: everything else */
+	/* Restore error messages... */
+	opterr = 1;
+	/* ...and index of the item to be processed by getopt(). */
+	optind = 1;
 	/* Note: the getopts print an error message about unknown arguments
 	 * or arguments which need a second token and that is missing now */
 	while((opt_ret = getopt_long(argc, argv, optstring, longopts, NULL))!=-1) {
@@ -280,7 +292,7 @@ int main(int argc, char *argv[])
 				cidr = strdup(optarg);
 				break;
 			case 'D':
-				nut_debug_level++;
+				/* nothing to do, here */
 				break;
 			case 'c':
 				if(!nutscan_avail_snmp) {

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -246,6 +246,8 @@ int main(int argc, char *argv[])
 	xml_sec.usec_timeout = -1; /* Override with the "timeout" common setting later */
 	xml_sec.peername = NULL;
 
+	nutscan_init();
+
 	display_func = nutscan_display_ups_conf;
 
 	/* Note: the getopts print an error message about unknown arguments
@@ -465,12 +467,6 @@ display_help:
 		allow_ipmi = 1;
 		/* BEWARE: allow_all does not include allow_eaton_serial! */
 	}
-
-	/* TODO: nutscan_init() should consider (via args? shared global vars?)
-	 * which scan types we desire at this run, and not try to load irrelevant
-	 * libraries.
-	 */
-	nutscan_init();
 
 /* TODO/discuss : Should the #else...#endif code below for lack of pthreads
  * during build also serve as a fallback for pthread failure at runtime?


### PR DESCRIPTION
As noted in #502 (https://github.com/networkupstools/nut/pull/502#issuecomment-373559680), that patch is a bit problematic and made some `nut-scanner`'s options unavailable -- something like this should work, instead, without those side effects.

...or we could lower our smartness a notch or two and simply list and process all the options always and then only call the relative routine if really available.