### PR TITLE
Fightwarn - find use for "extra" argument in instcmd()s all around the place

### DIFF
--- a/drivers/al175.c
+++ b/drivers/al175.c
@@ -1247,7 +1247,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		return (!err ? STAT_INSTCMD_HANDLED : STAT_INSTCMD_FAILED);
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s]", cmdname);
+	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/apcsmart-old.c
+++ b/drivers/apcsmart-old.c
@@ -1374,13 +1374,14 @@ static int instcmd(const char *cmdname, const char *extra)
 			ct = &apc_cmdtab[i];
 
 	if (!ct) {
-		upslogx(LOG_WARNING, "instcmd: unknown command [%s]", cmdname);
+		upslogx(LOG_WARNING, "instcmd: unknown command [%s] [%s]",
+			cmdname, extra);
 		return STAT_INSTCMD_UNKNOWN;
 	}
 
 	if ((ct->flags & APC_PRESENT) == 0) {
-		upslogx(LOG_WARNING, "instcmd: command [%s] is not supported",
-			cmdname);
+		upslogx(LOG_WARNING, "instcmd: command [%s] [%s] is not supported",
+			cmdname, extra);
 		return STAT_INSTCMD_UNKNOWN;
 	}
 

--- a/drivers/bcmxcp.c
+++ b/drivers/bcmxcp.c
@@ -1886,7 +1886,7 @@ static int instcmd(const char *cmdname, const char *extra)
 	int res, sec, outlet_num;
 	int sddelay = 0x03; /* outlet off in 3 seconds, by default */
 
-	upsdebugx(1, "entering instcmd(%s)", cmdname);
+	upsdebugx(1, "entering instcmd(%s)(%s)", cmdname, extra);
 
 	if (!strcasecmp(cmdname, "shutdown.return")) {
 		send_write_command(AUTHOR, 4);

--- a/drivers/belkin.c
+++ b/drivers/belkin.c
@@ -453,7 +453,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s]", cmdname);
+	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/belkinunv.c
+++ b/drivers/belkinunv.c
@@ -1231,7 +1231,7 @@ int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s]", cmdname);
+	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/bestfortress.c
+++ b/drivers/bestfortress.c
@@ -399,7 +399,7 @@ static int instcmd (const char *cmdname, const char *extra)
 		upssend ("OFF%s\r", p);
 		return STAT_INSTCMD_HANDLED;
 	}
-	upslogx(LOG_INFO, "instcmd: unknown command %s", cmdname);
+	upslogx(LOG_INFO, "instcmd: unknown command [%s] [%s]", cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/bestups.c
+++ b/drivers/bestups.c
@@ -122,7 +122,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s]", cmdname);
+	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/clone.c
+++ b/drivers/clone.c
@@ -381,7 +381,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s]", cmdname);
+	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/dummy-ups.c
+++ b/drivers/dummy-ups.c
@@ -206,7 +206,7 @@ static int instcmd(const char *cmdname, const char *extra)
 	 * if (mode == MODE_META) => ?
 	 */
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s]", cmdname);
+	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/etapro.c
+++ b/drivers/etapro.c
@@ -190,7 +190,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s]", cmdname);
+	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/ivtscd.c
+++ b/drivers/ivtscd.c
@@ -123,7 +123,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s]", cmdname);
+	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/liebert-esp2.c
+++ b/drivers/liebert-esp2.c
@@ -523,7 +523,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 */
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s]", cmdname);
+	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/metasys.c
+++ b/drivers/metasys.c
@@ -1016,7 +1016,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s]", cmdname);
+	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/mge-utalk.c
+++ b/drivers/mge-utalk.c
@@ -606,7 +606,7 @@ int instcmd(const char *cmdname, const char *extra)
 		}
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s]", cmdname);
+	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/netxml-ups.c
+++ b/drivers/netxml-ups.c
@@ -445,9 +445,9 @@ static int instcmd(const char *cmdname, const char *extra)
 		ser_send_buf(upsfd, ...);
 		return STAT_INSTCMD_HANDLED;
 	}
-
 */
-	upslogx(LOG_NOTICE, "%s: unknown command [%s]", __func__, cmdname);
+
+	upslogx(LOG_NOTICE, "%s: unknown command [%s] [%s]", __func__, cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/nutdrv_siemens_sitop.c
+++ b/drivers/nutdrv_siemens_sitop.c
@@ -180,7 +180,7 @@ static int instcmd(const char *cmdname, const char *extra) {
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s]", cmdname);
+	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/optiups.c
+++ b/drivers/optiups.c
@@ -286,7 +286,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s]", cmdname);
+	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/powercom.c
+++ b/drivers/powercom.c
@@ -322,7 +322,7 @@ static int instcmd (const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s]", cmdname);
+	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/powerman-pdu.c
+++ b/drivers/powerman-pdu.c
@@ -90,7 +90,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		return (rv==PM_ESUCCESS)?STAT_INSTCMD_HANDLED:STAT_SET_INVALID;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s]", cmdname);
+	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/powerp-bin.c
+++ b/drivers/powerp-bin.c
@@ -268,7 +268,7 @@ static int powpan_instcmd(const char *cmdname, const char *extra)
 			return STAT_INSTCMD_HANDLED;
 		}
 
-		upslogx(LOG_ERR, "%s: command [%s] failed", __func__, cmdname);
+		upslogx(LOG_ERR, "%s: command [%s] [%s] failed", __func__, cmdname, extra);
 		return STAT_INSTCMD_FAILED;
 	}
 

--- a/drivers/powerp-txt.c
+++ b/drivers/powerp-txt.c
@@ -152,7 +152,7 @@ static int powpan_instcmd(const char *cmdname, const char *extra)
 			return STAT_INSTCMD_HANDLED;
 		}
 
-		upslogx(LOG_ERR, "%s: command [%s] failed", __func__, cmdname);
+		upslogx(LOG_ERR, "%s: command [%s] [%s] failed", __func__, cmdname, extra);
 		return STAT_INSTCMD_FAILED;
 	}
 
@@ -175,7 +175,7 @@ static int powpan_instcmd(const char *cmdname, const char *extra)
 			snprintf(command, sizeof(command), "S%02dR%04d\r", offdelay / 60, ondelay);
 		}
 	} else {
-		upslogx(LOG_NOTICE, "%s: command [%s] unknown", __func__, cmdname);
+		upslogx(LOG_NOTICE, "%s: command [%s] [%s] unknown", __func__, cmdname, extra);
 		return STAT_INSTCMD_UNKNOWN;
 	}
 
@@ -183,7 +183,7 @@ static int powpan_instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_ERR, "%s: command [%s] failed", __func__, cmdname);
+	upslogx(LOG_ERR, "%s: command [%s] [%s] failed", __func__, cmdname, extra);
 	return STAT_INSTCMD_FAILED;
 }
 

--- a/drivers/rhino.c
+++ b/drivers/rhino.c
@@ -681,7 +681,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s]", cmdname);
+	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/riello_ser.c
+++ b/drivers/riello_ser.c
@@ -626,7 +626,7 @@ int riello_instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s]", cmdname);
+	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/riello_usb.c
+++ b/drivers/riello_usb.c
@@ -734,7 +734,7 @@ int riello_instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s]", cmdname);
+	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/safenet.c
+++ b/drivers/safenet.c
@@ -288,7 +288,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s]", cmdname);
+	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/solis.c
+++ b/drivers/solis.c
@@ -878,7 +878,7 @@ static int instcmd(const char *cmdname, const char *extra) {
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s]", cmdname);
+	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 
 }

--- a/drivers/tripplite.c
+++ b/drivers/tripplite.c
@@ -258,7 +258,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s]", cmdname);
+	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -793,7 +793,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s]", cmdname);
+	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/tripplitesu.c
+++ b/drivers/tripplitesu.c
@@ -514,7 +514,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		do_command(SET, TEST, "0", NULL);
 		return STAT_INSTCMD_HANDLED;
 	}
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s]", cmdname);
+	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/victronups.c
+++ b/drivers/victronups.c
@@ -210,7 +210,7 @@ static int instcmd(const char *cmdname, const char *extra)
 	}
 	else
 	{
-		upsdebugx(1, "instcmd: unknown command: %s", cmdname);
+		upsdebugx(1, "instcmd: unknown command: [%s] [%s]", cmdname, extra);
 		return STAT_INSTCMD_UNKNOWN;
 	}
 }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -34,12 +34,14 @@ CPPUNITTESTSRC = example.cpp nutclienttest.cpp
 cppunittest_SOURCES = $(CPPUNITTESTSRC) cpputest.cpp
 
 else !HAVE_CPPUNIT
+# Just redistribute test source into tarball
 
 EXTRA_DIST += example.cpp cpputest.cpp
 
 endif !HAVE_CPPUNIT
 
 else !HAVE_CXX11
+# Just redistribute test source into tarball
 
 EXTRA_DIST += example.cpp cpputest.cpp
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,15 +1,23 @@
 # Network UPS Tools: tests
 
+all: $(TESTS)
+
 EXTRA_DIST = nut-driver-enumerator-test.sh nut-driver-enumerator-test--ups.conf
 
+TESTS = nutlogtest
+
+check_PROGRAMS = $(TESTS)
+
+nutlogtest_SOURCES = nutlogtest.c
+nutlogtest_LDADD = ../common/libcommon.la
+
+### Optional tests which can not be built everywhere
 if HAVE_CXX11
 if HAVE_CPPUNIT
 # Note: per configure script this "SHOULD" also assume
 # that we HAVE_CXX11 - but better have it explicit
 
-TESTS = cppunittest
-
-check_PROGRAMS = $(TESTS)
+TESTS += cppunittest
 
 if WITH_VALGRIND
 check-local: $(check_PROGRAMS)

--- a/tests/cpputest.cpp
+++ b/tests/cpputest.cpp
@@ -29,19 +29,26 @@ int main(int argc, char* argv[])
   NUT_UNUSED_VARIABLE(argv);
 
   /* Get the top level suite from the registry */
+  std::cerr << "D: Getting test suite..." << std::endl;
   CppUnit::Test *suite = CppUnit::TestFactoryRegistry::getRegistry().makeTest();
 
   /* Adds the test to the list of test to run */
+  std::cerr << "D: Preparing test runner..." << std::endl;
   CppUnit::TextUi::TestRunner runner;
   runner.addTest( suite );
 
   /* Change the default outputter to a compiler error format outputter */
+  std::cerr << "D: Setting test runner outputter..." << std::endl;
   runner.setOutputter( new CppUnit::CompilerOutputter( &runner.result(),
                                                        std::cerr ) );
+
   /* Run the tests. */
+  std::cerr << "D: Launching the test run..." << std::endl;
   bool wasSucessful = runner.run();
 
   /* Return error code 1 if the one of test failed. */
+  std::cerr << "D: Got to the end of test suite with code " <<
+    "'" << wasSucessful << "'" << std::endl;
   return wasSucessful ? 0 : 1;
 }
 

--- a/tests/cpputest.cpp
+++ b/tests/cpputest.cpp
@@ -21,10 +21,13 @@
 #include <cppunit/CompilerOutputter.h>
 #include <cppunit/extensions/TestFactoryRegistry.h>
 #include <cppunit/ui/text/TestRunner.h>
-
+#include "common.h"
 
 int main(int argc, char* argv[])
 {
+  NUT_UNUSED_VARIABLE(argc);
+  NUT_UNUSED_VARIABLE(argv);
+
   /* Get the top level suite from the registry */
   CppUnit::Test *suite = CppUnit::TestFactoryRegistry::getRegistry().makeTest();
 

--- a/tests/cpputest.cpp
+++ b/tests/cpputest.cpp
@@ -43,8 +43,18 @@ int main(int argc, char* argv[])
                                                        std::cerr ) );
 
   /* Run the tests. */
-  std::cerr << "D: Launching the test run..." << std::endl;
-  bool wasSucessful = runner.run();
+  bool wasSucessful = false;
+  try {
+    std::cerr << "D: Launching the test run..." << std::endl;
+    wasSucessful = runner.run();
+  }
+  catch ( std::invalid_argument &e )  // Test path not resolved
+  {
+    std::cerr  << std::endl
+               << "ERROR: " <<  e.what()
+               << std::endl;
+    wasSucessful = false;
+  }
 
   /* Return error code 1 if the one of test failed. */
   std::cerr << "D: Got to the end of test suite with code " <<

--- a/tests/nutlogtest.c
+++ b/tests/nutlogtest.c
@@ -1,0 +1,12 @@
+/* nutlogtest - some trivial usage for upslog*() and upsdebug*() related
+ * routines to sanity-check their code (compiler does not warn, test runs
+ * do not crash).
+ */
+#include "common.h"
+
+int main(void) {
+    const char *s1 = "!NULL";
+    const char *s2 = NULL;
+    upsdebugx(0, "D: '%s' vs '%s'", s1, s2);
+    return 0;
+}


### PR DESCRIPTION
Discovered thanks to CI improvements from #844

Got a few nagging concerns about the chosen solution (to print the "extra" value to log if we failed to support the command):
* what if `extra` is NULL? (Would logging routine not break - easy to test but was not done yet; can be worked around with lots of `extra ? extra : "<null>"` replacements)
* is there a chance to leak something secret into the log?