### PR TITLE
fightwarn - avoid variable-length arrays, their support became optional after C99

### DIFF
--- a/drivers/apcsmart.c
+++ b/drivers/apcsmart.c
@@ -662,12 +662,17 @@ static void apc_flush(int flags)
 /* apc specific wrappers around set/del info - to handle "packed" variables */
 static void apc_dstate_delinfo(apc_vartab_t *vt, int skip)
 {
-	char name[vt->nlen0], *nidx;
+	char *name, *nidx;
 	int c;
 
 	/* standard not packed var */
 	if (!(vt->flags & APC_PACK)) {
 		dstate_delinfo(vt->name);
+		return;
+	}
+
+	if ( !(name = xmalloc(sizeof(char) * vt->nlen0)) ) {
+		upslogx(LOG_ERR, "apc_dstate_delinfo() failed to allocate buffer");
 		return;
 	}
 
@@ -680,17 +685,29 @@ static void apc_dstate_delinfo(apc_vartab_t *vt, int skip)
 	}
 
 	vt->cnt = 0;
+	free(name);
 }
 
 static void apc_dstate_setinfo(apc_vartab_t *vt, const char *upsval)
 {
-	char name[vt->nlen0], *nidx;
-	char temp[strlen(upsval) + 1], *vidx[APC_PACK_MAX], *com, *curr;
+	char *name, *nidx;
+	char *temp, *vidx[APC_PACK_MAX], *com, *curr;
 	int c;
 
 	/* standard not packed var */
 	if (!(vt->flags & APC_PACK)) {
 		dstate_setinfo(vt->name, "%s", convert_data(vt, upsval));
+		return;
+	}
+
+	if ( !(name = xmalloc(sizeof(char) * vt->nlen0)) ) {
+		upslogx(LOG_ERR, "apc_dstate_setinfo() failed to allocate buffer");
+		return;
+	}
+
+	if ( !(temp = xmalloc(sizeof(char) * (strlen(upsval) + 1))) ) {
+		upslogx(LOG_ERR, "apc_dstate_setinfo() failed to allocate buffer");
+		free(name);
 		return;
 	}
 
@@ -734,6 +751,9 @@ static void apc_dstate_setinfo(apc_vartab_t *vt, const char *upsval)
 		else
 			dstate_setinfo(name, "N/A");
 	}
+
+	free(name);
+	free(temp);
 }
 
 static const char *preread_data(apc_vartab_t *vt)

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -2778,20 +2778,29 @@ static int	qx_process_answer(item_t *item, const int len)
 /* See header file for details. */
 int	qx_process(item_t *item, const char *command)
 {
-	char	buf[sizeof(item->answer) - 1] = "",
-		cmd[command ? (strlen(command) >= SMALLBUF ? strlen(command) + 1 : SMALLBUF) : (item->command && strlen(item->command) >= SMALLBUF ? strlen(item->command) + 1 : SMALLBUF)];
+	char	buf[sizeof(item->answer) - 1] = "", *cmd;
 	int	len;
+	size_t cmdlen = command ?
+		(strlen(command) >= SMALLBUF ? strlen(command) + 1 : SMALLBUF) :
+		(item->command && strlen(item->command) >= SMALLBUF ? strlen(item->command) + 1 : SMALLBUF);
+	size_t cmdsz = (sizeof(char) * cmdlen); /* in bytes, to be pedantic */
+
+	if ( !(cmd = xmalloc(cmdsz)) ) {
+		upslogx(LOG_ERR, "qx_process() failed to allocate buffer");
+		return -1;
+	}
 
 	/* Prepare the command to be used */
-	memset(cmd, 0, sizeof(cmd));
-	snprintf(cmd, sizeof(cmd), "%s", command ? command : item->command);
+	memset(cmd, 0, cmdsz);
+	snprintf(cmd, cmdsz, "%s", command ? command : item->command);
 
 	/* Preprocess the command */
 	if (
 		item->preprocess_command != NULL &&
-		item->preprocess_command(item, cmd, sizeof(cmd)) == -1
+		item->preprocess_command(item, cmd, cmdsz) == -1
 	) {
 		upsdebugx(4, "%s: failed to preprocess command [%s]", __func__, item->info_type);
+		free (cmd);
 		return -1;
 	}
 
@@ -2808,9 +2817,12 @@ int	qx_process(item_t *item, const char *command)
 			upsdebugx(4, "%s: failed to preprocess answer [%s]", __func__, item->info_type);
 			/* Clear answer, preventing it from being reused by next items with same command */
 			memset(item->answer, 0, sizeof(item->answer));
+			free (cmd);
 			return -1;
 		}
 	}
+
+	free (cmd);
 
 	/* Process the answer to get the value */
 	return qx_process_answer(item, len);

--- a/drivers/rhino.c
+++ b/drivers/rhino.c
@@ -470,7 +470,8 @@ static int
 send_command( int cmd )
 {
 	static const size_t sizes = 19, iend = 18;
-	int i, chk, checksum = 0, ret, kount; /*, j, uc; */
+	size_t i;
+	int chk, checksum = 0, ret, kount; /*, j, uc; */
 	unsigned char ch, *psend = NULL;
 
 	if ( !(psend = xmalloc(sizeof(char) * sizes)) ) {

--- a/drivers/rhino.c
+++ b/drivers/rhino.c
@@ -748,13 +748,16 @@ void upsdrv_shutdown(void)
 
 	if (!SourceFail)     /* on line */
 	{
+		/* FIXME: Both legs of the if-clause send CMD_SHUT, where is the "forcing"? */
 		printf("On line, forcing shutdown command...\n");
-		send_command( CMD_SHUT );
+		/* send_command( CMD_SHUT ); */
+		sendshut();
 	}
 	else
 	{
 		printf("On battery, sending normal shutdown command...\n");
-		send_command( CMD_SHUT );
+		/* send_command( CMD_SHUT ); */
+		sendshut();
 	}
 }
 

--- a/drivers/rhino.c
+++ b/drivers/rhino.c
@@ -469,8 +469,14 @@ CommReceive(const unsigned char *bufptr, int size)
 static int
 send_command( int cmd )
 {
-	int i, chk, checksum = 0, iend = 18, sizes = 19, ret, kount; /*, j, uc; */
-	unsigned char ch, psend[sizes];
+	static const size_t sizes = 19, iend = 18;
+	int i, chk, checksum = 0, ret, kount; /*, j, uc; */
+	unsigned char ch, *psend = NULL;
+
+	if ( !(psend = xmalloc(sizeof(char) * sizes)) ) {
+		upslogx(LOG_ERR, "send_command() failed to allocate buffer");
+		return -1;
+	}
 
 	/* mounting buffer to send */
 
@@ -510,6 +516,8 @@ send_command( int cmd )
 		usleep( UPSDELAY ); /* delay between sent command */
 		kount++;
 	}
+
+	free (psend);
 	return ret;
 }
 

--- a/drivers/rhino.c
+++ b/drivers/rhino.c
@@ -529,8 +529,10 @@ static void sendshut( void )
 	for(i=0; i < 30000; i++)
 		usleep( UPSDELAY ); /* 15 seconds delay */
 
-	send_command( CMD_SHUT );
-	upslogx(LOG_NOTICE, "Ups shutdown command sent");
+	if ( send_command( CMD_SHUT ) < 1 )
+		upslogx(LOG_ERR, "Ups shutdown command sending failed");
+	else
+		upslogx(LOG_NOTICE, "Ups shutdown command sent");
 	printf("Ups shutdown command sent\n");
 }
 

--- a/drivers/solis.c
+++ b/drivers/solis.c
@@ -682,7 +682,7 @@ static void get_base_info(void) {
 #else
 	const char DaysOfWeek[7][4]={"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
 #endif
-	unsigned char packet[packet_size], syncEOR;
+	unsigned char packet[PACKET_SIZE], syncEOR;
 	int i1=0, i2=0, tam, i;
 
 	time_t tmt;


### PR DESCRIPTION
Follows up from #823 / #844 efforts, this PR avoids initializing variable-length arrays in the code. In most cases it was changed to dynamic `xmalloc/free-before-return` handling. A couple of subsequent fixes for `rhino.c` also got here, which depend on these changes.

In the `solis.c` driver it was just replaced by the macro which (in header) initializes the unmodifiable (right?) typed variable:
````
#define PACKET_SIZE 25
static const int packet_size = PACKET_SIZE;
````