### PR TITLE
common.c : BUILD_64 not detected in some distros, needs stdint.h

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -38,6 +38,7 @@ const char *UPS_VERSION = NUT_VERSION_MACRO;
 
 /* Know which bitness we were built for,
  * to adjust the search paths for get_libname() */
+#include "nut_stdint.h"
 #if UINTPTR_MAX == 0xffffffffffffffffULL
 # define BUILD_64   1
 #endif


### PR DESCRIPTION
A small typo with big consequences. Thanks to colleagues with a zoo of distros for helping notice this.