### PR TITLE
fightwarn - drivers/riello_usb.c: do not hijack system "errno" definition…

### DIFF
--- a/drivers/riello_usb.c
+++ b/drivers/riello_usb.c
@@ -101,7 +101,7 @@ static int cypress_setfeatures()
 static int Send_USB_Packet(uint8_t *send_str, uint16_t numbytes)
 {
 	uint8_t USB_buff_pom[10];
-	int i, err, size, errno;
+	int i, err, size;
 
 	/* is input correct ? */
 	if ((!send_str) || (!numbytes))
@@ -164,7 +164,7 @@ static int Send_USB_Packet(uint8_t *send_str, uint16_t numbytes)
 static int Get_USB_Packet(uint8_t *buffer)
 {
 	char inBuf[10];
-	int err, size, errno, ep;
+	int err, size, ep;
 
 	/* note: this function stop until some byte(s) is not arrived */
 	size = 8;


### PR DESCRIPTION
…and *seems* the routine has no use for local var of that name found anyway (the usage seen in code matches the usual system error reporting; no assignments to it either)

This was a nice one in compiler complaints, since in some systems `errno` is defined as a macro to something syntactically convoluted, so an expansion of `int errno;` declaration here just blew up :)