### PR TITLE
Problem: Attempts to start a nut-driver@bogusname actually run …

### DIFF
--- a/scripts/Solaris/nut-driver.xml.in
+++ b/scripts/Solaris/nut-driver.xml.in
@@ -2,14 +2,14 @@
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <!--
 #
-# Copyright 2016-2017 Jim Klimov
+# Copyright 2016 - 2019 Jim Klimov
 # Template manifest for instantiated NUT drivers
 #
 -->
 
 <service_bundle type='manifest' name='nut-driver'>
 
-	<service name='system/power/nut-driver' type='service' version='1'>
+	<service name='system/power/nut-driver' type='service' version='1.1'>
 
 	<!--
 	  Wait for all local and usr filesystem to be mounted - project is
@@ -85,13 +85,13 @@
 		<exec_method
 		type='method'
 		name='start'
-		exec='@SBINDIR@/upsdrvctl %m `@NUT_LIBEXECDIR@/nut-driver-enumerator.sh --get-device-for-service %i`'
+		exec='/sbin/sh -c &apos;NUTDEV="`@NUT_LIBEXECDIR@/nut-driver-enumerator.sh --get-device-for-service %i`" &amp;&amp; [ -n "$NUTDEV" ] || { echo "FATAL: Could not find a NUT device section for service unit %i" >&amp;2 ; exit 1 ; } ; @SBINDIR@/upsdrvctl %m "$NUTDEV"&apos;'
 		timeout_seconds='0'/>
 
 		<exec_method
 		type='method'
 		name='stop'
-		exec='@SBINDIR@/upsdrvctl %m `@NUT_LIBEXECDIR@/nut-driver-enumerator.sh --get-device-for-service %i`'
+		exec='/sbin/sh -c &apos;NUTDEV="`@NUT_LIBEXECDIR@/nut-driver-enumerator.sh --get-device-for-service %i`" &amp;&amp; [ -n "$NUTDEV" ] || { echo "FATAL: Could not find a NUT device section for service unit %i" >&amp;2 ; exit 1 ; } ; @SBINDIR@/upsdrvctl %m "$NUTDEV"&apos;'
 		timeout_seconds='60' />
 
 		<property_group name='startd' type='framework'>

--- a/scripts/systemd/nut-driver@.service.in
+++ b/scripts/systemd/nut-driver@.service.in
@@ -25,8 +25,8 @@ PartOf=nut-driver.target
 # Finally note that "nut-driver-enumerator.service" should take care of this.
 
 [Service]
-ExecStart=/bin/sh -c "@SBINDIR@/upsdrvctl start `@NUT_LIBEXECDIR@/nut-driver-enumerator.sh --get-device-for-service %i`"
-ExecStop=/bin/sh -c "@SBINDIR@/upsdrvctl stop `@NUT_LIBEXECDIR@/nut-driver-enumerator.sh --get-device-for-service %i`"
+ExecStart=/bin/sh -c 'NUTDEV="`@NUT_LIBEXECDIR@/nut-driver-enumerator.sh --get-device-for-service %i`" && [ -n "$NUTDEV" ] || { echo "FATAL: Could not find a NUT device section for service unit %i" >&2 ; exit 1 ; } ; /sbin/upsdrvctl start "$NUTDEV"'
+ExecStop=/bin/sh -c 'NUTDEV="`@NUT_LIBEXECDIR@/nut-driver-enumerator.sh --get-device-for-service %i`" && [ -n "$NUTDEV" ] || { echo "FATAL: Could not find a NUT device section for service unit %i" >&2 ; exit 1 ; } ; /sbin/upsdrvctl stop "$NUTDEV"'
 Type=forking
 # Note: If you customize the "maxstartdelay" in ups.conf or in your
 # NUT compilation defaults, so it exceeds the default systemd unit

--- a/scripts/systemd/nut-driver@.service.in
+++ b/scripts/systemd/nut-driver@.service.in
@@ -25,8 +25,8 @@ PartOf=nut-driver.target
 # Finally note that "nut-driver-enumerator.service" should take care of this.
 
 [Service]
-ExecStart=/bin/sh -c 'NUTDEV="`@NUT_LIBEXECDIR@/nut-driver-enumerator.sh --get-device-for-service %i`" && [ -n "$NUTDEV" ] || { echo "FATAL: Could not find a NUT device section for service unit %i" >&2 ; exit 1 ; } ; /sbin/upsdrvctl start "$NUTDEV"'
-ExecStop=/bin/sh -c 'NUTDEV="`@NUT_LIBEXECDIR@/nut-driver-enumerator.sh --get-device-for-service %i`" && [ -n "$NUTDEV" ] || { echo "FATAL: Could not find a NUT device section for service unit %i" >&2 ; exit 1 ; } ; /sbin/upsdrvctl stop "$NUTDEV"'
+ExecStart=/bin/sh -c 'NUTDEV="`@NUT_LIBEXECDIR@/nut-driver-enumerator.sh --get-device-for-service %i`" && [ -n "$NUTDEV" ] || { echo "FATAL: Could not find a NUT device section for service unit %i" >&2 ; exit 1 ; } ; @SBINDIR@/upsdrvctl start "$NUTDEV"'
+ExecStop=/bin/sh -c 'NUTDEV="`@NUT_LIBEXECDIR@/nut-driver-enumerator.sh --get-device-for-service %i`" && [ -n "$NUTDEV" ] || { echo "FATAL: Could not find a NUT device section for service unit %i" >&2 ; exit 1 ; } ; @SBINDIR@/upsdrvctl stop "$NUTDEV"'
 Type=forking
 # Note: If you customize the "maxstartdelay" in ups.conf or in your
 # NUT compilation defaults, so it exceeds the default systemd unit


### PR DESCRIPTION
…upsdrvctl on everything

Solution: First check if service instance name is valid, then use it
Should fix https://github.com/42ity/nut/issues/87 (same problem applies to upstream NUT too)

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>