### PR TITLE
Fightwarn - lgtm com - hiddenargs tripplite-usb

### DIFF
--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -162,11 +162,16 @@ static usb_device_id_t tripplite_usb_device_table[] = {
 	{ -1, -1, NULL }
 };
 
-static int subdriver_match_func(USBDevice_t *hd, void *privdata)
+static int subdriver_match_func(USBDevice_t *arghd, void *privdata)
 {
 	NUT_UNUSED_VARIABLE(privdata);
 
-	switch (is_usb_device_supported(tripplite_usb_device_table, hd))
+	/* FIXME? Should we save "arghd" into global "hd" variable?
+	 * This was previously shadowed by function argument named "hd"...
+	 */
+	/* hd = arghd; */
+
+	switch (is_usb_device_supported(tripplite_usb_device_table, arghd))
 	{
 	case SUPPORTED:
 		return 1;


### PR DESCRIPTION
drivers/tripplite_usb.c: subdriver_match_func(): do not shadow global varname "hd" with func argument "hd"

Fixes part of LGTM.com suggestions per https://github.com/networkupstools/nut/issues/823#issuecomment-724135948 concerning function arguments named same as global variables.

Changes proposed in this PR concern me a bit more than in others: "I wonder if we should we save the values of function arguments into the global variables for this driver instance?" (and then would it play well with several instances running), so additional review and sanity-checking would be very welcome.