### PR TITLE
m4/ax_c_pragmas.m4: separate support inside vs outside function bodies, and fix speed_t in bcmxcp_ser.c

### DIFF
--- a/drivers/bcmxcp_ser.c
+++ b/drivers/bcmxcp_ser.c
@@ -256,6 +256,13 @@ void upsdrv_comm_good()
 	ser_comm_good();
 }
 
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_BESIDEFUNC) && (!defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_INSIDEFUNC) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS_BESIDEFUNC)
+# pragma GCC diagnostic push
+#endif
+
+#if (!defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_INSIDEFUNC) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS_BESIDEFUNC)
+# pragma GCC diagnostic ignored "-Wtype-limits"
+#endif
 static void pw_comm_setup(const char *port)
 {
 	unsigned char command = PW_SET_REQ_ONLY_MODE;
@@ -351,6 +358,9 @@ static void pw_comm_setup(const char *port)
 
 	fatalx(EXIT_FAILURE, "Can't connect to the UPS on port %s!\n", port);
 }
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_BESIDEFUNC) && (!defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_INSIDEFUNC) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS_BESIDEFUNC)
+# pragma GCC diagnostic pop
+#endif
 
 void upsdrv_initups(void)
 {

--- a/drivers/bcmxcp_ser.c
+++ b/drivers/bcmxcp_ser.c
@@ -256,7 +256,7 @@ void upsdrv_comm_good()
 	ser_comm_good();
 }
 
-#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_BESIDEFUNC) && (!defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_INSIDEFUNC) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS_BESIDEFUNC) || (defined HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE_BESIDEFUNC )
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_BESIDEFUNC) && (!defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_INSIDEFUNC) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS_BESIDEFUNC) || (defined HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE_BESIDEFUNC) )
 # pragma GCC diagnostic push
 #endif
 
@@ -288,7 +288,7 @@ static void pw_comm_setup(const char *port)
 		 * termios.h happens to say that on some systems)...
 		 * But since we convert this setting from int, we assume...
 		 */
-#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE ) )
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) )
 /* Note for gating macros above: unsuffixed HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP
  * means support of contexts both inside and outside function body, so the push
  * above and pop below (outside this finction) are not used.
@@ -307,7 +307,7 @@ static void pw_comm_setup(const char *port)
 			case 2:	assert (br < INT16_MAX); break;
 			default:	assert (br < INT_MAX);
 		}
-#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE ) )
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) )
 # pragma GCC diagnostic pop
 #endif
 		baud = (speed_t)br;
@@ -370,7 +370,7 @@ static void pw_comm_setup(const char *port)
 
 	fatalx(EXIT_FAILURE, "Can't connect to the UPS on port %s!\n", port);
 }
-#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_BESIDEFUNC) && (!defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_INSIDEFUNC) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS_BESIDEFUNC)
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_BESIDEFUNC) && (!defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_INSIDEFUNC) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS_BESIDEFUNC) || (defined HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE_BESIDEFUNC) )
 # pragma GCC diagnostic pop
 #endif
 

--- a/drivers/bcmxcp_ser.c
+++ b/drivers/bcmxcp_ser.c
@@ -286,6 +286,10 @@ static void pw_comm_setup(const char *port)
 		 * But since we convert this setting from int, we assume...
 		 */
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS)
+/* Note for gating macros above: unsuffixed HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP
+ * means support of contexts both inside and outside function body, so the push
+ * above and pop below (outside this finction) are not used.
+ */
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wtype-limits"
 #endif

--- a/drivers/bcmxcp_ser.c
+++ b/drivers/bcmxcp_ser.c
@@ -4,7 +4,7 @@
 #include "bcmxcp_ser.h"
 #include "serial.h"
 #include "nut_stdint.h"
-
+#include <limits.h>
 
 #define SUBDRIVER_NAME    "RS-232 communication subdriver"
 #define SUBDRIVER_VERSION "0.20"

--- a/drivers/bcmxcp_ser.c
+++ b/drivers/bcmxcp_ser.c
@@ -256,12 +256,15 @@ void upsdrv_comm_good()
 	ser_comm_good();
 }
 
-#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_BESIDEFUNC) && (!defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_INSIDEFUNC) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS_BESIDEFUNC)
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_BESIDEFUNC) && (!defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_INSIDEFUNC) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS_BESIDEFUNC) || (defined HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE_BESIDEFUNC )
 # pragma GCC diagnostic push
 #endif
 
 #if (!defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_INSIDEFUNC) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS_BESIDEFUNC)
 # pragma GCC diagnostic ignored "-Wtype-limits"
+#endif
+#if (!defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_INSIDEFUNC) && (defined HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE_BESIDEFUNC)
+# pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"
 #endif
 static void pw_comm_setup(const char *port)
 {
@@ -285,13 +288,18 @@ static void pw_comm_setup(const char *port)
 		 * termios.h happens to say that on some systems)...
 		 * But since we convert this setting from int, we assume...
 		 */
-#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS)
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE ) )
 /* Note for gating macros above: unsuffixed HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP
  * means support of contexts both inside and outside function body, so the push
  * above and pop below (outside this finction) are not used.
  */
 # pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS
 # pragma GCC diagnostic ignored "-Wtype-limits"
+#endif
+#ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE
+# pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"
 #endif
 		switch(sizeof(speed_t)) {
 			case 8:	assert (br < INT64_MAX); break;
@@ -299,7 +307,7 @@ static void pw_comm_setup(const char *port)
 			case 2:	assert (br < INT16_MAX); break;
 			default:	assert (br < INT_MAX);
 		}
-#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS)
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE ) )
 # pragma GCC diagnostic pop
 #endif
 		baud = (speed_t)br;

--- a/drivers/bcmxcp_ser.c
+++ b/drivers/bcmxcp_ser.c
@@ -256,14 +256,14 @@ void upsdrv_comm_good()
 	ser_comm_good();
 }
 
-#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_BESIDEFUNC) && (!defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_INSIDEFUNC) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS_BESIDEFUNC) || (defined HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE_BESIDEFUNC) )
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_BESIDEFUNC) && (!defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_INSIDEFUNC) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS_BESIDEFUNC) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE_BESIDEFUNC) )
 # pragma GCC diagnostic push
 #endif
 
 #if (!defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_INSIDEFUNC) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS_BESIDEFUNC)
 # pragma GCC diagnostic ignored "-Wtype-limits"
 #endif
-#if (!defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_INSIDEFUNC) && (defined HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE_BESIDEFUNC)
+#if (!defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_INSIDEFUNC) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE_BESIDEFUNC)
 # pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"
 #endif
 static void pw_comm_setup(const char *port)
@@ -288,7 +288,7 @@ static void pw_comm_setup(const char *port)
 		 * termios.h happens to say that on some systems)...
 		 * But since we convert this setting from int, we assume...
 		 */
-#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) )
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) )
 /* Note for gating macros above: unsuffixed HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP
  * means support of contexts both inside and outside function body, so the push
  * above and pop below (outside this finction) are not used.
@@ -298,7 +298,7 @@ static void pw_comm_setup(const char *port)
 #ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS
 # pragma GCC diagnostic ignored "-Wtype-limits"
 #endif
-#ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE
 # pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"
 #endif
 		switch(sizeof(speed_t)) {
@@ -307,7 +307,7 @@ static void pw_comm_setup(const char *port)
 			case 2:	assert (br < INT16_MAX); break;
 			default:	assert (br < INT_MAX);
 		}
-#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) )
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) )
 # pragma GCC diagnostic pop
 #endif
 		baud = (speed_t)br;
@@ -370,7 +370,7 @@ static void pw_comm_setup(const char *port)
 
 	fatalx(EXIT_FAILURE, "Can't connect to the UPS on port %s!\n", port);
 }
-#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_BESIDEFUNC) && (!defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_INSIDEFUNC) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS_BESIDEFUNC) || (defined HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE_BESIDEFUNC) )
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_BESIDEFUNC) && (!defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_INSIDEFUNC) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS_BESIDEFUNC) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE_BESIDEFUNC) )
 # pragma GCC diagnostic pop
 #endif
 

--- a/drivers/bcmxcp_ser.c
+++ b/drivers/bcmxcp_ser.c
@@ -296,6 +296,9 @@ static void pw_comm_setup(const char *port)
 # pragma GCC diagnostic push
 #endif
 #ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS
+/* Note that the individual warning pragmas for use inside function bodies
+ * are named without a _INSIDEFUNC suffix, for simplicity and legacy reasons
+ */
 # pragma GCC diagnostic ignored "-Wtype-limits"
 #endif
 #ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE

--- a/drivers/bcmxcp_ser.c
+++ b/drivers/bcmxcp_ser.c
@@ -316,11 +316,14 @@ static void pw_comm_setup(const char *port)
 		}
 
 		if (ret > 0) {
-			upslogx(LOG_INFO, "Connected to UPS on %s with baudrate %d", port, baud);
+			/* Cast baud into max length unsigned, despite the POSIX
+			 * standard some systems vary in definition of this type
+			 */
+			upslogx(LOG_INFO, "Connected to UPS on %s with baudrate %llu", port, (unsigned long long int)baud);
 			return;
 		}
 
-		upslogx(LOG_ERR, "No response from UPS on %s with baudrate %d", port, baud);
+		upslogx(LOG_ERR, "No response from UPS on %s with baudrate %llu", port, (unsigned long long int)baud);
 	}
 
 	upslogx(LOG_INFO, "Attempting to autodect baudrate");

--- a/drivers/bcmxcp_ser.h
+++ b/drivers/bcmxcp_ser.h
@@ -5,14 +5,16 @@
 #ifndef BCMXCP_SER__
 #define BCMXCP_SER__
 
+#include "serial.h"	/* pulls termios.h to define speed_t */
+
 /* This header is needed for this line, to avoid warnings about it not
  * being static in C file (can't hide, is also needed by nut-scanner)
  */
 extern unsigned char AUT[4];
 
 typedef struct {
-	int rate;
-	int name;
+	speed_t rate;	/* Value like B19200 defined in termios.h; note: NOT the bitrate numerically */
+	size_t name;	/* Actual rate... WHY is this "name" - number to print interactively? */
 } pw_baud_rate_t;
 
 extern pw_baud_rate_t pw_baud_rates[];

--- a/m4/ax_c_pragmas.m4
+++ b/m4/ax_c_pragmas.m4
@@ -149,6 +149,33 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
     AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS_BESIDEFUNC], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wtype-limits" (outside functions)])
   ])
 
+  AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"],
+    [ax_cv__pragma__gcc__diags_ignored_tautological_constant_out_of_range_compare],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[void func(void) {
+#pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"
+}
+]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_tautological_constant_out_of_range_compare=yes],
+      [ax_cv__pragma__gcc__diags_ignored_tautological_constant_out_of_range_compare=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_tautological_constant_out_of_range_compare" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"])
+  ])
+
+  AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare" (outside functions)],
+    [ax_cv__pragma__gcc__diags_ignored_tautological_constant_out_of_range_compare_besidefunc],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_tautological_constant_out_of_range_compare_besidefunc=yes],
+      [ax_cv__pragma__gcc__diags_ignored_tautological_constant_out_of_range_compare_besidefunc=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_tautological_constant_out_of_range_compare_besidefunc" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE_BESIDEFUNC], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare" (outside functions)])
+  ])
+
   AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wunreachable-code-break"],
     [ax_cv__pragma__gcc__diags_ignored_unreachable_code_break],
     [AC_COMPILE_IFELSE(

--- a/m4/ax_c_pragmas.m4
+++ b/m4/ax_c_pragmas.m4
@@ -22,25 +22,59 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
          CXXFLAGS="${CXXFLAGS_SAVED} -Wall -Wextra -Werror"])
     ])
 
-  AC_CACHE_CHECK([for pragma GCC diagnostic push and pop],
-    [ax_cv__pragma__gcc__diags_push_pop],
+  AC_CACHE_CHECK([for pragma GCC diagnostic push and pop (outside functions)],
+    [ax_cv__pragma__gcc__diags_push_pop_besidefunc],
     [AC_COMPILE_IFELSE(
       [AC_LANG_PROGRAM([[
 #pragma GCC diagnostic push
 #pragma GCC diagnostic pop
         ]], [])],
-      [ax_cv__pragma__gcc__diags_push_pop=yes],
-      [ax_cv__pragma__gcc__diags_push_pop=no]
+      [ax_cv__pragma__gcc__diags_push_pop_besidefunc=yes],
+      [ax_cv__pragma__gcc__diags_push_pop_besidefunc=no]
     )]
   )
-  AS_IF([test "$ax_cv__pragma__gcc__diags_push_pop" = "yes"],[
+
+  dnl # Currently our code uses these pragmas as close to lines that cause
+  dnl # questions from linters as possible. GCC before 4.5 did not allow
+  dnl # for diag pragmas inside function bodies, but also did not complain
+  dnl # about messy code as new compilers do. For completeness, we support
+  dnl # the possibility of defining larger-scoped pragmas around whole
+  dnl # function bodies. In practice, we don't currently do that so in
+  dnl # most cases the shorter names (without _INSIDEFUNC) are used with
+  dnl # that implied meaning.
+
+  AC_CACHE_CHECK([for pragma GCC diagnostic push and pop (inside functions)],
+    [ax_cv__pragma__gcc__diags_push_pop_insidefunc],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[void func(void) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic pop
+}
+        ]], [])],
+      [ax_cv__pragma__gcc__diags_push_pop_insidefunc=yes],
+      [ax_cv__pragma__gcc__diags_push_pop_insidefunc=no]
+    )]
+  )
+
+  AS_IF([test "$ax_cv__pragma__gcc__diags_push_pop_insidefunc" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_INSIDEFUNC], 1, [define if your compiler has #pragma GCC diagnostic push and pop inside function bodies])
+  ])
+
+  AS_IF([test "$ax_cv__pragma__gcc__diags_push_pop_besidefunc" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_BESIDEFUNC], 1, [define if your compiler has #pragma GCC diagnostic push and pop outside function bodies])
+  ])
+
+  AS_IF([test "$ax_cv__pragma__gcc__diags_push_pop_besidefunc" = "yes" && test "$ax_cv__pragma__gcc__diags_push_pop_insidefunc" = "yes"],[
     AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP], 1, [define if your compiler has #pragma GCC diagnostic push and pop])
   ])
 
   AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wformat-nonliteral"],
     [ax_cv__pragma__gcc__diags_ignored_format_nonliteral],
     [AC_COMPILE_IFELSE(
-      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wformat-nonliteral"]], [])],
+      [AC_LANG_PROGRAM([[void func(void) {
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+}
+]], [])],
       [ax_cv__pragma__gcc__diags_ignored_format_nonliteral=yes],
       [ax_cv__pragma__gcc__diags_ignored_format_nonliteral=no]
     )]
@@ -49,10 +83,25 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
     AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_FORMAT_NONLITERAL], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wformat-nonliteral"])
   ])
 
+  AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wformat-nonliteral" (outside functions)],
+    [ax_cv__pragma__gcc__diags_ignored_format_nonliteral_besidefunc],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wformat-nonliteral"]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_format_nonliteral_besidefunc=yes],
+      [ax_cv__pragma__gcc__diags_ignored_format_nonliteral_besidefunc=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_format_nonliteral_besidefunc" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_FORMAT_NONLITERAL_BESIDEFUNC], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wformat-nonliteral" (outside functions)])
+  ])
+
   AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wformat-security"],
     [ax_cv__pragma__gcc__diags_ignored_format_security],
     [AC_COMPILE_IFELSE(
-      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wformat-security"]], [])],
+      [AC_LANG_PROGRAM([[void func(void) {
+#pragma GCC diagnostic ignored "-Wformat-security"
+}
+]], [])],
       [ax_cv__pragma__gcc__diags_ignored_format_security=yes],
       [ax_cv__pragma__gcc__diags_ignored_format_security=no]
     )]
@@ -61,10 +110,52 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
     AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_FORMAT_SECURITY], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wformat-security"])
   ])
 
+  AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wformat-security" (outside functions)],
+    [ax_cv__pragma__gcc__diags_ignored_format_security_besidefunc],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wformat-security"]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_format_security_besidefunc=yes],
+      [ax_cv__pragma__gcc__diags_ignored_format_security_besidefunc=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_format_security_besidefunc" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_FORMAT_SECURITY_BESIDEFUNC], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wformat-security" (outside functions)])
+  ])
+
+  AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wtype-limits"],
+    [ax_cv__pragma__gcc__diags_ignored_type_limits],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[void func(void) {
+#pragma GCC diagnostic ignored "-Wtype-limits"
+}
+]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_type_limits=yes],
+      [ax_cv__pragma__gcc__diags_ignored_type_limits=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_type_limits" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wtype-limits"])
+  ])
+
+  AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wtype-limits" (outside functions)],
+    [ax_cv__pragma__gcc__diags_ignored_type_limits_besidefunc],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wtype-limits"]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_type_limits_besidefunc=yes],
+      [ax_cv__pragma__gcc__diags_ignored_type_limits_besidefunc=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_type_limits_besidefunc" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS_BESIDEFUNC], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wtype-limits" (outside functions)])
+  ])
+
   AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wunreachable-code-break"],
     [ax_cv__pragma__gcc__diags_ignored_unreachable_code_break],
     [AC_COMPILE_IFELSE(
-      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wunreachable-code-break"]], [])],
+      [AC_LANG_PROGRAM([[void func(void) {
+#pragma GCC diagnostic ignored "-Wunreachable-code-break"
+}
+]], [])],
       [ax_cv__pragma__gcc__diags_ignored_unreachable_code_break=yes],
       [ax_cv__pragma__gcc__diags_ignored_unreachable_code_break=no]
     )]
@@ -73,10 +164,25 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
     AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE_BREAK], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wunreachable-code-break"])
   ])
 
+  AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wunreachable-code-break" (outside functions)],
+    [ax_cv__pragma__gcc__diags_ignored_unreachable_code_break_besidefunc],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wunreachable-code-break"]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_unreachable_code_break_besidefunc=yes],
+      [ax_cv__pragma__gcc__diags_ignored_unreachable_code_break_besidefunc=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_unreachable_code_break_besidefunc" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE_BREAK_BESIDEFUNC], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wunreachable-code-break" (outside functions)])
+  ])
+
   AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wunreachable-code"],
     [ax_cv__pragma__gcc__diags_ignored_unreachable_code],
     [AC_COMPILE_IFELSE(
-      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wunreachable-code"]], [])],
+      [AC_LANG_PROGRAM([[void func(void) {
+#pragma GCC diagnostic ignored "-Wunreachable-code"
+}
+]], [])],
       [ax_cv__pragma__gcc__diags_ignored_unreachable_code=yes],
       [ax_cv__pragma__gcc__diags_ignored_unreachable_code=no]
     )]
@@ -85,10 +191,25 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
     AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wunreachable-code"])
   ])
 
+  AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wunreachable-code" (outside functions)],
+    [ax_cv__pragma__gcc__diags_ignored_unreachable_code_besidefunc],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wunreachable-code"]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_unreachable_code_besidefunc=yes],
+      [ax_cv__pragma__gcc__diags_ignored_unreachable_code_besidefunc=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_unreachable_code_besidefunc" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE_BESIDEFUNC], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wunreachable-code" (outside functions)])
+  ])
+
   AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wformat-overflow"],
     [ax_cv__pragma__gcc__diags_ignored_format_overflow],
     [AC_COMPILE_IFELSE(
-      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wformat-overflow"]], [])],
+      [AC_LANG_PROGRAM([[void func(void) {
+#pragma GCC diagnostic ignored "-Wformat-overflow"
+}
+]], [])],
       [ax_cv__pragma__gcc__diags_ignored_format_overflow=yes],
       [ax_cv__pragma__gcc__diags_ignored_format_overflow=no]
     )]
@@ -97,10 +218,25 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
     AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_FORMAT_OVERFLOW], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wformat-overflow"])
   ])
 
+  AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wformat-overflow" (outside functions)],
+    [ax_cv__pragma__gcc__diags_ignored_format_overflow_besidefunc],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wformat-overflow"]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_format_overflow_besidefunc=yes],
+      [ax_cv__pragma__gcc__diags_ignored_format_overflow_besidefunc=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_format_overflow_besidefunc" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_FORMAT_OVERFLOW_BESIDEFUNC], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wformat-overflow" (outside functions)])
+  ])
+
   AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wcovered-switch-default"],
     [ax_cv__pragma__gcc__diags_ignored_covered_switch_default],
     [AC_COMPILE_IFELSE(
-      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wcovered-switch-default"]], [])],
+      [AC_LANG_PROGRAM([[void func(void) {
+#pragma GCC diagnostic ignored "-Wcovered-switch-default"
+}
+]], [])],
       [ax_cv__pragma__gcc__diags_ignored_covered_switch_default=yes],
       [ax_cv__pragma__gcc__diags_ignored_covered_switch_default=no]
     )]
@@ -109,10 +245,25 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
     AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wcovered-switch-default"])
   ])
 
+  AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wcovered-switch-default" (outside functions)],
+    [ax_cv__pragma__gcc__diags_ignored_covered_switch_default_besidefunc],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wcovered-switch-default"]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_covered_switch_default_besidefunc=yes],
+      [ax_cv__pragma__gcc__diags_ignored_covered_switch_default_besidefunc=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_covered_switch_default_besidefunc" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT_BESIDEFUNC], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wcovered-switch-default" (outside functions)])
+  ])
+
   AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wcast-align"],
     [ax_cv__pragma__gcc__diags_ignored_cast_align],
     [AC_COMPILE_IFELSE(
-      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wcast-align"]], [])],
+      [AC_LANG_PROGRAM([[void func(void) {
+#pragma GCC diagnostic ignored "-Wcast-align"
+}
+]], [])],
       [ax_cv__pragma__gcc__diags_ignored_cast_align=yes],
       [ax_cv__pragma__gcc__diags_ignored_cast_align=no]
     )]
@@ -121,10 +272,25 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
     AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_CAST_ALIGN], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wcast-align"])
   ])
 
+  AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wcast-align" (outside functions)],
+    [ax_cv__pragma__gcc__diags_ignored_cast_align_besidefunc],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wcast-align"]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_cast_align_besidefunc=yes],
+      [ax_cv__pragma__gcc__diags_ignored_cast_align_besidefunc=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_cast_align_besidefunc" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_CAST_ALIGN_BESIDEFUNC], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wcast-align" (outside functions)])
+  ])
+
   AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wstrict-prototypes"],
     [ax_cv__pragma__gcc__diags_ignored_strict_prototypes],
     [AC_COMPILE_IFELSE(
-      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wstrict-prototypes"]], [])],
+      [AC_LANG_PROGRAM([[void func(void) {
+#pragma GCC diagnostic ignored "-Wstrict-prototypes"
+}
+]], [])],
       [ax_cv__pragma__gcc__diags_ignored_strict_prototypes=yes],
       [ax_cv__pragma__gcc__diags_ignored_strict_prototypes=no]
     )]
@@ -133,16 +299,43 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
     AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_STRICT_PROTOTYPES], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wstrict-prototypes"])
   ])
 
+  AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wstrict-prototypes" (outside functions)],
+    [ax_cv__pragma__gcc__diags_ignored_strict_prototypes_besidefunc],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wstrict-prototypes"]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_strict_prototypes_besidefunc=yes],
+      [ax_cv__pragma__gcc__diags_ignored_strict_prototypes_besidefunc=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_strict_prototypes_besidefunc" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_STRICT_PROTOTYPES_BESIDEFUNC], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wstrict-prototypes" (outside functions)])
+  ])
+
   AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wassign-enum"],
     [ax_cv__pragma__gcc__diags_ignored_assign_enum],
     [AC_COMPILE_IFELSE(
-      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wassign-enum"]], [])],
+      [AC_LANG_PROGRAM([[void func(void) {
+#pragma GCC diagnostic ignored "-Wassign-enum"
+}
+]], [])],
       [ax_cv__pragma__gcc__diags_ignored_assign_enum=yes],
       [ax_cv__pragma__gcc__diags_ignored_assign_enum=no]
     )]
   )
   AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_assign_enum" = "yes"],[
     AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_ASSIGN_ENUM], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wassign-enum"])
+  ])
+
+  AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wassign-enum" (outside functions)],
+    [ax_cv__pragma__gcc__diags_ignored_assign_enum_besidefunc],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wassign-enum"]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_assign_enum_besidefunc=yes],
+      [ax_cv__pragma__gcc__diags_ignored_assign_enum_besidefunc=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_assign_enum_besidefunc" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_ASSIGN_ENUM_BESIDEFUNC], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wassign-enum" (outside functions)])
   ])
 
   AC_LANG_POP([C])
@@ -153,7 +346,10 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
   AC_CACHE_CHECK([for C++ pragma GCC diagnostic ignored "-Wc++98-compat-pedantic"],
     [ax_cv__pragma__gcc__diags_ignored_cxx98_compat_pedantic],
     [AC_COMPILE_IFELSE(
-      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wc++98-compat-pedantic"]], [])],
+      [AC_LANG_PROGRAM([[void func(void) {
+#pragma GCC diagnostic ignored "-Wc++98-compat-pedantic"
+}
+]], [])],
       [ax_cv__pragma__gcc__diags_ignored_cxx98_compat_pedantic=yes],
       [ax_cv__pragma__gcc__diags_ignored_cxx98_compat_pedantic=no]
     )]
@@ -162,10 +358,25 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
     AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_CXX98_COMPAT_PEDANTIC], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wc++98-compat-pedantic"])
   ])
 
+  AC_CACHE_CHECK([for C++ pragma GCC diagnostic ignored "-Wc++98-compat-pedantic" (outside functions)],
+    [ax_cv__pragma__gcc__diags_ignored_cxx98_compat_pedantic_besidefunc],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wc++98-compat-pedantic"]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_cxx98_compat_pedantic_besidefunc=yes],
+      [ax_cv__pragma__gcc__diags_ignored_cxx98_compat_pedantic_besidefunc=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_cxx98_compat_pedantic_besidefunc" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_CXX98_COMPAT_PEDANTIC_BESIDEFUNC], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wc++98-compat-pedantic" (outside functions)])
+  ])
+
   AC_CACHE_CHECK([for C++ pragma GCC diagnostic ignored "-Wc++98-compat"],
     [ax_cv__pragma__gcc__diags_ignored_cxx98_compat],
     [AC_COMPILE_IFELSE(
-      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wc++98-compat"]], [])],
+      [AC_LANG_PROGRAM([[void func(void) {
+#pragma GCC diagnostic ignored "-Wc++98-compat"
+}
+]], [])],
       [ax_cv__pragma__gcc__diags_ignored_cxx98_compat=yes],
       [ax_cv__pragma__gcc__diags_ignored_cxx98_compat=no]
     )]
@@ -174,10 +385,25 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
     AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_CXX98_COMPAT], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wc++98-compat"])
   ])
 
+  AC_CACHE_CHECK([for C++ pragma GCC diagnostic ignored "-Wc++98-compat" (outside functions)],
+    [ax_cv__pragma__gcc__diags_ignored_cxx98_compat_besidefunc],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wc++98-compat"]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_cxx98_compat_besidefunc=yes],
+      [ax_cv__pragma__gcc__diags_ignored_cxx98_compat_besidefunc=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_cxx98_compat_besidefunc" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_CXX98_COMPAT_BESIDEFUNC], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wc++98-compat" (outside functions)])
+  ])
+
   AC_CACHE_CHECK([for C++ pragma GCC diagnostic ignored "-Wglobal-constructors"],
     [ax_cv__pragma__gcc__diags_ignored_global_constructors],
     [AC_COMPILE_IFELSE(
-      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wglobal-constructors"]], [])],
+      [AC_LANG_PROGRAM([[void func(void) {
+#pragma GCC diagnostic ignored "-Wglobal-constructors"
+}
+]], [])],
       [ax_cv__pragma__gcc__diags_ignored_global_constructors=yes],
       [ax_cv__pragma__gcc__diags_ignored_global_constructors=no]
     )]
@@ -186,10 +412,25 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
     AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_GLOBAL_CONSTRUCTORS], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wglobal-constructors"])
   ])
 
+  AC_CACHE_CHECK([for C++ pragma GCC diagnostic ignored "-Wglobal-constructors" (outside functions)],
+    [ax_cv__pragma__gcc__diags_ignored_global_constructors_besidefunc],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wglobal-constructors"]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_global_constructors_besidefunc=yes],
+      [ax_cv__pragma__gcc__diags_ignored_global_constructors_besidefunc=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_global_constructors_besidefunc" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_GLOBAL_CONSTRUCTORS_BESIDEFUNC], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wglobal-constructors" (outside functions)])
+  ])
+
   AC_CACHE_CHECK([for C++ pragma GCC diagnostic ignored "-Wexit-time-destructors"],
     [ax_cv__pragma__gcc__diags_ignored_exit_time_destructors],
     [AC_COMPILE_IFELSE(
-      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wexit-time-destructors"]], [])],
+      [AC_LANG_PROGRAM([[void func(void) {
+#pragma GCC diagnostic ignored "-Wexit-time-destructors"
+}
+]], [])],
       [ax_cv__pragma__gcc__diags_ignored_exit_time_destructors=yes],
       [ax_cv__pragma__gcc__diags_ignored_exit_time_destructors=no]
     )]
@@ -198,11 +439,23 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
     AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_EXIT_TIME_DESTRUCTORS], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wexit-time-destructors"])
   ])
 
+  AC_CACHE_CHECK([for C++ pragma GCC diagnostic ignored "-Wexit-time-destructors" (outside functions)],
+    [ax_cv__pragma__gcc__diags_ignored_exit_time_destructors_besidefunc],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wexit-time-destructors"]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_exit_time_destructors_besidefunc=yes],
+      [ax_cv__pragma__gcc__diags_ignored_exit_time_destructors_besidefunc=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_exit_time_destructors_besidefunc" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_EXIT_TIME_DESTRUCTORS_BESIDEFUNC], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wexit-time-destructors" (outside functions)])
+  ])
+
   AC_LANG_POP([C++])
 
   dnl # Meta-macros for simpler use-cases where we pick
   dnl # equivalent-effect macros for different compiler versions
-  AS_IF([test "$ax_cv__pragma__gcc__diags_push_pop" = "yes"],[
+  AS_IF([test "$ax_cv__pragma__gcc__diags_push_pop_insidefunc" = "yes"],[
     AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_format_security" = "yes" || test "$ax_cv__pragma__gcc__diags_ignored_format_nonliteral" = "yes" ],[
         AC_DEFINE([HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_NONLITERAL], 1, [define if your compiler has pragmas for GCC diagnostic ignored "-Wformat-nonliteral" or "-Wformat-security" and for push-pop support])
     ])
@@ -214,30 +467,72 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
     ])
   ])
 
+  AS_IF([test "$ax_cv__pragma__gcc__diags_push_pop_besidefunc" = "yes"],[
+    AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_format_security" = "yes" || test "$ax_cv__pragma__gcc__diags_ignored_format_nonliteral" = "yes" ],[
+        AC_DEFINE([HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_NONLITERAL_BESIDEFUNC], 1, [define if your compiler has pragmas for GCC diagnostic ignored "-Wformat-nonliteral" or "-Wformat-security" and for push-pop support (outside function bodies)])
+    ])
+    AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_unreachable_code" = "yes" || test "$ax_cv__pragma__gcc__diags_ignored_unreachable_code_break" = "yes" ],[
+        AC_DEFINE([HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE_BESIDEFUNC], 1, [define if your compiler has pragmas for GCC diagnostic ignored "-Wunreachable-code(-break)" and for push-pop support (outside function bodies)])
+    ])
+    AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_cxx98_compat_pedantic" = "yes" || test "$ax_cv__pragma__gcc__diags_ignored_cxx98_compat" = "yes" ],[
+        AC_DEFINE([HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_CXX98_COMPAT_BESIDEFUNC], 1, [define if your compiler has pragmas for GCC diagnostic ignored "-Wc++98-compat(-pedantic)" and for push-pop support (outside function bodies)])
+    ])
+  ])
+
   dnl ### Sanity check if the CLI options actually work:
   AC_CACHE_CHECK([for pragma BOGUSforTest],
     [ax_cv__pragma__bogus],
     [AC_COMPILE_IFELSE(
-      [AC_LANG_PROGRAM([[#pragma BOGUSforTest]], [])],
+      [AC_LANG_PROGRAM([[void func(void) {
+#pragma BOGUSforTest
+}
+]], [])],
       [ax_cv__pragma__bogus=yes],
       [ax_cv__pragma__bogus=no]
+    )]
+  )
+
+  AC_CACHE_CHECK([for pragma BOGUSforTest (outside functions)],
+    [ax_cv__pragma__bogus_besidefunc],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[#pragma BOGUSforTest]], [])],
+      [ax_cv__pragma__bogus_besidefunc=yes],
+      [ax_cv__pragma__bogus_besidefunc=no]
     )]
   )
 
   AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-WBOGUSforTest"],
     [ax_cv__pragma__bogus_diag],
     [AC_COMPILE_IFELSE(
-      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-WBOGUSforTest"]], [])],
+      [AC_LANG_PROGRAM([[void func(void) {
+#pragma GCC diagnostic ignored "-WBOGUSforTest"
+}
+]], [])],
       [ax_cv__pragma__bogus_diag=yes],
       [ax_cv__pragma__bogus_diag=no]
+    )]
+  )
+
+  AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-WBOGUSforTest" (outside functions)],
+    [ax_cv__pragma__bogus_diag_besidefunc],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-WBOGUSforTest"]], [])],
+      [ax_cv__pragma__bogus_diag_besidefunc=yes],
+      [ax_cv__pragma__bogus_diag_besidefunc=no]
     )]
   )
 
   AS_IF([test "${ax_cv__pragma__bogus}" != "no"],
     [AC_MSG_WARN([A bogus test that was expected to fail did not! ax_cv__pragma__bogus=$ax_cv__pragma__bogus (not 'no')])])
 
+  AS_IF([test "${ax_cv__pragma__bogus_besidefunc}" != "no"],
+    [AC_MSG_WARN([A bogus test that was expected to fail did not! ax_cv__pragma__bogus_besidefunc=$ax_cv__pragma__bogus_besidefunc (not 'no')])])
+
   AS_IF([test "${ax_cv__pragma__bogus_diag}" != "no"],
     [AC_MSG_WARN([A bogus test that was expected to fail did not! ax_cv__pragma__bogus_diag=$ax_cv__pragma__bogus_diag (not 'no')])])
+
+  AS_IF([test "${ax_cv__pragma__bogus_diag_besidefunc}" != "no"],
+    [AC_MSG_WARN([A bogus test that was expected to fail did not! ax_cv__pragma__bogus_diag_besidefunc=$ax_cv__pragma__bogus_diag_besidefunc (not 'no')])])
 
   CFLAGS="${CFLAGS_SAVED}"
   CXXFLAGS="${CXXFLAGS_SAVED}"


### PR DESCRIPTION
Fixes issue #932 (checked on a system with gcc-4.4.4, and on a NUT buildbot that spewed over a hundred new warnings otherwise).

The applied use-case builds on top of, and so includes, data type fixes for baud-rate processing in `bcmxcp_ser.c` also.