### PR TITLE
Fix faulty dump mode logic

### DIFF
--- a/drivers/main.c
+++ b/drivers/main.c
@@ -744,9 +744,10 @@ int main(int argc, char **argv)
 			else
 				update_count++;
 		}
-
-		while (!dstate_poll_fds(timeout, extrafd) && !exit_flag) {
-			/* repeat until time is up or extrafd has data */
+		else {
+			while (!dstate_poll_fds(timeout, extrafd) && !exit_flag) {
+				/* repeat until time is up or extrafd has data */
+			}
 		}
 	}
 


### PR DESCRIPTION
This fixes a buffer overflow crash when NUT drivers are used in dump mode.