### PR TITLE
EXTRA_DIST scripts/systemd/nut.target also

### DIFF
--- a/scripts/systemd/Makefile.am
+++ b/scripts/systemd/Makefile.am
@@ -11,7 +11,7 @@ systemdsystemunit_DATA = \
         nut-driver.target   \
         nut.target
 
-EXTRA_DIST += nut-driver.target
+EXTRA_DIST += nut-driver.target nut.target
 
 systemdshutdown_SCRIPTS = nutshutdown
 


### PR DESCRIPTION
On some systems, distcheck complained without this in place, and passed with it.