### PR TITLE
netxml-ups: Report calibration status

### DIFF
--- a/drivers/mge-xml.c
+++ b/drivers/mge-xml.c
@@ -33,7 +33,7 @@
 #include "mge-xml.h"
 #include "main.h" /* for testvar() */
 
-#define MGE_XML_VERSION		"MGEXML/0.28"
+#define MGE_XML_VERSION		"MGEXML/0.29"
 
 #define MGE_XML_INITUPS		"/"
 #define MGE_XML_INITINFO	"/mgeups/product.xml /product.xml /ws/product.xml"
@@ -544,6 +544,7 @@ static const char *mge_sensitivity_info(const char *val)
 
 static const char *mge_test_result_info(const char *val)
 {
+	STATUS_CLR(CAL);
 	switch (atoi(val))
 	{
 	case 1:
@@ -555,6 +556,7 @@ static const char *mge_test_result_info(const char *val)
 	case 4:
 		return "aborted";
 	case 5:
+		STATUS_SET(CAL);
 		return "in progress";
 	case 6:
 		return "no test initiated";

--- a/drivers/netxml-ups.c
+++ b/drivers/netxml-ups.c
@@ -984,6 +984,9 @@ static void netxml_status_set(void)
 	if (STATUS_BIT(SHUTDOWNIMM)) {
 		status_set("FSD");		/* shutdown imminent */
 	}
+	if (STATUS_BIT(CAL)) {
+		status_set("CAL");		/* calibrating */
+	}
 }
 
 

--- a/drivers/netxml-ups.h
+++ b/drivers/netxml-ups.h
@@ -67,7 +67,8 @@ typedef enum {
 	CHARGERFAIL,	/* battery charger failure */
 	VRANGE,		/* voltage out of range */
 	FRANGE,		/* frequency out of range */
-	FUSEFAULT	/* fuse fault */
+	FUSEFAULT,	/* fuse fault */
+	CAL		/* calibrating */
 } status_bit_t;
 
 extern uint32_t	ups_status;


### PR DESCRIPTION
This sets the CAL status whenever a battery self-test is in progress. Tested on an Eaton 5PX 2200.