### PR TITLE
fightwarn - nutclient.{h,cpp} : fix an horde of warnings

### DIFF
--- a/clients/Makefile.am
+++ b/clients/Makefile.am
@@ -72,6 +72,9 @@ if HAVE_CXX11
 # libnutclient version information and build
 libnutclient_la_SOURCES = nutclient.h nutclient.cpp
 libnutclient_la_LDFLAGS = -version-info 1:0:0
+# Needed in not-standalone builds with -DHAVE_NUTCOMMON=1
+# which is defined for in-tree CXX builds above:
+libnutclient_la_LIBADD = $(top_builddir)/common/libcommonclient.la
 else
 EXTRA_DIST += nutclient.h nutclient.cpp
 endif

--- a/clients/Makefile.am
+++ b/clients/Makefile.am
@@ -1,6 +1,11 @@
 # Network UPS Tools: clients
 EXTRA_DIST =
 
+# nutclient.cpp for some legacy reason (maybe initial detached development?)
+# optionally includes "common.h" with the NUT build setup - and this option
+# was never triggered in fact, not until pushed through command line like this:
+AM_CXXFLAGS = -DHAVE_NUTCOMMON=1
+
 # by default, link programs in this directory with libcommon.a
 LDADD = ../common/libcommon.la libupsclient.la $(NETLIBS)
 if WITH_SSL

--- a/clients/Makefile.am
+++ b/clients/Makefile.am
@@ -4,7 +4,7 @@ EXTRA_DIST =
 # nutclient.cpp for some legacy reason (maybe initial detached development?)
 # optionally includes "common.h" with the NUT build setup - and this option
 # was never triggered in fact, not until pushed through command line like this:
-AM_CXXFLAGS = -DHAVE_NUTCOMMON=1
+AM_CXXFLAGS = -DHAVE_NUTCOMMON=1 -I$(top_srcdir)/include
 
 # by default, link programs in this directory with libcommon.a
 LDADD = ../common/libcommon.la libupsclient.la $(NETLIBS)

--- a/clients/nutclient.cpp
+++ b/clients/nutclient.cpp
@@ -60,6 +60,23 @@ static inline void *xrealloc(void *ptr, size_t size){return realloc(ptr, size);}
 static inline char *xstrdup(const char *string){return strdup(string);}
 #endif /* HAVE_NUTCOMMON */
 
+/* To stay in line with modern C++, we use nullptr (not numeric NULL
+ * or shim __null on some systems) which was defined after C++98.
+ * The NUT C++ interface is intended for C++11 and newer, so we
+ * quiesce these warnigns if possible.
+ * An idea might be to detect if we do build with old C++ standard versions
+ * and define a nullptr like https://stackoverflow.com/a/44517878/4715872
+ * but again - currently we do not intend to support that officially.
+ */
+#ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_CXX98_COMPAT
+#pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_CXX98_COMPAT_PEDANTIC
+#pragma GCC diagnostic ignored "-Wc++98-compat-pedantic"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_CXX98_COMPAT
+#pragma GCC diagnostic ignored "-Wc++98-compat"
+#endif
 
 namespace nut
 {
@@ -175,7 +192,7 @@ void Socket::connect(const std::string& host, int port)
 		}
 	}
 
-	for (ai = res; ai != NULL; ai = ai->ai_next) {
+	for (ai = res; ai != nullptr; ai = ai->ai_next) {
 
 		sock_fd = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
 
@@ -202,11 +219,11 @@ void Socket::connect(const std::string& host, int port)
 			if(errno == EINPROGRESS) {
 				FD_ZERO(&wfds);
 				FD_SET(sock_fd, &wfds);
-				select(sock_fd+1,NULL,&wfds,NULL, hasTimeout()?&_tv:NULL);
+				select(sock_fd+1, nullptr, &wfds, nullptr, hasTimeout() ? &_tv : nullptr);
 				if (FD_ISSET(sock_fd, &wfds)) {
 					error_size = sizeof(error);
-					getsockopt(sock_fd,SOL_SOCKET,SO_ERROR,
-							&error,&error_size);
+					getsockopt(sock_fd, SOL_SOCKET, SO_ERROR,
+							&error, &error_size);
 					if( error == 0) {
 						/* connect successful */
 						v = 0;
@@ -262,10 +279,10 @@ void Socket::connect(const std::string& host, int port)
 
 
 #ifdef OLD
-	struct hostent *hostinfo = NULL;
+	struct hostent *hostinfo = nullptr;
 	SOCKADDR_IN sin = { 0 };
 	hostinfo = ::gethostbyname(host.c_str());
-	if(hostinfo == NULL) /* Host doesnt exist */
+	if(hostinfo == nullptr) /* Host doesnt exist */
 	{
 		throw nut::UnknownHostException();
 	}
@@ -316,7 +333,7 @@ size_t Socket::read(void* buf, size_t sz)
 		fd_set fds;
 		FD_ZERO(&fds);
 		FD_SET(_sock, &fds);
-		int ret = select(_sock+1, &fds, NULL, NULL, &_tv);
+		int ret = select(_sock+1, &fds, nullptr, nullptr, &_tv);
 		if (ret < 1) {
 			throw nut::TimeoutException();
 		}
@@ -343,7 +360,7 @@ size_t Socket::write(const void* buf, size_t sz)
 		fd_set fds;
 		FD_ZERO(&fds);
 		FD_SET(_sock, &fds);
-		int ret = select(_sock+1, NULL, &fds, NULL, &_tv);
+		int ret = select(_sock+1, nullptr, &fds, nullptr, &_tv);
 		if (ret < 1) {
 			throw nut::TimeoutException();
 		}
@@ -427,7 +444,7 @@ Device Client::getDevice(const std::string& name)
 	if(hasDevice(name))
 		return Device(this, name);
 	else
-		return Device(NULL, "");
+		return Device(nullptr, "");
 }
 
 std::set<Device> Client::getDevices()
@@ -587,7 +604,7 @@ Device TcpClient::getDevice(const std::string& name)
 	catch(NutException& ex)
 	{
 		if(ex.str()=="UNKNOWN-UPS")
-			return Device(NULL, "");
+			return Device(nullptr, "");
 		else
 			throw;
 	}
@@ -1116,7 +1133,7 @@ Client* Device::getClient()
 
 bool Device::isOk()const
 {
-	return _client!=NULL && !_name.empty();
+	return _client!=nullptr && !_name.empty();
 }
 
 Device::operator bool()const
@@ -1189,7 +1206,7 @@ Variable Device::getVariable(const std::string& name)
 	if(getClient()->hasDeviceVariable(getName(), name))
 		return Variable(this, name);
 	else
-		return Variable(NULL, "");
+		return Variable(nullptr, "");
 }
 
 std::set<Variable> Device::getVariables()
@@ -1245,7 +1262,7 @@ Command Device::getCommand(const std::string& name)
 	if(getClient()->hasDeviceCommand(getName(), name))
 		return Command(this, name);
 	else
-		return Command(NULL, "");
+		return Command(nullptr, "");
 }
 
 TrackingID Device::executeCommand(const std::string& name, const std::string& param)
@@ -1326,7 +1343,7 @@ Device* Variable::getDevice()
 
 bool Variable::isOk()const
 {
-	return _device!=NULL && !_name.empty();
+	return _device!=nullptr && !_name.empty();
 
 }
 
@@ -1421,7 +1438,7 @@ Device* Command::getDevice()
 
 bool Command::isOk()const
 {
-	return _device!=NULL && !_name.empty();
+	return _device!=nullptr && !_name.empty();
 }
 
 Command::operator bool()const
@@ -1466,14 +1483,14 @@ extern "C" {
 strarr strarr_alloc(unsigned short count)
 {
 	strarr arr = (strarr)xcalloc(count+1, sizeof(char*));
-	arr[count] = NULL;
+	arr[count] = nullptr;
 	return arr;
 }
 
 void strarr_free(strarr arr)
 {
 	char** pstr = arr;
-	while(*pstr!=NULL)
+	while(*pstr!=nullptr)
 	{
 		free(*pstr);
 		++pstr;
@@ -1517,7 +1534,7 @@ NUTCLIENT_TCP_t nutclient_tcp_create_client(const char* host, unsigned short por
 	{
 		// TODO really catch it
 		delete client;
-		return NULL;
+		return nullptr;
 	}
 
 }
@@ -1709,7 +1726,7 @@ strarr nutclient_get_devices(NUTCLIENT_t client)
 			catch(...){}
 		}
 	}
-	return NULL;
+	return nullptr;
 }
 
 int nutclient_has_device(NUTCLIENT_t client, const char* dev)
@@ -1743,7 +1760,7 @@ char* nutclient_get_device_description(NUTCLIENT_t client, const char* dev)
 			catch(...){}
 		}
 	}
-	return NULL;
+	return nullptr;
 }
 
 strarr nutclient_get_device_variables(NUTCLIENT_t client, const char* dev)
@@ -1760,7 +1777,7 @@ strarr nutclient_get_device_variables(NUTCLIENT_t client, const char* dev)
 			catch(...){}
 		}
 	}
-	return NULL;
+	return nullptr;
 }
 
 strarr nutclient_get_device_rw_variables(NUTCLIENT_t client, const char* dev)
@@ -1777,7 +1794,7 @@ strarr nutclient_get_device_rw_variables(NUTCLIENT_t client, const char* dev)
 			catch(...){}
 		}
 	}
-	return NULL;
+	return nullptr;
 }
 
 int nutclient_has_device_variable(NUTCLIENT_t client, const char* dev, const char* var)
@@ -1811,7 +1828,7 @@ char* nutclient_get_device_variable_description(NUTCLIENT_t client, const char* 
 			catch(...){}
 		}
 	}
-	return NULL;
+	return nullptr;
 }
 
 strarr nutclient_get_device_variable_values(NUTCLIENT_t client, const char* dev, const char* var)
@@ -1828,7 +1845,7 @@ strarr nutclient_get_device_variable_values(NUTCLIENT_t client, const char* dev,
 			catch(...){}
 		}
 	}
-	return NULL;
+	return nullptr;
 }
 
 void nutclient_set_device_variable_value(NUTCLIENT_t client, const char* dev, const char* var, const char* value)
@@ -1885,7 +1902,7 @@ strarr nutclient_get_device_commands(NUTCLIENT_t client, const char* dev)
 			catch(...){}
 		}
 	}
-	return NULL;
+	return nullptr;
 }
 
 int nutclient_has_device_command(NUTCLIENT_t client, const char* dev, const char* cmd)
@@ -1919,7 +1936,7 @@ char* nutclient_get_device_command_description(NUTCLIENT_t client, const char* d
 			catch(...){}
 		}
 	}
-	return NULL;
+	return nullptr;
 }
 
 void nutclient_execute_device_command(NUTCLIENT_t client, const char* dev, const char* cmd, const char* param)
@@ -1937,5 +1954,9 @@ void nutclient_execute_device_command(NUTCLIENT_t client, const char* dev, const
 		}
 	}
 }
+
+#ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_CXX98_COMPAT
+#pragma GCC diagnostic pop
+#endif
 
 } /* extern "C" */

--- a/clients/nutclient.cpp
+++ b/clients/nutclient.cpp
@@ -1549,6 +1549,7 @@ NUTCLIENT_TCP_t nutclient_tcp_create_client(const char* host, unsigned short por
 	catch(nut::NutException& ex)
 	{
 		// TODO really catch it
+		NUT_UNUSED_VARIABLE(ex);
 		delete client;
 		return nullptr;
 	}

--- a/clients/nutclient.cpp
+++ b/clients/nutclient.cpp
@@ -98,6 +98,14 @@ std::string SystemException::err()
 	}
 }
 
+/* Implemented out-of-line to avoid "Weak vtables" warnings and related overheads */
+NutException::~NutException() {}
+SystemException::~SystemException() {}
+IOException::~IOException() {}
+UnknownHostException::~UnknownHostException() {}
+NotConnectedException::~NotConnectedException() {}
+TimeoutException::~TimeoutException() {}
+
 
 namespace internal
 {

--- a/clients/nutclient.cpp
+++ b/clients/nutclient.cpp
@@ -1480,7 +1480,7 @@ void Command::execute(const std::string& param)
 extern "C" {
 
 
-strarr strarr_alloc(unsigned short count)
+strarr strarr_alloc(size_t count)
 {
 	strarr arr = static_cast<strarr>(xcalloc(count+1, sizeof(char*)));
 	arr[count] = nullptr;

--- a/clients/nutclient.cpp
+++ b/clients/nutclient.cpp
@@ -423,7 +423,23 @@ void Socket::write(const std::string& str)
  *
  */
 
+/* Pedantic builds complain about the static variable below...
+ * It is assumed safe to ignore since it is a std::string with
+ * no complex teardown at program exit.
+ */
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_EXIT_TIME_DESTRUCTORS || defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_GLOBAL_CONSTRUCTORS)
+#pragma GCC diagnostic push
+# ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_GLOBAL_CONSTRUCTORS
+#  pragma GCC diagnostic ignored "-Wglobal-constructors"
+# endif
+# ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_EXIT_TIME_DESTRUCTORS
+#  pragma GCC diagnostic ignored "-Wexit-time-destructors"
+# endif
+#endif
 const Feature Client::TRACKING = "TRACKING";
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_EXIT_TIME_DESTRUCTORS || defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_GLOBAL_CONSTRUCTORS)
+#pragma GCC diagnostic pop
+#endif
 
 Client::Client()
 {

--- a/clients/nutclient.cpp
+++ b/clients/nutclient.cpp
@@ -169,7 +169,7 @@ void Socket::connect(const std::string& host, int port)
 		throw nut::UnknownHostException();
 	}
 
-	snprintf(sport, sizeof(sport), "%hu", (unsigned short int)port);
+	snprintf(sport, sizeof(sport), "%hu", static_cast<unsigned short int>(port));
 
 	memset(&hints, 0, sizeof(hints));
 	hints.ai_family = AF_UNSPEC;
@@ -345,7 +345,7 @@ size_t Socket::read(void* buf, size_t sz)
 		disconnect();
 		throw nut::IOException("Error while reading on socket");
 	}
-	return (size_t) res;
+	return static_cast<size_t>(res);
 }
 
 size_t Socket::write(const void* buf, size_t sz)
@@ -372,7 +372,7 @@ size_t Socket::write(const void* buf, size_t sz)
 		disconnect();
 		throw nut::IOException("Error while writing on socket");
 	}
-	return (size_t) res;
+	return static_cast<size_t>(res);
 }
 
 std::string Socket::read()
@@ -1482,7 +1482,7 @@ extern "C" {
 
 strarr strarr_alloc(unsigned short count)
 {
-	strarr arr = (strarr)xcalloc(count+1, sizeof(char*));
+	strarr arr = static_cast<strarr>(xcalloc(count+1, sizeof(char*)));
 	arr[count] = nullptr;
 	return arr;
 }
@@ -1528,7 +1528,7 @@ NUTCLIENT_TCP_t nutclient_tcp_create_client(const char* host, unsigned short por
 	try
 	{
 		client->connect(host, port);
-		return (NUTCLIENT_TCP_t)client;
+		return static_cast<NUTCLIENT_TCP_t>(client);
 	}
 	catch(nut::NutException& ex)
 	{
@@ -1543,7 +1543,7 @@ void nutclient_destroy(NUTCLIENT_t client)
 {
 	if(client)
 	{
-		delete (nut::Client*)client;
+		delete static_cast<nut::Client*>(client);
 	}
 }
 
@@ -1551,7 +1551,7 @@ int nutclient_tcp_is_connected(NUTCLIENT_TCP_t client)
 {
 	if(client)
 	{
-		nut::TcpClient* cl = dynamic_cast<nut::TcpClient*>((nut::Client*)client);
+		nut::TcpClient* cl = dynamic_cast<nut::TcpClient*>(static_cast<nut::Client*>(client));
 		if(cl)
 		{
 			return cl->isConnected() ? 1 : 0;
@@ -1564,7 +1564,7 @@ void nutclient_tcp_disconnect(NUTCLIENT_TCP_t client)
 {
 	if(client)
 	{
-		nut::TcpClient* cl = dynamic_cast<nut::TcpClient*>((nut::Client*)client);
+		nut::TcpClient* cl = dynamic_cast<nut::TcpClient*>(static_cast<nut::Client*>(client));
 		if(cl)
 		{
 			cl->disconnect();
@@ -1576,7 +1576,7 @@ int nutclient_tcp_reconnect(NUTCLIENT_TCP_t client)
 {
 	if(client)
 	{
-		nut::TcpClient* cl = dynamic_cast<nut::TcpClient*>((nut::Client*)client);
+		nut::TcpClient* cl = dynamic_cast<nut::TcpClient*>(static_cast<nut::Client*>(client));
 		if(cl)
 		{
 			try
@@ -1594,7 +1594,7 @@ void nutclient_tcp_set_timeout(NUTCLIENT_TCP_t client, long timeout)
 {
 	if(client)
 	{
-		nut::TcpClient* cl = dynamic_cast<nut::TcpClient*>((nut::Client*)client);
+		nut::TcpClient* cl = dynamic_cast<nut::TcpClient*>(static_cast<nut::Client*>(client));
 		if(cl)
 		{
 			cl->setTimeout(timeout);
@@ -1606,7 +1606,7 @@ long nutclient_tcp_get_timeout(NUTCLIENT_TCP_t client)
 {
 	if(client)
 	{
-		nut::TcpClient* cl = dynamic_cast<nut::TcpClient*>((nut::Client*)client);
+		nut::TcpClient* cl = dynamic_cast<nut::TcpClient*>(static_cast<nut::Client*>(client));
 		if(cl)
 		{
 			return cl->getTimeout();
@@ -1619,7 +1619,7 @@ void nutclient_authenticate(NUTCLIENT_t client, const char* login, const char* p
 {
 	if(client)
 	{
-		nut::Client* cl = (nut::Client*)client;
+		nut::Client* cl = static_cast<nut::Client*>(client);
 		if(cl)
 		{
 			try
@@ -1635,7 +1635,7 @@ void nutclient_logout(NUTCLIENT_t client)
 {
 	if(client)
 	{
-		nut::Client* cl = (nut::Client*)client;
+		nut::Client* cl = static_cast<nut::Client*>(client);
 		if(cl)
 		{
 			try
@@ -1651,7 +1651,7 @@ void nutclient_device_login(NUTCLIENT_t client, const char* dev)
 {
 	if(client)
 	{
-		nut::Client* cl = (nut::Client*)client;
+		nut::Client* cl = static_cast<nut::Client*>(client);
 		if(cl)
 		{
 			try
@@ -1667,7 +1667,7 @@ int nutclient_get_device_num_logins(NUTCLIENT_t client, const char* dev)
 {
 	if(client)
 	{
-		nut::Client* cl = (nut::Client*)client;
+		nut::Client* cl = static_cast<nut::Client*>(client);
 		if(cl)
 		{
 			try
@@ -1684,7 +1684,7 @@ void nutclient_device_master(NUTCLIENT_t client, const char* dev)
 {
 	if(client)
 	{
-		nut::Client* cl = (nut::Client*)client;
+		nut::Client* cl = static_cast<nut::Client*>(client);
 		if(cl)
 		{
 			try
@@ -1700,7 +1700,7 @@ void nutclient_device_forced_shutdown(NUTCLIENT_t client, const char* dev)
 {
 	if(client)
 	{
-		nut::Client* cl = (nut::Client*)client;
+		nut::Client* cl = static_cast<nut::Client*>(client);
 		if(cl)
 		{
 			try
@@ -1716,7 +1716,7 @@ strarr nutclient_get_devices(NUTCLIENT_t client)
 {
 	if(client)
 	{
-		nut::Client* cl = (nut::Client*)client;
+		nut::Client* cl = static_cast<nut::Client*>(client);
 		if(cl)
 		{
 			try
@@ -1733,7 +1733,7 @@ int nutclient_has_device(NUTCLIENT_t client, const char* dev)
 {
 	if(client)
 	{
-		nut::Client* cl = (nut::Client*)client;
+		nut::Client* cl = static_cast<nut::Client*>(client);
 		if(cl)
 		{
 			try
@@ -1750,7 +1750,7 @@ char* nutclient_get_device_description(NUTCLIENT_t client, const char* dev)
 {
 	if(client)
 	{
-		nut::Client* cl = (nut::Client*)client;
+		nut::Client* cl = static_cast<nut::Client*>(client);
 		if(cl)
 		{
 			try
@@ -1767,7 +1767,7 @@ strarr nutclient_get_device_variables(NUTCLIENT_t client, const char* dev)
 {
 	if(client)
 	{
-		nut::Client* cl = (nut::Client*)client;
+		nut::Client* cl = static_cast<nut::Client*>(client);
 		if(cl)
 		{
 			try
@@ -1784,7 +1784,7 @@ strarr nutclient_get_device_rw_variables(NUTCLIENT_t client, const char* dev)
 {
 	if(client)
 	{
-		nut::Client* cl = (nut::Client*)client;
+		nut::Client* cl = static_cast<nut::Client*>(client);
 		if(cl)
 		{
 			try
@@ -1801,7 +1801,7 @@ int nutclient_has_device_variable(NUTCLIENT_t client, const char* dev, const cha
 {
 	if(client)
 	{
-		nut::Client* cl = (nut::Client*)client;
+		nut::Client* cl = static_cast<nut::Client*>(client);
 		if(cl)
 		{
 			try
@@ -1818,7 +1818,7 @@ char* nutclient_get_device_variable_description(NUTCLIENT_t client, const char* 
 {
 	if(client)
 	{
-		nut::Client* cl = (nut::Client*)client;
+		nut::Client* cl = static_cast<nut::Client*>(client);
 		if(cl)
 		{
 			try
@@ -1835,7 +1835,7 @@ strarr nutclient_get_device_variable_values(NUTCLIENT_t client, const char* dev,
 {
 	if(client)
 	{
-		nut::Client* cl = (nut::Client*)client;
+		nut::Client* cl = static_cast<nut::Client*>(client);
 		if(cl)
 		{
 			try
@@ -1852,7 +1852,7 @@ void nutclient_set_device_variable_value(NUTCLIENT_t client, const char* dev, co
 {
 	if(client)
 	{
-		nut::Client* cl = (nut::Client*)client;
+		nut::Client* cl = static_cast<nut::Client*>(client);
 		if(cl)
 		{
 			try
@@ -1868,13 +1868,13 @@ void nutclient_set_device_variable_values(NUTCLIENT_t client, const char* dev, c
 {
 	if(client)
 	{
-		nut::Client* cl = (nut::Client*)client;
+		nut::Client* cl = static_cast<nut::Client*>(client);
 		if(cl)
 		{
 			try
 			{
 				std::vector<std::string> vals;
-				strarr pstr = (strarr)values;
+				strarr pstr = static_cast<strarr>(values);
 				while(*pstr)
 				{
 					vals.push_back(std::string(*pstr));
@@ -1892,7 +1892,7 @@ strarr nutclient_get_device_commands(NUTCLIENT_t client, const char* dev)
 {
 	if(client)
 	{
-		nut::Client* cl = (nut::Client*)client;
+		nut::Client* cl = static_cast<nut::Client*>(client);
 		if(cl)
 		{
 			try
@@ -1909,7 +1909,7 @@ int nutclient_has_device_command(NUTCLIENT_t client, const char* dev, const char
 {
 	if(client)
 	{
-		nut::Client* cl = (nut::Client*)client;
+		nut::Client* cl = static_cast<nut::Client*>(client);
 		if(cl)
 		{
 			try
@@ -1926,7 +1926,7 @@ char* nutclient_get_device_command_description(NUTCLIENT_t client, const char* d
 {
 	if(client)
 	{
-		nut::Client* cl = (nut::Client*)client;
+		nut::Client* cl = static_cast<nut::Client*>(client);
 		if(cl)
 		{
 			try
@@ -1943,7 +1943,7 @@ void nutclient_execute_device_command(NUTCLIENT_t client, const char* dev, const
 {
 	if(client)
 	{
-		nut::Client* cl = (nut::Client*)client;
+		nut::Client* cl = static_cast<nut::Client*>(client);
 		if(cl)
 		{
 			try

--- a/clients/nutclient.cpp
+++ b/clients/nutclient.cpp
@@ -730,7 +730,7 @@ std::map<std::string,std::map<std::string,std::vector<std::string> > > TcpClient
 			{
 				std::vector<std::string>& vals = *it2;
 				std::string var = vals[0];
-				vals.erase(vals.begin()),
+				vals.erase(vals.begin());
 				map2[var] = vals;
 			}
 			map[*it] = map2;

--- a/clients/nutclient.h
+++ b/clients/nutclient.h
@@ -51,7 +51,7 @@ class NutException : public std::exception
 {
 public:
 	NutException(const std::string& msg):_msg(msg){}
-	virtual ~NutException() {}
+	virtual ~NutException();
 	virtual const char * what() const noexcept {return this->_msg.c_str();}
 	virtual std::string str() const noexcept {return this->_msg;}
 private:
@@ -65,7 +65,7 @@ class SystemException : public NutException
 {
 public:
 	SystemException();
-	virtual ~SystemException() {}
+	virtual ~SystemException();
 private:
 	static std::string err();
 };
@@ -78,7 +78,7 @@ class IOException : public NutException
 {
 public:
 	IOException(const std::string& msg):NutException(msg){}
-	virtual ~IOException() {}
+	virtual ~IOException();
 };
 
 /**
@@ -88,7 +88,7 @@ class UnknownHostException : public IOException
 {
 public:
 	UnknownHostException():IOException("Unknown host"){}
-	virtual ~UnknownHostException() {}
+	virtual ~UnknownHostException();
 };
 
 /**
@@ -98,7 +98,7 @@ class NotConnectedException : public IOException
 {
 public:
 	NotConnectedException():IOException("Not connected"){}
-	virtual ~NotConnectedException() {}
+	virtual ~NotConnectedException();
 };
 
 /**
@@ -108,7 +108,7 @@ class TimeoutException : public IOException
 {
 public:
 	TimeoutException():IOException("Timeout"){}
-	virtual ~TimeoutException() {}
+	virtual ~TimeoutException();
 };
 
 /**

--- a/clients/nutclient.h
+++ b/clients/nutclient.h
@@ -781,7 +781,7 @@ typedef char** strarr;
 /**
  * Alloc an array of string.
  */
-strarr strarr_alloc(unsigned short count);
+strarr strarr_alloc(size_t count);
 
 /**
  * Free an array of string.

--- a/clients/nutclient.h
+++ b/clients/nutclient.h
@@ -985,7 +985,7 @@ typedef NUTCLIENT_t NUTCLIENT_TCP_t;
  * Create a client to NUTD using a TCP connection.
  * \param host Host name to connect to.
  * \param port Host port.
- * \return New client or NULL if failed.
+ * \return New client or nullptr if failed.
  */
 NUTCLIENT_TCP_t nutclient_tcp_create_client(const char* host, unsigned short port);
 /**

--- a/clients/nutclient.h
+++ b/clients/nutclient.h
@@ -151,13 +151,13 @@ public:
 	 * \todo Is his method is global to all connection protocol or is it specific to TCP ?
 	 * \note Actually, authentication fails only if already set, not if bad values are sent.
 	 */
-	virtual void authenticate(const std::string& user, const std::string& passwd)=0;
+	virtual void authenticate(const std::string& user, const std::string& passwd) = 0;
 
 	/**
 	 * Disconnect from the NUTD server.
 	 * \todo Is his method is global to all connection protocol or is it specific to TCP ?
 	 */
-	virtual void logout()=0;
+	virtual void logout() = 0;
 
 	/**
 	 * Device manipulations.
@@ -186,13 +186,13 @@ public:
 	 * Retrieve names of devices supported by NUTD server.
 	 * \return The set of names of supported devices.
 	 */
-	virtual std::set<std::string> getDeviceNames()=0;
+	virtual std::set<std::string> getDeviceNames() = 0;
 	/**
 	 * Retrieve the description of a device.
 	 * \param name Device name.
 	 * \return Device description.
 	 */
-	virtual std::string getDeviceDescription(const std::string& name)=0;
+	virtual std::string getDeviceDescription(const std::string& name) = 0;
 	/** \} */
 
 	/**
@@ -205,13 +205,13 @@ public:
 	 * \param dev Device name
 	 * \return Variable names
 	 */
-	virtual std::set<std::string> getDeviceVariableNames(const std::string& dev)=0;
+	virtual std::set<std::string> getDeviceVariableNames(const std::string& dev) = 0;
 	/**
 	 * Retrieve names of read/write variables supported by a device.
 	 * \param dev Device name
 	 * \return RW variable names
 	 */
-	virtual std::set<std::string> getDeviceRWVariableNames(const std::string& dev)=0;
+	virtual std::set<std::string> getDeviceRWVariableNames(const std::string& dev) = 0;
 	/**
 	 * Test if a variable is supported by a device.
 	 * \param dev Device name
@@ -225,14 +225,14 @@ public:
 	 * \param name Variable name
 	 * \return Variable description if provided.
 	 */
-	virtual std::string getDeviceVariableDescription(const std::string& dev, const std::string& name)=0;
+	virtual std::string getDeviceVariableDescription(const std::string& dev, const std::string& name) = 0;
 	/**
 	 * Retrieve values of a variable.
 	 * \param dev Device name
 	 * \param name Variable name
 	 * \return Variable values (usually one) if available.
 	 */
-	virtual std::vector<std::string> getDeviceVariableValue(const std::string& dev, const std::string& name)=0;
+	virtual std::vector<std::string> getDeviceVariableValue(const std::string& dev, const std::string& name) = 0;
 	/**
 	 * Retrieve values of all variables of a device.
 	 * \param dev Device name
@@ -251,14 +251,14 @@ public:
 	 * \param name Variable name
 	 * \param value Variable value
 	 */
-	virtual TrackingID setDeviceVariable(const std::string& dev, const std::string& name, const std::string& value)=0;
+	virtual TrackingID setDeviceVariable(const std::string& dev, const std::string& name, const std::string& value) = 0;
 	/**
 	 * Intend to set the value of a variable.
 	 * \param dev Device name
 	 * \param name Variable name
-	 * \param value Variable value
+	 * \param values Vector of variable values
 	 */
-	virtual TrackingID setDeviceVariable(const std::string& dev, const std::string& name, const std::vector<std::string>& values)=0;
+	virtual TrackingID setDeviceVariable(const std::string& dev, const std::string& name, const std::vector<std::string>& values) = 0;
 	/** \} */
 
 	/**
@@ -271,7 +271,7 @@ public:
 	 * \param dev Device name
 	 * \return Command names
 	 */
-	virtual std::set<std::string> getDeviceCommandNames(const std::string& dev)=0;
+	virtual std::set<std::string> getDeviceCommandNames(const std::string& dev) = 0;
 	/**
 	 * Test if a command is supported by a device.
 	 * \param dev Device name
@@ -285,14 +285,14 @@ public:
 	 * \param name Command name
 	 * \return Command description if provided.
 	 */
-	virtual std::string getDeviceCommandDescription(const std::string& dev, const std::string& name)=0;
+	virtual std::string getDeviceCommandDescription(const std::string& dev, const std::string& name) = 0;
 	/**
 	 * Intend to execute a command.
 	 * \param dev Device name
 	 * \param name Command name
 	 * \param param Additional command parameter
 	 */
-	virtual TrackingID executeDeviceCommand(const std::string& dev, const std::string& name, const std::string& param="")=0;
+	virtual TrackingID executeDeviceCommand(const std::string& dev, const std::string& name, const std::string& param="") = 0;
 	/** \} */
 
 	/**
@@ -303,25 +303,25 @@ public:
 	 * Log the current user (if authenticated) for a device.
 	 * \param dev Device name.
 	 */
-	virtual void deviceLogin(const std::string& dev)=0;
+	virtual void deviceLogin(const std::string& dev) = 0;
 	/**
 	 * Retrieve the number of user longged in the specified device.
 	 * \param dev Device name.
 	 * \return Number of logged-in users.
 	 */
-	virtual int deviceGetNumLogins(const std::string& dev)=0;
-	virtual void deviceMaster(const std::string& dev)=0;
-	virtual void deviceForcedShutdown(const std::string& dev)=0;
+	virtual int deviceGetNumLogins(const std::string& dev) = 0;
+	virtual void deviceMaster(const std::string& dev) = 0;
+	virtual void deviceForcedShutdown(const std::string& dev) = 0;
 
 	/**
 	 * Retrieve the result of a tracking ID.
 	 * \param id Tracking ID.
 	 */
-	virtual TrackingResult getTrackingResult(const TrackingID& id)=0;
+	virtual TrackingResult getTrackingResult(const TrackingID& id) = 0;
 
 	virtual bool hasFeature(const Feature& feature);
-	virtual bool isFeatureEnabled(const Feature& feature)=0;
-	virtual void setFeature(const Feature& feature, bool status)=0;
+	virtual bool isFeatureEnabled(const Feature& feature) = 0;
+	virtual void setFeature(const Feature& feature, bool status) = 0;
 
 	static const Feature TRACKING;
 
@@ -537,7 +537,7 @@ public:
 	/**
 	 * Intend to set values of a variable of the device.
 	 * \param name Variable name.
-	 * \param value New variable values.
+	 * \param values Vector of new variable values.
 	 */
 	void setVariable(const std::string& name, const std::vector<std::string>& values);
 
@@ -672,7 +672,7 @@ public:
 	void setValue(const std::string& value);
 	/**
 	 * Intend to set (multiple) values to the variable.
-	 * \param value New variable values.
+	 * \param values Vector of new variable values.
 	 */
 	void setValues(const std::vector<std::string>& values);
 
@@ -745,9 +745,8 @@ public:
 	std::string getDescription();
 
 	/**
-	 * Intend to retrieve command description.
-	 * \param param Additional command parameter
-	 * \return Command description if provided.
+	 * Intend to execute the instant command on device.
+	 * \param param Optional additional command parameter
 	 */
 	void execute(const std::string& param="");
 

--- a/configure.ac
+++ b/configure.ac
@@ -142,6 +142,7 @@ dnl Note: the compiler/pragma/attr methods below are custom for NUT codebase:
 NUT_COMPILER_FAMILY
 AX_C_PRAGMAS
 AX_C___ATTRIBUTE__
+AX_C_PRINTF_STRING_NULL
 AC_CHECK_FUNCS(flock lockf fcvt fcvtl pow10 round abs_val abs)
 AC_CHECK_FUNCS(fabs, [], [], [#include <math.h>])
 AC_CHECK_FUNCS(cfsetispeed tcsendbreak)

--- a/include/str.h
+++ b/include/str.h
@@ -29,6 +29,15 @@ extern "C" {
 /* *INDENT-ON* */
 #endif
 
+/* Some compilers and/or C libraries do not handle printf("%s", NULL) correctly */
+#ifndef NUT_STRARG
+# ifdef HAVE_PRINTF_STRING_NULL
+#  define NUT_STRARG(x) x
+# else
+#  define NUT_STRARG(x) (x?x:"(null)")
+# endif
+#endif
+
 /* Remove all
  * - leading and trailing (str_trim[_m]())
  * - leading (str_ltrim[_m]())

--- a/m4/ax_c_pragmas.m4
+++ b/m4/ax_c_pragmas.m4
@@ -194,3 +194,45 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
   CFLAGS="${CFLAGS_SAVED}"
   CXXFLAGS="${CXXFLAGS_SAVED}"
 ])
+
+AC_DEFUN([AX_C_PRINTF_STRING_NULL], [
+  dnl ### To be sure, bolt the language
+  AC_LANG_PUSH([C])
+
+  AC_CACHE_CHECK([for practical support to pritnf("%s", NULL)],
+    [ax_cv__printf_string_null],
+    [AC_RUN_IFELSE(
+        [AC_LANG_PROGRAM([dnl
+#include <stdio.h>
+#include <strings.h>
+], [dnl
+char buf[128];
+char *s = NULL;
+int res = snprintf(buf, sizeof(buf), "%s", s);
+buf[sizeof(buf)-1] = '\0';
+if (res < 0) {
+    printf(stderr, "FAILED to snprintf() a NULL string argument");
+    exit 1;
+}
+if (buf[0] == '\0')
+    printf(stderr, "RETURNED empty string from snprintf() with a NULL string argument");
+    exit 0;
+}
+if (strcasestr(buf, 'null') == NULL)
+    printf(stderr, "RETURNED some string from snprintf() with a NULL string argument: '%s'", buf);
+    exit 0;
+}
+printf(stderr, "SUCCESS: RETURNED a string that contains something like 'null' from snprintf() with a NULL string argument: '%s'", buf);
+exit 0;
+            ])],
+        [ax_cv__printf_string_null=yes],
+        [ax_cv__printf_string_null=no]
+    )]
+  )
+
+  AS_IF([test "$ax_cv__printf_string_null" = "yes"],[
+    AC_DEFINE([HAVE_PRINTF_STRING_NULL], 1, [define if your libc can printf("%s", NULL) sanely])
+  ])
+
+  AC_LANG_POP([C])
+])

--- a/m4/ax_c_pragmas.m4
+++ b/m4/ax_c_pragmas.m4
@@ -3,16 +3,23 @@ dnl e.g. diagnostics management to keep warnings quiet sometimes
 
 AC_DEFUN([AX_C_PRAGMAS], [
   CFLAGS_SAVED="${CFLAGS}"
+  CXXFLAGS_SAVED="${CXXFLAGS}"
+
+  dnl ### To be sure, bolt the language
+  AC_LANG_PUSH([C])
 
   dnl # This is expected to fail builds with unknown pragma names on GCC or CLANG at least
   AS_IF([test "${CLANG}" = "yes"],
-    [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning-option"],
+    [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning-option"
+     CXXFLAGS="${CXXFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning-option"],
     [AS_IF([test "${GCC}" = "yes"],
 dnl ### Despite the docs, this dies with lack of (apparently) support for
 dnl ### -Wunknown-warning(-options) on all GCC versions I tried (v5-v10)
 dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"],
-        [CFLAGS="${CFLAGS_SAVED} -Wall -Wextra -Werror"],
-        [CFLAGS="${CFLAGS_SAVED} -Wall -Wextra -Werror"])
+        [CFLAGS="${CFLAGS_SAVED} -Wall -Wextra -Werror"
+         CXXFLAGS="${CXXFLAGS_SAVED} -Wall -Wextra -Werror"],
+        [CFLAGS="${CFLAGS_SAVED} -Wall -Wextra -Werror"
+         CXXFLAGS="${CXXFLAGS_SAVED} -Wall -Wextra -Werror"])
     ])
 
   AC_CACHE_CHECK([for pragma GCC diagnostic push and pop],
@@ -78,6 +85,37 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
     AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wunreachable-code"])
   ])
 
+  AC_LANG_POP([C])
+
+  dnl ### Series of tests for C++ specific pragmas
+  AC_LANG_PUSH([C++])
+
+  AC_CACHE_CHECK([for C++ pragma GCC diagnostic ignored "-Wc++98-compat-pedantic"],
+    [ax_cv__pragma__gcc__diags_ignored_cxx98_compat_pedantic],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wc++98-compat-pedantic"]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_cxx98_compat_pedantic=yes],
+      [ax_cv__pragma__gcc__diags_ignored_cxx98_compat_pedantic=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_cxx98_compat_pedantic" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_CXX98_COMPAT_PEDANTIC], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wc++98-compat-pedantic"])
+  ])
+
+  AC_CACHE_CHECK([for C++ pragma GCC diagnostic ignored "-Wc++98-compat"],
+    [ax_cv__pragma__gcc__diags_ignored_cxx98_compat],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wc++98-compat"]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_cxx98_compat=yes],
+      [ax_cv__pragma__gcc__diags_ignored_cxx98_compat=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_cxx98_compat" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_CXX98_COMPAT], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wc++98-compat"])
+  ])
+
+  AC_LANG_POP([C++])
+
   dnl # Meta-macros for simpler use-cases where we pick
   dnl # equivalent-effect macros for different compiler versions
   AS_IF([test "$ax_cv__pragma__gcc__diags_push_pop" = "yes"],[
@@ -86,6 +124,9 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
     ])
     AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_unreachable_code" = "yes" || test "$ax_cv__pragma__gcc__diags_ignored_unreachable_code_break" = "yes" ],[
         AC_DEFINE([HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE], 1, [define if your compiler has pragmas for GCC diagnostic ignored "-Wunreachable-code(-break)" and for push-pop support])
+    ])
+    AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_cxx98_compat_pedantic" = "yes" || test "$ax_cv__pragma__gcc__diags_ignored_cxx98_compat" = "yes" ],[
+        AC_DEFINE([HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_CXX98_COMPAT], 1, [define if your compiler has pragmas for GCC diagnostic ignored "-Wc++98-compat(-pedantic)" and for push-pop support])
     ])
   ])
 
@@ -115,4 +156,5 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
     [AC_MSG_WARN([A bogus test that was expected to fail did not! ax_cv__pragma__bogus_diag=$ax_cv__pragma__bogus_diag (not 'no')])])
 
   CFLAGS="${CFLAGS_SAVED}"
+  CXXFLAGS="${CXXFLAGS_SAVED}"
 ])

--- a/m4/ax_c_pragmas.m4
+++ b/m4/ax_c_pragmas.m4
@@ -114,6 +114,30 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
     AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_CXX98_COMPAT], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wc++98-compat"])
   ])
 
+  AC_CACHE_CHECK([for C++ pragma GCC diagnostic ignored "-Wglobal-constructors"],
+    [ax_cv__pragma__gcc__diags_ignored_global_constructors],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wglobal-constructors"]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_global_constructors=yes],
+      [ax_cv__pragma__gcc__diags_ignored_global_constructors=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_global_constructors" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_GLOBAL_CONSTRUCTORS], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wglobal-constructors"])
+  ])
+
+  AC_CACHE_CHECK([for C++ pragma GCC diagnostic ignored "-Wexit-time-destructors"],
+    [ax_cv__pragma__gcc__diags_ignored_exit_time_destructors],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wexit-time-destructors"]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_exit_time_destructors=yes],
+      [ax_cv__pragma__gcc__diags_ignored_exit_time_destructors=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_exit_time_destructors" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_EXIT_TIME_DESTRUCTORS], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wexit-time-destructors"])
+  ])
+
   AC_LANG_POP([C++])
 
   dnl # Meta-macros for simpler use-cases where we pick

--- a/m4/ax_c_pragmas.m4
+++ b/m4/ax_c_pragmas.m4
@@ -85,6 +85,18 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
     AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wunreachable-code"])
   ])
 
+  AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wformat-overflow"],
+    [ax_cv__pragma__gcc__diags_ignored_format_overflow],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wformat-overflow"]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_format_overflow=yes],
+      [ax_cv__pragma__gcc__diags_ignored_format_overflow=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_format_overflow" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_FORMAT_OVERFLOW], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wformat-overflow"])
+  ])
+
   AC_LANG_POP([C])
 
   dnl ### Series of tests for C++ specific pragmas

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -15,6 +15,11 @@ nutlogtest_SOURCES = nutlogtest.c
 nutlogtest_LDADD = $(top_builddir)/common/libcommon.la
 
 ### Optional tests which can not be built everywhere
+# List of src files for CppUnit tests
+CPPUNITTESTSRC = example.cpp nutclienttest.cpp
+# The test driver which orchestrates running those tests above
+CPPUNITTESTERSRC = cpputest.cpp
+
 if HAVE_CXX11
 if HAVE_CPPUNIT
 # Note: per configure script this "SHOULD" also assume
@@ -30,16 +35,12 @@ endif
 cppunittest_CXXFLAGS = $(AM_CXXFLAGS) $(CPPUNIT_CFLAGS) $(CPPUNIT_CXXFLAGS) $(CPPUNIT_NUT_CXXFLAGS) $(CXXFLAGS)
 cppunittest_LDFLAGS = $(CPPUNIT_LIBS)
 cppunittest_LDADD = $(top_builddir)/clients/libnutclient.la
-
-# List of src files for CppUnit tests
-CPPUNITTESTSRC = example.cpp nutclienttest.cpp
-
-cppunittest_SOURCES = $(CPPUNITTESTSRC) cpputest.cpp
+cppunittest_SOURCES = $(CPPUNITTESTSRC) $(CPPUNITTESTERSRC)
 
 else !HAVE_CPPUNIT
 # Just redistribute test source into tarball
 
-EXTRA_DIST += example.cpp cpputest.cpp
+EXTRA_DIST += $(CPPUNITTESTSRC) $(CPPUNITTESTERSRC)
 
 endif !HAVE_CPPUNIT
 

--- a/tests/cpputest.cpp
+++ b/tests/cpputest.cpp
@@ -2,6 +2,7 @@
 
    Copyright (C)
 	2012	Emilien Kia <emilienkia-guest@alioth.debian.org>
+	2020	Jim Klimov <jimklimov@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -61,4 +62,3 @@ int main(int argc, char* argv[])
     "'" << ( wasSucessful ? "true" : "false" ) << "'" << std::endl;
   return wasSucessful ? 0 : 1;
 }
-

--- a/tests/cpputest.cpp
+++ b/tests/cpputest.cpp
@@ -58,7 +58,7 @@ int main(int argc, char* argv[])
 
   /* Return error code 1 if the one of test failed. */
   std::cerr << "D: Got to the end of test suite with code " <<
-    "'" << wasSucessful << "'" << std::endl;
+    "'" << ( wasSucessful ? "true" : "false" ) << "'" << std::endl;
   return wasSucessful ? 0 : 1;
 }
 

--- a/tests/example.cpp
+++ b/tests/example.cpp
@@ -2,6 +2,7 @@
 
    Copyright (C)
 	2012	Emilien Kia <emilienkia-guest@alioth.debian.org>
+	2020	Jim Klimov <jimklimov@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -58,5 +59,3 @@ void ExampleTest::testOne()
   // Check
   CPPUNIT_ASSERT_EQUAL( i, cast );
 }
-
-

--- a/tests/example.cpp
+++ b/tests/example.cpp
@@ -53,7 +53,7 @@ void ExampleTest::testOne()
   float f = 1.0;
 
   // Process
-  int cast = (int)f;
+  int cast = static_cast<int>(f);
 
   // Check
   CPPUNIT_ASSERT_EQUAL( i, cast );

--- a/tests/example.cpp
+++ b/tests/example.cpp
@@ -18,6 +18,20 @@
    along with this program; if not, write to the Free Software
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
+
+#include "common.h"
+
+/* Current CPPUnit offends the honor of C++98 */
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_EXIT_TIME_DESTRUCTORS || defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_GLOBAL_CONSTRUCTORS)
+#pragma GCC diagnostic push
+# ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_GLOBAL_CONSTRUCTORS
+#  pragma GCC diagnostic ignored "-Wglobal-constructors"
+# endif
+# ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_EXIT_TIME_DESTRUCTORS
+#  pragma GCC diagnostic ignored "-Wexit-time-destructors"
+# endif
+#endif
+
 #include <cppunit/extensions/HelperMacros.h>
 
 class ExampleTest : public CppUnit::TestFixture
@@ -59,3 +73,7 @@ void ExampleTest::testOne()
   // Check
   CPPUNIT_ASSERT_EQUAL( i, cast );
 }
+
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_EXIT_TIME_DESTRUCTORS || defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_GLOBAL_CONSTRUCTORS)
+#pragma GCC diagnostic pop
+#endif

--- a/tests/nutclienttest.cpp
+++ b/tests/nutclienttest.cpp
@@ -87,12 +87,12 @@ void NutClientTest::test_stringset_to_strarr()
 	strset.insert("world");
 
 	strarr arr = stringset_to_strarr(strset);
-	CPPUNIT_ASSERT_MESSAGE("stringset_to_strarr(...) result is null", arr!=NULL);
+	CPPUNIT_ASSERT_MESSAGE("stringset_to_strarr(...) result is null", arr != nullptr);
 
 	std::set<std::string> res;
 
 	char** ptr = arr;
-	while(*ptr!=NULL)
+	while(*ptr != nullptr)
 	{
 		res.insert(std::string(*ptr));
 		ptr++;
@@ -114,7 +114,7 @@ void NutClientTest::test_stringvector_to_strarr()
 	strset.push_back("world");
 
 	strarr arr = stringvector_to_strarr(strset);
-	CPPUNIT_ASSERT_MESSAGE("stringvector_to_strarr(...) result is null", arr!=NULL);
+	CPPUNIT_ASSERT_MESSAGE("stringvector_to_strarr(...) result is null", arr != nullptr);
 
 	char** ptr = arr;
 	CPPUNIT_ASSERT_EQUAL_MESSAGE("stringvector_to_strarr(...) result has not item 0==\"test\"", std::string("test"), std::string(*ptr));
@@ -123,7 +123,7 @@ void NutClientTest::test_stringvector_to_strarr()
 	++ptr;
 	CPPUNIT_ASSERT_EQUAL_MESSAGE("stringvector_to_strarr(...) result has not item 2==\"world\"", std::string("world"), std::string(*ptr));
 	++ptr;
-	CPPUNIT_ASSERT_EQUAL_MESSAGE("stringvector_to_strarr(...) result has not only 3 items", (char*)NULL, *ptr);
+	CPPUNIT_ASSERT_EQUAL_MESSAGE("stringvector_to_strarr(...) result has not only 3 items", nullptr, *ptr);
 
 	strarr_free(arr);
 }

--- a/tests/nutclienttest.cpp
+++ b/tests/nutclienttest.cpp
@@ -17,6 +17,20 @@
    along with this program; if not, write to the Free Software
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
+
+#include "common.h"
+
+/* Current CPPUnit offends the honor of C++98 */
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_EXIT_TIME_DESTRUCTORS || defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_GLOBAL_CONSTRUCTORS)
+#pragma GCC diagnostic push
+# ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_GLOBAL_CONSTRUCTORS
+#  pragma GCC diagnostic ignored "-Wglobal-constructors"
+# endif
+# ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_EXIT_TIME_DESTRUCTORS
+#  pragma GCC diagnostic ignored "-Wexit-time-destructors"
+# endif
+#endif
+
 #include <cppunit/extensions/HelperMacros.h>
 
 namespace nut {
@@ -203,3 +217,7 @@ void NutClientTest::test_copy_assignment_var() {
 }
 
 } // namespace nut {}
+
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_EXIT_TIME_DESTRUCTORS || defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_GLOBAL_CONSTRUCTORS)
+#pragma GCC diagnostic pop
+#endif

--- a/tests/nutclienttest.cpp
+++ b/tests/nutclienttest.cpp
@@ -123,7 +123,12 @@ void NutClientTest::test_stringvector_to_strarr()
 	++ptr;
 	CPPUNIT_ASSERT_EQUAL_MESSAGE("stringvector_to_strarr(...) result has not item 2==\"world\"", std::string("world"), std::string(*ptr));
 	++ptr;
-	CPPUNIT_ASSERT_EQUAL_MESSAGE("stringvector_to_strarr(...) result has not only 3 items", nullptr, *ptr);
+
+	/* https://stackoverflow.com/a/12565009/4715872
+	 * Can not compare nullptr_t and another data type (char*)
+	 * with CPPUNIT template assertEquals()
+	 */
+	CPPUNIT_ASSERT_MESSAGE("stringvector_to_strarr(...) result has not only 3 items", nullptr == *ptr);
 
 	strarr_free(arr);
 }

--- a/tests/nutclienttest.cpp
+++ b/tests/nutclienttest.cpp
@@ -98,7 +98,7 @@ void NutClientTest::test_stringset_to_strarr()
 		ptr++;
 	}
 
-	CPPUNIT_ASSERT_EQUAL_MESSAGE("stringset_to_strarr(...) result has not 3 items", (size_t)3, res.size());
+	CPPUNIT_ASSERT_EQUAL_MESSAGE("stringset_to_strarr(...) result has not 3 items", static_cast<size_t>(3), res.size());
 	CPPUNIT_ASSERT_MESSAGE("stringset_to_strarr(...) result has not item \"test\"", res.find("test")!=res.end());
 	CPPUNIT_ASSERT_MESSAGE("stringset_to_strarr(...) result has not item \"hello\"", res.find("hello")!=res.end());
 	CPPUNIT_ASSERT_MESSAGE("stringset_to_strarr(...) result has not item \"world\"", res.find("world")!=res.end());

--- a/tests/nutclienttest.cpp
+++ b/tests/nutclienttest.cpp
@@ -1,6 +1,7 @@
 /* nutclienttest - CppUnit nutclient unit test
 
    Copyright (C) 2016  Emilien Kia <emilien.kia@gmail.com>
+   Copyright (C) 2020  Jim Klimov <jimklimov@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/tests/nutlogtest.c
+++ b/tests/nutlogtest.c
@@ -7,6 +7,15 @@
 int main(void) {
     const char *s1 = "!NULL";
     const char *s2 = NULL;
+
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_FORMAT_OVERFLOW)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wformat-overflow"
+#endif
     upsdebugx(0, "D: '%s' vs '%s'", s1, s2);
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_FORMAT_OVERFLOW)
+#  pragma GCC diagnostic pop
+#endif
+
     return 0;
 }

--- a/tests/nutlogtest.c
+++ b/tests/nutlogtest.c
@@ -12,10 +12,28 @@ int main(void) {
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wformat-overflow"
 #endif
-    upsdebugx(0, "D: '%s' vs '%s'", s1, s2);
+    upsdebugx(0, "D: checking with libc handling of NULL: '%s' vs '%s'", s1, s2);
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_FORMAT_OVERFLOW)
 #  pragma GCC diagnostic pop
 #endif
+
+/* This explicitly does not work with -Wformat, due to verbatim NULL without a var:
+ * nutlogtest.c:20:5: error: reading through null pointer (argument 4) [-Werror=format=]
+ * and also due to (void*) vs (char*) in naive case:
+ *   upsdebugx(0, "D: '%s' vs '%s'", NUT_STRARG(NULL), NULL);
+ * but with casting the explicit NULL remains:
+ *   upsdebugx(0, "D: '%s' vs '%s'", NUT_STRARG((char *)NULL), (char *)NULL);
+ */
+
+    upsdebugx(0, "D: checking with NUT_STRARG macro: '%s' vs '%s'", NUT_STRARG(s2), s2);
+
+#ifdef NUT_STRARG
+#undef NUT_STRARG
+#endif
+
+#define NUT_STRARG(x) (x?x:"<N/A>")
+
+    upsdebugx(0, "D: checking that macro wrap trick works: '%s' vs '%s'", NUT_STRARG(s2), s2);
 
     return 0;
 }

--- a/tests/nutlogtest.c
+++ b/tests/nutlogtest.c
@@ -1,6 +1,23 @@
 /* nutlogtest - some trivial usage for upslog*() and upsdebug*() related
  * routines to sanity-check their code (compiler does not warn, test runs
  * do not crash).
+ *
+ * Copyright (C)
+ *	2020	Jim Klimov <jimklimov@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 #include "common.h"
 


### PR DESCRIPTION
After a practical fix for #880, at least 50 errors were emitted by clang-9 for the remaining C++ code in this file. Most though not all taste of syntactic sugar, but whatever - if it helps the code be clean and nice.

Follows up from #823 / #844 efforts.