### PR TITLE
fightwarn - a few small warnings and cosmetics

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -390,7 +390,7 @@ static void vupslog(int priority, const char *fmt, va_list va, int use_strerror)
 		snprintfcat(buf, sizeof(buf), ": %s", strerror(errno));
 
 	if (nut_debug_level > 0) {
-		static struct timeval	start = { 0 };
+		static struct timeval	start = { 0, 0 };
 		struct timeval		now;
 
 		gettimeofday(&now, NULL);

--- a/drivers/bcmxcp.c
+++ b/drivers/bcmxcp.c
@@ -1716,7 +1716,7 @@ void upsdrv_updateinfo(void)
 			upsdebugx(1, "Failed to extract Battery Status from answer");
 		}
 
-    		/*Extracting internal batteries ABM status*/
+		/*Extracting internal batteries ABM status*/
 		/*Placed first in ABM statuses list. For examples above - on position BCMXCP_BATTDATA_BLOCK_NUMBER_OF_STRINGS (18):
 		PW5115RM - 0 - no external strings, no status bytes,
 		so next byte (19) - number of ABM statuses, next (20) - first ABM Status for internal batteries.
@@ -2411,7 +2411,7 @@ int setvar (const char *varname, const char *val)
 		snprintf(success_msg, sizeof(success_msg)-1, "Outlet %d %s delay set to %d sec",
 					outlet_num, (onOff_setting == PW_AUTO_ON_DELAY)?"start":"shutdown", sec);
 
-       		return decode_setvar_exec(res, (unsigned char)answer[0], varname, success_msg);
+		return decode_setvar_exec(res, (unsigned char)answer[0], varname, success_msg);
 
 	}
 

--- a/drivers/eaton-pdu-marlin-mib.c
+++ b/drivers/eaton-pdu-marlin-mib.c
@@ -58,9 +58,9 @@ static info_lkp_t marlin_outletgroups_status_info[] = {
  * having the matching OID present means that the outlet/unit is
  * switchable. So, it should not require this value lookup */
 static info_lkp_t g2_unit_outlet_switchability_info[] = {
-	{ -1, "yes" },
-	{ 0, "yes" },
-	{ 0, NULL }
+	{ -1, "yes", NULL, NULL },
+	{ 0, "yes", NULL, NULL },
+	{ 0, NULL, NULL, NULL }
 };
 
 static info_lkp_t marlin_outlet_switchability_info[] = {

--- a/drivers/libusb.c
+++ b/drivers/libusb.c
@@ -75,8 +75,8 @@ static inline int typesafe_control_msg(usb_dev_handle *dev,
         int value, int index,
         unsigned char *bytes, unsigned size, int timeout)
 {
-        return usb_control_msg(dev, requesttype, request, value, index,
-                (char *) bytes, (int) size, timeout);
+	return usb_control_msg(dev, requesttype, request, value, index,
+		(char *) bytes, (int) size, timeout);
 }
 
 /* invoke matcher against device */
@@ -316,7 +316,7 @@ static int libusb_open(usb_dev_handle **udevp, USBDevice_t *curDevice, USBDevice
 			/* FIRST METHOD: ask for HID descriptor directly. */
 			/* res = usb_get_descriptor(udev, USB_DT_HID, hid_desc_index, buf, 0x9); */
 			res = usb_control_msg(udev, USB_ENDPOINT_IN+1, USB_REQ_GET_DESCRIPTOR,
-					      (USB_DT_HID << 8) + hid_desc_index, 0, buf, 0x9, USB_TIMEOUT);
+					(USB_DT_HID << 8) + hid_desc_index, 0, buf, 0x9, USB_TIMEOUT);
 
 			if (res < 0) {
 				upsdebugx(2, "Unable to get HID descriptor (%s)", usb_strerror());


### PR DESCRIPTION
The one in al175 had me puzzled, and seems to be more of a bug in some versions of GCC than in our code. Still, there are ways around it (checking the return for errors) that make sense other than plastering over the potential even if fantastic issues as in many other cases.

A few recent improvements introduced back cases of uninitialized structure members.

And a couple of whitespace cleanups that make code prettier and later PRs more focused on the bugs they solve.

Part of the effort started with #823.