### PR TITLE
snmp-ups: support extra param for instcmd (Eaton/HPE)

### DIFF
--- a/drivers/eaton-pdu-marlin-mib.c
+++ b/drivers/eaton-pdu-marlin-mib.c
@@ -34,7 +34,7 @@
 /* Eaton PDU-MIB - Marlin MIB
  * ************************** */
 
-#define EATON_MARLIN_MIB_VERSION	"0.45"
+#define EATON_MARLIN_MIB_VERSION	"0.46"
 #define EATON_MARLIN_SYSOID			".1.3.6.1.4.1.534.6.6.7"
 #define EATON_MARLIN_OID_MODEL_NAME	".1.3.6.1.4.1.534.6.6.7.1.2.1.2.0"
 
@@ -816,15 +816,24 @@ static snmp_info_t eaton_marlin_mib[] = {
 	{ "outlet.load.cycle", 0, DO_CYCLE, AR_OID_OUTLET_STATUS ".0",
 		NULL, SU_TYPE_CMD, NULL, NULL }, */
 
-	/* TODO: handle delays */
+	/* Delays handling:
+	 * 0-n :Time in seconds until the group command is issued
+	 * -1:Cancel a pending group-level Off/On/Reboot command */
 	{ "outlet.%i.load.off", 0, 1, ".1.3.6.1.4.1.534.6.6.7.6.6.1.3.%i.%i",
 		"0", SU_TYPE_CMD | SU_OUTLET | SU_TYPE_DAISY_1, NULL },
 	{ "outlet.%i.load.on", 0, 1, ".1.3.6.1.4.1.534.6.6.7.6.6.1.4.%i.%i",
 		"0", SU_TYPE_CMD | SU_OUTLET | SU_TYPE_DAISY_1, NULL },
 	{ "outlet.%i.load.cycle", 0, 1, ".1.3.6.1.4.1.534.6.6.7.6.6.1.5.%i.%i",
 		"0", SU_TYPE_CMD | SU_OUTLET | SU_TYPE_DAISY_1, NULL },
+	/* Delayed version, parameter is mandatory (so dfl is NULL)! */
+	{ "outlet.%i.load.off.delay", 0, 1, ".1.3.6.1.4.1.534.6.6.7.6.6.1.3.%i.%i",
+		NULL, SU_TYPE_CMD | SU_OUTLET | SU_TYPE_DAISY_1, NULL },
+	{ "outlet.%i.load.on.delay", 0, 1, ".1.3.6.1.4.1.534.6.6.7.6.6.1.4.%i.%i",
+		NULL, SU_TYPE_CMD | SU_OUTLET | SU_TYPE_DAISY_1, NULL },
+	{ "outlet.%i.load.cycle.delay", 0, 1, ".1.3.6.1.4.1.534.6.6.7.6.6.1.5.%i.%i",
+		NULL, SU_TYPE_CMD | SU_OUTLET | SU_TYPE_DAISY_1, NULL },
 
-	/* TODO: handle delays
+	/* Delays handling:
 	 * 0-n :Time in seconds until the group command is issued
 	 * -1:Cancel a pending group-level Off/On/Reboot command */
 	/* groupControlOffCmd.0.1 = Integer: -1 */
@@ -839,8 +848,18 @@ static snmp_info_t eaton_marlin_mib[] = {
 	{ "outlet.group.%i.load.cycle", 0, 1,
 		".1.3.6.1.4.1.534.6.6.7.5.6.1.5.%i.%i",
 		"0", SU_TYPE_CMD | SU_OUTLET_GROUP | SU_TYPE_DAISY_1, NULL },
-
-// FIXME: miss load.{on,off}.delay
+	/* Delayed version, parameter is mandatory (so dfl is NULL)! */
+	{ "outlet.group.%i.load.off.delay", 0, 1,
+		".1.3.6.1.4.1.534.6.6.7.5.6.1.3.%i.%i",
+		NULL, SU_TYPE_CMD | SU_OUTLET_GROUP | SU_TYPE_DAISY_1, NULL },
+	/* groupControl0nCmd.0.1 = Integer: -1 */
+	{ "outlet.group.%i.load.on.delay", 0, 1,
+		".1.3.6.1.4.1.534.6.6.7.5.6.1.4.%i.%i",
+		NULL, SU_TYPE_CMD | SU_OUTLET_GROUP | SU_TYPE_DAISY_1, NULL },
+	/* groupControlRebootCmd.0.1 = Integer: -1 */
+	{ "outlet.group.%i.load.cycle.delay", 0, 1,
+		".1.3.6.1.4.1.534.6.6.7.5.6.1.5.%i.%i",
+		NULL, SU_TYPE_CMD | SU_OUTLET_GROUP | SU_TYPE_DAISY_1, NULL },
 
 	/* end of structure. */
 	{ NULL, 0, 0, NULL, NULL, 0, NULL }

--- a/drivers/hpe-pdu-mib.c
+++ b/drivers/hpe-pdu-mib.c
@@ -24,7 +24,7 @@
 #include "hpe-pdu-mib.h"
 #include "dstate.h"
 
-#define HPE_EPDU_MIB_VERSION      "0.2"
+#define HPE_EPDU_MIB_VERSION      "0.30"
 #define HPE_EPDU_MIB_SYSOID       ".1.3.6.1.4.1.232.165.7"
 #define HPE_EPDU_OID_MODEL_NAME	".1.3.6.1.4.1.232.165.7.1.2.1.3.0"
 
@@ -37,7 +37,7 @@ static info_lkp_t hpe_pdu_outlet_status_info[] = {
 };
 
 static info_lkp_t hpe_pdu_outletgroups_status_info[] = {
-	{ 1, "N/A" },    /* notApplicable, if group.type == outlet-section */
+	{ 1, "N/A" }, /* notApplicable, if group.type == outlet-section */
 	{ 2, "on" },  /* breakerOn */
 	{ 3, "off" }, /* breakerOff */
 	{ 0, NULL }
@@ -871,6 +871,19 @@ static snmp_info_t hpe_pdu_mib[] = {
 	{ "outlet.%i.load.cycle", 0, 1,
 		".1.3.6.1.4.1.232.165.7.5.2.1.4.%i.%i",
 		"0", SU_TYPE_CMD | SU_OUTLET | SU_TYPE_DAISY_1, NULL },
+	/* Delayed version, parameter is mandatory (so dfl is NULL)! */
+	/* pdu2OutletControlOffCmd.0.%i = INTEGER: -1 */
+	{ "outlet.%i.load.off.delay", 0, 1,
+		".1.3.6.1.4.1.232.165.7.5.2.1.2.%i.%i",
+		NULL, SU_TYPE_CMD | SU_OUTLET | SU_TYPE_DAISY_1, NULL },
+	/* pdu2OutletControlOnCmd.0.%i = INTEGER: -1 */
+	{ "outlet.%i.load.on.delay", 0, 1,
+		".1.3.6.1.4.1.232.165.7.5.2.1.3.%i.%i",
+		NULL, SU_TYPE_CMD | SU_OUTLET | SU_TYPE_DAISY_1, NULL },
+	/* pdu2OutletControlRebootCmd.0.%i = INTEGER: -1 */
+	{ "outlet.%i.load.cycle.delay", 0, 1,
+		".1.3.6.1.4.1.232.165.7.5.2.1.4.%i.%i",
+		NULL, SU_TYPE_CMD | SU_OUTLET | SU_TYPE_DAISY_1, NULL },
 
 	/* end of structure. */
 	{ NULL, 0, 0, NULL, NULL, 0, NULL }


### PR DESCRIPTION
Add support for extra parameter for instant commands on Eaton and HPE ePDU

Signed-off-by: Arnaud Quette <ArnaudQuette@eaton.com>