### PR TITLE
fightwarn - fix how we work with enums

### DIFF
--- a/drivers/powerman-pdu.c
+++ b/drivers/powerman-pdu.c
@@ -20,7 +20,7 @@
 
 #include "main.h"
 
-#include <libpowerman.h>
+#include <libpowerman.h>	/* pm_err_t and other beasts */
 
 #define DRIVER_NAME	"Powerman PDU client driver"
 #define DRIVER_VERSION	"0.11"
@@ -49,7 +49,7 @@ static int reconnect_ups(void);
 
 static int instcmd(const char *cmdname, const char *extra)
 {
-	pm_err_t rv = -1;
+	pm_err_t rv = PM_EBADARG;
 	char *cmdsuffix = NULL;
 	char *cmdindex = NULL;
 	char outletname[SMALLBUF];

--- a/drivers/powerp-bin.c
+++ b/drivers/powerp-bin.c
@@ -481,6 +481,7 @@ static int powpan_updateinfo(void)
 		dstate_setinfo("input.frequency", "%.1f", op_freq(status.i_freq));
 		break;
 
+	case PR:
 	default:
 		dstate_setinfo("input.voltage", "%d", status.i_volt);
 		if (status.flags[0] & 0x84) {

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -207,6 +207,11 @@ static int is_binary_protocol()
 	switch(tl_model) {
 	case TRIPP_LITE_SMART_3005:
 		return 1;
+	case TRIPP_LITE_SMARTPRO:
+	case TRIPP_LITE_SMART_0004:
+	case TRIPP_LITE_OMNIVS:
+	case TRIPP_LITE_OMNIVS_2001:
+	case TRIPP_LITE_UNKNOWN:
 	default:
 		return 0;
 	}
@@ -222,6 +227,9 @@ static int is_smart_protocol()
 	case TRIPP_LITE_SMART_0004:
 	case TRIPP_LITE_SMART_3005:
 		return 1;
+	case TRIPP_LITE_OMNIVS:
+	case TRIPP_LITE_OMNIVS_2001:
+	case TRIPP_LITE_UNKNOWN:
 	default:
 		return 0;
 	}
@@ -777,6 +785,9 @@ static int control_outlet(int outlet_id, int state)
 #pragma GCC diagnostic pop
 #endif
 
+		case TRIPP_LITE_OMNIVS:
+		case TRIPP_LITE_OMNIVS_2001:
+		case TRIPP_LITE_UNKNOWN:
 		default:
 			upslogx(LOG_ERR, "control_outlet unimplemented for protocol %04x", tl_model);
 	}
@@ -1404,6 +1415,7 @@ void upsdrv_updateinfo(void)
 			dstate_setinfo("ups.load", "%d", hex2d(l_value+1, 2));
 			dstate_setinfo("ups.debug.L","%s", hexascdump(l_value+1, 7));
 			break;
+		case TRIPP_LITE_UNKNOWN:
 		default:
 			dstate_setinfo("ups.debug.L","%s", hexascdump(l_value+1, 7));
 			break;


### PR DESCRIPTION
Follows from efforts at #823 / #844 to squash as many bugs and "fishy coding" warnings found by newest compilers.

This PR is separated from the stream of others since it addresses a common theme - that a few `switch()` cases reacting to values of an `enum` did not cover all options listed in that enum - so something might end up not handled intentionally and just fell through default handling.

In case of `powerp` driver below, such change is trivial - there were two options in enum, so one handled already and other "obviously" same as `default`.

The case of `tripplite_usb` worries me more, since there are 6 options and just a small subset of these were handled initially, to state support of binary or smart protocol, and to control outlets. While the change to spell out the previously not listed options as aliases into `default` case does not change the practical outcome compared to older builds, a domain expert would be beneficial to check the actual support per model/protocol and maybe shuffle the lines to match actual hardware capabilities correctly. 
Comments in code imply there might be more options in reality (e.g. a "Add model 3004?"), revising and adding those to the driver would also be nice.
More so that it seems Tripplite support is a focus point enough that a vendor representative is active in the NUT mailing list.

One case was also of needlessly pre-assigning an invalid out-of-range value (that we did not use anyway, reassigned in code below that to functions' returns first).

Merging this PR should not change NUT behavior compared to existing codebase; it was exposed to focus attention of experts who might update the drivers in future PRs.