### PR TITLE
snmp-ups: fix regression on Eaton ePDU

### DIFF
--- a/drivers/eaton-pdu-marlin-mib.c
+++ b/drivers/eaton-pdu-marlin-mib.c
@@ -34,7 +34,7 @@
 /* Eaton PDU-MIB - Marlin MIB
  * ************************** */
 
-#define EATON_MARLIN_MIB_VERSION	"0.56"
+#define EATON_MARLIN_MIB_VERSION	"0.57"
 #define EATON_MARLIN_SYSOID			".1.3.6.1.4.1.534.6.6.7"
 #define EATON_MARLIN_OID_MODEL_NAME	".1.3.6.1.4.1.534.6.6.7.1.2.1.2.0"
 
@@ -622,7 +622,7 @@ static snmp_info_t eaton_marlin_mib[] = {
 	/* Ugly hack for older G2 ePDU: check the first outlet to determine unit switchability */
 	{ "outlet.switchable", ST_FLAG_STRING, SU_INFOSIZE,
 		".1.3.6.1.4.1.534.6.6.7.6.6.1.3.%i.1",
-		"no", SU_FLAG_STATIC | SU_FLAG_UNIQUE | SU_OUTLET | SU_FLAG_OK | SU_TYPE_DAISY_1, &g2_unit_outlet_switchability_info[0] },
+		"no", SU_FLAG_STATIC | SU_FLAG_UNIQUE | SU_FLAG_OK | SU_TYPE_DAISY_1, &g2_unit_outlet_switchability_info[0] },
 	/* The below ones are the same as the input.* equivalent */
 	/* FIXME: transition period, TO BE REMOVED, moved to input.* */
 	{ "outlet.frequency", 0, 0.1, ".1.3.6.1.4.1.534.6.6.7.3.1.1.3.%i.1",


### PR DESCRIPTION
Fix a regression that caused a mis-determination of the SNMP base
OID index (0 or 1, should be 1). This in turn caused a mis-iteration
over the outlets, from 0 to N-1 instead of 1 to N, which resulted in
the missing Nth outlet (last outlet of the PDU). This also caused some
data refresh issues

Signed-off-by: Arnaud Quette <ArnaudQuette@eaton.com>

Replay of https://github.com/42ity/nut/pull/124 into main development