### PR TITLE
Fix for Ferrups FE7000 "off" command

### DIFF
--- a/drivers/bestfcom.c
+++ b/drivers/bestfcom.c
@@ -444,7 +444,7 @@ void upsdrv_shutdown(void)
 {
 	/* NB: hard-wired password */
 	ser_send(upsfd, "pw377\r");
-	ser_send(upsfd, "off 1 a\r");	/* power off in 1 second and restart when line power returns */
+	ser_send(upsfd, "o 10 a\r");	/* power off in 10 seconds and restart when line power returns, FE7K required a min of 5 seconds for off to function */
 }
 
 /* list flags and values that you want to receive via -x */


### PR DESCRIPTION
"off" command for FE7000 required at least 5 seconds for the command to be accepted.  

Also should match the off with autostart or "o" with "a" to be consistent with the manual: https://www.eaton.com/content/dam/eaton/products/backup-power-ups-surge-it-power-distribution/backup-power-ups/eaton-ferrups-tower-ups/eaton-ferrups-FE-QFE-userguide-.pdf  (o [time] a is how the manual references the "short" command)