### PR TITLE
Fightwarn - floating-point abs()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -137,7 +137,8 @@ AC_C_BIGENDIAN
 AC_C_INLINE
 AC_C_FLEXIBLE_ARRAY_MEMBER
 AC_C_VARARRAYS
-AC_CHECK_FUNCS(flock lockf fcvt fcvtl pow10 round abs_val)
+AC_CHECK_FUNCS(flock lockf fcvt fcvtl pow10 round abs_val abs)
+AC_CHECK_FUNCS(fabs, [], [], [#include <math.h>])
 AC_CHECK_FUNCS(cfsetispeed tcsendbreak)
 AC_CHECK_FUNCS(seteuid setsid getpassphrase)
 AC_CHECK_FUNCS(on_exit strptime setlogmask)

--- a/drivers/belkin-hid.c
+++ b/drivers/belkin-hid.c
@@ -163,7 +163,7 @@ static const char *liebert_shutdownimm_fun(double value)
 static const char *liebert_config_voltage_fun(double value)
 {
 	if( value < 1 ) {
-		if( abs(value - 1e-7) < 1e-9 ) {
+		if( fabs(value - 1e-7) < 1e-9 ) {
 			liebert_config_voltage_mult = 1e8;
 			liebert_line_voltage_mult = 1e7; /* stomp this in case input voltage was low */
 			upsdebugx(2, "ConfigVoltage = %g -> assuming correction factor = %g",
@@ -181,7 +181,7 @@ static const char *liebert_config_voltage_fun(double value)
 static const char *liebert_line_voltage_fun(double value)
 {
 	if( value < 1 ) {
-		if( abs(value - 1e-7) < 1e-9 ) {
+		if( fabs(value - 1e-7) < 1e-9 ) {
 			liebert_line_voltage_mult = 1e7;
 			upsdebugx(2, "Input/OutputVoltage = %g -> assuming correction factor = %g",
 				value, liebert_line_voltage_mult);

--- a/drivers/belkin-hid.c
+++ b/drivers/belkin-hid.c
@@ -29,6 +29,8 @@
 #include "belkin-hid.h"
 #include "usb-common.h"
 
+#include <math.h>     /* for fabs() */
+
 #define BELKIN_HID_VERSION      "Belkin/Liebert HID 0.17"
 
 /* Belkin */

--- a/drivers/upscode2.c
+++ b/drivers/upscode2.c
@@ -838,7 +838,7 @@ void upsdrv_updateinfo(void)
 		dstate_setinfo("battery.runtime", "%.0f", batt_runtime*60);
 	}
 	else if (load > 0 && batt_disch_curr_max != 0) {
-		float est_battcurr = load * abs(batt_disch_curr_max);
+		float est_battcurr = load * fabs(batt_disch_curr_max);
 		/* Peukert equation */
 		float runtime = (batt_cap_nom*3600)/pow(est_battcurr, 1.35);
 


### PR DESCRIPTION
A number of maths comparisons for negligibly small values were originally done using `abs()` which is (per warnings from many systems) intended for integers. This PR changes those cases to use `fabs()` from `math.h`.

Discovered thanks to CI improvements from #844 