### PR TITLE
Add support for extra parameter for instant commands

### DIFF
--- a/clients/Makefile.am
+++ b/clients/Makefile.am
@@ -55,6 +55,7 @@ endif
 # http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
 libupsclient_la_LDFLAGS = -version-info 4:0:0
 
+# libnutclient version information
 libnutclient_la_SOURCES = nutclient.h nutclient.cpp
-libnutclient_la_LDFLAGS = -version-info 0:0:0
+libnutclient_la_LDFLAGS = -version-info 1:0:0
 

--- a/clients/nutclient.cpp
+++ b/clients/nutclient.cpp
@@ -674,9 +674,9 @@ std::string TcpClient::getDeviceCommandDescription(const std::string& dev, const
 	return get("CMDDESC", dev + " " + name)[0];
 }
 
-void TcpClient::executeDeviceCommand(const std::string& dev, const std::string& name)throw(NutException)
+void TcpClient::executeDeviceCommand(const std::string& dev, const std::string& name, const std::string& param)throw(NutException)
 {
-	detectError(sendQuery("INSTCMD " + dev + " " + name));
+	detectError(sendQuery("INSTCMD " + dev + " " + name + " " + param));
 }
 
 void TcpClient::deviceLogin(const std::string& dev)throw(NutException)
@@ -1072,10 +1072,10 @@ Command Device::getCommand(const std::string& name)throw(NutException)
     return Command(NULL, "");
 }
 
-void Device::executeCommand(const std::string& name)throw(NutException)
+void Device::executeCommand(const std::string& name, const std::string& param)throw(NutException)
 {
   if (!isOk()) throw NutException("Invalid device");
-  getClient()->executeDeviceCommand(getName(), name);
+  getClient()->executeDeviceCommand(getName(), name, param);
 }
 
 void Device::login()throw(NutException)
@@ -1252,9 +1252,9 @@ std::string Command::getDescription()throw(NutException)
 	return getDevice()->getClient()->getDeviceCommandDescription(getDevice()->getName(), getName());
 }
 
-void Command::execute()throw(NutException)
+void Command::execute(const std::string& param)throw(NutException)
 {
-	getDevice()->executeCommand(getName());
+	getDevice()->executeCommand(getName(), param);
 }
 
 } /* namespace nut */
@@ -1734,7 +1734,7 @@ char* nutclient_get_device_command_description(NUTCLIENT_t client, const char* d
 	return NULL;
 }
 
-void nutclient_execute_device_command(NUTCLIENT_t client, const char* dev, const char* cmd)
+void nutclient_execute_device_command(NUTCLIENT_t client, const char* dev, const char* cmd, const char* param)
 {
 	if(client)
 	{
@@ -1743,7 +1743,7 @@ void nutclient_execute_device_command(NUTCLIENT_t client, const char* dev, const
 		{
 			try
 			{
-				cl->executeDeviceCommand(dev, cmd);
+				cl->executeDeviceCommand(dev, cmd, param);
 			}
 			catch(...){}
 		}

--- a/clients/nutclient.h
+++ b/clients/nutclient.h
@@ -267,7 +267,7 @@ public:
 	 * \param name Command name
 	 * \param param Additional command parameter
 	 */
-	virtual void executeDeviceCommand(const std::string& dev, const std::string& name, const std::string& param)throw(NutException)=0;
+	virtual void executeDeviceCommand(const std::string& dev, const std::string& name, const std::string& param="")throw(NutException)=0;
 	/** \} */
 
 	/**
@@ -376,7 +376,7 @@ public:
 
 	virtual std::set<std::string> getDeviceCommandNames(const std::string& dev)throw(NutException);
 	virtual std::string getDeviceCommandDescription(const std::string& dev, const std::string& name)throw(NutException);
-	virtual void executeDeviceCommand(const std::string& dev, const std::string& name, const std::string& param)throw(NutException);
+	virtual void executeDeviceCommand(const std::string& dev, const std::string& name, const std::string& param="")throw(NutException);
 
  	virtual void deviceLogin(const std::string& dev)throw(NutException);
 	virtual void deviceMaster(const std::string& dev)throw(NutException);
@@ -530,7 +530,7 @@ public:
 	 * \param name Command name.
 	 * \param param Additional command parameter
 	 */
-	void executeCommand(const std::string& name, const std::string& param)throw(NutException);
+	void executeCommand(const std::string& name, const std::string& param="")throw(NutException);
 
 	/**
 	 * Login current client's user for the device.
@@ -692,7 +692,7 @@ public:
 	 * \param param Additional command parameter
 	 * \return Command description if provided.
 	 */
-	void execute(const std::string& param)throw(NutException);
+	void execute(const std::string& param="")throw(NutException);
 
 protected:
 	Command(Device* dev, const std::string& name);
@@ -904,7 +904,7 @@ char* nutclient_get_device_command_description(NUTCLIENT_t client, const char* d
  * \param dev Device name.
  * \param cmd Command name.
  */
-void nutclient_execute_device_command(NUTCLIENT_t client, const char* dev, const char* cmd, const char* param);
+void nutclient_execute_device_command(NUTCLIENT_t client, const char* dev, const char* cmd, const char* param="");
 
 /** \} */
 

--- a/clients/nutclient.h
+++ b/clients/nutclient.h
@@ -265,8 +265,9 @@ public:
 	 * Intend to execute a command.
 	 * \param dev Device name
 	 * \param name Command name
+	 * \param param Additional command parameter
 	 */
-	virtual void executeDeviceCommand(const std::string& dev, const std::string& name)throw(NutException)=0;
+	virtual void executeDeviceCommand(const std::string& dev, const std::string& name, const std::string& param)throw(NutException)=0;
 	/** \} */
 
 	/**
@@ -375,7 +376,7 @@ public:
 
 	virtual std::set<std::string> getDeviceCommandNames(const std::string& dev)throw(NutException);
 	virtual std::string getDeviceCommandDescription(const std::string& dev, const std::string& name)throw(NutException);
-	virtual void executeDeviceCommand(const std::string& dev, const std::string& name)throw(NutException);
+	virtual void executeDeviceCommand(const std::string& dev, const std::string& name, const std::string& param)throw(NutException);
 
  	virtual void deviceLogin(const std::string& dev)throw(NutException);
 	virtual void deviceMaster(const std::string& dev)throw(NutException);
@@ -527,8 +528,9 @@ public:
 	/**
 	 * Intend to execute a command on the device.
 	 * \param name Command name.
+	 * \param param Additional command parameter
 	 */
-	void executeCommand(const std::string& name)throw(NutException);
+	void executeCommand(const std::string& name, const std::string& param)throw(NutException);
 
 	/**
 	 * Login current client's user for the device.
@@ -687,9 +689,10 @@ public:
 
 	/**
 	 * Intend to retrieve command description.
+	 * \param param Additional command parameter
 	 * \return Command description if provided.
 	 */
-	void execute()throw(NutException);
+	void execute(const std::string& param)throw(NutException);
 
 protected:
 	Command(Device* dev, const std::string& name);
@@ -901,7 +904,7 @@ char* nutclient_get_device_command_description(NUTCLIENT_t client, const char* d
  * \param dev Device name.
  * \param cmd Command name.
  */
-void nutclient_execute_device_command(NUTCLIENT_t client, const char* dev, const char* cmd);
+void nutclient_execute_device_command(NUTCLIENT_t client, const char* dev, const char* cmd, const char* param);
 
 /** \} */
 

--- a/docs/net-protocol.txt
+++ b/docs/net-protocol.txt
@@ -388,8 +388,11 @@ INSTCMD
 
 Form:
 
-	INSTCMD <upsname> <cmdname>
+	INSTCMD <upsname> <cmdname> [cmdparam]
 	INSTCMD su700 test.panel.start
+	INSTCMD su700 load.off.delay 120
+
+NOTE: cmdparam is an additional and optional parameter for the command.
 
 
 LOGOUT

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 2432 utf-8
+personal_ws-1.1 en 2433 utf-8
 AAS
 ACFAIL
 ACFREQ
@@ -1338,6 +1338,7 @@ clueful
 cmd
 cmdline
 cmdname
+cmdparam
 cmds
 cmdvartab
 codebase


### PR DESCRIPTION
Instant commands were almost ready for supporting additional parameter.
However, it was not documented, and libnutclient was not supporting it yet

Signed-off-by: Arnaud Quette <arnaud.quette@free.fr>