### PR TITLE
fightwarn - initialize variables to avoid potential uninitialized use

### DIFF
--- a/drivers/bestfortress.c
+++ b/drivers/bestfortress.c
@@ -233,7 +233,8 @@ void upsdrv_updateinfo(void)
 	char temp[256];
 	char *p = NULL;
 	int loadva;
-	int len = -1, recv;
+	size_t len = 0;
+	int recv;
 	int retry;
 	char ch;
 	int checksum_ok = -1, is_online = 1, is_off, low_batt, trimming, boosting;
@@ -287,7 +288,7 @@ void upsdrv_updateinfo(void)
 		sleep(SER_WAIT_SEC);
 	}
 
-	if (!p || len < 0 || checksum_ok < 0) {
+	if (!p || len < 1 || checksum_ok < 0) {
 		upsdebugx(2, "pointer to data not initialized after processing");
 		dstate_datastale();
 		return;
@@ -295,7 +296,7 @@ void upsdrv_updateinfo(void)
 
 	if (!checksum_ok) {
 		upsdebugx(2, "checksum corruption");
-		upsdebug_hex(3, "buffer", temp, len);
+		upsdebug_hex(3, "buffer", temp, (int)len);
 		dstate_datastale();
 		return;
 	}

--- a/drivers/blazer.c
+++ b/drivers/blazer.c
@@ -692,7 +692,7 @@ void blazer_initinfo(void)
 
 	for (proto = 0; command[proto].status; proto++) {
 
-		int	ret;
+		int	ret = -1;
 
 		if (protocol && strcasecmp(protocol, command[proto].name)) {
 			upsdebugx(2, "Skipping %s protocol...", command[proto].name);
@@ -724,7 +724,7 @@ void blazer_initinfo(void)
 	}
 
 	if (command[proto].rating && !testvar("norating")) {
-		int	ret;
+		int	ret = -1;
 
 		for (retry = 1; retry <= MAXTRIES; retry++) {
 
@@ -744,7 +744,7 @@ void blazer_initinfo(void)
 	}
 
 	if (command[proto].vendor && !testvar("novendor")) {
-		int	ret;
+		int	ret = -1;
 
 		for (retry = 1; retry <= MAXTRIES; retry++) {
 

--- a/drivers/nut-libfreeipmi.c
+++ b/drivers/nut-libfreeipmi.c
@@ -519,7 +519,7 @@ static int libfreeipmi_get_sensors_info (IPMIDevice_t *ipmi_dev)
 	uint16_t record_count;
 	int found_device_id = 0;
 	uint16_t record_id;
-	uint8_t entity_id, entity_instance;
+	uint8_t entity_id = 0, entity_instance = 0;
 	int i;
 
 	if (ipmi_ctx == NULL)

--- a/drivers/powerpanel.c
+++ b/drivers/powerpanel.c
@@ -102,7 +102,7 @@ void upsdrv_updateinfo(void)
 
 void upsdrv_shutdown(void)
 {
-	int	i, ret;
+	int	i, ret = -1;
 
 	/*
 	 * Try to shutdown with delay and automatic reboot if the power
@@ -125,7 +125,7 @@ void upsdrv_shutdown(void)
 		}
 	}
 
-	if (ret) {
+	if (ret > 0) {
 		/*
 		 * When on battery, the 'shutdown.stayoff' command will make
 		 * the UPS switch back on when the power returns.
@@ -134,7 +134,7 @@ void upsdrv_shutdown(void)
 			upslogx(LOG_INFO, "Waiting for power to return...");
 			return;
 		}
-	} else {
+	} else if (ret == 0) {
 		/*
 		 * Apparently, the power came back already, so we just need to reboot.
 		 */

--- a/drivers/rhino.c
+++ b/drivers/rhino.c
@@ -471,7 +471,7 @@ send_command( int cmd )
 {
 	static const size_t sizes = 19, iend = 18;
 	size_t i;
-	int chk, checksum = 0, ret, kount; /*, j, uc; */
+	int chk, checksum = 0, ret = -1, kount; /*, j, uc; */
 	unsigned char ch, *psend = NULL;
 
 	if ( !(psend = xmalloc(sizeof(char) * sizes)) ) {

--- a/drivers/solis.c
+++ b/drivers/solis.c
@@ -752,7 +752,7 @@ static void get_base_info(void) {
 			break;
 	}
 
-	if (syncEOR != RESP_END || !syncEOR_was_read) {
+	if (!syncEOR_was_read || syncEOR != RESP_END) {
 		/* synchronization failed */
 		fatalx(EXIT_FAILURE, NO_SOLIS);
 	} else {

--- a/drivers/solis.c
+++ b/drivers/solis.c
@@ -682,7 +682,7 @@ static void get_base_info(void) {
 #else
 	const char DaysOfWeek[7][4]={"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
 #endif
-	unsigned char packet[PACKET_SIZE], syncEOR;
+	unsigned char packet[PACKET_SIZE], syncEOR = '\0', syncEOR_was_read = 0;
 	int i1=0, i2=0, tam, i;
 
 	time_t tmt;
@@ -747,11 +747,12 @@ static void get_base_info(void) {
 	*/
 	for (i = 0; i < packet_size*3; i++) {
 		ser_get_char(upsfd, &syncEOR, 3, 0);
+		syncEOR_was_read = 1;
 		if(syncEOR == RESP_END)
 			break;
 	}
 
-	if (syncEOR != RESP_END) {
+	if (syncEOR != RESP_END || !syncEOR_was_read) {
 		/* synchronization failed */
 		fatalx(EXIT_FAILURE, NO_SOLIS);
 	} else {


### PR DESCRIPTION
Follows up from #823 effort.

This PR adds error-checking for many of the cases, but has potential to somehow change interpretations of values in NUT calculations (especially where unsigned ints are pre-initialized into zeroes which might mean something as a value if actual read from wire was skipped for whatever reason), so careful review is encouraged.

Would prefer to merge after someone LGTMs this :)