### PR TITLE
Fightwarn - lgtm com - hiddenargs mgexml

### DIFF
--- a/drivers/mge-xml.c
+++ b/drivers/mge-xml.c
@@ -131,9 +131,9 @@ typedef struct {
 						   NULL if no further processing is required) */
 } xml_info_t;
 
-static const char *online_info(const char *val)
+static const char *online_info(const char *arg_val)
 {
-	if (val[0] == '1') {
+	if (arg_val[0] == '1') {
 		STATUS_SET(ONLINE);
 	} else {
 		STATUS_CLR(ONLINE);
@@ -142,9 +142,9 @@ static const char *online_info(const char *val)
 	return NULL;
 }
 
-static const char *discharging_info(const char *val)
+static const char *discharging_info(const char *arg_val)
 {
-	if (val[0] == '1') {
+	if (arg_val[0] == '1') {
 		STATUS_SET(DISCHRG);
 		/* Workaround NMC bug: both charging and discharging set to 1 */
 		if(STATUS_BIT(CHRG)) {
@@ -157,9 +157,9 @@ static const char *discharging_info(const char *val)
 	return NULL;
 }
 
-static const char *charging_info(const char *val)
+static const char *charging_info(const char *arg_val)
 {
-	if (val[0] == '1') {
+	if (arg_val[0] == '1') {
 		STATUS_SET(CHRG);
 	} else {
 		STATUS_CLR(CHRG);
@@ -168,9 +168,9 @@ static const char *charging_info(const char *val)
 	return NULL;
 }
 
-static const char *lowbatt_info(const char *val)
+static const char *lowbatt_info(const char *arg_val)
 {
-	if (val[0] == '1') {
+	if (arg_val[0] == '1') {
 		STATUS_SET(LOWBATT);
 	} else {
 		STATUS_CLR(LOWBATT);
@@ -179,9 +179,9 @@ static const char *lowbatt_info(const char *val)
 	return NULL;
 }
 
-static const char *overload_info(const char *val)
+static const char *overload_info(const char *arg_val)
 {
-	if (val[0] == '1') {
+	if (arg_val[0] == '1') {
 		STATUS_SET(OVERLOAD);
 	} else {
 		STATUS_CLR(OVERLOAD);
@@ -190,9 +190,9 @@ static const char *overload_info(const char *val)
 	return NULL;
 }
 
-static const char *replacebatt_info(const char *val)
+static const char *replacebatt_info(const char *arg_val)
 {
-	if (val[0] == '1') {
+	if (arg_val[0] == '1') {
 		STATUS_SET(REPLACEBATT);
 	} else {
 		STATUS_CLR(REPLACEBATT);
@@ -201,9 +201,9 @@ static const char *replacebatt_info(const char *val)
 	return NULL;
 }
 
-static const char *trim_info(const char *val)
+static const char *trim_info(const char *arg_val)
 {
-	if (val[0] == '1') {
+	if (arg_val[0] == '1') {
 		STATUS_SET(TRIM);
 	} else {
 		STATUS_CLR(TRIM);
@@ -212,9 +212,9 @@ static const char *trim_info(const char *val)
 	return NULL;
 }
 
-static const char *boost_info(const char *val)
+static const char *boost_info(const char *arg_val)
 {
-	if (val[0] == '1') {
+	if (arg_val[0] == '1') {
 		STATUS_SET(BOOST);
 	} else {
 		STATUS_CLR(BOOST);
@@ -223,9 +223,9 @@ static const char *boost_info(const char *val)
 	return NULL;
 }
 
-static const char *bypass_aut_info(const char *val)
+static const char *bypass_aut_info(const char *arg_val)
 {
-	if (val[0] == '1') {
+	if (arg_val[0] == '1') {
 		STATUS_SET(BYPASSAUTO);
 	} else {
 		STATUS_CLR(BYPASSAUTO);
@@ -234,9 +234,9 @@ static const char *bypass_aut_info(const char *val)
 	return NULL;
 }
 
-static const char *bypass_man_info(const char *val)
+static const char *bypass_man_info(const char *arg_val)
 {
-	if (val[0] == '1') {
+	if (arg_val[0] == '1') {
 		STATUS_SET(BYPASSMAN);
 	} else {
 		STATUS_CLR(BYPASSMAN);
@@ -245,9 +245,9 @@ static const char *bypass_man_info(const char *val)
 	return NULL;
 }
 
-static const char *off_info(const char *val)
+static const char *off_info(const char *arg_val)
 {
-	if (val[0] == '0') {
+	if (arg_val[0] == '0') {
 		STATUS_SET(OFF);
 	} else {
 		STATUS_CLR(OFF);
@@ -259,9 +259,9 @@ static const char *off_info(const char *val)
 /* note: this value is reverted (0=set, 1=not set). We report "battery
    not installed" rather than "battery installed", so that devices
    that don't implement this variable have a battery by default */
-static const char *nobattery_info(const char *val)
+static const char *nobattery_info(const char *arg_val)
 {
-	if (val[0] == '0') {
+	if (arg_val[0] == '0') {
 		STATUS_SET(NOBATTERY);
 	} else {
 		STATUS_CLR(NOBATTERY);
@@ -270,9 +270,9 @@ static const char *nobattery_info(const char *val)
 	return NULL;
 }
 
-static const char *fanfail_info(const char *val)
+static const char *fanfail_info(const char *arg_val)
 {
-	if (val[0] == '1') {
+	if (arg_val[0] == '1') {
 		STATUS_SET(FANFAIL);
 	} else {
 		STATUS_CLR(FANFAIL);
@@ -282,9 +282,9 @@ static const char *fanfail_info(const char *val)
 }
 
 #if 0
-static const char *shutdownimm_info(const char *val)
+static const char *shutdownimm_info(const char *arg_val)
 {
-	if (val[0] == '1') {
+	if (arg_val[0] == '1') {
 		STATUS_SET(SHUTDOWNIMM);
 	} else {
 		STATUS_CLR(SHUTDOWNIMM);
@@ -294,9 +294,9 @@ static const char *shutdownimm_info(const char *val)
 }
 #endif
 
-static const char *overheat_info(const char *val)
+static const char *overheat_info(const char *arg_val)
 {
-	if (val[0] == '1') {
+	if (arg_val[0] == '1') {
 		STATUS_SET(OVERHEAT);
 	} else {
 		STATUS_CLR(OVERHEAT);
@@ -305,9 +305,9 @@ static const char *overheat_info(const char *val)
 	return NULL;
 }
 
-static const char *commfault_info(const char *val)
+static const char *commfault_info(const char *arg_val)
 {
-	if (val[0] == '1') {
+	if (arg_val[0] == '1') {
 		STATUS_SET(COMMFAULT);
 	} else {
 		STATUS_CLR(COMMFAULT);
@@ -316,9 +316,9 @@ static const char *commfault_info(const char *val)
 	return NULL;
 }
 
-static const char *internalfailure_info(const char *val)
+static const char *internalfailure_info(const char *arg_val)
 {
-	if (val[0] == '1') {
+	if (arg_val[0] == '1') {
 		STATUS_SET(INTERNALFAULT);
 	} else {
 		STATUS_CLR(INTERNALFAULT);
@@ -327,9 +327,9 @@ static const char *internalfailure_info(const char *val)
 	return NULL;
 }
 
-static const char *battvoltlo_info(const char *val)
+static const char *battvoltlo_info(const char *arg_val)
 {
-	if (val[0] == '1') {
+	if (arg_val[0] == '1') {
 		STATUS_SET(BATTVOLTLO);
 	} else {
 		STATUS_CLR(BATTVOLTLO);
@@ -338,9 +338,9 @@ static const char *battvoltlo_info(const char *val)
 	return NULL;
 }
 
-static const char *battvolthi_info(const char *val)
+static const char *battvolthi_info(const char *arg_val)
 {
-	if (val[0] == '1') {
+	if (arg_val[0] == '1') {
 		STATUS_SET(BATTVOLTHI);
 	} else {
 		STATUS_CLR(BATTVOLTHI);
@@ -349,9 +349,9 @@ static const char *battvolthi_info(const char *val)
 	return NULL;
 }
 
-static const char *chargerfail_info(const char *val)
+static const char *chargerfail_info(const char *arg_val)
 {
-	if ((val[0] == '1') || !strncasecmp(val, "Yes", 3)) {
+	if ((arg_val[0] == '1') || !strncasecmp(arg_val, "Yes", 3)) {
 		STATUS_SET(CHARGERFAIL);
 	} else {
 		STATUS_CLR(CHARGERFAIL);
@@ -360,9 +360,9 @@ static const char *chargerfail_info(const char *val)
 	return NULL;
 }
 
-static const char *vrange_info(const char *val)
+static const char *vrange_info(const char *arg_val)
 {
-	if ((val[0] == '1') || !strncasecmp(val, "Yes", 3)) {
+	if ((arg_val[0] == '1') || !strncasecmp(arg_val, "Yes", 3)) {
 		STATUS_SET(VRANGE);
 	} else {
 		STATUS_CLR(VRANGE);
@@ -371,9 +371,9 @@ static const char *vrange_info(const char *val)
 	return NULL;
 }
 
-static const char *frange_info(const char *val)
+static const char *frange_info(const char *arg_val)
 {
-	if ((val[0] == '1') || !strncasecmp(val, "Yes", 3)) {
+	if ((arg_val[0] == '1') || !strncasecmp(arg_val, "Yes", 3)) {
 		STATUS_SET(FRANGE);
 	} else {
 		STATUS_CLR(FRANGE);
@@ -382,9 +382,9 @@ static const char *frange_info(const char *val)
 	return NULL;
 }
 
-static const char *fuse_fault_info(const char *val)
+static const char *fuse_fault_info(const char *arg_val)
 {
-	if (val[0] == '1') {
+	if (arg_val[0] == '1') {
 		STATUS_SET(FUSEFAULT);
 	} else {
 		STATUS_CLR(FUSEFAULT);
@@ -393,35 +393,35 @@ static const char *fuse_fault_info(const char *val)
 	return NULL;
 }
 
-static const char *yes_no_info(const char *val)
+static const char *yes_no_info(const char *arg_val)
 {
-	switch(val[0])
+	switch(arg_val[0])
 	{
 	case '1':
 		return "yes";
 	case '0':
 		return "no";
 	default:
-		upsdebugx(2, "%s: unexpected value [%s]", __func__, val);
+		upsdebugx(2, "%s: unexpected value [%s]", __func__, arg_val);
 		return "<unknown>";
 	}
 }
 
-static const char *on_off_info(const char *val)
+static const char *on_off_info(const char *arg_val)
 {
-	switch(val[0])
+	switch(arg_val[0])
 	{
 	case '1':
 		return "on";
 	case '0':
 		return "off";
 	default:
-		upsdebugx(2, "%s: unexpected value [%s]", __func__, val);
+		upsdebugx(2, "%s: unexpected value [%s]", __func__, arg_val);
 		return "<unknown>";
 	}
 }
 
-static const char *convert_deci(const char *val)
+static const char *convert_deci(const char *arg_val)
 {
 	/* Note: this routine was needed for original MGE devices, before the company
 	 * was bought out and split in 2007 between Eaton (1ph devices) and Schneider
@@ -440,7 +440,7 @@ static const char *convert_deci(const char *val)
 			upslogx(LOG_NOTICE, "%s() is now deprecated, so values from XML are normally not decimated. This driver instance has however configured do_convert_deci in your ups.conf, so this behavior for old MGE NetXML-capable devices is preserved.", __func__);
 			mge_report_deprecation__convert_deci = 0;
 		}
-		snprintf(mge_scratch_buf, sizeof(mge_scratch_buf), "%.1f", 0.1 * (float)atoi(val));
+		snprintf(mge_scratch_buf, sizeof(mge_scratch_buf), "%.1f", 0.1 * (float)atoi(arg_val));
 		return mge_scratch_buf;
 	}
 
@@ -448,57 +448,57 @@ static const char *convert_deci(const char *val)
 		upslogx(LOG_NOTICE, "%s() is now deprecated, so values from XML are not decimated. If you happen to have an old MGE NetXML-capable device that now shows measurements 10x too big, and a firmware update does not solve this, please inform NUT devs via the issue tracker at %s with details about your hardware and firmware versions. Also try to enable do_convert_deci in your ups.conf", __func__, PACKAGE_BUGREPORT );
 		mge_report_deprecation__convert_deci = 0;
 	}
-	upsdebugx(5, "%s() is now deprecated, so value '%s' is not decimated. If this change broke your setup, please see details logged above.", __func__, val);
-	return val;
+	upsdebugx(5, "%s() is now deprecated, so value '%s' is not decimated. If this change broke your setup, please see details logged above.", __func__, arg_val);
+	return arg_val;
 }
 
 /* Ignore a zero value if the UPS is not switched off */
-static const char *ignore_if_zero(const char *val)
+static const char *ignore_if_zero(const char *arg_val)
 {
-	if (atoi(val) == 0) {
+	if (atoi(arg_val) == 0) {
 		return NULL;
 	}
 
-	return convert_deci(val);
+	return convert_deci(arg_val);
 }
 
 /* Set the 'ups.date' from the combined value
  * (ex. 2008/03/01 15:23:26) and return the time */
-static const char *split_date_time(const char *val)
+static const char *split_date_time(const char *arg_val)
 {
 	char	*last = NULL;
 
-	snprintf(mge_scratch_buf, sizeof(mge_scratch_buf), "%s", val);
+	snprintf(mge_scratch_buf, sizeof(mge_scratch_buf), "%s", arg_val);
 	dstate_setinfo("ups.date", "%s", strtok_r(mge_scratch_buf, " -", &last));
 
 	return strtok_r(NULL, " ", &last);
 }
 
-static const char *url_convert(const char *val)
+static const char *url_convert(const char *arg_val)
 {
 	char	buf[256], *last = NULL;
 
-	snprintf(buf, sizeof(buf), "%s", val);
+	snprintf(buf, sizeof(buf), "%s", arg_val);
 	snprintf(mge_scratch_buf, sizeof(mge_scratch_buf), "/%s", strtok_r(buf, " \r\n\t", &last));
 
 	return mge_scratch_buf;
 }
 
-static const char *mge_battery_capacity(const char *val)
+static const char *mge_battery_capacity(const char *arg_val)
 {
-	snprintf(mge_scratch_buf, sizeof(mge_scratch_buf), "%.2f", (float)atoi(val) / 3600);
+	snprintf(mge_scratch_buf, sizeof(mge_scratch_buf), "%.2f", (float)atoi(arg_val) / 3600);
 	return mge_scratch_buf;
 }
 
-static const char *mge_powerfactor_conversion(const char *val)
+static const char *mge_powerfactor_conversion(const char *arg_val)
 {
-	snprintf(mge_scratch_buf, sizeof(mge_scratch_buf), "%.2f", (float)atoi(val) / 100);
+	snprintf(mge_scratch_buf, sizeof(mge_scratch_buf), "%.2f", (float)atoi(arg_val) / 100);
 	return mge_scratch_buf;
 }
 
-static const char *mge_beeper_info(const char *val)
+static const char *mge_beeper_info(const char *arg_val)
 {
-	switch (atoi(val))
+	switch (atoi(arg_val))
 	{
 	case 1:
 		return "disabled";
@@ -510,9 +510,9 @@ static const char *mge_beeper_info(const char *val)
 	return NULL;
 }
 
-static const char *mge_upstype_conversion(const char *val)
+static const char *mge_upstype_conversion(const char *arg_val)
 {
-	switch (atoi(val))
+	switch (atoi(arg_val))
 	{
 	case 1:
 		return "offline / line interactive";
@@ -528,9 +528,9 @@ static const char *mge_upstype_conversion(const char *val)
 	return NULL;
 }
 
-static const char *mge_sensitivity_info(const char *val)
+static const char *mge_sensitivity_info(const char *arg_val)
 {
-	switch (atoi(val))
+	switch (atoi(arg_val))
 	{
 	case 0:
 		return "normal";
@@ -542,10 +542,10 @@ static const char *mge_sensitivity_info(const char *val)
 	return NULL;
 }
 
-static const char *mge_test_result_info(const char *val)
+static const char *mge_test_result_info(const char *arg_val)
 {
 	STATUS_CLR(CAL);
-	switch (atoi(val))
+	switch (atoi(arg_val))
 	{
 	case 1:
 		return "done and passed";
@@ -566,12 +566,12 @@ static const char *mge_test_result_info(const char *val)
 	return NULL;
 }
 
-static const char *mge_ambient_info(const char *val)
+static const char *mge_ambient_info(const char *arg_val)
 {
 	switch (mge_ambient_value)
 	{
 	case 1:
-		return val;
+		return arg_val;
 	default:
 		return NULL;
 	}
@@ -595,9 +595,9 @@ static const char *mge_timer_shutdown(const char *delay_before_shutoff)
 	return val;
 }
 
-static const char *mge_shutdown_imminent(const char *val)
+static const char *mge_shutdown_imminent(const char *arg_val)
 {
-	const int shutdown_delay = atoi(val);
+	const int shutdown_delay = atoi(arg_val);
 
 	/* shutdown is already managed by mge_timer_shutdown, give up */
 	if(mge_shutdown_pending) {
@@ -606,7 +606,7 @@ static const char *mge_shutdown_imminent(const char *val)
 
 	/* We may have "NONE" or "-1" or ?? as value
 	 * We also double check both the string and numeric values to be zero!*/
-	if ((val) && (val[0] == '0') && (shutdown_delay == 0)) {
+	if ((arg_val) && (arg_val[0] == '0') && (shutdown_delay == 0)) {
 		STATUS_SET(SHUTDOWNIMM);
 	} else {
 		STATUS_CLR(SHUTDOWNIMM);


### PR DESCRIPTION
drivers/mge-xml.c: numerous routines: do not shadow global varname "val" (for XML element temp store?) with same-named func argument

Fixes part of LGTM.com suggestions per https://github.com/networkupstools/nut/issues/823#issuecomment-724135948 concerning function arguments named same as global variables.

Changes proposed in this PR concern me more than in others: what role does the global `val[]` play - is it a scratch buffer, or does it carry pieces of data between routines e.g. during XML parsing?

I wonder if we should we save the values of function arguments into the global variables for this driver instance? (and would it play well with several instances running), so additional review and sanity-checking would be very welcome.