### PR TITLE
nut-scanner and clients Makefile.am : comments about version-information

### DIFF
--- a/clients/Makefile.am
+++ b/clients/Makefile.am
@@ -51,11 +51,14 @@ if WITH_SSL
   libupsclient_la_LIBADD += $(LIBSSL_LIBS)
 endif
 
-# libupsclient version information
+# Below we set API versions of public libraries
 # http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
+# Note that changes here may have to be reflected in packaging (the shared
+# object .so names would differ)
+
+# libupsclient version information
 libupsclient_la_LDFLAGS = -version-info 4:0:0
 
 # libnutclient version information
 libnutclient_la_SOURCES = nutclient.h nutclient.cpp
 libnutclient_la_LDFLAGS = -version-info 1:0:0
-

--- a/tools/nut-scanner/Makefile.am
+++ b/tools/nut-scanner/Makefile.am
@@ -26,6 +26,13 @@ libnutscan_la_SOURCES = scan_nut.c scan_ipmi.c \
 			../../drivers/bcmxcp_ser.c \
 			../../common/common.c ../../common/str.c
 libnutscan_la_LIBADD = $(NETLIBS) $(LIBLTDL_LIBS)
+#
+# Below we set API versions of public libraries
+# http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
+# Note that changes here may have to be reflected in packaging (the shared
+# object .so names would differ)
+#
+# libnutscan version information
 libnutscan_la_LDFLAGS = $(SERLIBS) -version-info 1:0:0
 libnutscan_la_CFLAGS = -I$(top_srcdir)/clients -I$(top_srcdir)/include $(LIBLTDL_CFLAGS) -I$(top_srcdir)/drivers
 


### PR DESCRIPTION
While NUT itself currently does not provide packaging recipes, or at least not those so hardcoded to be directly impacted by the change in #652, these comments would serve to remind developers also associated with OS packaging distributions that changes in the `-version-info` parameter can have far-reaching effects.

Also these can serve as a reminder to somehow "macroize" and automate setting and finding the shared library versions, so the makefiles in NUT codebase and the consuming packaging recipes elsewhere can have a reliable contract to exchange this data.