### PR TITLE
Fightwarn - do not shadow global varname with same-named func argument

### DIFF
--- a/clients/upsset.c
+++ b/clients/upsset.c
@@ -764,11 +764,11 @@ static void do_type(const char *varname)
 	}
 }
 
-static void print_rw(const char *upsname, const char *varname)
+static void print_rw(const char *arg_upsname, const char *varname)
 {
 	const	char	*tmp;
 
-	printf("<!-- <TR><TD>Device</TD><TD>%s</TD></TR> -->\n", upsname);
+	printf("<!-- <TR><TD>Device</TD><TD>%s</TD></TR> -->\n", arg_upsname);
 
 	printf("<TR BGCOLOR=\"#60B0B0\" ALIGN=\"CENTER\">\n");
 

--- a/drivers/dummy-ups.c
+++ b/drivers/dummy-ups.c
@@ -427,13 +427,13 @@ static void upsconf_err(const char *errmsg)
 /* for dummy mode
  * parse the definition file and process its content
  */
-static int parse_data_file(int upsfd)
+static int parse_data_file(int arg_upsfd)
 {
 	char	fn[SMALLBUF];
 	char	*ptr, var_value[MAX_STRING_SIZE];
 	int		value_args = 0, counter;
 	time_t	now;
-	NUT_UNUSED_VARIABLE(upsfd);
+	NUT_UNUSED_VARIABLE(arg_upsfd);
 
 	time(&now);
 

--- a/drivers/libhid.c
+++ b/drivers/libhid.c
@@ -90,13 +90,13 @@ void free_report_buffer(reportbuf_t *rbuf)
 /* allocate a new report buffer. Return pointer on success, else NULL
    with errno set. The returned data structure must later be freed
    with free_report_buffer(). */
-reportbuf_t *new_report_buffer(HIDDesc_t *pDesc)
+reportbuf_t *new_report_buffer(HIDDesc_t *arg_pDesc)
 {
 	HIDData_t	*pData;
 	reportbuf_t	*rbuf;
 	int		i, id;
 
-	if (!pDesc)
+	if (!arg_pDesc)
 		return NULL;
 
 	rbuf = calloc(1, sizeof(*rbuf));
@@ -105,9 +105,9 @@ reportbuf_t *new_report_buffer(HIDDesc_t *pDesc)
 	}
 
 	/* now go through all items that are part of this report */
-	for (i=0; i<pDesc->nitems; i++) {
+	for (i=0; i<arg_pDesc->nitems; i++) {
 
-		pData = &pDesc->item[i];
+		pData = &arg_pDesc->item[i];
 
 		id = pData->ReportID;
 
@@ -116,7 +116,7 @@ reportbuf_t *new_report_buffer(HIDDesc_t *pDesc)
 			continue;
 
 		/* first byte holds id */
-		rbuf->len[id] = pDesc->replen[id] + 1;
+		rbuf->len[id] = arg_pDesc->replen[id] + 1;
 
 		/* skip zero length reports */
 		if (rbuf->len[id] < 1) {

--- a/drivers/libshut.c
+++ b/drivers/libshut.c
@@ -291,8 +291,8 @@ static void align_request(struct shut_ctrltransfer_s *ctrl)
  * information. This callback should return a value > 0 if the device
  * is accepted, or < 1 if not.
  */
-static int libshut_open(int *upsfd, SHUTDevice_t *curDevice, char *device_path,
-                 int (*callback)(int upsfd, SHUTDevice_t *hd,
+static int libshut_open(int *arg_upsfd, SHUTDevice_t *curDevice, char *arg_device_path,
+                 int (*callback)(int arg_upsfd, SHUTDevice_t *hd,
                  unsigned char *rdbuf, int rdlen))
 {
 	int ret, res;
@@ -309,21 +309,21 @@ static int libshut_open(int *upsfd, SHUTDevice_t *curDevice, char *device_path,
 	 * version is at index 1 (in which case, bcdDevice == 0x0202) */
 	int hid_desc_index = 0;
 
-	upsdebugx(2, "libshut_open: using port %s", device_path);
+	upsdebugx(2, "libshut_open: using port %s", arg_device_path);
 
 	/* If device is still open, close it */
-	if (*upsfd > 0) {
-		ser_close(*upsfd, device_path);
+	if (*arg_upsfd > 0) {
+		ser_close(*arg_upsfd, arg_device_path);
 	}
 
 	/* initialize serial port */
 	/* FIXME: add variable baudrate detection */
-	*upsfd = ser_open(device_path);
-	ser_set_speed(*upsfd, device_path, B2400);
-	setline(*upsfd, 1);
+	*arg_upsfd = ser_open(arg_device_path);
+	ser_set_speed(*arg_upsfd, arg_device_path, B2400);
+	setline(*arg_upsfd, 1);
 
 	/* initialise communication */
-	if (!shut_synchronise(*upsfd))
+	if (!shut_synchronise(*arg_upsfd))
 	{
 		upsdebugx(2, "No communication with UPS");
 		return -1;
@@ -338,7 +338,7 @@ static int libshut_open(int *upsfd, SHUTDevice_t *curDevice, char *device_path,
 
 	/* Get DEVICE descriptor */
 	dev_descriptor = (struct device_descriptor_s *)buf;
-	res = shut_get_descriptor(*upsfd, USB_DT_DEVICE, 0, buf, USB_DT_DEVICE_SIZE);
+	res = shut_get_descriptor(*arg_upsfd, USB_DT_DEVICE, 0, buf, USB_DT_DEVICE_SIZE);
 	/* res = shut_control_msg(devp, USB_ENDPOINT_IN+1, USB_REQ_GET_DESCRIPTOR,
 	(USB_DT_DEVICE << 8) + 0, 0, buf, 0x9, SHUT_TIMEOUT); */
 	if (res < 0)
@@ -372,7 +372,7 @@ static int libshut_open(int *upsfd, SHUTDevice_t *curDevice, char *device_path,
 	curDevice->bcdDevice = dev_descriptor->bcdDevice;
 	curDevice->Vendor = strdup("Eaton");
 	if (dev_descriptor->iManufacturer) {
-		ret = shut_get_string_simple(*upsfd, dev_descriptor->iManufacturer,
+		ret = shut_get_string_simple(*arg_upsfd, dev_descriptor->iManufacturer,
 			string, MAX_STRING_SIZE);
 		if (ret > 0) {
 			curDevice->Vendor = strdup(string);
@@ -381,7 +381,7 @@ static int libshut_open(int *upsfd, SHUTDevice_t *curDevice, char *device_path,
 
 	/* ensure iProduct retrieval */
 	if (dev_descriptor->iProduct) {
-		ret = shut_get_string_simple(*upsfd, dev_descriptor->iProduct, string, MAX_STRING_SIZE);
+		ret = shut_get_string_simple(*arg_upsfd, dev_descriptor->iProduct, string, MAX_STRING_SIZE);
 	} else {
 		ret = 0;
 	}
@@ -392,7 +392,7 @@ static int libshut_open(int *upsfd, SHUTDevice_t *curDevice, char *device_path,
 	}
 
 	if (dev_descriptor->iSerialNumber) {
-		ret = shut_get_string_simple(*upsfd, dev_descriptor->iSerialNumber, string, 0x25);
+		ret = shut_get_string_simple(*arg_upsfd, dev_descriptor->iSerialNumber, string, 0x25);
 	} else {
 		ret = 0;
 	}
@@ -419,7 +419,7 @@ static int libshut_open(int *upsfd, SHUTDevice_t *curDevice, char *device_path,
 
 	/* Get HID descriptor */
 	desc = (struct my_hid_descriptor *)buf;
-	res = shut_get_descriptor(*upsfd, USB_DT_HID, hid_desc_index, buf, 0x9);
+	res = shut_get_descriptor(*arg_upsfd, USB_DT_HID, hid_desc_index, buf, 0x9);
 	/* res = shut_control_msg(devp, USB_ENDPOINT_IN+1, USB_REQ_GET_DESCRIPTOR,
 			(USB_DT_HID << 8) + 0, 0, buf, 0x9, SHUT_TIMEOUT); */
 
@@ -454,13 +454,13 @@ static int libshut_open(int *upsfd, SHUTDevice_t *curDevice, char *device_path,
 	}
 
 	/* Get REPORT descriptor */
-	res = shut_get_descriptor(*upsfd, USB_DT_REPORT, hid_desc_index, rdbuf, rdlen);
+	res = shut_get_descriptor(*arg_upsfd, USB_DT_REPORT, hid_desc_index, rdbuf, rdlen);
 	/* res = shut_control_msg(devp, USB_ENDPOINT_IN+1, USB_REQ_GET_DESCRIPTOR,
 				(USB_DT_REPORT << 8) + 0, 0, ReportDesc,
 			desc->wDescriptorLength, SHUT_TIMEOUT); */
 	if (res == rdlen)
 	{
-		res = callback(*upsfd, curDevice, rdbuf, rdlen);
+		res = callback(*arg_upsfd, curDevice, rdbuf, rdlen);
 		if (res < 1) {
 			upsdebugx(2, "Caller doesn't like this device");
 			return -1;
@@ -488,28 +488,28 @@ static int libshut_open(int *upsfd, SHUTDevice_t *curDevice, char *device_path,
 	return -1;
 }
 
-static void libshut_close(int upsfd)
+static void libshut_close(int arg_upsfd)
 {
-	if (upsfd < 1) {
+	if (arg_upsfd < 1) {
 		return;
 	}
 
-	ser_close(upsfd, NULL);
+	ser_close(arg_upsfd, NULL);
 }
 
 /* return the report of ID=type in report
  * return -1 on failure, report length on success
  */
-static int libshut_get_report(int upsfd, int ReportId,
+static int libshut_get_report(int arg_upsfd, int ReportId,
                        unsigned char *raw_buf, int ReportSize )
 {
-	if (upsfd < 1) {
+	if (arg_upsfd < 1) {
 		return 0;
 	}
 
 	upsdebugx(4, "Entering libshut_get_report");
 
-	return shut_control_msg(upsfd,
+	return shut_control_msg(arg_upsfd,
 		REQUEST_TYPE_GET_REPORT,
 		/* == USB_ENDPOINT_IN + USB_TYPE_CLASS + USB_RECIP_INTERFACE, */
 		 0x01,
@@ -518,12 +518,12 @@ static int libshut_get_report(int upsfd, int ReportId,
 }
 
 /* return ReportSize upon success ; -1 otherwise */
-static int libshut_set_report(int upsfd, int ReportId,
+static int libshut_set_report(int arg_upsfd, int ReportId,
                        unsigned char *raw_buf, int ReportSize )
 {
 	int ret;
 
-	if (upsfd < 1) {
+	if (arg_upsfd < 1) {
 		return 0;
 	}
 
@@ -532,7 +532,7 @@ static int libshut_set_report(int upsfd, int ReportId,
 
 	upsdebug_hex (4, "==> Report after set", raw_buf, ReportSize);
 
-	ret = shut_control_msg(upsfd,
+	ret = shut_control_msg(arg_upsfd,
 		REQUEST_TYPE_SET_REPORT,
 		/* == USB_ENDPOINT_OUT + USB_TYPE_CLASS + USB_RECIP_INTERFACE, */
 		0x09,
@@ -542,15 +542,15 @@ static int libshut_set_report(int upsfd, int ReportId,
 	return ((ret == 0) ? ReportSize : ret);
 }
 
-static int libshut_get_string(int upsfd, int StringIdx, char *buf, size_t buflen)
+static int libshut_get_string(int arg_upsfd, int StringIdx, char *buf, size_t buflen)
 {
 	int ret;
 
-	if (upsfd < 1) {
+	if (arg_upsfd < 1) {
 		return -1;
 	}
 
-	ret = shut_get_string_simple(upsfd, StringIdx, buf, buflen);
+	ret = shut_get_string_simple(arg_upsfd, StringIdx, buf, buflen);
 	if (ret > 0)
 		upsdebugx(2, "-> String: %s (len = %i/%i)", buf, ret, (int)buflen);
 	else
@@ -559,17 +559,17 @@ static int libshut_get_string(int upsfd, int StringIdx, char *buf, size_t buflen
 	return ret;
 }
 
-static int libshut_get_interrupt(int upsfd, unsigned char *buf,
+static int libshut_get_interrupt(int arg_upsfd, unsigned char *buf,
                           int bufsize, int timeout)
 {
 	int ret;
 
-	if (upsfd < 1) {
+	if (arg_upsfd < 1) {
 		return -1;
 	}
 
 	/* FIXME: hardcoded interrupt EP => need to get EP descr for IF descr */
-	ret = shut_interrupt_read(upsfd, 0x81, buf, bufsize, timeout);
+	ret = shut_interrupt_read(arg_upsfd, 0x81, buf, bufsize, timeout);
 	if (ret > 0)
 		upsdebugx(6, " ok");
 	else
@@ -599,20 +599,20 @@ shut_communication_subdriver_t shut_subdriver = {
  * set : 1 to set comm
  * set : 0 to stop commupsh.
  */
-void setline(int upsfd, int set)
+void setline(int arg_upsfd, int set)
 {
-	if (upsfd < 1) {
+	if (arg_upsfd < 1) {
 		return;
 	}
 
 	upsdebugx(3, "entering setline(%i)", set);
 
 	if (set == 1) {
-		ser_set_dtr(upsfd, 0);
-		ser_set_rts(upsfd, 1);
+		ser_set_dtr(arg_upsfd, 0);
+		ser_set_rts(arg_upsfd, 1);
 	} else {
-		ser_set_dtr(upsfd, 1);
-		ser_set_rts(upsfd, 0);
+		ser_set_dtr(arg_upsfd, 1);
+		ser_set_rts(arg_upsfd, 0);
 	}
 }
 
@@ -624,7 +624,7 @@ void setline(int upsfd, int set)
  * return TRUE on success, FALSE on failure
  *
  *****************************************************************************/
-int shut_synchronise(int upsfd)
+int shut_synchronise(int arg_upsfd)
 {
 	int retCode = 0;
 	unsigned char c = SHUT_SYNC_OFF, reply;
@@ -654,13 +654,13 @@ int shut_synchronise(int upsfd)
 	{
 		upsdebugx (3, "Syncing communication (try %i)", try);
 
-		if ((ser_send_char(upsfd, c)) == -1)
+		if ((ser_send_char(arg_upsfd, c)) == -1)
 		{
 			upsdebugx (3, "Communication error while writing to port");
 			continue;
 		}
 
-		ser_get_char(upsfd, &reply, 1, 0);
+		ser_get_char(arg_upsfd, &reply, 1, 0);
 		if (reply == c)
 		{
 			upsdebugx (3, "Syncing and notification setting done");
@@ -686,7 +686,7 @@ static unsigned char shut_checksum(const unsigned char *buf, int bufsize)
 }
 
 
-static int shut_packet_recv(int upsfd, unsigned char *Buf, int datalen)
+static int shut_packet_recv(int arg_upsfd, unsigned char *Buf, int datalen)
 {
 	unsigned char   Start[2];
 	unsigned char   Frame[8];
@@ -703,7 +703,7 @@ static int shut_packet_recv(int upsfd, unsigned char *Buf, int datalen)
 	while(datalen>0 && Retry<3)
 	{
 		/* if(serial_read (SHUT_TIMEOUT, &Start[0]) > 0) */
-		if(ser_get_char(upsfd, &Start[0], SHUT_TIMEOUT/1000, 0) > 0)
+		if(ser_get_char(arg_upsfd, &Start[0], SHUT_TIMEOUT/1000, 0) > 0)
 		{
 			/* sdata.shut_pkt.bType = Start[0]; */
 			if(Start[0]==SHUT_SYNC)
@@ -721,14 +721,14 @@ static int shut_packet_recv(int upsfd, unsigned char *Buf, int datalen)
 			else
 			{
 				/* if((serial_read (SHUT_TIMEOUT, &Start[1]) > 0) && */
-				if( (ser_get_char(upsfd, &Start[1], SHUT_TIMEOUT/1000, 0) > 0) &&
+				if( (ser_get_char(arg_upsfd, &Start[1], SHUT_TIMEOUT/1000, 0) > 0) &&
 							((Start[1]>>4)==(Start[1]&0x0F)))
 				{
 					upsdebug_hex(4, "Receive", Start, 2);
 					Size=Start[1]&0x0F;
 					if( Size > 8 ) {
 						upsdebugx (4, "shut_packet_recv: invalid frame size = %d", Size);
-						ser_send_char(upsfd, SHUT_NOK);
+						ser_send_char(arg_upsfd, SHUT_NOK);
 						Retry++;
 						break;
 					}
@@ -736,13 +736,13 @@ static int shut_packet_recv(int upsfd, unsigned char *Buf, int datalen)
 					for(recv=0;recv<Size;recv++)
 					{
 						/* if(serial_read (SHUT_TIMEOUT, &Frame[recv]) < 1) */
-						if(ser_get_char(upsfd, &Frame[recv], SHUT_TIMEOUT/1000, 0) < 1)
+						if(ser_get_char(arg_upsfd, &Frame[recv], SHUT_TIMEOUT/1000, 0) < 1)
 							break;
 					}
 					upsdebug_hex(4, "Receive", Frame, Size);
 
 					/* serial_read (SHUT_TIMEOUT, &Chk[0]); */
-					ser_get_char(upsfd, &Chk[0], SHUT_TIMEOUT/1000, 0);
+					ser_get_char(arg_upsfd, &Chk[0], SHUT_TIMEOUT/1000, 0);
 					if(Chk[0]==shut_checksum(Frame, Size))
 					{
 						upsdebugx (4, "shut_checksum: %02x => OK", Chk[0]);
@@ -752,7 +752,7 @@ static int shut_packet_recv(int upsfd, unsigned char *Buf, int datalen)
 						Pos+=Size;
 						Retry=0;
 
-						ser_send_char(upsfd, SHUT_OK);
+						ser_send_char(arg_upsfd, SHUT_OK);
 						/* shut_token_send(SHUT_OK); */
 
 						/* Check if there are more data to receive */
@@ -775,7 +775,7 @@ static int shut_packet_recv(int upsfd, unsigned char *Buf, int datalen)
 					else
 					{
 						upsdebugx (4, "shut_checksum: %02x => NOK", Chk[0]);
-						ser_send_char(upsfd, SHUT_NOK);
+						ser_send_char(arg_upsfd, SHUT_NOK);
 						/* shut_token_send(SHUT_NOK); */
 						Retry++;
 					}
@@ -792,14 +792,14 @@ static int shut_packet_recv(int upsfd, unsigned char *Buf, int datalen)
 }
 
 /**********************************************************************/
-static int shut_interrupt_read(int upsfd, int ep, unsigned char *bytes, int size,
+static int shut_interrupt_read(int arg_upsfd, int ep, unsigned char *bytes, int size,
                         int timeout)
 {
 /*
 	usleep(timeout * 1000);
 */
 	/* FIXME: to be written */
-	NUT_UNUSED_VARIABLE(upsfd);
+	NUT_UNUSED_VARIABLE(arg_upsfd);
 	NUT_UNUSED_VARIABLE(ep);
 	NUT_UNUSED_VARIABLE(bytes);
 	NUT_UNUSED_VARIABLE(size);
@@ -808,13 +808,13 @@ static int shut_interrupt_read(int upsfd, int ep, unsigned char *bytes, int size
 }
 
 /**********************************************************************/
-static int shut_get_string_simple(int upsfd, int index,
+static int shut_get_string_simple(int arg_upsfd, int index,
                            char *buf, size_t buflen)
 {
 	unsigned char tbuf[255];       /* Some devices choke on size > 255 */
 	int ret, si, di;
 
-	ret = shut_control_msg(upsfd, USB_ENDPOINT_IN, USB_REQ_GET_DESCRIPTOR,
+	ret = shut_control_msg(arg_upsfd, USB_ENDPOINT_IN, USB_REQ_GET_DESCRIPTOR,
 			(USB_DT_STRING << 8) + index, 0x0, tbuf, buflen, SHUT_TIMEOUT);
 	if (ret < 0)
 		return ret;
@@ -856,19 +856,19 @@ static int shut_get_string_simple(int upsfd, int index,
  * return 0 on success, -1 on failure, -2 on NACK
  *
  *********************************************************************/
-static int shut_get_descriptor(int upsfd, unsigned char type,
+static int shut_get_descriptor(int arg_upsfd, unsigned char type,
                         unsigned char index, void *buf, int size)
 {
 	memset(buf, 0, size);
 
 	upsdebugx (2, "entering shut_get_descriptor(n %02x, %i)", type, size);
 
-	return shut_control_msg(upsfd, USB_ENDPOINT_IN+(type>=USB_DT_HID?1:0),
+	return shut_control_msg(arg_upsfd, USB_ENDPOINT_IN+(type>=USB_DT_HID?1:0),
 				 USB_REQ_GET_DESCRIPTOR, (type << 8) + index, 0, buf, size, SHUT_TIMEOUT);
 }
 
 /* Take care of a SHUT transfer (sending and receiving data) */
-static int shut_control_msg(int upsfd, int requesttype, int request,
+static int shut_control_msg(int arg_upsfd, int requesttype, int request,
                      int value, int index, unsigned char *bytes, int size, int timeout)
 {
 	unsigned char shut_pkt[11];
@@ -930,12 +930,12 @@ static int shut_control_msg(int upsfd, int requesttype, int request,
 		* NACK handling should take care of the rest */
 		if (Retry == 1)
 		{
-			ser_send_buf(upsfd, shut_pkt, data_size+3);
+			ser_send_buf(arg_upsfd, shut_pkt, data_size+3);
 			upsdebug_hex(3, "shut_control_msg", shut_pkt, data_size+3);
 			/* serial_send (shut_pkt, data_size+3); */
 		}
 
-		i = shut_wait_ack (upsfd);
+		i = shut_wait_ack (arg_upsfd);
 		switch (i)
 		{
 			case 0:
@@ -953,14 +953,14 @@ static int shut_control_msg(int upsfd, int requesttype, int request,
 
 					/* try to resync, and give one more try */
 					Retry--;
-					shut_synchronise(upsfd);
+					shut_synchronise(arg_upsfd);
 					return i;
 				}
 				else
 				{
 					upsdebugx(4, "Retry = %i", Retry);
 					/* Send a NACK to get a resend from the UPS */
-					ser_send_char(upsfd, SHUT_NOK);
+					ser_send_char(arg_upsfd, SHUT_NOK);
 					Retry++;
 				}
 				break;
@@ -968,7 +968,7 @@ static int shut_control_msg(int upsfd, int requesttype, int request,
 				/* FIXME: notification caught => to be processed */
 
 				/* Send a NACK for the moment, to get a resend from the UPS */
-				ser_send_char(upsfd, SHUT_NOK);
+				ser_send_char(arg_upsfd, SHUT_NOK);
 				Retry++;
 			default:
 				;
@@ -979,7 +979,7 @@ static int shut_control_msg(int upsfd, int requesttype, int request,
 
 	/* now receive data, except for SET_REPORT */
 	if (requesttype != REQUEST_TYPE_SET_REPORT)
-		ret = shut_packet_recv (upsfd, bytes, size);
+		ret = shut_packet_recv (arg_upsfd, bytes, size);
 
 	return ret;
 }
@@ -992,12 +992,12 @@ static int shut_control_msg(int upsfd, int requesttype, int request,
  * returns 0 on success, -1 on error, -2 on NACK, -3 on NOTIFICATION
  *
  *********************************************************************/
-int shut_wait_ack(int upsfd)
+int shut_wait_ack(int arg_upsfd)
 {
 	int retCode = -1;
 	unsigned char c = '\0';
 
-	ser_get_char(upsfd, &c, SHUT_TIMEOUT/1000, 0);
+	ser_get_char(arg_upsfd, &c, SHUT_TIMEOUT/1000, 0);
 	if (c == SHUT_OK)
 	{
 		upsdebugx (2, "shut_wait_ack(): ACK received");

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -2705,9 +2705,9 @@ bool_t su_ups_get(snmp_info_t *su_info_p)
 				if (!strcasecmp(su_info_p->info_type, "input.transfer.low")
 				 || !strcasecmp(su_info_p->info_type, "input.transfer.high")) {
 					/* Convert from three phase line-to-line voltage to line-to-neutral voltage */
-					double value = atof(buf);
-					value = value * 0.707;
-					snprintf(buf, sizeof(buf), "%.2f", value);
+					double tmp_dvalue = atof(buf);
+					tmp_dvalue = tmp_dvalue * 0.707;
+					snprintf(buf, sizeof(buf), "%.2f", tmp_dvalue);
 				}
 			}
 		}

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -2344,7 +2344,7 @@ static int process_phase_data(const char* type, long *nb_phases, snmp_info_t *su
 /* walk ups variables and set elements of the info array. */
 bool_t snmp_ups_walk(int mode)
 {
-	long *input_phases, *output_phases, *bypass_phases;
+	long *walked_input_phases, *walked_output_phases, *walked_bypass_phases;
 	static unsigned long iterations = 0;
 	snmp_info_t *su_info_p;
 	bool_t status = FALSE;
@@ -2458,26 +2458,26 @@ bool_t snmp_ups_walk(int mode)
 			 * Non matching items are disabled, and flags are cleared at init
 			 * time */
 			/* Process input phases information */
-			input_phases = &daisychain_info[current_device_number]->input_phases;
+			walked_input_phases = &daisychain_info[current_device_number]->input_phases;
 			if (su_info_p->flags & SU_INPHASES) {
-				upsdebugx(1, "Check input_phases (%ld)", *input_phases);
-				if (process_phase_data("input", input_phases, su_info_p) == 1)
+				upsdebugx(1, "Check input_phases (%ld)", *walked_input_phases);
+				if (process_phase_data("input", walked_input_phases, su_info_p) == 1)
 					continue;
 			}
 
 			/* Process output phases information */
-			output_phases = &daisychain_info[current_device_number]->output_phases;
+			walked_output_phases = &daisychain_info[current_device_number]->output_phases;
 			if (su_info_p->flags & SU_OUTPHASES) {
-				upsdebugx(1, "Check output_phases (%ld)", *output_phases);
-				if (process_phase_data("output", output_phases, su_info_p) == 1)
+				upsdebugx(1, "Check output_phases (%ld)", *walked_output_phases);
+				if (process_phase_data("output", walked_output_phases, su_info_p) == 1)
 					continue;
 			}
 
 			/* Process bypass phases information */
-			bypass_phases = &daisychain_info[current_device_number]->bypass_phases;
+			walked_bypass_phases = &daisychain_info[current_device_number]->bypass_phases;
 			if (su_info_p->flags & SU_BYPPHASES) {
-				upsdebugx(1, "Check bypass_phases (%ld)", *bypass_phases);
-				if (process_phase_data("input.bypass", bypass_phases, su_info_p) == 1)
+				upsdebugx(1, "Check bypass_phases (%ld)", *walked_bypass_phases);
+				if (process_phase_data("input.bypass", walked_bypass_phases, su_info_p) == 1)
 					continue;
 			}
 

--- a/drivers/upscode2.c
+++ b/drivers/upscode2.c
@@ -1187,19 +1187,19 @@ static void check_uppm(void)
 	if (strcmp(var, "ACPM"))
 		upslogx(LOG_ERR, "Bad response to UPPM: %s", var);
 	while (1) {
-		int val, stat;
+		int intval, stat;
 		upscrecv(var);
 		if (strlen(var) == 0)
 			break;
 		upsdebugx(2, "UPPM available: %s", var);
-		stat = sscanf(var, "P%2d", &val);
+		stat = sscanf(var, "P%2d", &intval);
 		if (stat != 1) {
 			upslogx(LOG_ERR, "Bad response to UPPM: %s", var);
 			return;
 		}
-		has_uppm_p[val] = 1;
-		if (val > last)
-			last = val;
+		has_uppm_p[intval] = 1;
+		if (intval > last)
+			last = intval;
 	}
 
 	for (i = 0; i <= last; i++) {

--- a/server/sstate.c
+++ b/server/sstate.c
@@ -341,7 +341,7 @@ const cmdlist_t *sstate_getcmdlist(const upstype_t *ups)
 	return ups->cmdlist;
 }
 
-int sstate_dead(upstype_t *ups, int maxage)
+int sstate_dead(upstype_t *ups, int arg_maxage)
 {
 	time_t	now;
 	double	elapsed;
@@ -363,12 +363,12 @@ int sstate_dead(upstype_t *ups, int maxage)
 	elapsed = difftime(now, ups->last_heard);
 
 	/* somewhere beyond a third of the maximum time - prod it to make it talk */
-	if ((elapsed > (maxage / 3)) && (difftime(now, ups->last_ping) > (maxage / 3)))
+	if ((elapsed > (arg_maxage / 3)) && (difftime(now, ups->last_ping) > (arg_maxage / 3)))
 		sendping(ups);
 
-	if (elapsed > maxage) {
+	if (elapsed > arg_maxage) {
 		upsdebugx(3, "sstate_dead: didn't hear from driver for UPS [%s] for %g seconds (max %d)",
-					ups->name, elapsed, maxage);
+					ups->name, elapsed, arg_maxage);
 		return 1;	/* dead */
 	}
 


### PR DESCRIPTION
Follows up from #823 effort and earlier work on shadowing arguments.