### PR TITLE
Fightwarn - macos llvm - ssize_t for read()/write()/send()

### DIFF
--- a/clients/upsclient.c
+++ b/clients/upsclient.c
@@ -572,9 +572,9 @@ const char *upscli_strerror(UPSCONN_t *ups)
 /* Read up to buflen bytes from fd and return the number of bytes
    read. If no data is available within d_sec + d_usec, return 0.
    On error, a value < 0 is returned (errno indicates error). */
-static int upscli_select_read(const int fd, void *buf, const size_t buflen, const long d_sec, const long d_usec)
+static ssize_t upscli_select_read(const int fd, void *buf, const size_t buflen, const long d_sec, const long d_usec)
 {
-	int		ret;
+	ssize_t		ret;
 	fd_set		fds;
 	struct timeval	tv;
 
@@ -594,9 +594,9 @@ static int upscli_select_read(const int fd, void *buf, const size_t buflen, cons
 }
 
 /* internal: abstract the SSL calls for the other functions */
-static int net_read(UPSCONN_t *ups, char *buf, size_t buflen, unsigned int timeout)
+static ssize_t net_read(UPSCONN_t *ups, char *buf, size_t buflen, unsigned int timeout)
 {
-	int	ret = -1;
+	ssize_t	ret = -1;
 
 #ifdef WITH_SSL
 	if (ups->ssl) {
@@ -633,9 +633,9 @@ static int net_read(UPSCONN_t *ups, char *buf, size_t buflen, unsigned int timeo
 /* Write up to buflen bytes to fd and return the number of bytes
    written. If no data is available within d_sec + d_usec, return 0.
    On error, a value < 0 is returned (errno indicates error). */
-static int upscli_select_write(const int fd, const void *buf, const size_t buflen, const long d_sec, const long d_usec)
+static ssize_t upscli_select_write(const int fd, const void *buf, const size_t buflen, const long d_sec, const long d_usec)
 {
-	int		ret;
+	ssize_t		ret;
 	fd_set		fds;
 	struct timeval	tv;
 
@@ -655,9 +655,9 @@ static int upscli_select_write(const int fd, const void *buf, const size_t bufle
 }
 
 /* internal: abstract the SSL calls for the other functions */
-static int net_write(UPSCONN_t *ups, const char *buf, size_t buflen, unsigned int timeout)
+static ssize_t net_write(UPSCONN_t *ups, const char *buf, size_t buflen, unsigned int timeout)
 {
-	int	ret = -1;
+	ssize_t	ret = -1;
 
 #ifdef WITH_SSL
 	if (ups->ssl) {
@@ -1353,9 +1353,9 @@ int upscli_list_next(UPSCONN_t *ups, unsigned int numq, const char **query,
 	return 1;
 }
 
-int upscli_sendline_timeout(UPSCONN_t *ups, const char *buf, size_t buflen, unsigned int timeout)
+ssize_t upscli_sendline_timeout(UPSCONN_t *ups, const char *buf, size_t buflen, unsigned int timeout)
 {
-	int	ret;
+	ssize_t	ret;
 
 	if (!ups) {
 		return -1;
@@ -1386,14 +1386,14 @@ int upscli_sendline_timeout(UPSCONN_t *ups, const char *buf, size_t buflen, unsi
 	return 0;
 }
 
-int upscli_sendline(UPSCONN_t *ups, const char *buf, size_t buflen)
+ssize_t upscli_sendline(UPSCONN_t *ups, const char *buf, size_t buflen)
 {
 	return upscli_sendline_timeout(ups, buf, buflen, 0);
 }
 
-int upscli_readline_timeout(UPSCONN_t *ups, char *buf, size_t buflen, unsigned int timeout)
+ssize_t upscli_readline_timeout(UPSCONN_t *ups, char *buf, size_t buflen, unsigned int timeout)
 {
-	int	ret;
+	ssize_t	ret;
 	size_t	recv;
 
 	if (!ups) {
@@ -1441,7 +1441,7 @@ int upscli_readline_timeout(UPSCONN_t *ups, char *buf, size_t buflen, unsigned i
 	return 0;
 }
 
-int upscli_readline(UPSCONN_t *ups, char *buf, size_t buflen)
+ssize_t upscli_readline(UPSCONN_t *ups, char *buf, size_t buflen)
 {
 	return upscli_readline_timeout(ups, buf, buflen, DEFAULT_NETWORK_TIMEOUT);
 }

--- a/clients/upsclient.h
+++ b/clients/upsclient.h
@@ -86,11 +86,11 @@ int upscli_list_start(UPSCONN_t *ups, unsigned int numq, const char **query);
 int upscli_list_next(UPSCONN_t *ups, unsigned int numq, const char **query,
 		unsigned int *numa, char ***answer);
 
-int upscli_sendline_timeout(UPSCONN_t *ups, const char *buf, size_t buflen, unsigned int timeout);
-int upscli_sendline(UPSCONN_t *ups, const char *buf, size_t buflen);
+ssize_t upscli_sendline_timeout(UPSCONN_t *ups, const char *buf, size_t buflen, unsigned int timeout);
+ssize_t upscli_sendline(UPSCONN_t *ups, const char *buf, size_t buflen);
 
-int upscli_readline_timeout(UPSCONN_t *ups, char *buf, size_t buflen, unsigned int timeout);
-int upscli_readline(UPSCONN_t *ups, char *buf, size_t buflen);
+ssize_t upscli_readline_timeout(UPSCONN_t *ups, char *buf, size_t buflen, unsigned int timeout);
+ssize_t upscli_readline(UPSCONN_t *ups, char *buf, size_t buflen);
 
 int upscli_splitname(const char *buf, char **upsname, char **hostname,
 			int *port);

--- a/common/common.c
+++ b/common/common.c
@@ -644,7 +644,7 @@ char *xstrdup(const char *string)
 /* Read up to buflen bytes from fd and return the number of bytes
    read. If no data is available within d_sec + d_usec, return 0.
    On error, a value < 0 is returned (errno indicates error). */
-int select_read(const int fd, void *buf, const size_t buflen, const long d_sec, const long d_usec)
+ssize_t select_read(const int fd, void *buf, const size_t buflen, const long d_sec, const long d_usec)
 {
 	int		ret;
 	fd_set		fds;
@@ -668,7 +668,7 @@ int select_read(const int fd, void *buf, const size_t buflen, const long d_sec, 
 /* Write up to buflen bytes to fd and return the number of bytes
    written. If no data is available within d_sec + d_usec, return 0.
    On error, a value < 0 is returned (errno indicates error). */
-int select_write(const int fd, const void *buf, const size_t buflen, const long d_sec, const long d_usec)
+ssize_t select_write(const int fd, const void *buf, const size_t buflen, const long d_sec, const long d_usec)
 {
 	int		ret;
 	fd_set		fds;

--- a/drivers/apcsmart.c
+++ b/drivers/apcsmart.c
@@ -434,11 +434,12 @@ static void alert_handler(char ch)
  * function is subtly different from generic ser_get_line_alert()
  */
 #define apc_read(b, l, f) apc_read_i(b, l, f, __func__, __LINE__)
-static int apc_read_i(char *buf, size_t buflen, int flags, const char *fn, unsigned int ln)
+static ssize_t apc_read_i(char *buf, size_t buflen, int flags, const char *fn, unsigned int ln)
 {
 	const char *iset = IGN_CHARS, *aset = "";
 	size_t	count = 0;
-	int	i, ret, sec = 3, usec = 0;
+	ssize_t	i, ret;
+	int	sec = 3, usec = 0;
 	char	temp[APC_LBUF];
 
 	if (upsfd == -1)

--- a/drivers/serial.c
+++ b/drivers/serial.c
@@ -125,7 +125,6 @@ static void lock_set(int fd, const char *port)
 
 /* Non fatal version of ser_open */
 int ser_open_nf(const char *port)
-
 {
 	int	fd;
 
@@ -257,12 +256,12 @@ int ser_close(int fd, const char *port)
 	return 0;
 }
 
-int ser_send_char(int fd, unsigned char ch)
+ssize_t ser_send_char(int fd, unsigned char ch)
 {
 	return ser_send_buf_pace(fd, 0, &ch, 1);
 }
 
-static int send_formatted(int fd, const char *fmt, va_list va, unsigned long d_usec)
+static ssize_t send_formatted(int fd, const char *fmt, va_list va, unsigned long d_usec)
 {
 	int	ret;
 	char	buf[LARGEBUF];
@@ -277,9 +276,9 @@ static int send_formatted(int fd, const char *fmt, va_list va, unsigned long d_u
 }
 
 /* send the results of the format string with d_usec delay after each char */
-int ser_send_pace(int fd, unsigned long d_usec, const char *fmt, ...)
+ssize_t ser_send_pace(int fd, unsigned long d_usec, const char *fmt, ...)
 {
-	int	ret;
+	ssize_t	ret;
 	va_list	ap;
 
 	va_start(ap, fmt);
@@ -292,9 +291,9 @@ int ser_send_pace(int fd, unsigned long d_usec, const char *fmt, ...)
 }
 
 /* send the results of the format string with no delay */
-int ser_send(int fd, const char *fmt, ...)
+ssize_t ser_send(int fd, const char *fmt, ...)
 {
-	int	ret;
+	ssize_t	ret;
 	va_list	ap;
 
 	va_start(ap, fmt);
@@ -307,16 +306,16 @@ int ser_send(int fd, const char *fmt, ...)
 }
 
 /* send buflen bytes from buf with no delay */
-int ser_send_buf(int fd, const void *buf, size_t buflen)
+ssize_t ser_send_buf(int fd, const void *buf, size_t buflen)
 {
 	return ser_send_buf_pace(fd, 0, buf, buflen);
 }
 
 /* send buflen bytes from buf with d_usec delay after each char */
-int ser_send_buf_pace(int fd, unsigned long d_usec, const void *buf,
+ssize_t ser_send_buf_pace(int fd, unsigned long d_usec, const void *buf,
 	size_t buflen)
 {
-	int	ret;
+	ssize_t	ret;
 	size_t	sent;
 	const char	*data = buf;
 
@@ -334,12 +333,12 @@ int ser_send_buf_pace(int fd, unsigned long d_usec, const void *buf,
 	return sent;
 }
 
-int ser_get_char(int fd, void *ch, long d_sec, long d_usec)
+ssize_t ser_get_char(int fd, void *ch, long d_sec, long d_usec)
 {
 	return select_read(fd, ch, 1, d_sec, d_usec);
 }
 
-int ser_get_buf(int fd, void *buf, size_t buflen, long d_sec, long d_usec)
+ssize_t ser_get_buf(int fd, void *buf, size_t buflen, long d_sec, long d_usec)
 {
 	memset(buf, '\0', buflen);
 
@@ -347,9 +346,9 @@ int ser_get_buf(int fd, void *buf, size_t buflen, long d_sec, long d_usec)
 }
 
 /* keep reading until buflen bytes are received or a timeout occurs */
-int ser_get_buf_len(int fd, void *buf, size_t buflen, long d_sec, long d_usec)
+ssize_t ser_get_buf_len(int fd, void *buf, size_t buflen, long d_sec, long d_usec)
 {
-	int	ret;
+	ssize_t	ret;
 	size_t	recv;
 	char	*data = buf;
 
@@ -369,11 +368,11 @@ int ser_get_buf_len(int fd, void *buf, size_t buflen, long d_sec, long d_usec)
 
 /* reads a line up to <endchar>, discarding anything else that may follow,
    with callouts to the handler if anything matches the alertset */
-int ser_get_line_alert(int fd, void *buf, size_t buflen, char endchar,
+ssize_t ser_get_line_alert(int fd, void *buf, size_t buflen, char endchar,
 	const char *ignset, const char *alertset, void handler(char ch),
 	long d_sec, long d_usec)
 {
-	int	i, ret;
+	ssize_t	i, ret;
 	char	tmp[64];
 	char	*data = buf;
 	size_t	count = 0, maxcount;
@@ -413,16 +412,16 @@ int ser_get_line_alert(int fd, void *buf, size_t buflen, char endchar,
 }
 
 /* as above, only with no alertset handling (just a wrapper) */
-int ser_get_line(int fd, void *buf, size_t buflen, char endchar,
+ssize_t ser_get_line(int fd, void *buf, size_t buflen, char endchar,
 	const char *ignset, long d_sec, long d_usec)
 {
 	return ser_get_line_alert(fd, buf, buflen, endchar, ignset, "", NULL,
 		d_sec, d_usec);
 }
 
-int ser_flush_in(int fd, const char *ignset, int verbose)
+ssize_t ser_flush_in(int fd, const char *ignset, int verbose)
 {
-	int	ret, extra = 0;
+	ssize_t	ret, extra = 0;
 	char	ch;
 
 	while ((ret = ser_get_char(fd, &ch, 0, 0)) > 0) {

--- a/drivers/serial.h
+++ b/drivers/serial.h
@@ -34,41 +34,41 @@ int ser_flush_io(int fd);
 
 int ser_close(int fd, const char *port);
 
-int ser_send_char(int fd, unsigned char ch);
+ssize_t ser_send_char(int fd, unsigned char ch);
 
 /* send the results of the format string with d_usec delay after each char */
-int ser_send_pace(int fd, unsigned long d_usec, const char *fmt, ...)
+ssize_t ser_send_pace(int fd, unsigned long d_usec, const char *fmt, ...)
 	__attribute__ ((__format__ (__printf__, 3, 4)));
 
 /* send the results of the format string with no delay */
-int ser_send(int fd, const char *fmt, ...)
+ssize_t ser_send(int fd, const char *fmt, ...)
 	__attribute__ ((__format__ (__printf__, 2, 3)));
 
 /* send buflen bytes from buf with no delay */
-int ser_send_buf(int fd, const void *buf, size_t buflen);
+ssize_t ser_send_buf(int fd, const void *buf, size_t buflen);
 
 /* send buflen bytes from buf with d_usec delay after each char */
-int ser_send_buf_pace(int fd, unsigned long d_usec, const void *buf, 
+ssize_t ser_send_buf_pace(int fd, unsigned long d_usec, const void *buf, 
 	size_t buflen);
 
-int ser_get_char(int fd, void *ch, long d_sec, long d_usec);
+ssize_t ser_get_char(int fd, void *ch, long d_sec, long d_usec);
 
-int ser_get_buf(int fd, void *buf, size_t buflen, long d_sec, long d_usec);
+ssize_t ser_get_buf(int fd, void *buf, size_t buflen, long d_sec, long d_usec);
 
 /* keep reading until buflen bytes are received or a timeout occurs */
-int ser_get_buf_len(int fd, void *buf, size_t buflen, long d_sec, long d_usec);
+ssize_t ser_get_buf_len(int fd, void *buf, size_t buflen, long d_sec, long d_usec);
 
 /* reads a line up to <endchar>, discarding anything else that may follow,
    with callouts to the handler if anything matches the alertset */
-int ser_get_line_alert(int fd, void *buf, size_t buflen, char endchar,
+ssize_t ser_get_line_alert(int fd, void *buf, size_t buflen, char endchar,
 	const char *ignset, const char *alertset, void handler (char ch), 
 	long d_sec, long d_usec);
 
 /* as above, only with no alertset handling (just a wrapper) */
-int ser_get_line(int fd, void *buf, size_t buflen, char endchar,
+ssize_t ser_get_line(int fd, void *buf, size_t buflen, char endchar,
 	const char *ignset, long d_sec, long d_usec);
 
-int ser_flush_in(int fd, const char *ignset, int verbose);
+ssize_t ser_flush_in(int fd, const char *ignset, int verbose);
 
 /* unified failure reporting: call these often */
 void ser_comm_fail(const char *fmt, ...)

--- a/include/common.h
+++ b/include/common.h
@@ -137,8 +137,8 @@ void *xcalloc(size_t number, size_t size);
 void *xrealloc(void *ptr, size_t size);
 char *xstrdup(const char *string);
 
-int select_read(const int fd, void *buf, const size_t buflen, const long d_sec, const long d_usec);
-int select_write(const int fd, const void *buf, const size_t buflen, const long d_sec, const long d_usec);
+ssize_t select_read(const int fd, void *buf, const size_t buflen, const long d_sec, const long d_usec);
+ssize_t select_write(const int fd, const void *buf, const size_t buflen, const long d_sec, const long d_usec);
 
 char * get_libname(const char* base_libname);
 


### PR DESCRIPTION
Routines for `read()` and `write()` or `send()` are defined with `ssize_t` wherever I found to look.

Builds on MacOS complained about bitness range mismatch of `int` and `ssize_t` so the chain of calls was modernized here.

Follows up from #823 and #844 efforts.