### PR TITLE
Fightwarn - nutdrv_qx_voltronic.c: avoid buffer overflows, possible NPE, and fix the check for hitting the sentinel entry

### DIFF
--- a/drivers/nutdrv_qx_voltronic.c
+++ b/drivers/nutdrv_qx_voltronic.c
@@ -4026,6 +4026,9 @@ static int	voltronic_p31b_set(item_t *item, char *value, const size_t valuelen)
 {
 	int	i;
 
+	if (!item->info_rw)
+		return -1;
+
 	for (i = 0; strlen(item->info_rw[i].value) > 0; i++) {
 
 		if (!strcasecmp(item->info_rw[i].value, value))
@@ -4034,7 +4037,7 @@ static int	voltronic_p31b_set(item_t *item, char *value, const size_t valuelen)
 	}
 
 	/* At this point value should already be checked against enum so this shouldn't happen.. however.. */
-	if (i >= (int)(sizeof(item->info_rw) / sizeof(item->info_rw[0]))) {
+	if (!strlen(item->info_rw[i].value)) {
 		upslogx(LOG_ERR, "%s: value [%s] out of range", item->info_type, value);
 		return -1;
 	}
@@ -4069,6 +4072,9 @@ static int	voltronic_p31g_set(item_t *item, char *value, const size_t valuelen)
 {
 	int	i;
 
+	if (!item->info_rw)
+		return -1;
+
 	for (i = 0; strlen(item->info_rw[i].value) > 0; i++) {
 
 		if (!strcasecmp(item->info_rw[i].value, value))
@@ -4077,7 +4083,7 @@ static int	voltronic_p31g_set(item_t *item, char *value, const size_t valuelen)
 	}
 
 	/* At this point value should have been already checked against enum so this shouldn't happen.. however.. */
-	if (i >= (int)(sizeof(item->info_rw) / sizeof(item->info_rw[0]))) {
+	if (!strlen(item->info_rw[i].value)) {
 		upslogx(LOG_ERR, "%s: value [%s] out of range", item->info_type, value);
 		return -1;
 	}
@@ -4136,6 +4142,9 @@ static int	voltronic_phase_set(item_t *item, char *value, const size_t valuelen)
 {
 	int	i;
 
+	if (!item->info_rw)
+		return -1;
+
 	for (i = 0; strlen(item->info_rw[i].value) > 0; i++) {
 
 		if (!strcasecmp(item->info_rw[i].value, value))
@@ -4144,7 +4153,7 @@ static int	voltronic_phase_set(item_t *item, char *value, const size_t valuelen)
 	}
 
 	/* At this point value should have been already checked against enum so this shouldn't happen.. however.. */
-	if (i >= (int)(sizeof(item->info_rw) / sizeof(item->info_rw[0]))) {
+	if (!strlen(item->info_rw[i].value)) {
 		upslogx(LOG_ERR, "%s: value [%s] out of range", item->info_type, value);
 		return -1;
 	}


### PR DESCRIPTION
drivers/nutdrv_qx_voltronic.c: avoid buffer overflows iterating item->info_rw, possible NPE, and fix the check for hitting the sentinel entry

Fix warnings like:
````
nutdrv_qx_voltronic.c:4037:39: error: division
 'sizeof (info_rw_t *) / sizeof (info_rw_t)' does not compute
 the number of array elements [-Werror=sizeof-pointer-div]

 4037 |  if (i >= (int)(sizeof(item->info_rw) / sizeof(item->info_rw[0]))) {
      |                                       ^

nutdrv_qx_voltronic.c: In function 'voltronic_p31g_set':
````

Discovered thanks to CI improvements from #844