### PR TITLE
Add USB device number matching

### DIFF
--- a/docs/man/blazer-common.txt
+++ b/docs/man/blazer-common.txt
@@ -148,6 +148,12 @@ Select a UPS on a specific USB bus or group of buses. The argument is
 a regular expression that must match the bus name where the UPS is
 connected (e.g. bus="002", bus="00[2-3]").
 
+*device =* 'regex'::
+
+Select a UPS on a specific USB device or group of devices. The argument is
+a regular expression that must match the device name where the UPS is
+connected (e.g. device="001", device="00[1-2]").
+
 *subdriver =* 'string'::
 
 Select a serial-over-USB subdriver to use. You have a choice between *phoenix*,

--- a/docs/man/blazer-common.txt
+++ b/docs/man/blazer-common.txt
@@ -153,6 +153,8 @@ connected (e.g. bus="002", bus="00[2-3]").
 Select a UPS on a specific USB device or group of devices. The argument is
 a regular expression that must match the device name where the UPS is
 connected (e.g. device="001", device="00[1-2]").
+Note that device numbers need not to be stable across re-boots or
+device re-plugging.
 
 *subdriver =* 'string'::
 

--- a/docs/man/blazer-common.txt
+++ b/docs/man/blazer-common.txt
@@ -153,8 +153,8 @@ connected (e.g. bus="002", bus="00[2-3]").
 Select a UPS on a specific USB device or group of devices. The argument is
 a regular expression that must match the device name where the UPS is
 connected (e.g. device="001", device="00[1-2]").
-Note that device numbers need not to be stable across re-boots or
-device re-plugging.
+Note that device numbers are not guaranteed by the OS to be stable across
+re-boots or device re-plugging.
 
 *subdriver =* 'string'::
 

--- a/docs/man/nutdrv_qx.txt
+++ b/docs/man/nutdrv_qx.txt
@@ -322,6 +322,10 @@ Examples:
 Select a UPS on a specific USB bus or group of buses.
 The argument is a regular expression that must match the bus name where the UPS is connected (e.g. +bus="002"+, +bus="00[2-3]"+).
 
+*device =* 'regex'::
+Select a UPS on a specific USB device or group of devices.
+The argument is a regular expression that must match the device name where the UPS is connected (e.g. +device="001"+, +device="00[1-2]"+).
+
 *subdriver =* 'string'::
 Select a serial-over-USB subdriver to use.
 You have a choice between *cypress*, *fabula*, *fuji*, *ippon*, *krauler*, *phoenix* and *sgs*.

--- a/docs/man/nutdrv_qx.txt
+++ b/docs/man/nutdrv_qx.txt
@@ -325,6 +325,7 @@ The argument is a regular expression that must match the bus name where the UPS 
 *device =* 'regex'::
 Select a UPS on a specific USB device or group of devices.
 The argument is a regular expression that must match the device name where the UPS is connected (e.g. +device="001"+, +device="00[1-2]"+).
+Note that device numbers need not to be stable across re-boots or device re-plugging.
 
 *subdriver =* 'string'::
 Select a serial-over-USB subdriver to use.

--- a/docs/man/nutdrv_qx.txt
+++ b/docs/man/nutdrv_qx.txt
@@ -325,7 +325,7 @@ The argument is a regular expression that must match the bus name where the UPS 
 *device =* 'regex'::
 Select a UPS on a specific USB device or group of devices.
 The argument is a regular expression that must match the device name where the UPS is connected (e.g. +device="001"+, +device="00[1-2]"+).
-Note that device numbers need not to be stable across re-boots or device re-plugging.
+Note that device numbers are not guaranteed by the OS to be stable across re-boots or device re-plugging.
 
 *subdriver =* 'string'::
 Select a serial-over-USB subdriver to use.

--- a/docs/man/tripplite_usb.txt
+++ b/docs/man/tripplite_usb.txt
@@ -79,6 +79,8 @@ This regular expression is used to match the USB bus (as seen in
 
 This regular expression is used to match the USB device (as seen in
 `/proc/bus/usb/devices` or lsusb(8); including leading zeroes).
+Note that device numbers need not to be stable across re-boots or
+device re-plugging.
 
 *product*::
 

--- a/docs/man/tripplite_usb.txt
+++ b/docs/man/tripplite_usb.txt
@@ -75,6 +75,11 @@ problems.
 This regular expression is used to match the USB bus (as seen in
 `/proc/bus/usb/devices` or lsusb(8); including leading zeroes).
 
+*device*::
+
+This regular expression is used to match the USB device (as seen in
+`/proc/bus/usb/devices` or lsusb(8); including leading zeroes).
+
 *product*::
 
 A regular expression to match the product string for the UPS.  This would be
@@ -131,15 +136,14 @@ please re-run the driver with `-DDD` to increase the verbosity.
 
 So far, the Tripp Lite UPSes do not seem to have a serial number or other
 globally unique identifier accessible through USB. Thus, when monitoring
-several Tripp Lite USB UPSes, you should use either the 'bus' or 'product'
-configuration options to uniquely specify which UPS a given driver instance
-should control.
+several Tripp Lite USB UPSes, you should use either the 'bus', 'device' or
+'product' configuration options to uniquely specify which UPS a given driver
+instance should control.
 
 For instance, you can easily monitor an OMNIVS1000 and a SMART1500RM2U at the
 same time, since they have different USB Product ID strings. If you have two
-SMART1500RM2U units, you would have to find which USB bus number each unit is
-on (via lsusb(8)), which may result in ambiguities if the available USB ports
-are on the same bus.
+SMART1500RM2U units, you would have to find which USB bus and device number
+each unit is on (via lsusb(8)).
 
 Some of the SMART*2U models have an ID number, but because this ID is not
 exposed as a USB string descriptor, there is no easy way to use this ID to

--- a/docs/man/tripplite_usb.txt
+++ b/docs/man/tripplite_usb.txt
@@ -79,8 +79,8 @@ This regular expression is used to match the USB bus (as seen in
 
 This regular expression is used to match the USB device (as seen in
 `/proc/bus/usb/devices` or lsusb(8); including leading zeroes).
-Note that device numbers need not to be stable across re-boots or
-device re-plugging.
+Note that device numbers are not guaranteed by the OS to be stable across
+re-boots or device re-plugging.
 
 *product*::
 

--- a/docs/man/usbhid-ups.txt
+++ b/docs/man/usbhid-ups.txt
@@ -118,8 +118,8 @@ connected (e.g. bus="002", bus="00[2-3]").
 Select a UPS on a specific USB device or group of devices. The argument is
 a regular expression that must match the device name where the UPS is
 connected (e.g. device="001", device="00[1-2]").
-Note that device numbers need not to be stable across re-boots or
-device re-plugging.
+Note that device numbers are not guaranteed by the OS to be stable across
+re-boots or device re-plugging.
 
 *explore*::
 With this option, the driver will connect to any device, including

--- a/docs/man/usbhid-ups.txt
+++ b/docs/man/usbhid-ups.txt
@@ -118,6 +118,8 @@ connected (e.g. bus="002", bus="00[2-3]").
 Select a UPS on a specific USB device or group of devices. The argument is
 a regular expression that must match the device name where the UPS is
 connected (e.g. device="001", device="00[1-2]").
+Note that device numbers need not to be stable across re-boots or
+device re-plugging.
 
 *explore*::
 With this option, the driver will connect to any device, including

--- a/docs/man/usbhid-ups.txt
+++ b/docs/man/usbhid-ups.txt
@@ -113,6 +113,12 @@ Select a UPS on a specific USB bus or group of buses. The argument is
 a regular expression that must match the bus name where the UPS is
 connected (e.g. bus="002", bus="00[2-3]"). 
 
+*device =* 'regex'::
+
+Select a UPS on a specific USB device or group of devices. The argument is
+a regular expression that must match the device name where the UPS is
+connected (e.g. device="001", device="00[1-2]").
+
 *explore*::
 With this option, the driver will connect to any device, including
 ones that are not yet supported. This must always be combined with the

--- a/drivers/blazer_usb.c
+++ b/drivers/blazer_usb.c
@@ -555,7 +555,7 @@ void upsdrv_initups(void)
 #ifndef TESTING
 	int	ret, langid;
 	char	tbuf[255]; /* Some devices choke on size > 255 */
-	char	*regex_array[6];
+	char	*regex_array[7];
 
 	char	*subdrv = getval("subdriver");
 
@@ -565,6 +565,7 @@ void upsdrv_initups(void)
 	regex_array[3] = getval("product");
 	regex_array[4] = getval("serial");
 	regex_array[5] = getval("bus");
+	regex_array[6] = getval("device");
 
 	/* check for language ID workaround (#1) */
 	if (getval("langid_fix")) {
@@ -680,5 +681,6 @@ void upsdrv_cleanup(void)
 	free(usbdevice.Product);
 	free(usbdevice.Serial);
 	free(usbdevice.Bus);
+	free(usbdevice.Device);
 #endif	/* TESTING */
 }

--- a/drivers/libusb.c
+++ b/drivers/libusb.c
@@ -63,6 +63,7 @@ void nut_usb_addvars(void)
 	addvar(VAR_VALUE, "productid", "Regular expression to match UPS Product numerical ID (4 digits hexadecimal)");
 
 	addvar(VAR_VALUE, "bus", "Regular expression to match USB bus name");
+	addvar(VAR_VALUE, "device", "Regular expression to match USB device name");
 	addvar(VAR_VALUE, "usb_set_altinterface", "Force redundant call to usb_set_altinterface() (value=bAlternateSetting; default=0)");
 }
 
@@ -200,11 +201,13 @@ static int libusb_open(usb_dev_handle **udevp, USBDevice_t *curDevice, USBDevice
 			free(curDevice->Product);
 			free(curDevice->Serial);
 			free(curDevice->Bus);
+			free(curDevice->Device);
 			memset(curDevice, '\0', sizeof(*curDevice));
 
 			curDevice->VendorID = dev->descriptor.idVendor;
 			curDevice->ProductID = dev->descriptor.idProduct;
 			curDevice->Bus = strdup(bus->dirname);
+			curDevice->Device = strdup(dev->filename);
 			curDevice->bcdDevice = dev->descriptor.bcdDevice;
 
 			if (dev->descriptor.iManufacturer) {
@@ -237,6 +240,7 @@ static int libusb_open(usb_dev_handle **udevp, USBDevice_t *curDevice, USBDevice
 			upsdebugx(2, "- Product: %s", curDevice->Product ? curDevice->Product : "unknown");
 			upsdebugx(2, "- Serial Number: %s", curDevice->Serial ? curDevice->Serial : "unknown");
 			upsdebugx(2, "- Bus: %s", curDevice->Bus ? curDevice->Bus : "unknown");
+			upsdebugx(2, "- Device: %s", curDevice->Device ? curDevice->Device : "unknown");
 			upsdebugx(2, "- Device release number: %04x", curDevice->bcdDevice);
 
 			if ((curDevice->VendorID == 0x463) && (curDevice->bcdDevice == 0x0202)) {

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -1968,7 +1968,7 @@ void	upsdrv_initups(void)
 	#ifndef TESTING
 		int	ret, langid;
 		char	tbuf[255];	/* Some devices choke on size > 255 */
-		char	*regex_array[6];
+		char	*regex_array[7];
 
 		char	*subdrv = getval("subdriver");
 
@@ -1978,6 +1978,7 @@ void	upsdrv_initups(void)
 		regex_array[3] = getval("product");
 		regex_array[4] = getval("serial");
 		regex_array[5] = getval("bus");
+		regex_array[6] = getval("device");
 
 		/* Check for language ID workaround (#1) */
 		if (getval("langid_fix")) {
@@ -2119,6 +2120,7 @@ void	upsdrv_cleanup(void)
 		free(usbdevice.Product);
 		free(usbdevice.Serial);
 		free(usbdevice.Bus);
+		free(usbdevice.Device);
 
 	#ifdef QX_SERIAL
 	}	/* is_usb */

--- a/drivers/riello_usb.c
+++ b/drivers/riello_usb.c
@@ -806,7 +806,7 @@ void upsdrv_initups(void)
 	};
 
 	int	ret;
-	char	*regex_array[6];
+	char	*regex_array[7];
 
 	char	*subdrv = getval("subdriver");
 
@@ -816,6 +816,7 @@ void upsdrv_initups(void)
 	regex_array[3] = getval("product");
 	regex_array[4] = getval("serial");
 	regex_array[5] = getval("bus");
+	regex_array[6] = getval("device");
 
 	/* pick up the subdriver name if set explicitly */
 	if (subdrv) {
@@ -1172,4 +1173,5 @@ void upsdrv_cleanup(void)
 	free(usbdevice.Product);
 	free(usbdevice.Serial);
 	free(usbdevice.Bus);
+	free(usbdevice.Device);
 }

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -1528,7 +1528,7 @@ void upsdrv_makevartable(void)
  */
 void upsdrv_initups(void)
 {
-	char *regex_array[6];
+	char *regex_array[7];
 	char *value;
 	int r;
 
@@ -1539,6 +1539,7 @@ void upsdrv_initups(void)
 	regex_array[3] = getval("product"); /* product string */
 	regex_array[4] = getval("serial"); /* probably won't see this */
 	regex_array[5] = getval("bus");
+	regex_array[6] = getval("device");
 
 	r = USBNewRegexMatcher(&regex_matcher, regex_array, REG_ICASE | REG_EXTENDED);
 	if (r==-1) {

--- a/drivers/usb-common.c
+++ b/drivers/usb-common.c
@@ -377,6 +377,12 @@ static int match_function_regex(USBDevice_t *hd, void *privdata)
 
 	r = match_regex(data->regex[6], hd->Device);
 	if (r != 1) {
+/*
+		upsdebugx(2, "%s: failed match of %s: %s !~ %s",
+		    __func__, "Device", hd->Device, data->regex[6]);
+*/
+		upsdebugx(2, "%s: failed match of %s: %s",
+		    __func__, "Device", hd->Device);
 		return r;
 	}
 	return 1;

--- a/drivers/usb-common.h
+++ b/drivers/usb-common.h
@@ -30,7 +30,7 @@
 
 /*!
  * USBDevice_t: Describe a USB device. This structure contains exactly
- * the pieces of information by which a USB device identifies
+ * the 5 pieces of information by which a USB device identifies
  * itself, so it serves as a kind of "fingerprint" of the device. This
  * information must be matched exactly when reopening a device, and
  * therefore must not be "improved" or updated by a client
@@ -38,11 +38,14 @@
  * corresponding string did not exist or could not be retrieved.
  */
 typedef struct USBDevice_s {
+	/* These 5 data points are common properties of an USB device: */
 	uint16_t	VendorID;  /*!< Device's Vendor ID    */
 	uint16_t	ProductID; /*!< Device's Product ID   */
 	char		*Vendor;   /*!< Device's Vendor Name  */
 	char		*Product;  /*!< Device's Product Name */
 	char		*Serial;   /*!< Product serial number */
+	/* These data points can be determined by the driver for some devices
+	   or by libusb to detail its connection topology: */
 	char		*Bus;      /*!< Bus name, e.g. "003"  */
 	uint16_t	bcdDevice; /*!< Device release number */
 	char		*Device;   /*!< Device name on the bus, e.g. "001"  */

--- a/drivers/usb-common.h
+++ b/drivers/usb-common.h
@@ -30,7 +30,7 @@
 
 /*!
  * USBDevice_t: Describe a USB device. This structure contains exactly
- * the 5 pieces of information by which a USB device identifies
+ * the pieces of information by which a USB device identifies
  * itself, so it serves as a kind of "fingerprint" of the device. This
  * information must be matched exactly when reopening a device, and
  * therefore must not be "improved" or updated by a client
@@ -44,6 +44,7 @@ typedef struct USBDevice_s {
 	char		*Product;  /*!< Device's Product Name */
 	char		*Serial;   /*!< Product serial number */
 	char		*Bus;      /*!< Bus name, e.g. "003"  */
+	char		*Device;   /*!< Device name, e.g. "001"  */
 	uint16_t	bcdDevice; /*!< Device release number */
 } USBDevice_t;
 

--- a/drivers/usb-common.h
+++ b/drivers/usb-common.h
@@ -44,8 +44,8 @@ typedef struct USBDevice_s {
 	char		*Product;  /*!< Device's Product Name */
 	char		*Serial;   /*!< Product serial number */
 	char		*Bus;      /*!< Bus name, e.g. "003"  */
-	char		*Device;   /*!< Device name, e.g. "001"  */
 	uint16_t	bcdDevice; /*!< Device release number */
+	char		*Device;   /*!< Device name on the bus, e.g. "001"  */
 } USBDevice_t;
 
 /*!

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -908,7 +908,7 @@ void upsdrv_initups(void)
 
 	subdriver_matcher = device_path;
 #else
-	char *regex_array[6];
+	char *regex_array[7];
 
 	upsdebugx(1, "upsdrv_initups (non-SHUT)...");
 
@@ -931,6 +931,7 @@ void upsdrv_initups(void)
 	regex_array[3] = getval("product");
 	regex_array[4] = getval("serial");
 	regex_array[5] = getval("bus");
+	regex_array[6] = getval("device");
 
 	ret = USBNewRegexMatcher(&regex_matcher, regex_array, REG_ICASE | REG_EXTENDED);
 	switch(ret)
@@ -1033,6 +1034,7 @@ void upsdrv_cleanup(void)
 	free(curDevice.Product);
 	free(curDevice.Serial);
 	free(curDevice.Bus);
+	free(curDevice.Device);
 #endif
 }
 


### PR DESCRIPTION
I needed a `device` argument for USB matching in order to independently match two identical UPSen attached to the same bus.

The changes to usb-common.[hc] and libusb.c are straightforward (sans the `DEBUG_EXACT_MATCH_DEVICE`, which I modelled after `DEBUG_EXACT_MATCH_BUS`, whatever that is used for).

The changes to the various USB drivers are mechanical. Maybe some `#define` for the regex array size (or even seven more `#defines` for the magical index values) would be useful.

I documented the `device` field only where the existing `bus` field was documented (which is not the case everywhere it's actually used).