### PR TITLE
Fightwarn - lgtm com - hiddenargs upscode2

### DIFF
--- a/drivers/upscode2.c
+++ b/drivers/upscode2.c
@@ -440,7 +440,7 @@ static cmd_t variables[] = {
 
 static int instcmd (const char *auxcmd, const char *data);
 static int setvar (const char *var, const char *data);
-static void upsc_setstatus(unsigned int status);
+static void upsc_setstatus(unsigned int upsc_status);
 static void upsc_flush_input(void);
 static void upsc_getbaseinfo(void);
 static int upsc_commandlist(void);
@@ -963,8 +963,10 @@ void upsdrv_cleanup(void)
 /*
  * Generate status string from bitfield
  */
-static void upsc_setstatus(unsigned int status)
+static void upsc_setstatus(unsigned int upsc_status)
 {
+	/* Save into global state variable for the driver instance */
+	status = upsc_status;
 
 	/*
 	 * I'll look for all available statuses, even though they might not be


### PR DESCRIPTION
upscode2.c: upsc_setstatus(): do not shadow global varname "status" with func argument "status"

Fixes part of LGTM.com suggestions per https://github.com/networkupstools/nut/issues/823#issuecomment-724135948 concerning function arguments named same as global variables.

Changes proposed in this PR concern me a bit more than in others: "should we save the value of function arguments into the global variables for this driver instance?" (and would it play well with several instances running), so additional review and sanity-checking would be very welcome.