### PR TITLE
SNMP MIB subdrivers: rename lookup tables to unique identifiers

### DIFF
--- a/drivers/apc-ats-mib.c
+++ b/drivers/apc-ats-mib.c
@@ -29,26 +29,26 @@
 #define APC_ATS_SYSOID       ".1.3.6.1.4.1.318.1.3.11"
 #define APC_ATS_OID_MODEL_NAME ".1.3.6.1.4.1.318.1.1.8.1.5.0"
 
-static info_lkp_t ats_sensitivity_info[] = {
+static info_lkp_t apc_ats_sensitivity_info[] = {
 	{ 1, "high", NULL, NULL },
 	{ 2, "low", NULL, NULL },
 	{ 0, NULL, NULL, NULL }
 };
 
-static info_lkp_t ats_output_status_info[] = {
+static info_lkp_t apc_ats_output_status_info[] = {
 	{ 1, "OFF", NULL, NULL }, /* fail */
 	{ 2, "OL", NULL, NULL },  /* ok */
 	{ 0, NULL, NULL, NULL }
 };
 
-static info_lkp_t ats_outletgroups_name_info[] = {
+static info_lkp_t apc_ats_outletgroups_name_info[] = {
 	{ 1, "total", NULL, NULL },
 	{ 2, "bank1", NULL, NULL },
 	{ 3, "bank2", NULL, NULL },
 	{ 0, NULL, NULL, NULL }
 };
 
-static info_lkp_t ats_outletgroups_status_info[] = {
+static info_lkp_t apc_ats_outletgroups_status_info[] = {
 	{ 1, "OL", NULL, NULL },   /* normal */
 	{ 2, "", NULL, NULL },     /* lowload */
 	{ 3, "", NULL, NULL },     /* nearoverload */
@@ -99,7 +99,7 @@ static snmp_info_t apc_ats_mib[] = {
 	/* atsInputFrequency.2 = INTEGER: 50 */
 	{ "input.2.frequency", 0, 1, ".1.3.6.1.4.1.318.1.1.8.5.3.2.1.4.2", NULL, SU_FLAG_OK, NULL },
 	/* atsConfigVoltageSensitivity.0 = INTEGER: high(1) */
-	{ "input.sensitivity", ST_FLAG_RW, 1, ".1.3.6.1.4.1.318.1.1.8.4.4.0", NULL, SU_FLAG_OK, &ats_sensitivity_info[0] },
+	{ "input.sensitivity", ST_FLAG_RW, 1, ".1.3.6.1.4.1.318.1.1.8.4.4.0", NULL, SU_FLAG_OK, &apc_ats_sensitivity_info[0] },
 	/* FIXME: RFC for input.count! */
 	/* atsNumInputs.0 = INTEGER: 2 */
 	{ "input.count", 0, 1, ".1.3.6.1.4.1.318.1.1.8.5.3.1.0", NULL, SU_FLAG_OK, NULL },
@@ -113,7 +113,7 @@ static snmp_info_t apc_ats_mib[] = {
 	/* UPS collection */
 	/* FIXME: RFC for device.status! */
 	/* atsStatusVoltageOutStatus.0 = INTEGER: ok(2) */
-	{ "ups.status", 0, 1, ".1.3.6.1.4.1.318.1.1.8.5.1.15.0", NULL, SU_FLAG_OK, &ats_output_status_info[0] },
+	{ "ups.status", 0, 1, ".1.3.6.1.4.1.318.1.1.8.5.1.15.0", NULL, SU_FLAG_OK, &apc_ats_output_status_info[0] },
 
 	/* Outlet groups collection */
 	/* Note: prefer the OutputBank data to the ConfigBank ones */
@@ -126,13 +126,13 @@ static snmp_info_t apc_ats_mib[] = {
 	/* atsOutputBankTableIndex.%i = INTEGER: %i */
 	{ "outlet.group.%i.id", 0, 1, ".1.3.6.1.4.1.318.1.1.8.5.4.5.1.1.%i", NULL, SU_FLAG_OK | SU_OUTLET_GROUP, NULL },
 	/* atsConfigBank.%i = INTEGER: total(1) */
-	/*{ "outlet.group.%i.name", 0, 1, ".1.3.6.1.4.1.318.1.1.8.4.14.1.2.%i", NULL, SU_FLAG_STATIC | SU_OUTLET_GROUP, &ats_group_name_info[0] },*/
+	/*{ "outlet.group.%i.name", 0, 1, ".1.3.6.1.4.1.318.1.1.8.4.14.1.2.%i", NULL, SU_FLAG_STATIC | SU_OUTLET_GROUP, &apc_ats_group_name_info[0] },*/
 	/* atsOutputBank.1 = INTEGER: total(1) */
-	{ "outlet.group.%i.name", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.318.1.1.8.5.4.5.1.3.%i", NULL, SU_FLAG_STATIC | SU_OUTLET_GROUP, &ats_outletgroups_name_info[0] },
+	{ "outlet.group.%i.name", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.318.1.1.8.5.4.5.1.3.%i", NULL, SU_FLAG_STATIC | SU_OUTLET_GROUP, &apc_ats_outletgroups_name_info[0] },
 	/* atsOutputBankCurrent.%i = Gauge32: 88 */
 	{ "outlet.group.%i.current", 0, 0.1, ".1.3.6.1.4.1.318.1.1.8.5.4.5.1.4.%i", NULL, SU_OUTLET_GROUP, NULL },
 	/* atsOutputBankState.%i = INTEGER: normal(1) */
-	{ "outlet.group.%i.status", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.318.1.1.8.5.4.5.1.5.%i", NULL, SU_OUTLET_GROUP, &ats_outletgroups_status_info[0] },
+	{ "outlet.group.%i.status", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.318.1.1.8.5.4.5.1.5.%i", NULL, SU_OUTLET_GROUP, &apc_ats_outletgroups_status_info[0] },
 	/* atsOutputBankOutputVoltage.%i = INTEGER: 215 */
 	{ "outlet.group.%i.voltage", 0, 1, ".1.3.6.1.4.1.318.1.1.8.5.4.5.1.6.%i", NULL, SU_OUTLET_GROUP, NULL },
 	/* atsOutputBankPower.1 = INTEGER: 1883 */

--- a/drivers/baytech-mib.c
+++ b/drivers/baytech-mib.c
@@ -30,7 +30,7 @@
 #define BAYTECH_OID_MIB			".1.3.6.1.4.1.4779"
 #define BAYTECH_OID_MODEL_NAME	".1.3.6.1.4.1.4779.1.3.5.2.1.24.1"
 
-static info_lkp_t outlet_status_info[] = {
+static info_lkp_t baytech_outlet_status_info[] = {
 	{ -1, "error", NULL, NULL },
 	{ 0, "off", NULL, NULL },
 	{ 1, "on", NULL, NULL },
@@ -76,7 +76,7 @@ static snmp_info_t baytech_mib[] = {
 	{ "outlet.voltage", 0, 0.1, ".1.3.6.1.4.1.4779.1.3.5.5.1.8.2.1", NULL, 0, NULL },
 
 	/* outlet template definition */
-	{ "outlet.%i.status", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.4779.1.3.5.3.1.3.1.%i", NULL, SU_OUTLET, &outlet_status_info[0] },
+	{ "outlet.%i.status", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.4779.1.3.5.3.1.3.1.%i", NULL, SU_OUTLET, &baytech_outlet_status_info[0] },
 	{ "outlet.%i.desc", ST_FLAG_RW | ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.4779.1.3.5.3.1.4.1.%i", NULL, SU_OUTLET, NULL },
 	{ "outlet.%i.id", 0, 1, ".1.3.6.1.4.1.4779.1.3.5.6.1.3.2.1.%i", "%i", SU_FLAG_STATIC | SU_FLAG_ABSENT | SU_OUTLET | SU_FLAG_OK, NULL },
 	{ "outlet.%i.switchable", 0, 1, ".1.3.6.1.4.1.4779.1.3.5.3.1.1.1.%i", "yes", SU_FLAG_STATIC | SU_OUTLET, NULL },

--- a/drivers/delta_ups-mib.c
+++ b/drivers/delta_ups-mib.c
@@ -31,7 +31,7 @@
 
 /* To create a value lookup structure (as needed on the 2nd line of the example
  * below), use the following kind of declaration, outside of the present snmp_info_t[]:
- * static info_lkp_t onbatt_info[] = {
+ * static info_lkp_t delta_onbatt_info[] = {
  * 	{ 1, "OB", NULL, NULL },
  * 	{ 2, "OL", NULL, NULL },
  * 	{ 0, NULL, NULL, NULL }
@@ -76,11 +76,11 @@ static snmp_info_t delta_ups_mib[] = {
 	 *
 	 * Example:
 	 * { "input.voltage", 0, 0.1, ".1.3.6.1.4.1.705.1.6.2.1.2.1", "", SU_INPUT_1, NULL },
-	 * { "ups.status", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.705.1.7.3.0", "", SU_FLAG_OK | SU_STATUS_BATT, onbatt_info },
+	 * { "ups.status", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.705.1.7.3.0", "", SU_FLAG_OK | SU_STATUS_BATT, delta_onbatt_info },
 	 *
 	 * To create a value lookup structure (as needed on the 2nd line), use the
 	 * following kind of declaration, outside of the present snmp_info_t[]:
-	 * static info_lkp_t onbatt_info[] = {
+	 * static info_lkp_t delta_onbatt_info[] = {
 	 * 	{ 1, "OB" },
 	 * 	{ 2, "OL" },
 	 * 	{ 0, NULL }

--- a/drivers/huawei-mib.c
+++ b/drivers/huawei-mib.c
@@ -29,7 +29,7 @@
 
 /* To create a value lookup structure (as needed on the 2nd line of the example
  * below), use the following kind of declaration, outside of the present snmp_info_t[]:
- * static info_lkp_t onbatt_info[] = {
+ * static info_lkp_t huawei_onbatt_info[] = {
  * 	{ 1, "OB", NULL, NULL },
  * 	{ 2, "OL", NULL, NULL },
  * 	{ 0, NULL, NULL, NULL }
@@ -130,11 +130,11 @@ static snmp_info_t huawei_mib[] = {
 	 *
 	 * Example:
 	 * { "input.voltage", 0, 0.1, ".1.3.6.1.4.1.705.1.6.2.1.2.1", "", SU_INPUT_1, NULL },
-	 * { "ups.status", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.705.1.7.3.0", "", SU_FLAG_OK | SU_STATUS_BATT, onbatt_info },
+	 * { "ups.status", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.705.1.7.3.0", "", SU_FLAG_OK | SU_STATUS_BATT, huawei_onbatt_info },
 	 *
 	 * To create a value lookup structure (as needed on the 2nd line), use the
 	 * following kind of declaration, outside of the present snmp_info_t[]:
-	 * static info_lkp_t onbatt_info[] = {
+	 * static info_lkp_t huawei_onbatt_info[] = {
 	 * 	{ 1, "OB" },
 	 * 	{ 2, "OL" },
 	 * 	{ 0, NULL }

--- a/drivers/mge-mib.c
+++ b/drivers/mge-mib.c
@@ -94,7 +94,7 @@ static info_lkp_t mge_transfer_reason_info[] = {
 	{ 0, NULL, NULL, NULL }
 };
 
-static info_lkp_t ietf_test_result_info[] = {
+static info_lkp_t mge_test_result_info[] = {
 	{ 1, "done and passed", NULL, NULL },
 	{ 2, "done and warning", NULL, NULL },
 	{ 3, "done and error", NULL, NULL },
@@ -104,14 +104,14 @@ static info_lkp_t ietf_test_result_info[] = {
 	{ 0, NULL, NULL, NULL }
 };
 
-static info_lkp_t ietf_beeper_status_info[] = {
+static info_lkp_t mge_beeper_status_info[] = {
 	{ 1, "disabled", NULL, NULL },
 	{ 2, "enabled", NULL, NULL },
 	{ 3, "muted", NULL, NULL },
 	{ 0, NULL, NULL, NULL }
 };
 
-static info_lkp_t ietf_yes_no_info[] = {
+static info_lkp_t mge_yes_no_info[] = {
 	{ 1, "yes", NULL, NULL },
 	{ 2, "no", NULL, NULL },
 	{ 0, NULL, NULL, NULL }
@@ -119,7 +119,7 @@ static info_lkp_t ietf_yes_no_info[] = {
 
 /* FIXME: the below may introduce status redundancy, that needs to be
  * addressed by the driver, as for usbhid-ups! */
-static info_lkp_t ietf_power_source_info[] = {
+static info_lkp_t mge_power_source_info[] = {
 	{ 1, "" /* other */, NULL, NULL },
 	{ 2, "OFF" /* none */, NULL, NULL },
 #if 0
@@ -154,17 +154,17 @@ static snmp_info_t mge_mib[] = {
 	{ "ups.firmware", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.705.1.1.4.0", "", SU_FLAG_STATIC | SU_FLAG_OK, NULL },
 	{ "ups.firmware.aux", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.705.1.12.12.0", "", SU_FLAG_STATIC | SU_FLAG_OK, NULL },
 	{ "ups.load", 0, 1, ".1.3.6.1.4.1.705.1.7.2.1.4.1", "", SU_OUTPUT_1, NULL },
-	{ "ups.beeper.status", ST_FLAG_STRING, SU_INFOSIZE, "1.3.6.1.2.1.33.1.9.8.0", "", 0, ietf_beeper_status_info },
+	{ "ups.beeper.status", ST_FLAG_STRING, SU_INFOSIZE, "1.3.6.1.2.1.33.1.9.8.0", "", 0, mge_beeper_status_info },
 	{ "ups.L1.load", 0, 1, ".1.3.6.1.4.1.705.1.7.2.1.4.1", "", SU_OUTPUT_3, NULL },
 	{ "ups.L2.load", 0, 1, ".1.3.6.1.4.1.705.1.7.2.1.4.2", "", SU_OUTPUT_3, NULL },
 	{ "ups.L3.load", 0, 1, ".1.3.6.1.4.1.705.1.7.2.1.4.3", "", SU_OUTPUT_3, NULL },
-	{ "ups.test.result", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.2.1.33.1.7.3.0", "", 0, ietf_test_result_info },
+	{ "ups.test.result", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.2.1.33.1.7.3.0", "", 0, mge_test_result_info },
 	{ "ups.delay.shutdown", ST_FLAG_STRING | ST_FLAG_RW, 6, "1.3.6.1.2.1.33.1.8.2.0", DEFAULT_OFFDELAY, SU_FLAG_ABSENT | SU_FLAG_OK, NULL },
 	{ "ups.delay.start", ST_FLAG_STRING | ST_FLAG_RW, 6, "1.3.6.1.2.1.33.1.8.3.0", DEFAULT_ONDELAY, SU_FLAG_ABSENT | SU_FLAG_OK, NULL },
 	{ "ups.timer.shutdown", 0, 1, "1.3.6.1.2.1.33.1.8.2.0", "", SU_FLAG_OK, NULL },
 	{ "ups.timer.start", 0, 1, "1.3.6.1.2.1.33.1.8.3.0", "", SU_FLAG_OK, NULL },
 	{ "ups.timer.reboot", 0, 1, "1.3.6.1.2.1.33.1.8.4.0", "", SU_FLAG_OK, NULL },
-	{ "ups.start.auto", ST_FLAG_RW, 1, "1.3.6.1.2.1.33.1.8.5.0", "", SU_FLAG_OK, ietf_yes_no_info },
+	{ "ups.start.auto", ST_FLAG_RW, 1, "1.3.6.1.2.1.33.1.8.5.0", "", SU_FLAG_OK, mge_yes_no_info },
 	/* status data */
 	{ "ups.status", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.705.1.5.11.0", "", SU_FLAG_OK | SU_STATUS_BATT, mge_replacebatt_info },
 	{ "ups.status", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.705.1.5.14.0", "", SU_FLAG_OK | SU_STATUS_BATT, mge_lowbatt_info },
@@ -175,7 +175,7 @@ static snmp_info_t mge_mib[] = {
 	{ "ups.status", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.705.1.7.8.0", "", SU_FLAG_OK | SU_STATUS_BATT, mge_boost_info },
 	{ "ups.status", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.705.1.7.10.0", "", SU_FLAG_OK | SU_STATUS_BATT, mge_overload_info },
 	{ "ups.status", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.705.1.7.12.0", "", SU_FLAG_OK | SU_STATUS_BATT, mge_trim_info },
-	{ "ups.status", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.2.1.33.1.4.1.0", "", SU_STATUS_PWR | SU_FLAG_OK, ietf_power_source_info },
+	{ "ups.status", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.2.1.33.1.4.1.0", "", SU_STATUS_PWR | SU_FLAG_OK, mge_power_source_info },
 
 	/* FIXME: Alarms
 	 * - upsmgBatteryChargerFault (.1.3.6.1.4.1.705.1.5.15.0), yes (1), no (2)

--- a/drivers/powerware-mib.c
+++ b/drivers/powerware-mib.c
@@ -105,13 +105,13 @@ static info_lkp_t pw_alarm_ob[] = {
 	{ 1, "OB", NULL, NULL },
 	{ 2, "", NULL, NULL },
 	{ 0, NULL, NULL, NULL }
-} ;
+};
 
 static info_lkp_t pw_alarm_lb[] = {
 	{ 1, "LB", NULL, NULL },
 	{ 2, "", NULL, NULL },
 	{ 0, NULL, NULL, NULL }
-} ;
+};
 
 static info_lkp_t pw_pwr_info[] = {
 	{   1, ""         /* other */, NULL, NULL },
@@ -165,9 +165,9 @@ static info_lkp_t pw_battery_abm_status[] = {
 /*	{ 4, "Resting", NULL, NULL }, */
 /*	{ 5, "Unknown", NULL, NULL }, */
 	{ 0, NULL, NULL, NULL }
-} ;
+};
 
-static info_lkp_t eaton_abm_status_info[] = {
+static info_lkp_t pw_abm_status_info[] = {
 	{ 1, "charging", NULL, NULL },
 	{ 2, "discharging", NULL, NULL },
 	{ 3, "floating", NULL, NULL },
@@ -188,7 +188,7 @@ static info_lkp_t pw_batt_test_info[] = {
 	{ 0, NULL, NULL, NULL }
 };
 
-static info_lkp_t ietf_yes_no_info[] = {
+static info_lkp_t pw_yes_no_info[] = {
 	{ 1, "yes", NULL, NULL },
 	{ 2, "no", NULL, NULL },
 	{ 0, NULL, NULL, NULL }
@@ -239,9 +239,9 @@ static snmp_info_t pw_mib[] = {
 	/* XUPS-MIB::xupsTestBatteryStatus */
 	{ "ups.test.result", ST_FLAG_STRING, SU_INFOSIZE, "1.3.6.1.4.1.534.1.8.2.0", "", 0, &pw_batt_test_info[0] },
 	/* UPS-MIB::upsAutoRestart */
-	{ "ups.start.auto", ST_FLAG_RW | ST_FLAG_STRING, SU_INFOSIZE, "1.3.6.1.2.1.33.1.8.5.0", "", SU_FLAG_OK, &ietf_yes_no_info[0] },
+	{ "ups.start.auto", ST_FLAG_RW | ST_FLAG_STRING, SU_INFOSIZE, "1.3.6.1.2.1.33.1.8.5.0", "", SU_FLAG_OK, &pw_yes_no_info[0] },
 	/* XUPS-MIB::xupsBatteryAbmStatus.0 */
-	{ "battery.charger.status", ST_FLAG_STRING, SU_INFOSIZE, "1.3.6.1.4.1.534.1.2.5.0", "", SU_STATUS_BATT, &eaton_abm_status_info[0] },
+	{ "battery.charger.status", ST_FLAG_STRING, SU_INFOSIZE, "1.3.6.1.4.1.534.1.2.5.0", "", SU_STATUS_BATT, &pw_abm_status_info[0] },
 
 	/* Battery page */
 	{ "battery.charge", 0, 1.0, PW_OID_BATT_CHARGE, "",

--- a/drivers/raritan-pdu-mib.c
+++ b/drivers/raritan-pdu-mib.c
@@ -38,7 +38,7 @@
 #define DO_ON		"1"
 #define DO_CYCLE	"2"
 
-static info_lkp_t outlet_status_info[] = {
+static info_lkp_t raritan_pdu_outlet_status_info[] = {
 	{ -1, "error", NULL, NULL },
 	{ 0, "off", NULL, NULL },
 	{ 1, "on", NULL, NULL },
@@ -91,7 +91,7 @@ static snmp_info_t raritan_mib[] = {
 	{ "outlet.%i.switchable", 0, 1, ".1.3.6.1.4.1.13742.1.2.2.1.1.%i", "yes", SU_FLAG_STATIC | SU_OUTLET, NULL },
 	{ "outlet.%i.id", 0, 1, NULL, "%i", SU_FLAG_STATIC | SU_FLAG_ABSENT | SU_FLAG_OK | SU_OUTLET, NULL },
 	{ "outlet.%i.desc", ST_FLAG_RW | ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.13742.1.2.2.1.2.%i", NULL, SU_OUTLET, NULL },
-	{ "outlet.%i.status", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.13742.1.2.2.1.3.%i", NULL, SU_FLAG_OK | SU_OUTLET, &outlet_status_info[0] },
+	{ "outlet.%i.status", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.13742.1.2.2.1.3.%i", NULL, SU_FLAG_OK | SU_OUTLET, &raritan_pdu_outlet_status_info[0] },
 	{ "outlet.%i.current", 0, 0.001, ".1.3.6.1.4.1.13742.1.2.2.1.4.%i", NULL, SU_OUTLET, NULL },
 	{ "outlet.%i.current.maximum", 0, 0.001, ".1.3.6.1.4.1.13742.1.2.2.1.5.%i", NULL, SU_OUTLET, NULL },
 	{ "outlet.%i.realpower", 0, 1.0, ".1.3.6.1.4.1.13742.1.2.2.1.7.%i", NULL, SU_OUTLET, NULL },

--- a/drivers/raritan-px2-mib.c
+++ b/drivers/raritan-px2-mib.c
@@ -57,7 +57,7 @@ static info_lkp_t raritanpx2_outlet_status_info[] = {
 	{ 0, "NULL", NULL, NULL }
 };
 
-static info_lkp_t outlet_switchability_info[] = {
+static info_lkp_t raritanpx2_outlet_switchability_info[] = {
 	{ -1, "yes", NULL, NULL },
 	{ 1, "yes", NULL, NULL },
 	{ 2, "no", NULL, NULL },
@@ -152,7 +152,7 @@ static snmp_info_t raritan_px2_mib[] = {
 	 * { "unmapped.measurementsOutletSensorValue", 0, 1, ".1.3.6.1.4.1.13742.6.5.4.3.1.4.1.1.14", NULL, SU_FLAG_OK, NULL }, */
 
 	/* outletSwitchable.1.%i = INTEGER: true(1) */
-	{ "outlet.%i.switchable", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.13742.6.3.5.3.1.28.1.%i", "no", SU_FLAG_STATIC | SU_OUTLET | SU_FLAG_OK, &outlet_switchability_info[0] },
+	{ "outlet.%i.switchable", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.13742.6.3.5.3.1.28.1.%i", "no", SU_FLAG_STATIC | SU_OUTLET | SU_FLAG_OK, &raritanpx2_outlet_switchability_info[0] },
 
 	/* instant commands. */
 	/* switchingOperation.1.1 = INTEGER: on(1) */

--- a/drivers/xppc-mib.c
+++ b/drivers/xppc-mib.c
@@ -30,7 +30,7 @@
 
 /* To create a value lookup structure (as needed on the 2nd line of the example
  * below), use the following kind of declaration, outside of the present snmp_info_t[]:
- * static info_lkp_t onbatt_info[] = {
+ * static info_lkp_t xpcc_onbatt_info[] = {
  * 	{ 1, "OB", NULL, NULL },
  * 	{ 2, "OL", NULL, NULL },
  * 	{ 0, NULL, NULL, NULL }
@@ -88,11 +88,11 @@ static snmp_info_t xppc_mib[] = {
 	 *
 	 * Example:
 	 * { "input.voltage", 0, 0.1, ".1.3.6.1.4.1.705.1.6.2.1.2.1", "", SU_INPUT_1, NULL },
-	 * { "ups.status", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.705.1.7.3.0", "", SU_FLAG_OK | SU_STATUS_BATT, onbatt_info },
+	 * { "ups.status", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.705.1.7.3.0", "", SU_FLAG_OK | SU_STATUS_BATT, xpcc_onbatt_info },
 	 *
 	 * To create a value lookup structure (as needed on the 2nd line), use the
 	 * following kind of declaration, outside of the present snmp_info_t[]:
-	 * static info_lkp_t onbatt_info[] = {
+	 * static info_lkp_t xpcc_onbatt_info[] = {
 	 * 	{ 1, "OB" },
 	 * 	{ 2, "OL" },
 	 * 	{ 0, NULL }


### PR DESCRIPTION
Ported from 42ity fork, this PR makes the SNMP MIB helper lookup table names unique across the codebase.

Originally this was required by DMF capability (to load tables by names from XML descriptor files), but now having the same fix in upstream also helps cross-pollination of the fork and upstream repos (more relevant diffs) as they both actively evolve.

Uniqueness verifiable with:
````
$ grep info_lkp_t drivers/*-mib.c | sed 's,^.*info_lkp_t.* \(.*\) =.*$,\1,' | sort | uniq -c | sort -n
````

Note there are some commented-away entries (seen by leading asterisk in the line when just grepping)