### PR TITLE
Fightwarn - lgtm com - hiddenargs nut-scanner serial

### DIFF
--- a/tools/nut-scanner/scan_eaton_serial.c
+++ b/tools/nut-scanner/scan_eaton_serial.c
@@ -118,18 +118,22 @@ unsigned char calc_checksum(const unsigned char *buf)
 
 /* Light version of of drivers/libshut.c->shut_synchronise()
  * return 1 if OK, 0 otherwise */
-int shut_synchronise(int upsfd)
+int shut_synchronise(int arg_upsfd)
 {
 	int try;
 	unsigned char reply = '\0';
+	/* FIXME? Should we save "arg_upsfd" into global "upsfd" variable?
+	 * This was previously shadowed by function argument named "upsfd"...
+	 */
+	/* upsfd = arg_upsfd; */
 
 	/* Sync with the UPS according to notification */
 	for (try = 0; try < MAX_TRY; try++) {
-		if ((ser_send_char(upsfd, SHUT_SYNC)) == -1) {
+		if ((ser_send_char(arg_upsfd, SHUT_SYNC)) == -1) {
 			continue;
 		}
 
-		ser_get_char(upsfd, &reply, 1, 0);
+		ser_get_char(arg_upsfd, &reply, 1, 0);
 		if (reply == SHUT_SYNC) {
 			return 1;
 		}


### PR DESCRIPTION
tools/nut-scanner/scan_eaton_serial.c: shut_synchronise(): do not shadow global varnames "upsfd" (from scan_eaton_serial.c and main.c) with func argument "upsfd"

Fixes part of LGTM.com suggestions per https://github.com/networkupstools/nut/issues/823#issuecomment-724135948 concerning function arguments named same as global variables.

Changes proposed in this PR concern me a bit more than in others: "should we save the value of function arguments into the global variables for this driver instance?" - was there some use for global `upsfd` that might be expecting to use the same fd in different places, so additional review and sanity-checking would be very welcome.