### PR TITLE
Add FD_CLOEXEC flag to config files, pipes and sockets

### DIFF
--- a/clients/upssched.c
+++ b/clients/upssched.c
@@ -46,6 +46,8 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <netinet/in.h>
+#include <unistd.h>
+#include <fcntl.h>
 
 #include "upssched.h"
 #include "timehead.h"
@@ -297,6 +299,9 @@ static int open_sock(void)
 	if (ret < 0)
 		fatal_with_errno(EXIT_FAILURE, "listen(%d, %d) failed", fd, US_LISTEN_BACKLOG);
 
+	/* don't leak socket to CMDSCRIPT */
+	fcntl(fd, F_SETFD, FD_CLOEXEC);
+
 	return fd;
 }
 
@@ -369,6 +374,9 @@ static void conn_add(int sockfd)
 		upslog_with_errno(LOG_ERR, "accept on unix fd failed");
 		return;
 	}
+
+	/* don't leak connection to CMDSCRIPT */
+	fcntl(acc, F_SETFD, FD_CLOEXEC);
 
 	/* enable nonblocking I/O */
 

--- a/common/parseconf.c
+++ b/common/parseconf.c
@@ -83,6 +83,7 @@
 #include <stdlib.h>
 #include <string.h>	
 #include <unistd.h>
+#include <fcntl.h>
 
 #include "parseconf.h"
 
@@ -442,6 +443,9 @@ int pconf_file_begin(PCONF_CTX_t *ctx, const char *fn)
 			fn, strerror(errno));
 		return 0;
 	}
+
+	/* prevent fd leaking to child processes */
+	fcntl(fileno(ctx->f), F_SETFD, FD_CLOEXEC);
 
 	return 1;	/* OK */
 }


### PR DESCRIPTION
File descriptors are leaking to processes spawned by upsmod and
upssched, leading to SELinux errors when (for example) sendmail
attempts to read from fd #4.