### PR TITLE
apcupsd-ups: add real power and current variables

### DIFF
--- a/drivers/apcupsd-ups.h
+++ b/drivers/apcupsd-ups.h
@@ -133,5 +133,10 @@ static apcuspd_info_t nut_data[] =
 	{ "MINTIMEL", "battery.runtime.low", ST_FLAG_RW, 60, "%.0f", DU_FLAG_NONE, NULL },
 	{ "RETPCT", "battery.charge.restart", ST_FLAG_RW, 1, "%1.1f", DU_FLAG_NONE, NULL },
 	{ "NOMPOWER", "ups.realpower.nominal", 0, 1, "%1.1f", DU_FLAG_INIT, NULL },
+	{ "LOAD_W", "ups.realpower", 0, 1, "%1.1f", DU_FLAG_INIT, NULL },
+	{ "LOADAPNT", "power.percent", ST_FLAG_RW, 1, "%1.1f", DU_FLAG_NONE, NULL },
+	{ "OUTCURNT", "output.current", 0, 1, "%1.2f", DU_FLAG_NONE, NULL },
+	{ "LOAD_VA", "ups.power", 0, 1, "%1.1f", DU_FLAG_INIT, NULL },
+	{ "NOMAPNT", "ups.power.nominal", 0, 1, "%.0f", DU_FLAG_NONE, NULL },
 	{ NULL, NULL, 0, 0, NULL, DU_FLAG_NONE, NULL }
 };

--- a/drivers/apcupsd-ups.h
+++ b/drivers/apcupsd-ups.h
@@ -133,10 +133,10 @@ static apcuspd_info_t nut_data[] =
 	{ "MINTIMEL", "battery.runtime.low", ST_FLAG_RW, 60, "%.0f", DU_FLAG_NONE, NULL },
 	{ "RETPCT", "battery.charge.restart", ST_FLAG_RW, 1, "%1.1f", DU_FLAG_NONE, NULL },
 	{ "NOMPOWER", "ups.realpower.nominal", 0, 1, "%1.1f", DU_FLAG_INIT, NULL },
-	{ "LOAD_W", "ups.realpower", 0, 1, "%1.1f", DU_FLAG_INIT, NULL },
+	{ "LOAD_W", "ups.realpower", 0, 1, "%1.1f", DU_FLAG_NONE, NULL },
 	{ "LOADAPNT", "power.percent", ST_FLAG_RW, 1, "%1.1f", DU_FLAG_NONE, NULL },
 	{ "OUTCURNT", "output.current", 0, 1, "%1.2f", DU_FLAG_NONE, NULL },
-	{ "LOAD_VA", "ups.power", 0, 1, "%1.1f", DU_FLAG_INIT, NULL },
-	{ "NOMAPNT", "ups.power.nominal", 0, 1, "%.0f", DU_FLAG_NONE, NULL },
+	{ "LOAD_VA", "ups.power", 0, 1, "%1.1f", DU_FLAG_NONE, NULL },
+	{ "NOMAPNT", "ups.power.nominal", 0, 1, "%.0f", DU_FLAG_INIT, NULL },
 	{ NULL, NULL, 0, 0, NULL, DU_FLAG_NONE, NULL }
 };


### PR DESCRIPTION
Added these new variables to mapping:

`LOAD_W` => `ups.realpower`
`LOADAPNT` => `power.percent`
`OUTCURNT` => `output.current`
`LOAD_VA` => `ups.power`
`NOMAPNT` => `ups.power.nominal`

From `apcaccess`:
```
LOADAPNT : 49.8 Percent
LOAD_VA  : 746.5 VA
LOAD_W   : 859.9 Watts
OUTCURNT : 5.97 Amps
```

From `upsc`:
```
power.percent: 49.8
ups.power: 746.5
ups.realpower: 859.9
output.current: 5.97
```