### PR TITLE
Fightwarn groundwork

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -838,9 +838,9 @@ _matrix_master:
 ### Enabled for branches with names containing "fightwarn" to perform
 ### builds that intend to actively fix the issues which preclude the
 ### following items from becoming green:
-#  - *_matrix_allowfail_linux
-#  - *_matrix_allowfail_osx
-#  - *_matrix_windows
+  - *_matrix_allowfail_linux
+  - *_matrix_allowfail_osx
+  - *_matrix_windows
 
 _matrix_fixbugs:
   include: &_matrix_fixbugs

--- a/.travis.yml
+++ b/.travis.yml
@@ -509,7 +509,7 @@ _matrix_linux_cstd_warn:
         packages:
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="c99-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c99-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++99" CC=clang CXX=clang++
     os: linux
     dist: xenial
     sudo: false
@@ -526,7 +526,7 @@ _matrix_linux_cstd_warn:
         - clang-format-5.0
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="c11-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++11" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c11-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++11" CC=clang CXX=clang++
     os: linux
     dist: xenial
     sudo: false
@@ -543,7 +543,7 @@ _matrix_linux_cstd_warn:
         - clang-format-5.0
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="c17-clang-8-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++17" CC=clang-8 CXX=clang++-8
+  - env: NUT_MATRIX_TAG="c17-clang-8-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++17" CC=clang-8 CXX=clang++-8
     os: linux
     dist: xenial
     sudo: false
@@ -617,7 +617,7 @@ _matrix_osx_gnustd_nowarn:
 
 _matrix_osx_gnustd_warn:
   include: &_matrix_osx_gnustd_warn
-  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=gnu++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=gnu++99" CC=clang CXX=clang++
     os: osx
     osx_image: xcode10.2
     compiler: clang
@@ -627,7 +627,7 @@ _matrix_osx_gnustd_warn:
       - $HOME/Library/Caches/Homebrew
       - $HOME/.ccache
 
-  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=gnu++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=gnu++17" CC=clang CXX=clang++
     os: osx
     osx_image: xcode10.2
     compiler: clang
@@ -661,7 +661,7 @@ _matrix_osx_cstd_nowarn:
 
 _matrix_osx_cstd_warn:
   include: &_matrix_osx_cstd_warn
-  - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++99" CC=clang CXX=clang++
     os: osx
     osx_image: xcode10.2
     compiler: clang
@@ -671,7 +671,7 @@ _matrix_osx_cstd_warn:
       - $HOME/Library/Caches/Homebrew
       - $HOME/.ccache
 
-  - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++17" CC=clang CXX=clang++
     os: osx
     osx_image: xcode10.2
     compiler: clang
@@ -681,7 +681,7 @@ _matrix_osx_cstd_warn:
       - $HOME/Library/Caches/Homebrew
       - $HOME/.ccache
 
-  - env: NUT_MATRIX_TAG="c17-clang-xcode7.3-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c17-clang-xcode7.3-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++17" CC=clang CXX=clang++
     os: osx
     osx_image: xcode7.3
     compiler: clang
@@ -723,7 +723,7 @@ _matrix_windows_cstd_nowarn:
 
 _matrix_windows_cstd_warn:
   include: &_matrix_windows_cstd_warn
-  - env: NUT_MATRIX_TAG="c99-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c99-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++99" CC=clang CXX=clang++
     os: windows
     compiler: clang
     if: branch =~ fightwarn
@@ -735,7 +735,7 @@ _matrix_windows_cstd_warn:
 
 # Incidentally, this is one platform we know to have clang-9,
 # the version which has (at least partial) C++20 support
-  - env: NUT_MATRIX_TAG="c20-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c20" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++20" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c20-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c20" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++20" CC=clang CXX=clang++
     os: windows
     compiler: clang
     if: branch =~ fightwarn
@@ -881,13 +881,13 @@ jobs:
   - env: NUT_MATRIX_TAG="c99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c11-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c11" CXXFLAGS="-std=c++11" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c17-clang-8-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c17" CXXFLAGS="-std=c++17" CC=clang-8 CXX=clang++-8
-  - env: NUT_MATRIX_TAG="c17-clang-8-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++17" CC=clang-8 CXX=clang++-8
+  - env: NUT_MATRIX_TAG="c17-clang-8-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++17" CC=clang-8 CXX=clang++-8
   - env: NUT_MATRIX_TAG="cDefault-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic" CXXFLAGS="-Wall -Wextra -Werror"
   - env: NUT_MATRIX_TAG="gnu99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++99"
   - env: NUT_MATRIX_TAG="c99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -std=c++99"
   - env: NUT_MATRIX_TAG="gnu99-gcc-7-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++99" CC=gcc-7 CXX=g++-7
-  - env: NUT_MATRIX_TAG="c99-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c11-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++11" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c99-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c11-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++11" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror -std=c++11"
   - env: NUT_MATRIX_TAG="gnu11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu11" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++11"
 #OK#  - env: NUT_MATRIX_TAG="gnu89-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu89" CXXFLAGS="-std=gnu++89"
@@ -897,18 +897,18 @@ jobs:
 #OK#  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
 #OK#  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang CXX=clang++
 #OK#  - env: NUT_MATRIX_TAG="gnu99-clang-xcode7.3-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=gnu++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=gnu++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=gnu++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=gnu++17" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c17" CXXFLAGS="-std=c++17" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++17" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c17-clang-xcode7.3-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c17-clang-xcode7.3-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++17" CC=clang CXX=clang++
 ### windows
   - env: NUT_MATRIX_TAG="gnu99-clang-win-nowarn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c99-clang-win-nowarn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c99-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c20-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c20" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++20" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c99-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c20-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c20" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++20" CC=clang CXX=clang++
 
 before_install:
 - |-

--- a/.travis.yml
+++ b/.travis.yml
@@ -413,7 +413,7 @@ _matrix_linux_cstd_nowarn:
 # Stuff with warnings made fatal... well, is usually fatal so far:
 _matrix_linux_gnustd_warn:
   include: &_matrix_linux_gnustd_warn
-  - env: NUT_MATRIX_TAG="cDefault-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic" CXXFLAGS="-Wall -Wextra -Werror"
+  - env: NUT_MATRIX_TAG="cDefault-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror"
     os: linux
     sudo: false
     services:
@@ -425,7 +425,7 @@ _matrix_linux_gnustd_warn:
         packages:
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="gnu99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++99"
+  - env: NUT_MATRIX_TAG="gnu99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=gnu++99"
     os: linux
     sudo: false
     services:
@@ -437,7 +437,7 @@ _matrix_linux_gnustd_warn:
         packages:
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="gnu11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu11" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++11"
+  - env: NUT_MATRIX_TAG="gnu11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=gnu11" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=gnu++11"
     os: linux
     sudo: false
     services:
@@ -449,7 +449,7 @@ _matrix_linux_gnustd_warn:
         packages:
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="gnu99-gcc-7-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++99" CC=gcc-7 CXX=g++-7
+  - env: NUT_MATRIX_TAG="gnu99-gcc-7-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=gnu++99" CC=gcc-7 CXX=g++-7
     os: linux
     sudo: false
     services:
@@ -465,7 +465,7 @@ _matrix_linux_gnustd_warn:
         - gcc-7
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="gnu17-gcc-9-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++17" CC=gcc-9 CXX=g++-9
+  - env: NUT_MATRIX_TAG="gnu17-gcc-9-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=gnu++17" CC=gcc-9 CXX=g++-9
     os: linux
     sudo: false
     services:
@@ -482,7 +482,7 @@ _matrix_linux_gnustd_warn:
         - *deps_driverlibs
 
 # Note: Fixing these would make NUT viable again on platforms with only ANSI C!
-  - env: NUT_MATRIX_TAG="gnu89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu89" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++89"
+  - env: NUT_MATRIX_TAG="gnu89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=gnu89" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=gnu++89"
     os: linux
     sudo: false
     services:
@@ -497,7 +497,7 @@ _matrix_linux_gnustd_warn:
 # The hardest of two worlds: both strict C standards on Linux and fatal warnings:
 _matrix_linux_cstd_warn:
   include: &_matrix_linux_cstd_warn
-  - env: NUT_MATRIX_TAG="c99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -std=c++99"
+  - env: NUT_MATRIX_TAG="c99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=c++99"
     os: linux
     sudo: false
     services:
@@ -509,7 +509,7 @@ _matrix_linux_cstd_warn:
         packages:
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="c99-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c99-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++99" CC=clang CXX=clang++
     os: linux
     dist: xenial
     sudo: false
@@ -526,7 +526,7 @@ _matrix_linux_cstd_warn:
         - clang-format-5.0
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="c11-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++11" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c11-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++11" CC=clang CXX=clang++
     os: linux
     dist: xenial
     sudo: false
@@ -543,7 +543,7 @@ _matrix_linux_cstd_warn:
         - clang-format-5.0
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="c17-clang-8-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++17" CC=clang-8 CXX=clang++-8
+  - env: NUT_MATRIX_TAG="c17-clang-8-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++17" CC=clang-8 CXX=clang++-8
     os: linux
     dist: xenial
     sudo: false
@@ -560,7 +560,7 @@ _matrix_linux_cstd_warn:
         - clang-format-8
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="c11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror -std=c++11"
+  - env: NUT_MATRIX_TAG="c11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=c++11"
     os: linux
     sudo: false
     services:
@@ -572,7 +572,7 @@ _matrix_linux_cstd_warn:
         packages:
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="c89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c89" CXXFLAGS="-Wall -Wextra -Werror -std=c++89"
+  - env: NUT_MATRIX_TAG="c89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=c89" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=c++89"
     os: linux
     sudo: false
     services:
@@ -617,7 +617,7 @@ _matrix_osx_gnustd_nowarn:
 
 _matrix_osx_gnustd_warn:
   include: &_matrix_osx_gnustd_warn
-  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=gnu++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=gnu++99" CC=clang CXX=clang++
     os: osx
     osx_image: xcode10.2
     compiler: clang
@@ -627,7 +627,7 @@ _matrix_osx_gnustd_warn:
       - $HOME/Library/Caches/Homebrew
       - $HOME/.ccache
 
-  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=gnu++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=gnu++17" CC=clang CXX=clang++
     os: osx
     osx_image: xcode10.2
     compiler: clang
@@ -661,7 +661,7 @@ _matrix_osx_cstd_nowarn:
 
 _matrix_osx_cstd_warn:
   include: &_matrix_osx_cstd_warn
-  - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++99" CC=clang CXX=clang++
     os: osx
     osx_image: xcode10.2
     compiler: clang
@@ -671,7 +671,7 @@ _matrix_osx_cstd_warn:
       - $HOME/Library/Caches/Homebrew
       - $HOME/.ccache
 
-  - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++17" CC=clang CXX=clang++
     os: osx
     osx_image: xcode10.2
     compiler: clang
@@ -681,7 +681,7 @@ _matrix_osx_cstd_warn:
       - $HOME/Library/Caches/Homebrew
       - $HOME/.ccache
 
-  - env: NUT_MATRIX_TAG="c17-clang-xcode7.3-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c17-clang-xcode7.3-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++17" CC=clang CXX=clang++
     os: osx
     osx_image: xcode7.3
     compiler: clang
@@ -723,7 +723,7 @@ _matrix_windows_cstd_nowarn:
 
 _matrix_windows_cstd_warn:
   include: &_matrix_windows_cstd_warn
-  - env: NUT_MATRIX_TAG="c99-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c99-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++99" CC=clang CXX=clang++
     os: windows
     compiler: clang
     if: branch =~ fightwarn
@@ -735,7 +735,7 @@ _matrix_windows_cstd_warn:
 
 # Incidentally, this is one platform we know to have clang-9,
 # the version which has (at least partial) C++20 support
-  - env: NUT_MATRIX_TAG="c20-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c20" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++20" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c20-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c20" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++20" CC=clang CXX=clang++
     os: windows
     compiler: clang
     if: branch =~ fightwarn
@@ -876,39 +876,39 @@ jobs:
 #OK#  - env: NUT_MATRIX_TAG="gnu17-gcc-9-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc-9 CXX=g++-9
 #OK#  - env: NUT_MATRIX_TAG="gnu99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
 #OK#  - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang-8 CXX=clang++-8
-  - env: NUT_MATRIX_TAG="gnu17-gcc-9-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++17" CC=gcc-9 CXX=g++-9
+  - env: NUT_MATRIX_TAG="gnu17-gcc-9-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=gnu++17" CC=gcc-9 CXX=g++-9
   - env: NUT_MATRIX_TAG="c99-clang-3.5-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang-3.5 CXX=clang++-3.5
   - env: NUT_MATRIX_TAG="c99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c11-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c11" CXXFLAGS="-std=c++11" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c17-clang-8-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c17" CXXFLAGS="-std=c++17" CC=clang-8 CXX=clang++-8
-  - env: NUT_MATRIX_TAG="c17-clang-8-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++17" CC=clang-8 CXX=clang++-8
-  - env: NUT_MATRIX_TAG="cDefault-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic" CXXFLAGS="-Wall -Wextra -Werror"
-  - env: NUT_MATRIX_TAG="gnu99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++99"
-  - env: NUT_MATRIX_TAG="c99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -std=c++99"
-  - env: NUT_MATRIX_TAG="gnu99-gcc-7-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++99" CC=gcc-7 CXX=g++-7
-  - env: NUT_MATRIX_TAG="c99-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c11-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++11" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror -std=c++11"
-  - env: NUT_MATRIX_TAG="gnu11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu11" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++11"
+  - env: NUT_MATRIX_TAG="c17-clang-8-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++17" CC=clang-8 CXX=clang++-8
+  - env: NUT_MATRIX_TAG="cDefault-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror"
+  - env: NUT_MATRIX_TAG="gnu99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=gnu++99"
+  - env: NUT_MATRIX_TAG="c99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=c++99"
+  - env: NUT_MATRIX_TAG="gnu99-gcc-7-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=gnu++99" CC=gcc-7 CXX=g++-7
+  - env: NUT_MATRIX_TAG="c99-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c11-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++11" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=c++11"
+  - env: NUT_MATRIX_TAG="gnu11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=gnu11" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=gnu++11"
 #OK#  - env: NUT_MATRIX_TAG="gnu89-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu89" CXXFLAGS="-std=gnu++89"
-  - env: NUT_MATRIX_TAG="c89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c89" CXXFLAGS="-Wall -Wextra -Werror -std=c++89"
-  - env: NUT_MATRIX_TAG="gnu89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu89" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++89"
+  - env: NUT_MATRIX_TAG="c89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=c89" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=c++89"
+  - env: NUT_MATRIX_TAG="gnu89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=gnu89" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=gnu++89"
 ### macosx
 #OK#  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
 #OK#  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang CXX=clang++
 #OK#  - env: NUT_MATRIX_TAG="gnu99-clang-xcode7.3-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=gnu++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=gnu++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=gnu++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=gnu++17" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c17" CXXFLAGS="-std=c++17" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++17" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c17-clang-xcode7.3-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c17-clang-xcode7.3-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++17" CC=clang CXX=clang++
 ### windows
   - env: NUT_MATRIX_TAG="gnu99-clang-win-nowarn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c99-clang-win-nowarn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c99-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c20-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c20" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++20" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c99-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c20-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c20" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++20" CC=clang CXX=clang++
 
 before_install:
 - |-

--- a/.travis.yml
+++ b/.travis.yml
@@ -413,7 +413,7 @@ _matrix_linux_cstd_nowarn:
 # Stuff with warnings made fatal... well, is usually fatal so far:
 _matrix_linux_gnustd_warn:
   include: &_matrix_linux_gnustd_warn
-  - env: NUT_MATRIX_TAG="cDefault-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic" CXXFLAGS="-Wall -Werror"
+  - env: NUT_MATRIX_TAG="cDefault-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic" CXXFLAGS="-Wall -Wextra -Werror"
     os: linux
     sudo: false
     services:
@@ -425,7 +425,7 @@ _matrix_linux_gnustd_warn:
         packages:
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="gnu99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Werror -std=gnu++99"
+  - env: NUT_MATRIX_TAG="gnu99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++99"
     os: linux
     sudo: false
     services:
@@ -437,7 +437,7 @@ _matrix_linux_gnustd_warn:
         packages:
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="gnu11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu11" CXXFLAGS="-Wall -Werror -std=gnu++11"
+  - env: NUT_MATRIX_TAG="gnu11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu11" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++11"
     os: linux
     sudo: false
     services:
@@ -482,7 +482,7 @@ _matrix_linux_gnustd_warn:
         - *deps_driverlibs
 
 # Note: Fixing these would make NUT viable again on platforms with only ANSI C!
-  - env: NUT_MATRIX_TAG="gnu89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu89" CXXFLAGS="-Wall -Werror -std=gnu++89"
+  - env: NUT_MATRIX_TAG="gnu89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu89" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++89"
     os: linux
     sudo: false
     services:
@@ -497,7 +497,7 @@ _matrix_linux_gnustd_warn:
 # The hardest of two worlds: both strict C standards on Linux and fatal warnings:
 _matrix_linux_cstd_warn:
   include: &_matrix_linux_cstd_warn
-  - env: NUT_MATRIX_TAG="c99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Werror -std=c++99"
+  - env: NUT_MATRIX_TAG="c99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -std=c++99"
     os: linux
     sudo: false
     services:
@@ -560,7 +560,7 @@ _matrix_linux_cstd_warn:
         - clang-format-8
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="c11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c11" CXXFLAGS="-Wall -Werror -std=c++11"
+  - env: NUT_MATRIX_TAG="c11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror -std=c++11"
     os: linux
     sudo: false
     services:
@@ -572,7 +572,7 @@ _matrix_linux_cstd_warn:
         packages:
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="c89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c89" CXXFLAGS="-Wall -Werror -std=c++89"
+  - env: NUT_MATRIX_TAG="c89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c89" CXXFLAGS="-Wall -Wextra -Werror -std=c++89"
     os: linux
     sudo: false
     services:
@@ -882,17 +882,17 @@ jobs:
   - env: NUT_MATRIX_TAG="c11-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c11" CXXFLAGS="-std=c++11" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c17-clang-8-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c17" CXXFLAGS="-std=c++17" CC=clang-8 CXX=clang++-8
   - env: NUT_MATRIX_TAG="c17-clang-8-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c17" CXXFLAGS="-Wall -Werror -std=c++17" CC=clang-8 CXX=clang++-8
-  - env: NUT_MATRIX_TAG="cDefault-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic" CXXFLAGS="-Wall -Werror"
-  - env: NUT_MATRIX_TAG="gnu99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Werror -std=gnu++99"
-  - env: NUT_MATRIX_TAG="c99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Werror -std=c++99"
+  - env: NUT_MATRIX_TAG="cDefault-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic" CXXFLAGS="-Wall -Wextra -Werror"
+  - env: NUT_MATRIX_TAG="gnu99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++99"
+  - env: NUT_MATRIX_TAG="c99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -std=c++99"
   - env: NUT_MATRIX_TAG="gnu99-gcc-7-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Werror -std=gnu++99" CC=gcc-7 CXX=g++-7
   - env: NUT_MATRIX_TAG="c99-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Werror -std=c++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c11-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c11" CXXFLAGS="-Wall -Werror -std=c++11" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c11" CXXFLAGS="-Wall -Werror -std=c++11"
-  - env: NUT_MATRIX_TAG="gnu11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu11" CXXFLAGS="-Wall -Werror -std=gnu++11"
+  - env: NUT_MATRIX_TAG="c11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror -std=c++11"
+  - env: NUT_MATRIX_TAG="gnu11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu11" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++11"
 #OK#  - env: NUT_MATRIX_TAG="gnu89-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu89" CXXFLAGS="-std=gnu++89"
-  - env: NUT_MATRIX_TAG="c89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c89" CXXFLAGS="-Wall -Werror -std=c++89"
-  - env: NUT_MATRIX_TAG="gnu89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu89" CXXFLAGS="-Wall -Werror -std=gnu++89"
+  - env: NUT_MATRIX_TAG="c89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c89" CXXFLAGS="-Wall -Wextra -Werror -std=c++89"
+  - env: NUT_MATRIX_TAG="gnu89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu89" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++89"
 ### macosx
 #OK#  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
 #OK#  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang CXX=clang++

--- a/.travis.yml
+++ b/.travis.yml
@@ -808,8 +808,11 @@ _matrix_cstd_nowarn:
   - *_matrix_linux_cstd_nowarn
   - *_matrix_osx_cstd_nowarn
   - *_matrix_windows_cstd_nowarn
-###  - *_matrix_osx_gnustd_nowarn
-###  - *_matrix_linux_gnustd_nowarn
+
+_matrix_gnustd_nowarn:
+  include: &_matrix_gnustd_nowarn
+  - *_matrix_osx_gnustd_nowarn
+  - *_matrix_linux_gnustd_nowarn
 
 _matrix_warn:
   include: &_matrix_warn

--- a/.travis.yml
+++ b/.travis.yml
@@ -449,7 +449,7 @@ _matrix_linux_gnustd_warn:
         packages:
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="gnu99-gcc-7-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Werror -std=gnu++99" CC=gcc-7 CXX=g++-7
+  - env: NUT_MATRIX_TAG="gnu99-gcc-7-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++99" CC=gcc-7 CXX=g++-7
     os: linux
     sudo: false
     services:
@@ -465,7 +465,7 @@ _matrix_linux_gnustd_warn:
         - gcc-7
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="gnu17-gcc-9-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Werror -std=gnu++17" CC=gcc-9 CXX=g++-9
+  - env: NUT_MATRIX_TAG="gnu17-gcc-9-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++17" CC=gcc-9 CXX=g++-9
     os: linux
     sudo: false
     services:
@@ -876,7 +876,7 @@ jobs:
 #OK#  - env: NUT_MATRIX_TAG="gnu17-gcc-9-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc-9 CXX=g++-9
 #OK#  - env: NUT_MATRIX_TAG="gnu99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
 #OK#  - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang-8 CXX=clang++-8
-  - env: NUT_MATRIX_TAG="gnu17-gcc-9-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Werror -std=gnu++17" CC=gcc-9 CXX=g++-9
+  - env: NUT_MATRIX_TAG="gnu17-gcc-9-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++17" CC=gcc-9 CXX=g++-9
   - env: NUT_MATRIX_TAG="c99-clang-3.5-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang-3.5 CXX=clang++-3.5
   - env: NUT_MATRIX_TAG="c99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c11-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c11" CXXFLAGS="-std=c++11" CC=clang CXX=clang++
@@ -885,7 +885,7 @@ jobs:
   - env: NUT_MATRIX_TAG="cDefault-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic" CXXFLAGS="-Wall -Wextra -Werror"
   - env: NUT_MATRIX_TAG="gnu99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++99"
   - env: NUT_MATRIX_TAG="c99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -std=c++99"
-  - env: NUT_MATRIX_TAG="gnu99-gcc-7-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Werror -std=gnu++99" CC=gcc-7 CXX=g++-7
+  - env: NUT_MATRIX_TAG="gnu99-gcc-7-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++99" CC=gcc-7 CXX=g++-7
   - env: NUT_MATRIX_TAG="c99-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Werror -std=c++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c11-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c11" CXXFLAGS="-Wall -Werror -std=c++11" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror -std=c++11"

--- a/.travis.yml
+++ b/.travis.yml
@@ -413,7 +413,7 @@ _matrix_linux_cstd_nowarn:
 # Stuff with warnings made fatal... well, is usually fatal so far:
 _matrix_linux_gnustd_warn:
   include: &_matrix_linux_gnustd_warn
-  - env: NUT_MATRIX_TAG="cDefault-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror"
+  - env: NUT_MATRIX_TAG="cDefault-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic" CXXFLAGS="-Wall -Wextra -Werror"
     os: linux
     sudo: false
     services:
@@ -425,7 +425,7 @@ _matrix_linux_gnustd_warn:
         packages:
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="gnu99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=gnu++99"
+  - env: NUT_MATRIX_TAG="gnu99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++99"
     os: linux
     sudo: false
     services:
@@ -437,7 +437,7 @@ _matrix_linux_gnustd_warn:
         packages:
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="gnu11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=gnu11" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=gnu++11"
+  - env: NUT_MATRIX_TAG="gnu11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu11" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++11"
     os: linux
     sudo: false
     services:
@@ -449,7 +449,7 @@ _matrix_linux_gnustd_warn:
         packages:
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="gnu99-gcc-7-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=gnu++99" CC=gcc-7 CXX=g++-7
+  - env: NUT_MATRIX_TAG="gnu99-gcc-7-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++99" CC=gcc-7 CXX=g++-7
     os: linux
     sudo: false
     services:
@@ -465,7 +465,7 @@ _matrix_linux_gnustd_warn:
         - gcc-7
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="gnu17-gcc-9-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=gnu++17" CC=gcc-9 CXX=g++-9
+  - env: NUT_MATRIX_TAG="gnu17-gcc-9-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++17" CC=gcc-9 CXX=g++-9
     os: linux
     sudo: false
     services:
@@ -482,7 +482,7 @@ _matrix_linux_gnustd_warn:
         - *deps_driverlibs
 
 # Note: Fixing these would make NUT viable again on platforms with only ANSI C!
-  - env: NUT_MATRIX_TAG="gnu89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=gnu89" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=gnu++89"
+  - env: NUT_MATRIX_TAG="gnu89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu89" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++89"
     os: linux
     sudo: false
     services:
@@ -497,7 +497,7 @@ _matrix_linux_gnustd_warn:
 # The hardest of two worlds: both strict C standards on Linux and fatal warnings:
 _matrix_linux_cstd_warn:
   include: &_matrix_linux_cstd_warn
-  - env: NUT_MATRIX_TAG="c99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=c++99"
+  - env: NUT_MATRIX_TAG="c99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -std=c++99"
     os: linux
     sudo: false
     services:
@@ -509,7 +509,7 @@ _matrix_linux_cstd_warn:
         packages:
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="c99-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c99-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++99" CC=clang CXX=clang++
     os: linux
     dist: xenial
     sudo: false
@@ -526,7 +526,7 @@ _matrix_linux_cstd_warn:
         - clang-format-5.0
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="c11-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++11" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c11-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++11" CC=clang CXX=clang++
     os: linux
     dist: xenial
     sudo: false
@@ -543,7 +543,7 @@ _matrix_linux_cstd_warn:
         - clang-format-5.0
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="c17-clang-8-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++17" CC=clang-8 CXX=clang++-8
+  - env: NUT_MATRIX_TAG="c17-clang-8-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++17" CC=clang-8 CXX=clang++-8
     os: linux
     dist: xenial
     sudo: false
@@ -560,7 +560,7 @@ _matrix_linux_cstd_warn:
         - clang-format-8
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="c11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=c++11"
+  - env: NUT_MATRIX_TAG="c11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror -std=c++11"
     os: linux
     sudo: false
     services:
@@ -572,7 +572,7 @@ _matrix_linux_cstd_warn:
         packages:
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="c89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=c89" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=c++89"
+  - env: NUT_MATRIX_TAG="c89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c89" CXXFLAGS="-Wall -Wextra -Werror -std=c++89"
     os: linux
     sudo: false
     services:
@@ -617,7 +617,7 @@ _matrix_osx_gnustd_nowarn:
 
 _matrix_osx_gnustd_warn:
   include: &_matrix_osx_gnustd_warn
-  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=gnu++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=gnu++99" CC=clang CXX=clang++
     os: osx
     osx_image: xcode10.2
     compiler: clang
@@ -627,7 +627,7 @@ _matrix_osx_gnustd_warn:
       - $HOME/Library/Caches/Homebrew
       - $HOME/.ccache
 
-  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=gnu++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=gnu++17" CC=clang CXX=clang++
     os: osx
     osx_image: xcode10.2
     compiler: clang
@@ -661,7 +661,7 @@ _matrix_osx_cstd_nowarn:
 
 _matrix_osx_cstd_warn:
   include: &_matrix_osx_cstd_warn
-  - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++99" CC=clang CXX=clang++
     os: osx
     osx_image: xcode10.2
     compiler: clang
@@ -671,7 +671,7 @@ _matrix_osx_cstd_warn:
       - $HOME/Library/Caches/Homebrew
       - $HOME/.ccache
 
-  - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++17" CC=clang CXX=clang++
     os: osx
     osx_image: xcode10.2
     compiler: clang
@@ -681,7 +681,7 @@ _matrix_osx_cstd_warn:
       - $HOME/Library/Caches/Homebrew
       - $HOME/.ccache
 
-  - env: NUT_MATRIX_TAG="c17-clang-xcode7.3-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c17-clang-xcode7.3-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++17" CC=clang CXX=clang++
     os: osx
     osx_image: xcode7.3
     compiler: clang
@@ -723,7 +723,7 @@ _matrix_windows_cstd_nowarn:
 
 _matrix_windows_cstd_warn:
   include: &_matrix_windows_cstd_warn
-  - env: NUT_MATRIX_TAG="c99-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c99-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++99" CC=clang CXX=clang++
     os: windows
     compiler: clang
     if: branch =~ fightwarn
@@ -735,7 +735,7 @@ _matrix_windows_cstd_warn:
 
 # Incidentally, this is one platform we know to have clang-9,
 # the version which has (at least partial) C++20 support
-  - env: NUT_MATRIX_TAG="c20-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c20" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++20" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c20-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c20" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++20" CC=clang CXX=clang++
     os: windows
     compiler: clang
     if: branch =~ fightwarn
@@ -876,39 +876,39 @@ jobs:
 #OK#  - env: NUT_MATRIX_TAG="gnu17-gcc-9-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc-9 CXX=g++-9
 #OK#  - env: NUT_MATRIX_TAG="gnu99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
 #OK#  - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang-8 CXX=clang++-8
-  - env: NUT_MATRIX_TAG="gnu17-gcc-9-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=gnu++17" CC=gcc-9 CXX=g++-9
+  - env: NUT_MATRIX_TAG="gnu17-gcc-9-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++17" CC=gcc-9 CXX=g++-9
   - env: NUT_MATRIX_TAG="c99-clang-3.5-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang-3.5 CXX=clang++-3.5
   - env: NUT_MATRIX_TAG="c99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c11-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c11" CXXFLAGS="-std=c++11" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c17-clang-8-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c17" CXXFLAGS="-std=c++17" CC=clang-8 CXX=clang++-8
-  - env: NUT_MATRIX_TAG="c17-clang-8-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++17" CC=clang-8 CXX=clang++-8
-  - env: NUT_MATRIX_TAG="cDefault-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror"
-  - env: NUT_MATRIX_TAG="gnu99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=gnu++99"
-  - env: NUT_MATRIX_TAG="c99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=c++99"
-  - env: NUT_MATRIX_TAG="gnu99-gcc-7-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=gnu++99" CC=gcc-7 CXX=g++-7
-  - env: NUT_MATRIX_TAG="c99-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c11-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++11" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=c++11"
-  - env: NUT_MATRIX_TAG="gnu11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=gnu11" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=gnu++11"
+  - env: NUT_MATRIX_TAG="c17-clang-8-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++17" CC=clang-8 CXX=clang++-8
+  - env: NUT_MATRIX_TAG="cDefault-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic" CXXFLAGS="-Wall -Wextra -Werror"
+  - env: NUT_MATRIX_TAG="gnu99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++99"
+  - env: NUT_MATRIX_TAG="c99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -std=c++99"
+  - env: NUT_MATRIX_TAG="gnu99-gcc-7-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++99" CC=gcc-7 CXX=g++-7
+  - env: NUT_MATRIX_TAG="c99-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c11-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++11" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror -std=c++11"
+  - env: NUT_MATRIX_TAG="gnu11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu11" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++11"
 #OK#  - env: NUT_MATRIX_TAG="gnu89-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu89" CXXFLAGS="-std=gnu++89"
-  - env: NUT_MATRIX_TAG="c89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=c89" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=c++89"
-  - env: NUT_MATRIX_TAG="gnu89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -pedantic -std=gnu89" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -std=gnu++89"
+  - env: NUT_MATRIX_TAG="c89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c89" CXXFLAGS="-Wall -Wextra -Werror -std=c++89"
+  - env: NUT_MATRIX_TAG="gnu89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu89" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++89"
 ### macosx
 #OK#  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
 #OK#  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang CXX=clang++
 #OK#  - env: NUT_MATRIX_TAG="gnu99-clang-xcode7.3-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=gnu++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=gnu++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=gnu++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=gnu++17" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c17" CXXFLAGS="-std=c++17" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++17" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c17-clang-xcode7.3-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c17-clang-xcode7.3-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++17" CC=clang CXX=clang++
 ### windows
   - env: NUT_MATRIX_TAG="gnu99-clang-win-nowarn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c99-clang-win-nowarn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c99-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c20-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -pedantic -std=c20" CXXFLAGS="-Wall -Wextra -Werror=implicit-fallthrough=3 -Werror -Weverything -Wno-unused-macros -std=c++20" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c99-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c20-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -pedantic -std=c20" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -std=c++20" CC=clang CXX=clang++
 
 before_install:
 - |-

--- a/.travis.yml
+++ b/.travis.yml
@@ -228,7 +228,12 @@ _matrix_required_linux_pass3_large:
 # Ordered by variants expected to succeed to run first,
 # although with current Travis CI implementation, the env
 # blocks listed in allowed_failures only run after all
-# those not listed:
+# those not listed. Jobs which currently fail until code
+# gets fixed are conditional with "if: branch =~ fightwarn"
+# so users (and NUT upstream) can define a branch with a
+# name containing this keyword to work on bug fixes, but by
+# default the main development would not bother Travis CI
+# to waste resources in vain.
 #
 
 _matrix_linux_gnustd_nowarn:
@@ -344,6 +349,7 @@ _matrix_linux_cstd_nowarn:
     services:
         - docker
     compiler: clang
+    if: branch =~ fightwarn
     addons:
       apt:
         sources:
@@ -360,6 +366,7 @@ _matrix_linux_cstd_nowarn:
     services:
         - docker
     compiler: clang
+    if: branch =~ fightwarn
     addons:
       apt:
         sources:
@@ -376,6 +383,7 @@ _matrix_linux_cstd_nowarn:
     services:
         - docker
     compiler: clang
+    if: branch =~ fightwarn
     addons:
       apt:
         sources:
@@ -392,6 +400,7 @@ _matrix_linux_cstd_nowarn:
     services:
         - docker
     compiler: clang
+    if: branch =~ fightwarn
     addons:
       apt:
         sources:
@@ -410,6 +419,7 @@ _matrix_linux_gnustd_warn:
     services:
         - docker
     compiler: gcc
+    if: branch =~ fightwarn
     addons:
       apt:
         packages:
@@ -421,6 +431,7 @@ _matrix_linux_gnustd_warn:
     services:
         - docker
     compiler: gcc
+    if: branch =~ fightwarn
     addons:
       apt:
         packages:
@@ -432,6 +443,7 @@ _matrix_linux_gnustd_warn:
     services:
         - docker
     compiler: gcc
+    if: branch =~ fightwarn
     addons:
       apt:
         packages:
@@ -443,6 +455,7 @@ _matrix_linux_gnustd_warn:
     services:
         - docker
     compiler: gcc
+    if: branch =~ fightwarn
     addons:
       apt:
         sources:
@@ -458,6 +471,7 @@ _matrix_linux_gnustd_warn:
     services:
         - docker
     compiler: gcc
+    if: branch =~ fightwarn
     addons:
       apt:
         sources:
@@ -474,6 +488,7 @@ _matrix_linux_gnustd_warn:
     services:
         - docker
     compiler: gcc
+    if: branch =~ fightwarn
     addons:
       apt:
         packages:
@@ -488,6 +503,7 @@ _matrix_linux_cstd_warn:
     services:
         - docker
     compiler: gcc
+    if: branch =~ fightwarn
     addons:
       apt:
         packages:
@@ -500,6 +516,7 @@ _matrix_linux_cstd_warn:
     services:
         - docker
     compiler: clang
+    if: branch =~ fightwarn
     addons:
       apt:
         sources:
@@ -516,6 +533,7 @@ _matrix_linux_cstd_warn:
     services:
         - docker
     compiler: clang
+    if: branch =~ fightwarn
     addons:
       apt:
         sources:
@@ -532,6 +550,7 @@ _matrix_linux_cstd_warn:
     services:
         - docker
     compiler: clang
+    if: branch =~ fightwarn
     addons:
       apt:
         sources:
@@ -547,6 +566,7 @@ _matrix_linux_cstd_warn:
     services:
         - docker
     compiler: gcc
+    if: branch =~ fightwarn
     addons:
       apt:
         packages:
@@ -558,6 +578,7 @@ _matrix_linux_cstd_warn:
     services:
         - docker
     compiler: gcc
+    if: branch =~ fightwarn
     addons:
       apt:
         packages:
@@ -600,6 +621,7 @@ _matrix_osx_gnustd_warn:
     os: osx
     osx_image: xcode10.2
     compiler: clang
+    if: branch =~ fightwarn
     cache:
       directories:
       - $HOME/Library/Caches/Homebrew
@@ -609,6 +631,7 @@ _matrix_osx_gnustd_warn:
     os: osx
     osx_image: xcode10.2
     compiler: clang
+    if: branch =~ fightwarn
     cache:
       directories:
       - $HOME/Library/Caches/Homebrew
@@ -620,6 +643,7 @@ _matrix_osx_cstd_nowarn:
     os: osx
     osx_image: xcode10.2
     compiler: clang
+    if: branch =~ fightwarn
     cache:
       directories:
       - $HOME/Library/Caches/Homebrew
@@ -629,6 +653,7 @@ _matrix_osx_cstd_nowarn:
     os: osx
     osx_image: xcode10.2
     compiler: clang
+    if: branch =~ fightwarn
     cache:
       directories:
       - $HOME/Library/Caches/Homebrew
@@ -640,6 +665,7 @@ _matrix_osx_cstd_warn:
     os: osx
     osx_image: xcode10.2
     compiler: clang
+    if: branch =~ fightwarn
     cache:
       directories:
       - $HOME/Library/Caches/Homebrew
@@ -649,6 +675,7 @@ _matrix_osx_cstd_warn:
     os: osx
     osx_image: xcode10.2
     compiler: clang
+    if: branch =~ fightwarn
     cache:
       directories:
       - $HOME/Library/Caches/Homebrew
@@ -658,6 +685,7 @@ _matrix_osx_cstd_warn:
     os: osx
     osx_image: xcode7.3
     compiler: clang
+    if: branch =~ fightwarn
     cache:
       directories:
       - $HOME/Library/Caches/Homebrew
@@ -674,6 +702,7 @@ _matrix_windows_gnustd_nowarn:
   - env: NUT_MATRIX_TAG="gnu99-clang-win-nowarn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
     os: windows
     compiler: clang
+    if: branch =~ fightwarn
     cache:
       directories:
       - $HOME/AppData/Local/Temp/chocolatey
@@ -685,6 +714,7 @@ _matrix_windows_cstd_nowarn:
   - env: NUT_MATRIX_TAG="c99-clang-win-nowarn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
     os: windows
     compiler: clang
+    if: branch =~ fightwarn
     cache:
       directories:
       - $HOME/AppData/Local/Temp/chocolatey
@@ -696,6 +726,7 @@ _matrix_windows_cstd_warn:
   - env: NUT_MATRIX_TAG="c99-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Werror -std=c++99" CC=clang CXX=clang++
     os: windows
     compiler: clang
+    if: branch =~ fightwarn
     cache:
       directories:
       - $HOME/AppData/Local/Temp/chocolatey
@@ -707,6 +738,7 @@ _matrix_windows_cstd_warn:
   - env: NUT_MATRIX_TAG="c20-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Werror -pedantic -std=c20" CXXFLAGS="-Wall -Werror -std=c++20" CC=clang CXX=clang++
     os: windows
     compiler: clang
+    if: branch =~ fightwarn
     cache:
       directories:
       - $HOME/AppData/Local/Temp/chocolatey
@@ -803,7 +835,8 @@ _matrix_all:
 _matrix_master:
   include: &_matrix_master
   - *_matrix_required
-### Enable for branch builds that intend to fix the issues which preclude
+### Enabled for branches with names containing "fightwarn" to perform
+### builds that intend to actively fix the issues which preclude the
 ### following items from becoming green:
 #  - *_matrix_allowfail_linux
 #  - *_matrix_allowfail_osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -857,10 +857,11 @@ _matrix_fixbugs:
 #
 # DO NOT COMMIT TO MASTER BRANCH TEST-MATRICES THAT ARE NOT _matrix-master!
 #
-# These days, "jobs" and "matrix" are same thing... at least, ours is an explicit list.
+# These days, "jobs" and "matrix" (Travis keywords) are same thing... at least,
+# ours is an explicit list.
 # By "fast_finish" we allow to assign a verdict based on completion of required
 # test cases. The "allow_failures" will proceed to run for our information
-# but not block nor delay PR considerations etc.
+# but should not block nor delay PR considerations etc.
 jobs:
   fast_finish: true
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -509,7 +509,7 @@ _matrix_linux_cstd_warn:
         packages:
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="c99-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Werror -std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c99-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++99" CC=clang CXX=clang++
     os: linux
     dist: xenial
     sudo: false
@@ -526,7 +526,7 @@ _matrix_linux_cstd_warn:
         - clang-format-5.0
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="c11-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c11" CXXFLAGS="-Wall -Werror -std=c++11" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c11-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++11" CC=clang CXX=clang++
     os: linux
     dist: xenial
     sudo: false
@@ -543,7 +543,7 @@ _matrix_linux_cstd_warn:
         - clang-format-5.0
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="c17-clang-8-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c17" CXXFLAGS="-Wall -Werror -std=c++17" CC=clang-8 CXX=clang++-8
+  - env: NUT_MATRIX_TAG="c17-clang-8-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++17" CC=clang-8 CXX=clang++-8
     os: linux
     dist: xenial
     sudo: false
@@ -617,7 +617,7 @@ _matrix_osx_gnustd_nowarn:
 
 _matrix_osx_gnustd_warn:
   include: &_matrix_osx_gnustd_warn
-  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Werror -std=gnu++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=gnu++99" CC=clang CXX=clang++
     os: osx
     osx_image: xcode10.2
     compiler: clang
@@ -627,7 +627,7 @@ _matrix_osx_gnustd_warn:
       - $HOME/Library/Caches/Homebrew
       - $HOME/.ccache
 
-  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Werror -std=gnu++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=gnu++17" CC=clang CXX=clang++
     os: osx
     osx_image: xcode10.2
     compiler: clang
@@ -661,7 +661,7 @@ _matrix_osx_cstd_nowarn:
 
 _matrix_osx_cstd_warn:
   include: &_matrix_osx_cstd_warn
-  - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Werror -std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++99" CC=clang CXX=clang++
     os: osx
     osx_image: xcode10.2
     compiler: clang
@@ -671,7 +671,7 @@ _matrix_osx_cstd_warn:
       - $HOME/Library/Caches/Homebrew
       - $HOME/.ccache
 
-  - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c17" CXXFLAGS="-Wall -Werror -std=c++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++17" CC=clang CXX=clang++
     os: osx
     osx_image: xcode10.2
     compiler: clang
@@ -681,7 +681,7 @@ _matrix_osx_cstd_warn:
       - $HOME/Library/Caches/Homebrew
       - $HOME/.ccache
 
-  - env: NUT_MATRIX_TAG="c17-clang-xcode7.3-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c17" CXXFLAGS="-Wall -Werror -std=c++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c17-clang-xcode7.3-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++17" CC=clang CXX=clang++
     os: osx
     osx_image: xcode7.3
     compiler: clang
@@ -723,7 +723,7 @@ _matrix_windows_cstd_nowarn:
 
 _matrix_windows_cstd_warn:
   include: &_matrix_windows_cstd_warn
-  - env: NUT_MATRIX_TAG="c99-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Werror -std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c99-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++99" CC=clang CXX=clang++
     os: windows
     compiler: clang
     if: branch =~ fightwarn
@@ -735,7 +735,7 @@ _matrix_windows_cstd_warn:
 
 # Incidentally, this is one platform we know to have clang-9,
 # the version which has (at least partial) C++20 support
-  - env: NUT_MATRIX_TAG="c20-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Werror -pedantic -std=c20" CXXFLAGS="-Wall -Werror -std=c++20" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c20-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c20" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++20" CC=clang CXX=clang++
     os: windows
     compiler: clang
     if: branch =~ fightwarn
@@ -881,13 +881,13 @@ jobs:
   - env: NUT_MATRIX_TAG="c99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c11-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c11" CXXFLAGS="-std=c++11" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c17-clang-8-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c17" CXXFLAGS="-std=c++17" CC=clang-8 CXX=clang++-8
-  - env: NUT_MATRIX_TAG="c17-clang-8-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c17" CXXFLAGS="-Wall -Werror -std=c++17" CC=clang-8 CXX=clang++-8
+  - env: NUT_MATRIX_TAG="c17-clang-8-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++17" CC=clang-8 CXX=clang++-8
   - env: NUT_MATRIX_TAG="cDefault-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic" CXXFLAGS="-Wall -Wextra -Werror"
   - env: NUT_MATRIX_TAG="gnu99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++99"
   - env: NUT_MATRIX_TAG="c99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -std=c++99"
   - env: NUT_MATRIX_TAG="gnu99-gcc-7-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++99" CC=gcc-7 CXX=g++-7
-  - env: NUT_MATRIX_TAG="c99-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Werror -std=c++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c11-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c11" CXXFLAGS="-Wall -Werror -std=c++11" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c99-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c11-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++11" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror -std=c++11"
   - env: NUT_MATRIX_TAG="gnu11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu11" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++11"
 #OK#  - env: NUT_MATRIX_TAG="gnu89-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu89" CXXFLAGS="-std=gnu++89"
@@ -897,18 +897,18 @@ jobs:
 #OK#  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
 #OK#  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang CXX=clang++
 #OK#  - env: NUT_MATRIX_TAG="gnu99-clang-xcode7.3-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Werror -std=gnu++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Werror -std=gnu++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=gnu++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=gnu++17" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Werror -std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c17" CXXFLAGS="-std=c++17" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c17" CXXFLAGS="-Wall -Werror -std=c++17" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c17-clang-xcode7.3-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Werror -pedantic -std=c17" CXXFLAGS="-Wall -Werror -std=c++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c17-clang-xcode7.3-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++17" CC=clang CXX=clang++
 ### windows
   - env: NUT_MATRIX_TAG="gnu99-clang-win-nowarn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c99-clang-win-nowarn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c99-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Werror -std=c++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c20-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Werror -pedantic -std=c20" CXXFLAGS="-Wall -Werror -std=c++20" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c99-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c20-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror -Weverything -pedantic -std=c20" CXXFLAGS="-Wall -Wextra -Werror -Weverything -std=c++20" CC=clang CXX=clang++
 
 before_install:
 - |-

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -262,7 +262,8 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
 
     echo "=== CONFIGURING NUT: ./configure ${CONFIG_OPTS[*]}"
     echo "=== CC='$CC' CXX='$CXX' CPP='$CPP'"
-    $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+    $CI_TIME ./configure "${CONFIG_OPTS[@]}" \
+    || { RES=$?; echo "=========== DUMPING config.log :"; cat config.log || true ; echo "=========== END OF config.log"; exit $RES; }
 
     case "$BUILD_TYPE" in
         "default-tgt:"*) # Hook for matrix of custom distchecks primarily

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -38,6 +38,14 @@ configure_nut() {
        }
 }
 
+build_to_only_catch_errors() {
+    ( echo "`date`: Starting the parallel build attempt (quietly to build what we can)..."; \
+      $CI_TIME make VERBOSE=0 -k -j8 all >/dev/null 2>&1 ; ) || \
+    ( echo "`date`: Starting the sequential build attempt (to list remaining files with errors considered fatal for this build configuration)..."; \
+      $CI_TIME make VERBOSE=1 all -k ) || return $?
+    return 0
+}
+
 echo "Processing BUILD_TYPE='${BUILD_TYPE}' ..."
 case "$BUILD_TYPE" in
 default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|default-nodoc|default-withdoc|"default-tgt:"*)
@@ -317,10 +325,7 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
             exit $?
             ;;
         "default-all-errors")
-            ( echo "`date`: Starting the parallel build attempt (quietly to build what we can)..."; \
-              $CI_TIME make VERBOSE=0 -k -j8 all >/dev/null 2>&1 ; ) || \
-            ( echo "`date`: Starting the sequential build attempt (to list remaining files with errors considered fatal for this build configuration)..."; \
-              $CI_TIME make VERBOSE=1 all -k )
+            build_to_only_catch_errors
             exit $?
             ;;
     esac

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -24,6 +24,20 @@ case "$CI_TRACE" in
         set -x ;;
 esac
 
+configure_nut() {
+    echo "=== CONFIGURING NUT: ./configure ${CONFIG_OPTS[*]}"
+    echo "=== CC='$CC' CXX='$CXX' CPP='$CPP'"
+    $CI_TIME ./configure "${CONFIG_OPTS[@]}" \
+    || { RES=$?
+        echo "FAILED ($RES) to configure nut, will dump config.log in a second to help troubleshoot CI" >&2
+        echo "    (or press Ctrl+C to abort now if running interactively)" >&2
+        sleep 1
+        echo "=========== DUMPING config.log :"; cat config.log || true ; echo "=========== END OF config.log"
+        echo "FATAL: FAILED ($RES) to ./configure ${CONFIG_OPTS[*]}" >&2
+        exit $RES
+       }
+}
+
 echo "Processing BUILD_TYPE='${BUILD_TYPE}' ..."
 case "$BUILD_TYPE" in
 default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|default-nodoc|default-withdoc|"default-tgt:"*)
@@ -260,17 +274,7 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
         sudo dpkg -r --force all pkg-config
     fi
 
-    echo "=== CONFIGURING NUT: ./configure ${CONFIG_OPTS[*]}"
-    echo "=== CC='$CC' CXX='$CXX' CPP='$CPP'"
-    $CI_TIME ./configure "${CONFIG_OPTS[@]}" \
-    || { RES=$?
-        echo "FAILED ($RES) to configure nut, will dump config.log in a second to help troubleshoot CI" >&2
-        echo "    (or press Ctrl+C to abort now if running interactively)" >&2
-        sleep 1
-        echo "=========== DUMPING config.log :"; cat config.log || true ; echo "=========== END OF config.log"
-        echo "FATAL: FAILED ($RES) to ./configure ${CONFIG_OPTS[*]}" >&2
-        exit $RES
-       }
+    configure_nut
 
     case "$BUILD_TYPE" in
         "default-tgt:"*) # Hook for matrix of custom distchecks primarily

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -253,7 +253,7 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
     if [ "$TRAVIS_OS_NAME" = "windows" ] ; then
         $CI_TIME ./autogen.sh || true
     else
-        $CI_TIME ./autogen.sh 2>/dev/null
+        $CI_TIME ./autogen.sh ### 2>/dev/null
     fi
     if [ "$NO_PKG_CONFIG" == "true" ] && [ "$TRAVIS_OS_NAME" = "linux" ] ; then
         echo "NO_PKG_CONFIG==true : BUTCHER pkg-config for this test case" >&2

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -325,8 +325,9 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
             exit $?
             ;;
         "default-all-errors")
-            build_to_only_catch_errors
-            exit $?
+            RES=0
+            build_to_only_catch_errors || RES=$?
+            exit $RES
             ;;
     esac
 

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -263,7 +263,14 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
     echo "=== CONFIGURING NUT: ./configure ${CONFIG_OPTS[*]}"
     echo "=== CC='$CC' CXX='$CXX' CPP='$CPP'"
     $CI_TIME ./configure "${CONFIG_OPTS[@]}" \
-    || { RES=$?; echo "=========== DUMPING config.log :"; cat config.log || true ; echo "=========== END OF config.log"; exit $RES; }
+    || { RES=$?
+        echo "FAILED ($RES) to configure nut, will dump config.log in a second to help troubleshoot CI" >&2
+        echo "    (or press Ctrl+C to abort now if running interactively)" >&2
+        sleep 1
+        echo "=========== DUMPING config.log :"; cat config.log || true ; echo "=========== END OF config.log"
+        echo "FATAL: FAILED ($RES) to ./configure ${CONFIG_OPTS[*]}" >&2
+        exit $RES
+       }
 
     case "$BUILD_TYPE" in
         "default-tgt:"*) # Hook for matrix of custom distchecks primarily

--- a/configure.ac
+++ b/configure.ac
@@ -1001,10 +1001,19 @@ then
 	dnl # Avoid new compilers' warnings/errors about libtool distro flaws in this test like:
 	dnl #   error: ISO C forbids conversion of function pointer to object pointer type [-Werror=pedantic]
 	dnl #   {"nm_test_func", (void *) &nm_test_func},
-	dnl # or ones about LTO as in https://www.mail-archive.com/libtool@gnu.org/msg14037.html
-	dnl # leading to undefined "global_symbol_pipe" in generated libtool script
+	dnl # or ones about LTO (-flto -fno-common) as discussed and suggested
+	dnl # in https://www.mail-archive.com/libtool@gnu.org/msg14037.html -
+	dnl # all leading to undefined "global_symbol_pipe" in the generated
+	dnl # libtool script, and resulting in errors like `... | | ...` below :
+	dnl # libtool: link: /usr/bin/nm -B .libs/upsclient.o \
+	dnl #   ../common/.libs/libcommonclient.a |  | /usr/bin/sed 's/.* //' \
+	dnl #   | sort | uniq > .libs/libupsclient.exp
+	dnl # ../libtool: syntax error: `|' unexpected
+
 	CFLAGS_SAVED_NOPEDANTIC="$CFLAGS"
-	CFLAGS="$CFLAGS -Wno-pedantic -ffat-lto-objects -Wno-error"
+	AS_CASE(["${CFLAGS}"],[*"-pedantic"*],[CFLAGS="${CFLAGS} -Wno-pedantic"])
+	AS_CASE(["${CFLAGS}"],[*"-Werror"*],[CFLAGS="${CFLAGS} -Wno-error"])
+	AS_CASE(["${CFLAGS}"],[*"-flto"*],[CFLAGS="${CFLAGS} -ffat-lto-objects"])
 fi
 AC_PROG_LIBTOOL
 if ( test "${GCC}" = "yes" )

--- a/configure.ac
+++ b/configure.ac
@@ -996,7 +996,21 @@ dnl ----------------------------------------------------------------------
 dnl checks related to --with-dev
 
 dnl We only init libtool there to allow AC_DISABLE_STATIC
+if ( test "${GCC}" = "yes" || test "${CLANG}" = "yes" )
+then
+	dnl # Avoid new compilers' warnings/errors about libtool distro flaws in this test like:
+	dnl #   error: ISO C forbids conversion of function pointer to object pointer type [-Werror=pedantic]
+	dnl #   {"nm_test_func", (void *) &nm_test_func},
+	dnl # or ones about LTO as in https://www.mail-archive.com/libtool@gnu.org/msg14037.html
+	dnl # leading to undefined "global_symbol_pipe" in generated libtool script
+	CFLAGS_SAVED_NOPEDANTIC="$CFLAGS"
+	CFLAGS="$CFLAGS -Wno-pedantic -ffat-lto-objects -Wno-error"
+fi
 AC_PROG_LIBTOOL
+if ( test "${GCC}" = "yes" || test "${CLANG}" = "yes" )
+then
+	CFLAGS="$CFLAGS_SAVED_NOPEDANTIC"
+fi
 
 dnl ${nut_with_dev}: any value except "yes" or "no" is treated as "auto".
 if test "${nut_with_dev}" != "no"; then

--- a/configure.ac
+++ b/configure.ac
@@ -996,7 +996,7 @@ dnl ----------------------------------------------------------------------
 dnl checks related to --with-dev
 
 dnl We only init libtool there to allow AC_DISABLE_STATIC
-if ( test "${GCC}" = "yes" || test "${CLANG}" = "yes" )
+if ( test "${GCC}" = "yes" )
 then
 	dnl # Avoid new compilers' warnings/errors about libtool distro flaws in this test like:
 	dnl #   error: ISO C forbids conversion of function pointer to object pointer type [-Werror=pedantic]
@@ -1007,7 +1007,7 @@ then
 	CFLAGS="$CFLAGS -Wno-pedantic -ffat-lto-objects -Wno-error"
 fi
 AC_PROG_LIBTOOL
-if ( test "${GCC}" = "yes" || test "${CLANG}" = "yes" )
+if ( test "${GCC}" = "yes" )
 then
 	CFLAGS="$CFLAGS_SAVED_NOPEDANTIC"
 fi

--- a/docs/developers.txt
+++ b/docs/developers.txt
@@ -324,9 +324,9 @@ it is not trivial to state whether the fall-through was intentional or
 really is a bug).
 
 Compilers which detect such problem usually offer ways to decorate the
-code with comments or attributes to quiesce it in cases where the jump
-is intentional; also C++17 introduces special keywords for that in the
-standard. NUT aiming to be portable and independent of compilers as
+code with comments or attributes to keep it quiet it in cases where the
+jump is intentional; also C++17 introduces special keywords for that in
+the standard. NUT aiming to be portable and independent of compilers as
 much as possible, prefers the arguably clearer and standards-based way
 of using `goto` into the next intended operation, even though it is a
 couple of lines away, e.g.:

--- a/docs/developers.txt
+++ b/docs/developers.txt
@@ -332,7 +332,7 @@ of using `goto` into the next intended operation, even though it is a
 couple of lines away, e.g.:
 
 	int uppercase = 0;
-	switch (charopt) {
+	switch (char_opt) {
 		case 'U':
 			uppercase = 1;
 			goto fallthrough_case_u_option;

--- a/docs/developers.txt
+++ b/docs/developers.txt
@@ -324,7 +324,7 @@ it is not trivial to state whether the fall-through was intentional or
 really is a bug).
 
 Compilers which detect such problem usually offer ways to decorate the
-code with comments or attributes to qiuesce it in cases where the jump
+code with comments or attributes to quiesce it in cases where the jump
 is intentional; also C++17 introduces special keywords for that in the
 standard. NUT aiming to be portable and independent of compilers as
 much as possible, prefers the arguably clearer and standards-based way

--- a/docs/developers.txt
+++ b/docs/developers.txt
@@ -316,7 +316,7 @@ fail to compile in some cases.  This is what we want.
 Switch case fall-through
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-While C standards allow to write `switch` statements th "fall through"
+While C standards allow to write `switch` statements to "fall through"
 from handling one case into another, modern compilers frown upon that
 practice and spew warnings which complicate detecting real bugs in the
 code (and also looking back at some of the cases written decades ago,

--- a/docs/developers.txt
+++ b/docs/developers.txt
@@ -313,11 +313,46 @@ or access something outside their scope will throw a warning or even
 fail to compile in some cases.  This is what we want.
 
 
+Switch case fall-through
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+While C standards allow to write `switch` statements th "fall through"
+from handling one case into another, modern compilers frown upon that
+practice and spew warnings which complicate detecting real bugs in the
+code (and also looking back at some of the cases written decades ago,
+it is not trivial to state whether the fall-through was intentional or
+really is a bug).
+
+Compilers which detect such problem usually offer ways to decorate the
+code with comments or attributes to qiuesce it in cases where the jump
+is intentional; also C++17 introduces special keywords for that in the
+standard. NUT aiming to be portable and independent of compilers as
+much as possible, prefers the arguably clearer and standards-based way
+of using `goto` into the next intended operation, even though it is a
+couple of lines away, e.g.:
+
+	int uppercase = 0;
+	switch (charopt) {
+		case 'U':
+			uppercase = 1;
+			goto fallthrough_case_u_option;
+		case 'u':
+		fallthrough_case_u_option:
+			process_u_option(uppercase);
+			break;
+	}
+
+In trivial cases, like falling through to `default` which just returns,
+it may be clearer and more maintainable (adding other option cases in
+the future) to just `return same_result` in the code block that would
+fall through otherwise and avoid `goto` statements altogether.
+
 Spaghetti
 ~~~~~~~~~
 
-If you use a goto, expect us to drop it when our head stops spinning.
-It gives us flashbacks to the very old code we wrote.
+If you use a `goto` that jumps over long distances (see "Switch case
+fall-through" section above), expect us to drop it when our head stops
+spinning. It gives us flashbacks to the very old code we wrote.
 We've tried to clean up our act, and you should make the effort
 as well.
 

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 2491 utf-8
+personal_ws-1.1 en 2492 utf-8
 AAS
 ACFAIL
 ACFREQ
@@ -1530,6 +1530,7 @@ extendedhistory
 extradata
 fabula
 facto
+fallthrough
 fatalx
 faultsensitivity
 fc

--- a/include/common.h
+++ b/include/common.h
@@ -53,6 +53,33 @@ extern "C" {
 
 extern const char *UPS_VERSION;
 
+/* A somewhat portable way to mark unused variables to avoid warnings
+   (wherever we implement an API or ifdef large parts of codebase) per
+   https://stackoverflow.com/a/12891181/4715872
+ */
+/* Example: void foo(int NUT_UNUSED(bar)) { ... } */
+#ifdef __GNUC__
+#  define NUT_UNUSED(x) NUT_UNUSED_ ## x __attribute__((__unused__))
+#else
+#  define NUT_UNUSED(x) NUT_UNUSED_ ## x
+#endif
+
+/* Example: static void NUT_UNUSED_FUNCTION(foo)(int bar) { ... } */
+#ifdef __GNUC__
+#  define NUT_UNUSED_FUNCTION(x) __attribute__((__unused__)) NUT_UNUSED_ ## x
+#else
+#  define NUT_UNUSED_FUNCTION(x) NUT_UNUSED_ ## x
+#endif
+
+/* Use in code to notify the developers and quiesce the compiler that
+ * (for this codepath) the argument or variable is unused intentionally.
+ * void f(int x) {
+ *   NUT_UNUSED_VARIABLE(x);
+ *   ...
+ * }
+ */
+#define NUT_UNUSED_VARIABLE(x) (void)(x)
+
 /** @brief Default timeout (in seconds) for network operations, as used by `upsclient` and `nut-scanner`. */
 #define DEFAULT_NETWORK_TIMEOUT		5
 


### PR DESCRIPTION
This PR follows up from #823 and is part of a larger effort to detect and fix warnings issued by newer compilers and exposing issues in NUT codebase; it just lays the groundwork for subsequent PRs that would propose fixes for different groups of problems (logic, maintainability, overflow, ...) detected.

It also enables optional Travis CI builds for the larger test matrix for branches whose names contain  "fightwarn" (or PRs targeted at branches so named) so that usual builds of NUT and its pull requests would not waste CI resources predictably-in-vain.

Over time as some test cases do become "green" and are moved to not being optional successes, this optional buildability would impact less and less cases, hopefully.

One practical point worth mentioning to the team is the addition of `developers.txt` section below on using `goto` as an explicit way to implement `switch` case fall-through; after several attempts, seems this is the only portable way to achieve that (and also quite self-documenting). Subsequent PRs would post the fixes for existing fall-through statements; for most of then the intention was quite apparent, but a few I'm not sure about - these would be posted separately to not block merging the main bunch.

This PR I intend to merge with little need for discussion, maybe within a week. Still, review and approval would be warmly appreciated :)