### PR TITLE
Report load for Tripp Lite USB 3005 protocol

### DIFF
--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -1362,6 +1362,9 @@ void upsdrv_updateinfo(void)
 		case TRIPP_LITE_SMARTPRO:
 			dstate_setinfo("ups.load", "%d", hex2d(l_value+1, 2));
 			break;
+		case TRIPP_LITE_SMART_3005:
+			dstate_setinfo("ups.load", "%d", hex_or_bin2d(l_value+1, 1));
+			break;
 		case TRIPP_LITE_SMART_0004:
 			dstate_setinfo("ups.load", "%d", hex2d(l_value+1, 2));
 			dstate_setinfo("ups.debug.L","%s", hexascdump(l_value+1, 7));


### PR DESCRIPTION
The debug output for a device using the Tripp Lite
09ae 3005 protocol seems to show that the
ups.debug.L is the load as noted on mailing
list posts. Decode it and report it as ups.load.

Tested on TRIPP LITE SMART500RT1U.