### PR TITLE
libnutclient: introduce getDevicesVariableValues()

### DIFF
--- a/clients/nutclient.cpp
+++ b/clients/nutclient.cpp
@@ -461,6 +461,18 @@ std::map<std::string,std::vector<std::string> > Client::getDeviceVariableValues(
   return res;
 }
 
+std::map<std::string,std::map<std::string,std::vector<std::string> > > Client::getDevicesVariableValues(const std::set<std::string>& devs)throw(NutException)
+{
+	std::map<std::string,std::map<std::string,std::vector<std::string> > > res;
+
+	for(std::set<std::string>::const_iterator it=devs.cbegin(); it!=devs.cend(); ++it)
+	{
+		res[*it] = getDeviceVariableValues(*it);
+	}
+
+	return res;
+}
+
 bool Client::hasDeviceCommand(const std::string& dev, const std::string& name)throw(NutException)
 {
   std::set<std::string> names = getDeviceCommandNames(dev);
@@ -640,6 +652,47 @@ std::map<std::string,std::vector<std::string> > TcpClient::getDeviceVariableValu
 	return map;
 }
 
+std::map<std::string,std::map<std::string,std::vector<std::string> > > TcpClient::getDevicesVariableValues(const std::set<std::string>& devs)throw(NutException)
+{
+	std::map<std::string,std::map<std::string,std::vector<std::string> > > map;
+
+	std::vector<std::string> queries;
+	for (std::set<std::string>::const_iterator it=devs.cbegin(); it!=devs.cend(); ++it)
+	{
+		queries.push_back("LIST VAR " + *it);
+	}
+	sendAsyncQueries(queries);
+
+	for (std::set<std::string>::const_iterator it=devs.cbegin(); it!=devs.cend(); ++it)
+	{
+		try
+		{
+			std::map<std::string,std::vector<std::string> > map2;
+			std::vector<std::vector<std::string> > res = parseList("VAR " + *it);
+			for (std::vector<std::vector<std::string> >::iterator it2=res.begin(); it2!=res.end(); ++it2)
+			{
+				std::vector<std::string>& vals = *it2;
+				std::string var = vals[0];
+				vals.erase(vals.begin()),
+				map2[var] = vals;
+			}
+			map[*it] = map2;
+		}
+		catch (NutException&)
+		{
+			// We sent a bunch of queries, we need to process them all to clear up the backlog.
+		}
+	}
+
+	if (map.empty())
+	{
+		// We may fail on some devices, but not on ALL devices.
+		throw NutException("Invalid device");
+	}
+
+	return map;
+}
+
 void TcpClient::setDeviceVariable(const std::string& dev, const std::string& name, const std::string& value)throw(NutException)
 {
 	std::string query = "SET VAR " + dev + " " + name + " " + escape(value);
@@ -727,7 +780,16 @@ std::vector<std::vector<std::string> > TcpClient::list
 	{
 		req += " " + params;
 	}
-	std::string res = sendQuery("LIST " + req);
+	std::vector<std::string> query;
+	query.push_back("LIST " + req);
+	sendAsyncQueries(query);
+	return parseList(req);
+}
+
+std::vector<std::vector<std::string> > TcpClient::parseList
+	(const std::string& req) throw(NutException)
+{
+	std::string res = _socket->read();
 	detectError(res);
 	if(res != ("BEGIN LIST " + req))
 	{
@@ -758,6 +820,14 @@ std::string TcpClient::sendQuery(const std::string& req)throw(IOException)
 {
 	_socket->write(req);
 	return _socket->read();
+}
+
+void TcpClient::sendAsyncQueries(const std::vector<std::string>& req)throw(IOException)
+{
+	for (std::vector<std::string>::const_iterator it = req.cbegin(); it != req.cend(); it++)
+	{
+		_socket->write(*it);
+	}
 }
 
 void TcpClient::detectError(const std::string& req)throw(NutException)

--- a/clients/nutclient.h
+++ b/clients/nutclient.h
@@ -221,6 +221,12 @@ public:
 	 */
 	virtual std::map<std::string,std::vector<std::string> > getDeviceVariableValues(const std::string& dev)throw(NutException);
 	/**
+	 * Retrieve values of all variables of a set of devices.
+	 * \param devs Device names
+	 * \return Variable values indexed by variable names, indexed by device names.
+	 */
+	virtual std::map<std::string,std::map<std::string,std::vector<std::string> > > getDevicesVariableValues(const std::set<std::string>& devs)throw(NutException);
+	/**
 	 * Intend to set the value of a variable.
 	 * \param dev Device name
 	 * \param name Variable name
@@ -371,6 +377,7 @@ public:
 	virtual std::string getDeviceVariableDescription(const std::string& dev, const std::string& name)throw(NutException);
 	virtual std::vector<std::string> getDeviceVariableValue(const std::string& dev, const std::string& name)throw(NutException);
 	virtual std::map<std::string,std::vector<std::string> > getDeviceVariableValues(const std::string& dev)throw(NutException);
+	virtual std::map<std::string,std::map<std::string,std::vector<std::string> > > getDevicesVariableValues(const std::set<std::string>& devs)throw(NutException);
 	virtual void setDeviceVariable(const std::string& dev, const std::string& name, const std::string& value)throw(NutException);
 	virtual void setDeviceVariable(const std::string& dev, const std::string& name, const std::vector<std::string>& values)throw(NutException);
 
@@ -385,12 +392,16 @@ public:
 
 protected:
 	std::string sendQuery(const std::string& req)throw(nut::IOException);
+	void sendAsyncQueries(const std::vector<std::string>& req)throw(IOException);
 	static void detectError(const std::string& req)throw(nut::NutException);
 
 	std::vector<std::string> get(const std::string& subcmd, const std::string& params = "")
 		throw(nut::NutException);
 
 	std::vector<std::vector<std::string> > list(const std::string& subcmd, const std::string& params = "")
+		throw(nut::NutException);
+
+	std::vector<std::vector<std::string> > parseList(const std::string& req)
 		throw(nut::NutException);
 
 	static std::vector<std::string> explode(const std::string& str, size_t begin=0);


### PR DESCRIPTION
A performance bottleneck was identified within the 42ity project, where querying all variable values from 300 ePDUs through upsd and libnutclient took 15 seconds to complete. The new method `TcpClient::getDevicesVariableValues()` allows querying device variable values in bulk, by sending all `LIST VAR` commands ahead of time and then parsing all the results at once. Throughput is vastly improved, with the mega-query completing about 15 times faster.