### PR TITLE
Introduce shell script syntax checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,6 +105,7 @@ matrix:
         packages:
         - coreutils
         - file
+        #TBD# - shellcheck
   - env: BUILD_TYPE=default-tgt:distcheck-valgrind
     os: linux
     sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,13 @@ matrix:
         packages: &deps_aspell
         - aspell
         - aspell-en
+  - env: BUILD_TYPE=default-shellcheck
+    os: linux
+    addons:
+      apt:
+        packages:
+        - coreutils
+        - file
   - env: BUILD_TYPE=default-tgt:distcheck-valgrind
     os: linux
     sudo: false

--- a/Makefile.am
+++ b/Makefile.am
@@ -59,7 +59,7 @@ doc spellcheck-sortdict:
 
 # This target adds syntax-checking for committed shell script files,
 # to avoid surprises and delays in finding fatal typos after packaging
-check-scripts-syntax shellcheck:
+check-scripts-syntax:
 	@echo 'NOTE: modern bash complains about scripts using backticks (which we ignore for portability reasons): `...` obsolete, use $(...)'
 	for F in `git ls-files || find . -type f` ; do \
 	    case "`file "$$F"`" in \
@@ -68,6 +68,15 @@ check-scripts-syntax shellcheck:
 	    esac || { RES=$$? ; echo "ERROR: Syntax check failed for script file: $$F" >&2 ; exit $$RES ; } ; \
 	done
 	@echo 'SUCCESS: Shell scripts syntax is acceptable, no fatal issues were found'
+
+shellcheck-disclaimer:
+	@echo "==============================================================================="
+	@echo "NOTICE: 'make shellcheck' is currently an alias for 'make check-scripts-syntax'"
+	@echo "Later it may become a call to the real shellcheck tool (if available on the"
+	@echo "build system during the configure phase)"
+	@echo "==============================================================================="
+
+shellcheck: shellcheck-disclaimer check-scripts-syntax
 
 # ----------------------------------------------------------------------
 # Automatically generate the ChangeLog from Git logs:

--- a/Makefile.am
+++ b/Makefile.am
@@ -69,8 +69,6 @@ check-scripts-syntax shellcheck:
 	done
 	@echo 'SUCCESS: Shell scripts syntax is acceptable, no fatal issues were found'
 
-check-local: check-scripts-syntax spellcheck
-
 # ----------------------------------------------------------------------
 # Automatically generate the ChangeLog from Git logs:
 MAINTAINERCLEAN_FILES = ChangeLog

--- a/Makefile.am
+++ b/Makefile.am
@@ -59,6 +59,16 @@ doc spellcheck-sortdict:
 
 # This target adds syntax-checking for committed shell script files,
 # to avoid surprises and delays in finding fatal typos after packaging
+###
+### Note: currently, shellcheck target calls check-scripts-syntax
+### so when both are invoked at once, in the end the check is only
+### executed once. Later it is anticipated that shellcheck would
+### be implemented by requiring, configuring and calling the tool
+### named "shellcheck" for even more code inspection and details.
+### Still, there remains value in also checking the script syntax
+### by the very version of the shell interpreter that would run
+### these scripts in production usage of the resulting packages.
+###
 check-scripts-syntax:
 	@echo 'NOTE: modern bash complains about scripts using backticks (warning not error), which we ignore in NUT codebase for portability reasons: `...` obsolete, use $$(...)'
 	for F in `git ls-files || find . -type f` ; do \

--- a/Makefile.am
+++ b/Makefile.am
@@ -60,7 +60,7 @@ doc spellcheck-sortdict:
 # This target adds syntax-checking for committed shell script files,
 # to avoid surprises and delays in finding fatal typos after packaging
 check-scripts-syntax:
-	@echo 'NOTE: modern bash complains about scripts using backticks (which we ignore for portability reasons): `...` obsolete, use $(...)'
+	@echo 'NOTE: modern bash complains about scripts using backticks (warning not error), which we ignore in NUT codebase for portability reasons: `...` obsolete, use $$(...)'
 	for F in `git ls-files || find . -type f` ; do \
 	    case "`file "$$F"`" in \
 	        *"Bourne-Again shell script"*) ( set -x ; /bin/bash -n "$$F" ; ) ;; \

--- a/Makefile.am
+++ b/Makefile.am
@@ -57,6 +57,20 @@ spellcheck spellcheck-interactive:
 doc spellcheck-sortdict:
 	cd $(srcdir)/docs && $(MAKE) $@
 
+# This target adds syntax-checking for committed shell script files,
+# to avoid surprises and delays in finding fatal typos after packaging
+check-scripts-syntax shellcheck:
+	@echo 'NOTE: modern bash complains about scripts using backticks (which we ignore for portability reasons): `...` obsolete, use $(...)'
+	for F in `git ls-files || find . -type f` ; do \
+	    case "`file "$$F"`" in \
+	        *"Bourne-Again shell script"*) ( set -x ; /bin/bash -n "$$F" ; ) ;; \
+	        *"POSIX shell script"*|*"shell script"*) ( set -x ; /bin/sh -n "$$F" ; ) ;; \
+	    esac || { RES=$$? ; echo "ERROR: Syntax check failed for script file: $$F" >&2 ; exit $$RES ; } ; \
+	done
+	@echo 'SUCCESS: Shell scripts syntax is acceptable, no fatal issues were found'
+
+check-local: check-scripts-syntax spellcheck
+
 # ----------------------------------------------------------------------
 # Automatically generate the ChangeLog from Git logs:
 MAINTAINERCLEAN_FILES = ChangeLog

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -25,7 +25,7 @@ case "$CI_TRACE" in
 esac
 
 case "$BUILD_TYPE" in
-default|default-alldrv|default-spellcheck|default-nodoc|default-withdoc|"default-tgt:"*)
+default|default-alldrv|default-spellcheck|default-shellcheck|default-nodoc|default-withdoc|"default-tgt:"*)
     LANG=C
     LC_ALL=C
     export LANG LC_ALL
@@ -111,7 +111,7 @@ default|default-alldrv|default-spellcheck|default-nodoc|default-withdoc|"default
             CONFIG_OPTS+=("--with-doc=no")
             DO_DISTCHECK=no
             ;;
-        "default-spellcheck")
+        "default-spellcheck"|"default-shellcheck")
             CONFIG_OPTS+=("--with-all=no")
             CONFIG_OPTS+=("--with-libltdl=no")
             CONFIG_OPTS+=("--with-doc=man=skip")
@@ -226,6 +226,11 @@ default|default-alldrv|default-spellcheck|default-nodoc|default-withdoc|"default
             # sub-Makefiles known to check corresponding directory's doc files.
             ( $CI_TIME make VERBOSE=1 SPELLCHECK_ERROR_FATAL=yes spellcheck )
             exit 0
+            ;;
+        "default-shellcheck")
+            [ -z "$CI_TIME" ] || echo "`date`: Trying to check shell script syntax validity of the currently tested project..."
+            ( $CI_TIME make VERBOSE=1 shellcheck )
+            exit $?
             ;;
     esac
 

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -115,6 +115,7 @@ default|default-alldrv|default-spellcheck|default-shellcheck|default-nodoc|defau
             CONFIG_OPTS+=("--with-all=no")
             CONFIG_OPTS+=("--with-libltdl=no")
             CONFIG_OPTS+=("--with-doc=man=skip")
+            #TBD# CONFIG_OPTS+=("--with-shellcheck=yes")
             DO_DISTCHECK=no
             ;;
         "default-withdoc")

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -230,7 +230,15 @@ default|default-alldrv|default-spellcheck|default-shellcheck|default-nodoc|defau
             ;;
         "default-shellcheck")
             [ -z "$CI_TIME" ] || echo "`date`: Trying to check shell script syntax validity of the currently tested project..."
-            ( $CI_TIME make VERBOSE=1 shellcheck )
+            ### Note: currently, shellcheck target calls check-scripts-syntax
+            ### so when both are invoked at once, in the end the check is only
+            ### executed once. Later it is anticipated that shellcheck would
+            ### be implemented by requiring, configuring and calling the tool
+            ### named "shellcheck" for even more code inspection and details.
+            ### Still, there remains value in also checking the script syntax
+            ### by the very version of the shell interpreter that would run
+            ### these scripts in production usage of the resulting packages.
+            ( $CI_TIME make VERBOSE=1 shellcheck check-scripts-syntax )
             exit $?
             ;;
     esac


### PR DESCRIPTION
It is annoying to find foolish typos like quotation mark mismatch after spending time to build a package... so this should happen no longer :)

NOTE: This is in the end not part of common required `check-local` because tools for this activity (like `file`) may be missing on an arbitrary system and should not block builds there. Maybe this can be extended by a `configure` check later on.

For good output, see e.g. https://travis-ci.org/networkupstools/nut/jobs/503591138

And a staged example failure at https://travis-ci.org/jimklimov/nut/jobs/503593246#L924 :
````
...
+/bin/sh -n tests/nut-driver-enumerator-test.sh
tests/nut-driver-enumerator-test.sh: 318: tests/nut-driver-enumerator-test.sh: Syntax error: newline unexpected (expecting ")")
ERROR: Syntax check failed for script file: tests/nut-driver-enumerator-test.sh
make: *** [shellcheck] Error 2
Command exited with non-zero status 2
````