### PR TITLE
More flexible Travis CI matrix test options: disable failed codepaths by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,11 @@ os:
 
 sudo: false
 
-# Tests for cppunit require C++11 which requires gcc-4.8 or newer
-# This is available in either "trusty" or newer distros, or in "docker" envs
-#dist: trusty
+# Tests for cppunit require C++11 which requires gcc-4.8 or newer.
+# This is available in either "trusty" or newer distros (e.g. "xenial"
+# which we also reference explicitly for additional repositories below),
+# or in "docker" envs.
+dist: xenial
 
 services:
 - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -222,6 +222,7 @@ matrix:
     sudo: false
     services:
         - docker
+    compiler: gcc
     addons:
       apt:
         packages:
@@ -232,6 +233,7 @@ matrix:
     sudo: false
     services:
         - docker
+    compiler: gcc
     addons:
       apt:
         sources:
@@ -246,6 +248,7 @@ matrix:
     sudo: false
     services:
         - docker
+    compiler: gcc
     addons:
       apt:
         sources:
@@ -261,6 +264,7 @@ matrix:
     sudo: false
     services:
         - docker
+    compiler: clang
     addons:
       apt:
         sources:
@@ -276,6 +280,7 @@ matrix:
     sudo: false
     services:
         - docker
+    compiler: clang
     addons:
       apt:
         sources:
@@ -291,6 +296,7 @@ matrix:
     sudo: false
     services:
         - docker
+    compiler: clang
     addons:
       apt:
         sources:
@@ -305,6 +311,7 @@ matrix:
     sudo: false
     services:
         - docker
+    compiler: gcc
     addons:
       apt:
         packages:
@@ -315,6 +322,7 @@ matrix:
     sudo: false
     services:
         - docker
+    compiler: gcc
     addons:
       apt:
         packages:
@@ -325,6 +333,7 @@ matrix:
     sudo: false
     services:
         - docker
+    compiler: gcc
     addons:
       apt:
         packages:
@@ -335,6 +344,7 @@ matrix:
     sudo: false
     services:
         - docker
+    compiler: gcc
     addons:
       apt:
         sources:
@@ -350,6 +360,7 @@ matrix:
     sudo: false
     services:
         - docker
+    compiler: clang
     addons:
       apt:
         sources:
@@ -365,6 +376,7 @@ matrix:
     sudo: false
     services:
         - docker
+    compiler: clang
     addons:
       apt:
         sources:
@@ -379,6 +391,7 @@ matrix:
     sudo: false
     services:
         - docker
+    compiler: gcc
     addons:
       apt:
         packages:
@@ -389,6 +402,7 @@ matrix:
     sudo: false
     services:
         - docker
+    compiler: gcc
     addons:
       apt:
         packages:
@@ -401,6 +415,7 @@ matrix:
     sudo: false
     services:
         - docker
+    compiler: gcc
     addons:
       apt:
         packages:
@@ -411,6 +426,7 @@ matrix:
     sudo: false
     services:
         - docker
+    compiler: gcc
     addons:
       apt:
         packages:
@@ -421,6 +437,7 @@ matrix:
     sudo: false
     services:
         - docker
+    compiler: gcc
     addons:
       apt:
         packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -565,6 +565,60 @@ _matrix_linux_cstd_warn:
 
 # Try also a range of platforms for MacOS X builds
 # Inspired by https://github.com/taocpp/operators/blob/master/.travis.yml
+_matrix_osx_gnustd_nowarn:
+  include: &_matrix_osx_gnustd_nowarn
+  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
+    os: osx
+    osx_image: xcode10.2
+    compiler: clang
+    cache:
+      directories:
+      - /usr/local/Cellar
+      - $HOME/Library/Caches/Homebrew
+      - $HOME/.ccache
+
+  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang CXX=clang++
+    os: osx
+    osx_image: xcode10.2
+    compiler: clang
+    cache:
+      directories:
+      - /usr/local/Cellar
+      - $HOME/Library/Caches/Homebrew
+      - $HOME/.ccache
+
+  - env: NUT_MATRIX_TAG="gnu99-clang-xcode7.3-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
+    os: osx
+    osx_image: xcode7.3
+    compiler: clang
+    cache:
+      directories:
+      - /usr/local/Cellar
+      - $HOME/Library/Caches/Homebrew
+      - $HOME/.ccache
+
+_matrix_osx_gnustd_warn:
+  include: &_matrix_osx_gnustd_warn
+  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Werror -std=gnu++99" CC=clang CXX=clang++
+    os: osx
+    osx_image: xcode10.2
+    compiler: clang
+    cache:
+      directories:
+      - /usr/local/Cellar
+      - $HOME/Library/Caches/Homebrew
+      - $HOME/.ccache
+
+  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Werror -std=gnu++17" CC=clang CXX=clang++
+    os: osx
+    osx_image: xcode10.2
+    compiler: clang
+    cache:
+      directories:
+      - /usr/local/Cellar
+      - $HOME/Library/Caches/Homebrew
+      - $HOME/.ccache
+
 _matrix_osx_cstd_nowarn:
   include: &_matrix_osx_cstd_nowarn
   - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
@@ -680,10 +734,16 @@ _matrix_allowfail_linux:
   - *_matrix_linux_gnustd_warn
   - *_matrix_linux_cstd_warn
 
+_matrix_allowfail_osx:
+  include: &_matrix_allowfail_osx
+  - *_matrix_osx_cstd_nowarn
+  - *_matrix_osx_gnustd_warn
+  - *_matrix_osx_cstd_warn
+
 _matrix_osx:
   include: &_matrix_osx
-  - *_matrix_osx_cstd_nowarn
-  - *_matrix_osx_cstd_warn
+  - *_matrix_osx_gnustd_nowarn
+  - *_matrix_allowfail_osx
 
 _matrix_windows:
   include: &_matrix_windows
@@ -696,12 +756,14 @@ _matrix_cstd_nowarn:
   - *_matrix_linux_cstd_nowarn
   - *_matrix_osx_cstd_nowarn
   - *_matrix_windows_cstd_nowarn
+###  - *_matrix_osx_gnustd_nowarn
 ###  - *_matrix_linux_gnustd_nowarn
 
 _matrix_warn:
   include: &_matrix_warn
   - *_matrix_linux_gnustd_warn
   - *_matrix_linux_cstd_warn
+  - *_matrix_osx_gnustd_warn
   - *_matrix_osx_cstd_warn
   - *_matrix_windows_cstd_warn
 
@@ -765,6 +827,11 @@ jobs:
   - env: NUT_MATRIX_TAG="c89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c89" CXXFLAGS="-Wall -Werror -std=c++89"
   - env: NUT_MATRIX_TAG="gnu89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu89" CXXFLAGS="-Wall -Werror -std=gnu++89"
 ### macosx
+#OK#  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
+#OK#  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="gnu99-clang-xcode7.3-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Werror -std=gnu++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Werror -std=gnu++17" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Werror -std=c++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c17" CXXFLAGS="-std=c++17" CC=clang CXX=clang++

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,9 +73,11 @@ env:
 # Note that the nut-driver-enumerator tests should be tried in at least
 # the shell interpreters reasonable for default setups of Solaris/illumos
 # (ksh) and Linux (bash, dash, etc.) common distros.
-matrix:
-  include:
 
+# First pass is a few default compilations that normally happen
+# early in Travis CI build chain
+_matrix_required_linux_pass1_quick:
+  include: &_matrix_required_linux_pass1_quick
   - env: BUILD_TYPE=default-nodoc
     os: linux
     addons:
@@ -105,6 +107,9 @@ matrix:
         packages:
         - *deps_driverlibs
 
+# Second pass is a number of shell script syntax checks in standard env:
+_matrix_required_linux_pass2_shell:
+  include: &_matrix_required_linux_pass2_shell
   - env: BUILD_TYPE=default-shellcheck
     os: linux
     addons:
@@ -114,7 +119,6 @@ matrix:
         - file
         #TBD# - shellcheck
 
-# Other quicker builds in standard env follow:
   - env: BUILD_TYPE=nut-driver-enumerator-test SHELL_PROGS=bash
     os: linux
     services:
@@ -148,6 +152,9 @@ matrix:
         packages:
         - ash
 
+# Third pass is a number of larger builds that confirm non-core code is clean:
+_matrix_required_linux_pass3_large:
+  include: &_matrix_required_linux_pass3_large
   - env: BUILD_TYPE=default-tgt:distcheck-valgrind
     os: linux
     sudo: false
@@ -217,6 +224,9 @@ matrix:
 # blocks listed in allowed_failures only run after all
 # those not listed:
 #
+
+_matrix_linux_gnustd_nowarn:
+  include: &_matrix_linux_gnustd_nowarn
   - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99"
     os: linux
     sudo: false
@@ -318,7 +328,9 @@ matrix:
         packages:
         - *deps_driverlibs
 
-# At this time, anything with strict C standard fails on Linux, even "nowarn" cases below:
+# At this time, anything with strict C standard fails on Linux, even "nowarn" cases:
+_matrix_linux_cstd_nowarn:
+  include: &_matrix_linux_cstd_nowarn
   - env: NUT_MATRIX_TAG="c99-clang-3.5-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang-3.5 CXX=clang++-3.5
     os: linux
     dist: xenial
@@ -384,6 +396,8 @@ matrix:
         - *deps_driverlibs
 
 # Stuff with warnings made fatal... well, is usually fatal so far:
+_matrix_linux_gnustd_warn:
+  include: &_matrix_linux_gnustd_warn
   - env: NUT_MATRIX_TAG="cDefault-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic" CXXFLAGS="-Wall -Werror"
     os: linux
     sudo: false
@@ -459,7 +473,9 @@ matrix:
         packages:
         - *deps_driverlibs
 
-# The hardest of two worlds follows: both strict C standards on Linux and fatal warnings:
+# The hardest of two worlds: both strict C standards on Linux and fatal warnings:
+_matrix_linux_cstd_warn:
+  include: &_matrix_linux_cstd_warn
   - env: NUT_MATRIX_TAG="c99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Werror -std=c++99"
     os: linux
     sudo: false
@@ -543,6 +559,8 @@ matrix:
 
 # Try also a range of platforms for MacOS X builds
 # Inspired by https://github.com/taocpp/operators/blob/master/.travis.yml
+_matrix_osx_cstd_nowarn:
+  include: &_matrix_osx_cstd_nowarn
   - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
     os: osx
     osx_image: xcode10.2
@@ -553,6 +571,8 @@ matrix:
     osx_image: xcode10.2
     compiler: clang
 
+_matrix_osx_cstd_warn:
+  include: &_matrix_osx_cstd_warn
   - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Werror -std=c++99" CC=clang CXX=clang++
     os: osx
     osx_image: xcode10.2
@@ -574,6 +594,8 @@ matrix:
 # a complex routine to add gcc if we'd need that)
 # and a Git Bash as default shell, but no ccache.
 # TODO: Eventually try native visualstudio compilers?
+_matrix_windows_cstd_nowarn:
+  include: &_matrix_windows_cstd_nowarn
   - env: NUT_MATRIX_TAG="c99-clang-win-nowarn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
     os: windows
     compiler: clang
@@ -583,6 +605,8 @@ matrix:
       - $HOME/.ccache
       - /C/tools
 
+_matrix_windows_cstd_warn:
+  include: &_matrix_windows_cstd_warn
   - env: NUT_MATRIX_TAG="c99-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Werror -std=c++99" CC=clang CXX=clang++
     os: windows
     compiler: clang
@@ -602,6 +626,82 @@ matrix:
       - $HOME/AppData/Local/Temp/chocolatey
       - $HOME/.ccache
       - /C/tools
+
+###################################################################################
+# Summarize the matrix blocks above to quickly enable/disable subsets
+# of tests in development (e.g. to focus on fixing bugs and not wasting
+# resources on rebuilding green codebase over and over)
+
+# The original set of tests that are required for master branch CI
+# ...and also the set of builds with various compilers and C standards
+# that should survive at least without warnings made fatal...
+
+_matrix_required_linux:
+  include: &_matrix_required_linux
+  - *_matrix_required_linux_pass1_quick
+  - *_matrix_required_linux_pass2_shell
+  - *_matrix_required_linux_pass3_large
+  - *_matrix_linux_gnustd_nowarn
+
+_matrix_allowfail_linux:
+  include: &_matrix_allowfail_linux
+  - *_matrix_linux_cstd_nowarn
+  - *_matrix_linux_gnustd_warn
+  - *_matrix_linux_cstd_warn
+
+_matrix_osx:
+  include: &_matrix_osx
+  - *_matrix_osx_cstd_nowarn
+  - *_matrix_osx_cstd_warn
+
+_matrix_windows:
+  include: &_matrix_windows
+  - *_matrix_windows_cstd_nowarn
+  - *_matrix_windows_cstd_warn
+
+# Different dissections of interest to fixers:
+_matrix_cstd_nowarn:
+  include: &_matrix_cstd_nowarn
+  - *_matrix_linux_cstd_nowarn
+  - *_matrix_osx_cstd_nowarn
+  - *_matrix_windows_cstd_nowarn
+###  - *_matrix_linux_gnustd_nowarn
+
+_matrix_warn:
+  include: &_matrix_warn
+  - *_matrix_linux_gnustd_warn
+  - *_matrix_linux_cstd_warn
+  - *_matrix_osx_cstd_warn
+  - *_matrix_windows_cstd_warn
+
+# Default "jobs:" matrix should reference at least this for master branches
+_matrix_required:
+  include: &_matrix_required
+  - *_matrix_required_linux
+
+_matrix_master:
+  include: &_matrix_master
+  - *_matrix_required
+  - *_matrix_allowfail_linux
+  - *_matrix_osx
+  - *_matrix_windows
+
+_matrix_fixbugs:
+  include: &_matrix_fixbugs
+  - *_matrix_cstd_nowarn
+  - *_matrix_warn
+
+###################################################################################
+# Developers can import some of the definitions above (e.g. _matrix-fixbugs
+# instead of _matrix-master) to get more relevant runs of Travis CI against
+# their branches for their iterations trying to fix stuff.
+#
+# DO NOT COMMIT TO MASTER BRANCH TEST-MATRICES THAT ARE NOT _matrix-master!
+#
+# These days, "jobs" and "matrix" are same thing... at least, ours is an explicit list.
+jobs:
+  include:
+  - *_matrix_master
 
 ###################################################################################
 # Note: "env" lines below must exactly describe a matrix option defined above

--- a/.travis.yml
+++ b/.travis.yml
@@ -431,6 +431,21 @@ matrix:
         - gcc-7
         - *deps_driverlibs
 
+  - env: NUT_MATRIX_TAG="gnu17-gcc-9-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Werror -std=gnu++17" CC=gcc-9 CXX=g++-9
+    os: linux
+    sudo: false
+    services:
+        - docker
+    compiler: gcc
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - g++-9
+        - gcc-9
+        - *deps_driverlibs
+
   - env: NUT_MATRIX_TAG="c99-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Werror -std=c++99" CC=clang CXX=clang++
     os: linux
     dist: xenial
@@ -461,6 +476,22 @@ matrix:
         packages:
         - clang-5.0
         - clang-format-5.0
+        - *deps_driverlibs
+
+  - env: NUT_MATRIX_TAG="c17-clang-8-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c17" CXXFLAGS="-Wall -Werror -std=c++17" CC=clang-8 CXX=clang++-8
+    os: linux
+    dist: xenial
+    sudo: false
+    services:
+        - docker
+    compiler: clang
+    addons:
+      apt:
+        sources:
+        - llvm-toolchain-xenial-8
+        packages:
+        - clang-8
+        - clang-format-8
         - *deps_driverlibs
 
   - env: NUT_MATRIX_TAG="c11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c11" CXXFLAGS="-Wall -Werror -std=c++11"
@@ -529,10 +560,12 @@ matrix:
   - env: NUT_MATRIX_TAG="gnu14-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu14" CXXFLAGS="-std=gnu++14" CC=gcc-7 CXX=g++-7
   - env: NUT_MATRIX_TAG="gnu17-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc-7 CXX=g++-7
   - env: NUT_MATRIX_TAG="gnu17-gcc-9-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc-9 CXX=g++-9
+  - env: NUT_MATRIX_TAG="gnu17-gcc-9-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Werror -std=gnu++17" CC=gcc-9 CXX=g++-9
   - env: NUT_MATRIX_TAG="c99-clang-3.5-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang-3.5 CXX=clang++-3.5
   - env: NUT_MATRIX_TAG="c99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c11-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c11" CXXFLAGS="-std=c++11" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c17-clang-8-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c17" CXXFLAGS="-std=c++17" CC=clang-8 CXX=clang++-8
+  - env: NUT_MATRIX_TAG="c17-clang-8-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c17" CXXFLAGS="-Wall -Werror -std=c++17" CC=clang-8 CXX=clang++-8
   - env: NUT_MATRIX_TAG="cDefault-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic" CXXFLAGS="-Wall -Werror"
   - env: NUT_MATRIX_TAG="gnu99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Werror -std=gnu++99"
   - env: NUT_MATRIX_TAG="c99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Werror -std=c++99"

--- a/.travis.yml
+++ b/.travis.yml
@@ -553,6 +553,11 @@ matrix:
     osx_image: xcode10.2
     compiler: clang
 
+  - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Werror -std=c++99" CC=clang CXX=clang++
+    os: osx
+    osx_image: xcode10.2
+    compiler: clang
+
   - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c17" CXXFLAGS="-Wall -Werror -std=c++17" CC=clang CXX=clang++
     os: osx
     osx_image: xcode10.2
@@ -626,6 +631,7 @@ matrix:
   - env: NUT_MATRIX_TAG="gnu89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu89" CXXFLAGS="-Wall -Werror -std=gnu++89"
 ### macosx
   - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Werror -std=c++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c17" CXXFLAGS="-std=c++17" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c17" CXXFLAGS="-Wall -Werror -std=c++17" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c17-clang-xcode6.4-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c17" CXXFLAGS="-Wall -Werror -std=c++17" CC=clang CXX=clang++

--- a/.travis.yml
+++ b/.travis.yml
@@ -573,7 +573,6 @@ _matrix_osx_gnustd_nowarn:
     compiler: clang
     cache:
       directories:
-      - /usr/local/Cellar
       - $HOME/Library/Caches/Homebrew
       - $HOME/.ccache
 
@@ -583,7 +582,6 @@ _matrix_osx_gnustd_nowarn:
     compiler: clang
     cache:
       directories:
-      - /usr/local/Cellar
       - $HOME/Library/Caches/Homebrew
       - $HOME/.ccache
 
@@ -593,7 +591,6 @@ _matrix_osx_gnustd_nowarn:
     compiler: clang
     cache:
       directories:
-      - /usr/local/Cellar
       - $HOME/Library/Caches/Homebrew
       - $HOME/.ccache
 
@@ -605,7 +602,6 @@ _matrix_osx_gnustd_warn:
     compiler: clang
     cache:
       directories:
-      - /usr/local/Cellar
       - $HOME/Library/Caches/Homebrew
       - $HOME/.ccache
 
@@ -615,7 +611,6 @@ _matrix_osx_gnustd_warn:
     compiler: clang
     cache:
       directories:
-      - /usr/local/Cellar
       - $HOME/Library/Caches/Homebrew
       - $HOME/.ccache
 
@@ -627,7 +622,6 @@ _matrix_osx_cstd_nowarn:
     compiler: clang
     cache:
       directories:
-      - /usr/local/Cellar
       - $HOME/Library/Caches/Homebrew
       - $HOME/.ccache
 
@@ -637,7 +631,6 @@ _matrix_osx_cstd_nowarn:
     compiler: clang
     cache:
       directories:
-      - /usr/local/Cellar
       - $HOME/Library/Caches/Homebrew
       - $HOME/.ccache
 
@@ -649,7 +642,6 @@ _matrix_osx_cstd_warn:
     compiler: clang
     cache:
       directories:
-      - /usr/local/Cellar
       - $HOME/Library/Caches/Homebrew
       - $HOME/.ccache
 
@@ -659,7 +651,6 @@ _matrix_osx_cstd_warn:
     compiler: clang
     cache:
       directories:
-      - /usr/local/Cellar
       - $HOME/Library/Caches/Homebrew
       - $HOME/.ccache
 
@@ -669,7 +660,6 @@ _matrix_osx_cstd_warn:
     compiler: clang
     cache:
       directories:
-      - /usr/local/Cellar
       - $HOME/Library/Caches/Homebrew
       - $HOME/.ccache
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -258,7 +258,7 @@ matrix:
         - gcc-7
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="gnu14-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu14" CXXFLAGS="-std=gnu++14" CC=gcc-7 CXX=g++-7
+  - env: NUT_MATRIX_TAG="gnu14-gcc-8-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu14" CXXFLAGS="-std=gnu++14" CC=gcc-8 CXX=g++-8
     os: linux
     sudo: false
     services:
@@ -269,23 +269,8 @@ matrix:
         sources:
         - ubuntu-toolchain-r-test
         packages:
-        - g++-7
-        - gcc-7
-        - *deps_driverlibs
-
-  - env: NUT_MATRIX_TAG="gnu17-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc-7 CXX=g++-7
-    os: linux
-    sudo: false
-    services:
-        - docker
-    compiler: gcc
-    addons:
-      apt:
-        sources:
-        - ubuntu-toolchain-r-test
-        packages:
-        - g++-7
-        - gcc-7
+        - g++-8
+        - gcc-8
         - *deps_driverlibs
 
   - env: NUT_MATRIX_TAG="gnu17-gcc-9-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc-9 CXX=g++-9
@@ -615,8 +600,7 @@ matrix:
 #OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=gcc-7 CXX=g++-7
 #OK#  - env: NUT_MATRIX_TAG="gnu11-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu11" CXXFLAGS="-std=gnu++11" CC=gcc-7 CXX=g++-7
 #OK#  - env: NUT_MATRIX_TAG="gnu99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="gnu14-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu14" CXXFLAGS="-std=gnu++14" CC=gcc-7 CXX=g++-7
-  - env: NUT_MATRIX_TAG="gnu17-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc-7 CXX=g++-7
+  - env: NUT_MATRIX_TAG="gnu14-gcc-8-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu14" CXXFLAGS="-std=gnu++14" CC=gcc-8 CXX=g++-8
 #OK#  - env: NUT_MATRIX_TAG="gnu17-gcc-9-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc-9 CXX=g++-9
   - env: NUT_MATRIX_TAG="gnu17-gcc-9-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Werror -std=gnu++17" CC=gcc-9 CXX=g++-9
   - env: NUT_MATRIX_TAG="c99-clang-3.5-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang-3.5 CXX=clang++-3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -258,6 +258,51 @@ matrix:
         - gcc-7
         - *deps_driverlibs
 
+  - env: NUT_MATRIX_TAG="gnu14-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu14" CXXFLAGS="-std=gnu++14" CC=gcc-7 CXX=g++-7
+    os: linux
+    sudo: false
+    services:
+        - docker
+    compiler: gcc
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - g++-7
+        - gcc-7
+        - *deps_driverlibs
+
+  - env: NUT_MATRIX_TAG="gnu17-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc-7 CXX=g++-7
+    os: linux
+    sudo: false
+    services:
+        - docker
+    compiler: gcc
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - g++-7
+        - gcc-7
+        - *deps_driverlibs
+
+  - env: NUT_MATRIX_TAG="gnu17-gcc-9-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc-9 CXX=g++-9
+    os: linux
+    sudo: false
+    services:
+        - docker
+    compiler: gcc
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - g++-9
+        - gcc-9
+        - *deps_driverlibs
+
   - env: NUT_MATRIX_TAG="gnu99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
     os: linux
     dist: xenial
@@ -272,6 +317,22 @@ matrix:
         packages:
         - clang-5.0
         - clang-format-5.0
+        - *deps_driverlibs
+
+  - env: NUT_MATRIX_TAG="c99-clang-3.5-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang-3.5 CXX=clang++-3.5
+    os: linux
+    dist: xenial
+    sudo: false
+    services:
+        - docker
+    compiler: clang
+    addons:
+      apt:
+        sources:
+        - llvm-toolchain-xenial-3.5
+        packages:
+        - clang-3.5
+        - clang-format-3.5
         - *deps_driverlibs
 
   - env: NUT_MATRIX_TAG="c99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
@@ -304,6 +365,22 @@ matrix:
         packages:
         - clang-5.0
         - clang-format-5.0
+        - *deps_driverlibs
+
+  - env: NUT_MATRIX_TAG="c17-clang-8-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c17" CXXFLAGS="-std=c++17" CC=clang-8 CXX=clang++-8
+    os: linux
+    dist: xenial
+    sudo: false
+    services:
+        - docker
+    compiler: clang
+    addons:
+      apt:
+        sources:
+        - llvm-toolchain-xenial-8
+        packages:
+        - clang-8
+        - clang-format-8
         - *deps_driverlibs
 
   - env: NUT_MATRIX_TAG="cDefault-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic" CXXFLAGS="-Wall -Werror"
@@ -449,8 +526,13 @@ matrix:
 #OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=gcc-7 CXX=g++-7
 #OK#  - env: NUT_MATRIX_TAG="gnu11-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu11" CXXFLAGS="-std=gnu++11" CC=gcc-7 CXX=g++-7
 #OK#  - env: NUT_MATRIX_TAG="gnu99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="gnu14-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu14" CXXFLAGS="-std=gnu++14" CC=gcc-7 CXX=g++-7
+  - env: NUT_MATRIX_TAG="gnu17-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc-7 CXX=g++-7
+  - env: NUT_MATRIX_TAG="gnu17-gcc-9-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc-9 CXX=g++-9
+  - env: NUT_MATRIX_TAG="c99-clang-3.5-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang-3.5 CXX=clang++-3.5
   - env: NUT_MATRIX_TAG="c99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c11-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c11" CXXFLAGS="-std=c++11" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c17-clang-8-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c17" CXXFLAGS="-std=c++17" CC=clang-8 CXX=clang++-8
   - env: NUT_MATRIX_TAG="cDefault-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic" CXXFLAGS="-Wall -Werror"
   - env: NUT_MATRIX_TAG="gnu99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Werror -std=gnu++99"
   - env: NUT_MATRIX_TAG="c99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Werror -std=c++99"

--- a/.travis.yml
+++ b/.travis.yml
@@ -563,9 +563,9 @@ matrix:
     osx_image: xcode10.2
     compiler: clang
 
-  - env: NUT_MATRIX_TAG="c17-clang-xcode6.4-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c17" CXXFLAGS="-Wall -Werror -std=c++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c17-clang-xcode7.3-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c17" CXXFLAGS="-Wall -Werror -std=c++17" CC=clang CXX=clang++
     os: osx
-    osx_image: xcode6.4
+    osx_image: xcode7.3
     compiler: clang
 
 # Try also a build on Windows to see our horizons
@@ -634,7 +634,7 @@ matrix:
   - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Werror -std=c++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c17" CXXFLAGS="-std=c++17" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c17" CXXFLAGS="-Wall -Werror -std=c++17" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c17-clang-xcode6.4-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c17" CXXFLAGS="-Wall -Werror -std=c++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c17-clang-xcode7.3-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c17" CXXFLAGS="-Wall -Werror -std=c++17" CC=clang CXX=clang++
 ### windows
   - env: NUT_MATRIX_TAG="c99-clang-win-nowarn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c99-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Werror -std=c++99" CC=clang CXX=clang++

--- a/.travis.yml
+++ b/.travis.yml
@@ -305,6 +305,20 @@ matrix:
         - clang-format-8
         - *deps_driverlibs
 
+# Note: some of the warnings that are hidden in this case seem to be serious
+# issues that may impact viability of binaries built by C89 mode compilers!
+  - env: NUT_MATRIX_TAG="gnu89-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu89" CXXFLAGS="-std=gnu++89"
+    os: linux
+    sudo: false
+    services:
+        - docker
+    compiler: gcc
+    addons:
+      apt:
+        packages:
+        - *deps_driverlibs
+
+# At this time, anything with strict C standard fails on Linux, even "nowarn" cases below:
   - env: NUT_MATRIX_TAG="c99-clang-3.5-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang-3.5 CXX=clang++-3.5
     os: linux
     dist: xenial
@@ -369,6 +383,7 @@ matrix:
         - clang-format-8
         - *deps_driverlibs
 
+# Stuff with warnings made fatal... well, is usually fatal so far:
   - env: NUT_MATRIX_TAG="cDefault-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic" CXXFLAGS="-Wall -Werror"
     os: linux
     sudo: false
@@ -391,7 +406,7 @@ matrix:
         packages:
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="c99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Werror -std=c++99"
+  - env: NUT_MATRIX_TAG="gnu11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu11" CXXFLAGS="-Wall -Werror -std=gnu++11"
     os: linux
     sudo: false
     services:
@@ -430,6 +445,30 @@ matrix:
         packages:
         - g++-9
         - gcc-9
+        - *deps_driverlibs
+
+# Note: Fixing these would make NUT viable again on platforms with only ANSI C!
+  - env: NUT_MATRIX_TAG="gnu89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu89" CXXFLAGS="-Wall -Werror -std=gnu++89"
+    os: linux
+    sudo: false
+    services:
+        - docker
+    compiler: gcc
+    addons:
+      apt:
+        packages:
+        - *deps_driverlibs
+
+# The hardest of two worlds follows: both strict C standards on Linux and fatal warnings:
+  - env: NUT_MATRIX_TAG="c99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Werror -std=c++99"
+    os: linux
+    sudo: false
+    services:
+        - docker
+    compiler: gcc
+    addons:
+      apt:
+        packages:
         - *deps_driverlibs
 
   - env: NUT_MATRIX_TAG="c99-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Werror -std=c++99" CC=clang CXX=clang++
@@ -491,42 +530,7 @@ matrix:
         packages:
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="gnu11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu11" CXXFLAGS="-Wall -Werror -std=gnu++11"
-    os: linux
-    sudo: false
-    services:
-        - docker
-    compiler: gcc
-    addons:
-      apt:
-        packages:
-        - *deps_driverlibs
-
-# Note: some of the warnings that are hidden in this case seem to be serious
-# issues that may impact viability of binaries built by C89 mode compilers!
-  - env: NUT_MATRIX_TAG="gnu89-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu89" CXXFLAGS="-std=gnu++89"
-    os: linux
-    sudo: false
-    services:
-        - docker
-    compiler: gcc
-    addons:
-      apt:
-        packages:
-        - *deps_driverlibs
-
   - env: NUT_MATRIX_TAG="c89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c89" CXXFLAGS="-Wall -Werror -std=c++89"
-    os: linux
-    sudo: false
-    services:
-        - docker
-    compiler: gcc
-    addons:
-      apt:
-        packages:
-        - *deps_driverlibs
-
-  - env: NUT_MATRIX_TAG="gnu89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu89" CXXFLAGS="-Wall -Werror -std=gnu++89"
     os: linux
     sudo: false
     services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,10 +59,7 @@ addons:
     - libxml2-utils
     - libmodbus-dev
 
-# Define at least two jobs in the matrix, to avoid a failing job
-# with "no environment variables set" and have them built (one
-# is too few); but others are listed below to prioritize the
-# longer jobs to start first as faster ones complete in parallel.
+# Common settings for jobs in the matrix built below
 env:
   global:
     - CI_TIME=true
@@ -79,6 +76,21 @@ env:
 matrix:
   include:
 
+  - env: BUILD_TYPE=default-nodoc
+    os: linux
+    addons:
+      apt:
+        packages:
+        - *deps_driverlibs
+
+  - env: BUILD_TYPE=default-spellcheck
+    os: linux
+    addons:
+      apt:
+        packages: &deps_aspell
+        - aspell
+        - aspell-en
+
   - env: BUILD_TYPE=default
     os: linux
     addons:
@@ -93,26 +105,6 @@ matrix:
         packages:
         - *deps_driverlibs
 
-  - env: BUILD_TYPE=default-withdoc
-    os: linux
-    addons:
-      apt:
-        packages: &deps_gendocs
-        - asciidoc
-        - xsltproc
-        - dblatex
-        - docbook-xsl
-        - docbook-xsl-ns
-        - source-highlight
-        - libxml2-utils
-
-  - env: BUILD_TYPE=default-spellcheck
-    os: linux
-    addons:
-      apt:
-        packages: &deps_aspell
-        - aspell
-        - aspell-en
   - env: BUILD_TYPE=default-shellcheck
     os: linux
     addons:
@@ -121,16 +113,7 @@ matrix:
         - coreutils
         - file
         #TBD# - shellcheck
-  - env: BUILD_TYPE=default-tgt:distcheck-valgrind
-    os: linux
-    sudo: false
-    services:
-        - docker
-    addons:
-      apt:
-        packages:
-        - *deps_driverlibs
-        - valgrind
+
 # Other quicker builds in standard env follow:
   - env: BUILD_TYPE=nut-driver-enumerator-test SHELL_PROGS=bash
     os: linux
@@ -164,12 +147,31 @@ matrix:
       apt:
         packages:
         - ash
-  - env: BUILD_TYPE=default-nodoc
+
+  - env: BUILD_TYPE=default-tgt:distcheck-valgrind
     os: linux
+    sudo: false
+    services:
+        - docker
     addons:
       apt:
         packages:
         - *deps_driverlibs
+        - valgrind
+
+  - env: BUILD_TYPE=default-withdoc
+    os: linux
+    addons:
+      apt:
+        packages: &deps_gendocs
+        - asciidoc
+        - xsltproc
+        - dblatex
+        - docbook-xsl
+        - docbook-xsl-ns
+        - source-highlight
+        - libxml2-utils
+
   - env: BUILD_TYPE=default-alldrv
     os: linux
     sudo: false
@@ -179,6 +181,7 @@ matrix:
       apt:
         packages:
         - *deps_driverlibs
+
   - env:
     - BUILD_TYPE=default-tgt:distcheck-light
     - NO_PKG_CONFIG=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -565,11 +565,21 @@ _matrix_osx_cstd_nowarn:
     os: osx
     osx_image: xcode10.2
     compiler: clang
+    cache:
+      directories:
+      - /usr/local/Cellar
+      - $HOME/Library/Caches/Homebrew
+      - $HOME/.ccache
 
   - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c17" CXXFLAGS="-std=c++17" CC=clang CXX=clang++
     os: osx
     osx_image: xcode10.2
     compiler: clang
+    cache:
+      directories:
+      - /usr/local/Cellar
+      - $HOME/Library/Caches/Homebrew
+      - $HOME/.ccache
 
 _matrix_osx_cstd_warn:
   include: &_matrix_osx_cstd_warn
@@ -577,16 +587,31 @@ _matrix_osx_cstd_warn:
     os: osx
     osx_image: xcode10.2
     compiler: clang
+    cache:
+      directories:
+      - /usr/local/Cellar
+      - $HOME/Library/Caches/Homebrew
+      - $HOME/.ccache
 
   - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c17" CXXFLAGS="-Wall -Werror -std=c++17" CC=clang CXX=clang++
     os: osx
     osx_image: xcode10.2
     compiler: clang
+    cache:
+      directories:
+      - /usr/local/Cellar
+      - $HOME/Library/Caches/Homebrew
+      - $HOME/.ccache
 
   - env: NUT_MATRIX_TAG="c17-clang-xcode7.3-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c17" CXXFLAGS="-Wall -Werror -std=c++17" CC=clang CXX=clang++
     os: osx
     osx_image: xcode7.3
     compiler: clang
+    cache:
+      directories:
+      - /usr/local/Cellar
+      - $HOME/Library/Caches/Homebrew
+      - $HOME/.ccache
 
 # Try also a build on Windows to see our horizons
 # https://docs.travis-ci.com/user/reference/windows/

--- a/.travis.yml
+++ b/.travis.yml
@@ -803,9 +803,11 @@ _matrix_all:
 _matrix_master:
   include: &_matrix_master
   - *_matrix_required
-  - *_matrix_allowfail_linux
-  - *_matrix_osx
-  - *_matrix_windows
+### Enable for branch builds that intend to fix the issues which preclude
+### following items from becoming green:
+#  - *_matrix_allowfail_linux
+#  - *_matrix_allowfail_osx
+#  - *_matrix_windows
 
 _matrix_fixbugs:
   include: &_matrix_fixbugs

--- a/.travis.yml
+++ b/.travis.yml
@@ -551,6 +551,64 @@ matrix:
         packages:
         - *deps_driverlibs
 
+# Try also a range of platforms for MacOS X builds
+# Inspired by https://github.com/taocpp/operators/blob/master/.travis.yml
+  - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
+    os: osx
+    osx_image: xcode10.2
+    compiler: clang
+
+  - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c17" CXXFLAGS="-std=c++17" CC=clang CXX=clang++
+    os: osx
+    osx_image: xcode10.2
+    compiler: clang
+
+  - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c17" CXXFLAGS="-Wall -Werror -std=c++17" CC=clang CXX=clang++
+    os: osx
+    osx_image: xcode10.2
+    compiler: clang
+
+  - env: NUT_MATRIX_TAG="c17-clang-xcode6.4-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c17" CXXFLAGS="-Wall -Werror -std=c++17" CC=clang CXX=clang++
+    os: osx
+    osx_image: xcode6.4
+    compiler: clang
+
+# Try also a build on Windows to see our horizons
+# https://docs.travis-ci.com/user/reference/windows/
+# says we have clang-9 there by default (and there is
+# a complex routine to add gcc if we'd need that)
+# and a Git Bash as default shell, but no ccache.
+# TODO: Eventually try native visualstudio compilers?
+  - env: NUT_MATRIX_TAG="c99-clang-win-nowarn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
+    os: windows
+    compiler: clang
+    cache:
+      directories:
+      - $HOME/AppData/Local/Temp/chocolatey
+      - $HOME/.ccache
+      - /C/tools
+
+  - env: NUT_MATRIX_TAG="c99-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Werror -std=c++99" CC=clang CXX=clang++
+    os: windows
+    compiler: clang
+    cache:
+      directories:
+      - $HOME/AppData/Local/Temp/chocolatey
+      - $HOME/.ccache
+      - /C/tools
+
+# Incidentally, this is one platform we know to have clang-9,
+# the version which has (at least partial) C++20 support
+  - env: NUT_MATRIX_TAG="c20-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Werror -pedantic -std=c20" CXXFLAGS="-Wall -Werror -std=c++20" CC=clang CXX=clang++
+    os: windows
+    compiler: clang
+    cache:
+      directories:
+      - $HOME/AppData/Local/Temp/chocolatey
+      - $HOME/.ccache
+      - /C/tools
+
+###################################################################################
 # Note: "env" lines below must exactly describe a matrix option defined above
   allow_failures:
 #OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99"
@@ -577,9 +635,30 @@ matrix:
 #OK#  - env: NUT_MATRIX_TAG="gnu89-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu89" CXXFLAGS="-std=gnu++89"
   - env: NUT_MATRIX_TAG="c89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c89" CXXFLAGS="-Wall -Werror -std=c++89"
   - env: NUT_MATRIX_TAG="gnu89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu89" CXXFLAGS="-Wall -Werror -std=gnu++89"
+### macosx
+  - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c17" CXXFLAGS="-std=c++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c17" CXXFLAGS="-Wall -Werror -std=c++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c17-clang-xcode6.4-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c17" CXXFLAGS="-Wall -Werror -std=c++17" CC=clang CXX=clang++
+### windows
+  - env: NUT_MATRIX_TAG="c99-clang-win-nowarn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c99-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Werror -std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c20-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Werror -pedantic -std=c20" CXXFLAGS="-Wall -Werror -std=c++20" CC=clang CXX=clang++
 
 before_install:
-- if [ $TRAVIS_OS_NAME == "osx" ] ; then brew update; brew install binutils asciidoc docbook-xsl ; XML_CATALOG_FILES=/usr/local/etc/xml/catalog ; export XML_CATALOG_FILES ; fi
+- if [ $TRAVIS_OS_NAME == "osx" ] ; then brew update; brew install binutils gd asciidoc docbook-xsl ; XML_CATALOG_FILES=/usr/local/etc/xml/catalog ; export XML_CATALOG_FILES ; fi
+- |-
+    if [[ $TRAVIS_OS_NAME == "windows" ]] ; then
+        if [[ ! -s C:/tools/bin/ccache.exe ]] ; then
+            mkdir -p C:/tools/bin/
+            pushd C:/tools/bin/ || exit
+                wget https://github.com/ccache/ccache/releases/download/v3.7.12/ccache-3.7.12-windows-64.zip || exit
+                7z x -y ccache-3.7.12-windows-64.zip || exit
+                rm -f ccache-3.7.12-windows-64.zip
+            popd
+        fi
+        export PATH=/C/tools/bin:$PATH
+    fi
 - if [ -n "${NUT_MATRIX_TAG}" ] ; then export CFLAGS CXXFLAGS ; [ -z "$CC" ] || export CC ; [ -z "$CXX" ] || export CXX ; fi
 
 # Hand off to generated script for each BUILD_TYPE

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,9 +67,6 @@ env:
   global:
     - CI_TIME=true
     - CI_TRACE=false
-  matrix:
-    - BUILD_TYPE=default
-    - BUILD_TYPE=default-tgt:distcheck-light
 
 # Builds with customized setups
 # Note that doc-related builds take the longest, and Travis CI cloud
@@ -81,6 +78,21 @@ env:
 # (ksh) and Linux (bash, dash, etc.) common distros.
 matrix:
   include:
+
+  - env: BUILD_TYPE=default
+    os: linux
+    addons:
+      apt:
+        packages:
+        - *deps_driverlibs
+
+  - env: BUILD_TYPE=default-tgt:distcheck-light
+    os: linux
+    addons:
+      apt:
+        packages:
+        - *deps_driverlibs
+
   - env: BUILD_TYPE=default-withdoc
     os: linux
     addons:
@@ -93,6 +105,7 @@ matrix:
         - docbook-xsl-ns
         - source-highlight
         - libxml2-utils
+
   - env: BUILD_TYPE=default-spellcheck
     os: linux
     addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -741,16 +741,29 @@ _matrix_allowfail_osx:
   - *_matrix_osx_gnustd_warn
   - *_matrix_osx_cstd_warn
 
+_matrix_required_osx:
+  include: &_matrix_required_osx
+  - *_matrix_osx_gnustd_nowarn
+
 _matrix_osx:
   include: &_matrix_osx
-  - *_matrix_osx_gnustd_nowarn
+  - *_matrix_required_osx
   - *_matrix_allowfail_osx
 
-_matrix_windows:
-  include: &_matrix_windows
+# Nothing this good yet
+#_matrix_required_windows:
+#  include: &_matrix_required_windows
+
+_matrix_allowfail_windows:
+  include: &_matrix_allowfail_windows
   - *_matrix_windows_gnustd_nowarn
   - *_matrix_windows_cstd_nowarn
   - *_matrix_windows_cstd_warn
+
+_matrix_windows:
+  include: &_matrix_windows
+#  - *_matrix_required_windows
+  - *_matrix_allowfail_windows
 
 # Different dissections of interest to fixers:
 _matrix_cstd_nowarn:
@@ -773,6 +786,8 @@ _matrix_warn:
 _matrix_required:
   include: &_matrix_required
   - *_matrix_required_linux
+  - *_matrix_required_osx
+#  - *_matrix_required_windows
 
 _matrix_master:
   include: &_matrix_master

--- a/.travis.yml
+++ b/.travis.yml
@@ -856,7 +856,7 @@ before_install:
             mkdir -p C:/tools/bin/
             pushd C:/tools/bin/ || exit
                 wget https://github.com/ccache/ccache/releases/download/v3.7.12/ccache-3.7.12-windows-64.zip || exit
-                7z x -y ccache-3.7.12-windows-64.zip || exit
+                7z e -y ccache-3.7.12-windows-64.zip || exit
                 rm -f ccache-3.7.12-windows-64.zip
             popd
         fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,12 @@ env:
   global:
     - CI_TIME=true
     - CI_TRACE=false
+    - CI_DEFAULT_HOMEBREW_NO_AUTO_UPDATE=1
+      # By default, avoid updating (including cleaning) osx worker beside what
+      # we require to install, compared to what Travis provides. Technically
+      # we can call master branch builds sometimes to update the workers cache
+      # of packages by manual or timer-driven runs with explicit setting like
+      # HOMEBREW_NO_AUTO_UPDATE=0
 
 # Builds with customized setups
 # Note that doc-related builds take the longest, and Travis CI cloud
@@ -771,10 +777,17 @@ jobs:
 
 before_install:
 - |-
-  if [ $TRAVIS_OS_NAME == "osx" ] ; then
-    brew update
+  if [ $TRAVIS_OS_NAME = "osx" ] ; then
+    [ -n "$HOMEBREW_NO_AUTO_UPDATE" ] || HOMEBREW_NO_AUTO_UPDATE="$CI_DEFAULT_HOMEBREW_NO_AUTO_UPDATE"
+    if [ "$HOMEBREW_NO_AUTO_UPDATE" = 1 ] ; then
+        echo "NOT CALLING 'brew update' as it takes too long and cleans up preinstalled env"
+        export HOMEBREW_NO_AUTO_UPDATE
+    else
+        unset HOMEBREW_NO_AUTO_UPDATE
+        brew update
+    fi
     brew install binutils ccache gd
-    if [ $BUILD_TYPE = default-withdoc ] ; then
+    if [ "$BUILD_TYPE" = default-withdoc ] ; then
         brew install asciidoc docbook-xsl
         XML_CATALOG_FILES=/usr/local/etc/xml/catalog
         export XML_CATALOG_FILES

--- a/.travis.yml
+++ b/.travis.yml
@@ -197,6 +197,12 @@ matrix:
 # and different lenience against warnings. Many of
 # these blocks look similar and all should have unique
 # "env" field to use some with allowed_failure below.
+# For a list of standards supported, see:
+#   https://gcc.gnu.org/onlinedocs/gcc/Standards.html
+#   https://gcc.gnu.org/projects/cxx-status.html
+#   https://clang.llvm.org/cxx_status.html
+# Note that while there is C++14 there is no C14:
+#   https://en.wikipedia.org/wiki/C_(programming_language)#History
 #
 # The leading NUT_MATRIX_TAG allows humans to understand
 # what a test case is about in Travis CI dashboard table

--- a/.travis.yml
+++ b/.travis.yml
@@ -831,7 +831,7 @@ jobs:
 ### macosx
 #OK#  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
 #OK#  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="gnu99-clang-xcode7.3-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
+#OK#  - env: NUT_MATRIX_TAG="gnu99-clang-xcode7.3-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Werror -std=gnu++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Werror -std=gnu++17" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
@@ -875,7 +875,8 @@ before_install:
         fi
         export PATH=/C/tools/bin:$PATH
         CI_TRACE=true
-        export CI_TRACE
+        CI_TIME=false
+        export CI_TRACE CI_TIME
     fi
 - if [ -n "${NUT_MATRIX_TAG}" ] ; then export CFLAGS CXXFLAGS ; [ -z "$CC" ] || export CC ; [ -z "$CXX" ] || export CXX ; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -699,7 +699,11 @@ _matrix_fixbugs:
 # DO NOT COMMIT TO MASTER BRANCH TEST-MATRICES THAT ARE NOT _matrix-master!
 #
 # These days, "jobs" and "matrix" are same thing... at least, ours is an explicit list.
+# By "fast_finish" we allow to assign a verdict based on completion of required
+# test cases. The "allow_failures" will proceed to run for our information
+# but not block nor delay PR considerations etc.
 jobs:
+  fast_finish: true
   include:
   - *_matrix_master
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -669,6 +669,17 @@ _matrix_osx_cstd_warn:
 # a complex routine to add gcc if we'd need that)
 # and a Git Bash as default shell, but no ccache.
 # TODO: Eventually try native visualstudio compilers?
+_matrix_windows_gnustd_nowarn:
+  include: &_matrix_windows_gnustd_nowarn
+  - env: NUT_MATRIX_TAG="gnu99-clang-win-nowarn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
+    os: windows
+    compiler: clang
+    cache:
+      directories:
+      - $HOME/AppData/Local/Temp/chocolatey
+      - $HOME/.ccache
+      - /C/tools
+
 _matrix_windows_cstd_nowarn:
   include: &_matrix_windows_cstd_nowarn
   - env: NUT_MATRIX_TAG="c99-clang-win-nowarn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
@@ -737,6 +748,7 @@ _matrix_osx:
 
 _matrix_windows:
   include: &_matrix_windows
+  - *_matrix_windows_gnustd_nowarn
   - *_matrix_windows_cstd_nowarn
   - *_matrix_windows_cstd_warn
 
@@ -828,6 +840,7 @@ jobs:
   - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c17" CXXFLAGS="-Wall -Werror -std=c++17" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c17-clang-xcode7.3-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c17" CXXFLAGS="-Wall -Werror -std=c++17" CC=clang CXX=clang++
 ### windows
+  - env: NUT_MATRIX_TAG="gnu99-clang-win-nowarn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c99-clang-win-nowarn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c99-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Werror -std=c++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c20-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Werror -pedantic -std=c20" CXXFLAGS="-Wall -Werror -std=c++20" CC=clang CXX=clang++

--- a/.travis.yml
+++ b/.travis.yml
@@ -617,7 +617,7 @@ matrix:
 #OK#  - env: NUT_MATRIX_TAG="gnu99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="gnu14-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu14" CXXFLAGS="-std=gnu++14" CC=gcc-7 CXX=g++-7
   - env: NUT_MATRIX_TAG="gnu17-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc-7 CXX=g++-7
-  - env: NUT_MATRIX_TAG="gnu17-gcc-9-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc-9 CXX=g++-9
+#OK#  - env: NUT_MATRIX_TAG="gnu17-gcc-9-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc-9 CXX=g++-9
   - env: NUT_MATRIX_TAG="gnu17-gcc-9-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Werror -std=gnu++17" CC=gcc-9 CXX=g++-9
   - env: NUT_MATRIX_TAG="c99-clang-3.5-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang-3.5 CXX=clang++-3.5
   - env: NUT_MATRIX_TAG="c99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++

--- a/.travis.yml
+++ b/.travis.yml
@@ -258,21 +258,6 @@ matrix:
         - gcc-7
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="gnu14-gcc-8-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu14" CXXFLAGS="-std=gnu++14" CC=gcc-8 CXX=g++-8
-    os: linux
-    sudo: false
-    services:
-        - docker
-    compiler: gcc
-    addons:
-      apt:
-        sources:
-        - ubuntu-toolchain-r-test
-        packages:
-        - g++-8
-        - gcc-8
-        - *deps_driverlibs
-
   - env: NUT_MATRIX_TAG="gnu17-gcc-9-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc-9 CXX=g++-9
     os: linux
     sudo: false
@@ -302,6 +287,22 @@ matrix:
         packages:
         - clang-5.0
         - clang-format-5.0
+        - *deps_driverlibs
+
+  - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang-8 CXX=clang++-8
+    os: linux
+    dist: xenial
+    sudo: false
+    services:
+        - docker
+    compiler: clang
+    addons:
+      apt:
+        sources:
+        - llvm-toolchain-xenial-8
+        packages:
+        - clang-8
+        - clang-format-8
         - *deps_driverlibs
 
   - env: NUT_MATRIX_TAG="c99-clang-3.5-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang-3.5 CXX=clang++-3.5
@@ -599,9 +600,9 @@ matrix:
 #OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99"
 #OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=gcc-7 CXX=g++-7
 #OK#  - env: NUT_MATRIX_TAG="gnu11-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu11" CXXFLAGS="-std=gnu++11" CC=gcc-7 CXX=g++-7
-#OK#  - env: NUT_MATRIX_TAG="gnu99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="gnu14-gcc-8-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu14" CXXFLAGS="-std=gnu++14" CC=gcc-8 CXX=g++-8
 #OK#  - env: NUT_MATRIX_TAG="gnu17-gcc-9-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc-9 CXX=g++-9
+#OK#  - env: NUT_MATRIX_TAG="gnu99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
+#OK#  - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang-8 CXX=clang++-8
   - env: NUT_MATRIX_TAG="gnu17-gcc-9-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Werror -std=gnu++17" CC=gcc-9 CXX=g++-9
   - env: NUT_MATRIX_TAG="c99-clang-3.5-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang-3.5 CXX=clang++-3.5
   - env: NUT_MATRIX_TAG="c99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++

--- a/.travis.yml
+++ b/.travis.yml
@@ -770,7 +770,16 @@ jobs:
   - env: NUT_MATRIX_TAG="c20-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Werror -pedantic -std=c20" CXXFLAGS="-Wall -Werror -std=c++20" CC=clang CXX=clang++
 
 before_install:
-- if [ $TRAVIS_OS_NAME == "osx" ] ; then brew update; brew install binutils gd asciidoc docbook-xsl ; XML_CATALOG_FILES=/usr/local/etc/xml/catalog ; export XML_CATALOG_FILES ; fi
+- |-
+  if [ $TRAVIS_OS_NAME == "osx" ] ; then
+    brew update
+    brew install binutils ccache gd
+    if [ $BUILD_TYPE = default-withdoc ] ; then
+        brew install asciidoc docbook-xsl
+        XML_CATALOG_FILES=/usr/local/etc/xml/catalog
+        export XML_CATALOG_FILES
+    fi
+  fi
 - |-
     if [[ $TRAVIS_OS_NAME == "windows" ]] ; then
         if [[ ! -s C:/tools/bin/ccache.exe ]] ; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -757,6 +757,8 @@ before_install:
             popd
         fi
         export PATH=/C/tools/bin:$PATH
+        CI_TRACE=true
+        export CI_TRACE
     fi
 - if [ -n "${NUT_MATRIX_TAG}" ] ; then export CFLAGS CXXFLAGS ; [ -z "$CC" ] || export CC ; [ -z "$CXX" ] || export CXX ; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -735,6 +735,11 @@ _matrix_allowfail_linux:
   - *_matrix_linux_gnustd_warn
   - *_matrix_linux_cstd_warn
 
+_matrix_linux:
+  include: &_matrix_linux
+  - *_matrix_required_linux
+  - *_matrix_allowfail_linux
+
 _matrix_allowfail_osx:
   include: &_matrix_allowfail_osx
   - *_matrix_osx_cstd_nowarn
@@ -788,6 +793,12 @@ _matrix_required:
   - *_matrix_required_linux
   - *_matrix_required_osx
 #  - *_matrix_required_windows
+
+_matrix_all:
+  include: &_matrix_all
+  - *_matrix_linux
+  - *_matrix_osx
+  - *_matrix_windows
 
 _matrix_master:
   include: &_matrix_master

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -162,9 +162,14 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
             CONFIG_OPTS+=("--with-doc=skip")
             # Enable as many binaries to build as current worker setup allows
             CONFIG_OPTS+=("--with-all=auto")
-            # Currently --with-all implies this, but better be sure to
-            # really build everything we can to be certain it builds:
-            CONFIG_OPTS+=("--with-cgi=yes")
+            if [[ $TRAVIS_OS_NAME != "windows" ]] ; then
+                # Currently --with-all implies this, but better be sure to
+                # really build everything we can to be certain it builds:
+                CONFIG_OPTS+=("--with-cgi=yes")
+            else
+                # No prereq dll and headers on win so far
+                CONFIG_OPTS+=("--with-cgi=auto")
+            fi
             ;;
         "default-alldrv")
             # Do not build the docs and make possible a distcheck below

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -255,7 +255,7 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
     else
         $CI_TIME ./autogen.sh 2>/dev/null
     fi
-    if [ "$NO_PKG_CONFIG" == "true" ] ; then
+    if [ "$NO_PKG_CONFIG" == "true" ] && [ "$TRAVIS_OS_NAME" = "linux" ] ; then
         echo "NO_PKG_CONFIG==true : BUTCHER pkg-config for this test case" >&2
         sudo dpkg -r --force all pkg-config
     fi

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -40,6 +40,17 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
     BUILD_PREFIX=$PWD/tmp
     INST_PREFIX=$PWD/.inst
 
+    echo "PATH='$PATH' before possibly applying CCACHE into the mix"
+    if [ -n "$CC" ]; then
+        echo "CC='$CC' before possibly applying CCACHE into the mix"
+        $CC --version || true
+    fi
+
+    if [ -n "$CXX" ]; then
+        echo "CXX='$CXX' before possibly applying CCACHE into the mix"
+        $CXX --version || true
+    fi
+
     PATH="`echo "$PATH" | sed -e 's,^/usr/lib/ccache/?:,,' -e 's,:/usr/lib/ccache/?:,,' -e 's,:/usr/lib/ccache/?$,,' -e 's,^/usr/lib/ccache/?$,,'`"
     CCACHE_PATH="$PATH"
     CCACHE_DIR="${HOME}/.ccache"

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -162,7 +162,7 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
             CONFIG_OPTS+=("--with-doc=skip")
             # Enable as many binaries to build as current worker setup allows
             CONFIG_OPTS+=("--with-all=auto")
-            if [[ $TRAVIS_OS_NAME != "windows" ]] ; then
+            if [[ "$TRAVIS_OS_NAME" != "windows" ]] ; then
                 # Currently --with-all implies this, but better be sure to
                 # really build everything we can to be certain it builds:
                 CONFIG_OPTS+=("--with-cgi=yes")
@@ -242,7 +242,7 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
 
     # Build and check this project; note that zprojects always have an autogen.sh
     [ -z "$CI_TIME" ] || echo "`date`: Starting build of currently tested project..."
-    CCACHE_BASEDIR=${PWD}
+    CCACHE_BASEDIR="${PWD}"
     export CCACHE_BASEDIR
 
     # Note: modern auto(re)conf requires pkg-config to generate the configure
@@ -250,7 +250,11 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
     # older system) we have to remove it when we already have the script.
     # This matches the use-case of distro-building from release tarballs that
     # include all needed pre-generated files to rely less on OS facilities.
-    $CI_TIME ./autogen.sh 2> /dev/null
+    if [ "$TRAVIS_OS_NAME" = "windows" ] ; then
+        $CI_TIME ./autogen.sh || true
+    else
+        $CI_TIME ./autogen.sh 2>/dev/null
+    fi
     if [ "$NO_PKG_CONFIG" == "true" ] ; then
         echo "NO_PKG_CONFIG==true : BUTCHER pkg-config for this test case" >&2
         sudo dpkg -r --force all pkg-config

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -24,6 +24,7 @@ case "$CI_TRACE" in
         set -x ;;
 esac
 
+echo "Processing BUILD_TYPE='${BUILD_TYPE}' ..."
 case "$BUILD_TYPE" in
 default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|default-nodoc|default-withdoc|"default-tgt:"*)
     LANG=C
@@ -338,6 +339,12 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
     ;;
 bindings)
     pushd "./bindings/${BINDING}" && ./ci_build.sh
+    ;;
+"")
+    echo "ERROR: No BUILD_TYPE was specified, doing a minimal default ritual"
+    ./autogen.sh
+    ./configure
+    make all && make check
     ;;
 *)
     pushd "./builds/${BUILD_TYPE}" && REPO_DIR="$(dirs -l +1)" ./ci_build.sh

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -41,13 +41,16 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
     INST_PREFIX=$PWD/.inst
 
     echo "PATH='$PATH' before possibly applying CCACHE into the mix"
+    ( echo "$PATH" | grep ccache ) >/dev/null && echo "WARNING: ccache is already in PATH"
     if [ -n "$CC" ]; then
         echo "CC='$CC' before possibly applying CCACHE into the mix"
+        $CC --version $CFLAGS || \
         $CC --version || true
     fi
 
     if [ -n "$CXX" ]; then
         echo "CXX='$CXX' before possibly applying CCACHE into the mix"
+        $CXX --version $CXXFLAGS || \
         $CXX --version || true
     fi
 


### PR DESCRIPTION
Follows up from #829 (for issue #823) to disable in master branch and PR builds the test cases which are currently failing and not actively being addressed, to conserve Travis CI resources. Developers who would pick up experiments on fixing those builds (warnings made fatal, strict C standards, Windows builds) can easily uncomment these lines in their branches, and eventually post to master new green lines for future commits to keep up as green.

There were other possibilities experimented, with Travis conditions https://docs.travis-ci.com/user/conditions-v1 as one possibility (reduce CI stress from "main" codebase by default, while letting more build in forks by default), or build stage support to avoid probably-failing builds if the required part of codebase fails to pass the tests, but they were too complex and did not work as expected. Maybe someone later would succeed in those or similar directions too.