### PR TITLE
Fightwarn - Introduce ARM64 builds and some minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ Makefile.in
 /conf_nut_report_feature
 /conf??????/
 /dir.??????/
+/configure-test*/
 /cscope.*
 /depcomp
 /INSTALL

--- a/.travis.yml
+++ b/.travis.yml
@@ -382,6 +382,7 @@ _matrix_linux_gnustd_nowarn_arm_64bit_fatal:
     services:
         - docker
     compiler: clang
+    if: branch =~ fightwarn
     addons:
       apt:
         sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -342,8 +342,8 @@ _matrix_linux_gnustd_nowarn:
         - *deps_driverlibs
 
 # Try ARM builds to check for issues with non-x86 CPUs
-_matrix_linux_gnustd_nowarn_arm_64bit:
-  include: &_matrix_linux_gnustd_nowarn_arm_64bit
+_matrix_linux_gnustd_nowarn_arm_64bit_viable:
+  include: &_matrix_linux_gnustd_nowarn_arm_64bit_viable
   - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn-ARM-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99"
     os: linux
     arch: arm64
@@ -372,6 +372,8 @@ _matrix_linux_gnustd_nowarn_arm_64bit:
         - gcc-9
         - *deps_driverlibs
 
+_matrix_linux_gnustd_nowarn_arm_64bit_fatal:
+  include: &_matrix_linux_gnustd_nowarn_arm_64bit_fatal
   - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn-ARM-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang-8 CXX=clang++-8
     os: linux
     arch: arm64
@@ -903,7 +905,7 @@ _matrix_required_linux:
   - *_matrix_required_linux_pass3_large
   - *_matrix_linux_gnustd_nowarn
   - *_matrix_linux_gnustd_warn_viable
-  - *_matrix_linux_gnustd_nowarn_arm_64bit
+  - *_matrix_linux_gnustd_nowarn_arm_64bit_viable
 
 _matrix_linux_gnustd_warn:
   include: &_matrix_linux_gnustd_warn
@@ -915,6 +917,12 @@ _matrix_allowfail_linux:
   - *_matrix_linux_cstd_nowarn
   - *_matrix_linux_gnustd_warn_fatal
   - *_matrix_linux_cstd_warn
+  - *_matrix_linux_gnustd_nowarn_arm_64bit_fatal
+
+_matrix_linux_gnustd_nowarn_arm_64bit:
+  include: &_matrix_linux_gnustd_nowarn_arm_64bit
+  - *_matrix_linux_gnustd_nowarn_arm_64bit_viable
+  - *_matrix_linux_gnustd_nowarn_arm_64bit_fatal
 
 _matrix_linux_arm:
   include: &_matrix_linux_arm
@@ -988,7 +996,8 @@ _matrix_gnustd_nowarn:
   - *_matrix_linux_gnustd_nowarn
   - *_matrix_freebsd_gnustd_nowarn
 #  -*_matrix_windows_gnustd_nowarn
-  - *_matrix_linux_gnustd_nowarn_arm_64bit
+  - *_matrix_linux_gnustd_nowarn_arm_64bit_viable
+  - *_matrix_linux_gnustd_nowarn_arm_64bit_fatal
 
 _matrix_warn:
   include: &_matrix_warn

--- a/.travis.yml
+++ b/.travis.yml
@@ -341,6 +341,77 @@ _matrix_linux_gnustd_nowarn:
         packages:
         - *deps_driverlibs
 
+# Try ARM builds to check for issues with non-x86 CPUs
+_matrix_linux_gnustd_nowarn_arm_32bit:
+  include: &_matrix_linux_gnustd_nowarn_arm_32bit
+  - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn-ARM-32bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99 -m32" CXXFLAGS="-std=gnu++99 -m32" CPPFLAGS="-m32"
+    os: linux
+    arch: arm32
+    sudo: false
+    services:
+        - docker
+    compiler: gcc
+    addons:
+      apt:
+        packages:
+        - *deps_driverlibs
+        - gcc-multilib
+        - g++-multilib
+
+  - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn-ARM-32bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17 -m32" CXXFLAGS="-std=gnu++17 -m32" CPPFLAGS="-m32" CC=clang-8 CXX=clang++-8
+    os: linux
+    arch: arm32
+    dist: xenial
+    sudo: false
+    services:
+        - docker
+    compiler: clang
+    addons:
+      apt:
+        sources:
+        - llvm-toolchain-xenial-8
+        packages:
+        - clang-8
+        - clang-format-8
+        - *deps_driverlibs
+        - gcc-multilib
+        - g++-multilib
+
+_matrix_linux_gnustd_nowarn_arm_64bit:
+  include: &_matrix_linux_gnustd_nowarn_arm_64bit
+  - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn-ARM-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99"
+    os: linux
+    arch: arm64
+    sudo: false
+    services:
+        - docker
+    compiler: gcc
+    addons:
+      apt:
+        packages:
+        - *deps_driverlibs
+        - gcc-multilib
+        - g++-multilib
+
+  - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn-ARM-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang-8 CXX=clang++-8
+    os: linux
+    arch: arm64
+    dist: xenial
+    sudo: false
+    services:
+        - docker
+    compiler: clang
+    addons:
+      apt:
+        sources:
+        - llvm-toolchain-xenial-8
+        packages:
+        - clang-8
+        - clang-format-8
+        - *deps_driverlibs
+        - gcc-multilib
+        - g++-multilib
+
 # At this time, anything with strict C standard fails on Linux, even "nowarn" cases:
 _matrix_linux_cstd_nowarn:
   include: &_matrix_linux_cstd_nowarn
@@ -855,6 +926,8 @@ _matrix_required_linux:
   - *_matrix_required_linux_pass3_large
   - *_matrix_linux_gnustd_nowarn
   - *_matrix_linux_gnustd_warn_viable
+  - *_matrix_linux_gnustd_nowarn_arm_32bit
+  - *_matrix_linux_gnustd_nowarn_arm_64bit
 
 _matrix_linux_gnustd_warn:
   include: &_matrix_linux_gnustd_warn
@@ -866,6 +939,11 @@ _matrix_allowfail_linux:
   - *_matrix_linux_cstd_nowarn
   - *_matrix_linux_gnustd_warn_fatal
   - *_matrix_linux_cstd_warn
+
+_matrix_linux_arm:
+  include: &_matrix_linux_arm
+  - *_matrix_linux_gnustd_nowarn_arm_32bit
+  - *_matrix_linux_gnustd_nowarn_arm_64bit
 
 _matrix_linux:
   include: &_matrix_linux
@@ -935,6 +1013,8 @@ _matrix_gnustd_nowarn:
   - *_matrix_linux_gnustd_nowarn
   - *_matrix_freebsd_gnustd_nowarn
 #  -*_matrix_windows_gnustd_nowarn
+  - *_matrix_linux_gnustd_nowarn_arm_32bit
+  - *_matrix_linux_gnustd_nowarn_arm_64bit
 
 _matrix_warn:
   include: &_matrix_warn
@@ -1020,6 +1100,13 @@ jobs:
 #OK#  - env: NUT_MATRIX_TAG="gnu89-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu89" CXXFLAGS="-std=gnu++89"
   - env: NUT_MATRIX_TAG="c89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c89" CXXFLAGS="-Wall -Wextra -Werror -std=c++89"
   - env: NUT_MATRIX_TAG="gnu89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu89" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++89"
+
+### Linux on ARM
+  - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn-ARM-32bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99 -m32" CXXFLAGS="-std=gnu++99 -m32" CPPFLAGS="-m32"
+  - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn-ARM-32bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17 -m32" CXXFLAGS="-std=gnu++17 -m32" CPPFLAGS="-m32" CC=clang-8 CXX=clang++-8
+  - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn-ARM-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99"
+  - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn-ARM-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang-8 CXX=clang++-8
+
 ### FreeBSD
 #OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-freebsd-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=gcc CXX=g++
 #OK#  - env: NUT_MATRIX_TAG="gnu99-clang-freebsd-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++

--- a/.travis.yml
+++ b/.travis.yml
@@ -355,8 +355,6 @@ _matrix_linux_gnustd_nowarn_arm_64bit:
       apt:
         packages:
         - *deps_driverlibs
-        - gcc-multilib
-        - g++-multilib
 
   - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn-ARM-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang-8 CXX=clang++-8
     os: linux
@@ -374,8 +372,6 @@ _matrix_linux_gnustd_nowarn_arm_64bit:
         - clang-8
         - clang-format-8
         - *deps_driverlibs
-        - gcc-multilib
-        - g++-multilib
 
 # At this time, anything with strict C standard fails on Linux, even "nowarn" cases:
 _matrix_linux_cstd_nowarn:

--- a/.travis.yml
+++ b/.travis.yml
@@ -240,7 +240,7 @@ _matrix_required_linux_pass3_large:
 
 _matrix_linux_gnustd_nowarn:
   include: &_matrix_linux_gnustd_nowarn
-  - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99"
+  - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++98"
     os: linux
     sudo: false
     services:
@@ -344,7 +344,7 @@ _matrix_linux_gnustd_nowarn:
 # Try ARM builds to check for issues with non-x86 CPUs
 _matrix_linux_gnustd_nowarn_arm_64bit_viable:
   include: &_matrix_linux_gnustd_nowarn_arm_64bit_viable
-  - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn-ARM-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99"
+  - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn-ARM-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++98"
     os: linux
     arch: arm64
     sudo: false
@@ -477,7 +477,7 @@ _matrix_linux_gnustd_warn_viable:
         packages:
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="gnu99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++99"
+  - env: NUT_MATRIX_TAG="gnu99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++98"
     os: linux
     sudo: false
     services:
@@ -552,7 +552,7 @@ _matrix_linux_gnustd_warn_fatal:
 # The hardest of two worlds: both strict C standards on Linux and fatal warnings:
 _matrix_linux_cstd_warn:
   include: &_matrix_linux_cstd_warn
-  - env: NUT_MATRIX_TAG="c99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -std=c++99"
+  - env: NUT_MATRIX_TAG="c99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -std=c++98"
     os: linux
     sudo: false
     services:
@@ -641,7 +641,7 @@ _matrix_linux_cstd_warn:
 
 _matrix_freebsd_gnustd_nowarn:
   include: &_matrix_freebsd_gnustd_nowarn
-  - env: NUT_MATRIX_TAG="gnu99-gcc-freebsd-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=gcc CXX=g++
+  - env: NUT_MATRIX_TAG="gnu99-gcc-freebsd-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++98" CC=gcc CXX=g++
     os: freebsd
     sudo: true
     compiler: gcc
@@ -675,7 +675,7 @@ _matrix_freebsd_gnustd_nowarn:
 
 _matrix_freebsd_gnustd_warn_viable:
   include: &_matrix_freebsd_gnustd_warn_viable
-  - env: NUT_MATRIX_TAG="gnu99-gcc-default-freebsd-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++99" CC=gcc CXX=g++
+  - env: NUT_MATRIX_TAG="gnu99-gcc-default-freebsd-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++98" CC=gcc CXX=g++
     os: freebsd
     sudo: true
     compiler: gcc
@@ -1060,7 +1060,7 @@ jobs:
 ###################################################################################
 # Note: "env" lines below must exactly describe a matrix option defined above
   allow_failures:
-#OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99"
+#OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++98"
 #OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++98" CC=gcc-7 CXX=g++-7
 #OK#  - env: NUT_MATRIX_TAG="gnu11-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu11" CXXFLAGS="-std=gnu++11" CC=gcc-7 CXX=g++-7
 #OK#  - env: NUT_MATRIX_TAG="gnu17-gcc-9-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc-9 CXX=g++-9
@@ -1073,8 +1073,8 @@ jobs:
   - env: NUT_MATRIX_TAG="c17-clang-8-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c17" CXXFLAGS="-std=c++17" CC=clang-8 CXX=clang++-8
   - env: NUT_MATRIX_TAG="c17-clang-8-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=c++17" CC=clang-8 CXX=clang++-8
 #OK#  - env: NUT_MATRIX_TAG="cDefault-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic" CXXFLAGS="-Wall -Wextra -Werror"
-#OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++99"
-  - env: NUT_MATRIX_TAG="c99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -std=c++99"
+#OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++98"
+  - env: NUT_MATRIX_TAG="c99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -std=c++98"
 #OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-7-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++98" CC=gcc-7 CXX=g++-7
   - env: NUT_MATRIX_TAG="c99-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=c++99" CC=clang-5.0 CXX=clang++-5.0
   - env: NUT_MATRIX_TAG="c11-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=c++11" CC=clang-5.0 CXX=clang++-5.0
@@ -1085,16 +1085,16 @@ jobs:
   - env: NUT_MATRIX_TAG="gnu89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu89" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++89"
 
 ### Linux on ARM
-#OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn-ARM-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99"
+#OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn-ARM-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++98"
 #OK#  - env: NUT_MATRIX_TAG="gnu17-gcc-9-nowarn-ARM-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc-9 CXX=g++-9
   - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn-ARM-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang-8 CXX=clang++-8
 
 ### FreeBSD
-#OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-freebsd-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=gcc CXX=g++
+#OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-freebsd-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++98" CC=gcc CXX=g++
 #OK#  - env: NUT_MATRIX_TAG="gnu99-clang-freebsd-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
 #OK#  - env: NUT_MATRIX_TAG="gnu17-gcc-freebsd-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++17" CC=gcc CXX=g++
 #OK#  - env: NUT_MATRIX_TAG="gnu17-clang-freebsd-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++17" CC=clang CXX=clang++
-#OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-default-freebsd-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++99" CC=gcc CXX=g++
+#OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-default-freebsd-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++98" CC=gcc CXX=g++
 #OK#  - env: NUT_MATRIX_TAG="gnu17-gcc-default-freebsd-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++17" CC=gcc CXX=g++
   - env: NUT_MATRIX_TAG="gnu99-clang-freebsd-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=gnu++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="gnu17-clang-freebsd-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=gnu++17" CC=clang CXX=clang++

--- a/.travis.yml
+++ b/.travis.yml
@@ -1085,8 +1085,8 @@ jobs:
   - env: NUT_MATRIX_TAG="gnu89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu89" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++89"
 
 ### Linux on ARM
-  - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn-ARM-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99"
-  - env: NUT_MATRIX_TAG="gnu17-gcc-9-nowarn-ARM-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc-9 CXX=g++-9
+#OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn-ARM-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99"
+#OK#  - env: NUT_MATRIX_TAG="gnu17-gcc-9-nowarn-ARM-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc-9 CXX=g++-9
   - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn-ARM-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang-8 CXX=clang++-8
 
 ### FreeBSD

--- a/.travis.yml
+++ b/.travis.yml
@@ -356,6 +356,22 @@ _matrix_linux_gnustd_nowarn_arm_64bit:
         packages:
         - *deps_driverlibs
 
+  - env: NUT_MATRIX_TAG="gnu17-gcc-9-nowarn-ARM-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc-9 CXX=g++-9
+    os: linux
+    arch: arm64
+    sudo: false
+    services:
+        - docker
+    compiler: gcc
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - g++-9
+        - gcc-9
+        - *deps_driverlibs
+
   - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn-ARM-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang-8 CXX=clang++-8
     os: linux
     arch: arm64
@@ -1061,6 +1077,7 @@ jobs:
 
 ### Linux on ARM
   - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn-ARM-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99"
+  - env: NUT_MATRIX_TAG="gnu17-gcc-9-nowarn-ARM-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc-9 CXX=g++-9
   - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn-ARM-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang-8 CXX=clang++-8
 
 ### FreeBSD

--- a/.travis.yml
+++ b/.travis.yml
@@ -1060,6 +1060,8 @@ jobs:
 ###################################################################################
 # Note: "env" lines below must exactly describe a matrix option defined above
   allow_failures:
+
+### Linux on x86_64
 #OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++98"
 #OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++98" CC=gcc-7 CXX=g++-7
 #OK#  - env: NUT_MATRIX_TAG="gnu11-gcc-7-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu11" CXXFLAGS="-std=gnu++11" CC=gcc-7 CXX=g++-7
@@ -1089,7 +1091,7 @@ jobs:
 #OK#  - env: NUT_MATRIX_TAG="gnu17-gcc-9-nowarn-ARM-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc-9 CXX=g++-9
   - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn-ARM-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang-8 CXX=clang++-8
 
-### FreeBSD
+### FreeBSD on x86_64
 #OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-freebsd-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++98" CC=gcc CXX=g++
 #OK#  - env: NUT_MATRIX_TAG="gnu99-clang-freebsd-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
 #OK#  - env: NUT_MATRIX_TAG="gnu17-gcc-freebsd-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++17" CC=gcc CXX=g++
@@ -1098,6 +1100,7 @@ jobs:
 #OK#  - env: NUT_MATRIX_TAG="gnu17-gcc-default-freebsd-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++17" CC=gcc CXX=g++
   - env: NUT_MATRIX_TAG="gnu99-clang-freebsd-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=gnu++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="gnu17-clang-freebsd-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=gnu++17" CC=clang CXX=clang++
+
 ### macosx
 #OK#  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
 #OK#  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang CXX=clang++
@@ -1109,7 +1112,8 @@ jobs:
   - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c17" CXXFLAGS="-std=c++17" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=c++17" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c11-clang-xcode7.3-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=c++11" CC=clang CXX=clang++
-### windows
+
+### windows on x86_64
   - env: NUT_MATRIX_TAG="gnu99-clang-win-nowarn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="gnu99-clang-win-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=c++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c99-clang-win-nowarn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++

--- a/.travis.yml
+++ b/.travis.yml
@@ -342,41 +342,6 @@ _matrix_linux_gnustd_nowarn:
         - *deps_driverlibs
 
 # Try ARM builds to check for issues with non-x86 CPUs
-_matrix_linux_gnustd_nowarn_arm_32bit:
-  include: &_matrix_linux_gnustd_nowarn_arm_32bit
-  - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn-ARM-32bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99 -m32" CXXFLAGS="-std=gnu++99 -m32" CPPFLAGS="-m32"
-    os: linux
-    arch: arm32
-    sudo: false
-    services:
-        - docker
-    compiler: gcc
-    addons:
-      apt:
-        packages:
-        - *deps_driverlibs
-        - gcc-multilib
-        - g++-multilib
-
-  - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn-ARM-32bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17 -m32" CXXFLAGS="-std=gnu++17 -m32" CPPFLAGS="-m32" CC=clang-8 CXX=clang++-8
-    os: linux
-    arch: arm32
-    dist: xenial
-    sudo: false
-    services:
-        - docker
-    compiler: clang
-    addons:
-      apt:
-        sources:
-        - llvm-toolchain-xenial-8
-        packages:
-        - clang-8
-        - clang-format-8
-        - *deps_driverlibs
-        - gcc-multilib
-        - g++-multilib
-
 _matrix_linux_gnustd_nowarn_arm_64bit:
   include: &_matrix_linux_gnustd_nowarn_arm_64bit
   - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn-ARM-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99"
@@ -926,7 +891,6 @@ _matrix_required_linux:
   - *_matrix_required_linux_pass3_large
   - *_matrix_linux_gnustd_nowarn
   - *_matrix_linux_gnustd_warn_viable
-  - *_matrix_linux_gnustd_nowarn_arm_32bit
   - *_matrix_linux_gnustd_nowarn_arm_64bit
 
 _matrix_linux_gnustd_warn:
@@ -942,7 +906,6 @@ _matrix_allowfail_linux:
 
 _matrix_linux_arm:
   include: &_matrix_linux_arm
-  - *_matrix_linux_gnustd_nowarn_arm_32bit
   - *_matrix_linux_gnustd_nowarn_arm_64bit
 
 _matrix_linux:
@@ -1013,7 +976,6 @@ _matrix_gnustd_nowarn:
   - *_matrix_linux_gnustd_nowarn
   - *_matrix_freebsd_gnustd_nowarn
 #  -*_matrix_windows_gnustd_nowarn
-  - *_matrix_linux_gnustd_nowarn_arm_32bit
   - *_matrix_linux_gnustd_nowarn_arm_64bit
 
 _matrix_warn:
@@ -1102,8 +1064,6 @@ jobs:
   - env: NUT_MATRIX_TAG="gnu89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu89" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++89"
 
 ### Linux on ARM
-  - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn-ARM-32bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99 -m32" CXXFLAGS="-std=gnu++99 -m32" CPPFLAGS="-m32"
-  - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn-ARM-32bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17 -m32" CXXFLAGS="-std=gnu++17 -m32" CPPFLAGS="-m32" CC=clang-8 CXX=clang++-8
   - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn-ARM-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99"
   - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn-ARM-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang-8 CXX=clang++-8
 

--- a/common/common.c
+++ b/common/common.c
@@ -41,6 +41,10 @@ const char *UPS_VERSION = NUT_VERSION_MACRO;
 #include "nut_stdint.h"
 #if UINTPTR_MAX == 0xffffffffffffffffULL
 # define BUILD_64   1
+#else
+# ifdef BUILD_64
+#  undef BUILD_64
+# endif
 #endif
 
 	int	nut_debug_level = 0;
@@ -720,18 +724,18 @@ static const char * search_paths[] = {
 	LIBDIR,
 	"/usr"LIBDIR,
 	"/usr/local"LIBDIR,
-#if BUILD_64
+#ifdef BUILD_64
 	// Fall back to explicit preference of 64-bit paths as named on some OSes
 	"/usr/lib/64",
 	"/usr/lib64",
 #endif
 	"/usr/lib",
-#if BUILD_64
+#ifdef BUILD_64
 	"/lib/64",
 	"/lib64",
 #endif
 	"/lib",
-#if BUILD_64
+#ifdef BUILD_64
 	"/usr/local/lib/64",
 	"/usr/local/lib64",
 #endif

--- a/drivers/gamatronic.c
+++ b/drivers/gamatronic.c
@@ -2,7 +2,7 @@
  *
  * SEC UPS Driver ported to the new NUT API for Gamatronic UPS Usage.
  *
- * Copyright (C) 
+ * Copyright (C)
  *   2001 John Marley <John.Marley@alcatel.com.au>
  *   2002 Jules Taplin <jules@netsitepro.co.uk>
  *   2002 Eric Lawson <elawson@inficad.com>
@@ -24,9 +24,9 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  *
  */
- 
+
 #include "main.h"
-#include "serial.h" 
+#include "serial.h"
 #include "gamatronic.h"
 
 #define DRIVER_NAME	"Gamatronic UPS driver"
@@ -45,9 +45,9 @@ upsdrv_info_t upsdrv_info = {
 	{ NULL }
 };
 
-#define ENDCHAR	'\r'	
-#define IGNCHARS ""
-#define SER_WAIT_SEC    1	/* allow 3.0 sec for ser_get calls */
+#define ENDCHAR	'\r'
+#define IGNCHARS	""
+#define SER_WAIT_SEC	1	/* allow 3.0 sec for ser_get calls */
 #define SER_WAIT_USEC	0
 
 int sec_upsrecv (char *buf)
@@ -55,7 +55,7 @@ int sec_upsrecv (char *buf)
 
  char lenbuf[4];
  int  ret;
-	
+
 
         ser_get_line(upsfd, buf, 140, ENDCHAR, IGNCHARS,SER_WAIT_SEC, SER_WAIT_USEC);
 	if (buf[0] ==  SEC_MSG_STARTCHAR){
@@ -75,8 +75,8 @@ int sec_upsrecv (char *buf)
 		default:
 		return(-2);
 		}
-	}	
-	else 
+	}
+	else
          { return (-2); }
 }
 
@@ -95,10 +95,10 @@ int sec_cmd(const char mode, const char *command, char *msgbuf, int *buflen)
     else {
 	snprintf(msg, sizeof(msg), "%c%c003%s", SEC_MSG_STARTCHAR,
 		mode, command);
-    }	
+    }
     upsdebugx(1, "PC-->UPS: \"%s\"",msg);
     ret = ser_send(upsfd, "%s", msg);
-    
+
     upsdebugx(1, " send returned: %d",ret);
 
     if (ret == -1) return -1;
@@ -137,39 +137,39 @@ void addquery(const char *cmd, int field, int varnum, int pollflag)
 }
 
 void sec_setinfo(int varnum, char *value)
-{	
+{
 
 	if (*sec_varlist[varnum].setcmd){/*Not empty*/
-		
+
 		if (sec_varlist[varnum].flags == FLAG_STRING) {
 			dstate_setinfo(sec_varlist[varnum].setcmd,"%s", value);
 	 	}
 		else if (sec_varlist[varnum].unit == 1) {
 			dstate_setinfo(sec_varlist[varnum].setcmd,"%s", value);
 		}
-		
+
 		else if (sec_varlist[varnum].flags == FLAG_MULTI) {
-			if (atoi(value) < 0) { 
+			if (atoi(value) < 0) {
 			dstate_setinfo(sec_varlist[varnum].setcmd,"0");
 			}
 			else
 			{dstate_setinfo(sec_varlist[varnum].setcmd,"%d", atoi(value) * sec_varlist[varnum].unit);
 			}
 			}
-		else { 
+		else {
 			dstate_setinfo(sec_varlist[varnum].setcmd,"%.1f", atof(value) / sec_varlist[varnum].unit);}
-			
+
 		}
-		
+
 }
-	
-	
-	
+
+
+
 void update_pseudovars( void )
 {
-	
+
 	status_init();
-	
+
 	if(strcmp(sec_varlist[9].value,"1")== 0) {
 	status_set("OFF");
 	}
@@ -194,22 +194,22 @@ void update_pseudovars( void )
 	if(strcmp(sec_varlist[22].value,"1")== 0) {
 	status_set("LB");
 	}
-	
+
 	if(strcmp(sec_varlist[19].value,"2")== 0) {
 	status_set("RB");
 	}
-	
+
 	status_commit();
 
 
 }
 
 void sec_poll ( int pollflag ) {
-	
+
 	int msglen,f,q;
 	char retbuf[140],*n,*r;
-  
-	 
+
+
   for (q=0; q<SEC_QUERYLIST_LEN; q++) {
 	if (sec_querylist[q].command == NULL) break;
         if (sec_querylist[q].pollflag != pollflag) continue;
@@ -221,23 +221,23 @@ void sec_poll ( int pollflag ) {
 	    n = strchr(r, ',');
 	   if (n != NULL) *n = '\0';
            if (sqv(q,f) > 0) {
-	     
+
 	   if (strcmp(sec_varlist[sqv(q,f)].value, r) != 0  ) {
 
-		    snprintf(sec_varlist[sqv(q,f)].value, 
+		    snprintf(sec_varlist[sqv(q,f)].value,
 			sizeof(sec_varlist[sqv(q,f)].value), "%s", r);
-                  
+
 		    sec_setinfo(sqv(q,f), r);
 		}
-		
+
 	/* If SEC VAR is alarm and its on, add it to the alarm property */
-	
+
 	if (sec_varlist[sqv(q,f)].flags & FLAG_ALARM && strcmp(r,"1")== 0) {
            alarm_set(sec_varlist[sqv(q,f)].name);  }
-           
+
 	  }
-	   
-	    
+
+
 	   if (n == NULL) break;
 	   r = n+1;
 	}
@@ -249,7 +249,7 @@ void upsdrv_initinfo(void)
 {
     int msglen, v;
     char *a,*p,avail_list[300];
- 
+
     /* find out which variables/commands this UPS supports */
     msglen = 0;
     sec_cmd(SEC_POLLCMD, SEC_AVAILP1, avail_list, &msglen);
@@ -258,39 +258,39 @@ void upsdrv_initinfo(void)
     msglen = 0;
     sec_cmd(SEC_POLLCMD, SEC_AVAILP2, p, &msglen);
     *(p+msglen) = '\0';
- 
-    
+
+
     if (strlen(avail_list) == 0){
      fatalx(EXIT_FAILURE, "No available variables found!");}
     a = avail_list;
-   while ((p = strtok(a, ",")) != NULL) {  
+   while ((p = strtok(a, ",")) != NULL) {
     a = NULL;
     v = atoi(p);
     /* don't bother adding a write-only variable */
    if (sec_varlist[v].flags == FLAG_WONLY) continue;
     addquery(sec_varlist[v].cmd, sec_varlist[v].field, v, sec_varlist[v].poll);
-    }  
-    
+    }
+
     /* poll one time values */
-    
+
    sec_poll(FLAG_POLLONCE);
-   
+
    printf("UPS: %s %s\n", dstate_getinfo("ups.mfr"), dstate_getinfo("ups.model"));
-    
-    
+
+
 }
 
 void upsdrv_updateinfo(void)
 {
-   
-	
+
+
 	alarm_init();
 	/* poll status values values */
 	sec_poll(FLAG_POLL);
 	alarm_commit();
 	update_pseudovars();
 	dstate_dataok();
-	
+
 }
 
 void upsdrv_shutdown(void)
@@ -342,13 +342,13 @@ void setup_serial(const char *port)
 {
     char temp[140];
     int i,ret;
- 
+
 
    /* Detect the ups baudrate  */
-    
-    
+
+
    for (i=0; i<5; i++) {
-	
+
         ser_set_speed(upsfd, device_path,baud_rates[i].rate);
         ret = ser_send(upsfd, "^P003MAN");
 	ret = sec_upsrecv(temp);
@@ -372,7 +372,7 @@ void upsdrv_initups(void)
           setup_serial(device_path);
 	/* upsfd = ser_open(device_path); */
 	/* ser_set_speed(upsfd, device_path, B1200); */
-   
+
 	/* probe ups type */
 
 	/* to get variables and flags from the command line, use this:
@@ -407,5 +407,5 @@ void upsdrv_initups(void)
 void upsdrv_cleanup(void)
 {
 	/* free(dynamic_mem); */
-	 ser_close(upsfd, device_path); 
+	 ser_close(upsfd, device_path);
 }

--- a/drivers/gamatronic.c
+++ b/drivers/gamatronic.c
@@ -140,77 +140,67 @@ void addquery(const char *cmd, int field, int varnum, int pollflag)
 
 void sec_setinfo(int varnum, char *value)
 {
-
-	if (*sec_varlist[varnum].setcmd){/*Not empty*/
-
+	if (*sec_varlist[varnum].setcmd)
+	{ /*Not empty*/
 		if (sec_varlist[varnum].flags == FLAG_STRING) {
 			dstate_setinfo(sec_varlist[varnum].setcmd,"%s", value);
 	 	}
 		else if (sec_varlist[varnum].unit == 1) {
 			dstate_setinfo(sec_varlist[varnum].setcmd,"%s", value);
 		}
-
 		else if (sec_varlist[varnum].flags == FLAG_MULTI) {
 			if (atoi(value) < 0) {
-			dstate_setinfo(sec_varlist[varnum].setcmd,"0");
+				dstate_setinfo(sec_varlist[varnum].setcmd,"0");
 			}
-			else
-			{dstate_setinfo(sec_varlist[varnum].setcmd,"%d", atoi(value) * sec_varlist[varnum].unit);
+			else {
+				dstate_setinfo(sec_varlist[varnum].setcmd,"%d", atoi(value) * sec_varlist[varnum].unit);
 			}
-			}
-		else {
-			dstate_setinfo(sec_varlist[varnum].setcmd,"%.1f", atof(value) / sec_varlist[varnum].unit);}
-
 		}
-
+		else {
+			dstate_setinfo(sec_varlist[varnum].setcmd,"%.1f", atof(value) / sec_varlist[varnum].unit);
+		}
+	}
 }
-
-
 
 void update_pseudovars( void )
 {
-
 	status_init();
 
 	if(strcmp(sec_varlist[9].value,"1")== 0) {
-	status_set("OFF");
+		status_set("OFF");
 	}
 	if(strcmp(sec_varlist[76].value,"0")== 0) {
-	status_set("OL");
+		status_set("OL");
 	}
 	if(strcmp(sec_varlist[76].value,"1")== 0) {
-	status_set("OB");
+		status_set("OB");
 	}
 	if(strcmp(sec_varlist[76].value,"2")== 0) {
-	status_set("BYPASS");
+		status_set("BYPASS");
 	}
 	if(strcmp(sec_varlist[76].value,"3")== 0) {
-	status_set("TRIM");
+		status_set("TRIM");
 	}
 	if(strcmp(sec_varlist[76].value,"4")== 0) {
-	status_set("BOOST");
+		status_set("BOOST");
 	}
 	if(strcmp(sec_varlist[10].value,"1")== 0) {
-	status_set("OVER");
+		status_set("OVER");
 	}
 	if(strcmp(sec_varlist[22].value,"1")== 0) {
-	status_set("LB");
+		status_set("LB");
 	}
-
 	if(strcmp(sec_varlist[19].value,"2")== 0) {
-	status_set("RB");
+		status_set("RB");
 	}
 
 	status_commit();
-
-
 }
 
 void sec_poll ( int pollflag ) {
 
 	int msglen,f,q;
 	char retbuf[140],*n,*r;
-
 
 	for (q=0; q<SEC_QUERYLIST_LEN; q++) {
 		if (sec_querylist[q].command == NULL) break;
@@ -223,24 +213,19 @@ void sec_poll ( int pollflag ) {
 		for (f=0; f<SEC_MAXFIELDS; f++) {
 			n = strchr(r, ',');
 			if (n != NULL) *n = '\0';
+
 			if (sqv(q,f) > 0) {
-
 				if (strcmp(sec_varlist[sqv(q,f)].value, r) != 0) {
-
 					snprintf(sec_varlist[sqv(q,f)].value,
-					sizeof(sec_varlist[sqv(q,f)].value), "%s", r);
-
+						sizeof(sec_varlist[sqv(q,f)].value), "%s", r);
 					sec_setinfo(sqv(q,f), r);
 				}
 
-				/* If SEC VAR is alarm and its on, add it to the alarm property */
-
+				/* If SEC VAR is alarm and it's on, add it to the alarm property */
 				if (sec_varlist[sqv(q,f)].flags & FLAG_ALARM && strcmp(r,"1")== 0) {
 					alarm_set(sec_varlist[sqv(q,f)].name);
 				}
-
 			}
-
 
 			if (n == NULL) break;
 			r = n+1;
@@ -284,15 +269,12 @@ void upsdrv_initinfo(void)
 
 void upsdrv_updateinfo(void)
 {
-
-
 	alarm_init();
 	/* poll status values values */
 	sec_poll(FLAG_POLL);
 	alarm_commit();
 	update_pseudovars();
 	dstate_dataok();
-
 }
 
 void upsdrv_shutdown(void)

--- a/include/timehead.h
+++ b/include/timehead.h
@@ -22,11 +22,11 @@
 #ifndef NUT_TIMEHEAD_H_SEEN
 #define NUT_TIMEHEAD_H_SEEN 1
 
-#if TIME_WITH_SYS_TIME
+#ifdef TIME_WITH_SYS_TIME
 # include <sys/time.h>
 # include <time.h>
 #else
-# if HAVE_SYS_TIME_H
+# ifdef HAVE_SYS_TIME_H
 #  include <sys/time.h>
 # else
 #  include <time.h>

--- a/m4/nut_report_feature.m4
+++ b/m4/nut_report_feature.m4
@@ -30,4 +30,13 @@ AC_DEFUN([NUT_REPORT_FEATURE],
 AC_DEFUN([NUT_PRINT_FEATURE_REPORT],
 [
    cat conf_nut_report_feature
+
+   echo "------------------"
+   echo "Compiler settings:"
+    printf 'CC      \t:%s\n' "$CC"
+    printf 'CFLAGS  \t:%s\n' "$CFLAGS"
+    printf 'CXX     \t:%s\n' "$CXX"
+    printf 'CXXFLAGS\t:%s\n' "$CXXFLAGS"
+    printf 'CPP     \t:%s\n' "$CPP"
+    printf 'CPPFLAGS\t:%s\n' "$CPPFLAGS"
 ])


### PR DESCRIPTION
Follows up from #823 and #844 efforts, to add a platform with different CPU type for comparison. A next step here might be `s390x` if it introduces a different (big) endianness also... Still, with routers and Raspberries and so on, an ARM system is quite likely to run NUT so is a practically interesting benchmark.

Early tests have already exposed issue #900 by the way.