### PR TITLE
Do not call `dstate_delinfo()` for LB-condition variables

### DIFF
--- a/drivers/apcupsd-ups.c
+++ b/drivers/apcupsd-ups.c
@@ -145,7 +145,7 @@ static int getdata(void)
 	char bfr[1024];
 
 	for(x=0;nut_data[x].info_type;x++)
-		if(!(nut_data[x].drv_flags&DU_FLAG_INIT))
+		if(!(nut_data[x].drv_flags & DU_FLAG_INIT) && !(nut_data[x].drv_flags & DU_FLAG_PRESERVE))
 			dstate_delinfo(nut_data[x].info_type);
 
 	if((p.fd=socket(AF_INET,SOCK_STREAM,0))==-1)

--- a/drivers/apcupsd-ups.h
+++ b/drivers/apcupsd-ups.h
@@ -89,6 +89,7 @@ typedef struct {
 #define DU_FLAG_TIME			8
 #define DU_FLAG_FW1			16
 #define DU_FLAG_FW2			32
+#define DU_FLAG_PRESERVE 	64
 
 /* ------------ */
 /*  Data table  */
@@ -124,12 +125,12 @@ static apcuspd_info_t nut_data[] =
 	{ "LINEFREQ", "input.frequency", ST_FLAG_RW, 1, "%1.1f", DU_FLAG_NONE, NULL },
 	{ "OUTPUTV", "output.voltage", ST_FLAG_RW, 1, "%1.1f", DU_FLAG_NONE, NULL },
 	{ "LINEFREQ", "output.frequency", ST_FLAG_RW, 1, "%1.1f", DU_FLAG_NONE, NULL },
-	{ "BCHARGE", "battery.charge", ST_FLAG_RW, 1, "%1.1f", DU_FLAG_NONE, NULL },
+	{ "BCHARGE", "battery.charge", ST_FLAG_RW, 1, "%1.1f", DU_FLAG_PRESERVE, NULL },
 	{ "MBATTCHG", "battery.charge.low", ST_FLAG_RW, 1, "%.0f", DU_FLAG_NONE, NULL },
 	{ "BATTDATE", "battery.date", ST_FLAG_STRING /* | ST_FLAG_RW */, 16, NULL, DU_FLAG_DATE, NULL },
 	{ "BATTV", "battery.voltage", 0, 1, "%1.1f", DU_FLAG_NONE, NULL },
 	{ "NOMBATTV", "battery.voltage.nominal", 0, 1, "%1.1f", DU_FLAG_NONE, NULL },
-	{ "TIMELEFT", "battery.runtime", ST_FLAG_RW, 60, "%1.1f", DU_FLAG_NONE, NULL },
+	{ "TIMELEFT", "battery.runtime", ST_FLAG_RW, 60, "%1.1f", DU_FLAG_PRESERVE, NULL },
 	{ "MINTIMEL", "battery.runtime.low", ST_FLAG_RW, 60, "%.0f", DU_FLAG_NONE, NULL },
 	{ "RETPCT", "battery.charge.restart", ST_FLAG_RW, 1, "%1.1f", DU_FLAG_NONE, NULL },
 	{ "NOMPOWER", "ups.realpower.nominal", 0, 1, "%1.1f", DU_FLAG_INIT, NULL },


### PR DESCRIPTION
This commit fixes the `ignorelb` flag for the `apcupsd-ups` driver. Previusly "battery.charge" and "battery.runtime" was cleared before invoking `status_commit()` which caused the LB-condition to always be `false`.