### PR TITLE
configure.ac : fix mismatched usage of have_cxx11 envvar

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1330,10 +1330,11 @@ dnl # Could use `AX_CXX_COMPILE_STDCXX_11([noext], [optional])` if it were
 dnl # available everywhere. Or AX_CHECK_COMPILE_FLAG if it was ubiquitous:
 dnl ###AX_CHECK_COMPILE_FLAG([-std=c++11],
 dnl ###    [CXXFLAGS="$CXXFLAGS -std=c++11"
-dnl ###     have_cxx11=1],
-dnl ###    [have_cxx11=0])
+dnl ###     have_cxx11=yes],
+dnl ###    [have_cxx11=no])
 
 AC_MSG_CHECKING(for C++11 support in current compiler)
+have_cxx11=unknown
 my_CXXFLAGS="$CXXFLAGS"
 AC_LANG_PUSH([C++])
 
@@ -1347,18 +1348,18 @@ CPLUSPLUS_MAIN='printf("%ld\n", __cplusplus);'
 
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[${CPLUSPLUS_DECL}]], [[${CPLUSPLUS_MAIN}]])],
     [AC_MSG_RESULT([yes, out of the box])
-     have_cxx11=1],
+     have_cxx11=yes],
     [CXXFLAGS="$CXXFLAGS -std=c++11"
      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[${CPLUSPLUS_DECL}]], [[${CPLUSPLUS_MAIN}]])],
         [AC_MSG_RESULT([yes, GCC-style (as C++11)])
-         have_cxx11=1],
+         have_cxx11=yes],
         [CXXFLAGS="$CXXFLAGS -std=c++0x"
          AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[${CPLUSPLUS_DECL}]], [[${CPLUSPLUS_MAIN}]])],
             [AC_MSG_RESULT([yes, GCC-style (as C++0X)])
-             have_cxx11=1],
+             have_cxx11=yes],
             [AC_MSG_RESULT([no])
              CXXFLAGS="$my_CXXFLAGS"
-             have_cxx11=0])])])
+             have_cxx11=no])])])
 AM_CONDITIONAL(HAVE_CXX11, test "${have_cxx11}" = "yes")
 AC_LANG_POP([C++])
 unset CPLUSPLUS_MAIN
@@ -1367,7 +1368,7 @@ unset CPLUSPLUS_DECL
 have_cppunit="no"
 CPPUNIT_NUT_CXXFLAGS=""
 AS_IF([test x"$have_PKG_CONFIG" = xyes],
-    [AS_IF([test "${have_cxx11}" = 1],
+    [AS_IF([test x"${have_cxx11}" = xyes],
         [PKG_CHECK_MODULES(CPPUNIT, cppunit, have_cppunit=yes, have_cppunit=no)
          AS_IF([test "${have_cppunit}" != "yes"],
             [AC_MSG_WARN([libcppunit not found - those C++ tests will not be built.])


### PR DESCRIPTION
/me bad, foolish typo... hid for log...