### PR TITLE
[WIP - DO NOT MERGE] Multiple polling mechanisms support for upsd

### DIFF
--- a/server/Makefile.am
+++ b/server/Makefile.am
@@ -25,6 +25,6 @@ upsd_SOURCES = upsd.c user.c conf.c netssl.c sstate.c desc.c		\
  netget.c netmisc.c netlist.c netuser.c netset.c netinstcmd.c		\
  conf.h nut_ctype.h desc.h netcmds.h neterr.h netget.h netinstcmd.h		\
  netlist.h netmisc.h netset.h netuser.h netssl.h sstate.h stype.h upsd.h   \
- upstype.h user-data.h user.h
+ upstype.h user-data.h user.h poller_poll.c poller.h
 
 sockdebug_SOURCES = sockdebug.c

--- a/server/poller.h
+++ b/server/poller.h
@@ -1,0 +1,71 @@
+/* poller.h - generic poller interface for upsd
+
+   Copyright (C) 2019  Jean-Baptiste Boric <JeanBaptisteBORIC@eaton.com>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
+#ifndef POLLER_H_SEEN
+#define POLLER_H_SEEN
+
+#include "attribute.h"
+
+#include "common.h"
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#include "timehead.h"
+
+#include <sys/file.h>
+
+#include "parseconf.h"
+#include "nut_ctype.h"
+#include "upstype.h"
+
+#ifdef __cplusplus
+/* *INDENT-OFF* */
+extern "C" {
+/* *INDENT-ON* */
+#endif
+
+typedef enum {
+	HANDLER_INVALID = 0,
+	HANDLER_DRIVER,
+	HANDLER_CLIENT,
+	HANDLER_SERVER
+} handler_type_t;
+
+typedef enum {
+	POLLER_EVENT_ERROR,
+	POLLER_EVENT_READY
+} poller_event_t;
+
+extern const char* handler_type_string[];
+
+void poller_register_fd(int fd, handler_type_t type, void *data);
+void poller_unregister_fd(int fd);
+void poller_cleanup(void);
+void poller_reload(void);
+void poller_mainloop(void);
+
+#ifdef __cplusplus
+/* *INDENT-OFF* */
+}
+/* *INDENT-ON* */
+#endif
+
+#endif	/* POLLER_H_SEEN */

--- a/server/poller_epoll.c
+++ b/server/poller_epoll.c
@@ -1,0 +1,146 @@
+/* poller_epoll.c - epoll implementation of poller for Linux
+
+   Copyright (C) 2019  Jean-Baptiste Boric <JeanBaptisteBORIC@eaton.com>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
+#include "upsd.h"
+#include "upstype.h"
+#include "conf.h"
+
+#include "upsconf.h"
+
+#include <sys/epoll.h>
+
+#include "stype.h"
+#include "sstate.h"
+
+typedef struct {
+	handler_type_t	type;
+	void		*data;
+} handler_t;
+
+	/* epollfd */
+	static int			epoll_fd;
+	static struct epoll_event	*events = NULL;
+	static handler_t		*handlers = NULL;
+	static int			num_fds;
+
+void poller_register_fd(int fd, handler_type_t type, void *data)
+{
+	struct epoll_event ev;
+
+	if (fd < maxconn) {
+		ev.events = EPOLLIN;
+		ev.data.fd = fd;
+		if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, fd, &ev) == -1) {
+			upsdebugx(2, "%s: failed to register %s fd %d, call to epoll_ctl() failed", __func__, handler_type_string[type], fd);
+			return;
+		}
+
+		handlers[fd].type = type;
+		handlers[fd].data = data;
+
+		num_fds++;
+
+		upsdebugx(3, "%s: registered %s fd %d", __func__, handler_type_string[type], fd);
+	}
+	else {
+		upsdebugx(2, "%s: failed to register %s fd %d, out of free slots", __func__, handler_type_string[type], fd);
+	}
+}
+
+void poller_unregister_fd(int fd)
+{
+	if (epoll_ctl(epoll_fd, EPOLL_CTL_DEL, fd, NULL) == -1) {
+		upsdebugx(2, "%s: call to epoll_ctl() failed", __func__);
+	}
+	handlers[fd].type = HANDLER_INVALID;
+	upsdebugx(3, "%s: unregistered %s fd %d", __func__, handler_type_string[handlers[fd].type], fd);
+	num_fds--;
+}
+
+void poller_cleanup(void)
+{
+	free(events);
+	free(handlers);
+	close(epoll_fd);
+}
+
+void poller_reload(void)
+{
+	int	ret;
+
+	ret = sysconf(_SC_OPEN_MAX);
+
+	if (ret < maxconn) {
+		fatalx(EXIT_FAILURE,
+			"Your system limits the maximum number of connections to %d\n"
+			"but you requested %d. The server won't start until this\n"
+			"problem is resolved.\n", ret, maxconn);
+	}
+
+	if (!epoll_fd) {
+		epoll_fd = epoll_create1(0);
+		if (epoll_fd == -1) {
+			fatalx(EXIT_FAILURE, "Couldn't allocate epoll file descriptor, can't proceed without one.");
+		}
+	}
+	handlers = xrealloc(handlers, maxconn * sizeof(*handlers));
+	events = xrealloc(events, maxconn * sizeof(*events));
+
+	upsdebugx(3, "%s: set fd limit to %d", __func__, maxconn);
+}
+
+/* service requests and check on new data */
+void poller_mainloop(void)
+{
+	int			i, ret;
+	struct epoll_event	*event;
+	handler_t		*handler;
+	poller_event_t		poller_event;
+
+	poller_tick();
+
+	upsdebugx(2, "%s: epolling %d file descriptors", __func__, num_fds);
+	ret = epoll_wait(epoll_fd, events, maxconn, 2000);
+
+	if (ret == 0) {
+		upsdebugx(2, "%s: no data available", __func__);
+		return;
+	}
+	else if (ret < 0) {
+		upslog_with_errno(LOG_ERR, "%s", __func__);
+		return;
+	}
+
+	for (i = 0; i < ret; i++) {
+		event = &events[i];
+		handler = &handlers[event->data.fd];
+
+		if (event->events & (EPOLLHUP|EPOLLERR)) {
+			poller_event = POLLER_EVENT_ERROR;
+		}
+		else if (event->events & EPOLLIN) {
+			poller_event = POLLER_EVENT_READY;
+		}
+		else {
+			continue;
+		}
+
+		poller_callback(handler->type, handler->data, poller_event, event->data.fd);
+	}
+}

--- a/server/poller_poll.c
+++ b/server/poller_poll.c
@@ -1,0 +1,135 @@
+/* poller_poll.c - poll implementation of poller for Unixes
+
+   Copyright (C) 2019  Jean-Baptiste Boric <JeanBaptisteBORIC@eaton.com>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
+#include "upsd.h"
+#include "upstype.h"
+#include "conf.h"
+
+#include "upsconf.h"
+
+#include <poll.h>
+
+#include "stype.h"
+#include "sstate.h"
+
+typedef struct {
+	handler_type_t	type;
+	void		*data;
+} handler_t;
+
+	/* pollfd */
+	static struct pollfd	*events = NULL;
+	static handler_t	*handlers = NULL;
+	static int		num_fds;
+
+void poller_register_fd(int fd, handler_type_t type, void *data)
+{
+	if (num_fds < maxconn) {
+		events[num_fds].fd = fd;
+		events[num_fds].events = POLLIN;
+
+		handlers[num_fds].type = type;
+		handlers[num_fds].data = data;
+
+		num_fds++;
+
+		upsdebugx(3, "%s: registered %s fd %d", __func__, handler_type_string[type], fd);
+	}
+	else {
+		upsdebugx(2, "%s: failed to register %s fd %d, out of free slots", __func__, handler_type_string[type], fd);
+	}
+}
+
+void poller_unregister_fd(int fd)
+{
+	int	i;
+
+	for (i = 0; i < num_fds; i++) {
+		if (events[i].fd == fd) {
+			upsdebugx(3, "%s: unregistered %s fd %d", __func__, handler_type_string[handlers[i].type], fd);
+			memmove(&events[i], &events[i+1], sizeof(*events) * (num_fds - i - 1));
+			memmove(&handlers[i], &handlers[i+1], sizeof(*handlers) * (num_fds - i - 1));
+			num_fds--;
+			return;
+		}
+	}
+
+	upsdebugx(2, "%s: tried to unregister unknown fd %d", __func__, fd);
+}
+
+void poller_cleanup(void)
+{
+	free(events);
+	free(handlers);
+}
+
+void poller_reload(void)
+{
+	int	ret;
+
+	ret = sysconf(_SC_OPEN_MAX);
+
+	if (ret < maxconn) {
+		fatalx(EXIT_FAILURE,
+			"Your system limits the maximum number of connections to %d\n"
+			"but you requested %d. The server won't start until this\n"
+			"problem is resolved.\n", ret, maxconn);
+	}
+
+	events = xrealloc(events, maxconn * sizeof(*events));
+	handlers = xrealloc(handlers, maxconn * sizeof(*handlers));
+
+	upsdebugx(3, "%s: set fd limit to %d", __func__, maxconn);
+}
+
+/* service requests and check on new data */
+void poller_mainloop(void)
+{
+	int		i, ret;
+	poller_event_t	poller_event;
+
+	poller_tick();
+
+	upsdebugx(2, "%s: polling %d file descriptors", __func__, num_fds);
+
+	ret = poll(events, num_fds, 2000);
+
+	if (ret == 0) {
+		upsdebugx(2, "%s: no data available", __func__);
+		return;
+	}
+	else if (ret < 0) {
+		upslog_with_errno(LOG_ERR, "%s", __func__);
+		return;
+	}
+
+	for (i = 0; i < num_fds; i++) {
+		if (events[i].revents & (POLLHUP|POLLERR|POLLNVAL)) {
+			poller_event = POLLER_EVENT_ERROR;
+		}
+		else if (events[i].revents & POLLIN) {
+			poller_event = POLLER_EVENT_READY;
+		}
+		else {
+			continue;
+		}
+
+		poller_callback(handlers[i].type, handlers[i].data, poller_event, events[i].fd);
+	}
+}

--- a/server/sstate.c
+++ b/server/sstate.c
@@ -25,6 +25,7 @@
 #include "timehead.h"
 
 #include "sstate.h"
+#include "poller.h"
 #include "upstype.h"
 
 #include <fcntl.h>
@@ -218,6 +219,7 @@ int sstate_connect(upstype_t *ups)
 	}
 
 	pconf_init(&ups->sock_ctx, NULL);
+	poller_register_fd(fd, HANDLER_DRIVER, ups);
 
 	ups->dumpdone = 0;
 	ups->stale = 0;
@@ -244,6 +246,7 @@ void sstate_disconnect(upstype_t *ups)
 
 	pconf_finish(&ups->sock_ctx);
 
+	poller_unregister_fd(ups->sock_fd);
 	close(ups->sock_fd);
 	ups->sock_fd = -1;
 }

--- a/server/upsd.h
+++ b/server/upsd.h
@@ -41,7 +41,9 @@
 
 #include "parseconf.h"
 #include "nut_ctype.h"
+#include "stype.h"
 #include "upstype.h"
+#include "poller.h"
 
 #define NUT_NET_ANSWER_MAX SMALLBUF
 
@@ -68,12 +70,22 @@ void server_free(void);
 
 void check_perms(const char *fn);
 
+void client_connect(stype_t *server);
+void client_readline(nut_ctype_t *client);
+void client_disconnect(nut_ctype_t *client);
+void ups_data_stale(upstype_t *ups);
+void ups_data_ok(upstype_t *ups);
+
+void poller_tick();
+void poller_callback(handler_type_t type, void *data, poller_event_t event, int fd);
+
 /* declarations from upsd.c */
 
 extern int		maxage, maxconn;
 extern char		*statepath, *datapath;
 extern upstype_t	*firstups;
 extern nut_ctype_t	*firstclient;
+extern int		reload_flag, exit_flag;
 
 /* map commands onto signals */
 


### PR DESCRIPTION
This is a PoC that allows upsd to use different polling mechanisms for its sockets at compile-time. It provides two polling implementations:
* `poll` for UNIX (current existing mechanism in upsd) ;
* `epoll` for Linux.

`poll` has scaling issues with large file descriptor sets, so it makes sense to use something better if possible. Using the `epoll` implementation on Linux reduces the sys load of upsd a fair bit when there are ~300 sockets to monitor, winnings are expected to scale with number of devices to monitor. Other polling mechanisms can be implemented as required.

This incomplete pull request is meant for @aquette. Notably, GNU autotools magic bits are missing.