### PR TITLE
Fightwarn - standardize warnings we care about via configure script arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -913,9 +913,6 @@ _matrix_osx_gnustd_nowarn:
       - $HOME/Library/Caches/Homebrew
       - $HOME/.ccache
 
-# -Wno-reserved-id-macro -- configure script tends to define _GNU_SOURCE_, __EXTENSIONS__ etc.
-# -Wno-unused-macros -- system headers define a lot of stuff we do not use, gotta be fatal right?
-# -Wno-padded -- NSPR and NSS headers get to issue lots of that
 _matrix_osx_gnustd_warn:
   include: &_matrix_osx_gnustd_warn
   - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++

--- a/.travis.yml
+++ b/.travis.yml
@@ -489,7 +489,7 @@ _matrix_linux_gnustd_nowarn_s390x_64bit_viable:
 
 _matrix_linux_gnustd_nowarn_s390x_64bit_fatal:
   include: &_matrix_linux_gnustd_nowarn_s390x_64bit_fatal
-  - env: NUT_MATRIX_TAG="gnu17-clang-8-warn-s390x-64bit" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=gnu++17" CC=clang-8 CXX=clang++-8
+  - env: NUT_MATRIX_TAG="gnu17-clang-8-warn-s390x-64bit" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang-8 CXX=clang++-8
     os: linux
     arch: s390x
     dist: xenial
@@ -633,7 +633,7 @@ _matrix_linux_cstd_nowarn:
 # Stuff with warnings made fatal... and codebase got good enough to survive!
 _matrix_linux_gnustd_warn_viable:
   include: &_matrix_linux_gnustd_warn_viable
-  - env: NUT_MATRIX_TAG="cDefault-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic" CXXFLAGS="-Wall -Wextra -Werror"
+  - env: NUT_MATRIX_TAG="cDefault-gcc-default-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard
     os: linux
     sudo: false
     services:
@@ -645,7 +645,7 @@ _matrix_linux_gnustd_warn_viable:
         packages:
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="gnu99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++98"
+  - env: NUT_MATRIX_TAG="gnu99-gcc-default-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++98"
     os: linux
     sudo: false
     services:
@@ -657,7 +657,7 @@ _matrix_linux_gnustd_warn_viable:
         packages:
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="gnu11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu11" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++11"
+  - env: NUT_MATRIX_TAG="gnu11-gcc-default-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=gnu11" CXXFLAGS="-std=gnu++11"
     os: linux
     sudo: false
     services:
@@ -669,7 +669,7 @@ _matrix_linux_gnustd_warn_viable:
         packages:
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="gnu99-gcc-7-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++98" CC=gcc-7 CXX=g++-7
+  - env: NUT_MATRIX_TAG="gnu99-gcc-7-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++98" CC=gcc-7 CXX=g++-7
     os: linux
     sudo: false
     services:
@@ -685,7 +685,7 @@ _matrix_linux_gnustd_warn_viable:
         - gcc-7
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="gnu17-gcc-9-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++17" CC=gcc-9 CXX=g++-9
+  - env: NUT_MATRIX_TAG="gnu17-gcc-9-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc-9 CXX=g++-9
     os: linux
     sudo: false
     services:
@@ -705,7 +705,7 @@ _matrix_linux_gnustd_warn_viable:
 _matrix_linux_gnustd_warn_fatal:
   include: &_matrix_linux_gnustd_warn_fatal
 # Note: Fixing these would make NUT viable again on platforms with only ANSI C!
-  - env: NUT_MATRIX_TAG="gnu89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu89" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++89"
+  - env: NUT_MATRIX_TAG="gnu89-gcc-default-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=gnu89" CXXFLAGS="-std=gnu++89"
     os: linux
     sudo: false
     services:
@@ -720,7 +720,7 @@ _matrix_linux_gnustd_warn_fatal:
 # The hardest of two worlds: both strict C standards on Linux and fatal warnings:
 _matrix_linux_cstd_warn:
   include: &_matrix_linux_cstd_warn
-  - env: NUT_MATRIX_TAG="c99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -std=c++98"
+  - env: NUT_MATRIX_TAG="c99-gcc-default-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=c99" CXXFLAGS="-std=c++98"
     os: linux
     sudo: false
     services:
@@ -732,7 +732,7 @@ _matrix_linux_cstd_warn:
         packages:
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="c99-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=c++99" CC=clang-5.0 CXX=clang++-5.0
+  - env: NUT_MATRIX_TAG="c99-clang-5.0-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang-5.0 CXX=clang++-5.0
     os: linux
     dist: xenial
     sudo: false
@@ -749,7 +749,7 @@ _matrix_linux_cstd_warn:
         - clang-format-5.0
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="c11-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=c++11" CC=clang-5.0 CXX=clang++-5.0
+  - env: NUT_MATRIX_TAG="c11-clang-5.0-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=c11" CXXFLAGS="-std=c++11" CC=clang-5.0 CXX=clang++-5.0
     os: linux
     dist: xenial
     sudo: false
@@ -766,7 +766,7 @@ _matrix_linux_cstd_warn:
         - clang-format-5.0
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="c17-clang-8-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=c++17" CC=clang-8 CXX=clang++-8
+  - env: NUT_MATRIX_TAG="c17-clang-8-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=c17" CXXFLAGS="-std=c++17" CC=clang-8 CXX=clang++-8
     os: linux
     dist: xenial
     sudo: false
@@ -783,7 +783,7 @@ _matrix_linux_cstd_warn:
         - clang-format-8
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="c11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror -std=c++11"
+  - env: NUT_MATRIX_TAG="c11-gcc-default-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=c11" CXXFLAGS="-std=c++11"
     os: linux
     sudo: false
     services:
@@ -795,7 +795,7 @@ _matrix_linux_cstd_warn:
         packages:
         - *deps_driverlibs
 
-  - env: NUT_MATRIX_TAG="c89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c89" CXXFLAGS="-Wall -Wextra -Werror -std=c++89"
+  - env: NUT_MATRIX_TAG="c89-gcc-default-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=c89" CXXFLAGS="-std=c++89"
     os: linux
     sudo: false
     services:
@@ -843,7 +843,7 @@ _matrix_freebsd_gnustd_nowarn:
 
 _matrix_freebsd_gnustd_warn_viable:
   include: &_matrix_freebsd_gnustd_warn_viable
-  - env: NUT_MATRIX_TAG="gnu99-gcc-default-freebsd-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++98" CC=gcc CXX=g++
+  - env: NUT_MATRIX_TAG="gnu99-gcc-default-freebsd-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++98" CC=gcc CXX=g++
     os: freebsd
     sudo: true
     compiler: gcc
@@ -852,7 +852,7 @@ _matrix_freebsd_gnustd_warn_viable:
       directories:
       - $HOME/.ccache
 
-  - env: NUT_MATRIX_TAG="gnu17-gcc-default-freebsd-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++17" CC=gcc CXX=g++
+  - env: NUT_MATRIX_TAG="gnu17-gcc-default-freebsd-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc CXX=g++
     os: freebsd
     sudo: true
     compiler: gcc
@@ -863,7 +863,7 @@ _matrix_freebsd_gnustd_warn_viable:
 
 _matrix_freebsd_gnustd_warn_fatal:
   include: &_matrix_freebsd_gnustd_warn_fatal
-  - env: NUT_MATRIX_TAG="gnu99-clang-freebsd-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=gnu++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="gnu99-clang-freebsd-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
     os: freebsd
     sudo: true
     compiler: clang
@@ -872,7 +872,7 @@ _matrix_freebsd_gnustd_warn_fatal:
       directories:
       - $HOME/.ccache
 
-  - env: NUT_MATRIX_TAG="gnu17-clang-freebsd-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=gnu++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="gnu17-clang-freebsd-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang CXX=clang++
     os: freebsd
     sudo: true
     compiler: clang
@@ -918,7 +918,7 @@ _matrix_osx_gnustd_nowarn:
 # -Wno-padded -- NSPR and NSS headers get to issue lots of that
 _matrix_osx_gnustd_warn:
   include: &_matrix_osx_gnustd_warn
-  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=gnu++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
     os: osx
     osx_image: xcode10.2
     compiler: clang
@@ -928,7 +928,7 @@ _matrix_osx_gnustd_warn:
       - $HOME/Library/Caches/Homebrew
       - $HOME/.ccache
 
-  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=gnu++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang CXX=clang++
     os: osx
     osx_image: xcode10.2
     compiler: clang
@@ -962,7 +962,7 @@ _matrix_osx_cstd_nowarn:
 
 _matrix_osx_cstd_warn:
   include: &_matrix_osx_cstd_warn
-  - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
     os: osx
     osx_image: xcode10.2
     compiler: clang
@@ -972,7 +972,7 @@ _matrix_osx_cstd_warn:
       - $HOME/Library/Caches/Homebrew
       - $HOME/.ccache
 
-  - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=c++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=c17" CXXFLAGS="-std=c++17" CC=clang CXX=clang++
     os: osx
     osx_image: xcode10.2
     compiler: clang
@@ -982,7 +982,7 @@ _matrix_osx_cstd_warn:
       - $HOME/Library/Caches/Homebrew
       - $HOME/.ccache
 
-  - env: NUT_MATRIX_TAG="c11-clang-xcode7.3-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=c++11" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c11-clang-xcode7.3-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=c11" CXXFLAGS="-std=c++11" CC=clang CXX=clang++
     os: osx
     osx_image: xcode7.3
     compiler: clang
@@ -1012,7 +1012,7 @@ _matrix_windows_gnustd_nowarn:
 
 _matrix_windows_gnustd_warn:
   include: &_matrix_windows_gnustd_warn
-  - env: NUT_MATRIX_TAG="gnu99-clang-win-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="gnu99-clang-win-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
     os: windows
     compiler: clang
     if: branch =~ fightwarn
@@ -1036,7 +1036,7 @@ _matrix_windows_cstd_nowarn:
 
 _matrix_windows_cstd_warn:
   include: &_matrix_windows_cstd_warn
-  - env: NUT_MATRIX_TAG="c99-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c99-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
     os: windows
     compiler: clang
     if: branch =~ fightwarn
@@ -1048,7 +1048,7 @@ _matrix_windows_cstd_warn:
 
 # Incidentally, this is one platform we know to have clang-9,
 # the version which has (at least partial) C++20 support
-  - env: NUT_MATRIX_TAG="c20-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=c20" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=c++20" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c20-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=c20" CXXFLAGS="-std=c++20" CC=clang CXX=clang++
     os: windows
     compiler: clang
     if: branch =~ fightwarn
@@ -1251,31 +1251,31 @@ jobs:
 #OK#  - env: NUT_MATRIX_TAG="gnu17-gcc-9-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc-9 CXX=g++-9
 #OK#  - env: NUT_MATRIX_TAG="gnu99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang-5.0 CXX=clang++-5.0
 #OK#  - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang-8 CXX=clang++-8
-#OK#  - env: NUT_MATRIX_TAG="gnu17-gcc-9-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++17" CC=gcc-9 CXX=g++-9
+#OK#  - env: NUT_MATRIX_TAG="gnu17-gcc-9-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc-9 CXX=g++-9
 #OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn-x86-32bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99 -m32" CXXFLAGS="-std=gnu++99 -m32" CPPFLAGS="-m32" LDFLAGS="-m32"
 #OK#  - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn-x86-32bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17 -m32" CXXFLAGS="-std=gnu++17 -m32" CPPFLAGS="-m32" LDFLAGS="-m32" CC=clang-8 CXX=clang++-8
   - env: NUT_MATRIX_TAG="c99-clang-3.5-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang-3.5 CXX=clang++-3.5
   - env: NUT_MATRIX_TAG="c99-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang-5.0 CXX=clang++-5.0
   - env: NUT_MATRIX_TAG="c11-clang-5.0-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c11" CXXFLAGS="-std=c++11" CC=clang-5.0 CXX=clang++-5.0
   - env: NUT_MATRIX_TAG="c17-clang-8-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c17" CXXFLAGS="-std=c++17" CC=clang-8 CXX=clang++-8
-  - env: NUT_MATRIX_TAG="c17-clang-8-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=c++17" CC=clang-8 CXX=clang++-8
-#OK#  - env: NUT_MATRIX_TAG="cDefault-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic" CXXFLAGS="-Wall -Wextra -Werror"
-#OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++98"
-  - env: NUT_MATRIX_TAG="c99-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -std=c++98"
-#OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-7-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++98" CC=gcc-7 CXX=g++-7
-  - env: NUT_MATRIX_TAG="c99-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=c++99" CC=clang-5.0 CXX=clang++-5.0
-  - env: NUT_MATRIX_TAG="c11-clang-5.0-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=c++11" CC=clang-5.0 CXX=clang++-5.0
-  - env: NUT_MATRIX_TAG="c11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror -std=c++11"
-#OK#  - env: NUT_MATRIX_TAG="gnu11-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu11" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++11"
+  - env: NUT_MATRIX_TAG="c17-clang-8-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=c17" CXXFLAGS="-std=c++17" CC=clang-8 CXX=clang++-8
+#OK#  - env: NUT_MATRIX_TAG="cDefault-gcc-default-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard
+#OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-default-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++98"
+  - env: NUT_MATRIX_TAG="c99-gcc-default-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=c99" CXXFLAGS="-std=c++98"
+#OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-7-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++98" CC=gcc-7 CXX=g++-7
+  - env: NUT_MATRIX_TAG="c99-clang-5.0-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang-5.0 CXX=clang++-5.0
+  - env: NUT_MATRIX_TAG="c11-clang-5.0-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=c11" CXXFLAGS="-std=c++11" CC=clang-5.0 CXX=clang++-5.0
+  - env: NUT_MATRIX_TAG="c11-gcc-default-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=c11" CXXFLAGS="-std=c++11"
+#OK#  - env: NUT_MATRIX_TAG="gnu11-gcc-default-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=gnu11" CXXFLAGS="-std=gnu++11"
 #OK#  - env: NUT_MATRIX_TAG="gnu89-gcc-default-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu89" CXXFLAGS="-std=gnu++89"
-  - env: NUT_MATRIX_TAG="c89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=c89" CXXFLAGS="-Wall -Wextra -Werror -std=c++89"
-  - env: NUT_MATRIX_TAG="gnu89-gcc-default-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu89" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++89"
+  - env: NUT_MATRIX_TAG="c89-gcc-default-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=c89" CXXFLAGS="-std=c++89"
+  - env: NUT_MATRIX_TAG="gnu89-gcc-default-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=gnu89" CXXFLAGS="-std=gnu++89"
 
 ### Linux on s390x (BigEndian)
 #OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn-s390x-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++98"
 #OK#  - env: NUT_MATRIX_TAG="gnu17-gcc-9-nowarn-s390x-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc-9 CXX=g++-9
 #OK#  - env: NUT_MATRIX_TAG="gnu17-clang-8-nowarn-s390x-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang-8 CXX=clang++-8
-  - env: NUT_MATRIX_TAG="gnu17-clang-8-warn-s390x-64bit" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=gnu++17" CC=clang-8 CXX=clang++-8
+  - env: NUT_MATRIX_TAG="gnu17-clang-8-warn-s390x-64bit" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang-8 CXX=clang++-8
 
 ### Linux on ARM
 #OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-default-nowarn-ARM-64bit" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++98"
@@ -1287,29 +1287,29 @@ jobs:
 #OK#  - env: NUT_MATRIX_TAG="gnu99-clang-freebsd-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
 #OK#  - env: NUT_MATRIX_TAG="gnu17-gcc-freebsd-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++17" CC=gcc CXX=g++
 #OK#  - env: NUT_MATRIX_TAG="gnu17-clang-freebsd-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++17" CC=clang CXX=clang++
-#OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-default-freebsd-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++98" CC=gcc CXX=g++
-#OK#  - env: NUT_MATRIX_TAG="gnu17-gcc-default-freebsd-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -std=gnu++17" CC=gcc CXX=g++
-  - env: NUT_MATRIX_TAG="gnu99-clang-freebsd-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=gnu++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="gnu17-clang-freebsd-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=gnu++17" CC=clang CXX=clang++
+#OK#  - env: NUT_MATRIX_TAG="gnu99-gcc-default-freebsd-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++98" CC=gcc CXX=g++
+#OK#  - env: NUT_MATRIX_TAG="gnu17-gcc-default-freebsd-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=gcc CXX=g++
+  - env: NUT_MATRIX_TAG="gnu99-clang-freebsd-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="gnu17-clang-freebsd-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang CXX=clang++
 
 ### macosx
 #OK#  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
 #OK#  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang CXX=clang++
 #OK#  - env: NUT_MATRIX_TAG="gnu99-clang-xcode7.3-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=gnu99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=gnu++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=gnu17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=gnu++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="gnu99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="gnu17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=gnu17" CXXFLAGS="-std=gnu++17" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c99-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-nowarn" BUILD_TYPE=default-all-errors CFLAGS="-std=c17" CXXFLAGS="-std=c++17" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=c17" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=c++17" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c11-clang-xcode7.3-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=c11" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=c++11" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c17-clang-xcode10.2-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=c17" CXXFLAGS="-std=c++17" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c11-clang-xcode7.3-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=c11" CXXFLAGS="-std=c++11" CC=clang CXX=clang++
 
 ### windows on x86_64
   - env: NUT_MATRIX_TAG="gnu99-clang-win-nowarn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-std=gnu99" CXXFLAGS="-std=gnu++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="gnu99-clang-win-warn" BUILD_TYPE=default-all-errors CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="gnu99-clang-win-warn" BUILD_TYPE=default-all-errors BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
   - env: NUT_MATRIX_TAG="c99-clang-win-nowarn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c99-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=c99" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=c++99" CC=clang CXX=clang++
-  - env: NUT_MATRIX_TAG="c20-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" CFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -std=c20" CXXFLAGS="-Wall -Wextra -Werror -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -std=c++20" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c99-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=c99" CXXFLAGS="-std=c++99" CC=clang CXX=clang++
+  - env: NUT_MATRIX_TAG="c20-clang-win-warn" BUILD_TYPE=default-all-errors CPPFLAGS="-fms-extensions" BUILD_WARNFATAL=yes BUILD_WARNOPT=hard CFLAGS="-std=c20" CXXFLAGS="-std=c++20" CC=clang CXX=clang++
 
 before_install:
 - |-

--- a/autogen.sh
+++ b/autogen.sh
@@ -41,4 +41,7 @@ fi
 
 # now we can safely call autoreconf
 echo "Calling autoreconf..."
-autoreconf -iv
+autoreconf -iv && {
+    sh -n configure 2>/dev/null >/dev/null \
+    || { echo "FAILED: configure script did not pass shell interpreter syntax checks" >&2 ; exit 1; }
+}

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -200,7 +200,7 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
             CONFIG_OPTS+=("--with-doc=skip")
             # Enable as many binaries to build as current worker setup allows
             CONFIG_OPTS+=("--with-all=auto")
-            if [[ "$TRAVIS_OS_NAME" != "windows" ]] && [[ "$TRAVIS_OS_NAME" != "freebsd" ]] ; then
+            if [[ "$TRAVIS_OS_NAME" != "windows" ]] && [[ "$TRAVIS_OS_NAME" != "freebsd" ]] && [ "${BUILD_LIBGD_CGI-}" != "auto" ] ; then
                 # Currently --with-all implies this, but better be sure to
                 # really build everything we can to be certain it builds:
                 if pkg-config --exists libgd || pkg-config --exists libgd2 || pkg-config --exists libgd3 || pkg-config --exists gdlib ; then

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -65,13 +65,13 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
     LC_ALL=C
     export LANG LC_ALL
 
-    if [ -d "./tmp" ]; then
-        rm -rf ./tmp
+    if [ -d "./tmp/" ]; then
+        rm -rf ./tmp/
     fi
-    if [ -d "./.inst" ]; then
-        rm -rf ./.inst
+    if [ -d "./.inst/" ]; then
+        rm -rf ./.inst/
     fi
-    mkdir -p tmp .inst
+    mkdir -p tmp/ .inst/
     BUILD_PREFIX=$PWD/tmp
     INST_PREFIX=$PWD/.inst
 
@@ -97,7 +97,7 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
     if which ccache && ls -la /usr/lib/ccache ; then
         HAVE_CCACHE=yes
     fi
-    mkdir -p "${CCACHE_DIR}" || HAVE_CCACHE=no
+    mkdir -p "${CCACHE_DIR}"/ || HAVE_CCACHE=no
 
     if [ "$HAVE_CCACHE" = yes ] && [ -d "$CCACHE_DIR" ]; then
         echo "CCache stats before build:"

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -291,6 +291,14 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
     CCACHE_BASEDIR="${PWD}"
     export CCACHE_BASEDIR
 
+    if [ -n "${BUILD_WARNOPT-}" ]; then
+        CONFIG_OPTS+=("--enable-warnings=${BUILD_WARNOPT}")
+    fi
+
+    if [ -n "${BUILD_WARNFATAL-}" ]; then
+        CONFIG_OPTS+=("--enable-Werror=${BUILD_WARNFATAL}")
+    fi
+
     # Note: modern auto(re)conf requires pkg-config to generate the configure
     # script, so to stage the situation of building without one (as if on an
     # older system) we have to remove it when we already have the script.

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -352,7 +352,7 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
             ;;
         "default-all-errors")
             RES=0
-            if pkg-config --exists nss && pkg-config --exists openssl ; then
+            if pkg-config --exists nss && pkg-config --exists openssl && [ "${BUILD_SSL_ONCE-}" != "true" ] ; then
                 # Try builds for both cases as they are ifdef-ed
 
                 echo "=== Building with SSL=openssl..."

--- a/configure.ac
+++ b/configure.ac
@@ -1922,8 +1922,9 @@ AS_CASE(["${nut_enable_warnings}"],
 )
 AC_MSG_RESULT(["${nut_enable_warnings}"])
 
-dnl FIXME: At the moment there is no major difference of hard vs easy presets
-dnl Nothing special for gcc - we tend to survive it with GNU standard >= 99
+dnl # Nothing special for gcc - we tend to survive it with GNU standard >= 99
+dnl # and fail with strict C standard. Suggestions welcome for "gcc-hard" to
+dnl # make a difference.
 dnl ### Special picks for clang:
 dnl # -Wno-unused-macros -- system headers define a lot of stuff we do not use, gotta be fatal right?
 dnl # -Wno-reserved-id-macro -- configure script tends to define _GNU_SOURCE_, __EXTENSIONS__ etc.
@@ -1939,8 +1940,8 @@ AS_CASE(["${nut_enable_warnings}"],
         CXXFLAGS="${CXXFLAGS} -ferror-limit=0 -Wall -Wextra -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -Wno-c++98-compat-pedantic -Wno-c++98-compat"
         ],
     [clang-minimal], [
-        CFLAGS="${CFLAGS} -ferror-limit=0 -Wall -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded"
-        CXXFLAGS="${CXXFLAGS} -ferror-limit=0 -Wall -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -Wno-c++98-compat-pedantic -Wno-c++98-compat"
+        CFLAGS="${CFLAGS} -ferror-limit=0 -Wall -Wextra"
+        CXXFLAGS="${CXXFLAGS} -ferror-limit=0 -Wall -Wextra"
         ],
     [gcc-legacy], [CFLAGS="${CFLAGS} -Wall -Wsign-compare"],
     [gcc-minimal|gcc-hard], [

--- a/configure.ac
+++ b/configure.ac
@@ -337,7 +337,7 @@ dnl the usual builds can pass by default on systems without asciidoc.
 nut_with_docs="man=auto"
 NUT_ARG_WITH([docs], [build and install documentation (alias to --with-doc)], [man=auto])
 NUT_ARG_WITH([doc], [build and install documentation (see docs/configure.txt for many variants of the option)], [${nut_with_docs}])
-NUT_ARG_ENABLE([warnings], [enable warning presets that were picked as useful in maintainership and CI practice (variants include gcc-minimal, gcc-hard, clang-minimal, clang-hard, all; auto-choosers: hard, minimal, yes=auto='gcc or clang or all at hardcoded default difficulty')], [no])
+NUT_ARG_ENABLE([warnings], [enable warning presets that were picked as useful in maintainership and CI practice (variants include gcc-minimal, gcc-hard, clang-minimal, clang-hard, all; auto-choosers: hard, minimal, yes=auto='gcc or clang or all at hardcoded default difficulty')], [legacy])
 NUT_ARG_ENABLE([Werror], [fail the build if compiler emits any warnings (treat them as errors)], [no])
 
 dnl ----------------------------------------------------------------------
@@ -1893,10 +1893,12 @@ AC_SUBST(udevdir)
 dnl Filter through known variants first, so automatic choices can be made.
 dnl Note that clang identifies as gcc-compatible so should be probed first.
 dnl TODO: Flip this default to "hard" when we clear existing codebase.
+dnl Note: the "gcc-legacy" option is intentionally undocumented, it acts as
+dnl least-surprise default if caller did not specify any --enable-warnings.
 nut_warning_difficulty="minimal"
 AC_MSG_CHECKING([whether to pre-set warnings])
 AS_CASE(["${nut_enable_warnings}"],
-    [no|all|gcc-minimal|clang-minimal|gcc-hard|clang-hard], [],
+    [no|all|gcc-legacy|gcc-minimal|clang-minimal|gcc-hard|clang-hard], [],
     [gcc|clang], [nut_enable_warnings="${nut_enable_warnings}-${nut_warning_difficulty}"],
     [yes|auto|""], [
         AS_IF([test "${CLANGCC}" = "yes"], [nut_enable_warnings="clang-${nut_warning_difficulty}"],
@@ -1913,6 +1915,7 @@ AS_CASE(["${nut_enable_warnings}"],
             [AS_IF([test "${GCC}" = "yes"], [nut_enable_warnings="gcc-minimal"], [nut_enable_warnings="all"])
             ])
         ],
+    [legacy], [AS_IF([test "${GCC}" = "yes"], [nut_enable_warnings="gcc-legacy"], [nut_enable_warnings="no"])],
     [AC_MSG_WARN([Unsupported variant for --enable-warnings=${nut_enable_warnings}, ignored])
      nut_enable_warnings="no"
     ]
@@ -1933,6 +1936,7 @@ AS_CASE(["${nut_enable_warnings}"],
         CFLAGS="${CFLAGS} -ferror-limit=0 -Wall -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded"
         CXXFLAGS="${CXXFLAGS} -ferror-limit=0 -Wall -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -Wno-c++98-compat-pedantic -Wno-c++98-compat"
         ],
+    [gcc-legacy], [CFLAGS="${CFLAGS} -Wall -Wsign-compare"],
     [gcc-minimal|gcc-hard], [
         CFLAGS="${CFLAGS} -Wall -Wextra -Wsign-compare -pedantic"
         CXXFLAGS="${CXXFLAGS} -Wall -Wextra"

--- a/configure.ac
+++ b/configure.ac
@@ -1923,6 +1923,12 @@ AS_CASE(["${nut_enable_warnings}"],
 AC_MSG_RESULT(["${nut_enable_warnings}"])
 
 dnl FIXME: At the moment there is no major difference of hard vs easy presets
+dnl Nothing special for gcc - we tend to survive it with GNU standard >= 99
+dnl ### Special picks for clang:
+dnl # -Wno-unused-macros -- system headers define a lot of stuff we do not use, gotta be fatal right?
+dnl # -Wno-reserved-id-macro -- configure script tends to define _GNU_SOURCE_, __EXTENSIONS__ etc.
+dnl # -Wno-padded -- NSPR and NSS headers get to issue lots of that
+dnl # -Wno-c++98-compat-pedantic -Wno-c++98-compat -- our C++ code uses nullptr as requested by newer linters, and C++98 does not
 AS_CASE(["${nut_enable_warnings}"],
     [all], [
         CFLAGS="${CFLAGS} -Wall"

--- a/configure.ac
+++ b/configure.ac
@@ -1925,11 +1925,20 @@ AC_MSG_RESULT(["${nut_enable_warnings}"])
 dnl # Nothing special for gcc - we tend to survive it with GNU standard >= 99
 dnl # and fail with strict C standard. Suggestions welcome for "gcc-hard" to
 dnl # make a difference.
-dnl ### Special picks for clang:
-dnl # -Wno-unused-macros -- system headers define a lot of stuff we do not use, gotta be fatal right?
-dnl # -Wno-reserved-id-macro -- configure script tends to define _GNU_SOURCE_, __EXTENSIONS__ etc.
+dnl # Majority of sanity checks are enabled by "-Wextra" on both GCC and CLANG
+dnl # and "-Weverything" additionally on CLANG. They are impractically picky,
+dnl # especially with fallout from system headers that we can not impact anyway
+dnl # so the "difficulty level" pre-sets exclude certain warning classes from
+dnl # that report.
+dnl ### Special exclusion picks for clang-hard:
+dnl # -Wno-unused-macros -- system headers define a lot of stuff we do not use,
+dnl #    gotta be fatal right?
+dnl # -Wno-reserved-id-macro -- configure script tends to define _GNU_SOURCE_,
+dnl #    __EXTENSIONS__ etc. which are underscored and reserved for compilers
 dnl # -Wno-padded -- NSPR and NSS headers get to issue lots of that
-dnl # -Wno-c++98-compat-pedantic -Wno-c++98-compat -- our C++ code uses nullptr as requested by newer linters, and C++98 does not
+dnl # -Wno-c++98-compat-pedantic -Wno-c++98-compat -- our C++ code uses nullptr
+dnl #    as requested by newer linters, and C++98 does not. We require C++11
+dnl #    or newer anyway, and skip building C++ library and test otherwise.
 AS_CASE(["${nut_enable_warnings}"],
     [all], [
         CFLAGS="${CFLAGS} -Wall"

--- a/configure.ac
+++ b/configure.ac
@@ -1930,7 +1930,7 @@ AS_CASE(["${nut_enable_warnings}"],
         ],
     [clang-hard], [
         CFLAGS="${CFLAGS} -ferror-limit=0 -Wall -Wextra -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic"
-        CXXFLAGS="${CXXFLAGS} -ferror-limit=0 -Wall -Wextra -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded"
+        CXXFLAGS="${CXXFLAGS} -ferror-limit=0 -Wall -Wextra -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -Wno-c++98-compat-pedantic -Wno-c++98-compat"
         ],
     [clang-minimal], [
         CFLAGS="${CFLAGS} -ferror-limit=0 -Wall -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded"

--- a/configure.ac
+++ b/configure.ac
@@ -337,7 +337,7 @@ dnl the usual builds can pass by default on systems without asciidoc.
 nut_with_docs="man=auto"
 NUT_ARG_WITH([docs], [build and install documentation (alias to --with-doc)], [man=auto])
 NUT_ARG_WITH([doc], [build and install documentation (see docs/configure.txt for many variants of the option)], [${nut_with_docs}])
-NUT_ARG_ENABLE([warnings], [enable warning presets that were picked as useful in maintainership and CI practice (variants include gcc-minimal, gcc-hard, clang-minimal, clang-hard, all; auto-choosers: hard, minimal, yes=auto='gcc or clang or all at hardcoded default difficulty')], [legacy])
+NUT_ARG_ENABLE([warnings], [enable warning presets that were picked as useful in maintainership and CI practice (variants include gcc-minimal, gcc-medium, gcc-hard, clang-minimal, clang-medium, clang-hard, all; auto-choosers: hard, medium, minimal, yes=auto='gcc or clang or all at hardcoded default difficulty')], [legacy])
 NUT_ARG_ENABLE([Werror], [fail the build if compiler emits any warnings (treat them as errors)], [no])
 
 dnl ----------------------------------------------------------------------
@@ -1898,7 +1898,7 @@ dnl least-surprise default if caller did not specify any --enable-warnings.
 nut_warning_difficulty="minimal"
 AC_MSG_CHECKING([whether to pre-set warnings])
 AS_CASE(["${nut_enable_warnings}"],
-    [no|all|gcc-legacy|gcc-minimal|clang-minimal|gcc-hard|clang-hard], [],
+    [no|all|gcc-legacy|gcc-minimal|clang-minimal|gcc-medium|clang-medium|gcc-hard|clang-hard], [],
     [gcc|clang], [nut_enable_warnings="${nut_enable_warnings}-${nut_warning_difficulty}"],
     [yes|auto|""], [
         AS_IF([test "${CLANGCC}" = "yes"], [nut_enable_warnings="clang-${nut_warning_difficulty}"],
@@ -1908,6 +1908,11 @@ AS_CASE(["${nut_enable_warnings}"],
     [hard|auto-hard|auto=hard], [
         AS_IF([test "${CLANGCC}" = "yes"], [nut_enable_warnings="clang-hard"],
             [AS_IF([test "${GCC}" = "yes"], [nut_enable_warnings="gcc-hard"], [nut_enable_warnings="all"])
+            ])
+        ],
+    [medium|auto-medium|auto=medium], [
+        AS_IF([test "${CLANGCC}" = "yes"], [nut_enable_warnings="clang-medium"],
+            [AS_IF([test "${GCC}" = "yes"], [nut_enable_warnings="gcc-medium"], [nut_enable_warnings="all"])
             ])
         ],
     [minimal|auto-minimal|auto=minimal], [
@@ -1939,6 +1944,13 @@ dnl # -Wno-padded -- NSPR and NSS headers get to issue lots of that
 dnl # -Wno-c++98-compat-pedantic -Wno-c++98-compat -- our C++ code uses nullptr
 dnl #    as requested by newer linters, and C++98 does not. We require C++11
 dnl #    or newer anyway, and skip building C++ library and test otherwise.
+dnl ### Special exclusion picks for clang-medium (same as hard, plus...):
+dnl # -Wno-float-conversion -Wno-double-promotion -Wno-implicit-float-conversion
+dnl #    -- reduce noise due to floating-point literals like "3.14" being a C
+dnl #    double type (a "3.14f" literal is a C float) cast implicitly into
+dnl #    float variables. Also variadic functions like printf() cast their
+dnl #    floating-point arguments into double (and small integer types into
+dnl #    "int") which then confuses pedantic checks of printf("%f", floatval).
 AS_CASE(["${nut_enable_warnings}"],
     [all], [
         CFLAGS="${CFLAGS} -Wall"
@@ -1948,12 +1960,16 @@ AS_CASE(["${nut_enable_warnings}"],
         CFLAGS="${CFLAGS} -ferror-limit=0 -Wall -Wextra -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic"
         CXXFLAGS="${CXXFLAGS} -ferror-limit=0 -Wall -Wextra -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -Wno-c++98-compat-pedantic -Wno-c++98-compat"
         ],
+    [clang-medium], [
+        CFLAGS="${CFLAGS} -ferror-limit=0 -Wall -Wextra -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic -Wno-float-conversion -Wno-double-promotion -Wno-implicit-float-conversion"
+        CXXFLAGS="${CXXFLAGS} -ferror-limit=0 -Wall -Wextra -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -Wno-c++98-compat-pedantic -Wno-c++98-compat"
+        ],
     [clang-minimal], [
         CFLAGS="${CFLAGS} -ferror-limit=0 -Wall -Wextra"
         CXXFLAGS="${CXXFLAGS} -ferror-limit=0 -Wall -Wextra"
         ],
     [gcc-legacy], [CFLAGS="${CFLAGS} -Wall -Wsign-compare"],
-    [gcc-minimal|gcc-hard], [
+    [gcc-minimal|gcc-medium|gcc-hard], [
         CFLAGS="${CFLAGS} -Wall -Wextra -Wsign-compare -pedantic"
         CXXFLAGS="${CXXFLAGS} -Wall -Wextra"
         ]

--- a/configure.ac
+++ b/configure.ac
@@ -217,15 +217,6 @@ AC_CHECK_FUNCS(vsnprintf snprintf, [], [
 
 AC_REPLACE_FUNCS(setenv strerror atexit)
 
-
-dnl
-dnl Only use these when compiling with gcc
-dnl
-if ( test "${GCC}" = "yes" )
-then
-  CFLAGS="${CFLAGS} -Wall -Wsign-compare"
-fi
-
 case ${target_os} in
    solaris2* )
       dnl On Solaris, this allows errno to use thread local storage
@@ -346,6 +337,8 @@ dnl the usual builds can pass by default on systems without asciidoc.
 nut_with_docs="man=auto"
 NUT_ARG_WITH([docs], [build and install documentation (alias to --with-doc)], [man=auto])
 NUT_ARG_WITH([doc], [build and install documentation (see docs/configure.txt for many variants of the option)], [${nut_with_docs}])
+NUT_ARG_ENABLE([warnings], [enable warning presets that were picked as useful in maintainership and CI practice (variants include gcc-minimal, gcc-hard, clang-minimal, clang-hard, all; auto-choosers: hard, minimal, yes=auto='gcc or clang or all at hardcoded default difficulty')], [no])
+NUT_ARG_ENABLE([Werror], [fail the build if compiler emits any warnings (treat them as errors)], [no])
 
 dnl ----------------------------------------------------------------------
 dnl Check for presence and compiler flags of various libraries
@@ -1897,6 +1890,69 @@ AC_SUBST(auglensdir)
 AC_SUBST(hotplugdir)
 AC_SUBST(udevdir)
 
+dnl Filter through known variants first, so automatic choices can be made.
+dnl Note that clang identifies as gcc-compatible so should be probed first.
+dnl TODO: Flip this default to "hard" when we clear existing codebase.
+nut_warning_difficulty="minimal"
+AC_MSG_CHECKING([whether to pre-set warnings])
+AS_CASE(["${nut_enable_warnings}"],
+    [no|all|gcc-minimal|clang-minimal|gcc-hard|clang-hard], [],
+    [gcc|clang], [nut_enable_warnings="${nut_enable_warnings}-${nut_warning_difficulty}"],
+    [yes|auto|""], [
+        AS_IF([test "${CLANGCC}" = "yes"], [nut_enable_warnings="clang-${nut_warning_difficulty}"],
+            [AS_IF([test "${GCC}" = "yes"], [nut_enable_warnings="gcc-${nut_warning_difficulty}"], [nut_enable_warnings="all"])
+            ])
+        ],
+    [hard|auto-hard|auto=hard], [
+        AS_IF([test "${CLANGCC}" = "yes"], [nut_enable_warnings="clang-hard"],
+            [AS_IF([test "${GCC}" = "yes"], [nut_enable_warnings="gcc-hard"], [nut_enable_warnings="all"])
+            ])
+        ],
+    [minimal|auto-minimal|auto=minimal], [
+        AS_IF([test "${CLANGCC}" = "yes"], [nut_enable_warnings="clang-minimal"],
+            [AS_IF([test "${GCC}" = "yes"], [nut_enable_warnings="gcc-minimal"], [nut_enable_warnings="all"])
+            ])
+        ],
+    [AC_MSG_WARN([Unsupported variant for --enable-warnings=${nut_enable_warnings}, ignored])
+     nut_enable_warnings="no"
+    ]
+)
+AC_MSG_RESULT(["${nut_enable_warnings}"])
+
+dnl FIXME: At the moment there is no major difference of hard vs easy presets
+AS_CASE(["${nut_enable_warnings}"],
+    [all], [
+        CFLAGS="${CFLAGS} -Wall"
+        CXXFLAGS="${CXXFLAGS} -Wall"
+        ],
+    [clang-hard], [
+        CFLAGS="${CFLAGS} -ferror-limit=0 -Wall -Wextra -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -pedantic"
+        CXXFLAGS="${CXXFLAGS} -ferror-limit=0 -Wall -Wextra -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded"
+        ],
+    [clang-minimal], [
+        CFLAGS="${CFLAGS} -ferror-limit=0 -Wall -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded"
+        CXXFLAGS="${CXXFLAGS} -ferror-limit=0 -Wall -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -Wno-c++98-compat-pedantic -Wno-c++98-compat"
+        ],
+    [gcc-minimal|gcc-hard], [
+        CFLAGS="${CFLAGS} -Wall -Wextra -Wsign-compare -pedantic"
+        CXXFLAGS="${CXXFLAGS} -Wall -Wextra"
+        ]
+)
+
+AC_MSG_CHECKING([whether to make warnings fatal])
+AS_CASE(["${nut_enable_Werror}"],
+    [yes|auto], [
+        CFLAGS="${CFLAGS} -Werror"
+        CXXFLAGS="${CXXFLAGS} -Werror"
+        ],
+    [no], [
+        CFLAGS="${CFLAGS} -Wno-error"
+        CXXFLAGS="${CXXFLAGS} -Wno-error"
+        ]
+)
+AC_MSG_RESULT(["${nut_enable_Werror}"])
+
+dnl Finally restore warnings setings that the caller might have provided in CFLAGS etc
 NUT_POP_WARNINGS
 
 AC_OUTPUT([

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -1,6 +1,10 @@
 DISTCLEANFILES =
 EXTRA_DIST =
 
+# Is "egrep == grep -E" always valid? (maybe all a job for configure.ac)
+EGREP = egrep
+#EGREP = grep -E
+
 IMAGE_FILES = images/asciidoc.png \
 	images/hostedby.png \
 	images/nut_layering.png \
@@ -87,7 +91,7 @@ html-chunked: $(ASCIIDOC_HTML_CHUNKED)
 check-pdf: $(ASCIIDOC_PDF)
 	@FAILED=""; LANG=C; LC_ALL=C; export LANG; export LC_ALL; \
 	for F in $(ASCIIDOC_PDF) ; do \
-	    test -s "$$F" && { file "$$F" | egrep 'PDF document' > /dev/null ; } || FAILED="$$FAILED $$F" ; \
+	    test -s "$$F" && { file "$$F" | $(EGREP) -i 'PDF document' > /dev/null ; } || FAILED="$$FAILED $$F" ; \
 	done; if test -n "$$FAILED" ; then \
 	    echo "FAILED PDF sanity check for:$$FAILED" >&2 ; file $$FAILED >&2 ; exit 1; \
 	fi; echo "PASSED PDF sanity check"; exit 0
@@ -95,7 +99,7 @@ check-pdf: $(ASCIIDOC_PDF)
 check-html-single: $(ASCIIDOC_HTML_SINGLE)
 	@FAILED=""; LANG=C; LC_ALL=C; export LANG; export LC_ALL; \
 	for F in $(ASCIIDOC_HTML_SINGLE) ; do \
-	    test -s "$$F" && { file "$$F" | egrep '(XML|HTML.*document)' > /dev/null ; } || FAILED="$$FAILED $$F" ; \
+	    test -s "$$F" && { file "$$F" | $(EGREP) -i '(XML|HTML.*document)' > /dev/null ; } || FAILED="$$FAILED $$F" ; \
 	done; if test -n "$$FAILED" ; then \
 	    echo "FAILED HTML-single sanity check for:$$FAILED" >&2 ; file $$FAILED >&2 ; exit 1; \
 	fi; echo "PASSED HTML-single sanity check"; exit 0
@@ -104,10 +108,10 @@ check-html-chunked: $(ASCIIDOC_HTML_CHUNKED)
 	@FAILED=""; LANG=C; LC_ALL=C; export LANG; export LC_ALL; \
 	for D in $(ASCIIDOC_HTML_CHUNKED); do \
 	    for F in "$$D"/*.html ; do \
-	        test -s "$$F" && { file "$$F" | egrep '(XML|HTML.*document)' > /dev/null ; } || FAILED="$$FAILED $$F" ; \
+	        test -s "$$F" && { file "$$F" | $(EGREP) -i '(XML|HTML.*document)' > /dev/null ; } || FAILED="$$FAILED $$F" ; \
 	    done; \
 	    for F in "$$D"/*.css ; do \
-	        test -s "$$F" && { egrep 'CSS stylesheet' "$$F" > /dev/null ; } || FAILED="$$FAILED $$F" ; \
+	        test -s "$$F" && { $(EGREP) -i 'CSS stylesheet' "$$F" > /dev/null ; } || FAILED="$$FAILED $$F" ; \
 	    done; \
 	done; if test -n "$$FAILED" ; then \
 	    echo "FAILED HTML-chunked sanity check for:$$FAILED" >&2 ; file $$FAILED >&2 ; exit 1; \
@@ -196,7 +200,6 @@ SPELLCHECK_SRC = $(ALL_TXT_SRC) ../README ../INSTALL.nut ../UPGRADING  ../NEWS \
 # interpreted as commands, and seems this feature can not be turned off.
 # See also http://aspell.net/man-html/Through-A-Pipe.html
 # TODO: Is "grep -a" or "grep -b" (treat input as ascii/bin) portable enough?
-# Is "egrep == grep -E" always valid? (maybe all a job for configure.ac)
 # Set SPELLCHECK_ERROR_FATAL=no if there are some unavoidable issues
 # due to spellchecking, to temporarily not fail builds due to this.
 # For Travis CI in particular, see ci_build.sh in NUT codebase root.
@@ -213,14 +216,14 @@ spellcheck:
 		LANG=$(ASPELL_ENV_LANG); LC_ALL=$(ASPELL_ENV_LANG); export LANG; export LC_ALL; \
 		$(ASPELL) --help || true; \
 		dpkg -l |grep -i aspell || true ; \
-		echo "ASPELL automatic execution line is : ( sed 's,^\(.*\)$$, \1,' < docfile.txt | $(ASPELL) -a -t $(ASPELL_NUT_COMMON_ARGS) | egrep -b -v '$(ASPELL_OUT_NOTERRORS)' )" ; \
+		echo "ASPELL automatic execution line is : ( sed 's,^\(.*\)$$, \1,' < docfile.txt | $(ASPELL) -a -t $(ASPELL_NUT_COMMON_ARGS) | $(EGREP) -b -v '$(ASPELL_OUT_NOTERRORS)' )" ; \
 		echo "ASPELL proceeding to spellchecking job..."; \
 	 else true; fi
 	@FAILED="" ; LANG=C; LC_ALL=C; export LANG; export LC_ALL; \
 	 for docsrc in $(SPELLCHECK_SRC); do \
 		echo "  ASPELL   Spell checking on $$docsrc"; \
 		OUT="`sed 's,^\(.*\)$$, \1,' < $$docsrc | $(ASPELL) -a -t $(ASPELL_NUT_COMMON_ARGS) 2>&1`" && \
-			{ if test -n "$$OUT" ; then OUT="`echo "$$OUT" | grep -E -b -v '$(ASPELL_OUT_NOTERRORS)' `" ; fi; \
+			{ if test -n "$$OUT" ; then OUT="`echo "$$OUT" | $(EGREP) -b -v '$(ASPELL_OUT_NOTERRORS)' `" ; fi; \
 			  test -z "$$OUT" ; } || \
 			{ echo "FAILED : Aspell reported errors here:" >&2 && echo "----- vvv" >&2 && echo "$$OUT" >&2 && echo "----- ^^^" >&2 && \
 			  FAILED="$$FAILED $$docsrc"; } ; \

--- a/docs/developers.txt
+++ b/docs/developers.txt
@@ -175,12 +175,88 @@ compilers and C standard revisions, e.g. save a local file like this:
 fixing bugs file-by-file running a `make` after each save to confirm
 your solutions and uncover the next issue to address :-)
 
+Note that while spelling out sets of warnings can help in a quest to
+fix certain bugs during development (if only by removing noise from
+classes of warnings not relevant to the issue one is working on), there
+is a reasonable set of warnings which NUT codebase actively tries to
+be clean about (and checks in CI), detailed in the next section.
+
+For the `ci_build.sh` usage like above, one can instead pass the setting
+via `BUILD_WARNOPT=...`, and require that all emitted warnings are fatal
+for their build, e.g.:
+
+	$ cat _fightwarn-clang9-gnu11.sh
+	#!/bin/sh
+
+	BUILD_TYPE=default-all-errors \
+	BUILD_WARNOPT=hard BUILD_WARNFATAL=yes \
+	CFLAGS="-std=gnu11" \
+	CXXFLAGS="-std=gnu++11" \
+	CC=clang-9 CXX=clang++-9 CPP=clang-cpp \
+		./ci_build.sh
+
 As a rule of thumb, new contributions must not emit any warnings when
-built in GNU99 mode. Technically they must survive the part of test
-matrix across the several platforms tested by Travis CI and marked
-as required to pass, to be accepted for pull request merge.
+built in GNU99 mode with a `minimal` "difficulty" level of warnings.
+Technically they must survive the part of test matrix across the several
+platforms tested by Travis CI and marked in project settings as required
+to pass, to be accepted for a pull request merge.
+
+Developers aiming to post successful pull requests to improve NUT can
+pass the `--enable-warnings` option to the `configure` script in local
+builds to see how that behaves and ensure that at least in some set-up
+their contribution is viable. Note that different compiler versions and
+vendors (gcc/clang/...), building against different OS and third-party
+dependencies, with different CPU architectures and different language
+specification revisions, might all complain about different issues --
+and catching this in as diverse range of set-ups as possible is why we
+have CI tests.
+
+It can be beneficial for serial developers to set up a local BuildBot
+or a Jenkins instance with a matrix test job, to test their local git
+repository branches with whatever systems they have available.
 
 * https://github.com/networkupstools/nut/issues/823
+
+Pre-set warning options
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The options chosen into pre-sets that can be selected by `configure`
+script options are ones we use for different layers of CI tests.
+
+Values to note include:
+
+* `--enable-Werror(=yes/no)` -- make warnings fatal;
+
+* `--enable-warnings(=.../no)` -- enable certain warning presets:
+
+** `gcc-hard`, `clang-hard`, `gcc-minimal`, `clang-minimal`, `all` --
+   actual definitions that are compiler-dependent (the latter just adds
+   `-Wall` which may be relatively portable);
+
+** `hard` or `minimal` - if current compiler is detected as CLANG or GCC,
+   apply corresponding setting from above (or `all` otherwise);
+
+** `gcc` or `clang` - apply the set of options (regardless of detected
+   compiler) with default "difficulty" hard-coded in `configure` script,
+   to tweak as our codebase becomes cleaner;
+
+** `yes`/`auto` (also takes effect if `--enable-warnings` is requested
+   without an `=ARG` part) - if current compiler is detected as CLANG
+   or GCC, apply corresponding setting with default "difficulty" from
+   above (or `all` otherwise).
+
+Note that for backwards-compatibility reasons and to help filter out
+introduction of blatant errors, builds with compilers that claim GCC
+compatibility can enable a few easy warning presets by default. This
+can be avoided with an explicit argument to `--disable-warnings` (or
+`--enable-warnings=no`).
+
+Hopefully this mechanism is extensible enough if we would need to add
+more compilers and/or "difficulty levels" in the future.
+
+Finally, note that such pre-set warnings can be mixed with options
+passed through `CFLAGS` or `CXXFLAGS` values to your local `configure`
+run, but it is up to your compiler how it interprets the resulting mix.
 
 Coding style
 ------------

--- a/docs/developers.txt
+++ b/docs/developers.txt
@@ -229,19 +229,19 @@ Values to note include:
 
 * `--enable-warnings(=.../no)` -- enable certain warning presets:
 
-** `gcc-hard`, `clang-hard`, `gcc-minimal`, `clang-minimal`, `all` --
-   actual definitions that are compiler-dependent (the latter just adds
-   `-Wall` which may be relatively portable);
+** `gcc-hard`, `clang-hard`, `gcc-medium`, `clang-medium`, `gcc-minimal`,
+   `clang-minimal`, `all` -- actual definitions that are compiler-dependent
+   (the latter just adds `-Wall` which may be relatively portable);
 
-** `hard` or `minimal` - if current compiler is detected as CLANG or GCC,
-   apply corresponding setting from above (or `all` otherwise);
+** `hard`, `medium` or `minimal` -- if current compiler is detected as
+   CLANG or GCC, apply corresponding setting from above (or `all` otherwise);
 
-** `gcc` or `clang` - apply the set of options (regardless of detected
+** `gcc` or `clang` -- apply the set of options (regardless of detected
    compiler) with default "difficulty" hard-coded in `configure` script,
    to tweak as our codebase becomes cleaner;
 
 ** `yes`/`auto` (also takes effect if `--enable-warnings` is requested
-   without an `=ARG` part) - if current compiler is detected as CLANG
+   without an `=ARG` part) -- if current compiler is detected as CLANG
    or GCC, apply corresponding setting with default "difficulty" from
    above (or `all` otherwise).
 

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -16,6 +16,10 @@
 #   but enabled the DOC_INSTALL_DISTED_MANS toggle so we deliver disted
 #   files from source tree
 
+# Is "egrep == grep -E" always valid? (maybe all a job for configure.ac)
+EGREP = egrep
+#EGREP = grep -E
+
 # Base configuration and client manpages, always installed
 SRC_CONF_PAGES = \
 	nut.conf.txt \
@@ -740,7 +744,7 @@ check-html-man: $(HTML_MANS)
 	@FAILED=""; CHECKED=0; LANG=C; LC_ALL=C; export LANG; export LC_ALL; \
 	for F in $(HTML_MANS) ; do \
 	    CHECKED="`expr $$CHECKED + 1`"; \
-	    test -s "$$F" && { file "$$F" | egrep '(XML|HTML.*document)' > /dev/null ; } || FAILED="$$FAILED $$F" ; \
+	    test -s "$$F" && { file "$$F" | $(EGREP) -i '(XML|HTML.*document)' > /dev/null ; } || FAILED="$$FAILED $$F" ; \
 	done; if test -n "$$FAILED" ; then \
 	    echo "FAILED HTML-man sanity check for:$$FAILED" >&2 ; file $$FAILED >&2 ; exit 1; \
 	fi; echo "PASSED HTML-man sanity check (checked $$CHECKED files)"; exit 0
@@ -753,8 +757,8 @@ check-man-pages: $(MAN_MANS)
 	@FAILED=""; CHECKED=0; LANG=C; LC_ALL=C; export LANG; export LC_ALL; \
 	for F in $(MAN_MANS) ; do \
 	    CHECKED="`expr $$CHECKED + 1`"; \
-	    ( test -s "$(abs_srcdir)/$$F" && { file "$(abs_srcdir)/$$F" | egrep '(troff.* input|C source|ASCII text)' > /dev/null ; } ) || \
-	    ( test -s "$(abs_builddir)/$$F" && { file "$(abs_builddir)/$$F" | egrep '(troff.* input|C source|ASCII text)' > /dev/null ; } ) || \
+	    ( test -s "$(abs_srcdir)/$$F" && { file "$(abs_srcdir)/$$F" | $(EGREP) -i '(troff.* input|C source|ASCII text)' > /dev/null ; } ) || \
+	    ( test -s "$(abs_builddir)/$$F" && { file "$(abs_builddir)/$$F" | $(EGREP) -i '(troff.* input|C source|ASCII text)' > /dev/null ; } ) || \
 	    FAILED="$$FAILED $$F" ; \
 	done; if test -n "$$FAILED" ; then \
 	    echo "FAILED man-page sanity check for:$$FAILED" >&2 ; \
@@ -770,7 +774,7 @@ check-man-txt: $(SRC_ALL_PAGES)
 	cd $(abs_srcdir) || exit; \
 	for F in $(SRC_ALL_PAGES) ; do \
 	    CHECKED="`expr $$CHECKED + 1`"; \
-	    test -s "$$F" && { file "$$F" | egrep '(ASCII|UTF-8|Unicode|ISO-8859|English).* text' > /dev/null ; } || FAILED="$$FAILED $$F" ; \
+	    test -s "$$F" && { file "$$F" | $(EGREP) -i '(ASCII|UTF-8|Unicode|ISO-8859|English).* text' > /dev/null ; } || FAILED="$$FAILED $$F" ; \
 	done; if test -n "$$FAILED" ; then \
 	    echo "FAILED man-source sanity check for:$$FAILED" >&2 ; file $$FAILED >&2 ; exit 1; \
 	fi; echo "PASSED man-source sanity check (checked $$CHECKED files)"; exit 0

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 2527 utf-8
+personal_ws-1.1 en 2532 utf-8
 AAS
 ACFAIL
 ACFREQ
@@ -134,6 +134,7 @@ Brabec
 Breiland
 Brownell
 Bs
+BuildBot
 Buildbot
 Bxx
 ByPass
@@ -163,6 +164,7 @@ COMMOK
 CONTEXTs
 CPAN
 CPM
+CPP
 CPUs
 CRC
 CREAD
@@ -1128,6 +1130,8 @@ Viktor
 Vout
 Václav
 WALKMODE
+WARNFATAL
+WARNOPT
 WELI
 WHAD
 WMNut
@@ -1416,6 +1420,7 @@ coreutils
 cout
 coverity
 cp
+cpp
 cpqpower
 cpsups
 cr

--- a/m4/nut_arg_with.m4
+++ b/m4/nut_arg_with.m4
@@ -1,9 +1,21 @@
 dnl simplified declaration of some feature options
 
+dnl Working With External Software (might name a variant or other contextual arg)
+dnl https://www.gnu.org/software/autoconf/manual/autoconf-2.66/html_node/External-Software.html#External-Software
 AC_DEFUN([NUT_ARG_WITH],
 [  AC_ARG_WITH($1,
       AC_HELP_STRING([--with-$1], [$2 ($3)]),
       [nut_with_$1="${withval}"],
       [nut_with_$1="$3"]
+   )
+])
+
+dnl Enable a feature (might name a variant), or yes/no
+dnl https://www.gnu.org/software/autoconf/manual/autoconf-2.66/html_node/Package-Options.html
+AC_DEFUN([NUT_ARG_ENABLE],
+[  AC_ARG_ENABLE($1,
+      AC_HELP_STRING([--enable-$1], [$2 ($3)]),
+      [nut_enable_$1="${enableval}"],
+      [nut_enable_$1="$3"]
    )
 ])

--- a/m4/nut_compiler_family.m4
+++ b/m4/nut_compiler_family.m4
@@ -33,7 +33,7 @@ AC_DEFUN([NUT_COMPILER_FAMILY],
   AC_CACHE_CHECK([if CC compiler family is clang],
     [nut_cv_CLANGCC],
     [AS_IF([test -n "$CC"],
-        [AS_IF([$CC --version 2>&1 | grep 'clang version' > /dev/null],
+        [AS_IF([$CC --version 2>&1 | grep -E '(clang version|Apple LLVM version .*clang-)' > /dev/null],
             [nut_cv_CLANGCC=yes],[nut_cv_CLANGCC=no])],
         [AC_MSG_ERROR([CC is not set])]
     )])
@@ -41,7 +41,7 @@ AC_DEFUN([NUT_COMPILER_FAMILY],
   AC_CACHE_CHECK([if CXX compiler family is clang],
     [nut_cv_CLANGXX],
     [AS_IF([test -n "$CXX"],
-        [AS_IF([$CXX --version 2>&1 | grep 'clang version' > /dev/null],
+        [AS_IF([$CXX --version 2>&1 | grep -E '(clang version|Apple LLVM version .*clang-)' > /dev/null],
             [nut_cv_CLANGXX=yes],[nut_cv_CLANGXX=no])],
         [AC_MSG_ERROR([CXX is not set])]
     )])
@@ -49,7 +49,7 @@ AC_DEFUN([NUT_COMPILER_FAMILY],
   AC_CACHE_CHECK([if CPP preprocessor family is clang],
     [nut_cv_CLANGPP],
     [AS_IF([test -n "$CPP"],
-        [AS_IF([$CPP --version 2>&1 | grep 'clang version' > /dev/null],
+        [AS_IF([$CPP --version 2>&1 | grep -E '(clang version|Apple LLVM version .*clang-)' > /dev/null],
             [nut_cv_CLANGPP=yes],[nut_cv_CLANGPP=no])],
         [AC_MSG_ERROR([CPP is not set])]
     )])

--- a/m4/nut_compiler_family.m4
+++ b/m4/nut_compiler_family.m4
@@ -31,10 +31,10 @@ AC_DEFUN([NUT_COMPILER_FAMILY],
   AS_IF([test "x$GPP" = "x" && test "$nut_cv_GPP" = yes],   [GPP=yes])
 
   AC_CACHE_CHECK([if CC compiler family is clang],
-    [nut_cv_CLANG],
+    [nut_cv_CLANGCC],
     [AS_IF([test -n "$CC"],
         [AS_IF([$CC --version 2>&1 | grep 'clang version' > /dev/null],
-            [nut_cv_CLANG=yes],[nut_cv_CLANG=no])],
+            [nut_cv_CLANGCC=yes],[nut_cv_CLANGCC=no])],
         [AC_MSG_ERROR([CC is not set])]
     )])
 


### PR DESCRIPTION
The options chosen into pre-sets are what we use for Travis CI tests since #823, and revised further for what I used locally for some builds.

This PR adds support for:
* `--enable-Werror(=yes/no)` - make warnings fatal
* `--enable-warnings(=arg)` - enable certain warning presets:
** `gcc-hard`, `clang-hard`, `gcc-minimal`, `clang-minimal`, `all` - actual definitions that are compiler-dependent (the latter just adds `-Wall` which may be relatively portable)
** `hard` or `minimal` - if current compiler is detected as CLANG or GCC, apply corresponding setting from above (or `all` otherwise)
** `gcc` or `clang` - apply the set of options (regardless of detected compiler) with default "difficulty" hard-coded in configure script, to tweak as our codebase becomes cleaner
** `yes`/`auto` - if current compiler is detected as CLANG or GCC, apply corresponding setting with default "difficulty" from above (or `all` otherwise)
** intentionally undocumented `gcc-legacy` pre-set (applied from `legacy` argument if compiler is GCC or detected claims to be compatible), this is the default value of the `--enable-warnings` option to behave same as before this PR: apply a few non-fatal warnings if compiling with GCC

As a side effect, this simplifies the Travis CI test case specifications and allows to define e.g. Jenkins test matrix or local workstation builds more easily and hands-off. This simplification may play a role in addressing issue #869 at some point.

Hopefully this mechanism is extensible enough if we would need to add more compilers and/or "difficulty levels" in the future.