### PR TITLE
Fightwarn - lgtm.com - bogus comparisons

### DIFF
--- a/drivers/bcmxcp.c
+++ b/drivers/bcmxcp.c
@@ -1207,7 +1207,7 @@ void init_limit(void)
 
 	/* Horn Status: */
 	value = answer[BCMXCP_EXT_LIMITS_BLOCK_HORN_STATUS];
-	if (value >= 0 && value <= 2) {
+	if (value <= 2) {
 		dstate_setinfo("ups.beeper.status", "%s", horn_stat[value]);
 	}
 
@@ -1523,7 +1523,7 @@ void upsdrv_updateinfo(void)
 	unsigned char answer[PW_ANSWER_MAX_SIZE];
 	unsigned char status, topology;
 	char sValue[128];
-	int iIndex, res,value;
+	int iIndex, res, value;
 	bool_t has_ups_load = FALSE;
 	int batt_status = 0;
 	const char *nutvalue;
@@ -1762,7 +1762,7 @@ void upsdrv_updateinfo(void)
 		/* Horn Status: */
 		value = answer[BCMXCP_EXT_LIMITS_BLOCK_HORN_STATUS];
 
-		if (value >= 0 && value <= 2) {
+		if (value <= 2) {
 			dstate_setinfo("ups.beeper.status", "%s", horn_stat[value]);
 		}
 		/* AAmbient Temperature Upper Alarm Limit  */

--- a/drivers/pijuice.c
+++ b/drivers/pijuice.c
@@ -438,8 +438,7 @@ static void get_status()
 	     powerInput5vIo <= POWER_PRESENT )
 	{
 		if ( powerInput       == POWER_NOT_PRESENT &&
-		     ( powerInput5vIo != POWER_NOT_PRESENT &&
-		       powerInput5vIo <= POWER_PRESENT ))
+		     ( powerInput5vIo != POWER_NOT_PRESENT ))
 		{
 			if ( usb_power != 1 || gpio_power != 0 )
 			{

--- a/drivers/powercom.c
+++ b/drivers/powercom.c
@@ -663,13 +663,13 @@ static float load_level(void)
 			if (model==525) return raw_data[UPS_LOAD]*110.0/load525[voltage];
 			if (model==625) return raw_data[UPS_LOAD]*110.0/load625[voltage];
 			if (model<2000) return raw_data[UPS_LOAD]*1.13;
-			if (model>=2000) return raw_data[UPS_LOAD]*110.0/load2k[voltage];
+			return raw_data[UPS_LOAD]*110.0/load2k[voltage];
 		} else {
 			if (model==425) return raw_data[UPS_LOAD]*110.0/load425i[voltage];
 			if (model==525) return raw_data[UPS_LOAD]*110.0/load525i[voltage];
 			if (model==625) return raw_data[UPS_LOAD]*110.0/load625i[voltage];
 			if (model<2000) return raw_data[UPS_LOAD]*1.66;
-			if (model>=2000) return raw_data[UPS_LOAD]*110.0/load2ki[voltage];
+			return raw_data[UPS_LOAD]*110.0/load2ki[voltage];
 		}
 	} else if ( !strcmp(types[type].name, "IMP") || !strcmp(types[type].name, "OPTI")) {
 		return raw_data[UPS_LOAD];


### PR DESCRIPTION
Fixes part of LGTM.com suggestions per https://github.com/networkupstools/nut/issues/823#issuecomment-724135948

We have a number of cases where either an uint type is tested for (non-)negativity, or a signed int was recently assigned from a function that returns unsigned types (the latter I am reluctant to "fix" as different OSes might return different types and ranges), or was assigned from an element of an array of uint's.