### PR TITLE
Fightwarn - lgtm com - hiddenargs simple

### DIFF
--- a/drivers/phoenixcontact_modbus.c
+++ b/drivers/phoenixcontact_modbus.c
@@ -33,7 +33,7 @@
 modbus_t *ctx = NULL;
 int errcount = 0;
 
-static int mrir(modbus_t * ctx, int addr, int nb, uint16_t * dest);
+static int mrir(modbus_t * arg_ctx, int addr, int nb, uint16_t * dest);
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -177,10 +177,10 @@ void upsdrv_cleanup(void)
 }
 
 /* Modbus Read Input Registers */
-static int mrir(modbus_t * ctx, int addr, int nb, uint16_t * dest)
+static int mrir(modbus_t * arg_ctx, int addr, int nb, uint16_t * dest)
 {
 	int r;
-	r = modbus_read_input_registers(ctx, addr, nb, dest);
+	r = modbus_read_input_registers(arg_ctx, addr, nb, dest);
 	if (r == -1) {
 		upslogx(LOG_ERR, "mrir: modbus_read_input_registers(addr:%d, count:%d): %s (%s)", addr, nb, modbus_strerror(errno), device_path);
 		errcount++;

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -1036,7 +1036,7 @@ void upsdrv_cleanup(void)
  * Support functions
  *********************************************************************/
 
-void possibly_supported(const char *mfr, HIDDevice_t *hd)
+void possibly_supported(const char *mfr, HIDDevice_t *arghd)
 {
 	upsdebugx(0,
 "This %s device (%04x:%04x) is not (or perhaps not yet) supported\n"
@@ -1044,7 +1044,7 @@ void possibly_supported(const char *mfr, HIDDevice_t *hd)
 "this does not fix the problem, try running the driver with the\n"
 "'-x productid=%04x' option. Please report your results to the NUT user's\n"
 "mailing list <nut-upsuser@lists.alioth.debian.org>.\n",
-	mfr, hd->VendorID, hd->ProductID, hd->ProductID);
+	mfr, arghd->VendorID, arghd->ProductID, arghd->ProductID);
 }
 
 /* Update ups_status to remember this status item. Interpretation is


### PR DESCRIPTION
Fixes part of LGTM.com suggestions per https://github.com/networkupstools/nut/issues/823#issuecomment-724135948 concerning function arguments named same as global variables.

Changes proposed in this PR seem relatively straightforward, but additional review and sanity-checking would be welcome.