### PR TITLE
Fightwarn - wraphead

### DIFF
--- a/clients/cgilib.h
+++ b/clients/cgilib.h
@@ -17,6 +17,9 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
+#ifndef NUT_CGILIB_H_SEEN
+#define NUT_CGILIB_H_SEEN 1
+
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 extern "C" {
@@ -41,3 +44,4 @@ int checkhost(const char *host, char **desc);
 /* *INDENT-ON* */
 #endif
 
+#endif	/* NUT_CGILIB_H_SEEN */

--- a/clients/status.h
+++ b/clients/status.h
@@ -17,6 +17,9 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
+#ifndef NUT_STATUS_H_SEEN
+#define NUT_STATUS_H_SEEN 1
+
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 extern "C" {
@@ -48,3 +51,4 @@ struct {
 /* *INDENT-ON* */
 #endif
 
+#endif	/* NUT_STATUS_H_SEEN */

--- a/clients/upsimagearg.h
+++ b/clients/upsimagearg.h
@@ -17,6 +17,9 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
+#ifndef NUT_UPSIMAGEARG_H_SEEN
+#define NUT_UPSIMAGEARG_H_SEEN 1
+
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 extern "C" {
@@ -71,3 +74,4 @@ extern imgvar_t imgvar[];
 /* *INDENT-ON* */
 #endif
 
+#endif	/* NUT_UPSIMAGEARG_H_SEEN */

--- a/clients/upslog.h
+++ b/clients/upslog.h
@@ -1,5 +1,8 @@
 /* upslog.h - table of functions for handling various logging functions */
 
+#ifndef NUT_UPSLOG_H_SEEN
+#define NUT_UPSLOG_H_SEEN 1
+
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 extern "C" {
@@ -40,3 +43,4 @@ struct {
 /* *INDENT-ON* */
 #endif
 
+#endif	/* NUT_UPSLOG_H_SEEN */

--- a/clients/upsmon.h
+++ b/clients/upsmon.h
@@ -17,6 +17,9 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
+#ifndef NUT_UPSMON_H_SEEN
+#define NUT_UPSMON_H_SEEN 1
+
 /* flags for ups->status */
 
 #define ST_ONLINE      (1 << 0)       /* UPS is on line (OL)                  */
@@ -125,3 +128,5 @@ struct {
 }
 /* *INDENT-ON* */
 #endif
+
+#endif	/* NUT_UPSMON_H_SEEN */

--- a/clients/upssched.h
+++ b/clients/upssched.h
@@ -1,5 +1,8 @@
 /* upssched.h - supporting structures */
 
+#ifndef NUT_UPSSCHED_H_SEEN
+#define NUT_UPSSCHED_H_SEEN 1
+
 #include <parseconf.h>
 
 #define SERIALIZE_INIT 1
@@ -25,3 +28,4 @@ typedef struct conn_s {
 /* *INDENT-ON* */
 #endif
 
+#endif	/* NUT_UPSSCHED_H_SEEN */

--- a/clients/upsstats.h
+++ b/clients/upsstats.h
@@ -17,6 +17,9 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
+#ifndef NUT_UPSSTATS_H_SEEN
+#define NUT_UPSSTATS_H_SEEN 1
+
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 extern "C" {
@@ -35,3 +38,4 @@ typedef struct {
 /* *INDENT-ON* */
 #endif
 
+#endif	/* NUT_UPSSTATS_H_SEEN */

--- a/drivers/apcsmart-old.h
+++ b/drivers/apcsmart-old.h
@@ -18,6 +18,9 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
+#ifndef NUT_APCSMART_OLD_H_SEEN
+#define NUT_APCSMART_OLD_H_SEEN 1
+
 #include <ctype.h>
 #include <sys/ioctl.h>
 #include "serial.h"
@@ -289,3 +292,5 @@ struct {
 
 	{ NULL,		NULL,			0 },
 };
+
+#endif  /* NUT_APCSMART_OLD_H_SEEN */

--- a/drivers/apcsmart.h
+++ b/drivers/apcsmart.h
@@ -20,8 +20,8 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 
-#ifndef __apcsmart_h__
-#define __apcsmart_h__
+#ifndef NUT_APCSMART_H_SEEN
+#define NUT_APCSMART_H_SEEN 1
 
 #define DRIVER_NAME	"APC Smart protocol driver"
 #define DRIVER_VERSION	"3.1"
@@ -172,4 +172,4 @@
 #define logx(lev, fmt, ...) upslogx(lev, "%s: " fmt, __func__ , ## __VA_ARGS__)
 #define debx(lev, fmt, ...) upsdebugx(lev, "%s: " fmt, __func__ , ## __VA_ARGS__)
 
-#endif
+#endif  /* NUT_APCSMART_H_SEEN */

--- a/drivers/apcsmart_tabs.h
+++ b/drivers/apcsmart_tabs.h
@@ -20,8 +20,8 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 
-#ifndef __apcsmart_tabs_h__
-#define __apcsmart_tabs_h__
+#ifndef NUT_APCSMART_TABS_H_SEEN
+#define NUT_APCSMART_TABS_H_SEEN 1
 
 #include "main.h"
 
@@ -103,4 +103,4 @@ extern apc_cmdtab_t apc_cmdtab[];
 extern apc_compattab_t apc_compattab[];
 extern upsdrv_info_t apc_tab_info;
 
-#endif
+#endif  /* NUT_APCSMART_TABS_H_SEEN */

--- a/drivers/apcupsd-ups.h
+++ b/drivers/apcupsd-ups.h
@@ -18,6 +18,9 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
+#ifndef NUT_APCUPSD_UPS_H_SEEN
+#define NUT_APCUPSD_UPS_H_SEEN 1
+
 /* from usbhid-ups.h */
 /* --------------------------------------------------------------- */
 /* Struct & data for ups.status processing                         */
@@ -141,3 +144,5 @@ static apcuspd_info_t nut_data[] =
 	{ "NOMAPNT", "ups.power.nominal", 0, 1, "%.0f", DU_FLAG_INIT, NULL },
 	{ NULL, NULL, 0, 0, NULL, DU_FLAG_NONE, NULL }
 };
+
+#endif  /* NUT_APCUPSD_UPS_H_SEEN */

--- a/drivers/dummy-ups.h
+++ b/drivers/dummy-ups.h
@@ -18,6 +18,9 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
+#ifndef NUT_DUMMY_UPS_H_SEEN
+#define NUT_DUMMY_UPS_H_SEEN 1
+
 /* This file lists all valid data with their type and info.
  *
  * These are then enabled through a definition file, specified
@@ -234,3 +237,5 @@ beeper.disable
 	/* end of structure. */
 	{ NULL, 0, 0, NULL, DU_FLAG_NONE, NULL }
 };
+
+#endif	/* NUT_DUMMY_UPS_H_SEEN */

--- a/drivers/gamatronic.h
+++ b/drivers/gamatronic.h
@@ -2,13 +2,13 @@
  *
  * SEC UPS Driver ported to the new NUT API for Gamatronic UPS Usage.
  *
- * Copyright (C) 
+ * Copyright (C)
  *   2001 John Marley <John.Marley@alcatel.com.au>
  *   2002 Jules Taplin <jules@netsitepro.co.uk>
  *   2002 Eric Lawson <elawson@inficad.com>
  *   2005 Arnaud Quette <http://arnaud.quette.free.fr/contact.html>
  *   2005 Nadav Moskovitch <blutz@walla.com / http://www.gamatronic.com>
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -24,7 +24,10 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  *
  */
- 
+
+#ifndef NUT_GAMATRONIC_H_SEEN
+#define NUT_GAMATRONIC_H_SEEN 1
+
 #define SEC_MSG_STARTCHAR	'^'
 #define SEC_POLLCMD		'P'
 #define SEC_SETCMD		'S'
@@ -199,3 +202,4 @@ struct {
 
 #define sqv(a,b) sec_querylist[a].varnum[b]
 
+#endif	/* NUT_GAMATRONIC_H_SEEN */

--- a/drivers/genericups.h
+++ b/drivers/genericups.h
@@ -17,6 +17,9 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
+#ifndef NUT_GENERICUPS_H_SEEN
+#define NUT_GENERICUPS_H_SEEN 1
+
 struct {
 	const	char	*mfr;			/* value for INFO_MFR	*/
 	const	char	*model;			/* value for INFO_MODEL	*/
@@ -270,3 +273,5 @@ struct {
 	  0
 	}
 };
+
+#endif	/* NUT_GENERICUPS_H_SEEN */

--- a/drivers/hidparser.h
+++ b/drivers/hidparser.h
@@ -22,8 +22,8 @@
  *
  * -------------------------------------------------------------------------- */
 
-#ifndef HIDPARS_H
-#define HIDPARS_H
+#ifndef NUT_HID_PARSER_H_SEEN
+#define NUT_HID_PARSER_H_SEEN
 
 
 #ifdef __cplusplus
@@ -70,4 +70,4 @@ void SetValue(const HIDData_t *pData, unsigned char *Buf, long Value);
 /* *INDENT-ON* */
 #endif /* __cplusplus */
 
-#endif
+#endif	/* NUT_HID_PARSER_H_SEEN */

--- a/drivers/libhid.h
+++ b/drivers/libhid.h
@@ -26,8 +26,8 @@
  *
  * -------------------------------------------------------------------------- */
 
-#ifndef _LIBHID_H
-#define _LIBHID_H
+#ifndef NUT_LIBHID_H_SEEN
+#define NUT_LIBHID_H_SEEN
 
 #include "config.h"
 
@@ -148,4 +148,4 @@ const char *HIDDataType(const HIDData_t *hiddata);
 void free_report_buffer(reportbuf_t *rbuf);
 reportbuf_t *new_report_buffer(HIDDesc_t *pDesc);
 
-#endif /* _LIBHID_H */
+#endif /* NUT_LIBHID_H_SEEN */

--- a/drivers/libshut.h
+++ b/drivers/libshut.h
@@ -24,8 +24,8 @@
  *
  * -------------------------------------------------------------------------- */
 
-#ifndef LIBSHUT_H
-#define LIBSHUT_H
+#ifndef NUT_LIBSHUT_H_SEEN
+#define NUT_LIBSHUT_H_SEEN 1
 
 #include "main.h"	/* for subdrv_info_t */
 #include "nut_stdint.h"	/* for uint16_t */
@@ -85,4 +85,4 @@ extern shut_communication_subdriver_t	shut_subdriver;
 					/* Ellipse models */
 #define DEFAULT_NOTIFICATION COMPLETE_NOTIFICATION
 
-#endif /* LIBSHUT_H */
+#endif /* NUT_LIBSHUT_H_SEEN */

--- a/drivers/libusb.h
+++ b/drivers/libusb.h
@@ -28,8 +28,8 @@
  *
  * -------------------------------------------------------------------------- */
 
-#ifndef LIBUSB_H
-#define LIBUSB_H
+#ifndef NUT_LIBUSB_H_SEEN
+#define NUT_LIBUSB_H_SEEN 1
 
 #include "main.h"	/* for subdrv_info_t */
 #include "usb-common.h"	/* for USBDevice_t and USBDeviceMatcher_t */
@@ -62,5 +62,5 @@ typedef struct usb_communication_subdriver_s {
 
 extern usb_communication_subdriver_t	usb_subdriver;
 
-#endif /* LIBUSB_H */
+#endif /* NUT_LIBUSB_H_SEEN */
 

--- a/drivers/main.h
+++ b/drivers/main.h
@@ -1,5 +1,5 @@
-#ifndef MAIN_H
-#define MAIN_H
+#ifndef NUT_MAIN_H_SEEN
+#define NUT_MAIN_H_SEEN
 
 #include "common.h"
 #include "upsconf.h"
@@ -76,4 +76,4 @@ typedef struct upsdrv_info_s {
 /* public driver information from the driver file */
 extern upsdrv_info_t	upsdrv_info;
 
-#endif /* MAIN_H */
+#endif /* NUT_MAIN_H_SEEN */

--- a/drivers/mge-utalk.h
+++ b/drivers/mge-utalk.h
@@ -28,6 +28,9 @@
  *
  */
 
+#ifndef NUT_MGE_UTALK_H_SEEN
+#define NUT_MGE_UTALK_H_SEEN 1
+
 /* --------------------------------------------------------------- */
 /*                 Default Values for UPS Variables                */
 /* --------------------------------------------------------------- */
@@ -233,3 +236,5 @@ static mge_info_item_t mge_info[] = {
 	/* terminating element */
 	{ NULL, 0, 0, "\0", "\0", NONE, FALSE }
 };
+
+#endif	/* NUT_MGE_UTALK_H_SEEN */

--- a/drivers/oneac.h
+++ b/drivers/oneac.h
@@ -22,6 +22,9 @@
  *
 */
 
+#ifndef NUT_ONEAC_H_SEEN
+#define NUT_ONEAC_H_SEEN 1
+
 /*misc stuff*/
 #define ENDCHAR '\r'
 #define IGNCHARS "\n"
@@ -181,3 +184,5 @@
 #define CODE_OVERLOAD		"c8"	/*"slight" overload*/
 #define CODE_GROSS_OVLE		"c9"	/*gross overload 1 minute to power off*/
 #define CODE_CHRGR_FUSE_OPEN "u1"	/*battery charger fuse probably open*/
+
+#endif	/* NUT_ONEAC_H_SEEN */

--- a/drivers/powercom.h
+++ b/drivers/powercom.h
@@ -21,6 +21,9 @@
  *
  */
 
+#ifndef NUT_POWERCOM_H_SEEN
+#define NUT_POWERCOM_H_SEEN 1
+
 /* C-libary includes */
 #include <sys/file.h>
 #include <sys/stat.h>
@@ -97,3 +100,5 @@ struct type {
 	 */
 	float         voltage[4];
 };
+
+#endif	/* NUT_POWERCOM_H_SEEN */

--- a/drivers/riello.h
+++ b/drivers/riello.h
@@ -26,8 +26,8 @@
  * Reference of the derivative work: blazer driver
  */
 
-#ifndef dev_dataH
-#define dev_dataH
+#ifndef NUT_RIELLO_H_SEEN
+#define NUT_RIELLO_H_SEEN 1
 
 #include <stdint.h>
 
@@ -176,4 +176,4 @@ uint8_t riello_test_nak(uint8_t type, uint8_t* buffer);
 void riello_parse_serialport(uint8_t typedev, uint8_t* buffer, uint8_t checksum);
 void riello_comm_setup(const char *port);
 
-#endif
+#endif /* NUT_RIELLO_H_SEEN */

--- a/drivers/safenet.h
+++ b/drivers/safenet.h
@@ -18,6 +18,9 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 
+#ifndef NUT_SAFENET_H_SEEN
+#define NUT_SAFENET_H_SEEN 1
+
 /*
  * The following commands where traced on the serial port. From these, the
  * COM_POLL_STAT command is just an example of how this command looks.
@@ -58,3 +61,5 @@ struct safenet {
 	char	systemtest;
 	char	dunno_10;
 };
+
+#endif	/* NUT_SAFENET_H_SEEN */

--- a/drivers/tripplite.h
+++ b/drivers/tripplite.h
@@ -23,6 +23,9 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
+#ifndef NUT_TRIPPLITE_H_SEEN
+#define NUT_TRIPPLITE_H_SEEN 1
+
 #define ENDCHAR '\n'           /* replies end with CR LF -- use LF to end */
 #define IGNCHAR '\r'           /* ignore CR */
 #define MAXTRIES 3             /* max number of times we try to detect ups */
@@ -56,3 +59,4 @@
 #define MAX_VOLT 13.4          /* Max battery voltage (100%) */
 #define MIN_VOLT 11.0          /* Min battery voltage (10%) */
 
+#endif	/* NUT_TRIPPLITE_H_SEEN */

--- a/include/attribute.h
+++ b/include/attribute.h
@@ -1,4 +1,23 @@
-/* portability hacks for __attribute__ usage in other header files */
+/* attribute.h - portability hacks for __attribute__ usage in other header files
+
+   Copyright (C) 2001  Russell Kroll <rkroll@exploits.org>
+	2005	Arnaud Quette <arnaud.quette@free.fr>
+	2020	Jim Klimov <jimklimov@gmail.com>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+*/
 
 #ifndef NUT_ATTRIBUTE_H_SEEN
 #define NUT_ATTRIBUTE_H_SEEN 1

--- a/include/attribute.h
+++ b/include/attribute.h
@@ -1,7 +1,7 @@
 /* portability hacks for __attribute__ usage in other header files */
 
-#ifndef ATTRIBUTE_H_SEEN
-#define ATTRIBUTE_H_SEEN 1
+#ifndef NUT_ATTRIBUTE_H_SEEN
+#define NUT_ATTRIBUTE_H_SEEN 1
 
 #ifndef __attribute__
 # if __GNUC__ < 2 || (__GNUC__ == 2 && __GNUC_MINOR__ < 8) || __STRICT_ANSI__
@@ -9,4 +9,4 @@
 # endif
 #endif
 
-#endif /* ATTRIBUTE_H_SEEN */
+#endif /* NUT_ATTRIBUTE_H_SEEN */

--- a/include/common.h
+++ b/include/common.h
@@ -1,6 +1,3 @@
-#ifndef NUT_COMMON_H
-#define NUT_COMMON_H
-
 /* common.h - prototypes for the common useful functions
 
    Copyright (C) 2000  Russell Kroll <rkroll@exploits.org>
@@ -19,6 +16,9 @@
    along with this program; if not, write to the Free Software
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
+
+#ifndef NUT_COMMON_H_SEEN
+#define NUT_COMMON_H_SEEN 1
 
 #include "config.h"		/* must be the first header */
 
@@ -193,4 +193,4 @@ extern int optind;
 /* *INDENT-ON* */
 #endif
 
-#endif /* NUT_COMMON_H */
+#endif /* NUT_COMMON_H_SEEN */

--- a/include/extstate.h
+++ b/include/extstate.h
@@ -1,7 +1,7 @@
 /* external state structures used by things like upsd */
 
-#ifndef EXTSTATE_H_SEEN
-#define EXTSTATE_H_SEEN 1
+#ifndef NUT_EXTSTATE_H_SEEN
+#define NUT_EXTSTATE_H_SEEN 1
 
 #ifdef __cplusplus
 /* *INDENT-OFF* */
@@ -44,4 +44,4 @@ typedef struct cmdlist_s {
 /* *INDENT-ON* */
 #endif
 
-#endif	/* EXTSTATE_H_SEEN */
+#endif	/* NUT_EXTSTATE_H_SEEN */

--- a/include/extstate.h
+++ b/include/extstate.h
@@ -1,4 +1,26 @@
-/* external state structures used by things like upsd */
+/* extstate.h - external state structures used by things like upsd
+
+   Copyright (C) 2001  Russell Kroll <rkroll@exploits.org>
+	2005	Arnaud Quette <arnaud.quette@free.fr>
+	2007	Peter Selinger <selinger@users.sourceforge.net>
+	2008	Arjen de Korte <adkorte-guest@alioth.debian.org>
+	2013	Emilien Kia <kiae.dev@gmail.com>
+	2020	Jim Klimov <jimklimov@gmail.com>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+*/
 
 #ifndef NUT_EXTSTATE_H_SEEN
 #define NUT_EXTSTATE_H_SEEN 1

--- a/include/extstate.h
+++ b/include/extstate.h
@@ -21,7 +21,7 @@ extern "C" {
 
 /* list of possible ENUM values */
 typedef struct enum_s {
-	char    *val;
+	char	*val;
 	struct enum_s	*next;
 } enum_t;
 
@@ -34,8 +34,8 @@ typedef struct range_s {
 
 /* list of instant commands */
 typedef struct cmdlist_s {
-        char    *name;
-        struct cmdlist_s	*next;
+	char	*name;
+	struct cmdlist_s	*next;
 } cmdlist_t;
 
 #ifdef __cplusplus

--- a/include/nut_platform.h
+++ b/include/nut_platform.h
@@ -1,6 +1,3 @@
-#ifndef nut_platform_h
-#define nut_platform_h
-
 /**
  *  \brief  Platform-specific checks
  *
@@ -16,6 +13,9 @@
  *  \author  Vaclav Krpec  <VaclavKrpec@Eaton.com>
  *  \date    2012/10/12
  */
+
+#ifndef NUT_PLATFORM_H_SEEN
+#define NUT_PLATFORM_H_SEEN 1
 
 /*
  * In case doxygen source doc isn't generated
@@ -121,5 +121,5 @@
 	#endif
 #endif
 
-#endif  /* end of #ifndef nut_platform_h */
+#endif  /* NUT_PLATFORM_H_SEEN */
 

--- a/include/nut_stdint.h
+++ b/include/nut_stdint.h
@@ -19,7 +19,7 @@
  */
 
 #ifndef NUT_STDINT_H_SEEN
-#define NUT_STDINT_H_SEEN
+#define NUT_STDINT_H_SEEN 1
 
 #include "config.h"
 

--- a/include/proto.h
+++ b/include/proto.h
@@ -1,5 +1,5 @@
-#ifndef PROTO_H
-#define PROTO_H
+#ifndef NUT_PROTO_H_SEEN
+#define NUT_PROTO_H_SEEN 1
 
 #include "attribute.h"
 
@@ -91,4 +91,4 @@ int putenv(char *);
 /* *INDENT-ON* */
 #endif
 
-#endif /* PROTO_H */
+#endif /* NUT_PROTO_H_SEEN */

--- a/include/proto.h
+++ b/include/proto.h
@@ -1,3 +1,26 @@
+/* proto.h - fill in the gaps about prototypes and definitions for portability
+
+   Copyright (C) 2001  Russell Kroll <rkroll@exploits.org>
+	2005	Arnaud Quette <arnaud.quette@free.fr>
+	2006	Peter Selinger <selinger@users.sourceforge.net>
+	2013	Emilien Kia <kiae.dev@gmail.com>
+	2020	Jim Klimov <jimklimov@gmail.com>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
 #ifndef NUT_PROTO_H_SEEN
 #define NUT_PROTO_H_SEEN 1
 

--- a/include/state.h
+++ b/include/state.h
@@ -19,8 +19,8 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
-#ifndef STATE_H_SEEN
-#define STATE_H_SEEN
+#ifndef NUT_STATE_H_SEEN
+#define NUT_STATE_H_SEEN 1
 
 #include "extstate.h"
 
@@ -77,4 +77,4 @@ st_tree_t *state_tree_find(st_tree_t *node, const char *var);
 /* *INDENT-ON* */
 #endif
 
-#endif /* STATE_H_SEEN */
+#endif /* NUT_STATE_H_SEEN */

--- a/include/str.h
+++ b/include/str.h
@@ -20,8 +20,8 @@
  *
  */
 
-#ifndef STR_H
-#define STR_H
+#ifndef NUT_STR_H_SEEN
+#define NUT_STR_H_SEEN 1
 
 #ifdef __cplusplus
 /* *INDENT-OFF* */
@@ -126,4 +126,4 @@ int	str_to_double_strict(const char *string, double *number, const int base);
 /* *INDENT-ON* */
 #endif
 
-#endif	/* STR_H */
+#endif	/* NUT_STR_H_SEEN */

--- a/include/timehead.h
+++ b/include/timehead.h
@@ -1,5 +1,8 @@
 /* from the autoconf docs: sanely include the right time headers everywhere */
 
+#ifndef NUT_TIMEHEAD_H_SEEN
+#define NUT_TIMEHEAD_H_SEEN 1
+
 #if TIME_WITH_SYS_TIME
 # include <sys/time.h>
 # include <time.h>
@@ -11,3 +14,4 @@
 # endif
 #endif
 
+#endif	/* NUT_TIMEHEAD_H_SEEN */

--- a/include/timehead.h
+++ b/include/timehead.h
@@ -1,4 +1,23 @@
-/* from the autoconf docs: sanely include the right time headers everywhere */
+/* timehead.h - from the autoconf docs: sanely include the right time headers everywhere
+
+   Copyright (C) 2001  Russell Kroll <rkroll@exploits.org>
+	2005	Arnaud Quette <arnaud.quette@free.fr>
+	2020	Jim Klimov <jimklimov@gmail.com>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+*/
 
 #ifndef NUT_TIMEHEAD_H_SEEN
 #define NUT_TIMEHEAD_H_SEEN 1

--- a/include/upsconf.h
+++ b/include/upsconf.h
@@ -7,10 +7,10 @@ extern "C" {
 
 /* callback function from read_upsconf */
 void do_upsconf_args(char *upsname, char *var, char *val);
-   
+
 /* open the ups.conf, parse it, and call back do_upsconf_args() */
 void read_upsconf(void);
-   
+
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 }

--- a/include/upsconf.h
+++ b/include/upsconf.h
@@ -20,6 +20,9 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
+#ifndef NUT_UPSCONF_H_SEEN
+#define NUT_UPSCONF_H_SEEN 1
+
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 extern "C" {
@@ -38,3 +41,4 @@ void read_upsconf(void);
 /* *INDENT-ON* */
 #endif
 
+#endif	/* NUT_UPSCONF_H_SEEN */

--- a/include/upsconf.h
+++ b/include/upsconf.h
@@ -1,3 +1,24 @@
+/* upsconf.h - prototypes for upsconf.c
+
+   Copyright (C) 2001  Russell Kroll <rkroll@exploits.org>
+	2005	Arnaud Quette <arnaud.quette@free.fr>
+	2013	Emilien Kia <kiae.dev@gmail.com>
+	2020	Jim Klimov <jimklimov@gmail.com>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+*/
 
 #ifdef __cplusplus
 /* *INDENT-OFF* */

--- a/server/netcmds.h
+++ b/server/netcmds.h
@@ -1,6 +1,11 @@
 /* netcmds.h - upsd support structure details
 
    Copyright (C) 2001  Russell Kroll <rkroll@exploits.org>
+	2005	Arnaud Quette <arnaud.quette@free.fr>
+	2007	Peter Selinger <selinger@users.sourceforge.net>
+	2010	Arjen de Korte <adkorte-guest@alioth.debian.org>
+	2012	Emilien Kia <kiae.dev@gmail.com>
+	2020	Jim Klimov <jimklimov@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/server/neterr.h
+++ b/server/neterr.h
@@ -24,6 +24,12 @@
 #ifndef NUT_NETERR_H_SEEN
 #define NUT_NETERR_H_SEEN 1
 
+#ifdef __cplusplus
+/* *INDENT-OFF* */
+extern "C" {
+/* *INDENT-ON* */
+#endif
+
 /* network error definitions for consistency */
 
 #define NUT_ERR_ACCESS_DENIED		"ACCESS-DENIED"
@@ -59,5 +65,11 @@
 #define NUT_ERR_UNKNOWN_INSTCMD		"UNKNOWN-INSTCMD"
 #define NUT_ERR_MISSING_ARGUMENT	"MISSING-ARGUMENT"
 #define NUT_ERR_INVALID_VALUE		"INVALID-VALUE"
+
+#ifdef __cplusplus
+/* *INDENT-OFF* */
+}
+/* *INDENT-ON* */
+#endif
 
 #endif /* NUT_NETERR_H_SEEN */

--- a/server/netget.h
+++ b/server/netget.h
@@ -1,3 +1,27 @@
+/* netget.h - GET handlers for upsd
+
+   Copyright (C)
+	2003	Russell Kroll <rkroll@exploits.org>
+	2005	Arnaud Quette <arnaud.quette@free.fr>
+	2007	Peter Selinger <selinger@users.sourceforge.net>
+	2013	Emilien Kia <kiae.dev@gmail.com>
+	2020	Jim Klimov <jimklimov@gmail.com>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 extern "C" {

--- a/server/netget.h
+++ b/server/netget.h
@@ -22,6 +22,9 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
+#ifndef NUT_NETGET_H_SEEN
+#define NUT_NETGET_H_SEEN 1
+
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 extern "C" {
@@ -36,3 +39,4 @@ void net_get(nut_ctype_t *client, int numarg, const char **arg);
 /* *INDENT-ON* */
 #endif
 
+#endif /* NUT_NETGET_H_SEEN */

--- a/server/netinstcmd.h
+++ b/server/netinstcmd.h
@@ -22,6 +22,9 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
+#ifndef NUT_NETINSTCMD_H_SEEN
+#define NUT_NETINSTCMD_H_SEEN 1
+
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 extern "C" {
@@ -36,3 +39,4 @@ void net_instcmd(nut_ctype_t *client, int numarg, const char **arg);
 /* *INDENT-ON* */
 #endif
 
+#endif /* NUT_NETINSTCMD_H_SEEN */

--- a/server/netinstcmd.h
+++ b/server/netinstcmd.h
@@ -1,3 +1,27 @@
+/* netinstcmd.h - network instand command definitions for NUT
+
+   Copyright (C)
+	2003	Russell Kroll <rkroll@exploits.org>
+	2005	Arnaud Quette <arnaud.quette@free.fr>
+	2007	Peter Selinger <selinger@users.sourceforge.net>
+	2013	Emilien Kia <kiae.dev@gmail.com>
+	2020	Jim Klimov <jimklimov@gmail.com>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 extern "C" {

--- a/server/netlist.h
+++ b/server/netlist.h
@@ -22,6 +22,9 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
+#ifndef NUT_NETLIST_H_SEEN
+#define NUT_NETLIST_H_SEEN 1
+
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 extern "C" {
@@ -36,3 +39,4 @@ void net_list(nut_ctype_t *client, int numarg, const char **arg);
 /* *INDENT-ON* */
 #endif
 
+#endif /* NUT_NETLIST_H_SEEN */

--- a/server/netlist.h
+++ b/server/netlist.h
@@ -1,3 +1,27 @@
+/* netlist.h - LIST handlers for upsd
+
+   Copyright (C)
+	2003	Russell Kroll <rkroll@exploits.org>
+	2005	Arnaud Quette <arnaud.quette@free.fr>
+	2007	Peter Selinger <selinger@users.sourceforge.net>
+	2013	Emilien Kia <kiae.dev@gmail.com>
+	2020	Jim Klimov <jimklimov@gmail.com>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 extern "C" {

--- a/server/netmisc.h
+++ b/server/netmisc.h
@@ -22,6 +22,9 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
+#ifndef NUT_NETMISC_H_SEEN
+#define NUT_NETMISC_H_SEEN 1
+
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 extern "C" {
@@ -39,3 +42,4 @@ void net_fsd(nut_ctype_t *client, int numarg, const char **arg);
 /* *INDENT-ON* */
 #endif
 
+#endif /* NUT_NETMISC_H_SEEN */

--- a/server/netmisc.h
+++ b/server/netmisc.h
@@ -1,3 +1,27 @@
+/* netmisc.h - miscellaneous network handlers for upsd (VER, HELP, FSD)
+
+   Copyright (C)
+	2003	Russell Kroll <rkroll@exploits.org>
+	2007	Peter Selinger <selinger@users.sourceforge.net>
+	2012	Arnaud Quette <arnaud.quette.free.fr>
+	2013	Emilien Kia <kiae.dev@gmail.com>
+	2020	Jim Klimov <jimklimov@gmail.com>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 extern "C" {

--- a/server/netset.h
+++ b/server/netset.h
@@ -22,6 +22,9 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
+#ifndef NUT_NETSET_H_SEEN
+#define NUT_NETSET_H_SEEN 1
+
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 extern "C" {
@@ -36,3 +39,4 @@ void net_set(nut_ctype_t *client, int numarg, const char **arg);
 /* *INDENT-ON* */
 #endif
 
+#endif /* NUT_NETSET_H_SEEN */

--- a/server/netset.h
+++ b/server/netset.h
@@ -1,3 +1,27 @@
+/* netset.h - SET handler for upsd
+
+   Copyright (C)
+	2003	Russell Kroll <rkroll@exploits.org>
+	2005	Arnaud Quette <arnaud.quette@free.fr>
+	2007	Peter Selinger <selinger@users.sourceforge.net>
+	2013	Emilien Kia <kiae.dev@gmail.com>
+	2020	Jim Klimov <jimklimov@gmail.com>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 extern "C" {

--- a/server/netssl.h
+++ b/server/netssl.h
@@ -17,8 +17,8 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
-#ifndef NETSSL_H_SEEN
-#define NETSSL_H_SEEN 1
+#ifndef NUT_NETSSL_H_SEEN
+#define NUT_NETSSL_H_SEEN 1
 
 #include "nut_ctype.h"
 
@@ -59,4 +59,4 @@ void net_starttls(nut_ctype_t *client, int numarg, const char **arg);
 /* *INDENT-ON* */
 #endif
 
-#endif	/* NETSSL_H_SEEN */
+#endif	/* NUT_NETSSL_H_SEEN */

--- a/server/netuser.h
+++ b/server/netuser.h
@@ -22,6 +22,9 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
+#ifndef NUT_NETUSER_H_SEEN
+#define NUT_NETUSER_H_SEEN 1
+
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 extern "C" {
@@ -40,3 +43,4 @@ void net_password(nut_ctype_t *client, int numarg, const char **arg);
 /* *INDENT-ON* */
 #endif
 
+#endif /* NUT_NETUSER_H_SEEN */

--- a/server/netuser.h
+++ b/server/netuser.h
@@ -1,3 +1,27 @@
+/* netuser.c - LOGIN/LOGOUT/USERNAME/PASSWORD/MASTER handlers for upsd
+
+   Copyright (C)
+	2003	Russell Kroll <rkroll@exploits.org>
+	2005	Arnaud Quette <arnaud.quette@free.fr>
+	2007	Peter Selinger <selinger@users.sourceforge.net>
+	2013	Emilien Kia <kiae.dev@gmail.com>
+	2020	Jim Klimov <jimklimov@gmail.com>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 extern "C" {

--- a/server/nut_ctype.h
+++ b/server/nut_ctype.h
@@ -4,6 +4,8 @@
 	2002	Russell Kroll <rkroll@exploits.org>
 	2008	Arjen de Korte <adkorte-guest@alioth.debian.org>
 	2011	Arnaud Quette <arnaud.quette@free.fr>
+	2013	Emilien Kia <kiae.dev@gmail.com>
+	2020	Jim Klimov <jimklimov@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -37,6 +39,12 @@
 
 #include "parseconf.h"
 
+#ifdef __cplusplus
+/* *INDENT-OFF* */
+extern "C" {
+/* *INDENT-ON* */
+#endif
+
 /* client structure */
 typedef struct nut_ctype_s {
 	char	*addr;
@@ -64,5 +72,11 @@ typedef struct nut_ctype_s {
 	struct nut_ctype_s	*prev;
 	struct nut_ctype_s	*next;
 } nut_ctype_t;
+
+#ifdef __cplusplus
+/* *INDENT-OFF* */
+}
+/* *INDENT-ON* */
+#endif
 
 #endif	/* NUT_CTYPE_H_SEEN */

--- a/server/sstate.h
+++ b/server/sstate.h
@@ -20,8 +20,8 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
-#ifndef SSTATE_H_SEEN
-#define SSTATE_H_SEEN
+#ifndef NUT_SSTATE_H_SEEN
+#define NUT_SSTATE_H_SEEN 1
 
 #include "state.h"
 #include "upstype.h"
@@ -59,4 +59,4 @@ const st_tree_t *sstate_getnode(const upstype_t *ups, const char *varname);
 /* *INDENT-ON* */
 #endif
 
-#endif /* SSTATE_H_SEEN */
+#endif /* NUT_SSTATE_H_SEEN */

--- a/server/stype.h
+++ b/server/stype.h
@@ -18,8 +18,8 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
-#ifndef STYPE_H_SEEN
-#define STYPE_H_SEEN 1
+#ifndef NUT_STYPE_H_SEEN
+#define NUT_STYPE_H_SEEN 1
 
 #include <netdb.h>
 
@@ -50,4 +50,4 @@ typedef struct stype_s {
 /* *INDENT-ON* */
 #endif
 
-#endif	/* STYPE_H_SEEN */
+#endif	/* NUT_STYPE_H_SEEN */

--- a/server/upstype.h
+++ b/server/upstype.h
@@ -19,8 +19,8 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
-#ifndef UPSTYPE_H_SEEN
-#define UPSTYPE_H_SEEN 1
+#ifndef NUT_UPSTYPE_H_SEEN
+#define NUT_UPSTYPE_H_SEEN 1
 
 #include "parseconf.h"
 
@@ -64,4 +64,4 @@ extern upstype_t	*firstups;
 /* *INDENT-ON* */
 #endif
 
-#endif	/* UPSTYPE_H_SEEN */
+#endif	/* NUT_UPSTYPE_H_SEEN */

--- a/server/user-data.h
+++ b/server/user-data.h
@@ -1,6 +1,11 @@
 /* user-data.h - structures for user.c
 
    Copyright (C) 2001  Russell Kroll <rkroll@exploits.org>
+	2005	Arnaud Quette <arnaud.quette@free.fr>
+	2007	Peter Selinger <selinger@users.sourceforge.net>
+	2008	Arjen de Korte <adkorte-guest@alioth.debian.org>
+	2013	Emilien Kia <kiae.dev@gmail.com>
+	2020	Jim Klimov <jimklimov@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/server/user-data.h
+++ b/server/user-data.h
@@ -17,6 +17,9 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
+#ifndef NUT_USERDATA_H_SEEN
+#define NUT_USERDATA_H_SEEN 1
+
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 extern "C" {
@@ -47,3 +50,4 @@ typedef struct {
 /* *INDENT-ON* */
 #endif
 
+#endif /* NUT_USERDATA_H_SEEN */

--- a/server/user.h
+++ b/server/user.h
@@ -17,6 +17,9 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
+#ifndef NUT_USER_H_SEEN
+#define NUT_USER_H_SEEN 1
+
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 extern "C" {
@@ -39,3 +42,4 @@ void check_perms(const char *fn);
 /* *INDENT-ON* */
 #endif
 
+#endif /* NUT_USER_H_SEEN */

--- a/server/user.h
+++ b/server/user.h
@@ -1,6 +1,11 @@
 /* user.c - supporting elements of user handling functions for upsd
 
    Copyright (C) 2001  Russell Kroll <rkroll@exploits.org>
+	2005	Arnaud Quette <arnaud.quette@free.fr>
+	2007	Peter Selinger <selinger@users.sourceforge.net>
+	2008	Arjen de Korte <adkorte-guest@alioth.debian.org>
+	2013	Emilien Kia <kiae.dev@gmail.com>
+	2020	Jim Klimov <jimklimov@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
As commented in #823, LGTM.com scans of our sources highlighted that we do not have header guards in many files.

Also took the chance to standardize the naming pattern for many of those guards, and to add or revise copyright/license headers (though there are some files left not fixed for these nuances due to lack of time).