### PR TITLE
cyberpower-mib: Add shutdown capability and other instant commands

### DIFF
--- a/drivers/cyberpower-mib.c
+++ b/drivers/cyberpower-mib.c
@@ -111,6 +111,25 @@ static snmp_info_t cyberpower_mib[] = {
 	{ "output.voltage", 0, 0.1, ".1.3.6.1.4.1.3808.1.1.1.4.2.1.0", "",
 		0, NULL },
 
+	/* instant commands. */
+	/* upsAdvanceControlUpsOff */
+	{ "load.off", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.6.2.1.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	/* upsAdvanceControlTurnOnUPS */
+	{ "load.on", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.6.2.6.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	/* upsAdvanceControlUpsOff */
+	{ "shutdown.stayoff", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.6.2.6.0", "3", SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	/* upsBaseControlConserveBattery */
+	{ "shutdown.return", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.6.1.1.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	/* upsAdvanceControlSimulatePowerFail */
+	{ "test.failure.start", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.6.2.4.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	/* upsAdvanceTestIndicators */
+	{ "test.panel.start", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.7.2.5.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	/* upsAdvanceTestDiagnostics */
+	{ "test.battery.start", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.7.2.2.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	/* upsAdvanceTestRuntimeCalibration */
+	{ "calibrate.start", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.7.2.6.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "calibrate.stop", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.7.2.6.0", "3", SU_TYPE_CMD | SU_FLAG_OK, NULL },
+
 	/* end of structure. */
 	{ NULL, 0, 0, NULL, NULL, 0, NULL }
 } ;

--- a/drivers/cyberpower-mib.c
+++ b/drivers/cyberpower-mib.c
@@ -90,8 +90,8 @@ static snmp_info_t cyberpower_mib[] = {
 	{ "ups.load", 0, 1.0, ".1.3.6.1.4.1.3808.1.1.1.4.2.3.0", "",
 		0, NULL },
 
-	/* Battery runtime is expressed in minutes */
-	{ "battery.runtime", 0, 60.0, ".1.3.6.1.4.1.3808.1.1.1.2.2.4.0", "",
+	/* Battery runtime is expressed in seconds */
+	{ "battery.runtime", 0, 1.0, ".1.3.6.1.4.1.3808.1.1.1.2.2.4.0", "",
 		0, NULL },
 	/* The elapsed time in seconds since the
 	 * UPS has switched to battery power */

--- a/drivers/cyberpower-mib.c
+++ b/drivers/cyberpower-mib.c
@@ -125,22 +125,22 @@ static snmp_info_t cyberpower_mib[] = {
 		SU_FLAG_OK | SU_TYPE_TIME, NULL },
 	/* instant commands. */
 	/* upsAdvanceControlUpsOff */
-	{ "load.off", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.6.2.1.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "load.off", 0, 2, ".1.3.6.1.4.1.3808.1.1.1.6.2.1.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
 	/* upsAdvanceControlTurnOnUPS */
-	{ "load.on", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.6.2.6.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "load.on", 0, 2, ".1.3.6.1.4.1.3808.1.1.1.6.2.6.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
 	/* upsAdvanceControlUpsOff */
-	{ "shutdown.stayoff", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.6.2.6.0", "3", SU_TYPE_CMD | SU_FLAG_OK, NULL },
-	/* upsBaseControlConserveBattery */
-	{ "shutdown.return", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.6.1.1.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "shutdown.stayoff", 0, 3, ".1.3.6.1.4.1.3808.1.1.1.6.2.6.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	/* upsAdvanceControlUpsSleep */
+	{ "shutdown.return", 0, 3, ".1.3.6.1.4.1.3808.1.1.1.6.2.3.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
 	/* upsAdvanceControlSimulatePowerFail */
-	{ "test.failure.start", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.6.2.4.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "test.failure.start", 0, 2, ".1.3.6.1.4.1.3808.1.1.1.6.2.4.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
 	/* upsAdvanceTestIndicators */
-	{ "test.panel.start", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.7.2.5.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "test.panel.start", 0, 2, ".1.3.6.1.4.1.3808.1.1.1.7.2.5.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
 	/* upsAdvanceTestDiagnostics */
-	{ "test.battery.start", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.7.2.2.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "test.battery.start", 0, 2, ".1.3.6.1.4.1.3808.1.1.1.7.2.2.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
 	/* upsAdvanceTestRuntimeCalibration */
-	{ "calibrate.start", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.7.2.6.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
-	{ "calibrate.stop", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.7.2.6.0", "3", SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "calibrate.start", 0, 2, ".1.3.6.1.4.1.3808.1.1.1.7.2.6.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "calibrate.stop", 0, 3, ".1.3.6.1.4.1.3808.1.1.1.7.2.6.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
 
 	/* end of structure. */
 	{ NULL, 0, 0, NULL, NULL, 0, NULL }

--- a/drivers/cyberpower-mib.c
+++ b/drivers/cyberpower-mib.c
@@ -33,11 +33,11 @@
 static info_lkp_t cyberpower_power_status[] = {
 	{ 2, "OL" },
 	{ 3, "OB" },
-	{ 4, "OL" },
-	{ 5, "OL" },
+	{ 4, "OL BOOST" },
+	{ 5, "OFF" },
 	{ 7, "OL" },
 	{ 1, "NULL" },
-	{ 6, "NULL" },
+	{ 6, "OFF" },
 	{ 0, NULL }
 } ;
 

--- a/drivers/cyberpower-mib.c
+++ b/drivers/cyberpower-mib.c
@@ -125,22 +125,22 @@ static snmp_info_t cyberpower_mib[] = {
 		SU_FLAG_OK | SU_TYPE_TIME, NULL },
 	/* instant commands. */
 	/* upsAdvanceControlUpsOff */
-	{ "load.off", 0, 2, ".1.3.6.1.4.1.3808.1.1.1.6.2.1.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "load.off", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.6.2.1.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
 	/* upsAdvanceControlTurnOnUPS */
-	{ "load.on", 0, 2, ".1.3.6.1.4.1.3808.1.1.1.6.2.6.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "load.on", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.6.2.6.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
 	/* upsAdvanceControlUpsOff */
-	{ "shutdown.stayoff", 0, 3, ".1.3.6.1.4.1.3808.1.1.1.6.2.6.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
-	/* upsAdvanceControlUpsSleep */
-	{ "shutdown.return", 0, 3, ".1.3.6.1.4.1.3808.1.1.1.6.2.3.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "shutdown.stayoff", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.6.2.6.0", "3", SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	/* upsBaseControlConserveBattery */
+	{ "shutdown.return", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.6.1.1.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
 	/* upsAdvanceControlSimulatePowerFail */
-	{ "test.failure.start", 0, 2, ".1.3.6.1.4.1.3808.1.1.1.6.2.4.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "test.failure.start", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.6.2.4.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
 	/* upsAdvanceTestIndicators */
-	{ "test.panel.start", 0, 2, ".1.3.6.1.4.1.3808.1.1.1.7.2.5.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "test.panel.start", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.7.2.5.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
 	/* upsAdvanceTestDiagnostics */
-	{ "test.battery.start", 0, 2, ".1.3.6.1.4.1.3808.1.1.1.7.2.2.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "test.battery.start", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.7.2.2.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
 	/* upsAdvanceTestRuntimeCalibration */
-	{ "calibrate.start", 0, 2, ".1.3.6.1.4.1.3808.1.1.1.7.2.6.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
-	{ "calibrate.stop", 0, 3, ".1.3.6.1.4.1.3808.1.1.1.7.2.6.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "calibrate.start", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.7.2.6.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "calibrate.stop", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.7.2.6.0", "3", SU_TYPE_CMD | SU_FLAG_OK, NULL },
 
 	/* end of structure. */
 	{ NULL, 0, 0, NULL, NULL, 0, NULL }

--- a/drivers/cyberpower-mib.c
+++ b/drivers/cyberpower-mib.c
@@ -114,22 +114,22 @@ static snmp_info_t cyberpower_mib[] = {
 
 	/* instant commands. */
 	/* upsAdvanceControlUpsOff */
-	{ "load.off", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.6.2.1.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "load.off", 0, 2, ".1.3.6.1.4.1.3808.1.1.1.6.2.1.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
 	/* upsAdvanceControlTurnOnUPS */
-	{ "load.on", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.6.2.6.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "load.on", 0, 2, ".1.3.6.1.4.1.3808.1.1.1.6.2.6.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
 	/* upsAdvanceControlUpsOff */
-	{ "shutdown.stayoff", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.6.2.6.0", "3", SU_TYPE_CMD | SU_FLAG_OK, NULL },
-	/* upsBaseControlConserveBattery */
-	{ "shutdown.return", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.6.1.1.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "shutdown.stayoff", 0, 3, ".1.3.6.1.4.1.3808.1.1.1.6.2.6.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	/* upsAdvanceControlUpsSleep */
+	{ "shutdown.return", 0, 3, ".1.3.6.1.4.1.3808.1.1.1.6.2.3.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
 	/* upsAdvanceControlSimulatePowerFail */
-	{ "test.failure.start", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.6.2.4.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "test.failure.start", 0, 2, ".1.3.6.1.4.1.3808.1.1.1.6.2.4.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
 	/* upsAdvanceTestIndicators */
-	{ "test.panel.start", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.7.2.5.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "test.panel.start", 0, 2, ".1.3.6.1.4.1.3808.1.1.1.7.2.5.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
 	/* upsAdvanceTestDiagnostics */
-	{ "test.battery.start", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.7.2.2.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "test.battery.start", 0, 2, ".1.3.6.1.4.1.3808.1.1.1.7.2.2.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
 	/* upsAdvanceTestRuntimeCalibration */
-	{ "calibrate.start", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.7.2.6.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
-	{ "calibrate.stop", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.7.2.6.0", "3", SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "calibrate.start", 0, 2, ".1.3.6.1.4.1.3808.1.1.1.7.2.6.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "calibrate.stop", 0, 3, ".1.3.6.1.4.1.3808.1.1.1.7.2.6.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
 
 	/* end of structure. */
 	{ NULL, 0, 0, NULL, NULL, 0, NULL }

--- a/drivers/cyberpower-mib.c
+++ b/drivers/cyberpower-mib.c
@@ -27,7 +27,8 @@
 #define CYBERPOWER_MIB_VERSION		"0.2"
 #define CYBERPOWER_OID_MODEL_NAME	".1.3.6.1.4.1.3808.1.1.1.1.1.1.0"
 
-#define CYBERPOWER_SYSOID			".1.3.6.1.4.1.3808"
+/* CPS-MIB::ups */
+#define CYBERPOWER_SYSOID			".1.3.6.1.4.1.3808.1.1.1"
 
 static info_lkp_t cyberpower_power_status[] = {
 	{ 2, "OL" },

--- a/drivers/cyberpower-mib.c
+++ b/drivers/cyberpower-mib.c
@@ -115,13 +115,13 @@ static snmp_info_t cyberpower_mib[] = {
 	/* Delays affecting instant commands */
 
 	/* upsAdvanceConfigReturnDelay */
-	{ "ups.delay.start", ST_FLAG_RW, 1.0, ".1.3.6.1.4.1.3808.1.1.1.5.2.9", "0",
+	{ "ups.delay.start", ST_FLAG_RW, 1.0, ".1.3.6.1.4.1.3808.1.1.1.5.2.9.0", "0",
 		SU_FLAG_OK | SU_TYPE_TIME, NULL },
 	/* Not provided by CPS-MIB */
 	{ "ups.delay.reboot", 0, 1.0, NULL, "0",
 		SU_FLAG_OK | SU_FLAG_ABSENT, NULL },
 	/* upsAdvanceConfigSleepDelay */
-	{ "ups.delay.shutdown", ST_FLAG_RW, 1.0, ".1.3.6.1.4.1.3808.1.1.1.5.2.11", "60",
+	{ "ups.delay.shutdown", ST_FLAG_RW, 1.0, ".1.3.6.1.4.1.3808.1.1.1.5.2.11.0", "60",
 		SU_FLAG_OK | SU_TYPE_TIME, NULL },
 	/* instant commands. */
 	/* upsAdvanceControlUpsOff */

--- a/drivers/cyberpower-mib.c
+++ b/drivers/cyberpower-mib.c
@@ -40,6 +40,26 @@ static info_lkp_t cyberpower_power_status[] = {
 	{ 0, NULL }
 } ;
 
+static info_lkp_t cyberpower_battery_status[] = {
+	{ 1, "" },	/* unknown */
+	{ 2, "" },	/* batteryNormal */
+	{ 3, "LB" },	/* batteryLow */
+	{ 0, NULL }
+} ;
+
+static info_lkp_t cyberpower_cal_status[] = {
+	{ 1, "" },          /* Calibration Successful */
+	{ 2, "" },          /* Calibration Invalid */
+	{ 3, "CAL" },       /* Calibration in progress */
+	{ 0, NULL }
+};
+
+static info_lkp_t cyberpower_battrepl_status[] = {
+	{ 1, "" },          /* No battery needs replacing */
+	{ 2, "RB" },        /* Batteries need to be replaced */
+	{ 0, NULL }
+};
+
 /* Snmp2NUT lookup table for CyberPower MIB */
 static snmp_info_t cyberpower_mib[] = {
 	/* Device page */
@@ -59,7 +79,13 @@ static snmp_info_t cyberpower_mib[] = {
 		0, NULL },
 
 	{ "ups.status", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.3808.1.1.1.4.1.1.0", "",
-		0 /*SU_STATUS_PWR*/, &cyberpower_power_status[0] },
+		SU_FLAG_OK | SU_STATUS_PWR, &cyberpower_power_status[0] },
+	{ "ups.status", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.3808.1.1.1.2.1.1.0", "",
+		SU_FLAG_OK | SU_STATUS_BATT, &cyberpower_battery_status[0] },
+	{ "ups.status", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.3808.1.1.1.7.2.7.0", "",
+		SU_FLAG_OK | SU_STATUS_CAL, &cyberpower_cal_status[0] },
+	{ "ups.status", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.3808.1.1.1.2.2.5.0", "",
+		SU_FLAG_OK | SU_STATUS_RB, &cyberpower_battrepl_status[0] },
 	{ "ups.load", 0, 1.0, ".1.3.6.1.4.1.3808.1.1.1.4.2.3.0", "",
 		0, NULL },
 

--- a/drivers/cyberpower-mib.c
+++ b/drivers/cyberpower-mib.c
@@ -112,6 +112,17 @@ static snmp_info_t cyberpower_mib[] = {
 	{ "output.voltage", 0, 0.1, ".1.3.6.1.4.1.3808.1.1.1.4.2.1.0", "",
 		0, NULL },
 
+	/* Delays affecting instant commands */
+
+	/* upsAdvanceConfigReturnDelay */
+	{ "ups.delay.start", ST_FLAG_RW, 1.0, ".1.3.6.1.4.1.3808.1.1.1.5.2.9", "0",
+		SU_FLAG_OK | SU_TYPE_TIME, NULL },
+	/* Not provided by CPS-MIB */
+	{ "ups.delay.reboot", 0, 1.0, NULL, "0",
+		SU_FLAG_OK | SU_FLAG_ABSENT, NULL },
+	/* upsAdvanceConfigSleepDelay */
+	{ "ups.delay.shutdown", ST_FLAG_RW, 1.0, ".1.3.6.1.4.1.3808.1.1.1.5.2.11", "60",
+		SU_FLAG_OK | SU_TYPE_TIME, NULL },
 	/* instant commands. */
 	/* upsAdvanceControlUpsOff */
 	{ "load.off", 0, 2, ".1.3.6.1.4.1.3808.1.1.1.6.2.1.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },


### PR DESCRIPTION
## Shutdown commands:
1. `shutdown.return`
1. `shutdown.stayoff`

### Related variables
1. `ups.delay.start`
1. `ups.delay.shutdown`
    * CyberPower's CPS-MIB provides different delay values for return vs stayoff. I am using the return (aka sleep) value, because that is the more common use case.
1. `ups.delay.reboot`
    * Not supported by CPS-MIB but the subdriver reports as 0, because that is the de facto default for CyberPower.

## Other Commands
1. `load.off/on`
1. `test.failure.start`
1. `test.panel.start`
1. `test.battery.start`
1. `calibrate.start/stop`

## Also fixed
* `sysOID` was CyberPower's enterprise OID, not what the UPS RMCARDxxx returns, which is `CPS-MIB::ups` (*CyberPower_enterprise_OID*.1.1.1)
* `ups.status` is more informative
    1. Reports BOOST
    1. Reports RB (replace battery)
    1. Reports CAL (calibration in progress)
* `battery.runtime` now returns the correct units for upsd (seconds not minutes)