### PR TITLE
Fix incorrect usmAESPrivProtocol import in nut-scanner

### DIFF
--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -62,7 +62,7 @@
 #include "nutscan-snmp.h"
 
 /* Address API change */
-#ifndef usmAESPrivProtocol
+#if ( ! NUT_HAVE_LIBNETSNMP_usmAESPrivProtocol ) && ( ! defined usmAESPrivProtocol )
 #define USMAESPRIVPROTOCOL "usmAES128PrivProtocol"
 #else
 #define USMAESPRIVPROTOCOL "usmAESPrivProtocol"


### PR DESCRIPTION
In libnetsnmp, usmAES128PrivProtocol is a pointer, while usmAESPrivProtocol is an array.
This change is the same as in c7cf507454bcf6f40b24b58e61c130c7772c5bf2.