### PR TITLE
Fightwarn - a bit more groundwork

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,8 @@ addons:
     - libxpm-dev
     - libxml2-utils
     - libmodbus-dev
+    - libnss3-dev
+    - libssl-dev
 
 # Common settings for jobs in the matrix built below
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -467,9 +467,6 @@ _matrix_linux_gnustd_warn_viable:
         - gcc-7
         - *deps_driverlibs
 
-# Stuff with warnings made fatal... well, is usually fatal so far:
-_matrix_linux_gnustd_warn_fatal:
-  include: &_matrix_linux_gnustd_warn_fatal
   - env: NUT_MATRIX_TAG="gnu17-gcc-9-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++17" CC=gcc-9 CXX=g++-9
     os: linux
     sudo: false
@@ -486,6 +483,9 @@ _matrix_linux_gnustd_warn_fatal:
         - gcc-9
         - *deps_driverlibs
 
+# Stuff with warnings made fatal... well, is usually fatal so far:
+_matrix_linux_gnustd_warn_fatal:
+  include: &_matrix_linux_gnustd_warn_fatal
 # Note: Fixing these would make NUT viable again on platforms with only ANSI C!
   - env: NUT_MATRIX_TAG="gnu89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu89" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++89"
     os: linux
@@ -886,7 +886,7 @@ jobs:
 #OK#  - env: NUT_MATRIX_TAG="gnu17-gcc-9-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc-9 CXX=g++-9
   - env: NUT_MATRIX_TAG="gnu99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
 #OK#  - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang-8 CXX=clang++-8
-  - env: NUT_MATRIX_TAG="gnu17-gcc-9-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++17" CC=gcc-9 CXX=g++-9
+#OK#  - env: NUT_MATRIX_TAG="gnu17-gcc-9-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++17" CC=gcc-9 CXX=g++-9
   - env: NUT_MATRIX_TAG="c99-clang-3.5-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang-3.5 CXX=clang++-3.5
   - env: NUT_MATRIX_TAG="c99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c11-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c11" CXXFLAGS="-std=c++11" CC=clang CXX=clang++


### PR DESCRIPTION
This PR follows up from #823 and #844, and enables the results of recently added commits:
* to mark a newly successful test-case as part of required baseline,
* and to actually test on Travis CI both OpenSSL and Mozilla NSS implementations (follows up from #871).