### PR TITLE
fightwarn - fix diags pragmas to use our configured-support macros for cleaner fencing (unreachable code)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -138,6 +138,8 @@ AC_C_BIGENDIAN
 AC_C_INLINE
 AC_C_FLEXIBLE_ARRAY_MEMBER
 AC_C_VARARRAYS
+dnl Note: the compiler/pragma/attr methods below are custom for NUT codebase:
+NUT_COMPILER_FAMILY
 AX_C_PRAGMAS
 AX_C___ATTRIBUTE__
 AC_CHECK_FUNCS(flock lockf fcvt fcvtl pow10 round abs_val abs)

--- a/drivers/libusb.c
+++ b/drivers/libusb.c
@@ -251,14 +251,16 @@ static int libusb_open(usb_dev_handle **udevp, USBDevice_t *curDevice, USBDevice
 					goto next_device;
 				} else if (ret==-1) {
 					fatal_with_errno(EXIT_FAILURE, "matcher");
-#if defined (__GNUC__) || defined (__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunreachable-code-break"
-#pragma GCC diagnostic ignored "-Wunreachable-code"
-#endif
+#ifndef HAVE___ATTRIBUTE__NORETURN
+# if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNR
+EACHABLE_CODE)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wunreachable-code"
+# endif
 					goto next_device;
-#if defined (__GNUC__) || defined (__clang__)
-#pragma GCC diagnostic pop
+# if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE)
+#  pragma GCC diagnostic pop
+# endif
 #endif
 				} else if (ret==-2) {
 					upsdebugx(2, "matcher: unspecified error");

--- a/drivers/nutdrv_atcl_usb.c
+++ b/drivers/nutdrv_atcl_usb.c
@@ -320,14 +320,16 @@ static int usb_device_open(usb_dev_handle **handlep, USBDevice_t *device, USBDev
 					goto next_device;
 				case -1:
 					fatal_with_errno(EXIT_FAILURE, "matcher");
-#if defined (__GNUC__) || defined (__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunreachable-code-break"
-#pragma GCC diagnostic ignored "-Wunreachable-code"
-#endif
+#ifndef HAVE___ATTRIBUTE__NORETURN
+# if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNR
+EACHABLE_CODE)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wunreachable-code"
+# endif
 					goto next_device;
-#if defined (__GNUC__) || defined (__clang__)
-#pragma GCC diagnostic pop
+# if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE)
+#  pragma GCC diagnostic pop
+# endif
 #endif
 				case -2:
 					upsdebugx(4, "matcher: unspecified error");

--- a/drivers/richcomm_usb.c
+++ b/drivers/richcomm_usb.c
@@ -312,14 +312,15 @@ static int usb_device_open(usb_dev_handle **handlep, USBDevice_t *device, USBDev
 					goto next_device;
 				case -1:
 					fatal_with_errno(EXIT_FAILURE, "matcher");
-#if defined (__GNUC__) || defined (__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunreachable-code-break"
-#pragma GCC diagnostic ignored "-Wunreachable-code"
-#endif
+#ifndef HAVE___ATTRIBUTE__NORETURN
+# if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wunreachable-code"
+# endif
 					goto next_device;
-#if defined (__GNUC__) || defined (__clang__)
-#pragma GCC diagnostic pop
+# if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE)
+#  pragma GCC diagnostic pop
+# endif
 #endif
 				case -2:
 					upsdebugx(4, "matcher: unspecified error");

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -737,13 +737,17 @@ static int control_outlet(int outlet_id, int state)
 			} else {
 				return 1;
 			}
-#if defined (__GNUC__) || defined (__clang__)
+#ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
 #pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE_BREAK
 #pragma GCC diagnostic ignored "-Wunreachable-code-break"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
 #pragma GCC diagnostic ignored "-Wunreachable-code"
 #endif
 			break;
-#if defined (__GNUC__) || defined (__clang__)
+#ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
 #pragma GCC diagnostic pop
 #endif
 
@@ -759,13 +763,17 @@ static int control_outlet(int outlet_id, int state)
 			} else {
 				return 1;
 			}
-#if defined (__GNUC__) || defined (__clang__)
+#ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
 #pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE_BREAK
 #pragma GCC diagnostic ignored "-Wunreachable-code-break"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
 #pragma GCC diagnostic ignored "-Wunreachable-code"
 #endif
 			break;
-#if defined (__GNUC__) || defined (__clang__)
+#ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
 #pragma GCC diagnostic pop
 #endif
 

--- a/m4/ax_c_pragmas.m4
+++ b/m4/ax_c_pragmas.m4
@@ -3,10 +3,17 @@ dnl e.g. diagnostics management to keep warnings quiet sometimes
 
 AC_DEFUN([AX_C_PRAGMAS], [
   CFLAGS_SAVED="${CFLAGS}"
-  AS_IF([test "${GCC}" = "yes"],
-    [dnl # This is expected to fail builds with unknown pragma names on GCC or CLANG at least
-     CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning-option"],
-    [CFLAGS="${CFLAGS_SAVED} -Wall -Wextra -Werror"])
+
+  dnl # This is expected to fail builds with unknown pragma names on GCC or CLANG at least
+  AS_IF([test "${CLANG}" = "yes"],
+    [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning-option"],
+    [AS_IF([test "${GCC}" = "yes"],
+dnl ### Despite the docs, this dies with lack of (apparently) support for
+dnl ### -Wunknown-warning(-options) on all GCC versions I tried (v5-v10)
+dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"],
+        [CFLAGS="${CFLAGS_SAVED} -Wall -Wextra -Werror"],
+        [CFLAGS="${CFLAGS_SAVED} -Wall -Wextra -Werror"])
+    ])
 
   AC_CACHE_CHECK([for pragma GCC diagnostic push and pop],
     [ax_cv__pragma__gcc__diags_push_pop],

--- a/m4/ax_c_pragmas.m4
+++ b/m4/ax_c_pragmas.m4
@@ -89,6 +89,7 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
     ])
   ])
 
+  dnl ### Sanity check if the CLI options actually work:
   AC_CACHE_CHECK([for pragma BOGUSforTest],
     [ax_cv__pragma__bogus],
     [AC_COMPILE_IFELSE(
@@ -106,6 +107,12 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
       [ax_cv__pragma__bogus_diag=no]
     )]
   )
+
+  AS_IF([test "${ax_cv__pragma__bogus}" != "no"],
+    [AC_MSG_WARN([A bogus test that was expected to fail did not! ax_cv__pragma__bogus=$ax_cv__pragma__bogus (not 'no')])])
+
+  AS_IF([test "${ax_cv__pragma__bogus_diag}" != "no"],
+    [AC_MSG_WARN([A bogus test that was expected to fail did not! ax_cv__pragma__bogus_diag=$ax_cv__pragma__bogus_diag (not 'no')])])
 
   CFLAGS="${CFLAGS_SAVED}"
 ])

--- a/m4/nut_compiler_family.m4
+++ b/m4/nut_compiler_family.m4
@@ -1,0 +1,60 @@
+dnl detect if current compiler is clang or gcc (or...)
+
+AC_DEFUN([NUT_COMPILER_FAMILY],
+[
+  AC_CACHE_CHECK([if CC compiler family is GCC],
+    [nut_cv_GCC],
+    [AS_IF([test -n "$CC"],
+        [AS_IF([$CC --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+            [nut_cv_GCC=yes],[nut_cv_GCC=no])],
+        [AC_MSG_ERROR([CC is not set])]
+    )])
+
+  AC_CACHE_CHECK([if CXX compiler family is GCC],
+    [nut_cv_GXX],
+    [AS_IF([test -n "$CXX"],
+        [AS_IF([$CXX --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+            [nut_cv_GXX=yes],[nut_cv_GXX=no])],
+        [AC_MSG_ERROR([CXX is not set])]
+    )])
+
+  AC_CACHE_CHECK([if CPP preprocessor family is GCC],
+    [nut_cv_GPP],
+    [AS_IF([test -n "$CPP"],
+        [AS_IF([$CPP --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+            [nut_cv_GPP=yes],[nut_cv_GPP=no])],
+        [AC_MSG_ERROR([CPP is not set])]
+    )])
+
+  AS_IF([test "x$GCC" = "x" && test "$nut_cv_GCC" = yes],   [GCC=yes])
+  AS_IF([test "x$GXX" = "x" && test "$nut_cv_GXX" = yes],   [GXX=yes])
+  AS_IF([test "x$GPP" = "x" && test "$nut_cv_GPP" = yes],   [GPP=yes])
+
+  AC_CACHE_CHECK([if CC compiler family is clang],
+    [nut_cv_CLANG],
+    [AS_IF([test -n "$CC"],
+        [AS_IF([$CC --version 2>&1 | grep 'clang version' > /dev/null],
+            [nut_cv_CLANG=yes],[nut_cv_CLANG=no])],
+        [AC_MSG_ERROR([CC is not set])]
+    )])
+
+  AC_CACHE_CHECK([if CXX compiler family is clang],
+    [nut_cv_CLANGXX],
+    [AS_IF([test -n "$CXX"],
+        [AS_IF([$CXX --version 2>&1 | grep 'clang version' > /dev/null],
+            [nut_cv_CLANGXX=yes],[nut_cv_CLANGXX=no])],
+        [AC_MSG_ERROR([CXX is not set])]
+    )])
+
+  AC_CACHE_CHECK([if CPP preprocessor family is clang],
+    [nut_cv_CLANGPP],
+    [AS_IF([test -n "$CPP"],
+        [AS_IF([$CPP --version 2>&1 | grep 'clang version' > /dev/null],
+            [nut_cv_CLANGPP=yes],[nut_cv_CLANGPP=no])],
+        [AC_MSG_ERROR([CPP is not set])]
+    )])
+
+  AS_IF([test "x$CLANGCC" = "x" && test "$nut_cv_CLANGCC" = yes],   [CLANGCC=yes])
+  AS_IF([test "x$CLANGXX" = "x" && test "$nut_cv_CLANGXX" = yes],   [CLANGXX=yes])
+  AS_IF([test "x$CLANGPP" = "x" && test "$nut_cv_CLANGPP" = yes],   [CLANGPP=yes])
+])


### PR DESCRIPTION
Follows up from #823 and #879 in particular.