### PR TITLE
Problem: OpenBSD mktemp complains on short pattern

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -148,8 +148,8 @@ dnl We need to relative-symlink some files. Or hardlink. Or copy...
 LN_S_R="cp -pR"
 if test "$as_ln_s" = "ln -s" ; then
     LN_S_R="ln"
-    DIR1="$(mktemp -d "dir1.XXXXX")" && \
-    DIR2="$(mktemp -d "dir2.XXXXX")" && \
+    DIR1="$(mktemp -d "dir1.XXXXXXX")" && \
+    DIR2="$(mktemp -d "dir2.XXXXXXX")" && \
     touch "${DIR1}/a" && \
     $as_ln_s -r "${DIR1}/a" "${DIR2}/b" && \
     ls -la "${DIR2}/b" | grep '\.\./' > /dev/null && \


### PR DESCRIPTION
Solution: bump from XXXXX to XXXXXXX which did not complain in another part of the configure script

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>

Example errors here : http://buildbot.networkupstools.org/public/nut/builders/OpenBSD-x64/builds/579/steps/compile/logs/stdio and recently here : http://buildbot.networkupstools.org/public/nut/builders/OpenBSD-x64/builds/706/steps/configure/logs/stdio

````
...
checking for strptime... yes
checking for setlogmask... yes
checking whether LOG_UPTO is declared... yes

checking whether ln -sr works... mktemp: insufficient number of Xs in template `dir1.XXXXX'
no, using ln

checking for unsigned long long int... yes
checking for vsnprintf... yes
...
````