### PR TITLE
Fightwarn - sscanf signed vs unsigned

### DIFF
--- a/drivers/blazer_usb.c
+++ b/drivers/blazer_usb.c
@@ -536,10 +536,12 @@ void upsdrv_initups(void)
 	/* check for language ID workaround (#1) */
 	if (getval("langid_fix")) {
 		/* skip "0x" prefix and set back to hexadecimal */
-		if (sscanf(getval("langid_fix") + 2, "%x", &langid_fix) != 1) {
+		unsigned int u_langid_fix;
+		if ( (sscanf(getval("langid_fix") + 2, "%x", &u_langid_fix) != 1) || (u_langid_fix > INT_MAX) ) {
 			upslogx(LOG_NOTICE, "Error enabling language ID workaround");
 		}
 		else {
+			langid_fix = u_langid_fix;
 			upsdebugx(2, "language ID workaround enabled (using '0x%x')", langid_fix);
 		}
 	}

--- a/drivers/netxml-ups.c
+++ b/drivers/netxml-ups.c
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <limits.h>
 
 #include <ne_request.h>
 #include <ne_basic.h>
@@ -773,15 +774,34 @@ static int netxml_alarm_subscribe(const char *page)
 	/* due to different formats used by the various NMCs, we need to\
 	   break up the reply in lines and parse each one separately */
 	for (s = strtok(resp_buf, "\r\n"); s != NULL; s = strtok(NULL, "\r\n")) {
+		long long int	tmp_port = -1, tmp_secret = -1;
 		upsdebugx(2, "%s: parsing %s", __func__, s);
 
-		if (!strncasecmp(s, "<Port>", 6) && (sscanf(s+6, "%u", &port) != 1)) {
+		if (!strncasecmp(s, "<Port>", 6) && (sscanf(s+6, "%lli", &tmp_port) != 1)) {
 			return NE_RETRY;
 		}
 
-		if (!strncasecmp(s, "<Secret>", 8) && (sscanf(s+8, "%u", &secret) != 1)) {
+		/* FIXME? Does a port==0 make sense here? Or should the test below be for port<1?
+		 * Legacy code until a fix here used sscanf() above to get a '%u' value...
+		 */
+		if (tmp_port < 0 || tmp_port > UINT_MAX) {
+			upsdebugx(2, "%s: parsing initial subcription failed, bad port value", __func__);
 			return NE_RETRY;
 		}
+
+		if (!strncasecmp(s, "<Secret>", 8) && (sscanf(s+8, "%lli", &tmp_secret) != 1)) {
+			return NE_RETRY;
+		}
+
+		if (tmp_secret < 0 || tmp_secret > UINT_MAX) {
+			upsdebugx(2, "%s: parsing initial subcription failed, bad secret value", __func__);
+			return NE_RETRY;
+		}
+
+		/* Range of valid values constrained above */
+		port = tmp_port;
+		secret = tmp_secret;
+
 	}
 
 	if ((port == -1) || (secret == -1)) {

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -1944,9 +1944,11 @@ void	upsdrv_initups(void)
 		/* Check for language ID workaround (#1) */
 		if (getval("langid_fix")) {
 			/* Skip "0x" prefix and set back to hexadecimal */
-			if (sscanf(getval("langid_fix") + 2, "%x", &langid_fix) != 1) {
+			unsigned int u_langid_fix;
+			if ( (sscanf(getval("langid_fix") + 2, "%x", &u_langid_fix) != 1) || (u_langid_fix > INT_MAX)) {
 				upslogx(LOG_NOTICE, "Error enabling language ID workaround");
 			} else {
+				langid_fix = u_langid_fix;
 				upsdebugx(2, "Language ID workaround enabled (using '0x%x')", langid_fix);
 			}
 		}


### PR DESCRIPTION
We had a number of data reads formatted as unsigned ints or hexes, written into signed variables with insufficient range for scanf'ing the potential size of unsigned original number. Commits in this PR aim to work around those situations.

Discovered thanks to CI improvements from #844