### PR TITLE
Use HID_ID to match devices instead of USB specific sysfs attributes

### DIFF
--- a/tools/nut-usbinfo.pl
+++ b/tools/nut-usbinfo.pl
@@ -108,7 +108,7 @@ sub gen_usb_files
 	# Udev file header
 	open my $outUdev, ">$outputUdev" || die "error $outputUdev : $!";
 	print $outUdev '# This file is generated and installed by the Network UPS Tools package.'."\n\n";
-	print $outUdev 'ACTION!="add|change", GOTO="nut-usbups_rules_end"'."\n";
+	print $outUdev 'ACTION=="remove", GOTO="nut-usbups_rules_end"'."\n";
 	print $outUdev 'SUBSYSTEM=="usb_device", GOTO="nut-usbups_rules_real"'."\n";
 	print $outUdev 'SUBSYSTEM=="usb", GOTO="nut-usbups_rules_real"'."\n";
 	print $outUdev 'SUBSYSTEM!="usb", GOTO="nut-usbups_rules_end"'."\n\n";

--- a/tools/nut-usbinfo.pl
+++ b/tools/nut-usbinfo.pl
@@ -111,6 +111,7 @@ sub gen_usb_files
 	print $outUdev 'ACTION=="remove", GOTO="nut-usbups_rules_end"'."\n";
 	print $outUdev 'SUBSYSTEM=="usb_device", GOTO="nut-usbups_rules_real"'."\n";
 	print $outUdev 'SUBSYSTEM=="usb", GOTO="nut-usbups_rules_real"'."\n";
+	print $outUdev 'SUBSYSTEM=="hid", GOTO="nut-usbups_rules_real"'."\n";
 	print $outUdev 'SUBSYSTEM!="usb", GOTO="nut-usbups_rules_end"'."\n\n";
 	print $outUdev 'LABEL="nut-usbups_rules_real"'."\n";
 
@@ -195,11 +196,11 @@ sub gen_usb_files
 					if ($vendorName{$vendorId}) {
 						$tmpOutputUPower = $tmpOutputUPower."\n# ".$vendorName{$vendorId}."\n";
 					}
-					print $outputUPower "ATTRS{idVendor}==\"".removeHexPrefix($vendorId)."\", ENV{UPOWER_VENDOR}=\"".$vendorName{$vendorId}."\"\n";
+					print $outputUPower "ENV{HID_ID}==\"*:0000".uc(removeHexPrefix($vendorId)).":*\", ENV{UPOWER_VENDOR}=\"".$vendorName{$vendorId}."\"\n";
 					$upowerMfrHeaderDone = 1;
 				}
-				$tmpOutputUPower = $tmpOutputUPower."ATTRS{idVendor}==\"".removeHexPrefix($vendorId);
-				$tmpOutputUPower = $tmpOutputUPower."\", ATTRS{idProduct}==\"".removeHexPrefix($productId)."\",";
+				$tmpOutputUPower = $tmpOutputUPower."ENV{HID_ID}==\"0003:0000".uc(removeHexPrefix($vendorId)).":";
+				$tmpOutputUPower = $tmpOutputUPower."0000".uc(removeHexPrefix($productId))."\",";
 				$tmpOutputUPower = $tmpOutputUPower.' ENV{UPOWER_BATTERY_TYPE}="ups"'."\n";
 			}
 

--- a/tools/nut-usbinfo.pl
+++ b/tools/nut-usbinfo.pl
@@ -112,7 +112,7 @@ sub gen_usb_files
 	print $outUdev 'SUBSYSTEM=="usb_device", GOTO="nut-usbups_rules_real"'."\n";
 	print $outUdev 'SUBSYSTEM=="usb", GOTO="nut-usbups_rules_real"'."\n";
 	print $outUdev 'SUBSYSTEM=="hid", GOTO="nut-usbups_rules_real"'."\n";
-	print $outUdev 'SUBSYSTEM!="usb", GOTO="nut-usbups_rules_end"'."\n\n";
+	print $outUdev 'GOTO="nut-usbups_rules_end"'."\n\n";
 	print $outUdev 'LABEL="nut-usbups_rules_real"'."\n";
 
 	open my $out_devd, ">$output_devd" || die "error $output_devd : $!";


### PR DESCRIPTION
This should make it possible to use `hid-recorder` and `hid-replay` to emulate UPSes.

See https://gitlab.freedesktop.org/libevdev/hid-tools/-/issues/25

@bentiss, does this look correct to you?

(I haven't tested this beyond checking that the generated files look correct)