### PR TITLE
Fightwarn fallthrough questionable - mge-xml

### DIFF
--- a/drivers/mge-xml.c
+++ b/drivers/mge-xml.c
@@ -1361,8 +1361,12 @@ static int mge_xml_startelm_cb(void *userdata, int parent, const char *nspace, c
 			state = XC_GENERAL;
 			break;
 		}
+		/* FIXME? Is the fall-through to handling "GENERAL" intended?
+		 * was so in legacy code before the goto below... */
+		goto fallthrough_case_general;
 
 	case XC_GENERAL:
+	fallthrough_case_general:
 		if (!strcasecmp(name, "STARTUP")) {
 			/* config="CENTRALIZED" */
 			state = XC_STARTUP;


### PR DESCRIPTION
* drivers/mge-xml.c: avoid implicit switch fall-through (and comment whether that wondering is the right thing to do though)

Discovered thanks to CI improvements from #844