### PR TITLE
fightwarn - mark up some more NUT_UNUSED_VARIABLEs and drop redundant semicolons

### DIFF
--- a/drivers/bcmxcp.c
+++ b/drivers/bcmxcp.c
@@ -1813,7 +1813,7 @@ void upsdrv_updateinfo(void)
 		if (value != 0) {
 			dstate_setinfo("battery.charge.restart","%d",value);
 		}
-	};
+	}
 
 	res = command_read_sequence(PW_CONFIG_BLOCK_REQ, answer);
 	if (res <= 0) {

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -1192,14 +1192,14 @@ int dstate_detect_phasecount(
 		 * tables should take care of this with converion routine and numeric
 		 * data type flags. */
 #define dstate_getinfo_nonzero(var, suffix) \
-		{ strncpy(bufrw_ptr, suffix, bufrw_max); \
+		do { strncpy(bufrw_ptr, suffix, bufrw_max); \
 		  if ( (var = dstate_getinfo(buf)) ) { \
 		    if ( (var[0] == '0' && var[1] == '\0') || \
 		         (var[0] == '\0') ) { \
 		      var = NULL; \
 		    } \
 		  } \
-		} ;
+		} while(0)
 
 		dstate_getinfo_nonzero(v1,  "L1.voltage");
 		dstate_getinfo_nonzero(v2,  "L2.voltage");

--- a/drivers/powercom.c
+++ b/drivers/powercom.c
@@ -391,8 +391,7 @@ static int ups_getinfo(void)
 			return 0;
 		} else
 			upsdebugx(5, "Num of bytes received from UPS: %d", c);
-
-	};
+	}
 
 	/* optional dump of raw data */
 	if (nut_debug_level > 4) {
@@ -400,15 +399,15 @@ static int ups_getinfo(void)
 		printf("Raw data from UPS:\n");
 		for (i = 0; i < types[type].num_of_bytes_from_ups; i++) {
 			printf("%2d 0x%02x (%c)\n", i, raw_data[i], raw_data[i]>=0x20 ? raw_data[i] : ' ');
-		};
-	};
+		}
+	}
 
 	/* validate raw data for correctness */
 	if (validate_raw_data() != 0) {
 		upslogx(LOG_NOTICE, "data receiving error (validation check)");
 		dstate_datastale();
 		return 0;
-	};
+	}
 	return 1;
 }
 
@@ -855,7 +854,7 @@ void upsdrv_initups(void)
 			exit (1);
 		}
 		type = i;
-	};
+	}
 
 	/* check line voltage from arguments */
 	if (getval("linevoltage") != NULL) {
@@ -863,9 +862,9 @@ void upsdrv_initups(void)
 		if (! ( (tmp >= 200 && tmp <= 240) || (tmp >= 100 && tmp <= 120) ) ) {
 			printf("Given line voltage '%d' is out of range (100-120 or 200-240 V)\n", tmp);
 			exit (1);
-		};
+		}
 		linevoltage = (unsigned int) tmp;
-	};
+	}
 
 	if (getval("numOfBytesFromUPS") != NULL) {
 		tmp = atoi(getval("numOfBytesFromUPS"));
@@ -873,7 +872,7 @@ void upsdrv_initups(void)
 			printf("Given numOfBytesFromUPS '%d' is out of range (1 to %d)\n",
 			       tmp, MAX_NUM_OF_BYTES_FROM_UPS);
 			exit (1);
-		};
+		}
 		types[type].num_of_bytes_from_ups = (unsigned char) tmp;
 	}
 
@@ -887,7 +886,7 @@ void upsdrv_initups(void)
 			printf("Given methodOfFlowControl '%s' isn't valid!\n",
 					getval("methodOfFlowControl"));
 			exit (1);
-		};
+		}
 		types[type].flowControl = types[i].flowControl;
 	}
 

--- a/drivers/riello.c
+++ b/drivers/riello.c
@@ -769,9 +769,9 @@ void riello_parse_sentr(uint8_t* buffer, TRielloData* data)
 		data->Uinp1 = buffer[35]*230/100;
 		data->Uinp2 = buffer[36]*230/100;
 		data->Uinp3 = buffer[37]*230/100;
-		data->Iinp1 = ((pom/690)*buffer[38])/100;;
-		data->Iinp2 = ((pom/690)*buffer[39])/100;;
-		data->Iinp3 = ((pom/690)*buffer[40])/100;;
+		data->Iinp1 = ((pom/690)*buffer[38])/100;
+		data->Iinp2 = ((pom/690)*buffer[39])/100;
+		data->Iinp3 = ((pom/690)*buffer[40])/100;
 		data->Finp = buffer[41]+256*buffer[42];
 
 		if (buffer[79] & 0x80) {

--- a/tools/nut-scanner/nutscan-device.c
+++ b/tools/nut-scanner/nutscan-device.c
@@ -77,7 +77,7 @@ static void deep_free_device(nutscan_device_t * device)
 		}
 
 		free(current);
-	};
+	}
 
 	if(device->prev) {
 		device->prev->next = device->next;

--- a/tools/nut-scanner/scan_avahi.c
+++ b/tools/nut-scanner/scan_avahi.c
@@ -532,6 +532,8 @@ fail:
 /* stub function */
 nutscan_device_t * nutscan_scan_avahi(long usec_timeout)
 {
+	NUT_UNUSED_VARIABLE(usec_timeout);
+
 	return NULL;
 }
 #endif /* WITH_AVAHI */

--- a/tools/nut-scanner/scan_ipmi.c
+++ b/tools/nut-scanner/scan_ipmi.c
@@ -610,6 +610,10 @@ nutscan_device_t * nutscan_scan_ipmi(const char * start_ip, const char * stop_ip
 /* stub function */
 nutscan_device_t *  nutscan_scan_ipmi(const char * startIP, const char * stopIP, nutscan_ipmi_t * sec)
 {
+	NUT_UNUSED_VARIABLE(startIP);
+	NUT_UNUSED_VARIABLE(stopIP);
+	NUT_UNUSED_VARIABLE(sec);
+
 	return NULL;
 }
 #endif /* WITH_IPMI */

--- a/tools/nut-scanner/scan_ipmi.c
+++ b/tools/nut-scanner/scan_ipmi.c
@@ -601,7 +601,7 @@ nutscan_device_t * nutscan_scan_ipmi(const char * start_ip, const char * stop_ip
 			}
 			/* Prepare the next iteration */
 			ip_str = nutscan_ip_iter_inc(&ip);
-		};
+		}
 	}
 
 	return nutscan_rewind_device(current_nut_dev);

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -757,10 +757,12 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 	return result;
 }
 #else /* WITH_SNMP */
-nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip,long usec_timeout, nutscan_snmp_t * sec)
+nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip, long usec_timeout, nutscan_snmp_t * sec)
 {
+	NUT_UNUSED_VARIABLE(start_ip);
+	NUT_UNUSED_VARIABLE(stop_ip);
+	NUT_UNUSED_VARIABLE(usec_timeout);
+	NUT_UNUSED_VARIABLE(sec);
 	return NULL;
 }
 #endif /* WITH_SNMP */
-
-

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -743,7 +743,7 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 		try_SysOID((void *)tmp_sec);
 #endif
 		ip_str = nutscan_ip_iter_inc(&ip);
-	};
+	}
 
 #ifdef HAVE_PTHREAD
 	for ( i=0; i < thread_count ; i++) {

--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -409,7 +409,7 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 /*				free(ip_str); */ /* One of these free()s seems to cause a double-free */
 				ip_str = nutscan_ip_iter_inc(&ip);
 /*				free(tmp_sec); */
-			};
+			}
 
 #ifdef HAVE_PTHREAD
 			if (thread_array != NULL) {

--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -449,6 +449,10 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 #else /* WITH_NEON */
 nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char * end_ip, long usec_timeout, nutscan_xml_t * sec)
 {
+	NUT_UNUSED_VARIABLE(start_ip);
+	NUT_UNUSED_VARIABLE(end_ip);
+	NUT_UNUSED_VARIABLE(usec_timeout);
+	NUT_UNUSED_VARIABLE(sec);
 	return NULL;
 }
 #endif /* WITH_NEON */


### PR DESCRIPTION
Follows up from #823, this PR is more of a syntactic sugar regarding "useless no-op statements" represented by a single extra semicolon being the end of empty statement.

Also some ifdef-ed build cases were found where variables introduced due to API were not actually used - those are now not complaining any more.