### PR TITLE
scripts/augeas/gen-nutupsconf-aug.py: drop unused "global" vars

### DIFF
--- a/scripts/augeas/gen-nutupsconf-aug.py
+++ b/scripts/augeas/gen-nutupsconf-aug.py
@@ -59,11 +59,11 @@ def grep(string,list):
 if __name__ == '__main__':
 
 	rawCount = 0
-	global finalCount
+	#global finalCount
 	variableNames = []
 	specificVars = ""
-	global inLensContent
-	global finalLensContent
+	#global inLensContent
+	#global finalLensContent
 	Exceptionlist = ['../../drivers/main.c', '../../drivers/skel.c']
 	outputFilename = 'nutupsconf.aug.in'
 	templateFilename = 'nutupsconf.aug.tpl'


### PR DESCRIPTION
    scripts/augeas/gen-nutupsconf-aug.py: drop unused variables
    
    Originally PR meant to drop "global" modifier outside a local
    function context, but found that nothing defines or uses these
    three names. Must be some leftover from planned but unfinished
    development.
    
    Re-ran ./autogen.sh and it generates the same file for the build.

Fixes part of LGTM.com suggestions per https://github.com/networkupstools/nut/issues/823#issuecomment-724135948

And replaces PR #881