### PR TITLE
Check for <CR> in status answer

### DIFF
--- a/drivers/blazer.c
+++ b/drivers/blazer.c
@@ -189,7 +189,7 @@ static int blazer_status(const char *cmd)
 	 *    01234567890123456789012345678901234567890123456
 	 *    0         1         2         3         4
 	 */
-	if (blazer_command(cmd, buf, sizeof(buf)) < 46) {
+	if (blazer_command(cmd, buf, sizeof(buf)) < 47) {
 		upsdebugx(2, "%s: short reply", __func__);
 		return -1;
 	}


### PR DESCRIPTION
This commit fix no check for trailing character <CR> in status answer.