### PR TITLE
nut_check_libgd.m4: try to find gd through pkg-config

### DIFF
--- a/m4/nut_check_libgd.m4
+++ b/m4/nut_check_libgd.m4
@@ -12,50 +12,62 @@ if test -z "${nut_have_libgd_seen}"; then
 	LDFLAGS_ORIG="${LDFLAGS}"
 	LIBS_ORIG="${LIBS}"
 
-	dnl Initial defaults. These are only used if gdlib-config is
-	dnl unusable and the user fails to pass better values in --with
-	dnl arguments
-	CFLAGS=""
-	LDFLAGS="-L/usr/X11R6/lib"
-	LIBS="-lgd -lpng -lz -ljpeg -lfreetype -lm -lXpm -lX11"
-
-	dnl By default seek in PATH
-	GDLIB_CONFIG=gdlib-config
-	AC_ARG_WITH(gdlib-config,
-		AS_HELP_STRING([@<:@--with-gdlib-config=/path/to/gdlib-config@:>@],
-			[path to program that reports GDLIB configuration]),
-	[
-		case "${withval}" in
-		"") ;;
-		yes|no)
-			AC_MSG_ERROR(invalid option --with(out)-gdlib-config - see docs/configure.txt)
-			;;
-		*)
-			GDLIB_CONFIG="${withval}"
-			;;
-		esac
-	])
-
-	AC_MSG_CHECKING(for gd version via ${GDLIB_CONFIG})
-	GD_VERSION=`${GDLIB_CONFIG} --version 2>/dev/null`
-	if test "$?" != "0" -o -z "${GD_VERSION}"; then
+	AC_MSG_CHECKING(for gd version via pkg-config)
+	GD_VERSION="`pkg-config --silence-errors --modversion gdlib 2>/dev/null`"
+	if test "$?" = "0" -a -n "${GD_VERSION}"; then
+		CFLAGS="`pkg-config --silence-errors --cflags gdlib 2>/dev/null`"
+		LIBS="`pkg-config --silence-errors --libs gdlib 2>/dev/null`"
+	else
 		GD_VERSION="none"
 	fi
 	AC_MSG_RESULT(${GD_VERSION} found)
 
-	case "${GD_VERSION}" in
-	none)
-		;;
-	2.0.5 | 2.0.6 | 2.0.7)
-		AC_MSG_WARN([[gd ${GD_VERSION} detected, unable to use ${GDLIB_CONFIG} script]])
-		AC_MSG_WARN([[If gd detection fails, upgrade gd or use --with-gd-includes and --with-gd-libs]])
-		;;
-	*)
-		CFLAGS="`${GDLIB_CONFIG} --includes 2>/dev/null`"
-		LDFLAGS="`${GDLIB_CONFIG} --ldflags 2>/dev/null`"
-		LIBS="`${GDLIB_CONFIG} --libs 2>/dev/null`"
-		;;
-	esac
+	if test "${GD_VERSION}" = "none"; then
+		dnl Initial defaults. These are only used if gdlib-config is
+		dnl unusable and the user fails to pass better values in --with
+		dnl arguments
+		CFLAGS=""
+		LDFLAGS="-L/usr/X11R6/lib"
+		LIBS="-lgd -lpng -lz -ljpeg -lfreetype -lm -lXpm -lX11"
+
+		dnl By default seek in PATH
+		GDLIB_CONFIG=gdlib-config
+		AC_ARG_WITH(gdlib-config,
+			AS_HELP_STRING([@<:@--with-gdlib-config=/path/to/gdlib-config@:>@],
+				[path to program that reports GDLIB configuration]),
+		[
+			case "${withval}" in
+			"") ;;
+			yes|no)
+				AC_MSG_ERROR(invalid option --with(out)-gdlib-config - see docs/configure.txt)
+				;;
+			*)
+				GDLIB_CONFIG="${withval}"
+				;;
+			esac
+		])
+
+		AC_MSG_CHECKING(for gd version via ${GDLIB_CONFIG})
+		GD_VERSION=`${GDLIB_CONFIG} --version 2>/dev/null`
+		if test "$?" != "0" -o -z "${GD_VERSION}"; then
+			GD_VERSION="none"
+		fi
+		AC_MSG_RESULT(${GD_VERSION} found)
+
+		case "${GD_VERSION}" in
+		none)
+			;;
+		2.0.5 | 2.0.6 | 2.0.7)
+			AC_MSG_WARN([[gd ${GD_VERSION} detected, unable to use ${GDLIB_CONFIG} script]])
+			AC_MSG_WARN([[If gd detection fails, upgrade gd or use --with-gd-includes and --with-gd-libs]])
+			;;
+		*)
+			CFLAGS="`${GDLIB_CONFIG} --includes 2>/dev/null`"
+			LDFLAGS="`${GDLIB_CONFIG} --ldflags 2>/dev/null`"
+			LIBS="`${GDLIB_CONFIG} --libs 2>/dev/null`"
+			;;
+		esac
+	fi
 
 	dnl Now allow overriding gd settings if the user knows best
 	AC_MSG_CHECKING(for gd include flags)


### PR DESCRIPTION
gdlib-config has been dropped from version 2.3.0 with https://github.com/libgd/libgd/commit/d62f608c7c4a814c70d4ba777725e3e62d9e2cde

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>