### PR TITLE
Upssvc improvements upstreaming

### DIFF
--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 2433 utf-8
+personal_ws-1.1 en 2435 utf-8
 AAS
 ACFAIL
 ACFREQ
@@ -1186,6 +1186,7 @@ apctest
 apcupsd
 aphel
 ar
+arg
 argc
 args
 argv
@@ -2000,6 +2001,7 @@ privProtocol
 probu
 proc
 productid
+prog
 psu
 pw
 pwl

--- a/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
+++ b/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
@@ -1010,7 +1010,26 @@ nut_driver_enumerator_main() {
 
     # Return 42 if there was a change applied succesfully
     # (but e.g. some services should restart - upsd, maybe upsmon)
-    if upslist_equals "$UPSLIST_FILE" "$UPSLIST_SVCS" ; then
+    UPSLIST_EQ_RES=0
+    upslist_equals "$UPSLIST_FILE" "$UPSLIST_SVCS" || UPSLIST_EQ_RES=$?
+
+    # File processing and service startups take a while;
+    # make sure upsconf did not change while we worked...
+    # NOTE: Check this at the last moment to minimize
+    # the chance of still not noticing the change made
+    # at just the wrong moment.
+    UPSCONF_CHECKSUM_END="`calc_md5_file "$UPSCONF"`" || true
+    if [ "$UPSCONF_CHECKSUM_END" != "$UPSCONF_CHECKSUM_START" ] ; then
+        # NOTE: even if daemonized, the sleep between iterations
+        # can be configured into an uncomfortably long lag, so
+        # we should re-sync the system config in any case.
+        echo "`date -u` : '$UPSCONF' changed while $0 $* was processing its older contents; re-running the script to pick up the late-coming changes"
+        ( nut_driver_enumerator_main ) ; return $?
+        # The "main" routine at the end of recursions will
+        # do REPORT_RESTART_42 logic or the error exit-code
+    fi
+
+    if [ "$UPSLIST_EQ_RES" = 0 ] ; then
         echo "`date -u` : OK: No more changes to reconcile between ${SERVICE_FRAMEWORK} service instances and device configurations in '$UPSCONF'"
         [ "${REPORT_RESTART_42-}" = no ] && return 0 || return 42
     fi
@@ -1033,6 +1052,10 @@ daemonize() (
     done
     exit $?
 )
+
+# Save the checksum of ups.conf as early as possible,
+# to test in the end that it is still the same file.
+UPSCONF_CHECKSUM_START="`calc_md5_file "$UPSCONF"`" || true
 
 # By default, update wrapping of devices into services
 if [ $# = 0 ]; then
@@ -1140,10 +1163,26 @@ while [ $# -gt 0 ]; do
 
             # Return 42 if there was a change applied succesfully
             # (but e.g. some services should restart - upsd, maybe upsmon)
-            if upslist_equals "$UPSLIST_FILE" "$UPSLIST_SVCS" ; then
+            UPSLIST_EQ_RES=0
+            upslist_equals "$UPSLIST_FILE" "$UPSLIST_SVCS" || UPSLIST_EQ_RES=$?
+
+            # File processing and service startups take a while;
+            # make sure upsconf did not change while we worked...
+            # NOTE: Check this at the last moment to minimize
+            # the chance of still not noticing the change made
+            # at just the wrong moment.
+            UPSCONF_CHECKSUM_END="`calc_md5_file "$UPSCONF"`" || true
+            if [ "$UPSCONF_CHECKSUM_END" != "$UPSCONF_CHECKSUM_START" ] ; then
+                echo "`date -u` : '$UPSCONF' changed while $0 $* was processing its older contents; re-running the script to pick up the late-coming changes"
+                $0 ; exit $?
+                # The "main" routine will do REPORT_RESTART_42 logic too
+            fi
+
+            if [ "$UPSLIST_EQ_RES" = 0 ] ; then
                 echo "`date -u` : OK: No more changes to reconcile between ${SERVICE_FRAMEWORK} service instances and device configurations in '$UPSCONF'"
                 [ "${REPORT_RESTART_42-}" = no ] && exit 0 || exit 42
             fi
+
             exit 13
             ;;
         --list-devices)

--- a/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
+++ b/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
@@ -162,6 +162,7 @@ UPSLIST_SVCS=""
 # Framework-specific implementations are generally hooked here:
 hook_registerInstance=""
 hook_unregisterInstance=""
+hook_refreshSupervizor=""
 hook_listInstances=""
 hook_listInstances_raw=""
 hook_validInstanceName=""
@@ -176,6 +177,7 @@ case "${SERVICE_FRAMEWORK-}" in
     smf)
         hook_registerInstance="smf_registerInstance"
         hook_unregisterInstance="smf_unregisterInstance"
+        hook_refreshSupervizor="smf_refreshSupervizor"
         hook_listInstances="smf_listInstances"
         hook_listInstances_raw="smf_listInstances_raw"
         hook_validInstanceName="smf_validInstanceName"
@@ -189,6 +191,7 @@ case "${SERVICE_FRAMEWORK-}" in
     systemd)
         hook_registerInstance="systemd_registerInstance"
         hook_unregisterInstance="systemd_unregisterInstance"
+        hook_refreshSupervizor="systemd_refreshSupervizor"
         hook_listInstances="systemd_listInstances"
         hook_listInstances_raw="systemd_listInstances_raw"
         hook_validInstanceName="systemd_validInstanceName"
@@ -202,6 +205,7 @@ case "${SERVICE_FRAMEWORK-}" in
     selftest)
         hook_registerInstance="selftest_NOOP"
         hook_unregisterInstance="selftest_NOOP"
+        hook_refreshSupervizor="selftest_NOOP"
         hook_listInstances="selftest_NOOP"
         hook_listInstances_raw="selftest_NOOP"
         hook_validInstanceName="selftest_NOOP"
@@ -597,6 +601,9 @@ smf_unregisterInstance() {
     /usr/sbin/svcadm disable -ts 'nut-driver:'"$1" || false
     /usr/sbin/svccfg -s nut-driver delete "$1"
 }
+smf_refreshSupervizor() {
+    :
+}
 smf_listInstances_raw() {
     # Newer versions have pattern matching; older SMF might not have this luxury
     /usr/bin/svcs -a -H -o fmri | egrep '/nut-driver:'
@@ -722,6 +729,9 @@ systemd_unregisterInstance() {
     rm -rf "${SYSTEMD_CONFPATH}/nut-driver@$1.service.d"
     /bin/systemctl reset-failed 'nut-driver@'"$1".service
 }
+systemd_refreshSupervizor() {
+    /bin/systemctl daemon-reload
+}
 systemd_listInstances_raw() {
     /bin/systemctl show 'nut-driver@*' -p Id | egrep '=nut-driver' | sed 's,^Id=,,'
 }
@@ -746,7 +756,6 @@ systemd_setSavedMD5() {
 Environment='$PROP=$2'
 EOF
     [ $? = 0 ] && echo "OK" || { echo "FAILED to stash the checksum">&2 ; return 1 ; }
-    /bin/systemctl daemon-reload
 }
 systemd_restart_upsd() {
     # Do not restart/reload if not already running
@@ -989,6 +998,7 @@ nut_driver_enumerator_main() {
     if [ -n "$UPSLIST_FILE" ]; then
         # Add services for sections that are in config file but not yet wrapped
         upslist_addSvcs
+        $hook_refreshSupervizor
         upslist_readSvcs "after checking for new config sections to define service instances"
     fi
 
@@ -1145,6 +1155,10 @@ while [ $# -gt 0 ]; do
 
             # Save new checksum of global config
             $hook_setSavedMD5 "" "`upsconf_getSection_MD5 ""`"
+
+            # Service units were manipulated, including saving of checksums;
+            # refresh the service management daemon if needed
+            $hook_refreshSupervizor
 
             if [ -n "$UPSLIST_SVCS" ] ; then
                 echo "=== The currently defined service instances are:"

--- a/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
+++ b/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
@@ -1034,6 +1034,9 @@ nut_driver_enumerator_main() {
         # can be configured into an uncomfortably long lag, so
         # we should re-sync the system config in any case.
         echo "`date -u` : '$UPSCONF' changed while $0 $* was processing its older contents; re-running the script to pick up the late-coming changes"
+        # Make sure the cycle does not repeat itself due to diffs
+        # from an ages-old state of the file from when we started.
+        UPSCONF_CHECKSUM_START="$UPSCONF_CHECKSUM_END"
         ( nut_driver_enumerator_main ) ; return $?
         # The "main" routine at the end of recursions will
         # do REPORT_RESTART_42 logic or the error exit-code

--- a/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
+++ b/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
@@ -1050,7 +1050,12 @@ nut_driver_enumerator_main() {
 }
 
 daemonize() (
-    trap '-' 1
+    # Support (SIG)HUP == signal code 1 to quickly reconfigure,
+    # e.g. to request it while the sleep is happening or while
+    # "main" is processing an earlier change of the file.
+    RECONFIGURE_ASAP=false
+    trap 'RECONFIGURE_ASAP=true' 1
+
     # Note: this loop would die on errors with config file or
     # inability to ensure that it matches the list of services.
     # If caller did not `export REPORT_RESTART_42=no` then the
@@ -1058,10 +1063,15 @@ daemonize() (
     # of the service which wraps this daemon do topple others that
     # depend on it.
     while nut_driver_enumerator_main ; do
-        sleep $DAEMON_SLEEP &
-        trap "kill $! ; echo 'Sleep interrupted, processing configs now!'>&2" 1
-        wait $!
-        trap '-' 1
+        if $RECONFIGURE_ASAP ; then
+            echo "`date -u` : Trapped a SIGHUP during last run of nut_driver_enumerator_main, repeating reconfiguration quickly" >&2
+        else
+            sleep $DAEMON_SLEEP &
+            trap "kill $! ; echo 'Sleep interrupted, processing configs now!'>&2" 1
+            wait $!
+        fi
+        RECONFIGURE_ASAP=false
+        trap 'RECONFIGURE_ASAP=true' 1
     done
     exit $?
 )

--- a/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
+++ b/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
@@ -508,9 +508,22 @@ upsconf_debug() {
 }
 
 calc_md5() {
+    # Tries several ways to produce an MD5 of the "$1" argument
     _MD5="`echo "$1" | md5sum 2>/dev/null | awk '{print $1}'`" && [ -n "$_MD5" ] || \
     { _MD5="`echo "$1" | openssl dgst -md5 2>/dev/null | awk '{print $NF}'`" && [ -n "$_MD5" ]; } || \
     return 1
+
+    echo "$_MD5"
+}
+
+calc_md5_file() {
+    # Tries several ways to produce an MD5 of the file named by "$1" argument
+    [ -s "$1" ] || return 2
+
+    _MD5="`md5sum 2>/dev/null < "$1" | awk '{print $1}'`" && [ -n "$_MD5" ] || \
+    { _MD5="`openssl dgst -md5 2>/dev/null < "$1" | awk '{print $NF}'`" && [ -n "$_MD5" ]; } || \
+    return 1
+
     echo "$_MD5"
 }
 

--- a/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
+++ b/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
@@ -1062,6 +1062,10 @@ daemonize() (
     # loop would exit with code 42, and probably trigger restart
     # of the service which wraps this daemon do topple others that
     # depend on it.
+    # Note: do not quickly skip the "main" based on full-file
+    # checksum refresh, to ensure that whatever is configured
+    # gets applied (e.g. if user disabled some services or they
+    # died, or some config was not applied due to coding error).
     while nut_driver_enumerator_main ; do
         if $RECONFIGURE_ASAP ; then
             echo "`date -u` : Trapped a SIGHUP during last run of nut_driver_enumerator_main, repeating reconfiguration quickly" >&2


### PR DESCRIPTION
This version should be more robust (than the originally integrated iteration) against editions of `ups.conf` coming in sooner than processing of previous change has completed, by keeping track of whether the file has changed during processing. 

For single-run mode, this still leaves a miniscule window of opportunity for the config file to change and end up unprocessed between the near-end of script where this comparison is made, and the final change of systemd unit status change to not-active (so the state where systemd path-unit trigger would try to activate an already-active unit and so do nothing), so for systems under load or intensively changing the NUT configs, the daemonized mode may be preferable. Maybe the triggering unit can be made smarter later on, w.g. to wait until its victim is not active, or to just wait some arbitrary timeout :\

CC @bigon as the resident systemd expert :)