### PR TITLE
Fightwarn - lgtm com - hiddenargs netxml

### DIFF
--- a/drivers/netxml-ups.c
+++ b/drivers/netxml-ups.c
@@ -1590,9 +1590,9 @@ static object_query_t *set_object_deserialise_raw(ne_buffer *buff) {
  *  \return HTTP status code if response was sent, 0 on send error
  */
 static int send_http_request(
-	ne_session *session,
+	ne_session *argsession,
 	const char *method,
-	const char *uri,
+	const char *arguri,
 	const char *ct,
 	ne_buffer  *req_body,
 	ne_buffer  *resp_body)
@@ -1602,7 +1602,7 @@ static int send_http_request(
 	ne_request *req = NULL;
 
 	/* Create request */
-	req = ne_request_create(session, method, uri);
+	req = ne_request_create(argsession, method, arguri);
 
 	/* Neon claims that request creation is always successful */
 	assert(NULL != req);


### PR DESCRIPTION
drivers/netxml-ups.c: send_http_request(): do not shadow global varnames "session" and "uri" with func arguments

Fixes part of LGTM.com suggestions per https://github.com/networkupstools/nut/issues/823#issuecomment-724135948 concerning function arguments named same as global variables.

Changes proposed in this PR concern me a bit more than in others: "I wonder if we should we save the values of function arguments into the global variables for this driver instance?" (and would it play well with several instances running), so additional review and sanity-checking would be very welcome.