### PR TITLE
Readme broken url

### DIFF
--- a/README
+++ b/README
@@ -171,7 +171,7 @@ For example, it is available on Debian systems as:
 
 	/usr/share/nut/driver.list
 
-This table is also available link:http://www.networkupstools.org/stable-hcl.html[online].
+This table is also available link:http://www.networkupstools.org/stable-hcl.html [online].
 
 
 If your driver has vanished, see the link:FAQ.html[FAQ] and

--- a/README
+++ b/README
@@ -171,7 +171,7 @@ For example, it is available on Debian systems as:
 
 	/usr/share/nut/driver.list
 
-This table is also available online: http://www.networkupstools.org/stable-hcl.html 
+This table is also available online: http://www.networkupstools.org/stable-hcl.html
 
 
 If your driver has vanished, see the link:FAQ.html[FAQ] and

--- a/README
+++ b/README
@@ -171,7 +171,7 @@ For example, it is available on Debian systems as:
 
 	/usr/share/nut/driver.list
 
-This table is also available link:http://www.networkupstools.org/stable-hcl.html [online].
+This table is also available online: http://www.networkupstools.org/stable-hcl.html 
 
 
 If your driver has vanished, see the link:FAQ.html[FAQ] and


### PR DESCRIPTION
Noticed a broken link in README when I was trying to research NUT for my use case so I thought I would fix it. I also reworded just a bit as it looked odd just having [online]. at the end after the hyperlink. 