### PR TITLE
Help troubleshoot USB driver setups

### DIFF
--- a/drivers/blazer_usb.c
+++ b/drivers/blazer_usb.c
@@ -508,9 +508,33 @@ int blazer_command(const char *cmd, char *buf, size_t buflen)
 #endif	/* TESTING */
 }
 
+#ifndef TESTING
+const struct subdriver_t {
+	const char	*name;
+	int		(*command)(const char *cmd, char *buf, size_t buflen);
+} subdriver[] = {
+	{ "cypress", &cypress_command },
+	{ "phoenix", &phoenix_command },
+	{ "ippon", &ippon_command },
+	{ "krauler", &krauler_command },
+	{ NULL, NULL }
+};
+#endif	/* TESTING */
 
 void upsdrv_help(void)
 {
+#ifndef TESTING
+    printf("\nAcceptable values for 'subdriver' via -x or ups.conf in this driver: ");
+    size_t i;
+
+    for (i = 0; subdriver[i].name != NULL; i++) {
+        if (i>0)
+            printf(", ");
+        printf("%s", subdriver[i].name);
+    }
+    printf("\n\n");
+#endif	/* TESTING */
+
 	printf("Read The Fine Manual ('man 8 blazer_usb')\n");
 }
 
@@ -529,17 +553,6 @@ void upsdrv_makevartable(void)
 void upsdrv_initups(void)
 {
 #ifndef TESTING
-	const struct {
-		const char	*name;
-		int		(*command)(const char *cmd, char *buf, size_t buflen);
-	} subdriver[] = {
-		{ "cypress", &cypress_command },
-		{ "phoenix", &phoenix_command },
-		{ "ippon", &ippon_command },
-		{ "krauler", &krauler_command },
-		{ NULL, NULL }
-	};
-
 	int	ret, langid;
 	char	tbuf[255]; /* Some devices choke on size > 255 */
 	char	*regex_array[6];

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -1634,8 +1634,41 @@ void	upsdrv_shutdown(void)
 	fatalx(EXIT_FAILURE, "Shutdown failed!");
 }
 
+#ifdef QX_USB
+	#ifndef TESTING
+		const struct {
+			const char	*name;
+			int		(*command)(const char *cmd, char *buf, size_t buflen);
+		} usbsubdriver[] = {
+			{ "cypress", &cypress_command },
+			{ "phoenix", &phoenix_command },
+			{ "ippon", &ippon_command },
+			{ "krauler", &krauler_command },
+			{ "fabula", &fabula_command },
+			{ "fuji", &fuji_command },
+			{ "sgs", &sgs_command },
+			{ NULL, NULL }
+		};
+    #endif
+#endif
+
+
 void	upsdrv_help(void)
 {
+#ifdef QX_USB
+	#ifndef TESTING
+    printf("\nAcceptable values for 'subdriver' via -x or ups.conf in this driver: ");
+    size_t i;
+
+    for (i = 0; usbsubdriver[i].name != NULL; i++) {
+        if (i>0)
+            printf(", ");
+        printf("%s", usbsubdriver[i].name);
+    }
+    printf("\n\n");
+    #endif
+#endif
+
 	printf("Read The Fine Manual ('man 8 nutdrv_qx')\n");
 }
 
@@ -1933,21 +1966,6 @@ void	upsdrv_initups(void)
 #ifdef QX_USB
 
 	#ifndef TESTING
-
-		const struct {
-			const char	*name;
-			int		(*command)(const char *cmd, char *buf, size_t buflen);
-		} usbsubdriver[] = {
-			{ "cypress", &cypress_command },
-			{ "phoenix", &phoenix_command },
-			{ "ippon", &ippon_command },
-			{ "krauler", &krauler_command },
-			{ "fabula", &fabula_command },
-			{ "fuji", &fuji_command },
-			{ "sgs", &sgs_command },
-			{ NULL, NULL }
-		};
-
 		int	ret, langid;
 		char	tbuf[255];	/* Some devices choke on size > 255 */
 		char	*regex_array[6];

--- a/drivers/usb-common.c
+++ b/drivers/usb-common.c
@@ -79,27 +79,41 @@ static int match_function_exact(USBDevice_t *hd, void *privdata)
 {
 	USBDevice_t	*data = (USBDevice_t *)privdata;
 
+	upsdebugx(3, "%s: matching a device...", __func__);
+
 	if (hd->VendorID != data->VendorID) {
+		upsdebugx(2, "%s: failed match of %s: %4x != %4x",
+		    __func__, "VendorID", hd->VendorID, data->VendorID);
 		return 0;
 	}
 
 	if (hd->ProductID != data->ProductID) {
+		upsdebugx(2, "%s: failed match of %s: %4x != %4x",
+		    __func__, "ProductID", hd->ProductID, data->ProductID);
 		return 0;
 	}
 
 	if (strcmp_null(hd->Vendor, data->Vendor) != 0) {
+		upsdebugx(2, "%s: failed match of %s: %s != %s",
+		    __func__, "Vendor", hd->Vendor, data->Vendor);
 		return 0;
 	}
 
 	if (strcmp_null(hd->Product, data->Product) != 0) {
+		upsdebugx(2, "%s: failed match of %s: %s != %s",
+		    __func__, "Product", hd->Product, data->Product);
 		return 0;
 	}
 
 	if (strcmp_null(hd->Serial, data->Serial) != 0) {
+		upsdebugx(2, "%s: failed match of %s: %s != %s",
+		    __func__, "Serial", hd->Serial, data->Serial);
 		return 0;
 	}
 #ifdef DEBUG_EXACT_MATCH_BUS
 	if (strcmp_null(hd->Bus, data->Bus) != 0) {
+		upsdebugx(2, "%s: failed match of %s: %s != %s",
+		    __func__, "Bus", hd->Bus, data->Bus);
 		return 0;
 	}
 #endif
@@ -280,33 +294,71 @@ static int match_function_regex(USBDevice_t *hd, void *privdata)
 	regex_matcher_data_t	*data = (regex_matcher_data_t *)privdata;
 	int r;
 
+	upsdebugx(3, "%s: matching a device...", __func__);
+
 	r = match_regex_hex(data->regex[0], hd->VendorID);
 	if (r != 1) {
+/*
+		upsdebugx(2, "%s: failed match of %s: %4x !~ %s",
+		    __func__, "VendorID", hd->VendorID, data->regex[0]);
+*/
+		upsdebugx(2, "%s: failed match of %s: %4x",
+		    __func__, "VendorID", hd->VendorID);
 		return r;
 	}
 
 	r = match_regex_hex(data->regex[1], hd->ProductID);
 	if (r != 1) {
+/*
+		upsdebugx(2, "%s: failed match of %s: %4x !~ %s",
+		    __func__, "ProductID", hd->ProductID, data->regex[1]);
+*/
+		upsdebugx(2, "%s: failed match of %s: %4x",
+		    __func__, "ProductID", hd->ProductID);
 		return r;
 	}
 
 	r = match_regex(data->regex[2], hd->Vendor);
 	if (r != 1) {
+/*
+		upsdebugx(2, "%s: failed match of %s: %s !~ %s",
+		    __func__, "Vendor", hd->Vendor, data->regex[2]);
+*/
+		upsdebugx(2, "%s: failed match of %s: %s",
+		    __func__, "Vendor", hd->Vendor);
 		return r;
 	}
 
 	r = match_regex(data->regex[3], hd->Product);
 	if (r != 1) {
+/*
+		upsdebugx(2, "%s: failed match of %s: %s !~ %s",
+		    __func__, "Product", hd->Product, data->regex[3]);
+*/
+		upsdebugx(2, "%s: failed match of %s: %s",
+		    __func__, "Product", hd->Product);
 		return r;
 	}
 
 	r = match_regex(data->regex[4], hd->Serial);
 	if (r != 1) {
+/*
+		upsdebugx(2, "%s: failed match of %s: %s !~ %s",
+		    __func__, "Serial", hd->Serial, data->regex[4]);
+*/
+		upsdebugx(2, "%s: failed match of %s: %s",
+		    __func__, "Serial", hd->Serial);
 		return r;
 	}
 
 	r = match_regex(data->regex[5], hd->Bus);
 	if (r != 1) {
+/*
+		upsdebugx(2, "%s: failed match of %s: %s !~ %s",
+		    __func__, "Bus", hd->Bus, data->regex[5]);
+*/
+		upsdebugx(2, "%s: failed match of %s: %s",
+		    __func__, "Bus", hd->Bus);
 		return r;
 	}
 	return 1;

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -484,11 +484,15 @@ static int match_function_subdriver(HIDDevice_t *d, void *privdata) {
 	int i;
 	NUT_UNUSED_VARIABLE(privdata);
 
+	upsdebugx(2, "%s (non-SHUT mode): matching a device...", __func__);
+
 	for (i=0; subdriver_list[i] != NULL; i++) {
 		if (subdriver_list[i]->claim(d)) {
 			return 1;
 		}
 	}
+
+	upsdebugx(2, "%s (non-SHUT mode): failed to match a subdriver to vendor and/or product ID", __func__);
 	return 0;
 }
 


### PR DESCRIPTION
Following up with issue #940, this PR adds some debug tracing for device-vs.-driver matching in codepaths I've encountered in practice. A cursory look across the codebase exposed similar logic used in some other drivers, but it is not something I can test quickly now, nor decide if similar change is welcome there too. Anyway, later PRs can be modeled after this one ;)

Also just two drivers were recognized to support the "subdriver" flag, `nutdrv_qx` (only for USB mode) and `blazer_usb` so only their help routines were updated to list the USB subdrivers. Example output:
````
$ ./drivers/nutdrv_qx -h
...

Acceptable values for 'subdriver' via -x or ups.conf in this driver: cypress, phoenix, ippon, krauler, fabula, fuji, sgs

Read The Fine Manual ('man 8 nutdrv_qx')
````

There is also `riello_usb` whose code structure seems very related, and it registers one `cypress` subdriver into the equivalent array, but does not register the `subdriver` keyword support (although can handle its value, still).

Equivalent logic in `snmp-ups` library of MIBs is handled already, by `snmp-ups -s test -port=test -x mibs=--list` to display a table of details about recognized MIBs.

The `usbhid-ups` driver in the end only matches devices it knows to the subdrivers it picks, but there does not seem to currently be a way for user to influence that choice.