### PR TITLE
fightwarn - use size_t where a size_t is due: for numargs parsing

### DIFF
--- a/clients/upsclient.c
+++ b/clients/upsclient.c
@@ -1161,9 +1161,9 @@ static int upscli_errcheck(UPSCONN_t *ups, char *buf)
 }
 
 static void build_cmd(char *buf, size_t bufsize, const char *cmdname,
-	int numarg, const char **arg)
+	size_t numarg, const char **arg)
 {
-	int	i;
+	size_t	i;
 	size_t	len;
 	char	enc[UPSCLI_NETBUF_LEN];
 	const char	*format;

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -1107,7 +1107,7 @@ static void checkmode(char *cfgentry, char *oldvalue, char *newvalue,
 }
 
 /* returns 1 if used, 0 if not, so we can complain about bogus configs */
-static int parse_conf_arg(int numargs, char **arg)
+static int parse_conf_arg(size_t numargs, char **arg)
 {
 	/* using up to arg[1] below */
 	if (numargs < 2)

--- a/clients/upssched.c
+++ b/clients/upssched.c
@@ -459,14 +459,14 @@ static int sock_arg(conn_t *conn)
 	return 0;
 }
 
-static void log_unknown(int numarg, char **arg)
+static void log_unknown(size_t numarg, char **arg)
 {
-	int	i;
+	size_t	i;
 
 	upslogx(LOG_INFO, "Unknown command on socket: ");
 
 	for (i = 0; i < numarg; i++)
-		upslogx(LOG_INFO, "arg %d: %s", i, arg[i]);
+		upslogx(LOG_INFO, "arg %zu: %s", i, arg[i]);
 }
 
 static int sock_read(conn_t *conn)
@@ -837,7 +837,7 @@ static void parse_at(const char *ntype, const char *un, const char *cmd,
 	upslogx(LOG_ERR, "Invalid command: %s", cmd);
 }
 
-static int conf_arg(int numargs, char **arg)
+static int conf_arg(size_t numargs, char **arg)
 {
 	if (numargs < 2)
 		return 0;

--- a/clients/upsset.c
+++ b/clients/upsset.c
@@ -163,7 +163,7 @@ static void do_hidden(const char *next)
 }
 
 /* generate SELECT chooser from hosts.conf entries */
-static void upslist_arg(int numargs, char **arg)
+static void upslist_arg(size_t numargs, char **arg)
 {
 	if (numargs < 3)
 		return;

--- a/common/state.c
+++ b/common/state.c
@@ -404,9 +404,9 @@ const range_t *state_getrangelist(st_tree_t *root, const char *var)
 	return sttmp->range_list;
 }
 
-void state_setflags(st_tree_t *root, const char *var, int numflags, char **flag)
+void state_setflags(st_tree_t *root, const char *var, size_t numflags, char **flag)
 {
-	int	i;
+	size_t	i;
 	st_tree_t	*sttmp;
 
 	/* find the tree node for var */

--- a/drivers/clone-outlet.c
+++ b/drivers/clone-outlet.c
@@ -66,7 +66,7 @@ static int	dumpdone = 0;
 static PCONF_CTX_t	sock_ctx;
 static time_t	last_heard = 0, last_ping = 0, last_connfail = 0;
 
-static int parse_args(int numargs, char **arg)
+static int parse_args(size_t numargs, char **arg)
 {
 	if (numargs < 1) {
 		return 0;

--- a/drivers/clone.c
+++ b/drivers/clone.c
@@ -68,7 +68,7 @@ static time_t	last_poll = 0, last_heard = 0,
 static int instcmd(const char *cmdname, const char *extra);
 
 
-static int parse_args(int numargs, char **arg)
+static int parse_args(size_t numargs, char **arg)
 {
 	if (numargs < 1) {
 		return 0;

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -391,7 +391,7 @@ static void send_tracking(conn_t *conn, const char *id, int value)
 	send_to_one(conn, "TRACKING %s %i\n", id, value);
 }
 
-static int sock_arg(conn_t *conn, int numarg, char **arg)
+static int sock_arg(conn_t *conn, size_t numarg, char **arg)
 {
 	if (numarg < 1) {
 		return 0;

--- a/drivers/dummy-ups.c
+++ b/drivers/dummy-ups.c
@@ -431,7 +431,7 @@ static int parse_data_file(int arg_upsfd)
 {
 	char	fn[SMALLBUF];
 	char	*ptr, var_value[MAX_STRING_SIZE];
-	int		value_args = 0, counter;
+	size_t	value_args = 0, counter;
 	time_t	now;
 	NUT_UNUSED_VARIABLE(arg_upsfd);
 

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -3078,7 +3078,7 @@ int su_instcmd(const char *cmdname, const char *extradata)
 /* FIXME: the below functions can be removed since these were for loading
  * the mib2nut information from a file instead of the .h definitions... */
 /* return 1 if usable, 0 if not */
-static int parse_mibconf_args(int numargs, char **arg)
+static int parse_mibconf_args(size_t numargs, char **arg)
 {
 	bool_t ret;
 

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -3110,11 +3110,13 @@ static int parse_mibconf_args(size_t numargs, char **arg)
 
 	return 1;
 }
+
 /* called for fatal errors in parseconf like malloc failures */
 static void mibconf_err(const char *errmsg)
 {
 	upslogx(LOG_ERR, "Fatal error in parseconf (*mib.conf): %s", errmsg);
 }
+
 /* load *mib.conf into an snmp_info_t structure */
 void read_mibconf(char *mib)
 {

--- a/include/state.h
+++ b/include/state.h
@@ -61,7 +61,7 @@ int state_getflags(st_tree_t *root, const char *var);
 int state_getaux(st_tree_t *root, const char *var);
 const enum_t *state_getenumlist(st_tree_t *root, const char *var);
 const range_t *state_getrangelist(st_tree_t *root, const char *var);
-void state_setflags(st_tree_t *root, const char *var, int numflags, char **flags);
+void state_setflags(st_tree_t *root, const char *var, size_t numflags, char **flags);
 int state_addcmd(cmdlist_t **list, const char *cmd);
 void state_infofree(st_tree_t *node);
 void state_cmdfree(cmdlist_t *list);

--- a/server/conf.c
+++ b/server/conf.c
@@ -114,7 +114,7 @@ static void ups_update(const char *fn, const char *name, const char *desc)
 }
 
 /* return 1 if usable, 0 if not */
-static int parse_upsd_conf_args(int numargs, char **arg)
+static int parse_upsd_conf_args(size_t numargs, char **arg)
 {
 	/* everything below here uses up through arg[1] */
 	if (numargs < 2)

--- a/server/netcmds.h
+++ b/server/netcmds.h
@@ -45,7 +45,7 @@ extern "C" {
 
 static struct {
 	const	char	*name;
-	void	(*func)(nut_ctype_t *client, int numargs, const char **arg);
+	void	(*func)(nut_ctype_t *client, size_t numargs, const char **arg);
 	int	flags;
 } netcmds[] = {
 	{ "VER",	net_ver,	0		},
@@ -68,7 +68,7 @@ static struct {
 	{ "SET",	net_set,	FLAG_USER	},
 	{ "INSTCMD",	net_instcmd,	FLAG_USER	},
 
-	{ NULL,		(void(*)(struct nut_ctype_s *, int,  const char **))(NULL), 0		}
+	{ NULL,		(void(*)(struct nut_ctype_s *, size_t,  const char **))(NULL), 0		}
 };
 
 #ifdef __cplusplus

--- a/server/netget.c
+++ b/server/netget.c
@@ -214,7 +214,7 @@ static void get_var(nut_ctype_t *client, const char *upsname, const char *var)
 		sendback(client, "VAR %s %s \"%s\"\n", upsname, var, val);
 }
 
-void net_get(nut_ctype_t *client, int numarg, const char **arg)
+void net_get(nut_ctype_t *client, size_t numarg, const char **arg)
 {
 	if (numarg < 1) {
 		send_err(client, NUT_ERR_INVALID_ARGUMENT);

--- a/server/netget.h
+++ b/server/netget.h
@@ -31,7 +31,7 @@ extern "C" {
 /* *INDENT-ON* */
 #endif
 
-void net_get(nut_ctype_t *client, int numarg, const char **arg);
+void net_get(nut_ctype_t *client, size_t numarg, const char **arg);
 
 #ifdef __cplusplus
 /* *INDENT-OFF* */

--- a/server/netinstcmd.c
+++ b/server/netinstcmd.c
@@ -108,7 +108,7 @@ static void send_instcmd(nut_ctype_t *client, const char *upsname,
 		sendback(client, "OK\n");
 }
 
-void net_instcmd(nut_ctype_t *client, int numarg, const char **arg)
+void net_instcmd(nut_ctype_t *client, size_t numarg, const char **arg)
 {
 	const char *devname = NULL;
 	const char *cmdname = NULL;

--- a/server/netinstcmd.h
+++ b/server/netinstcmd.h
@@ -31,7 +31,7 @@ extern "C" {
 /* *INDENT-ON* */
 #endif
 
-void net_instcmd(nut_ctype_t *client, int numarg, const char **arg);
+void net_instcmd(nut_ctype_t *client, size_t numarg, const char **arg);
 
 #ifdef __cplusplus
 /* *INDENT-OFF* */

--- a/server/netlist.c
+++ b/server/netlist.c
@@ -285,7 +285,7 @@ static void list_clients(nut_ctype_t *client, const char *upsname)
 	sendback(client, "END LIST CLIENT %s\n", upsname);
 }
 
-void net_list(nut_ctype_t *client, int numarg, const char **arg)
+void net_list(nut_ctype_t *client, size_t numarg, const char **arg)
 {
 	if (numarg < 1) {
 		send_err(client, NUT_ERR_INVALID_ARGUMENT);

--- a/server/netlist.h
+++ b/server/netlist.h
@@ -31,7 +31,7 @@ extern "C" {
 /* *INDENT-ON* */
 #endif
 
-void net_list(nut_ctype_t *client, int numarg, const char **arg);
+void net_list(nut_ctype_t *client, size_t numarg, const char **arg);
 
 #ifdef __cplusplus
 /* *INDENT-OFF* */

--- a/server/netmisc.c
+++ b/server/netmisc.c
@@ -29,7 +29,7 @@
 
 #include "netmisc.h"
 
-void net_ver(nut_ctype_t *client, int numarg, const char **arg)
+void net_ver(nut_ctype_t *client, size_t numarg, const char **arg)
 {
 	NUT_UNUSED_VARIABLE(arg);
 	if (numarg != 0) {
@@ -41,7 +41,7 @@ void net_ver(nut_ctype_t *client, int numarg, const char **arg)
 		UPS_VERSION);
 }
 
-void net_netver(nut_ctype_t *client, int numarg, const char **arg)
+void net_netver(nut_ctype_t *client, size_t numarg, const char **arg)
 {
 	NUT_UNUSED_VARIABLE(arg);
 	if (numarg != 0) {
@@ -52,7 +52,7 @@ void net_netver(nut_ctype_t *client, int numarg, const char **arg)
 	sendback(client, "%s\n", NUT_NETVERSION);
 }
 
-void net_help(nut_ctype_t *client, int numarg, const char **arg)
+void net_help(nut_ctype_t *client, size_t numarg, const char **arg)
 {
 	NUT_UNUSED_VARIABLE(arg);
 	if (numarg != 0) {
@@ -64,7 +64,7 @@ void net_help(nut_ctype_t *client, int numarg, const char **arg)
 		" USERNAME PASSWORD STARTTLS\n");
 }
 
-void net_fsd(nut_ctype_t *client, int numarg, const char **arg)
+void net_fsd(nut_ctype_t *client, size_t numarg, const char **arg)
 {
 	upstype_t	*ups;
 

--- a/server/netmisc.h
+++ b/server/netmisc.h
@@ -31,10 +31,10 @@ extern "C" {
 /* *INDENT-ON* */
 #endif
 
-void net_ver(nut_ctype_t *client, int numarg, const char **arg);
-void net_netver(nut_ctype_t *client, int numarg, const char **arg);
-void net_help(nut_ctype_t *client, int numarg, const char **arg);
-void net_fsd(nut_ctype_t *client, int numarg, const char **arg);
+void net_ver(nut_ctype_t *client, size_t numarg, const char **arg);
+void net_netver(nut_ctype_t *client, size_t numarg, const char **arg);
+void net_help(nut_ctype_t *client, size_t numarg, const char **arg);
+void net_fsd(nut_ctype_t *client, size_t numarg, const char **arg);
 
 #ifdef __cplusplus
 /* *INDENT-OFF* */

--- a/server/netset.c
+++ b/server/netset.c
@@ -166,7 +166,7 @@ static void set_var(nut_ctype_t *client, const char *upsname, const char *var,
 		sendback(client, "OK\n");
 }
 
-void net_set(nut_ctype_t *client, int numarg, const char **arg)
+void net_set(nut_ctype_t *client, size_t numarg, const char **arg)
 {
 	char	tracking_id[UUID4_LEN] = "";
 

--- a/server/netset.h
+++ b/server/netset.h
@@ -31,7 +31,7 @@ extern "C" {
 /* *INDENT-ON* */
 #endif
 
-void net_set(nut_ctype_t *client, int numarg, const char **arg);
+void net_set(nut_ctype_t *client, size_t numarg, const char **arg);
 
 #ifdef __cplusplus
 /* *INDENT-OFF* */

--- a/server/netssl.c
+++ b/server/netssl.c
@@ -61,7 +61,7 @@ static int	ssl_initialized = 0;
 #ifndef WITH_SSL
 
 /* stubs for non-ssl compiles */
-void net_starttls(nut_ctype_t *client, int numarg, const char **arg)
+void net_starttls(nut_ctype_t *client, size_t numarg, const char **arg)
 {
 	send_err(client, NUT_ERR_FEATURE_NOT_SUPPORTED);
 	return;
@@ -233,7 +233,7 @@ static void HandshakeCallback(PRFileDesc *fd, nut_ctype_t *client_data)
 
 #endif /* WITH_OPENSSL | WITH_NSS */
 
-void net_starttls(nut_ctype_t *client, int numarg, const char **arg)
+void net_starttls(nut_ctype_t *client, size_t numarg, const char **arg)
 {
 #ifdef WITH_OPENSSL
 	int ret;

--- a/server/netssl.h
+++ b/server/netssl.h
@@ -51,7 +51,7 @@ void ssl_cleanup(void);
 int ssl_read(nut_ctype_t *client, char *buf, size_t buflen);
 int ssl_write(nut_ctype_t *client, const char *buf, size_t buflen);
 
-void net_starttls(nut_ctype_t *client, int numarg, const char **arg);
+void net_starttls(nut_ctype_t *client, size_t numarg, const char **arg);
 
 #ifdef __cplusplus
 /* *INDENT-OFF* */

--- a/server/netuser.c
+++ b/server/netuser.c
@@ -28,7 +28,7 @@
 #include "netuser.h"
 
 /* LOGIN <ups> */
-void net_login(nut_ctype_t *client, int numarg, const char **arg)
+void net_login(nut_ctype_t *client, size_t numarg, const char **arg)
 {
 	upstype_t	*ups;
 
@@ -65,7 +65,7 @@ void net_login(nut_ctype_t *client, int numarg, const char **arg)
 	sendback(client, "OK\n");
 }
 
-void net_logout(nut_ctype_t *client, int numarg, const char **arg)
+void net_logout(nut_ctype_t *client, size_t numarg, const char **arg)
 {
 	NUT_UNUSED_VARIABLE(arg);
 	if (numarg != 0) {
@@ -84,7 +84,7 @@ void net_logout(nut_ctype_t *client, int numarg, const char **arg)
 }
 
 /* MASTER <upsname> */
-void net_master(nut_ctype_t *client, int numarg, const char **arg)
+void net_master(nut_ctype_t *client, size_t numarg, const char **arg)
 {
 	upstype_t	*ups;
 
@@ -111,7 +111,7 @@ void net_master(nut_ctype_t *client, int numarg, const char **arg)
 }
 
 /* USERNAME <username> */
-void net_username(nut_ctype_t *client, int numarg, const char **arg)
+void net_username(nut_ctype_t *client, size_t numarg, const char **arg)
 {
 	if (numarg != 1) {
 		send_err(client, NUT_ERR_INVALID_ARGUMENT);
@@ -131,7 +131,7 @@ void net_username(nut_ctype_t *client, int numarg, const char **arg)
 }
 
 /* PASSWORD <password> */
-void net_password(nut_ctype_t *client, int numarg, const char **arg)
+void net_password(nut_ctype_t *client, size_t numarg, const char **arg)
 {
 	if (numarg != 1) {
 		send_err(client, NUT_ERR_INVALID_ARGUMENT);

--- a/server/netuser.h
+++ b/server/netuser.h
@@ -31,11 +31,11 @@ extern "C" {
 /* *INDENT-ON* */
 #endif
 
-void net_login(nut_ctype_t *client, int numarg, const char **arg);
-void net_logout(nut_ctype_t *client, int numarg, const char **arg);
-void net_master(nut_ctype_t *client, int numarg, const char **arg);
-void net_username(nut_ctype_t *client, int numarg, const char **arg);
-void net_password(nut_ctype_t *client, int numarg, const char **arg);
+void net_login(nut_ctype_t *client, size_t numarg, const char **arg);
+void net_logout(nut_ctype_t *client, size_t numarg, const char **arg);
+void net_master(nut_ctype_t *client, size_t numarg, const char **arg);
+void net_username(nut_ctype_t *client, size_t numarg, const char **arg);
+void net_password(nut_ctype_t *client, size_t numarg, const char **arg);
 
 #ifdef __cplusplus
 /* *INDENT-OFF* */

--- a/server/sockdebug.c
+++ b/server/sockdebug.c
@@ -31,11 +31,11 @@
 
 	PCONF_CTX_t	sock_ctx;
 
-static void sock_arg(int numarg, char **arg)
+static void sock_arg(size_t numarg, char **arg)
 {
-	int	i;
+	size_t	i;
 
-	printf("numarg=%d : ", numarg);
+	printf("numarg=%zu : ", numarg);
 
 	for (i = 0; i < numarg; i++)
 		printf("[%s] ", arg[i]);

--- a/server/sstate.c
+++ b/server/sstate.c
@@ -36,7 +36,7 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 
-static int parse_args(upstype_t *ups, int numargs, char **arg)
+static int parse_args(upstype_t *ups, size_t numargs, char **arg)
 {
 	if (numargs < 1)
 		return 0;

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -434,7 +434,7 @@ int ups_available(const upstype_t *ups, nut_ctype_t *client)
 }
 
 /* check flags and access for an incoming command from the network */
-static void check_command(int cmdnum, nut_ctype_t *client, int numarg,
+static void check_command(int cmdnum, nut_ctype_t *client, size_t numarg,
 	const char **arg)
 {
 	if (netcmds[cmdnum].flags & FLAG_USER) {
@@ -465,7 +465,7 @@ static void check_command(int cmdnum, nut_ctype_t *client, int numarg,
 	}
 
 	/* looks good - call the command */
-	netcmds[cmdnum].func(client, numarg - 1, numarg > 1 ? &arg[1] : NULL);
+	netcmds[cmdnum].func(client, (numarg < 2) ? 0 : (numarg - 1), (numarg > 1) ? &arg[1] : NULL);
 }
 
 /* parse requests from the network */

--- a/server/user.c
+++ b/server/user.c
@@ -370,9 +370,9 @@ static void parse_var(char *var, char *val)
 }
 
 /* parse first var+val pair, then flip through remaining vals */
-static void parse_rest(char *var, char *fval, char **arg, int next, int left)
+static void parse_rest(char *var, char *fval, char **arg, size_t next, size_t left)
 {
-	int	i;
+	size_t	i;
 
 	/* no globals supported yet, so there's no sense in continuing */
 	if (!curr_user) {
@@ -390,7 +390,7 @@ static void parse_rest(char *var, char *fval, char **arg, int next, int left)
 	}
 }
 
-static void user_parse_arg(int numargs, char **arg)
+static void user_parse_arg(size_t numargs, char **arg)
 {
 	char	*ep;
 
@@ -414,7 +414,7 @@ static void user_parse_arg(int numargs, char **arg)
 		/*      0       1       2  ... */
 		/* foo=bar <rest1> <rest2> ... */
 
-		parse_rest(arg[0], ep+1, arg, 1, numargs - 1);
+		parse_rest(arg[0], ep+1, arg, 1, (numargs < 2) ? 0 : (numargs - 1));
 		return;
 	}
 
@@ -448,7 +448,7 @@ static void user_parse_arg(int numargs, char **arg)
 
 		/* parse first var/val, plus subsequent values (if any) */
 
-		parse_rest(arg[0], arg[2], arg, 3, numargs - 3);
+		parse_rest(arg[0], arg[2], arg, 3, (numargs < 4) ? 0 : (numargs - 3));
 		return;
 	}
 


### PR DESCRIPTION
Follows up for #823 effort. This PR aligns the definition of `ctx.numargs` as a `size_t` across many routines that use it and pass around, but originally did so as `int`.

Some cases reduced the passed numeric value when requesting further routines, these now check for truncating to zero at lowest, to keep the unsigned type in order.

There were also a few cases where the number (or an iterator `i` for it) was printed or logged; wherever I saw it - the format string was updated to `%zu` (C99+ for `size_t`). UPDATE: Reviewed the routines changed by this PR, saw no other prints involving such variables.