### PR TITLE
Issue #823 follow-up: add explicitly x86 32-bit builds in Travis CI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -342,6 +342,11 @@ _matrix_linux_gnustd_nowarn:
         - *deps_driverlibs
 
 # Make sure we don't assume "long int" is a "int64_t" and so on
+# Seems we'd have to use tricks like 32-bit docker in 64-bit VM per
+#   https://stackoverflow.com/questions/29361465/request-for-32bit-travis-build-machine
+#   https://github.com/travis-ci/travis-ci/issues/5770#issuecomment-197771661
+#     services: docker
+#     script: "docker run -i -v \"${PWD}:/MyProgram\" toopher/centos-i386:centos6 /bin/bash -c \"linux32 --32bit i386 /MyProgram/build.sh\""
 _matrix_linux_gnustd_nowarn_x86_32bit:
   include: &_matrix_linux_gnustd_nowarn_x86_32bit
   - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn-x86-32bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99 -m32" CXXFLAGS="-std=gnu++99 -m32" CPPFLAGS="-m32"

--- a/.travis.yml
+++ b/.travis.yml
@@ -361,7 +361,9 @@ _matrix_linux_gnustd_nowarn_x86_32bit:
         packages:
         - *deps_driverlibs
         - gcc-multilib
-        - g++-multilib
+### Seems this one precludes builds against OpenSSL or Mozilla NSS
+### Needed for C++ build that we skip without C++11 anyway
+#        - g++-multilib
 
   - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn-x86-32bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17 -m32" CXXFLAGS="-std=gnu++17 -m32" CPPFLAGS="-m32" CC=clang-8 CXX=clang++-8
     os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -407,6 +407,8 @@ _matrix_linux_gnustd_nowarn_x86_32bit:
         - yes | sudo apt-get install -f
         - yes | sudo apt-get install -y --force-yes libperl5.22:i386
         - yes | sudo apt-get install -y --force-yes libsnmp-dev:i386
+        - yes | sudo apt-get remove -y --force-yes libfreetype6:amd64 || true
+        - yes | sudo apt-get remove -y --force-yes libltdl7:amd64 || true
 
   - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn-x86-32bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17 -m32" CXXFLAGS="-std=gnu++17 -m32" CPPFLAGS="-m32" LDFLAGS="-m32" CC=clang-8 CXX=clang++-8
     os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ addons:
     - libmodbus-dev
     - libnss3-dev
     - libssl-dev
+# NOTE: Keep the list above in sync with replicas like deps_driverlibs_cross_i386 below
 
 # Common settings for jobs in the matrix built below
 env:
@@ -352,24 +353,53 @@ _matrix_linux_gnustd_nowarn_x86_32bit:
   - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn-x86-32bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99 -m32" CXXFLAGS="-std=gnu++99 -m32" CPPFLAGS="-m32"
     os: linux
     arch: x86
-    sudo: false
+    sudo: true
+    before_install: sudo dpkg --add-architecture i386 && sudo apt-get update
     services:
         - docker
     compiler: gcc
     addons:
       apt:
-        packages:
-        - *deps_driverlibs
+        packages: &deps_driverlibs_cross_i386
+        - git
+        - ccache
         - gcc-multilib
-### Seems this one precludes builds against OpenSSL or Mozilla NSS
-### Needed for C++ build that we skip without C++11 anyway
-#        - g++-multilib
+        - g++-multilib
+        - libcppunit-dev:i386
+        - libcppunit-subunit-dev:i386
+        - libneon27:i386
+        - libneon27-dev:i386
+        - libltdl7:i386
+        - libltdl-dev:i386
+        #MISSING:i386? hdr only?# - libi2c-dev:i386
+        - libi2c-dev
+        - lua5.1:i386
+        - liblua5.1-0-dev:i386
+        - libsnmp-dev:i386
+        - libfreeipmi-dev:i386
+        - libipmimonitoring-dev:i386
+        - libusb-dev:i386
+        - linux-libc-dev:i386
+        - libpowerman0-dev:i386
+        - libavahi-common-dev:i386
+        - libavahi-core-dev:i386
+        - libavahi-client-dev:i386
+        - libgd2-xpm-dev:i386
+        - libpng-dev:i386
+        - libjpeg-dev:i386
+        - libfreetype6-dev:i386
+        - libxpm-dev:i386
+        - libxml2-utils:i386
+        - libmodbus-dev:i386
+        - libnss3-dev:i386
+        - libssl-dev:i386
 
   - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn-x86-32bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17 -m32" CXXFLAGS="-std=gnu++17 -m32" CPPFLAGS="-m32" CC=clang-8 CXX=clang++-8
     os: linux
     arch: x86
     dist: xenial
-    sudo: false
+    sudo: true
+    before_install: sudo dpkg --add-architecture i386 && sudo apt-get update
     services:
         - docker
     compiler: clang
@@ -380,9 +410,7 @@ _matrix_linux_gnustd_nowarn_x86_32bit:
         packages:
         - clang-8
         - clang-format-8
-        - g++-multilib
-        - gcc-multilib
-        - *deps_driverlibs
+        - *deps_driverlibs_cross_i386
 
 # Try s390x builds to check for issues with endianness
 # (it is one current Travis offer with BigEndian CPUs)

--- a/.travis.yml
+++ b/.travis.yml
@@ -350,7 +350,7 @@ _matrix_linux_gnustd_nowarn:
 #     script: "docker run -i -v \"${PWD}:/MyProgram\" toopher/centos-i386:centos6 /bin/bash -c \"linux32 --32bit i386 /MyProgram/build.sh\""
 _matrix_linux_gnustd_nowarn_x86_32bit:
   include: &_matrix_linux_gnustd_nowarn_x86_32bit
-  - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn-x86-32bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99 -m32" CXXFLAGS="-std=gnu++99 -m32" CPPFLAGS="-m32"
+  - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn-x86-32bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99 -m32" CXXFLAGS="-std=gnu++99 -m32" CPPFLAGS="-m32" LDFLAGS="-m32"
     os: linux
     arch: i386
     sudo: true
@@ -408,7 +408,7 @@ _matrix_linux_gnustd_nowarn_x86_32bit:
         - yes | sudo apt-get install -y --force-yes libperl5.22:i386
         - yes | sudo apt-get install -y --force-yes libsnmp-dev:i386
 
-  - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn-x86-32bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17 -m32" CXXFLAGS="-std=gnu++17 -m32" CPPFLAGS="-m32" CC=clang-8 CXX=clang++-8
+  - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn-x86-32bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17 -m32" CXXFLAGS="-std=gnu++17 -m32" CPPFLAGS="-m32" LDFLAGS="-m32" CC=clang-8 CXX=clang++-8
     os: linux
     arch: x86
     dist: xenial
@@ -1249,8 +1249,8 @@ jobs:
 #OK#  - env: NUT_MATRIX_TAG="gnu99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang-5.0 CXX=clang++-5.0
 #OK#  - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang-8 CXX=clang++-8
 #OK#  - env: NUT_MATRIX_TAG="gnu17-gcc-9-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++17" CC=gcc-9 CXX=g++-9
-  - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn-x86-32bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99 -m32" CXXFLAGS="-std=gnu++99 -m32" CPPFLAGS="-m32"
-  - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn-x86-32bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17 -m32" CXXFLAGS="-std=gnu++17 -m32" CPPFLAGS="-m32" CC=clang-8 CXX=clang++-8
+  - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn-x86-32bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99 -m32" CXXFLAGS="-std=gnu++99 -m32" CPPFLAGS="-m32" LDFLAGS="-m32"
+  - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn-x86-32bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17 -m32" CXXFLAGS="-std=gnu++17 -m32" CPPFLAGS="-m32" LDFLAGS="-m32" CC=clang-8 CXX=clang++-8
   - env: NUT_MATRIX_TAG="c99-clang-3.5-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang-3.5 CXX=clang++-3.5
   - env: NUT_MATRIX_TAG="c99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang-5.0 CXX=clang++-5.0
   - env: NUT_MATRIX_TAG="c11-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c11" CXXFLAGS="-std=c++11" CC=clang-5.0 CXX=clang++-5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -341,6 +341,38 @@ _matrix_linux_gnustd_nowarn:
         packages:
         - *deps_driverlibs
 
+# Make sure we don't assume "long int" is a "int64_t" and so on
+_matrix_linux_gnustd_nowarn_x86_32bit:
+  include: &_matrix_linux_gnustd_nowarn_x86_32bit
+  - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn-x86-32bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99 -m32" CXXFLAGS="-std=gnu++99 -m32" CPPFLAGS="-m32"
+    os: linux
+    arch: x86
+    sudo: false
+    services:
+        - docker
+    compiler: gcc
+    addons:
+      apt:
+        packages:
+        - *deps_driverlibs
+
+  - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn-x86-32bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17 -m32" CXXFLAGS="-std=gnu++17 -m32" CPPFLAGS="-m32" CC=clang-8 CXX=clang++-8
+    os: linux
+    arch: x86
+    dist: xenial
+    sudo: false
+    services:
+        - docker
+    compiler: clang
+    addons:
+      apt:
+        sources:
+        - llvm-toolchain-xenial-8
+        packages:
+        - clang-8
+        - clang-format-8
+        - *deps_driverlibs
+
 # Try s390x builds to check for issues with endianness
 # (it is one current Travis offer with BigEndian CPUs)
 _matrix_linux_gnustd_nowarn_s390x_64bit_viable:
@@ -979,6 +1011,7 @@ _matrix_required_linux:
   - *_matrix_required_linux_pass3_large
   - *_matrix_linux_gnustd_nowarn
   - *_matrix_linux_gnustd_warn_viable
+  - *_matrix_linux_gnustd_nowarn_x86_32bit
   - *_matrix_linux_gnustd_nowarn_arm_64bit_viable
   - *_matrix_linux_gnustd_nowarn_s390x_64bit_viable
 
@@ -1081,6 +1114,7 @@ _matrix_gnustd_nowarn:
   - *_matrix_linux_gnustd_nowarn
   - *_matrix_freebsd_gnustd_nowarn
 #  -*_matrix_windows_gnustd_nowarn
+  - *_matrix_linux_gnustd_nowarn_x86_32bit
   - *_matrix_linux_gnustd_nowarn_arm_64bit_viable
   - *_matrix_linux_gnustd_nowarn_arm_64bit_fatal
   - *_matrix_linux_gnustd_nowarn_s390x_64bit_viable
@@ -1156,6 +1190,8 @@ jobs:
 #OK#  - env: NUT_MATRIX_TAG="gnu99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang-5.0 CXX=clang++-5.0
 #OK#  - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang-8 CXX=clang++-8
 #OK#  - env: NUT_MATRIX_TAG="gnu17-gcc-9-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++17" CC=gcc-9 CXX=g++-9
+  - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn-x86-32bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99 -m32" CXXFLAGS="-std=gnu++99 -m32" CPPFLAGS="-m32"
+  - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn-x86-32bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17 -m32" CXXFLAGS="-std=gnu++17 -m32" CPPFLAGS="-m32" CC=clang-8 CXX=clang++-8
   - env: NUT_MATRIX_TAG="c99-clang-3.5-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang-3.5 CXX=clang++-3.5
   - env: NUT_MATRIX_TAG="c99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang-5.0 CXX=clang++-5.0
   - env: NUT_MATRIX_TAG="c11-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c11" CXXFLAGS="-std=c++11" CC=clang-5.0 CXX=clang++-5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -352,9 +352,15 @@ _matrix_linux_gnustd_nowarn_x86_32bit:
   include: &_matrix_linux_gnustd_nowarn_x86_32bit
   - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn-x86-32bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99 -m32" CXXFLAGS="-std=gnu++99 -m32" CPPFLAGS="-m32"
     os: linux
-    arch: x86
+    arch: i386
     sudo: true
-    before_install: sudo dpkg --add-architecture i386 && sudo apt-get update
+        # Perl is packaged poorly for multiarch, across several distro releases:
+        # https://bugs.launchpad.net/ubuntu/+source/pkgbinarymangler/+bug/1574351
+        # NOTE: According to https://docs.travis-ci.com/user/job-lifecycle/ the
+        # before_install phase happens AFTER addons/apt processing! So we install
+        # that big list first (except pkg's that pull perl) and add them later.
+#    before_install:
+#        - sudo dpkg --add-architecture i386 && sudo apt-get update ; yes | sudo apt-get install -y --force-yes libperl5.22:i386 || true ; sudo rm -f /usr/share/doc/libperl5.22/changelog.Debian.gz ; yes | sudo apt-get install -y --force-yes libperl5.22
     services:
         - docker
     compiler: gcc
@@ -375,7 +381,7 @@ _matrix_linux_gnustd_nowarn_x86_32bit:
         - libi2c-dev
         - lua5.1:i386
         - liblua5.1-0-dev:i386
-        - libsnmp-dev:i386
+        #PULLSPERL# - libsnmp-dev:i386
         - libfreeipmi-dev:i386
         - libipmimonitoring-dev:i386
         - libusb-dev:i386
@@ -393,13 +399,27 @@ _matrix_linux_gnustd_nowarn_x86_32bit:
         - libmodbus-dev:i386
         - libnss3-dev:i386
         - libssl-dev:i386
+    # See comments above about perl
+    before_install: &before_install_x86_32bit
+        - sudo dpkg --add-architecture i386 && sudo apt-get update
+        - yes | sudo apt-get install -y --force-yes libperl5.22 || true
+        - sudo rm -f /usr/share/doc/libperl5.22/changelog.Debian.gz
+        - yes | sudo apt-get install -f
+        - yes | sudo apt-get install -y --force-yes libperl5.22:i386
+        - yes | sudo apt-get install -y --force-yes libsnmp-dev:i386
 
   - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn-x86-32bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17 -m32" CXXFLAGS="-std=gnu++17 -m32" CPPFLAGS="-m32" CC=clang-8 CXX=clang++-8
     os: linux
     arch: x86
     dist: xenial
     sudo: true
-    before_install: sudo dpkg --add-architecture i386 && sudo apt-get update
+    before_install:
+        - *before_install_x86_32bit
+#        - sudo dpkg --add-architecture i386 && sudo apt-get update
+#        - yes | sudo apt-get install -y --force-yes libperl5.22 || true
+#        - sudo rm -f /usr/share/doc/libperl5.22/changelog.Debian.gz
+#        - sudo apt-get install -f
+#        - yes | apt-get install -y --force-yes libperl5.22:i386
     services:
         - docker
     compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -360,6 +360,8 @@ _matrix_linux_gnustd_nowarn_x86_32bit:
       apt:
         packages:
         - *deps_driverlibs
+        - gcc-multilib
+        - g++-multilib
 
   - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn-x86-32bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17 -m32" CXXFLAGS="-std=gnu++17 -m32" CPPFLAGS="-m32" CC=clang-8 CXX=clang++-8
     os: linux
@@ -377,6 +379,8 @@ _matrix_linux_gnustd_nowarn_x86_32bit:
         - clang-8
         - clang-format-8
         - *deps_driverlibs
+        - gcc-multilib
+        - g++-multilib
 
 # Try s390x builds to check for issues with endianness
 # (it is one current Travis offer with BigEndian CPUs)

--- a/.travis.yml
+++ b/.travis.yml
@@ -380,9 +380,9 @@ _matrix_linux_gnustd_nowarn_x86_32bit:
         packages:
         - clang-8
         - clang-format-8
-        - *deps_driverlibs
-        - gcc-multilib
         - g++-multilib
+        - gcc-multilib
+        - *deps_driverlibs
 
 # Try s390x builds to check for issues with endianness
 # (it is one current Travis offer with BigEndian CPUs)

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -203,7 +203,15 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
             if [[ "$TRAVIS_OS_NAME" != "windows" ]] && [[ "$TRAVIS_OS_NAME" != "freebsd" ]] ; then
                 # Currently --with-all implies this, but better be sure to
                 # really build everything we can to be certain it builds:
-                CONFIG_OPTS+=("--with-cgi=yes")
+                if pkg-config --exists libgd ; then
+                    CONFIG_OPTS+=("--with-cgi=yes")
+                else
+                    # Note: CI-wise, our goal IS to test as much as we can
+                    # with this build, so environments should be set up to
+                    # facilitate that as much as feasible. But reality is...
+                    echo "WARNING: Seems libgd is not present, CGI build may be skipped!" >&2
+                    CONFIG_OPTS+=("--with-cgi=auto")
+                fi
             else
                 # No prereq dll and headers on win so far
                 CONFIG_OPTS+=("--with-cgi=auto")

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -203,13 +203,13 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
             if [[ "$TRAVIS_OS_NAME" != "windows" ]] && [[ "$TRAVIS_OS_NAME" != "freebsd" ]] ; then
                 # Currently --with-all implies this, but better be sure to
                 # really build everything we can to be certain it builds:
-                if pkg-config --exists libgd ; then
+                if pkg-config --exists libgd || pkg-config --exists libgd2 || pkg-config --exists libgd3 ; then
                     CONFIG_OPTS+=("--with-cgi=yes")
                 else
                     # Note: CI-wise, our goal IS to test as much as we can
                     # with this build, so environments should be set up to
                     # facilitate that as much as feasible. But reality is...
-                    echo "WARNING: Seems libgd is not present, CGI build may be skipped!" >&2
+                    echo "WARNING: Seems libgd{,2,3} is not present, CGI build may be skipped!" >&2
                     CONFIG_OPTS+=("--with-cgi=auto")
                 fi
             else


### PR DESCRIPTION
Picks up the torch from #901 and #911 to bring yet more tested platforms to CI of NUT. It took some effort to set up a 32-bit (i386) environment inside the 64-bit Xenial, in a way that all needed packages are present and linker would not try to mix different-bitness binaries. Probably this ordeal could be solved more cleanly, future improvements are not ruled out. But, this contraption "as is" works and passes the builds.