### PR TITLE
fightwarn - avoid "bad function cast" by casting explicitly the return value of the function

### DIFF
--- a/drivers/bestfortress.c
+++ b/drivers/bestfortress.c
@@ -167,10 +167,7 @@ static inline void setinfo_float (const char *key, const char * fmt, const char 
 #ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_FORMAT_SECURITY
 #pragma GCC diagnostic ignored "-Wformat-security"
 #endif
-	/* FIXME (bitness-dependent?):
-	 *   error: cast from function call of type 'int' to non-matching type 'double' [-Werror,-Wbad-function-cast]
-	 */
-	dstate_setinfo (key, fmt, factor * (double)atoi (buf));
+	dstate_setinfo (key, fmt, factor * (double)(atoi (buf)));
 #ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_NONLITERAL
 #pragma GCC diagnostic pop
 #endif

--- a/drivers/mge-xml.c
+++ b/drivers/mge-xml.c
@@ -438,7 +438,7 @@ static const char *convert_deci(const char *arg_val)
 			upslogx(LOG_NOTICE, "%s() is now deprecated, so values from XML are normally not decimated. This driver instance has however configured do_convert_deci in your ups.conf, so this behavior for old MGE NetXML-capable devices is preserved.", __func__);
 			mge_report_deprecation__convert_deci = 0;
 		}
-		snprintf(mge_scratch_buf, sizeof(mge_scratch_buf), "%.1f", 0.1 * (float)atoi(arg_val));
+		snprintf(mge_scratch_buf, sizeof(mge_scratch_buf), "%.1f", 0.1 * (float)(atoi(arg_val)));
 		return mge_scratch_buf;
 	}
 
@@ -484,13 +484,13 @@ static const char *url_convert(const char *arg_val)
 
 static const char *mge_battery_capacity(const char *arg_val)
 {
-	snprintf(mge_scratch_buf, sizeof(mge_scratch_buf), "%.2f", (float)atoi(arg_val) / 3600);
+	snprintf(mge_scratch_buf, sizeof(mge_scratch_buf), "%.2f", (float)(atoi(arg_val)) / 3600.0);
 	return mge_scratch_buf;
 }
 
 static const char *mge_powerfactor_conversion(const char *arg_val)
 {
-	snprintf(mge_scratch_buf, sizeof(mge_scratch_buf), "%.2f", (float)atoi(arg_val) / 100);
+	snprintf(mge_scratch_buf, sizeof(mge_scratch_buf), "%.2f", (float)(atoi(arg_val)) / 100.0);
 	return mge_scratch_buf;
 }
 

--- a/drivers/tripplite.c
+++ b/drivers/tripplite.c
@@ -381,7 +381,7 @@ void upsdrv_updateinfo(void)
 	}
 
 	send_cmd(":B\r", buf, sizeof buf);
-	bv = (float)hex2d(buf, 2) / 10.0;
+	bv = (float)(hex2d(buf, 2)) / 10.0;
 	if (bv > 50.0 || bv < 0.0) {
 		++numfails;
 		if (numfails > MAXTRIES) {

--- a/drivers/tripplitesu.c
+++ b/drivers/tripplitesu.c
@@ -723,15 +723,15 @@ void upsdrv_updateinfo(void)
 	ptr = field(response, 3);
 	if (ptr)
 		dstate_setinfo("output.voltage", "%03.1f",
-		               (double) atoi(ptr) / 10.0);
+		               (double) (atoi(ptr)) / 10.0);
 	ptr = field(response, 1);
 	if (ptr)
 		dstate_setinfo("output.frequency", "%03.1f",
-		               (double) atoi(ptr) / 10.0);
+		               (double) (atoi(ptr)) / 10.0);
 	ptr = field(response, 4);
 	if (ptr)
 		dstate_setinfo("output.current", "%03.1f",
-		               (double) atoi(ptr) / 10.0);
+		               (double) (atoi(ptr)) / 10.0);
 
 	low_battery = 0;
 	if (do_command(POLL, STATUS_BATTERY, "", response) <= 0) {
@@ -758,11 +758,11 @@ void upsdrv_updateinfo(void)
 	ptr = field(response, 6);
 	if (ptr)
 		dstate_setinfo("battery.voltage", "%03.1f",
-		               (double) atoi(ptr) / 10.0);
+		               (double) (atoi(ptr)) / 10.0);
 	ptr = field(response, 7);
 	if (ptr)
 		dstate_setinfo("battery.current", "%03.1f",
-		               (double) atoi(ptr) / 10.0);
+		               (double) (atoi(ptr)) / 10.0);
 	if (low_battery)
 		status_set("LB");
 
@@ -778,11 +778,11 @@ void upsdrv_updateinfo(void)
 		ptr = field(response, 2);
 		if (ptr)
 			dstate_setinfo("input.voltage", "%03.1f",
-			               (double) atoi(ptr) / 10.0);
+			               (double) (atoi(ptr)) / 10.0);
 		ptr = field(response, 1);
 		if (ptr)
-			dstate_setinfo("input.frequency",
-				       "%03.1f", (double) atoi(ptr) / 10.0);
+			dstate_setinfo("input.frequency", "%03.1f",
+			               (double) (atoi(ptr)) / 10.0);
 	}
 
 	if (do_command(POLL, TEST_RESULT, "", response) > 0) {


### PR DESCRIPTION
Follows up from #823 effort.

This PR has potential to somehow change interpretations of numbers in NUT calculations, so careful review is encouraged. Also I hope I did not mix up parenthesis grouping and negations, but it is late night here so everything is possible (caught some of those before posting)...

Would merge after someone LGTMs this :)