### PR TITLE
avoid index out of bounds

### DIFF
--- a/drivers/solis.c
+++ b/drivers/solis.c
@@ -457,7 +457,7 @@ static void scan_received_pack(void) {
 	if (im < 3)
 		autonomy_calc(im);
 	else {
-		if (BattExtension == 80)
+		if (BattExtension == 80 && im == 3)
 			autonomy_calc(im + 1);
 		else
 			autonomy_calc(im);


### PR DESCRIPTION
the parameter passed to autonomy_calc() indexes an array of 5 position and variable 'im' can be equal to '4' at line 460, leading to an index out of bounds.