### PR TITLE
Nut scanner deps

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,7 @@ ACLOCAL_AMFLAGS = -I m4
 
 # subdirectories to build and distribute. The order matters, as
 # several subdirectories depend on stuff in "common" or tools being built first
-SUBDIRS = include common clients conf data tools docs drivers \
+SUBDIRS = include common clients conf data docs drivers tools \
   lib scripts server tests
 
 # COPYING is included automatically.

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,9 +1,3 @@
-# TODO: remove redundancies!
-
-# XXX this does not work with Automake!!!
-#
-# In fact the very concept is entirely antithetical to Automake.
-#
 # SUBDIRS are explicitly a listing of all the directories that make
 # must recurse into BEFORE processing the current directory.
 #
@@ -13,7 +7,8 @@
 #
 # Anyway, for the time being, we force build in ./ before nut-scanner,
 # to have nutscan-{usb,snmp}.h built before going into the nut-scanner
-# sub-directory
+# sub-directory. For good measure we also call this from nut-scanner's
+# make, to handle developer workflow (editing the *.c sources this uses).
 SUBDIRS = . nut-scanner
 
 EXTRA_DIST = nut-usbinfo.pl nut-recorder.sh nut-ddl-dump.sh \
@@ -37,10 +32,7 @@ GENERATED_USB_FILES += ../scripts/upower/95-upower-hid.rules
 
 all: nut-scanner-deps $(GENERATED_USB_FILES)
 
-# XXX these rules are all bogus!  They cause un-named target files to
-# always be rebuilt!  None of that is ever the right way to use make,
-# and especially not Automake.  Explicit filenames and their exact
-# dependencies need to be properly listed.
+# This target is called from the making of nut-scanner to ensure its bits
 nut-scanner-deps: nut-scanner/nutscan-snmp.h nut-scanner/nutscan-usb.h
 
 $(GENERATED_SNMP_FILES): $(top_srcdir)/drivers/*-mib.c

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -19,30 +19,47 @@ SUBDIRS = . nut-scanner
 EXTRA_DIST = nut-usbinfo.pl nut-recorder.sh nut-ddl-dump.sh \
   gitlog2changelog.py nut-snmpinfo.py driver-list-format.sh
 
-all: nut-scanner-deps 
+GENERATED_USB_FILES = nut-scanner/nutscan-usb.h
+
+# Hotplug output file
+GENERATED_USB_FILES += ../scripts/hotplug/libhid.usermap
+
+# udev output file
+GENERATED_USB_FILES += ../scripts/udev/nut-usbups.rules.in
+
+# BSD devd output file
+GENERATED_USB_FILES += ../scripts/devd/nut-usb.conf.in
+
+# UPower output file
+GENERATED_USB_FILES += ../scripts/upower/95-upower-hid.rules
+
+all: nut-scanner-deps $(GENERATED_USB_FILES)
 
 # XXX these rules are all bogus!  They cause un-named target files to
 # always be rebuilt!  None of that is ever the right way to use make,
 # and especially not Automake.  Explicit filenames and their exact
 # dependencies need to be properly listed.
-nut-scanner-deps:
+nut-scanner-deps: nut-scanner/nutscan-snmp.h nut-scanner/nutscan-usb.h
+
+nut-scanner/nutscan-snmp.h: ../drivers/*-mib.c
 	@if python -c 1; then \
-		echo "Regenerating the SNMP helper files."; \
+		echo "Regenerating the SNMP helper files in SRC dir."; \
 		$(top_srcdir)/tools/nut-snmpinfo.py; \
 	else \
 		echo "----------------------------------------------------------------------"; \
 		echo "Warning: Python is not available."; \
-		echo "Skipping the SNMP helper files regeneration."; \
+		echo "Skipping the SNMP helper files regeneration in SRC dir."; \
 		echo "----------------------------------------------------------------------"; \
 	fi
 
+$(GENERATED_USB_FILES): ../drivers/*-hid.c ../drivers/*usb*.c
 	@if perl -e 1; then \
-		echo "Regenerating the USB helper files."; \
+		echo "Regenerating the USB helper files in SRC dir."; \
 		$(top_srcdir)/tools/nut-usbinfo.pl; \
 	else \
 		echo "----------------------------------------------------------------------"; \
 		echo "Warning: Perl is not available."; \
-		echo "Skipping the USB helper files regeneration."; \
+		echo "Skipping the USB helper files regeneration in SRC dir."; \
 		echo "----------------------------------------------------------------------"; \
 	fi
 
@@ -52,22 +69,22 @@ nut-scanner-deps:
 # Also ensure that data/driver.list is well formatted
 dist-hook:
 	@if python -c 1; then \
-		echo "Regenerating the SNMP helper files."; \
-		$(distdir)/nut-snmpinfo.py; \
+		echo "Regenerating the SNMP helper files in DIST dir."; \
+		cd $(distdir) && ./nut-snmpinfo.py; \
 	else \
 		echo "----------------------------------------------------------------------"; \
 		echo "Warning: Python is not available."; \
-		echo "Skipping the SNMP helper files regeneration."; \
+		echo "Skipping the SNMP helper files regeneration in DIST dir."; \
 		echo "----------------------------------------------------------------------"; \
 	fi
 
 	@if perl -e 1; then \
-		echo "Regenerating the USB helper files."; \
-		$(distdir)/nut-usbinfo.pl; \
+		echo "Regenerating the USB helper files in DIST dir."; \
+		cd $(distdir) && ./nut-usbinfo.pl; \
 	else \
 		echo "----------------------------------------------------------------------"; \
 		echo "Warning: Perl is not available."; \
-		echo "Skipping the USB helper files regeneration."; \
+		echo "Skipping the USB helper files regeneration in DIST dir."; \
 		echo "----------------------------------------------------------------------"; \
 	fi
 

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -56,7 +56,7 @@ $(GENERATED_SNMP_FILES): $(top_srcdir)/drivers/*-mib.c
 		echo "----------------------------------------------------------------------"; \
 	fi
 
-$(GENERATED_USB_FILES): $(top_srcdir)/drivers/*-hid.c $(top_srcdir)/drivers/*usb*.c
+$(GENERATED_USB_FILES): $(top_srcdir)/drivers/*-hid.c $(top_srcdir)/drivers/*usb*.c $(top_srcdir)/drivers/nutdrv_qx.c
 	@if perl -e 1; then \
 		echo "Regenerating the USB helper files in SRC dir."; \
 		TOP_SRCDIR="$(top_srcdir)" ; export TOP_SRCDIR; \

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -44,7 +44,9 @@ nut-scanner-deps: nut-scanner/nutscan-snmp.h nut-scanner/nutscan-usb.h
 nut-scanner/nutscan-snmp.h: $(top_srcdir)/drivers/*-mib.c
 	@if python -c 1; then \
 		echo "Regenerating the SNMP helper files in SRC dir."; \
-		$(top_srcdir)/tools/nut-snmpinfo.py; \
+		TOP_SRCDIR="$(top_srcdir)" ; export TOP_SRCDIR; \
+		TOP_BUILDDIR="$(top_builddir)" ; export TOP_BUILDDIR; \
+		cd $(builddir) && $(top_srcdir)/tools/nut-snmpinfo.py; \
 	else \
 		echo "----------------------------------------------------------------------"; \
 		echo "Warning: Python is not available."; \
@@ -55,7 +57,9 @@ nut-scanner/nutscan-snmp.h: $(top_srcdir)/drivers/*-mib.c
 $(GENERATED_USB_FILES): $(top_srcdir)/drivers/*-hid.c $(top_srcdir)/drivers/*usb*.c
 	@if perl -e 1; then \
 		echo "Regenerating the USB helper files in SRC dir."; \
-		$(top_srcdir)/tools/nut-usbinfo.pl; \
+		TOP_SRCDIR="$(top_srcdir)" ; export TOP_SRCDIR; \
+		TOP_BUILDDIR="$(top_builddir)" ; export TOP_BUILDDIR; \
+		cd $(builddir) && $(top_srcdir)/tools/nut-usbinfo.pl; \
 	else \
 		echo "----------------------------------------------------------------------"; \
 		echo "Warning: Perl is not available."; \
@@ -70,6 +74,8 @@ $(GENERATED_USB_FILES): $(top_srcdir)/drivers/*-hid.c $(top_srcdir)/drivers/*usb
 dist-hook:
 	@if python -c 1; then \
 		echo "Regenerating the SNMP helper files in DIST dir."; \
+		TOP_SRCDIR="$(top_srcdir)" ; export TOP_SRCDIR; \
+		TOP_BUILDDIR="$(top_builddir)" ; export TOP_BUILDDIR; \
 		cd $(distdir) && ./nut-snmpinfo.py; \
 	else \
 		echo "----------------------------------------------------------------------"; \
@@ -80,6 +86,8 @@ dist-hook:
 
 	@if perl -e 1; then \
 		echo "Regenerating the USB helper files in DIST dir."; \
+		TOP_SRCDIR="$(top_srcdir)" ; export TOP_SRCDIR; \
+		TOP_BUILDDIR="$(top_builddir)" ; export TOP_BUILDDIR; \
 		cd $(distdir) && ./nut-usbinfo.pl; \
 	else \
 		echo "----------------------------------------------------------------------"; \

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -19,6 +19,8 @@ SUBDIRS = . nut-scanner
 EXTRA_DIST = nut-usbinfo.pl nut-recorder.sh nut-ddl-dump.sh \
   gitlog2changelog.py nut-snmpinfo.py driver-list-format.sh
 
+GENERATED_SNMP_FILES = nut-scanner/nutscan-snmp.h
+
 GENERATED_USB_FILES = nut-scanner/nutscan-usb.h
 
 # Hotplug output file
@@ -41,7 +43,7 @@ all: nut-scanner-deps $(GENERATED_USB_FILES)
 # dependencies need to be properly listed.
 nut-scanner-deps: nut-scanner/nutscan-snmp.h nut-scanner/nutscan-usb.h
 
-nut-scanner/nutscan-snmp.h: $(top_srcdir)/drivers/*-mib.c
+$(GENERATED_SNMP_FILES): $(top_srcdir)/drivers/*-mib.c
 	@if python -c 1; then \
 		echo "Regenerating the SNMP helper files in SRC dir."; \
 		TOP_SRCDIR="$(top_srcdir)" ; export TOP_SRCDIR; \

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -41,7 +41,7 @@ all: nut-scanner-deps $(GENERATED_USB_FILES)
 # dependencies need to be properly listed.
 nut-scanner-deps: nut-scanner/nutscan-snmp.h nut-scanner/nutscan-usb.h
 
-nut-scanner/nutscan-snmp.h: ../drivers/*-mib.c
+nut-scanner/nutscan-snmp.h: $(top_srcdir)/drivers/*-mib.c
 	@if python -c 1; then \
 		echo "Regenerating the SNMP helper files in SRC dir."; \
 		$(top_srcdir)/tools/nut-snmpinfo.py; \
@@ -52,7 +52,7 @@ nut-scanner/nutscan-snmp.h: ../drivers/*-mib.c
 		echo "----------------------------------------------------------------------"; \
 	fi
 
-$(GENERATED_USB_FILES): ../drivers/*-hid.c ../drivers/*usb*.c
+$(GENERATED_USB_FILES): $(top_srcdir)/drivers/*-hid.c $(top_srcdir)/drivers/*usb*.c
 	@if perl -e 1; then \
 		echo "Regenerating the USB helper files in SRC dir."; \
 		$(top_srcdir)/tools/nut-usbinfo.pl; \

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -71,12 +71,15 @@ $(GENERATED_USB_FILES): $(top_srcdir)/drivers/*-hid.c $(top_srcdir)/drivers/*usb
 # call the SNMP info script upon "make dist", and if Python is present
 # and call both for building nut-scanner
 # Also ensure that data/driver.list is well formatted
+# NOTE: Beware that current working directory for the script should be builddir
+# so it may write the files in "dist" case (read-only sources), but the script
+# is called from the distdir where its copy is present.
 dist-hook:
 	@if python -c 1; then \
 		echo "Regenerating the SNMP helper files in DIST dir."; \
 		TOP_SRCDIR="$(top_srcdir)" ; export TOP_SRCDIR; \
 		TOP_BUILDDIR="$(top_builddir)" ; export TOP_BUILDDIR; \
-		cd $(distdir) && ./nut-snmpinfo.py; \
+		$(distdir)/nut-snmpinfo.py; \
 	else \
 		echo "----------------------------------------------------------------------"; \
 		echo "Warning: Python is not available."; \
@@ -88,7 +91,7 @@ dist-hook:
 		echo "Regenerating the USB helper files in DIST dir."; \
 		TOP_SRCDIR="$(top_srcdir)" ; export TOP_SRCDIR; \
 		TOP_BUILDDIR="$(top_builddir)" ; export TOP_BUILDDIR; \
-		cd $(distdir) && ./nut-usbinfo.pl; \
+		$(distdir)/nut-usbinfo.pl; \
 	else \
 		echo "----------------------------------------------------------------------"; \
 		echo "Warning: Perl is not available."; \

--- a/tools/nut-scanner/Makefile.am
+++ b/tools/nut-scanner/Makefile.am
@@ -6,6 +6,8 @@ NUT_SCANNER_DEPS = $(NUT_SCANNER_DEPS_H)
 
 BUILT_SOURCES = $(NUT_SCANNER_DEPS)
 
+# Make sure we have the freshest files (no-op if built earlier and then
+# no driver sources and other dependencies were edited by a developer)
 $(NUT_SCANNER_DEPS):
 	cd ..; $(MAKE) $(AM_MAKEFLAGS) nut-scanner-deps
 

--- a/tools/nut-scanner/Makefile.am
+++ b/tools/nut-scanner/Makefile.am
@@ -1,6 +1,12 @@
-BUILT_SOURCES = nutscan-usb.h nutscan-snmp.h
+# Headers re-generated for nut-scanner in the parent dir
+NUT_SCANNER_DEPS_H = nutscan-usb.h nutscan-snmp.h
 
-nutscan-usb.h nutscan-snmp.h:
+# General set of nut-scanner dependencies generated in the parent dir
+NUT_SCANNER_DEPS = $(NUT_SCANNER_DEPS_H)
+
+BUILT_SOURCES = $(NUT_SCANNER_DEPS)
+
+$(NUT_SCANNER_DEPS):
 	cd ..; $(MAKE) $(AM_MAKEFLAGS) nut-scanner-deps
 
 # Only build nut-scanner, and its library, if libltdl was found (required!)
@@ -43,7 +49,7 @@ if WITH_IPMI
   libnutscan_la_CFLAGS += $(LIBIPMI_CFLAGS)
 endif
 
-dist_noinst_HEADERS = nutscan-usb.h nutscan-snmp.h
+dist_noinst_HEADERS = $(NUT_SCANNER_DEPS_H)
 
 if WITH_DEV
  include_HEADERS = nut-scan.h nutscan-device.h nutscan-ip.h nutscan-init.h
@@ -51,5 +57,5 @@ else
  dist_noinst_HEADERS += nut-scan.h nutscan-device.h nutscan-ip.h nutscan-init.h nutscan-serial.h
 endif
 
-CLEANFILES = nutscan-usb.h nutscan-snmp.h
+CLEANFILES = $(BUILT_SOURCES)
 

--- a/tools/nut-snmpinfo.py
+++ b/tools/nut-snmpinfo.py
@@ -21,8 +21,17 @@
 import glob
 import re
 import sys
+import os
 
-output_file_name="./nut-scanner/nutscan-snmp.h"
+TOP_SRCDIR = os.getenv('TOP_SRCDIR');
+if TOP_SRCDIR is None:
+    TOP_SRCDIR="..";
+
+TOP_BUILDDIR = os.getenv('TOP_BUILDDIR');
+if TOP_BUILDDIR is None:
+    TOP_BUILDDIR="..";
+
+output_file_name = TOP_BUILDDIR + "/tools/nut-scanner/nutscan-snmp.h"
 output_file = open(output_file_name,'w')
 
 #expand #define constant
@@ -80,7 +89,7 @@ output_file.write( "\n" )
 output_file.write( "/* SNMP IDs device table */\n" )
 output_file.write( "static snmp_device_id_t snmp_device_table[] = {\n" )
 
-for filename in sorted(glob.glob('../drivers/*-mib.c')):
+for filename in sorted(glob.glob(TOP_SRCDIR + '/drivers/*-mib.c')):
 	list_of_line = open(filename,'r').read().split(';')
 	for line in list_of_line:
 		if "mib2nut_info_t" in line:

--- a/tools/nut-usbinfo.pl
+++ b/tools/nut-usbinfo.pl
@@ -28,20 +28,31 @@
 use File::Find;
 use strict;
 
+
+my $TOP_SRCDIR = "..";
+if (defined $ENV{'TOP_SRCDIR'}) {
+    $TOP_SRCDIR = $ENV{'TOP_SRCDIR'};
+}
+
+my $TOP_BUILDDIR = "..";
+if (defined $ENV{'TOP_BUILDDIR'}) {
+    $TOP_BUILDDIR = $ENV{'TOP_BUILDDIR'};
+}
+
 # path to scan for USB_DEVICE pattern
-my $scanPath="../drivers";
+my $scanPath="$TOP_SRCDIR/drivers";
 
 # Hotplug output file
-my $outputHotplug="../scripts/hotplug/libhid.usermap";
+my $outputHotplug="$TOP_BUILDDIR/scripts/hotplug/libhid.usermap";
 
 # udev output file
-my $outputUdev="../scripts/udev/nut-usbups.rules.in";
+my $outputUdev="$TOP_BUILDDIR/scripts/udev/nut-usbups.rules.in";
 
 # BSD devd output file
-my $output_devd="../scripts/devd/nut-usb.conf.in";
+my $output_devd="$TOP_BUILDDIR/scripts/devd/nut-usb.conf.in";
 
 # UPower output file
-my $outputUPower="../scripts/upower/95-upower-hid.rules";
+my $outputUPower="$TOP_BUILDDIR/scripts/upower/95-upower-hid.rules";
 
 # tmp output, to allow generating the ENV{UPOWER_VENDOR} header list
 my $tmpOutputUPower;
@@ -49,7 +60,7 @@ my $tmpOutputUPower;
 my $upowerMfrHeaderDone = 0;
 
 # NUT device scanner - C header
-my $outputDevScanner = "./nut-scanner/nutscan-usb.h";
+my $outputDevScanner = "$TOP_BUILDDIR/tools/nut-scanner/nutscan-usb.h";
 
 my $GPL_header = "\
  *  Copyright (C) 2011 - Arnaud Quette <arnaud.quette\@free.fr>\


### PR DESCRIPTION
Avoid rebuilding nut-scanner upon every invokation of `make` or after `make deps`.