### PR TITLE
Reshuffle Travis CI matrix of allowed_failure jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -383,7 +383,7 @@ matrix:
 # Note: "env" lines below must exactly describe a matrix option defined above
   allow_failures:
   - env: NUT_MATRIX_TAG="cDefault-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99"
-  - env: NUT_MATRIX_TAG="gnu99-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=gcc-7 CXX=g++-7
+#OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=gcc-7 CXX=g++-7
   - env: NUT_MATRIX_TAG="gnu11-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu11" CXXFLAGS="-std=gnu++11" CC=gcc-7 CXX=g++-7
   - env: NUT_MATRIX_TAG="gnu99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++

--- a/.travis.yml
+++ b/.travis.yml
@@ -220,6 +220,22 @@ matrix:
         - g++-7
         - gcc-7
         - *deps_driverlibs
+
+  - env: NUT_MATRIX_TAG="gnu99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
+    os: linux
+    dist: xenial
+    sudo: false
+    services:
+        - docker
+    addons:
+      apt:
+        sources:
+        - llvm-toolchain-xenial-5.0
+        packages:
+        - clang-5.0
+        - clang-format-5.0
+        - *deps_driverlibs
+
   - env: NUT_MATRIX_TAG="c99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
     os: linux
     dist: xenial
@@ -369,6 +385,7 @@ matrix:
   - env: NUT_MATRIX_TAG="cDefault-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99"
   - env: NUT_MATRIX_TAG="gnu99-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=gcc-7 CXX=g++-7
   - env: NUT_MATRIX_TAG="gnu11-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu11" CXXFLAGS="-std=gnu++11" CC=gcc-7 CXX=g++-7
+  - env: NUT_MATRIX_TAG="gnu99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c11-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c11" CXXFLAGS="-std=c++11" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="cDefault-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic" CXXFLAGS="-Wall -Werror"

--- a/.travis.yml
+++ b/.travis.yml
@@ -183,7 +183,7 @@ matrix:
 # for sub-makes like distcheck; verify thoroughly before
 # trying to enable those if that would make sense anytime.
 # Ordered by variants expected to succeed to run first:
-  - env: NUT_MATRIX_TAG="c99-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99"
+  - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99"
     os: linux
     sudo: false
     services:
@@ -394,7 +394,7 @@ matrix:
 
 # Note: "env" lines below must exactly describe a matrix option defined above
   allow_failures:
-  - env: NUT_MATRIX_TAG="cDefault-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99"
+#OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99"
 #OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=gcc-7 CXX=g++-7
 #OK#  - env: NUT_MATRIX_TAG="gnu11-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu11" CXXFLAGS="-std=gnu++11" CC=gcc-7 CXX=g++-7
 #OK#  - env: NUT_MATRIX_TAG="gnu99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++

--- a/.travis.yml
+++ b/.travis.yml
@@ -360,6 +360,8 @@ matrix:
         packages:
         - *deps_driverlibs
 
+# Note: some of the warnings that are hidden in this case seem to be serious
+# issues that may impact viability of binaries built by C89 mode compilers!
   - env: NUT_MATRIX_TAG="gnu89-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu89" CXXFLAGS="-std=gnu++89"
     os: linux
     sudo: false
@@ -406,7 +408,7 @@ matrix:
   - env: NUT_MATRIX_TAG="c11-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c11" CXXFLAGS="-Wall -Werror -std=c++11" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c11" CXXFLAGS="-Wall -Werror -std=c++11"
   - env: NUT_MATRIX_TAG="gnu11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu11" CXXFLAGS="-Wall -Werror -std=gnu++11"
-  - env: NUT_MATRIX_TAG="gnu89-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu89" CXXFLAGS="-std=gnu++89"
+#OK#  - env: NUT_MATRIX_TAG="gnu89-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu89" CXXFLAGS="-std=gnu++89"
   - env: NUT_MATRIX_TAG="c89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c89" CXXFLAGS="-Wall -Werror -std=c++89"
   - env: NUT_MATRIX_TAG="gnu89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu89" CXXFLAGS="-Wall -Werror -std=gnu++89"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -207,6 +207,19 @@ matrix:
         - gcc-7
         - *deps_driverlibs
 
+  - env: NUT_MATRIX_TAG="gnu11-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu11" CXXFLAGS="-std=gnu++11" CC=gcc-7 CXX=g++-7
+    os: linux
+    sudo: false
+    services:
+        - docker
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - g++-7
+        - gcc-7
+        - *deps_driverlibs
   - env: NUT_MATRIX_TAG="c99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
     os: linux
     dist: xenial
@@ -355,6 +368,7 @@ matrix:
   allow_failures:
   - env: NUT_MATRIX_TAG="cDefault-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99"
   - env: NUT_MATRIX_TAG="gnu99-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=gcc-7 CXX=g++-7
+  - env: NUT_MATRIX_TAG="gnu11-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu11" CXXFLAGS="-std=gnu++11" CC=gcc-7 CXX=g++-7
   - env: NUT_MATRIX_TAG="c99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c11-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c11" CXXFLAGS="-std=c++11" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="cDefault-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic" CXXFLAGS="-Wall -Werror"

--- a/.travis.yml
+++ b/.travis.yml
@@ -360,6 +360,16 @@ matrix:
         packages:
         - *deps_driverlibs
 
+  - env: NUT_MATRIX_TAG="gnu89-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu89" CXXFLAGS="-std=gnu++89"
+    os: linux
+    sudo: false
+    services:
+        - docker
+    addons:
+      apt:
+        packages:
+        - *deps_driverlibs
+
   - env: NUT_MATRIX_TAG="c89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c89" CXXFLAGS="-Wall -Werror -std=c++89"
     os: linux
     sudo: false
@@ -396,6 +406,7 @@ matrix:
   - env: NUT_MATRIX_TAG="c11-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c11" CXXFLAGS="-Wall -Werror -std=c++11" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c11" CXXFLAGS="-Wall -Werror -std=c++11"
   - env: NUT_MATRIX_TAG="gnu11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu11" CXXFLAGS="-Wall -Werror -std=gnu++11"
+  - env: NUT_MATRIX_TAG="gnu89-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu89" CXXFLAGS="-std=gnu++89"
   - env: NUT_MATRIX_TAG="c89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c89" CXXFLAGS="-Wall -Werror -std=c++89"
   - env: NUT_MATRIX_TAG="gnu89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu89" CXXFLAGS="-Wall -Werror -std=gnu++89"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -394,8 +394,8 @@ matrix:
   allow_failures:
   - env: NUT_MATRIX_TAG="cDefault-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99"
 #OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=gcc-7 CXX=g++-7
-  - env: NUT_MATRIX_TAG="gnu11-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu11" CXXFLAGS="-std=gnu++11" CC=gcc-7 CXX=g++-7
-  - env: NUT_MATRIX_TAG="gnu99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
+#OK#  - env: NUT_MATRIX_TAG="gnu11-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu11" CXXFLAGS="-std=gnu++11" CC=gcc-7 CXX=g++-7
+#OK#  - env: NUT_MATRIX_TAG="gnu99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c11-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c11" CXXFLAGS="-std=c++11" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="cDefault-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic" CXXFLAGS="-Wall -Werror"

--- a/.travis.yml
+++ b/.travis.yml
@@ -179,10 +179,20 @@ matrix:
 # and different lenience against warnings. Many of
 # these blocks look similar and all should have unique
 # "env" field to use some with allowed_failure below.
+#
+# The leading NUT_MATRIX_TAG allows humans to understand
+# what a test case is about in Travis CI dashboard table
+# of jobs, but otherwise it is not used by script code.
+#
 # Note that passing multi-token C*FLAGS may be problematic
 # for sub-makes like distcheck; verify thoroughly before
 # trying to enable those if that would make sense anytime.
-# Ordered by variants expected to succeed to run first:
+#
+# Ordered by variants expected to succeed to run first,
+# although with current Travis CI implementation, the env
+# blocks listed in allowed_failures only run after all
+# those not listed:
+#
   - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99"
     os: linux
     sudo: false

--- a/docs/developers.txt
+++ b/docs/developers.txt
@@ -108,7 +108,7 @@ There are still older systems out there that don't do C++ style comments.
 --------------------------------------
 
 Newer versions of gcc allow you to declare a variable inside a function
-somewhat like the way C++ operates, like this:
+after code, somewhat like the way C++ operates, like this:
 
 --------------------------------------------------------------------------------
 function do_stuff(void)
@@ -124,6 +124,23 @@ function do_stuff(void)
 While this will compile and run on these newer versions, it will fail
 miserably for anyone on an older system.  That means you must not use
 it.  gcc only warns about this with -pedantic.
+
+At this point NUT is expected to work correctly when built with a C99
+(or GNU99 on Linux) or newer standard.
+
+The NUT codebase may build in a mode without warnings made fatal on C89
+(GNU89), but the emitted warnings indicate that those binaries may crash.
+If somebody in the community requires to build and run NUT on systems
+that old, pull requests to fix the offending coding issues are welcome.
+
+The NUT project on GitHub has integration with Travis CI to test a large
+set of compiler and option combinations, covering different versions of
+gcc and clang, C standards, and requiring to pass builds at least in a
+mode without warnings (and checking the other cases where any warnings
+are made fatal). Developers can use the scripts involved to fix existing
+code or ensure support for new compilers and C standard revisions.
+
+* https://github.com/networkupstools/nut/issues/823
 
 Coding style
 ------------

--- a/docs/developers.txt
+++ b/docs/developers.txt
@@ -125,6 +125,20 @@ While this will compile and run on these newer versions, it will fail
 miserably for anyone on an older system.  That means you must not use
 it.  gcc only warns about this with -pedantic.
 
+Another feature that does not work on some compilers (e.g. conforming
+to ANSI C / C89 standard) is initial variable declaration inside a
+'for loop' block, like this:
+--------------------------------------------------------------------------------
+function do_stuff(void)
+{
+	/* This should declare "int i;" first, then use it in "for" loop: */
+	for (int i = 0; i < INT_MAX; ++i) { ... }
+
+	/* Additional loops cause also an error about re-declaring a variable: */
+	for (int i = 10; i < 15; ++i) { ... }
+}
+--------------------------------------------------------------------------------
+
 At this point NUT is expected to work correctly when built with a C99
 (or GNU99 on Linux) or newer standard.
 

--- a/drivers/solis.c
+++ b/drivers/solis.c
@@ -139,8 +139,9 @@ inline static int is_binary(char ch ) {
 /* convert string to binary */
 static int str2bin( char *binStr ) {
 	int result = 0;
+	int i;
 
-	for (int i = 0; i < 7; ++i) {
+	for (i = 0; i < 7; ++i) {
 		char ch = binStr[i];
 		if (is_binary(ch))
 			result += ( (ch - '0') << (6 - i) );
@@ -154,14 +155,15 @@ static int str2bin( char *binStr ) {
 /* revert firmware format to standard string binary days */
 static unsigned char revert_days(unsigned char dweek) {
 	char alt[8];
+	int i;
 
-	for (int i = 0; i < (6 - weekn); ++i)
+	for (i = 0; i < (6 - weekn); ++i)
 		alt[i] = (dweek >> (5 - weekn - i)) & 0x01;
 	
-	for (int i = 0; i < weekn+1; ++i)
+	for (i = 0; i < weekn+1; ++i)
 		alt[i+(6-weekn)] = (dweek >> (6 - i)) & 0x01;
 
-	for (int i=0; i < 7; i++)
+	for (i=0; i < 7; i++)
 		alt[i] += '0';
 
 	alt[7] = 0; /* string terminator */
@@ -187,7 +189,9 @@ static int is_hour(char *hour, int qual) {
 }
 
 static void send_shutdown( void ) {
-	for (int i=0; i < 10; i++)
+	int i;
+
+	for (i = 0; i < 10; i++)
 	  ser_send_char(upsfd, CMD_SHUT );
 
 	upslogx(LOG_NOTICE, "Ups shutdown command sent");
@@ -233,9 +237,10 @@ static void print_info( void ) {
 	if (prgups > 0) {
 		/*sunday, monday, tuesday, wednesday, thursday, friday, saturday*/
 		int week_days[7] = {0, 0, 0, 0, 0, 0, 0};
+		int i;
 
 		/* this is the string to binary standard */
-		for (int i = 0; i < 7; ++i)
+		for (i = 0; i < 7; ++i)
 			week_days[i] = (DaysStd >> (6 - i)) & 0x01;
 
 		if (prgups == 3)
@@ -594,14 +599,15 @@ static void scan_received_pack(void) {
 
 static void comm_receive(const unsigned char *bufptr,  int size) {
 	if (size == packet_size) {
+		int CheckSum = 0, i;
+
 		memcpy(RecPack, bufptr, packet_size);
 		
 		if (nut_debug_level >= 3)
 			upsdebug_hex(3, "comm_receive: RecPack", RecPack, size);
 
 		/* CheckSum verify */
-		int CheckSum = 0;
-		for (int i = 0 ; i < packet_size-2 ; ++i )
+		for (i = 0 ; i < packet_size-2 ; ++i )
 			CheckSum += RecPack[i];
 		CheckSum = CheckSum % 256;
 		upsdebugx(4, "%s: calculated checksum = 0x%02x, RecPack[23] = 0x%02x", __func__, CheckSum, RecPack[23]);
@@ -676,7 +682,7 @@ static void get_base_info(void) {
 	const char DaysOfWeek[7][4]={"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
 #endif
 	unsigned char packet[packet_size], syncEOR;
-	int i1=0, i2=0, tam;
+	int i1=0, i2=0, tam, i;
 
 	time_t tmt;
 	struct tm *now;
@@ -688,7 +694,7 @@ static void get_base_info(void) {
 	ihour = now->tm_hour;
 	imin = now->tm_min;
 	isec = now->tm_sec;
-    weekn = now->tm_wday;
+	weekn = now->tm_wday;
 
 	strcpy(seman, DaysOfWeek[weekn]);
 
@@ -737,7 +743,7 @@ static void get_base_info(void) {
 	 * read up to 3 packets in size before giving up 
 	 * synchronizing with the device.
 	*/
-	for (int i=0; i<packet_size*3; i++) {
+	for (i = 0; i < packet_size*3; i++) {
 		ser_get_char(upsfd, &syncEOR, 3, 0);
 		if(syncEOR == RESP_END)
 			break;


### PR DESCRIPTION
Follows up for PR #824 answering to issue #823 to bring green (nowarn) jobs into the realm of configs no longer allowed to fail, and fix a minor issue with `solis.c` driver to have at least no-warn builds of NUT in gnu89 mode too.

This also documents in `developers.txt` that we support C99 at this time.