### PR TITLE
Retire some terminology

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,14 @@ For a complete and more detailed list of changes, please refer to the
 ChangeLog file.
 
 ---------------------------------------------------------------------------
+Release notes for NUT 2.7.5 (brewing) - what's new since 2.7.4:
+
+ - Master/Slave terminology was deprecated in favor of Primary/Secondary
+   modes of upsmon client. Respective keywords in the configuration are
+   supported as backwards-compatible settings, but obsoleted values are
+   no longer documented.
+
+---------------------------------------------------------------------------
 Release notes for NUT 2.7.4 - what's new since 2.7.3:
 
  - New class of device supported: ATS - Automatic Transfer Switch are now

--- a/README
+++ b/README
@@ -292,7 +292,13 @@ first have disconnected or a critical threshold was passed.
 
 If your UPS is plugged directly into a system's serial or USB port, the
 `upsmon` process on that system should define its relation to that UPS
-as a manager.
+as a manager. It may be more complicated for higher-end UPSes with a
+shared network management capability (typically via SNMP) or several
+serial/USB ports that can be used simultaneously, and depends on what
+vendors and drivers implement. Setups with several competing managers
+(for redundancy) are technically possible, if each one runs its own
+full stack of NUT, but results can be random (currently NUT does not
+provide a way to coordinate several managers of the same device).
 
 For a typical home user, there's one computer connected to one UPS.
 That means you would run on the same computer the whole NUT stack --

--- a/README
+++ b/README
@@ -273,9 +273,9 @@ separate section in the documentation since it is so important.
 
 You configure it by telling it about UPSes that you want to monitor in
 upsmon.conf.  Each UPS can be defined as one of two possible types:
-a "manager" or "subordinate".
+a "primary" or "secondary".
 
-Manager
+Primary
 ~~~~~~~
 
 The monitored UPS possibly supplies power to this system running `upsmon`,
@@ -286,39 +286,39 @@ depleted (or in another approach, lingering to deplete it or to tell the
 UPS to reboot its load after too much time has elapsed and this system
 is still alive -- meaning wall power returned at a  "wrong" moment).
 
-The shutdown of this (manager) system itself, as well as eventually an
-UPS shutdown, occurs after any subordinate systems ordered to shut down
-first have disconnected or a critical threshold was passed.
+The shutdown of this (primary) system itself, as well as eventually an
+UPS shutdown, occurs after any secondary systems ordered to shut down
+first have disconnected, or a critical urgency threshold was passed.
 
 If your UPS is plugged directly into a system's serial or USB port, the
 `upsmon` process on that system should define its relation to that UPS
-as a manager. It may be more complicated for higher-end UPSes with a
+as a primary. It may be more complicated for higher-end UPSes with a
 shared network management capability (typically via SNMP) or several
 serial/USB ports that can be used simultaneously, and depends on what
-vendors and drivers implement. Setups with several competing managers
+vendors and drivers implement. Setups with several competing primaries
 (for redundancy) are technically possible, if each one runs its own
 full stack of NUT, but results can be random (currently NUT does not
-provide a way to coordinate several managers of the same device).
+provide a way to coordinate several entities managing the same device).
 
 For a typical home user, there's one computer connected to one UPS.
 That means you would run on the same computer the whole NUT stack --
-a suitable driver, `upsd`, and `upsmon` in manager mode.
+a suitable driver, `upsd`, and `upsmon` in primary mode.
 
-Subordinate
-~~~~~~~~~~~
+Secondary
+~~~~~~~~~
 
-The monitored UPS may supply power to the system running `upsmon`
-(or alternatively, it may be a monitoring station with zero PSUs
-fed by that UPS), but this system can't shut it down directly
-(through a locally running NUT driver).
+The monitored UPS may supply power to the system running `upsmon` (or
+alternatively, it may be a monitoring station with zero PSUs fed by
+that UPS), but more importantly, this system can't manage the UPS --
+e.g. shut it down directly (through a locally running NUT driver).
 
 Use this mode when you run multiple computers on the same UPS.
 Obviously, only one can be connected to the serial or USB port
-on a typical UPS, and that system is the manager. Everything
-else is a subordinate.
+on a typical UPS, and that system is the primary. Everything
+else is a secondary.
 
 For a typical home user, there's one computer connected to one UPS.
-That means you run a driver, `upsd`, and `upsmon` in manager mode.
+That means you run a driver, `upsd`, and `upsmon` in primary mode.
 
 Additional Information
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/README
+++ b/README
@@ -273,32 +273,46 @@ separate section in the documentation since it is so important.
 
 You configure it by telling it about UPSes that you want to monitor in
 upsmon.conf.  Each UPS can be defined as one of two possible types:
+a "manager" or "subordinate".
 
-Master
-~~~~~~
+Manager
+~~~~~~~
 
-This UPS supplies power to the system running `upsmon`, and this system is also
-responsible for shutting it down when the battery is depleted.  This occurs
-after any slave systems have disconnected safely.
+The monitored UPS possibly supplies power to this system running `upsmon`,
+but more importantly -- this system can manage the UPS (typically, this
+instance of `upsmon` runs on the same system as the `upsd` and driver(s)):
+it is capable and responsible for shutting it down when the battery is
+depleted (or in another approach, lingering to deplete it or to tell the
+UPS to reboot its load after too much time has elapsed and this system
+is still alive -- meaning wall power returned at a  "wrong" moment).
 
-If your UPS is plugged directly into a system's serial port, the `upsmon`
-process on that system should define that UPS as a master.
+The shutdown of this (manager) system itself, as well as eventually an
+UPS shutdown, occurs after any subordinate systems ordered to shut down
+first have disconnected or a critical threshold was passed.
 
-For a typical home user, there's one computer connected to one UPS.
-That means you run a driver, `upsd`, and `upsmon` in master mode.
-
-Slave
-~~~~~
-
-This UPS may supply power to the system running `upsmon`, but this system can't
-shut it down directly.
-
-Use this mode when you run multiple computers on the same UPS.  Obviously, only
-one can be connected to the serial port on the UPS, and that system is the
-master.  Everything else is a slave.
+If your UPS is plugged directly into a system's serial or USB port, the
+`upsmon` process on that system should define its relation to that UPS
+as a manager.
 
 For a typical home user, there's one computer connected to one UPS.
-That means you run a driver, upsd, and upsmon in master mode.
+That means you would run on the same computer the whole NUT stack --
+a suitable driver, `upsd`, and `upsmon` in manager mode.
+
+Subordinate
+~~~~~~~~~~~
+
+The monitored UPS may supply power to the system running `upsmon`
+(or alternatively, it may be a monitoring station with zero PSUs
+fed by that UPS), but this system can't shut it down directly
+(through a locally running NUT driver).
+
+Use this mode when you run multiple computers on the same UPS.
+Obviously, only one can be connected to the serial or USB port
+on a typical UPS, and that system is the manager. Everything
+else is a subordinate.
+
+For a typical home user, there's one computer connected to one UPS.
+That means you run a driver, `upsd`, and `upsmon` in manager mode.
 
 Additional Information
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/clients/nutclient.cpp
+++ b/clients/nutclient.cpp
@@ -802,7 +802,7 @@ void TcpClient::deviceLogin(const std::string& dev)
 	detectError(sendQuery("LOGIN " + dev));
 }
 
-/* FIXME: Protocol update needed to handle master/manager alias
+/* FIXME: Protocol update needed to handle master/primary alias
  * and probably an API bump also, to rename/alias the routine.
  */
 void TcpClient::deviceMaster(const std::string& dev)
@@ -1304,7 +1304,7 @@ void Device::login()
 	getClient()->deviceLogin(getName());
 }
 
-/* FIXME: Protocol update needed to handle master/manager alias
+/* FIXME: Protocol update needed to handle master/primary alias
  * and probably an API bump also, to rename/alias the routine.
  */
 void Device::master()
@@ -1711,7 +1711,7 @@ int nutclient_get_device_num_logins(NUTCLIENT_t client, const char* dev)
 	return -1;
 }
 
-/* FIXME: Protocol update needed to handle master/manager alias
+/* FIXME: Protocol update needed to handle master/primary alias
  * and probably an API bump also, to rename/alias the routine.
  */
 void nutclient_device_master(NUTCLIENT_t client, const char* dev)

--- a/clients/nutclient.cpp
+++ b/clients/nutclient.cpp
@@ -802,6 +802,9 @@ void TcpClient::deviceLogin(const std::string& dev)
 	detectError(sendQuery("LOGIN " + dev));
 }
 
+/* FIXME: Protocol update needed to handle master/manager alias
+ * and probably an API bump also, to rename/alias the routine.
+ */
 void TcpClient::deviceMaster(const std::string& dev)
 {
 	detectError(sendQuery("MASTER " + dev));
@@ -1301,6 +1304,9 @@ void Device::login()
 	getClient()->deviceLogin(getName());
 }
 
+/* FIXME: Protocol update needed to handle master/manager alias
+ * and probably an API bump also, to rename/alias the routine.
+ */
 void Device::master()
 {
 	if (!isOk()) throw NutException("Invalid device");
@@ -1705,6 +1711,9 @@ int nutclient_get_device_num_logins(NUTCLIENT_t client, const char* dev)
 	return -1;
 }
 
+/* FIXME: Protocol update needed to handle master/manager alias
+ * and probably an API bump also, to rename/alias the routine.
+ */
 void nutclient_device_master(NUTCLIENT_t client, const char* dev)
 {
 	if(client)

--- a/clients/nutclient.h
+++ b/clients/nutclient.h
@@ -310,7 +310,7 @@ public:
 	 * \return Number of logged-in users.
 	 */
 	virtual int deviceGetNumLogins(const std::string& dev) = 0;
-	/* FIXME: Protocol update needed to handle master/manager alias
+	/* FIXME: Protocol update needed to handle master/primary alias
 	 * and probably an API bump also, to rename/alias the routine.
 	 */
 	virtual void deviceMaster(const std::string& dev) = 0;
@@ -420,7 +420,7 @@ public:
 	virtual TrackingID executeDeviceCommand(const std::string& dev, const std::string& name, const std::string& param="");
 
  	virtual void deviceLogin(const std::string& dev);
-	/* FIXME: Protocol update needed to handle master/manager alias
+	/* FIXME: Protocol update needed to handle master/primary alias
 	 * and probably an API bump also, to rename/alias the routine.
 	 */
 	virtual void deviceMaster(const std::string& dev);
@@ -591,7 +591,7 @@ public:
 	 * Login current client's user for the device.
 	 */
 	void login();
-	/* FIXME: Protocol update needed to handle master/manager alias
+	/* FIXME: Protocol update needed to handle master/primary alias
 	 * and probably an API bump also, to rename/alias the routine.
 	 */
 	void master();
@@ -850,7 +850,7 @@ int nutclient_get_device_num_logins(NUTCLIENT_t client, const char* dev);
  * \param client Nut client handle.
  * \param dev Device name to test.
  */
-/* FIXME: Protocol update needed to handle master/manager alias
+/* FIXME: Protocol update needed to handle master/primary alias
  * and probably an API bump also, to rename/alias the routine.
  */
 void nutclient_device_master(NUTCLIENT_t client, const char* dev);

--- a/clients/nutclient.h
+++ b/clients/nutclient.h
@@ -310,6 +310,9 @@ public:
 	 * \return Number of logged-in users.
 	 */
 	virtual int deviceGetNumLogins(const std::string& dev) = 0;
+	/* FIXME: Protocol update needed to handle master/manager alias
+	 * and probably an API bump also, to rename/alias the routine.
+	 */
 	virtual void deviceMaster(const std::string& dev) = 0;
 	virtual void deviceForcedShutdown(const std::string& dev) = 0;
 
@@ -417,6 +420,9 @@ public:
 	virtual TrackingID executeDeviceCommand(const std::string& dev, const std::string& name, const std::string& param="");
 
  	virtual void deviceLogin(const std::string& dev);
+	/* FIXME: Protocol update needed to handle master/manager alias
+	 * and probably an API bump also, to rename/alias the routine.
+	 */
 	virtual void deviceMaster(const std::string& dev);
 	virtual void deviceForcedShutdown(const std::string& dev);
 	virtual int deviceGetNumLogins(const std::string& dev);
@@ -585,6 +591,9 @@ public:
 	 * Login current client's user for the device.
 	 */
 	void login();
+	/* FIXME: Protocol update needed to handle master/manager alias
+	 * and probably an API bump also, to rename/alias the routine.
+	 */
 	void master();
 	void forcedShutdown();
 	/**
@@ -840,6 +849,9 @@ int nutclient_get_device_num_logins(NUTCLIENT_t client, const char* dev);
  * Set current user as master user of the device.
  * \param client Nut client handle.
  * \param dev Device name to test.
+ */
+/* FIXME: Protocol update needed to handle master/manager alias
+ * and probably an API bump also, to rename/alias the routine.
  */
 void nutclient_device_master(NUTCLIENT_t client, const char* dev);
 

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -44,7 +44,7 @@ static	int	minsupplies = 1, sleepval = 5, deadtime = 15;
 	/* default polling interval = 5 sec */
 static	int	pollfreq = 5, pollfreqalert = 5;
 
-	/* subordinate hosts are given 15 sec by default to logout from upsd */
+	/* secondary hosts are given 15 sec by default to logout from upsd */
 static	int	hostsync = 15;
 
 	/* sum of all power values from config file */
@@ -200,29 +200,30 @@ static void do_notify(const utype_t *ups, int ntype)
 }
 
 /* check for master permissions on the server for this ups */
-/* TODO: API change pending to replace deprecated MASTER with MANAGER
- * and SLAVE with SUBORDINATE (and backwards-compatible alias handling)
+/* TODO: API change pending to replace deprecated MASTER with PRIMARY
+ * and SLAVE with SECONDARY (and backwards-compatible alias handling)
  */
+/* TODO: Rename routine */
 static int checkmaster(utype_t *ups)
 {
 	char	buf[SMALLBUF];
 
-	/* don't bother if we're not configured as a manager for this ups */
-	if (!flag_isset(ups->status, ST_MANAGER))
+	/* don't bother if we're not configured as a primary for this ups */
+	if (!flag_isset(ups->status, ST_PRIMARY))
 		return 1;
 
 	/* this shouldn't happen (LOGIN checks it earlier) */
 	if ((ups->upsname == NULL) || (strlen(ups->upsname) == 0)) {
-		upslogx(LOG_ERR, "Set manager on UPS [%s] failed: empty upsname",
+		upslogx(LOG_ERR, "Set primary managerial mode on UPS [%s] failed: empty upsname",
 			ups->sys);
 		return 0;
 	}
 
-	/* TODO: Use MANAGER first but if talking to older server, retry with MASTER */
+	/* TODO: Use PRIMARY first but if talking to older server, retry with MASTER */
 	snprintf(buf, sizeof(buf), "MASTER %s\n", ups->upsname);
 
 	if (upscli_sendline(&ups->conn, buf, strlen(buf)) < 0) {
-		upslogx(LOG_ALERT, "Can't set manager mode on UPS [%s] - %s",
+		upslogx(LOG_ALERT, "Can't set primary managerial mode on UPS [%s] - %s",
 			ups->sys, upscli_strerror(&ups->conn));
 		return 0;
 	}
@@ -233,12 +234,12 @@ static int checkmaster(utype_t *ups)
 
 		/* not ERR, but not caught by readline either? */
 
-		upslogx(LOG_ALERT, "Manager privileges unavailable on UPS [%s]",
+		upslogx(LOG_ALERT, "Primary managerial privileges unavailable on UPS [%s]",
 			ups->sys);
 		upslogx(LOG_ALERT, "Response: [%s]", buf);
 	}
 	else {	/* something caught by readraw's parsing call */
-		upslogx(LOG_ALERT, "Manager privileges unavailable on UPS [%s]",
+		upslogx(LOG_ALERT, "Primary managerial privileges unavailable on UPS [%s]",
 			ups->sys);
 		upslogx(LOG_ALERT, "Reason: %s", upscli_strerror(&ups->conn));
 	}
@@ -247,8 +248,8 @@ static int checkmaster(utype_t *ups)
 }
 
 /* authenticate to upsd, plus do LOGIN and MASTER if applicable */
-/* TODO: API change pending to replace deprecated MASTER with MANAGER
- * and SLAVE with SUBORDINATE (and backwards-compatible alias handling)
+/* TODO: API change pending to replace deprecated MASTER with PRIMARY
+ * and SLAVE with SECONDARY (and backwards-compatible alias handling)
  */
 static int do_upsd_auth(utype_t *ups)
 {
@@ -327,7 +328,8 @@ static int do_upsd_auth(utype_t *ups)
 	upsdebugx(1, "Logged into UPS %s", ups->sys);
 	setflag(&ups->status, ST_LOGIN);
 
-	/* now see if we also need to test manager permissions */
+	/* now see if we also need to test primary managerial-mode permissions */
+	/* TODO: Rename routine */
 	return checkmaster(ups);
 }
 
@@ -598,9 +600,10 @@ static int get_var(utype_t *ups, const char *var, char *buf, size_t bufsize)
 	return 0;
 }
 
-/* TODO: API change pending to replace deprecated MASTER with MANAGER
- * and SLAVE with SUBORDINATE (and backwards-compatible alias handling)
+/* TODO: API change pending to replace deprecated MASTER with PRIMARY
+ * and SLAVE with SECONDARY (and backwards-compatible alias handling)
  */
+/* TODO: Rename routine */
 static void slavesync(void)
 {
 	utype_t	*ups;
@@ -615,8 +618,8 @@ static void slavesync(void)
 
 		for (ups = firstups; ups != NULL; ups = ups->next) {
 
-			/* only check login count on our manager(s) */
-			if (!flag_isset(ups->status, ST_MANAGER))
+			/* only check login count on our primary(ies) */
+			if (!flag_isset(ups->status, ST_PRIMARY))
 				continue;
 
 			set_alarm();
@@ -631,12 +634,15 @@ static void slavesync(void)
 			clear_alarm();
 		}
 
-		/* if no UPS has more than 1 login (us), then subordinates are gone */
-		/* TO THINK: how about redundant setups with several managers? */
+		/* if no UPS has more than 1 login (that would be us),
+		 * then secondaries are all gone */
+		/* TO THINK: how about redundant setups with several primary-mode
+		 * clients managing an UPS, or possibly differend UPSes, with the
+		 * same upsd? */
 		if (maxlogins <= 1)
 			return;
 
-		/* after HOSTSYNC seconds, assume subordinates are stuck and bail */
+		/* after HOSTSYNC seconds, assume secondaries are stuck - and bail */
 		time(&now);
 
 		if ((now - start) > hostsync) {
@@ -654,28 +660,29 @@ static void forceshutdown(void)
 static void forceshutdown(void)
 {
 	utype_t	*ups;
-	int	isamanager = 0;
+	int	isaprimary = 0;
 
-	upsdebugx(1, "Shutting down any UPSes in MANAGER mode...");
+	upsdebugx(1, "Shutting down any UPSes in PRIMARY mode...");
 
-	/* set FSD on any "manager" UPS entries (forced shutdown in progress) */
+	/* set FSD on any "primary" UPS entries (forced shutdown in progress) */
 	for (ups = firstups; ups != NULL; ups = ups->next)
-		if (flag_isset(ups->status, ST_MANAGER)) {
-			isamanager = 1;
+		if (flag_isset(ups->status, ST_PRIMARY)) {
+			isaprimary = 1;
 			setfsd(ups);
 		}
 
-	/* if we're not a manager on anything, we should shut down now */
-	if (!isamanager)
+	/* if we're not a primary on anything, we should shut down now */
+	if (!isaprimary)
 		doshutdown();
 
-	/* must be the manager now */
-	upsdebugx(1, "This system is a manager... waiting for subordinate logout...");
+	/* we must be the primary now */
+	upsdebugx(1, "This system is a primary... waiting for secondaries to logout...");
 
-	/* wait up to HOSTSYNC seconds for subordinates to logout */
+	/* wait up to HOSTSYNC seconds for secondaries to logout */
+	/* TODO: Rename routine */
 	slavesync();
 
-	/* time expired or all the subordinates are gone, so shutdown */
+	/* time expired or all the secondaries are gone, so shutdown */
 	doshutdown();
 }
 
@@ -683,7 +690,7 @@ static int is_ups_critical(utype_t *ups)
 {
 	time_t	now;
 
-	/* FSD = the manager is forcing a shutdown, or a driver forwarded the flag
+	/* FSD = the primary is forcing a shutdown, or a driver forwarded the flag
 	 * from a smarter UPS depending on vendor protocol, ability and settings
 	 * (e.g. is charging but battery too low to guarantee safety to the load)
 	 */
@@ -710,19 +717,19 @@ static int is_ups_critical(utype_t *ups)
 		return 0;
 	}
 
-	/* if we're a manager, declare it critical so we set FSD on it */
-	if (flag_isset(ups->status, ST_MANAGER))
+	/* if we're a primary, declare it critical so we set FSD on it */
+	if (flag_isset(ups->status, ST_PRIMARY))
 		return 1;
 
-	/* must be a subordinate now */
+	/* must be a secondary now */
 
-	/* FSD isn't set, so the manager hasn't seen it yet */
+	/* FSD isn't set, so the primary hasn't seen it yet */
 
 	time(&now);
 
-	/* give the manager up to HOSTSYNC seconds before shutting down */
+	/* give the primary up to HOSTSYNC seconds before shutting down */
 	if ((now - ups->lastnoncrit) > hostsync) {
-		upslogx(LOG_WARNING, "Giving up on the manager for UPS [%s]",
+		upslogx(LOG_WARNING, "Giving up on the primary for UPS [%s]",
 			ups->sys);
 		return 1;
 	}
@@ -841,7 +848,7 @@ static void drop_connection(utype_t *ups)
 
 /* change some UPS parameters during reloading */
 static void redefine_ups(utype_t *ups, int pv, const char *un,
-		const char *pw, const char *manager)
+		const char *pw, const char *managerialOption)
 {
 	ups->retain = 1;
 
@@ -919,35 +926,37 @@ static void redefine_ups(utype_t *ups, int pv, const char *un,
 		}
 	}
 
-	/* slave|subordinate -> master|manager */
-	if ( ( (!strcasecmp(manager, "manager")) || (!strcasecmp(manager, "master")) )
-	     && (!flag_isset(ups->status, ST_MANAGER)) ) {
-		upslogx(LOG_INFO, "UPS [%s]: redefined as manager", ups->sys);
-		setflag(&ups->status, ST_MANAGER);
+	/* secondary|slave -> primary|master */
+	if ( (   (!strcasecmp(managerialOption, "primary"))
+	      || (!strcasecmp(managerialOption, "master"))  )
+	     && (!flag_isset(ups->status, ST_PRIMARY)) ) {
+		upslogx(LOG_INFO, "UPS [%s]: redefined as a primary", ups->sys);
+		setflag(&ups->status, ST_PRIMARY);
 
-		/* reset connection to ensure manager mode gets checked */
+		/* reset connection to ensure primary mode gets checked */
 		drop_connection(ups);
 		return;
 	}
 
-	/* manager|master -> subordnate|slave */
-	if ( ( (!strcasecmp(manager, "subordinate")) || (!strcasecmp(manager, "slave")) )
-	     && (flag_isset(ups->status, ST_MANAGER)) ) {
-		upslogx(LOG_INFO, "UPS [%s]: redefined as subordinate", ups->sys);
-		clearflag(&ups->status, ST_MANAGER);
+	/* primary|master -> secondary|slave */
+	if ( (   (!strcasecmp(managerialOption, "secondary"))
+	      || (!strcasecmp(managerialOption, "slave"))  )
+	     && (flag_isset(ups->status, ST_PRIMARY)) ) {
+		upslogx(LOG_INFO, "UPS [%s]: redefined as a secondary", ups->sys);
+		clearflag(&ups->status, ST_PRIMARY);
 		return;
 	}
 }
 
 static void addups(int reloading, const char *sys, const char *pvs,
-		const char *un, const char *pw, const char *manager)
+		const char *un, const char *pw, const char *managerialOption)
 {
 	int	pv;
 	utype_t	*tmp, *last;
 
 	/* the username is now required - no more host-based auth */
 
-	if ((!sys) || (!pvs) || (!pw) || (!manager) || (!un)) {
+	if ((!sys) || (!pvs) || (!pw) || (!managerialOption) || (!un)) {
 		upslogx(LOG_WARNING, "Ignoring invalid MONITOR line in %s!", configfile);
 		upslogx(LOG_WARNING, "MONITOR configuration directives require five arguments.");
 		return;
@@ -969,7 +978,7 @@ static void addups(int reloading, const char *sys, const char *pvs,
 		/* check for duplicates */
 		if (!strcmp(tmp->sys, sys)) {
 			if (reloading)
-				redefine_ups(tmp, pv, un, pw, manager);
+				redefine_ups(tmp, pv, un, pw, managerialOption);
 			else
 				upslogx(LOG_WARNING, "Warning: ignoring duplicate"
 					" UPS [%s]", sys);
@@ -1001,8 +1010,10 @@ static void addups(int reloading, const char *sys, const char *pvs,
 	tmp->lastrbwarn = 0;
 	tmp->lastncwarn = 0;
 
-	if ( (!strcasecmp(manager, "manager")) || (!strcasecmp(manager, "master")) )
-		setflag(&tmp->status, ST_MANAGER);
+	if (   (!strcasecmp(managerialOption, "primary"))
+	    || (!strcasecmp(managerialOption, "master"))  ) {
+		setflag(&tmp->status, ST_PRIMARY);
+	}
 
 	tmp->next = NULL;
 
@@ -1013,7 +1024,7 @@ static void addups(int reloading, const char *sys, const char *pvs,
 
 	if (tmp->pv)
 		upslogx(LOG_INFO, "UPS: %s (%s) (power value %d)", tmp->sys,
-			flag_isset(tmp->status, ST_MANAGER) ? "manager" : "subordinate",
+			flag_isset(tmp->status, ST_PRIMARY) ? "primary" : "secondary",
 			tmp->pv);
 	else
 		upslogx(LOG_INFO, "UPS: %s (monitoring only)", tmp->sys);
@@ -1278,7 +1289,7 @@ static int parse_conf_arg(size_t numargs, char **arg)
 			fatalx(EXIT_FAILURE, "Fatal error: unusable configuration");
 		}
 
-		/* <sys> <pwrval> <user> <pw> ("manager"|"master" | "subordinate"|"slave") */
+		/* <sys> <pwrval> <user> <pw> ("primary"|"master" | "secondary"|"slave") */
 		addups(reload_flag, arg[1], arg[2], arg[3], arg[4], arg[5]);
 		return 1;
 	}
@@ -1723,7 +1734,7 @@ static void help(const char *arg_progname)
 	printf("usage: %s [OPTIONS]\n\n", arg_progname);
 	printf("  -c <cmd>	send command to running process\n");
 	printf("		commands:\n");
-	printf("		 - fsd: shutdown all manager-mode UPSes (use with caution)\n");
+	printf("		 - fsd: shutdown all primary-mode UPSes (use with caution)\n");
 	printf("		 - reload: reread configuration\n");
 	printf("		 - stop: stop monitoring and exit\n");
 	printf("  -D		raise debugging level\n");

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -200,6 +200,9 @@ static void do_notify(const utype_t *ups, int ntype)
 }
 
 /* check for master permissions on the server for this ups */
+/* TODO: API change pending to replace deprecated MASTER with MANAGER
+ * and SLAVE with SUBORDINATE (and backwards-compatible alias handling)
+ */
 static int checkmaster(utype_t *ups)
 {
 	char	buf[SMALLBUF];
@@ -244,6 +247,9 @@ static int checkmaster(utype_t *ups)
 }
 
 /* authenticate to upsd, plus do LOGIN and MASTER if applicable */
+/* TODO: API change pending to replace deprecated MASTER with MANAGER
+ * and SLAVE with SUBORDINATE (and backwards-compatible alias handling)
+ */
 static int do_upsd_auth(utype_t *ups)
 {
 	char	buf[SMALLBUF];
@@ -592,6 +598,9 @@ static int get_var(utype_t *ups, const char *var, char *buf, size_t bufsize)
 	return 0;
 }
 
+/* TODO: API change pending to replace deprecated MASTER with MANAGER
+ * and SLAVE with SUBORDINATE (and backwards-compatible alias handling)
+ */
 static void slavesync(void)
 {
 	utype_t	*ups;

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -683,7 +683,10 @@ static int is_ups_critical(utype_t *ups)
 {
 	time_t	now;
 
-	/* FSD = the manager is forcing a shutdown */
+	/* FSD = the manager is forcing a shutdown, or a driver forwarded the flag
+	 * from a smarter UPS depending on vendor protocol, ability and settings
+	 * (e.g. is charging but battery too low to guarantee safety to the load)
+	 */
 	if (flag_isset(ups->status, ST_FSD))
 		return 1;
 

--- a/clients/upsmon.h
+++ b/clients/upsmon.h
@@ -25,8 +25,9 @@
 #define ST_ONLINE      (1 << 0)       /* UPS is on line (OL)                  */
 #define ST_ONBATT      (1 << 1)       /* UPS is on battery (OB)               */
 #define ST_LOWBATT     (1 << 2)       /* UPS has a low battery (LB)           */
-#define ST_FSD         (1 << 3)       /* master has set forced shutdown flag  */
-#define ST_MASTER      (1 << 4)       /* we are the master on this UPS        */
+#define ST_FSD         (1 << 3)       /* manager has set forced shutdown flag */
+#define ST_MANAGER     (1 << 4)       /* we are the manager of this UPS       */
+#define ST_MASTER      ST_MANAGER     /* legacy alias                         */
 #define ST_LOGIN       (1 << 5)       /* we are logged into this UPS          */
 #define ST_CONNECTED   (1 << 6)       /* upscli_connect returned OK           */
 #define ST_CAL         (1 << 7)       /* UPS calibration in progress (CAL)    */
@@ -72,7 +73,7 @@ typedef struct {
 #define NOTIFY_ONLINE	0	/* UPS went on-line			*/
 #define NOTIFY_ONBATT	1	/* UPS went on battery			*/
 #define NOTIFY_LOWBATT	2	/* UPS went to low battery		*/
-#define NOTIFY_FSD	3	/* Master upsmon set FSD flag		*/
+#define NOTIFY_FSD	3	/* Manager upsmon set FSD flag		*/
 #define NOTIFY_COMMOK	4	/* Communication established		*/
 #define NOTIFY_COMMBAD	5	/* Communication lost			*/
 #define NOTIFY_SHUTDOWN	6	/* System shutdown in progress		*/

--- a/clients/upsmon.h
+++ b/clients/upsmon.h
@@ -22,15 +22,15 @@
 
 /* flags for ups->status */
 
-#define ST_ONLINE      (1 << 0)       /* UPS is on line (OL)                  */
-#define ST_ONBATT      (1 << 1)       /* UPS is on battery (OB)               */
-#define ST_LOWBATT     (1 << 2)       /* UPS has a low battery (LB)           */
-#define ST_FSD         (1 << 3)       /* manager has set forced shutdown flag */
-#define ST_MANAGER     (1 << 4)       /* we are the manager of this UPS       */
-#define ST_MASTER      ST_MANAGER     /* legacy alias                         */
-#define ST_LOGIN       (1 << 5)       /* we are logged into this UPS          */
-#define ST_CONNECTED   (1 << 6)       /* upscli_connect returned OK           */
-#define ST_CAL         (1 << 7)       /* UPS calibration in progress (CAL)    */
+#define ST_ONLINE      (1 << 0)       /* UPS is on line (OL)                      */
+#define ST_ONBATT      (1 << 1)       /* UPS is on battery (OB)                   */
+#define ST_LOWBATT     (1 << 2)       /* UPS has a low battery (LB)               */
+#define ST_FSD         (1 << 3)       /* primary has set forced shutdown flag     */
+#define ST_PRIMARY     (1 << 4)       /* we are the primary (manager) of this UPS */
+#define ST_MASTER      ST_PRIMARY     /* legacy alias                             */
+#define ST_LOGIN       (1 << 5)       /* we are logged into this UPS              */
+#define ST_CONNECTED   (1 << 6)       /* upscli_connect returned OK               */
+#define ST_CAL         (1 << 7)       /* UPS calibration in progress (CAL)        */
 
 /* required contents of flag file */
 #define SDMAGIC "upsmon-shutdown-file"
@@ -70,17 +70,17 @@ typedef struct {
 
 /* notify identifiers */
 
-#define NOTIFY_ONLINE	0	/* UPS went on-line			*/
-#define NOTIFY_ONBATT	1	/* UPS went on battery			*/
-#define NOTIFY_LOWBATT	2	/* UPS went to low battery		*/
-#define NOTIFY_FSD	3	/* Manager upsmon set FSD flag		*/
-#define NOTIFY_COMMOK	4	/* Communication established		*/
-#define NOTIFY_COMMBAD	5	/* Communication lost			*/
-#define NOTIFY_SHUTDOWN	6	/* System shutdown in progress		*/
-#define NOTIFY_REPLBATT	7	/* UPS battery needs to be replaced	*/
-#define NOTIFY_NOCOMM	8	/* UPS hasn't been contacted in awhile	*/
-#define NOTIFY_NOPARENT	9	/* privileged parent process died	*/
-#define NOTIFY_CAL		10	/* UPS is performing calibration   */
+#define NOTIFY_ONLINE	0	/* UPS went on-line                     */
+#define NOTIFY_ONBATT	1	/* UPS went on battery                  */
+#define NOTIFY_LOWBATT	2	/* UPS went to low battery              */
+#define NOTIFY_FSD		3	/* Primary upsmon set FSD flag          */
+#define NOTIFY_COMMOK	4	/* Communication established	            */
+#define NOTIFY_COMMBAD	5	/* Communication lost                   */
+#define NOTIFY_SHUTDOWN	6	/* System shutdown in progress          */
+#define NOTIFY_REPLBATT	7	/* UPS battery needs to be replaced     */
+#define NOTIFY_NOCOMM	8	/* UPS hasn't been contacted in a while	*/
+#define NOTIFY_NOPARENT	9	/* privileged parent process died       */
+#define NOTIFY_CAL		10	/* UPS is performing calibration        */
 
 /* notify flag values */
 

--- a/conf/ups.conf.sample
+++ b/conf/ups.conf.sample
@@ -30,13 +30,14 @@
 #
 # If you have a UPS called snoopy, your section header would be "[snoopy]".
 # On a system called "doghouse", the line in your upsmon.conf to monitor
-# it would look something like this:
+# and manage it would look something like this:
 #
-#   MONITOR snoopy@doghouse 1 upsmonuser mypassword master
+#   MONITOR snoopy@doghouse 1 upsmonuser mypassword manager
 #
-# It might look like this if monitoring in slave mode:
+# It might look like this if monitoring in subordinate mode from a different
+# system:
 #
-#   MONITOR snoopy@doghouse 1 upsmonuser mypassword slave
+#   MONITOR snoopy@doghouse 1 upsmonuser mypassword subordinate
 #
 # Configuration directives
 # ------------------------

--- a/conf/ups.conf.sample
+++ b/conf/ups.conf.sample
@@ -32,12 +32,12 @@
 # On a system called "doghouse", the line in your upsmon.conf to monitor
 # and manage it would look something like this:
 #
-#   MONITOR snoopy@doghouse 1 upsmonuser mypassword manager
+#   MONITOR snoopy@doghouse 1 upsmonuser mypassword primary
 #
-# It might look like this if monitoring in subordinate mode from a different
-# system:
+# It might look like this if monitoring in "secondary" mode (without any
+# ability to directly manage the UPS) from a different system:
 #
-#   MONITOR snoopy@doghouse 1 upsmonuser mypassword subordinate
+#   MONITOR snoopy@doghouse 1 upsmonuser mypassword secondary
 #
 # Configuration directives
 # ------------------------

--- a/conf/upsd.users.sample
+++ b/conf/upsd.users.sample
@@ -63,13 +63,13 @@
 #
 #   [upsmon]
 #       password  = pass
-#       upsmon master
+#       upsmon manager
 # or
-#       upsmon slave
+#       upsmon subordinate
 #
 # The matching MONITOR line in your upsmon.conf would look like this:
 #
-# MONITOR myups@localhost 1 upsmon pass master	(or slave)
+# MONITOR myups@localhost 1 upsmon pass manager	(or subordinate)
 #
 # See comments in the upsmon.conf(.sample) file for details about this
-# keyword and the difference of NUT slave and master systems.
+# keyword and the difference of NUT subordinate and manager systems.

--- a/conf/upsd.users.sample
+++ b/conf/upsd.users.sample
@@ -63,13 +63,13 @@
 #
 #   [upsmon]
 #       password  = pass
-#       upsmon manager
+#       upsmon primary
 # or
-#       upsmon subordinate
+#       upsmon secondary
 #
 # The matching MONITOR line in your upsmon.conf would look like this:
 #
-# MONITOR myups@localhost 1 upsmon pass manager	(or subordinate)
+# MONITOR myups@localhost 1 upsmon pass primary	(or secondary)
 #
 # See comments in the upsmon.conf(.sample) file for details about this
-# keyword and the difference of NUT subordinate and manager systems.
+# keyword and the difference of NUT secondary and primary systems.

--- a/conf/upsmon.conf.sample.in
+++ b/conf/upsmon.conf.sample.in
@@ -30,7 +30,7 @@
 # RUN_AS_USER @RUN_AS_USER@
 
 # --------------------------------------------------------------------------
-# MONITOR <system> <powervalue> <username> <password> ("manager"|"subordinate")
+# MONITOR <system> <powervalue> <username> <password> ("primary"|"secondary")
 #
 # List systems you want to monitor.  Not all of these may supply power
 # to the system running upsmon, but if you want to watch it, it has to
@@ -71,35 +71,36 @@
 #
 #	[upsmon]
 #		password  = blah
-#		upsmon manager 	# (or subordinate)
+#		upsmon primary 	# (or secondary)
 #
-# "manager" means this system will shutdown last, allowing the subordinate
+# "primary" means this system will shutdown last, allowing the secondary
 # systems time to shutdown first.
 #
-# "subordinate" means this system shuts down immediately when power goes
+# "secondary" means this system shuts down immediately when power goes
 # critical and less than MINSUPPLIES power sources have reliable input feeds.
 #
-# The general assumption is that the "manager" system is the one with direct
-# connection to an UPS (such as serial or USB cable), so the manager system
+# The general assumption is that the "primary" system is the one with direct
+# connection to an UPS (such as serial or USB cable), so the primary system
 # runs the NUT driver and 'upsd' server locally and can manage the device,
 # and it would often tell the UPS to completely power itself off as a step
 # in power-race avoidance (see POWERDOWNFLAG for details).
-# Also, since the manager system stays up the longest, it suffers higher risks
+#
+# Also, since the primary system stays up the longest, it suffers higher risks
 # of ungraceful shutdown if the estimation of remaining runtime (or of the
 # time it takes to shut down this system) was guessed wrong. By consequence,
-# the "subordinate" systems typically monitor the power environment state
-# through the 'upsd' processes running on the remote (often "manager") systems
+# the "secondary" systems typically monitor the power environment state
+# through the 'upsd' processes running on the remote (often "primary") systems
 # and do not directly interact with an UPS (no local NUT drivers are running
-# on the subordinate systems). As such, subordinates typically shut down as
+# on the secondary systems). As such, secondaries typically shut down as
 # soon as there is a sufficiently long power outage, or a low-battery alert
-# from the UPS, or a loss of connection to the manager while the power was
+# from the UPS, or a loss of connection to the primary while the power was
 # last known to be missing.
 #
 # This assumption and configuration can also make sense for networked UPSes,
 # where a rack full of servers might overload the communications capacity
 # of the networked management card on the UPS - in this case you might either
 # reduce the 'snmp-ups' or 'netxml-ups' driver polling rate, or dedicate a
-# "manager" server and set up the rest as "subordinate" systems.
+# "primary" server and set up the rest as "secondary" systems.
 #
 # In case of such large setups as mentioned above, beware also that shutdown
 # times of the rack done all at once can substantially differ from smaller
@@ -111,9 +112,9 @@
 #
 # Examples:
 #
-# MONITOR myups@bigserver 1 upswired blah manager
-# MONITOR su700@server.example.com 1 upsmon secretpass subordinate
-# MONITOR myups@localhost 1 upsmon pass manager	# (or subordinate)
+# MONITOR myups@bigserver 1 upswired blah primary
+# MONITOR su700@server.example.com 1 upsmon secretpass secondary
+# MONITOR myups@localhost 1 upsmon pass primary	# (or secondary)
 
 # --------------------------------------------------------------------------
 # MINSUPPLIES <num>
@@ -194,17 +195,17 @@ POLLFREQALERT 5
 # --------------------------------------------------------------------------
 # HOSTSYNC - How long upsmon will wait before giving up on another upsmon
 #
-# The manager upsmon process uses this number when waiting for subordinate
+# The primary upsmon process uses this number when waiting for secondary
 # systems to disconnect once it has set the forced shutdown (FSD) flag.
 # If they don't disconnect after this many seconds, it goes on without them.
 #
-# Similarly, upsmon subordinate processes wait up to this interval for the
-# manager upsmon to set FSD when a UPS they are monitoring goes critical -
-# that is, on battery and low battery.  If the manager doesn't do its job,
-# the subordinates will shut down anyway to avoid damage to the file systems.
+# Similarly, upsmon secondary processes wait up to this interval for the
+# primary upsmon to set FSD when an UPS they are monitoring goes critical -
+# that is, on battery and low battery.  If the primary doesn't do its job,
+# the secondaries will shut down anyway to avoid damage to the file systems.
 #
 # This "wait for FSD" is done to avoid races where the status changes
-# to critical and back between polls by the manager.
+# to critical and back between polls by the primary.
 
 HOSTSYNC 15
 
@@ -228,9 +229,9 @@ HOSTSYNC 15
 DEADTIME 15
 
 # --------------------------------------------------------------------------
-# POWERDOWNFLAG - Flag file for forcing UPS shutdown on the manager system
+# POWERDOWNFLAG - Flag file for forcing UPS shutdown on the primary system
 #
-# upsmon will create a file with this name in manager mode when it's time
+# upsmon will create a file with this name in primary mode when it's time
 # to shut down the load.  You should check for this file's existence in
 # your shutdown scripts and run 'upsdrvctl shutdown' if it exists, to tell
 # the UPS(es) to power off.
@@ -267,7 +268,7 @@ POWERDOWNFLAG /etc/killpower
 # ONLINE   : UPS is back online
 # ONBATT   : UPS is on battery
 # LOWBATT  : UPS has a low battery (if also on battery, it's "critical")
-# FSD      : UPS is being shutdown by the manager (FSD = "Forced Shutdown")
+# FSD      : UPS is being shutdown by the primary (FSD = "Forced Shutdown")
 # COMMOK   : Communications established with the UPS
 # COMMBAD  : Communications lost to the UPS
 # SHUTDOWN : The system is being shutdown
@@ -328,7 +329,7 @@ NOCOMMWARNTIME 300
 # --------------------------------------------------------------------------
 # FINALDELAY - last sleep interval before shutting down the system
 #
-# On a manager, upsmon will wait this long after sending the NOTIFY_SHUTDOWN
+# On a primary, upsmon will wait this long after sending the NOTIFY_SHUTDOWN
 # before executing your SHUTDOWNCMD.  If you need to do something in between
 # those events, increase this number.  Remember, at this point your UPS is
 # almost depleted, so don't make this too high.  If needed, on high-end UPS
@@ -339,8 +340,8 @@ NOCOMMWARNTIME 300
 # it's time to shut down.  Some UPSes don't give much warning for low
 # battery and will require a value of 0 here for a safe shutdown.
 #
-# Note: If FINALDELAY on the subordinate is greater than HOSTSYNC on the
-# manager, the manager will give up waiting for that subordinate system
+# Note: If FINALDELAY on the secondary is greater than HOSTSYNC on the
+# primary, the primary will give up waiting for that secondary system
 # to disconnect.
 
 FINALDELAY 5

--- a/conf/upsmon.conf.sample.in
+++ b/conf/upsmon.conf.sample.in
@@ -30,7 +30,7 @@
 # RUN_AS_USER @RUN_AS_USER@
 
 # --------------------------------------------------------------------------
-# MONITOR <system> <powervalue> <username> <password> ("master"|"slave")
+# MONITOR <system> <powervalue> <username> <password> ("manager"|"subordinate")
 #
 # List systems you want to monitor.  Not all of these may supply power
 # to the system running upsmon, but if you want to watch it, it has to
@@ -66,43 +66,46 @@
 # changes for a given UPS without shutting down when it goes critical.
 #
 # <username> and <password> must match an entry in that system's
-# upsd.users.  If your username is "monmaster" and your password is
+# upsd.users.  If your username is "upsmon" and your password is
 # "blah", the upsd.users would look like this:
 #
-#	[monmaster]
+#	[upsmon]
 #		password  = blah
-#		upsmon master 	(or slave)
+#		upsmon manager 	# (or subordinate)
 #
-# "master" means this system will shutdown last, allowing the slaves
-# time to shutdown first.
+# "manager" means this system will shutdown last, allowing the subordinate
+# systems time to shutdown first.
 #
-# "slave" means this system shuts down immediately when power goes critical.
+# "subordinate" means this system shuts down immediately when power goes
+# critical.
 #
-# The general assumption is that the "master" system is the one with direct
-# connection to an UPS (such as serial or USB cable), so the master system
-# can manage the device, and would often tell the UPS to completely power
-# itself off as a step in power-race avoidance (see POWERDOWNFLAG for details).
-# Also, since the master system stays up the longest, it suffers higher risks
+# The general assumption is that the "manager" system is the one with direct
+# connection to an UPS (such as serial or USB cable), so the manager system
+# runs the NUT driver and 'upsd' server locally and can manage the device,
+# and it would often tell the UPS to completely power itself off as a step
+# in power-race avoidance (see POWERDOWNFLAG for details).
+# Also, since the manager system stays up the longest, it suffers higher risks
 # of ungraceful shutdown if the estimation of remaining runtime (or of the
 # time it takes to shut down this system) was guessed wrong. By consequence,
-# the "slave" systems typically monitor the power environment state through
-# the 'upsd' processes running on the "master" systems and do not directly
-# interact with an UPS (no local NUT drivers are running on slaves). As such,
-# slaves typically shut down as soon as there is a sufficiently long power
-# outage, or a low-battery alert from the UPS, or a loss of connection to
-# the master while the power was last known to be missing.
+# the "subordinate" systems typically monitor the power environment state
+# through the 'upsd' processes running on the remote (often "manager") systems
+# and do not directly interact with an UPS (no local NUT drivers are running
+# on the subordinate systems). As such, subordinates typically shut down as
+# soon as there is a sufficiently long power outage, or a low-battery alert
+# from the UPS, or a loss of connection to the manager while the power was
+# last known to be missing.
 #
 # This assumption and configuration can also make sense for networked UPSes,
 # where a rack full of servers might overload the communications capacity
 # of the networked management card on the UPS - in this case you might either
 # reduce the 'snmp-ups' or 'netxml-ups' driver polling rate, or dedicate a
-# "master" server and set up the rest as "slave" systems.
+# "manager" server and set up the rest as "subordinate" systems.
 #
 # Examples:
 #
-# MONITOR myups@bigserver 1 monmaster blah master
-# MONITOR su700@server.example.com 1 upsmon secretpass slave
-# MONITOR myups@localhost 1 upsmon pass master	(or slave)
+# MONITOR myups@bigserver 1 upswired blah manager
+# MONITOR su700@server.example.com 1 upsmon secretpass subordinate
+# MONITOR myups@localhost 1 upsmon pass manager	# (or subordinate)
 
 # --------------------------------------------------------------------------
 # MINSUPPLIES <num>
@@ -183,17 +186,17 @@ POLLFREQALERT 5
 # --------------------------------------------------------------------------
 # HOSTSYNC - How long upsmon will wait before giving up on another upsmon
 #
-# The master upsmon process uses this number when waiting for slaves to
-# disconnect once it has set the forced shutdown (FSD) flag.  If they
-# don't disconnect after this many seconds, it goes on without them.
+# The manager upsmon process uses this number when waiting for subordinate
+# systems to disconnect once it has set the forced shutdown (FSD) flag.
+# If they don't disconnect after this many seconds, it goes on without them.
 #
-# Similarly, upsmon slave processes wait up to this interval for the
-# master upsmon to set FSD when a UPS they are monitoring goes critical -
-# that is, on battery and low battery.  If the master doesn't do its job,
-# the slaves will shut down anyway to avoid damage to the file systems.
+# Similarly, upsmon subordinate processes wait up to this interval for the
+# manager upsmon to set FSD when a UPS they are monitoring goes critical -
+# that is, on battery and low battery.  If the manager doesn't do its job,
+# the subordinates will shut down anyway to avoid damage to the file systems.
 #
 # This "wait for FSD" is done to avoid races where the status changes
-# to critical and back between polls by the master.
+# to critical and back between polls by the manager.
 
 HOSTSYNC 15
 
@@ -217,11 +220,12 @@ HOSTSYNC 15
 DEADTIME 15
 
 # --------------------------------------------------------------------------
-# POWERDOWNFLAG - Flag file for forcing UPS shutdown on the master system
+# POWERDOWNFLAG - Flag file for forcing UPS shutdown on the manager system
 #
-# upsmon will create a file with this name in master mode when it's time
+# upsmon will create a file with this name in manager mode when it's time
 # to shut down the load.  You should check for this file's existence in
-# your shutdown scripts and run 'upsdrvctl shutdown' if it exists.
+# your shutdown scripts and run 'upsdrvctl shutdown' if it exists, to tell
+# the UPS(es) to power off.
 #
 # See the config-notes.txt file in the docs subdirectory for more information.
 # Refer to the section:
@@ -255,7 +259,7 @@ POWERDOWNFLAG /etc/killpower
 # ONLINE   : UPS is back online
 # ONBATT   : UPS is on battery
 # LOWBATT  : UPS has a low battery (if also on battery, it's "critical")
-# FSD      : UPS is being shutdown by the master (FSD = "Forced Shutdown")
+# FSD      : UPS is being shutdown by the manager (FSD = "Forced Shutdown")
 # COMMOK   : Communications established with the UPS
 # COMMBAD  : Communications lost to the UPS
 # SHUTDOWN : The system is being shutdown
@@ -316,7 +320,7 @@ NOCOMMWARNTIME 300
 # --------------------------------------------------------------------------
 # FINALDELAY - last sleep interval before shutting down the system
 #
-# On a master, upsmon will wait this long after sending the NOTIFY_SHUTDOWN
+# On a manager, upsmon will wait this long after sending the NOTIFY_SHUTDOWN
 # before executing your SHUTDOWNCMD.  If you need to do something in between
 # those events, increase this number.  Remember, at this point your UPS is
 # almost depleted, so don't make this too high.
@@ -325,8 +329,9 @@ NOCOMMWARNTIME 300
 # it's time to shut down.  Some UPSes don't give much warning for low
 # battery and will require a value of 0 here for a safe shutdown.
 #
-# Note: If FINALDELAY on the slave is greater than HOSTSYNC on the master,
-# the master will give up waiting for the slave to disconnect.
+# Note: If FINALDELAY on the subordinate is greater than HOSTSYNC on the
+# manager, the manager will give up waiting for that subordinate system
+# to disconnect.
 
 FINALDELAY 5
 

--- a/docs/config-notes.txt
+++ b/docs/config-notes.txt
@@ -451,24 +451,25 @@ The exact behavior depends on the specific device, and is related to:
    - battery.charge and battery.charge.low
    - battery.runtime and battery.runtime.low
 
-3. The upsmon master notices and sets "FSD" -- the "forced shutdown"
-   flag to tell all slave systems that it will soon power down the load.
+3. The upsmon manager notices and sets "FSD" -- the "forced shutdown"
+   flag to tell all subordinate systems that it will soon power down
+   the load.
 +
-(If you have no slaves, skip to step 6)
+(If you have no subordinate systems, skip to step 6)
 
-4. upsmon slave systems see "FSD" and:
+4. upsmon subordinate systems see "FSD" and:
 
    - generate a NOTIFY_SHUTDOWN event
    - wait FINALDELAY seconds -- typically 5
    - call their SHUTDOWNCMD
    - disconnect from upsd
 
-5. The upsmon master system waits up to HOSTSYNC seconds (typically 15)
-   for the slaves to disconnect from upsd.  If any are connected after
-   this time, upsmon stops waiting and proceeds with the shutdown
-   process.
+5. The upsmon manager system waits up to HOSTSYNC seconds (typically 15)
+   for the subordinate systems to disconnect from upsd.  If any are still
+   connected after this time, upsmon manager stops waiting and proceeds
+   with the shutdown process.
 
-6. The upsmon master:
+6. The upsmon manager:
 
    - generates a NOTIFY_SHUTDOWN event
    - waits FINALDELAY seconds -- typically 5
@@ -482,7 +483,7 @@ The exact behavior depends on the specific device, and is related to:
    POWERDOWNFLAG, finds it, and tells the UPS driver(s) to power off
    the load.
 
-9. The system loses power.
+9. All the systems lose power.
 
 10. Time passes.  The power returns, and the UPS switches back on.
 
@@ -504,8 +505,8 @@ authenticate.  This example is for a user called "monuser":
 
 	[monuser]
 		password = mypass
-		upsmon master
-		# or upsmon slave
+		upsmon manager
+		# or upsmon subordinate
 
 References: linkman:upsd[8], linkman:upsd.users[5]
 
@@ -559,21 +560,22 @@ Create a MONITOR directive for upsmon
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Edit upsmon.conf and create a MONITOR line with the UPS definition
-(<upsname>@<hostname>), username and password from the <<NUT_user_creation, NUT user creation>>
-step, and the master or slave setting.
+(<upsname>@<hostname>), username and password from the
+<<NUT_user_creation, NUT user creation>> step, and the
+manager or subordinate setting.
 
-If it's the master (i.e., it's connected to this UPS directly):
+If it's the manager (i.e., it's connected to this UPS directly):
 
-	MONITOR myupsname@mybox 1 monuser mypass master
+	MONITOR myupsname@mybox 1 monuser mypass manager
 
-If it's just monitoring this UPS over the network, and some other system is the
-master:
+If it's just monitoring this UPS over the network, and some other
+system is the manager:
 
-	MONITOR myupsname@mybox 1 monuser mypass slave
+	MONITOR myupsname@mybox 1 monuser mypass subordinate
 
-The number "1" here is the power value.  This should always be set to 1 unless
-you have a very special (read: expensive) system with redundant power supplies.
-In such cases, refer to the User Manual:
+The number "1" here is the power value.  This should always be set
+to 1 unless you have a very special (read: expensive) system with
+redundant power supplies. In such cases, refer to the User Manual:
 
 - <<BigServers,typical setups for big servers>>,
 - <<DataRoom,typical setups for data rooms>>.
@@ -804,8 +806,8 @@ Once you identify a system's type, use this list to decide which of the
 programs need to be run for monitoring:
 
 - A: driver and upsd
-- B: upsmon (as slave)
-- C: driver, upsd, and upsmon (as master)
+- B: upsmon (in subordinate mode)
+- C: driver, upsd, and upsmon (as manager)
 
 To further complicate things, you can have a system that is hooked to
 multiple UPSes, but only depends on one for power.  This particular
@@ -834,8 +836,8 @@ image:images/bigbox.png[]
 Example configuration
 ~~~~~~~~~~~~~~~~~~~~~
 
-For the examples in this section, we will use a server with four power supplies
-installed.
+For the examples in this section, we will use a server with four power
+supplies installed and locally running the full NUT stack as the UPS manager.
 
 Two UPS, 'Alpha' and 'Beta', are each driving two of the power supplies.
 This means that either 'Alpha' *or* 'Beta' can totally shut down and the
@@ -843,8 +845,8 @@ server will be able to keep running.
 
 The upsmon.conf configuration that reflect this is the following:
 
-	MONITOR ups-alpha@myhost 2 monuser mypass master
-	MONITOR ups-beta@myhost 2 monuser mypass master
+	MONITOR ups-alpha@myhost 2 monuser mypass manager
+	MONITOR ups-beta@myhost 2 monuser mypass manager
 	MINSUPPLIES 2
 
 With that configuration, upsmon will only shut down when both UPS reaches
@@ -852,8 +854,8 @@ a critical (on battery + low battery) condition, since 'Alpha' and 'Beta'
 provide the same power value.
 
 As an added bonus, this means you can move a running server from one UPS
-to another (for maintenance purpose for example) without bringing it down since
-the minimum power will be provided at all times.
+to another (for maintenance purpose for example) without bringing it down
+since the minimum sufficient power will be provided at all times.
 
 The MINSUPPLIES line tells upsmon that we need at least 2 power supplies
 to be receiving power from a good UPS (on line or on battery, just not

--- a/docs/config-notes.txt
+++ b/docs/config-notes.txt
@@ -451,25 +451,25 @@ The exact behavior depends on the specific device, and is related to:
    - battery.charge and battery.charge.low
    - battery.runtime and battery.runtime.low
 
-3. The upsmon manager notices and sets "FSD" -- the "forced shutdown"
-   flag to tell all subordinate systems that it will soon power down
+3. The upsmon primary notices and sets "FSD" -- the "forced shutdown"
+   flag to tell all secondary systems that it will soon power down
    the load.
 +
-(If you have no subordinate systems, skip to step 6)
+(If you have no secondary systems, skip to step 6)
 
-4. upsmon subordinate systems see "FSD" and:
+4. upsmon secondary systems see "FSD" and:
 
    - generate a NOTIFY_SHUTDOWN event
    - wait FINALDELAY seconds -- typically 5
    - call their SHUTDOWNCMD
    - disconnect from upsd
 
-5. The upsmon manager system waits up to HOSTSYNC seconds (typically 15)
-   for the subordinate systems to disconnect from upsd.  If any are still
-   connected after this time, upsmon manager stops waiting and proceeds
+5. The upsmon primary system waits up to HOSTSYNC seconds (typically 15)
+   for the secondary systems to disconnect from upsd.  If any are still
+   connected after this time, upsmon primary stops waiting and proceeds
    with the shutdown process.
 
-6. The upsmon manager:
+6. The upsmon primary:
 
    - generates a NOTIFY_SHUTDOWN event
    - waits FINALDELAY seconds -- typically 5
@@ -505,8 +505,8 @@ authenticate.  This example is for a user called "monuser":
 
 	[monuser]
 		password = mypass
-		upsmon manager
-		# or upsmon subordinate
+		upsmon primary
+		# or upsmon secondary
 
 References: linkman:upsd[8], linkman:upsd.users[5]
 
@@ -562,16 +562,17 @@ Create a MONITOR directive for upsmon
 Edit upsmon.conf and create a MONITOR line with the UPS definition
 (<upsname>@<hostname>), username and password from the
 <<NUT_user_creation, NUT user creation>> step, and the
-manager or subordinate setting.
+"primary" or "secondary" setting.
 
-If it's the manager (i.e., it's connected to this UPS directly):
+If this system is the UPS manager (i.e., it's connected to this UPS directly
+and can manage it using a suitable NUT driver), its upsmon is the primary:
 
-	MONITOR myupsname@mybox 1 monuser mypass manager
+	MONITOR myupsname@mybox 1 monuser mypass primary
 
 If it's just monitoring this UPS over the network, and some other
-system is the manager:
+system is the primary, then this one is a secondary:
 
-	MONITOR myupsname@mybox 1 monuser mypass subordinate
+	MONITOR myupsname@mybox 1 monuser mypass secondary
 
 The number "1" here is the power value.  This should always be set
 to 1 unless you have a very special (read: expensive) system with
@@ -810,8 +811,8 @@ Once you identify a system's type, use this list to decide which of the
 programs need to be run for monitoring:
 
 - A: driver and upsd
-- B: upsmon (in subordinate mode)
-- C: driver, upsd, and upsmon (as manager)
+- B: upsmon (in secondary mode)
+- C: driver, upsd, and upsmon (in primary mode, as the UPS manager)
 
 To further complicate things, you can have a system that is hooked to
 multiple UPSes, but only depends on one for power.  This particular
@@ -841,7 +842,8 @@ Example configuration
 ~~~~~~~~~~~~~~~~~~~~~
 
 For the examples in this section, we will use a server with four power
-supplies installed and locally running the full NUT stack as the UPS manager.
+supplies installed and locally running the full NUT stack, including
+`upsmon` in primary mode -- as the UPS manager.
 
 Two UPSes, 'Alpha' and 'Beta', are each driving two of the power supplies
 (by adding up, we know about the four power supplies of the current system).
@@ -850,8 +852,8 @@ server will be able to keep running.
 
 The upsmon.conf configuration that reflect this is the following:
 
-	MONITOR ups-alpha@myhost 2 monuser mypass manager
-	MONITOR ups-beta@myhost 2 monuser mypass manager
+	MONITOR ups-alpha@myhost 2 monuser mypass primary
+	MONITOR ups-beta@myhost 2 monuser mypass primary
 	MINSUPPLIES 2
 
 With that configuration, upsmon will only shut down when both UPS reaches

--- a/docs/design.txt
+++ b/docs/design.txt
@@ -135,11 +135,11 @@ This scenario requires some configuration, obviously:
 
 	[monuser]
 		password = somepass
-		upsmon manager
+		upsmon primary
 
 4. upsmon is set to monitor this UPS in upsmon.conf.
 
-	MONITOR myups@localhost 1 monuser somepass manager
+	MONITOR myups@localhost 1 monuser somepass primary
 
 5. upsmon is set to EXEC the NOTIFYCMD for the ONBATT condition in
    upsmon.conf.

--- a/docs/design.txt
+++ b/docs/design.txt
@@ -135,11 +135,11 @@ This scenario requires some configuration, obviously:
 
 	[monuser]
 		password = somepass
-		upsmon master
+		upsmon manager
 
 4. upsmon is set to monitor this UPS in upsmon.conf.
 
-	MONITOR myups@localhost 1 monuser somepass master
+	MONITOR myups@localhost 1 monuser somepass manager
 
 5. upsmon is set to EXEC the NOTIFYCMD for the ONBATT condition in
    upsmon.conf.

--- a/docs/features.txt
+++ b/docs/features.txt
@@ -180,9 +180,9 @@ driver, `upsd`, and `upsmon` running.
 image:images/advanced.png[]
 
 One UPS, multiple computers. Only one of them can actually talk to the UPS
-directly. That's where the network comes in. The Master system runs the
-relevant driver, `upsd`, and `upsmon` in master mode. The Slave systems
-only run `upsmon` in slave mode.
+directly. That's where the network comes in. The Manager system runs the
+relevant driver, `upsd`, and `upsmon` in manager mode. The Subordinate systems
+only run `upsmon` in subordinate mode which all connect to `upsd` on Manager.
 
 This is useful when you have a very large UPS that's capable of running
 multiple systems simultaneously. There is no longer the need to buy a bunch
@@ -196,15 +196,18 @@ the sharing for you.
 - Multiple systems may monitor a single UPS using only their network
 connections -- no special "UPS sharing" hardware is required.
 
-- "Slave and master" monitoring design synchronizes shutdowns so that
-slaves can bring down their operating systems cleanly before the master
-switches off the power.
+- "Subordinate and manager" monitoring design synchronizes shutdowns so that
+subordinate systems can bring down their operating systems cleanly before
+the manager switches off the power.
 
 === Many UPSes, many clients ===
 
-- Each upsd process can serve status data for multiple UPSes to many clients.
+- Each `upsd` process can serve status data for multiple UPSes to many clients.
+Multiple NUT drivers need to be configured and running locally on the system
+with `upsd` then, and have appropriate media connections to the power devices.
 
-- Each upsmon process can monitor multiple UPSes for status data.
+- Each `upsmon` process can monitor multiple UPSes, possibly from multiple
+`upsd` hosts, for status data.
 
 //////////////////////////////////////////////////////////////////////////////
 
@@ -216,7 +219,7 @@ image:images/bigbox.png[]
 Some systems have multiple power supplies and cords. You typically find
 this on high-end servers that allow hot-swap and other fun features.
 In this case, you run multiple drivers (one per UPS), a single `upsd`,
-and a single `upsmon` (as a master for both UPS 1 and UPS 2)
+and a single `upsmon` (as a manager for both UPS 1 and UPS 2)
 
 This software understands that some of these servers can also run with
 some of the supplies gone. For this reason, every UPS is assigned a
@@ -242,8 +245,8 @@ monitored, so it's drafted to supply a serial port for the purpose.
 This PC may in fact be getting its own power from some other UPS. This is
 not a problem for the set-up.
 
-The first system ("mixed") is a Master for UPS 1, but is only monitoring
-UPS 2. The other systems are Slaves of UPS 2.
+The first system ("mixed") is a Manager for UPS 1, but is only monitoring
+UPS 2. The other systems are Subordinates of UPS 2.
 
 Image credits
 -------------

--- a/docs/features.txt
+++ b/docs/features.txt
@@ -180,9 +180,13 @@ driver, `upsd`, and `upsmon` running.
 image:images/advanced.png[]
 
 One UPS, multiple computers. Only one of them can actually talk to the UPS
-directly. That's where the network comes in. The Manager system runs the
-relevant driver, `upsd`, and `upsmon` in manager mode. The Subordinate systems
-only run `upsmon` in subordinate mode which all connect to `upsd` on Manager.
+directly. That's where the network comes in:
+
+- The Primary system runs the relevant driver, `upsd`, and `upsmon` in
+"primary" mode.
+
+- The Secondary systems only run `upsmon` in "secondary" mode which all
+connect to `upsd` on Primary.
 
 This is useful when you have a very large UPS that's capable of running
 multiple systems simultaneously. There is no longer the need to buy a bunch
@@ -196,9 +200,9 @@ the sharing for you.
 - Multiple systems may monitor a single UPS using only their network
 connections -- no special "UPS sharing" hardware is required.
 
-- "Subordinate and manager" monitoring design synchronizes shutdowns so that
-subordinate systems can bring down their operating systems cleanly before
-the manager switches off the power.
+- "Secondaries and a primary" monitoring design synchronizes shutdowns so that
+secondary systems can bring down their operating systems cleanly before
+the primary tells the UPS to switch off the power.
 
 === Many UPSes, many clients ===
 
@@ -219,7 +223,7 @@ image:images/bigbox.png[]
 Some systems have multiple power supplies and cords. You typically find
 this on high-end servers that allow hot-swap and other fun features.
 In this case, you run multiple drivers (one per UPS), a single `upsd`,
-and a single `upsmon` (as a manager for both UPS 1 and UPS 2)
+and a single `upsmon` (as a primary for both UPS 1 and UPS 2)
 
 This software understands that some of these servers can also run with
 some of the supplies gone. For this reason, every UPS is assigned a
@@ -245,8 +249,8 @@ monitored, so it's drafted to supply a serial port for the purpose.
 This PC may in fact be getting its own power from some other UPS. This is
 not a problem for the set-up.
 
-The first system ("mixed") is a Manager for UPS 1, but is only monitoring
-UPS 2. The other systems are Subordinates of UPS 2.
+The first system ("mixed") is a Primary for UPS 1, but is only monitoring
+UPS 2. The other systems are Secondaries of UPS 2.
 
 Image credits
 -------------

--- a/docs/history.txt
+++ b/docs/history.txt
@@ -155,13 +155,12 @@ This is also when the web pages moved from the old
 at `http://www.exploits.org/nut/` to coincide with the name change.
 
 More drivers were written and the hardware support continued to grow. upsmon
-picked up the concepts of what is now known as "manager" and "subordinate",
+picked up the concepts of what is now known as "primary" and "secondary",
 and could now handle environments where multiple systems get power from a
 single UPS.
 
 Manager mode was added to allow changing the value of read/write variables
-in certain UPS models (Note: not related to "manager" in the multiple-system
-setup mentioned above).
+in certain UPS models.
 
 June 2001: common driver core
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/history.txt
+++ b/docs/history.txt
@@ -155,10 +155,13 @@ This is also when the web pages moved from the old
 at `http://www.exploits.org/nut/` to coincide with the name change.
 
 More drivers were written and the hardware support continued to grow. upsmon
-picked up the concepts of "master" and "slave", and could now handle
-environments where multiple systems get power from a single UPS. Manager mode
-was added to allow changing the value of read/write variables in certain UPS
-models.
+picked up the concepts of what is now known as "manager" and "subordinate",
+and could now handle environments where multiple systems get power from a
+single UPS.
+
+Manager mode was added to allow changing the value of read/write variables
+in certain UPS models (Note: not related to "manager" in the multiple-system
+setup mentioned above).
 
 June 2001: common driver core
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/man/clone.txt
+++ b/docs/man/clone.txt
@@ -75,8 +75,8 @@ socket that the "real" UPS driver is using. For example:
 
 IMPORTANT
 ---------
-Unlike a real UPS, you should *not* configure a upsmon master for this
-driver.  When a upsmon master sees the OB LB flags and tells the upsd server
+Unlike a real UPS, you should *not* configure a upsmon manager for this
+driver.  When a upsmon manager sees the OB LB flags and tells the upsd server
 it is OK to initiate the shutdown sequence, the server will latch the FSD
 status and it will not be possible to restart the systems connected without
 restarting the upsd server.
@@ -84,7 +84,7 @@ restarting the upsd server.
 This will be a problem if the power returns after the clone UPS initiated
 the shutdown sequence on it's outlet, but returns before the real UPS begins
 shutting down. The solution is in the clone driver, that will insert the
-FSD flag if needed without the help of a upsmon master.
+FSD flag if needed without the help of a upsmon manager.
 
 CAVEATS
 -------

--- a/docs/man/clone.txt
+++ b/docs/man/clone.txt
@@ -75,8 +75,8 @@ socket that the "real" UPS driver is using. For example:
 
 IMPORTANT
 ---------
-Unlike a real UPS, you should *not* configure a upsmon manager for this
-driver.  When a upsmon manager sees the OB LB flags and tells the upsd server
+Unlike a real UPS, you should *not* configure a upsmon primary mode for this
+driver.  When a upsmon primary sees the OB LB flags and tells the upsd server
 it is OK to initiate the shutdown sequence, the server will latch the FSD
 status and it will not be possible to restart the systems connected without
 restarting the upsd server.
@@ -84,7 +84,7 @@ restarting the upsd server.
 This will be a problem if the power returns after the clone UPS initiated
 the shutdown sequence on it's outlet, but returns before the real UPS begins
 shutting down. The solution is in the clone driver, that will insert the
-FSD flag if needed without the help of a upsmon manager.
+FSD flag if needed without the help of a upsmon primary.
 
 CAVEATS
 -------

--- a/docs/man/genericups.txt
+++ b/docs/man/genericups.txt
@@ -364,7 +364,7 @@ that if the connection between the UPS and computer is interrupted, you
 may not be able to sense this in software.
 
 Most contact-closure UPSes will not power down the load if the line power
-is present.  This can create a race when using slave linkman:upsmon[8]
+is present.  This can create a race when using subordinate linkman:upsmon[8]
 systems.  See the linkman:upsmon[8] man page for more information.
 
 The solution to both of these problems is to upgrade to a smart protocol

--- a/docs/man/genericups.txt
+++ b/docs/man/genericups.txt
@@ -364,7 +364,7 @@ that if the connection between the UPS and computer is interrupted, you
 may not be able to sense this in software.
 
 Most contact-closure UPSes will not power down the load if the line power
-is present.  This can create a race when using subordinate linkman:upsmon[8]
+is present.  This can create a race when using secondary linkman:upsmon[8]
 systems.  See the linkman:upsmon[8] man page for more information.
 
 The solution to both of these problems is to upgrade to a smart protocol

--- a/docs/man/libnutclient_misc.txt
+++ b/docs/man/libnutclient_misc.txt
@@ -40,7 +40,7 @@ is drawing power from this UPS.
 The *nutclient_get_device_num_logins()* function retrieves the number of
 clients which have been logged for this device.
 
-The *nutclient_device_master()* function makes sure that manager-level
+The *nutclient_device_master()* function makes sure that primary-mode
 functions like FSD are available if necessary. (Note: API change may be
 pending to rename/alias the deprecated function name)
 

--- a/docs/man/libnutclient_misc.txt
+++ b/docs/man/libnutclient_misc.txt
@@ -26,25 +26,26 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-The *nutclient_authenticate()* function authenticate the user.
+The *nutclient_authenticate()* function authenticates the user.
 
 'login' is the user name.
 
 'passwd' is the user password.
 
-The *nutclient_logout()* function disconnect gracefully from the server.
+The *nutclient_logout()* function disconnects gracefully from the server.
 
-The *nutclient_device_login()* function log the fact that a system
+The *nutclient_device_login()* function logs the fact that a system
 is drawing power from this UPS.
 
-The *nutclient_get_device_num_logins()* function retrieve the number of clients
-which have been logged for this device.
+The *nutclient_get_device_num_logins()* function retrieves the number of
+clients which have been logged for this device.
 
-The *nutclient_device_master()* function make sure that manager-level
+The *nutclient_device_master()* function makes sure that manager-level
 functions like FSD are available if necessary. (Note: API change may be
 pending to rename/alias the deprecated function name)
 
-The *nutclient_device_forced_shutdown()* function sets the "forced shutdown" flag on the device.
+The *nutclient_device_forced_shutdown()* function sets the "forced shutdown"
+flag on the device.
 
 'dev' is the device name.
 

--- a/docs/man/libnutclient_misc.txt
+++ b/docs/man/libnutclient_misc.txt
@@ -40,8 +40,9 @@ is drawing power from this UPS.
 The *nutclient_get_device_num_logins()* function retrieve the number of clients
 which have been logged for this device.
 
-The *nutclient_device_master()* function make sure that master-level
-functions like FSD are available if necessary.
+The *nutclient_device_master()* function make sure that manager-level
+functions like FSD are available if necessary. (Note: API change may be
+pending to rename/alias the deprecated function name)
 
 The *nutclient_device_forced_shutdown()* function sets the "forced shutdown" flag on the device.
 

--- a/docs/man/nut.conf.txt
+++ b/docs/man/nut.conf.txt
@@ -64,7 +64,7 @@ more details.  It is ignored when 'MODE' above indicates that no
 upsmon should be running.
 
 *POWEROFF_WAIT*::
-Optional.  At the end of an emergency system halt, the upsmon master
+Optional.  At the end of an emergency system halt, the upsmon manager
 will signal the UPS to switch off.  This may fail for a number of
 reasons.  Most notably is the case that mains power returns during
 the shutdown process.  See the section "Power races" in

--- a/docs/man/nut.conf.txt
+++ b/docs/man/nut.conf.txt
@@ -64,7 +64,7 @@ more details.  It is ignored when 'MODE' above indicates that no
 upsmon should be running.
 
 *POWEROFF_WAIT*::
-Optional.  At the end of an emergency system halt, the upsmon manager
+Optional.  At the end of an emergency system halt, the upsmon primary
 will signal the UPS to switch off.  This may fail for a number of
 reasons.  Most notably is the case that mains power returns during
 the shutdown process.  See the section "Power races" in

--- a/docs/man/nutdrv_atcl_usb.txt
+++ b/docs/man/nutdrv_atcl_usb.txt
@@ -36,19 +36,20 @@ devices, such as linkman:nutdrv_qx[8].
 BUGS
 ----
 The UPS returns the same code for "load power is off" as for "on line power".
-This condition will not be observed if the NUT master is powered by the UPS,
-but may be an issue if the UPS is monitored by a remote system.
+This condition will not be observed if the NUT `upsmon` in manager mode runs
+on the box powered by the UPS, but may be an issue if the UPS is monitored
+by a remote (subordinate) system.
 
 The time between the shutdown command and removal of power seems to be fixed at
 30 seconds. Ensure that the NUT shutdown script is invoked as late as possible
 in the shutdown procedure (in case some services take longer than others to
 clean up).
 
-Most contact-closure UPSes will not power down the load if the line power
-is present. This can create a race when using slave linkman:upsmon[8] systems.
-See the linkman:upsmon[8] man page for more information. The solution to this
-problem is to upgrade to a smart protocol UPS of some kind that allows
-detection and proper load cycling on command.
+Most contact-closure UPSes will not power down the load if the line power is
+present. This can create a race when using subordinate linkman:upsmon[8]
+systems. See the linkman:upsmon[8] man page for more information.
+The solution to this problem is to upgrade to a smart protocol UPS of some
+kind that allows detection and proper load cycling on command.
 
 AUTHORS
 -------

--- a/docs/man/nutdrv_atcl_usb.txt
+++ b/docs/man/nutdrv_atcl_usb.txt
@@ -36,9 +36,9 @@ devices, such as linkman:nutdrv_qx[8].
 BUGS
 ----
 The UPS returns the same code for "load power is off" as for "on line power".
-This condition will not be observed if the NUT `upsmon` in manager mode runs
+This condition will not be observed if the NUT `upsmon` in primary mode runs
 on the box powered by the UPS, but may be an issue if the UPS is monitored
-by a remote (subordinate) system.
+by a remote (secondary) system.
 
 The time between the shutdown command and removal of power seems to be fixed at
 30 seconds. Ensure that the NUT shutdown script is invoked as late as possible
@@ -46,7 +46,7 @@ in the shutdown procedure (in case some services take longer than others to
 clean up).
 
 Most contact-closure UPSes will not power down the load if the line power is
-present. This can create a race when using subordinate linkman:upsmon[8]
+present. This can create a race when using secondary linkman:upsmon[8]
 systems. See the linkman:upsmon[8] man page for more information.
 The solution to this problem is to upgrade to a smart protocol UPS of some
 kind that allows detection and proper load cycling on command.

--- a/docs/man/richcomm_usb.txt
+++ b/docs/man/richcomm_usb.txt
@@ -22,7 +22,7 @@ OB, and LB.  See also linkman:genericups[8].
 BUGS
 ----
 Most contact-closure UPSes will not power down the load if the line power
-is present.  This can create a race when using slave linkman:upsmon[8]
+is present.  This can create a race when using subordinate linkman:upsmon[8]
 systems.  See the linkman:upsmon[8] man page for more information.
 
 The solution to both of these problems is to upgrade to a smart protocol

--- a/docs/man/richcomm_usb.txt
+++ b/docs/man/richcomm_usb.txt
@@ -22,7 +22,7 @@ OB, and LB.  See also linkman:genericups[8].
 BUGS
 ----
 Most contact-closure UPSes will not power down the load if the line power
-is present.  This can create a race when using subordinate linkman:upsmon[8]
+is present.  This can create a race when using secondary linkman:upsmon[8]
 systems.  See the linkman:upsmon[8] man page for more information.
 
 The solution to both of these problems is to upgrade to a smart protocol

--- a/docs/man/upsd.txt
+++ b/docs/man/upsd.txt
@@ -80,7 +80,7 @@ on the files, or run upsd as another user that will be able to read them.
 
 DO NOT make your upsd.conf or upsd.users world-readable, as those files
 hold important authentication information.  In the wrong hands, it could
-be used by some evil person to spoof your manager-mode upsmon and command
+be used by some evil person to spoof your primary-mode upsmon and command
 your systems to shut down.
 
 DIAGNOSTICS

--- a/docs/man/upsd.txt
+++ b/docs/man/upsd.txt
@@ -80,8 +80,8 @@ on the files, or run upsd as another user that will be able to read them.
 
 DO NOT make your upsd.conf or upsd.users world-readable, as those files
 hold important authentication information.  In the wrong hands, it could
-be used by some evil person to spoof your master upsmon and command your
-systems to shut down.
+be used by some evil person to spoof your manager-mode upsmon and command
+your systems to shut down.
 
 DIAGNOSTICS
 -----------

--- a/docs/man/upsd.users.txt
+++ b/docs/man/upsd.users.txt
@@ -30,13 +30,13 @@ Here are some examples to get you started:
 		instcmds = test.panel.start
 		instcmds = test.panel.stop
 
-	[monmaster]
+	[upswired]
 		password = blah
-		upsmon master
+		upsmon manager
 
-	[monslave]
+	[observer]
 		password = abcd
-		upsmon slave
+		upsmon subordinate
 
 FIELDS
 ------
@@ -72,7 +72,7 @@ of most of the known command names.
 *upsmon*::
 
 Add the necessary actions for a upsmon process to work.  This is either
-set to "master" or "slave".
+set to "manager" or "subordinate".
 +
 Do not attempt to assign actions to upsmon by hand, as you may miss
 something important.  This method of designating a "upsmon user" was

--- a/docs/man/upsd.users.txt
+++ b/docs/man/upsd.users.txt
@@ -32,11 +32,11 @@ Here are some examples to get you started:
 
 	[upswired]
 		password = blah
-		upsmon manager
+		upsmon primary
 
 	[observer]
 		password = abcd
-		upsmon subordinate
+		upsmon secondary
 
 FIELDS
 ------
@@ -72,7 +72,7 @@ of most of the known command names.
 *upsmon*::
 
 Add the necessary actions for a upsmon process to work.  This is either
-set to "manager" or "subordinate".
+set to "primary" or "secondary".
 +
 Do not attempt to assign actions to upsmon by hand, as you may miss
 something important.  This method of designating a "upsmon user" was

--- a/docs/man/upsmon.conf.txt
+++ b/docs/man/upsmon.conf.txt
@@ -130,16 +130,26 @@ without shutting down when it goes critical.
 The 'username' and 'password' on this line must match an entry in
 the `upsd` server system's linkman:upsd.users[5] file.
 
-If your username is "upswired" and your password is "blah", the
-MONITOR line might look like this:
+If your username is "observer" and your password is "abcd", the MONITOR
+line might look like this (likely on a remote subordinate system):
 
-+MONITOR myups@bigserver 1 upswired blah manager+
++MONITOR myups@bigserver 1 observer abcd subordinate+
 
 Meanwhile, the `upsd.users` on `bigserver` would look like this:
 
+	[observer]
+		password = abcd
+		upsmon subordinate
+	
 	[upswired]
 		password = blah
 		upsmon manager
+
+And the copy of upsmon on that bigserver would run with the manager
+configuration:
+
++MONITOR myups@bigserver 1 upswired blah manager+
+
 
 The 'type' refers to the relationship with linkman:upsd[8].  It can
 be either "manager" or "subordinate".  See linkman:upsmon[8] for more

--- a/docs/man/upsmon.conf.txt
+++ b/docs/man/upsmon.conf.txt
@@ -43,7 +43,7 @@ values, and multiply by 3.
 
 *FINALDELAY* 'seconds'::
 
-When running in master mode, upsmon waits this long after sending the
+When running in manager mode, upsmon waits this long after sending the
 NOTIFY_SHUTDOWN to warn the users.  After the timer elapses, it then
 runs your SHUTDOWNCMD.  By default this is set to 5 seconds.
 +
@@ -55,28 +55,29 @@ Alternatively, you can set this very low so you don't wait around when
 it's time to shut down.  Some UPSes don't give much warning for low
 battery and will require a value of 0 here for a safe shutdown.
 +
-NOTE: If FINALDELAY on the slave is greater than HOSTSYNC on the master,
-the master will give up waiting for the slave to disconnect.
+NOTE: If FINALDELAY on the subordinate is greater than HOSTSYNC on the
+manager, the manager will give up waiting for that subordinate upsmon
+to disconnect.
 
 *HOSTSYNC* 'seconds'::
 
-upsmon will wait up to this many seconds in master mode for the slaves
+upsmon will wait up to this many seconds in manager mode for the subordinates
 to disconnect during a shutdown situation.  By default, this is 15
 seconds.
 +
 When a UPS goes critical (on battery + low battery, or "FSD": forced
-shutdown), the slaves are supposed to disconnect and shut down right
-away.  The HOSTSYNC timer keeps the master upsmon from sitting there
-forever if one of the slaves gets stuck.
+shutdown), the subordinate systems are supposed to disconnect and shut
+down right away.  The HOSTSYNC timer keeps the manager upsmon from sitting
+there forever if one of the subordinates gets stuck.
 +
-This value is also used to keep slave systems from getting stuck if
-the master fails to respond in time.  After a UPS becomes critical,
-the slave will wait up to HOSTSYNC seconds for the master to set the
-FSD flag.  If that timer expires, the slave will assume that the master
-is broken and will shut down anyway.
+This value is also used to keep subordinate systems from getting stuck if
+the manager fails to respond in time.  After a UPS becomes critical, the
+subordinate will wait up to HOSTSYNC seconds for the manager to set the
+FSD flag.  If that timer expires, the subordinate will assume that the
+manager (or communications path to it) is broken and will shut down anyway.
 +
-This keeps the slaves from shutting down during a short-lived status
-change to "OB LB" that the slaves see but the master misses.
+This keeps the subordinates from shutting down during a short-lived status
+change to "OB LB" and back that the subordinates see but the manager misses.
 
 *MINSUPPLIES* 'num'::
 
@@ -126,22 +127,24 @@ doesn't actually supply power to this system.  This is useful when you
 want to have upsmon do notifications about status changes on a UPS
 without shutting down when it goes critical.
 
-The 'username' and 'password' on this line must match an entry
-in that system's linkman:upsd.users[5].  If your username is "monmaster"
-and your password is "blah", the MONITOR line might look like this:
+The 'username' and 'password' on this line must match an entry in
+the `upsd` server system's linkman:upsd.users[5] file.
 
-+MONITOR myups@bigserver 1 monmaster blah master+
+If your username is "upswired" and your password is "blah", the
+MONITOR line might look like this:
+
++MONITOR myups@bigserver 1 upswired blah manager+
 
 Meanwhile, the `upsd.users` on `bigserver` would look like this:
 
-	[monmaster]
-		password  = blah
-		upsmon master #  (or slave)
+	[upswired]
+		password = blah
+		upsmon manager
 
 The 'type' refers to the relationship with linkman:upsd[8].  It can
-be either "master" or "slave".  See linkman:upsmon[8] for more information
-on the meaning of these modes.  The mode you pick here also goes in
-the `upsd.users` file, as seen in the example above.
+be either "manager" or "subordinate".  See linkman:upsmon[8] for more
+information on the meaning of these modes.  The mode you pick here
+also goes in the `upsd.users` file, as seen in the example above.
 
 *NOCOMMWARNTIME* 'seconds'::
 
@@ -201,7 +204,7 @@ ONBATT;; UPS is on battery
 
 LOWBATT;; UPS is on battery and has a low battery (is critical)
 
-FSD;; UPS is being shutdown by the master (FSD = "Forced Shutdown")
+FSD;; UPS is being shutdown by the manager (FSD = "Forced Shutdown")
 
 COMMOK;; Communications established with the UPS
 
@@ -266,12 +269,12 @@ also apply here.
 
 *POWERDOWNFLAG* 'filename'::
 
-upsmon creates this file when running in master mode when the UPS needs
+upsmon creates this file when running in manager mode when the UPS needs
 to be powered off.  You should check for this file in your shutdown
 scripts and call `upsdrvctl shutdown` if it exists.
 +
-This is done to forcibly reset the slaves, so they don't get stuck at
-the "halted" stage even if the power returns during the shutdown
+This is done to forcibly reset the subordinate systems, so they don't get
+stuck at the "halted" stage even if the power returns during the shutdown
 process.  This usually does not work well on contact-closure UPSes that
 use the genericups driver.
 +
@@ -313,10 +316,10 @@ malicious, then wait for upsmon to be restarted.
 *SHUTDOWNCMD* 'command'::
 
 upsmon runs this command when the system needs to be brought down.  If
-it is a slave, it will do that immediately whenever the current overall
-power value drops below the MINSUPPLIES value above.
+it is a subordinate, it will do that immediately whenever the current
+overall power value drops below the MINSUPPLIES value above.
 +
-When upsmon is a master, it will allow any slaves to log out before
+When upsmon is a manager, it will allow any subordinates to log out before
 starting the local shutdown procedure.
 +
 Note that the command needs to be one element in the config file.  If

--- a/docs/man/upsmon.conf.txt
+++ b/docs/man/upsmon.conf.txt
@@ -43,7 +43,7 @@ values, and multiply by 3.
 
 *FINALDELAY* 'seconds'::
 
-When running in manager mode, upsmon waits this long after sending the
+When running in primary mode, upsmon waits this long after sending the
 NOTIFY_SHUTDOWN to warn the users.  After the timer elapses, it then
 runs your SHUTDOWNCMD.  By default this is set to 5 seconds.
 +
@@ -55,29 +55,29 @@ Alternatively, you can set this very low so you don't wait around when
 it's time to shut down.  Some UPSes don't give much warning for low
 battery and will require a value of 0 here for a safe shutdown.
 +
-NOTE: If FINALDELAY on the subordinate is greater than HOSTSYNC on the
-manager, the manager will give up waiting for that subordinate upsmon
+NOTE: If FINALDELAY on the secondary is greater than HOSTSYNC on the
+primary, the primary will give up waiting for that secondary upsmon
 to disconnect.
 
 *HOSTSYNC* 'seconds'::
 
-upsmon will wait up to this many seconds in manager mode for the subordinates
+upsmon will wait up to this many seconds in primary mode for the secondaries
 to disconnect during a shutdown situation.  By default, this is 15
 seconds.
 +
 When a UPS goes critical (on battery + low battery, or "FSD": forced
-shutdown), the subordinate systems are supposed to disconnect and shut
-down right away.  The HOSTSYNC timer keeps the manager upsmon from sitting
-there forever if one of the subordinates gets stuck.
+shutdown), the secondary systems are supposed to disconnect and shut
+down right away.  The HOSTSYNC timer keeps the primary upsmon from sitting
+there forever if one of the secondaries gets stuck.
 +
-This value is also used to keep subordinate systems from getting stuck if
-the manager fails to respond in time.  After a UPS becomes critical, the
-subordinate will wait up to HOSTSYNC seconds for the manager to set the
-FSD flag.  If that timer expires, the subordinate will assume that the
-manager (or communications path to it) is broken and will shut down anyway.
+This value is also used to keep secondary systems from getting stuck if
+the primary fails to respond in time.  After a UPS becomes critical, the
+secondary will wait up to HOSTSYNC seconds for the primary to set the
+FSD flag.  If that timer expires, the secondary upsmon will assume that the
+primary (or communications path to it) is broken and will shut down anyway.
 +
-This keeps the subordinates from shutting down during a short-lived status
-change to "OB LB" and back that the subordinates see but the manager misses.
+This keeps the secondaries from shutting down during a short-lived status
+change to "OB LB" and back that the secondaries see but the primary misses.
 
 *MINSUPPLIES* 'num'::
 
@@ -131,28 +131,28 @@ The 'username' and 'password' on this line must match an entry in
 the `upsd` server system's linkman:upsd.users[5] file.
 
 If your username is "observer" and your password is "abcd", the MONITOR
-line might look like this (likely on a remote subordinate system):
+line might look like this (likely on a remote secondary system):
 
-+MONITOR myups@bigserver 1 observer abcd subordinate+
++MONITOR myups@bigserver 1 observer abcd secondary+
 
 Meanwhile, the `upsd.users` on `bigserver` would look like this:
 
 	[observer]
 		password = abcd
-		upsmon subordinate
+		upsmon secondary
 	
 	[upswired]
 		password = blah
-		upsmon manager
+		upsmon primary
 
-And the copy of upsmon on that bigserver would run with the manager
+And the copy of upsmon on that bigserver would run with the primary
 configuration:
 
-+MONITOR myups@bigserver 1 upswired blah manager+
++MONITOR myups@bigserver 1 upswired blah primary+
 
 
 The 'type' refers to the relationship with linkman:upsd[8].  It can
-be either "manager" or "subordinate".  See linkman:upsmon[8] for more
+be either "primary" or "secondary".  See linkman:upsmon[8] for more
 information on the meaning of these modes.  The mode you pick here
 also goes in the `upsd.users` file, as seen in the example above.
 
@@ -214,7 +214,7 @@ ONBATT;; UPS is on battery
 
 LOWBATT;; UPS is on battery and has a low battery (is critical)
 
-FSD;; UPS is being shutdown by the manager (FSD = "Forced Shutdown")
+FSD;; UPS is being shutdown by the primary (FSD = "Forced Shutdown")
 
 COMMOK;; Communications established with the UPS
 
@@ -279,11 +279,11 @@ also apply here.
 
 *POWERDOWNFLAG* 'filename'::
 
-upsmon creates this file when running in manager mode when the UPS needs
+upsmon creates this file when running in primary mode when the UPS needs
 to be powered off.  You should check for this file in your shutdown
 scripts and call `upsdrvctl shutdown` if it exists.
 +
-This is done to forcibly reset the subordinate systems, so they don't get
+This is done to forcibly reset the secondary systems, so they don't get
 stuck at the "halted" stage even if the power returns during the shutdown
 process.  This usually does not work well on contact-closure UPSes that
 use the genericups driver.
@@ -326,10 +326,10 @@ malicious, then wait for upsmon to be restarted.
 *SHUTDOWNCMD* 'command'::
 
 upsmon runs this command when the system needs to be brought down.  If
-it is a subordinate, it will do that immediately whenever the current
+it is a secondary, it will do that immediately whenever the current
 overall power value drops below the MINSUPPLIES value above.
 +
-When upsmon is a manager, it will allow any subordinates to log out before
+When upsmon is a primary, it will allow any secondaries to log out before
 starting the local shutdown procedure.
 +
 Note that the command needs to be one element in the config file.  If

--- a/docs/man/upsmon.txt
+++ b/docs/man/upsmon.txt
@@ -421,8 +421,12 @@ by calling upsmon again to set the flag, i.e.:
 +upsmon -c fsd+
 
 After that, the manager and the subordinates will do their usual shutdown
-sequence as if the battery had gone critical.  This is much easier on your UPS
-equipment, and it beats crawling under a desk to find the plug.
+sequence as if the battery had gone critical, while you can time how long
+it takes for them.  This is much easier on your UPS equipment, and it beats
+crawling under a desk to find the plug.
+
+Note you can also use a dummy SHUTDOWNCMD setting to just report that the
+systems would shut down at this point, without actually disrupting their work.
 
 FILES
 -----

--- a/docs/man/upsmon.txt
+++ b/docs/man/upsmon.txt
@@ -25,7 +25,7 @@ power events.
 
 upsmon can monitor multiple systems using a single process.  Every UPS
 that is defined in the linkman:upsmon.conf[5] configuration file is assigned
-a power value and a type (*slave* or *master*).
+a power value and a type (*subordinate* or *manager*).
 
 OPTIONS
 -------
@@ -37,7 +37,7 @@ Display the help message.
 Send the command 'command' to the existing upsmon process.  Valid
 commands are:
 
-*fsd*;; shutdown all master UPSes (use with caution)
+*fsd*;; shutdown all manager-mode UPSes (use with caution)
 
 *stop*;; stop monitoring and exit
 
@@ -104,11 +104,11 @@ The 'username' is a section in your linkman:upsd.users[5] file.
 Whatever password you set in that section must match the 'password'
 set in this file.
 
-The type set in that section must also match the 'type' here--
-*master* or *slave*.  In general, a master process is one
+The type set in that section must also match the 'type' here --
+*manager* or *subordinate*.  In general, a manager process is one
 running on the system with the UPS actually plugged into a serial
-port, and a slave is drawing power from the UPS but can't talk to it
-directly.  See the section on UPS types for more.
+port, and a subordinate is drawing power from the UPS but can't
+talk to it directly.  See the section on UPS types for more.
 
 NOTIFY EVENTS
 -------------
@@ -233,23 +233,23 @@ power supplies that the UPS runs on the current system.
 
 Normally, you only have one power supply, so it will be set to 1.
 
-+MONITOR myups@myhost 1 username mypassword master+
++MONITOR myups@myhost 1 username mypassword manager+
 
 On a large server with redundant power supplies, the power value for a UPS
 may be greater than 1.  You may also have more than one of them defined.
 
-+MONITOR ups-alpha@myhost 2 username mypassword master+
++MONITOR ups-alpha@myhost 2 username mypassword manager+
 
-+MONITOR ups-beta@myhost 2 username mypassword master+
++MONITOR ups-beta@myhost 2 username mypassword manager+
 
 You can also set the power value for a UPS to 0 if it does not supply any
 power to that system.  This is generally used when you want to use the
 upsmon notification features for a UPS even though it's not actually
-running the system that hosts upsmon.  Don't set this to "master" unless
+running the system that hosts upsmon.  Don't set this to "manager" unless
 you really want to power this UPS off when this instance of upsmon needs
 to shut down for its own reasons.
 
-+MONITOR faraway@anotherbox 0 username mypassword slave+
++MONITOR faraway@anotherbox 0 username mypassword subordinate+
 
 The "minimum power value" is the number of power supplies that must be
 receiving power in order to keep the computer running.
@@ -276,31 +276,31 @@ UPS TYPES
 
 *upsmon* and linkman:upsd[8] don't always run on the same system.  When they
 do, any UPSes that are directly attached to the upsmon host should be
-monitored in "master" mode.  This makes upsmon take charge of that
-equipment, and it will wait for slaves to disconnect before shutting
+monitored in "manager" mode.  This makes upsmon take charge of that equipment,
+and it will wait for the subordinate systems to disconnect before shutting
 down the local system.  This allows the distant systems (monitoring over
 the network) to shut down cleanly before `upsdrvctl shutdown` runs
 and turns them all off.
 
-When upsmon runs as a slave, it is relying on the distant system to tell
+When upsmon runs as a subordinate, it is relying on the distant system to tell
 it about the state of the UPS.  When that UPS goes critical (on battery
 and low battery), it immediately invokes the local shutdown command.  This
-needs to happen quickly.  Once it disconnects from the distant
-linkman:upsd[8] server, the master upsmon will start its own shutdown
-process.  Your slaves must all shut down before the master turns off the
-power or filesystem damage may result.
+needs to happen quickly.  Once all subordinates disconnect from the distant
+linkman:upsd[8] server, its manager-mode upsmon will start its own shutdown
+process.  Your subordinate systems must all quiesce and shut down before the
+manager turns off the shared power source, or filesystem damage may result.
 
-upsmon deals with slaves that get wedged, hang, or otherwise fail to
+upsmon deals with subordinates that get wedged, hang, or otherwise fail to
 disconnect from linkman:upsd[8] in a timely manner with the HOSTSYNC
-timer.  During a shutdown situation, the master upsmon will give up after
-this interval and it will shut down anyway.  This keeps the master from
-sitting there forever (which would endanger that host) if a slave should
-break somehow.  This defaults to 15 seconds.
+timer.  During a shutdown situation, the manager upsmon will give up after
+this interval and it will shut down anyway.  This keeps the manager from
+sitting there forever (which would endanger that host) if a subordinate
+should break somehow.  This defaults to 15 seconds.
 
-If your master system is shutting down too quickly, set the FINALDELAY
+If your manager system is shutting down too quickly, set the FINALDELAY
 interval to something greater than the default 15 seconds.  Don't set
 this too high, or your UPS battery may run out of power before the
-master upsmon process shuts down that system.
+manager upsmon process shuts down that system.
 
 TIMED SHUTDOWNS
 ---------------
@@ -353,9 +353,10 @@ MIXED OPERATIONS
 
 Besides being able to monitor multiple UPSes, upsmon can also monitor them
 as different roles.  If you have a system with multiple power supplies
-serviced by separate UPS batteries, it's possible to be a master on one
-and a slave on the other.  This usually happens when you run out of serial
-ports and need to do the monitoring through another system nearby.
+serviced by separate UPS batteries, it's possible to be a manager on one
+UPS and a subordinate on the other.  This usually happens when you run
+out of serial or USB ports and need to do the monitoring through another
+system nearby.
 
 This is also complicated, especially when it comes time to power down a
 UPS that has gone critical but doesn't supply the local system.  You can
@@ -366,15 +367,15 @@ FORCED SHUTDOWNS
 ----------------
 
 When upsmon is forced to bring down the local system, it sets the
-"FSD" (forced shutdown) flag on any UPSes that it is running in master
-mode.  This is used to synchronize slaves in the event that a master UPS
-that is otherwise OK needs to be brought down due to some pressing event
-on the master.
+"FSD" (forced shutdown) flag on any UPSes that it is running in manager
+mode.  This is used to synchronize subordinate systems in the event that
+a UPS manager that is otherwise OK needs to be brought down due to some
+pressing event on the manager.
 
-You can manually invoke this mode on the master upsmon by starting another
-copy with `-c fsd`.  This is useful when you want to initiate a shutdown
-before the critical stage through some external means, such as
-linkman:upssched[8].
+You can manually invoke this mode on the system with manager-mode upsmon
+by starting another copy of the program with `-c fsd` command line argument.
+This is useful when you want to initiate a shutdown before the critical
+stage through some external means, such as linkman:upssched[8].
 
 DEAD UPSES
 ----------
@@ -419,8 +420,8 @@ by calling upsmon again to set the flag, i.e.:
 
 +upsmon -c fsd+
 
-After that, the master and the slaves will do their usual shutdown sequence
-as if the battery had gone critical.  This is much easier on your UPS
+After that, the manager and the subordinates will do their usual shutdown
+sequence as if the battery had gone critical.  This is much easier on your UPS
 equipment, and it beats crawling under a desk to find the plug.
 
 FILES

--- a/docs/man/upsmon.txt
+++ b/docs/man/upsmon.txt
@@ -25,7 +25,7 @@ power events.
 
 upsmon can monitor multiple systems using a single process.  Every UPS
 that is defined in the linkman:upsmon.conf[5] configuration file is assigned
-a power value and a type (*subordinate* or *manager*).
+a power value and a type (*primary* or *secondary*).
 
 OPTIONS
 -------
@@ -37,7 +37,7 @@ Display the help message.
 Send the command 'command' to the existing upsmon process.  Valid
 commands are:
 
-*fsd*;; shutdown all manager-mode UPSes (use with caution)
+*fsd*;; shutdown all primary-mode UPSes (use with caution)
 
 *stop*;; stop monitoring and exit
 
@@ -105,9 +105,9 @@ Whatever password you set in that section must match the 'password'
 set in this file.
 
 The type set in that section must also match the 'type' here --
-*manager* or *subordinate*.  In general, a manager process is one
+*primary* or *secondary*.  In general, a primary process is one
 running on the system with the UPS actually plugged into a serial
-port, and a subordinate is drawing power from the UPS but can't
+port, and a secondary is drawing power from the UPS but can't
 talk to it directly.  See the section on UPS types for more.
 
 NOTIFY EVENTS
@@ -233,23 +233,23 @@ power supplies that the UPS runs on the current system.
 
 Normally, you only have one power supply, so it will be set to 1.
 
-+MONITOR myups@myhost 1 username mypassword manager+
++MONITOR myups@myhost 1 username mypassword primary+
 
 On a large server with redundant power supplies, the power value for a UPS
 may be greater than 1.  You may also have more than one of them defined.
 
-+MONITOR ups-alpha@myhost 2 username mypassword manager+
++MONITOR ups-alpha@myhost 2 username mypassword primary+
 
-+MONITOR ups-beta@myhost 2 username mypassword manager+
++MONITOR ups-beta@myhost 2 username mypassword primary+
 
 You can also set the power value for a UPS to 0 if it does not supply any
 power to that system.  This is generally used when you want to use the
 upsmon notification features for a UPS even though it's not actually
-running the system that hosts upsmon.  Don't set this to "manager" unless
+running the system that hosts upsmon.  Don't set this to "primary" unless
 you really want to power this UPS off when this instance of upsmon needs
 to shut down for its own reasons.
 
-+MONITOR faraway@anotherbox 0 username mypassword subordinate+
++MONITOR faraway@anotherbox 0 username mypassword secondary+
 
 The "minimum power value" is the number of power supplies that must be
 receiving power in order to keep the computer running.
@@ -276,31 +276,31 @@ UPS TYPES
 
 *upsmon* and linkman:upsd[8] don't always run on the same system.  When they
 do, any UPSes that are directly attached to the upsmon host should be
-monitored in "manager" mode.  This makes upsmon take charge of that equipment,
-and it will wait for the subordinate systems to disconnect before shutting
+monitored in "primary" mode.  This makes upsmon take charge of that equipment,
+and it will wait for the "secondary" systems to disconnect before shutting
 down the local system.  This allows the distant systems (monitoring over
 the network) to shut down cleanly before `upsdrvctl shutdown` runs
 and turns them all off.
 
-When upsmon runs as a subordinate, it is relying on the distant system to tell
+When upsmon runs as a secondary, it is relying on the distant system to tell
 it about the state of the UPS.  When that UPS goes critical (on battery
 and low battery), it immediately invokes the local shutdown command.  This
-needs to happen quickly.  Once all subordinates disconnect from the distant
-linkman:upsd[8] server, its manager-mode upsmon will start its own shutdown
-process.  Your subordinate systems must all quiesce and shut down before the
-manager turns off the shared power source, or filesystem damage may result.
+needs to happen quickly.  Once all secondaries disconnect from the distant
+linkman:upsd[8] server, its primary-mode upsmon will start its own shutdown
+process.  Your secondary systems must all quiesce and shut down before the
+primary turns off the shared power source, or filesystem damage may result.
 
-upsmon deals with subordinates that get wedged, hang, or otherwise fail to
+upsmon deals with secondaries that get wedged, hang, or otherwise fail to
 disconnect from linkman:upsd[8] in a timely manner with the HOSTSYNC
-timer.  During a shutdown situation, the manager upsmon will give up after
-this interval and it will shut down anyway.  This keeps the manager from
-sitting there forever (which would endanger that host) if a subordinate
+timer.  During a shutdown situation, the primary upsmon will give up after
+this interval and it will shut down anyway.  This keeps the primary from
+sitting there forever (which would endanger that host) if a secondary
 should break somehow.  This defaults to 15 seconds.
 
-If your manager system is shutting down too quickly, set the FINALDELAY
+If your primary system is shutting down too quickly, set the FINALDELAY
 interval to something greater than the default 15 seconds.  Don't set
 this too high, or your UPS battery may run out of power before the
-manager upsmon process shuts down that system.
+primary upsmon process shuts down that system.
 
 TIMED SHUTDOWNS
 ---------------
@@ -353,8 +353,8 @@ MIXED OPERATIONS
 
 Besides being able to monitor multiple UPSes, upsmon can also monitor them
 as different roles.  If you have a system with multiple power supplies
-serviced by separate UPS batteries, it's possible to be a manager on one
-UPS and a subordinate on the other.  This usually happens when you run
+serviced by separate UPS batteries, it's possible to be a primary on one
+UPS and a secondary on the other.  This usually happens when you run
 out of serial or USB ports and need to do the monitoring through another
 system nearby.
 
@@ -367,12 +367,12 @@ FORCED SHUTDOWNS
 ----------------
 
 When upsmon is forced to bring down the local system, it sets the
-"FSD" (forced shutdown) flag on any UPSes that it is running in manager
-mode.  This is used to synchronize subordinate systems in the event that
-a UPS manager that is otherwise OK needs to be brought down due to some
-pressing event on the manager.
+"FSD" (forced shutdown) flag on any UPSes that it is running in primary
+mode.  This is used to synchronize secondary systems in the event that
+a primary which is otherwise OK needs to be brought down due to some
+pressing event on the UPS manager system.
 
-You can manually invoke this mode on the system with manager-mode upsmon
+You can manually invoke this mode on the system with primary-mode upsmon
 by starting another copy of the program with `-c fsd` command line argument.
 This is useful when you want to initiate a shutdown before the critical
 stage through some external means, such as linkman:upssched[8].
@@ -420,7 +420,7 @@ by calling upsmon again to set the flag, i.e.:
 
 +upsmon -c fsd+
 
-After that, the manager and the subordinates will do their usual shutdown
+After that, the primary and the secondary will do their usual shutdown
 sequence as if the battery had gone critical, while you can time how long
 it takes for them.  This is much easier on your UPS equipment, and it beats
 crawling under a desk to find the plug.

--- a/docs/net-protocol.txt
+++ b/docs/net-protocol.txt
@@ -507,6 +507,10 @@ NOTE: This requires "upsmon manager" in upsd.users
 This function doesn't do much by itself.  It is used by upsmon to make
 sure that manager-level functions like FSD are available if necessary.
 
+NOTE: This command will be eventually renamed to "MANAGER" with the older
+name "MASTER" kept as deprecated alias for compatibility; a protocol bump
+or special backwards-compatibility handling may be needed for that however.
+
 
 FSD
 ---

--- a/docs/net-protocol.txt
+++ b/docs/net-protocol.txt
@@ -74,7 +74,7 @@ Response:
 	NUMLOGINS su700 1
 
 '<value>' is the number of clients which have done LOGIN for this UPS.
-This is used by the master upsmon to determine how many clients are
+This is used by the upsmon in manager mode to determine how many clients are
 still connected when starting the shutdown process.
 
 This replaces the old "REQ NUMLOGINS" command.
@@ -479,11 +479,11 @@ Response:
 
 or <<np-errors,various errors>>
 
-NOTE: This requires "upsmon slave" or "upsmon master" in upsd.users
+NOTE: This requires "upsmon subordinate" or "upsmon manager" in upsd.users
 
 Use this to log the fact that a system is drawing power from this UPS.
-The upsmon master will wait until the count of attached systems reaches
-1 -- itself.  This allows the slaves to shut down first.
+The upsmon manager will wait until the count of attached systems reaches
+1 -- itself.  This allows the subordinates to shut down first.
 
 NOTE: You probably shouldn't send this command unless you are upsmon,
 or a upsmon replacement.
@@ -502,10 +502,10 @@ Response:
 
 or <<np-errors,various errors>>
 
-NOTE: This requires "upsmon master" in upsd.users
+NOTE: This requires "upsmon manager" in upsd.users
 
 This function doesn't do much by itself.  It is used by upsmon to make
-sure that master-level functions like FSD are available if necessary.
+sure that manager-level functions like FSD are available if necessary.
 
 
 FSD
@@ -521,12 +521,12 @@ Response:
 
 or <<np-errors,various errors>>
 
-NOTE: This requires "upsmon master" in upsd.users, or "FSD" action
+NOTE: This requires "upsmon manager" in upsd.users, or "FSD" action
 granted in upsd.users
 
-upsmon in master mode is the primary user of this function.  It sets this
+upsmon in manager mode is the primary user of this function.  It sets this
 "forced shutdown" flag on any UPS when it plans to power it off.  This is
-done so that slave systems will know about it and shut down before the
+done so that subordinate systems will know about it and shut down before the
 power disappears.
 
 Setting this flag makes "FSD" appear in a STATUS request for this UPS.

--- a/docs/net-protocol.txt
+++ b/docs/net-protocol.txt
@@ -74,7 +74,7 @@ Response:
 	NUMLOGINS su700 1
 
 '<value>' is the number of clients which have done LOGIN for this UPS.
-This is used by the upsmon in manager mode to determine how many clients are
+This is used by the upsmon in primary mode to determine how many clients are
 still connected when starting the shutdown process.
 
 This replaces the old "REQ NUMLOGINS" command.
@@ -479,11 +479,11 @@ Response:
 
 or <<np-errors,various errors>>
 
-NOTE: This requires "upsmon subordinate" or "upsmon manager" in upsd.users
+NOTE: This requires "upsmon secondary" or "upsmon primary" in upsd.users
 
 Use this to log the fact that a system is drawing power from this UPS.
-The upsmon manager will wait until the count of attached systems reaches
-1 -- itself.  This allows the subordinates to shut down first.
+The upsmon primary will wait until the count of attached systems reaches
+1 -- itself.  This allows the secondaries to shut down first.
 
 NOTE: You probably shouldn't send this command unless you are upsmon,
 or a upsmon replacement.
@@ -502,12 +502,12 @@ Response:
 
 or <<np-errors,various errors>>
 
-NOTE: This requires "upsmon manager" in upsd.users
+NOTE: This requires "upsmon primary" in upsd.users
 
 This function doesn't do much by itself.  It is used by upsmon to make
-sure that manager-level functions like FSD are available if necessary.
+sure that primary-mode functions like FSD are available if necessary.
 
-NOTE: This command will be eventually renamed to "MANAGER" with the older
+NOTE: This command will be eventually renamed to "PRIMARY" with the older
 name "MASTER" kept as deprecated alias for compatibility; a protocol bump
 or special backwards-compatibility handling may be needed for that however.
 
@@ -525,12 +525,12 @@ Response:
 
 or <<np-errors,various errors>>
 
-NOTE: This requires "upsmon manager" in upsd.users, or "FSD" action
+NOTE: This requires "upsmon primary" in upsd.users, or "FSD" action
 granted in upsd.users
 
-upsmon in manager mode is the primary user of this function.  It sets this
+upsmon in primary mode is the primary user of this function.  It sets this
 "forced shutdown" flag on any UPS when it plans to power it off.  This is
-done so that subordinate systems will know about it and shut down before the
+done so that secondary systems will know about it and shut down before the
 power disappears.
 
 Setting this flag makes "FSD" appear in a STATUS request for this UPS.

--- a/docs/new-drivers.txt
+++ b/docs/new-drivers.txt
@@ -237,7 +237,7 @@ duplication and ugliness otherwise.
 [NOTE]
 ==============================================================================
 
-- upsd injects `FSD` by itself following that command by a manager upsmon
+- upsd injects `FSD` by itself following that command by a primary upsmon
 process.  Drivers must not set that value, apart from specific cases (see
 below).
 

--- a/docs/new-drivers.txt
+++ b/docs/new-drivers.txt
@@ -237,7 +237,7 @@ duplication and ugliness otherwise.
 [NOTE]
 ==============================================================================
 
-- upsd injects `FSD` by itself following that command by a master upsmon
+- upsd injects `FSD` by itself following that command by a manager upsmon
 process.  Drivers must not set that value, apart from specific cases (see
 below).
 

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 2532 utf-8
+personal_ws-1.1 en 2537 utf-8
 AAS
 ACFAIL
 ACFREQ
@@ -2098,6 +2098,7 @@ qgs
 qpi
 qs
 queequeg
+quiesce
 qx
 qx's
 qxflags
@@ -2433,6 +2434,7 @@ upsset
 upsstats
 upstype
 upsuser
+upswired
 uptime
 urpmi
 usb

--- a/docs/scheduling.txt
+++ b/docs/scheduling.txt
@@ -250,8 +250,8 @@ Just be sure to cancel this timer if you go back ONLINE before then.
 
 The best way to do this is to use the upsmon callback feature.  You can
 make upsmon set the "forced shutdown" (FSD) flag on the upsd so your
-slave systems shut down early too.  Just do something like this in your
-CMDSCRIPT:
+subordinate systems shut down early too.  Just do something like this
+in your CMDSCRIPT:
 
 	/sbin/upsmon -c fsd
 
@@ -262,8 +262,8 @@ link:http://refspecs.linuxfoundation.org/fhs.shtml[FHS -- Filesystem Hierarchy S
 (so `/sbin/upsmon`).
 
 It's not a good idea to call your system's shutdown routine directly
-from the CMDSCRIPT, since there's no synchronization with the slave
-systems hooked to the same UPS.  FSD is the master's way of saying
+from the CMDSCRIPT, since there's no synchronization with the subordinate
+systems hooked to the same UPS.  FSD is the manager's way of saying
 "we're shutting down *now* like it or not, so you'd better get ready".
 
 

--- a/docs/scheduling.txt
+++ b/docs/scheduling.txt
@@ -250,7 +250,7 @@ Just be sure to cancel this timer if you go back ONLINE before then.
 
 The best way to do this is to use the upsmon callback feature.  You can
 make upsmon set the "forced shutdown" (FSD) flag on the upsd so your
-subordinate systems shut down early too.  Just do something like this
+secondary systems shut down early too.  Just do something like this
 in your CMDSCRIPT:
 
 	/sbin/upsmon -c fsd
@@ -262,8 +262,8 @@ link:http://refspecs.linuxfoundation.org/fhs.shtml[FHS -- Filesystem Hierarchy S
 (so `/sbin/upsmon`).
 
 It's not a good idea to call your system's shutdown routine directly
-from the CMDSCRIPT, since there's no synchronization with the subordinate
-systems hooked to the same UPS.  FSD is the manager's way of saying
+from the CMDSCRIPT, since there's no synchronization with the secondary
+systems hooked to the same UPS.  FSD is the primary's way of saying
 "we're shutting down *now* like it or not, so you'd better get ready".
 
 

--- a/docs/security.txt
+++ b/docs/security.txt
@@ -139,8 +139,14 @@ NUT has its own official IANA port: 3493/tcp.
 
 The `upsmon` process on subordinate systems, as well as any other NUT client
 (such as `upsc`, `upscmd`, `upsrw`, NUT-Monitor, ...) connects to the `upsd`
-process on the system which manages the UPS, via this TCP port. The `upsd`
-process does not connect out.
+process on the system which manages the UPS, via this TCP port. Usually an
+`upsmon` process runs on the latter system in "manager" mode for the devices
+connected to it.
+
+The `upsd` process does not initiate outgoing connections.
+
+Certain NUT drivers (for network-managed devices) can initiate their own
+connections to various ports according to corresponding vendor protocol.
 
 You should use this to restrict network access.
 

--- a/docs/security.txt
+++ b/docs/security.txt
@@ -137,9 +137,10 @@ Firewall
 
 NUT has its own official IANA port: 3493/tcp.
 
-The `upsmon` process on slave systems, as well as any other NUT client (such
-as `upsc`, `upscmd`, `upsrw`, NUT-Monitor, ...) connects to the `upsd` process
-on the master system via this TCP port. The `upsd` process does not connect out.
+The `upsmon` process on subordinate systems, as well as any other NUT client
+(such as `upsc`, `upscmd`, `upsrw`, NUT-Monitor, ...) connects to the `upsd`
+process on the system which manages the UPS, via this TCP port. The `upsd`
+process does not connect out.
 
 You should use this to restrict network access.
 
@@ -161,7 +162,7 @@ into the server.
 `hosts.allow`:
 
 	upsd : admin@127.0.0.1/32
-	upsd : monslave@127.0.0.1/32 monslave@192.168.1.0/24
+	upsd : observer@127.0.0.1/32 observer@192.168.1.0/24
 
 `hosts.deny`:
 
@@ -257,8 +258,8 @@ Example:
 If you already have a file with that name in there, increment the
 0 until you get a unique filename that works.
 
-If you have multiple client systems (like upsmon slaves), be sure
-to install this file on them as well.
+If you have multiple client systems (like upsmon instances in
+subordinate mode), be sure to install this file on them as well.
 
 We recommend making a directory under your existing confpath to
 keep everything in the same place.  Remember the path you created,

--- a/docs/security.txt
+++ b/docs/security.txt
@@ -137,10 +137,10 @@ Firewall
 
 NUT has its own official IANA port: 3493/tcp.
 
-The `upsmon` process on subordinate systems, as well as any other NUT client
+The `upsmon` process on secondary systems, as well as any other NUT client
 (such as `upsc`, `upscmd`, `upsrw`, NUT-Monitor, ...) connects to the `upsd`
 process on the system which manages the UPS, via this TCP port. Usually an
-`upsmon` process runs on the latter system in "manager" mode for the devices
+`upsmon` process runs on the latter system in "primary" mode for the devices
 connected to it.
 
 The `upsd` process does not initiate outgoing connections.
@@ -265,7 +265,7 @@ If you already have a file with that name in there, increment the
 0 until you get a unique filename that works.
 
 If you have multiple client systems (like upsmon instances in
-subordinate mode), be sure to install this file on them as well.
+secondary mode), be sure to install this file on them as well.
 
 We recommend making a directory under your existing confpath to
 keep everything in the same place.  Remember the path you created,

--- a/drivers/optiups.c
+++ b/drivers/optiups.c
@@ -225,8 +225,9 @@ static int instcmd(const char *cmdname, const char *extra)
 	}
 	else if (!strcasecmp(cmdname, "load.off"))
 	{
-		/* You do realize this will kill power to ourself.  Would probably only
-		 *   be useful for killing power for a subordinate computer */
+		/* You do realize this will kill power to ourself.
+		 * Would probably only be useful for killing power for
+		 * a computer with upsmon in "secondary" mode */
 		if ( optimodel == OPTIMODEL_ZINTO )
 		{
 			optiquery( "Ct1" );

--- a/drivers/optiups.c
+++ b/drivers/optiups.c
@@ -226,7 +226,7 @@ static int instcmd(const char *cmdname, const char *extra)
 	else if (!strcasecmp(cmdname, "load.off"))
 	{
 		/* You do realize this will kill power to ourself.  Would probably only
-		 *   be useful for killing power for a slave computer */
+		 *   be useful for killing power for a subordinate computer */
 		if ( optimodel == OPTIMODEL_ZINTO )
 		{
 			optiquery( "Ct1" );

--- a/scripts/augeas/README
+++ b/scripts/augeas/README
@@ -240,7 +240,7 @@ a.set(("/files/etc/nut/upsd.users/%s/instcmds" % user), "ALL")
 monuser = "monuser"
 monpasswd = "******"
 a.set(("/files/etc/nut/upsd.users/%s/password" % monuser), monpasswd)
-a.set(("/files/etc/nut/upsd.users/%s/upsmon" % monuser), "master")
+a.set(("/files/etc/nut/upsd.users/%s/upsmon" % monuser), "manager")
 
 # Generate upsmon.conf
 a.set("/files/etc/nut/upsmon.conf/MONITOR/system/upsname", device_name)
@@ -250,7 +250,7 @@ a.set("/files/etc/nut/upsmon.conf/MONITOR/system/upsname", device_name)
 a.set("/files/etc/nut/upsmon.conf/MONITOR/powervalue", "1")
 a.set("/files/etc/nut/upsmon.conf/MONITOR/username", monuser)
 a.set("/files/etc/nut/upsmon.conf/MONITOR/password", monpasswd)
-a.set("/files/etc/nut/upsmon.conf/MONITOR/type", "master")
+a.set("/files/etc/nut/upsmon.conf/MONITOR/type", "manager")
 
 # FIXME: glitch on the generated content
 a.set("/files/etc/nut/upsmon.conf/SHUTDOWNCMD", "/sbin/shutdown -h +0")

--- a/scripts/augeas/README
+++ b/scripts/augeas/README
@@ -240,7 +240,7 @@ a.set(("/files/etc/nut/upsd.users/%s/instcmds" % user), "ALL")
 monuser = "monuser"
 monpasswd = "******"
 a.set(("/files/etc/nut/upsd.users/%s/password" % monuser), monpasswd)
-a.set(("/files/etc/nut/upsd.users/%s/upsmon" % monuser), "manager")
+a.set(("/files/etc/nut/upsd.users/%s/upsmon" % monuser), "primary")
 
 # Generate upsmon.conf
 a.set("/files/etc/nut/upsmon.conf/MONITOR/system/upsname", device_name)
@@ -250,7 +250,7 @@ a.set("/files/etc/nut/upsmon.conf/MONITOR/system/upsname", device_name)
 a.set("/files/etc/nut/upsmon.conf/MONITOR/powervalue", "1")
 a.set("/files/etc/nut/upsmon.conf/MONITOR/username", monuser)
 a.set("/files/etc/nut/upsmon.conf/MONITOR/password", monpasswd)
-a.set("/files/etc/nut/upsmon.conf/MONITOR/type", "manager")
+a.set("/files/etc/nut/upsmon.conf/MONITOR/type", "primary")
 
 # FIXME: glitch on the generated content
 a.set("/files/etc/nut/upsmon.conf/SHUTDOWNCMD", "/sbin/shutdown -h +0")

--- a/scripts/augeas/nutupsdusers.aug.in
+++ b/scripts/augeas/nutupsdusers.aug.in
@@ -67,7 +67,7 @@ let upsd_users_instcmds   = [ del_spc
 
 let upsd_users_upsmon    = [ del_spc
                                . key "upsmon" . sep_spc
-                               . store /master|slave/ . eol ]
+                               . store /master|manager|slave|subordinate/ . eol ]
 
 let upsd_users_title    = IniFile.indented_title IniFile.record_re
 

--- a/scripts/augeas/nutupsdusers.aug.in
+++ b/scripts/augeas/nutupsdusers.aug.in
@@ -67,7 +67,7 @@ let upsd_users_instcmds   = [ del_spc
 
 let upsd_users_upsmon    = [ del_spc
                                . key "upsmon" . sep_spc
-                               . store /master|manager|slave|subordinate/ . eol ]
+                               . store /master|primary|slave|secondary/ . eol ]
 
 let upsd_users_title    = IniFile.indented_title IniFile.record_re
 

--- a/scripts/augeas/tests/test_nut.aug
+++ b/scripts/augeas/tests/test_nut.aug
@@ -56,11 +56,11 @@ let upsd_users = "
 
 	[upswired]
 		password = blah
-		upsmon manager
+		upsmon primary
 
 	[observer]
 		password = abcd
-		upsmon subordinate
+		upsmon secondary
 "
 
 test NutUpsdUsers.upsd_users_lns get upsd_users = 
@@ -79,14 +79,14 @@ test NutUpsdUsers.upsd_users_lns get upsd_users =
 		{ }  }
 	{ "upswired"
 		{ "password" = "blah" }
-		{ "upsmon" = "manager" }
+		{ "upsmon" = "primary" }
 		{ }  }
 	{ "observer"
 		{ "password" = "abcd" }
-		{ "upsmon" = "subordinate" } }
+		{ "upsmon" = "secondary" } }
 
 let upsmon_conf = "
-MONITOR testups@localhost 1 upswired blah manager
+MONITOR testups@localhost 1 upswired blah primary
 
 MINSUPPLIES 1
 SHUTDOWNCMD /sbin/shutdown -h +0
@@ -109,7 +109,7 @@ test NutUpsmonConf.upsmon_lns get upsmon_conf =
 		{ "powervalue" = "1"                }
 		{ "username"   = "upswired"          }
 		{ "password"   = "blah"           }
-		{ "type"       = "manager"           } }
+		{ "type"       = "primary"           } }
 	{ }
 	{ "MINSUPPLIES"   = "1"  }
 	{ "SHUTDOWNCMD"   = "/sbin/shutdown -h +0" }

--- a/scripts/augeas/tests/test_nut.aug
+++ b/scripts/augeas/tests/test_nut.aug
@@ -54,13 +54,13 @@ let upsd_users = "
 		instcmds = test.panel.start
 		instcmds = test.panel.stop
 
-	[monmaster]
+	[upswired]
 		password = blah
-		upsmon master
+		upsmon manager
 
-	[monslave]
+	[observer]
 		password = abcd
-		upsmon slave
+		upsmon subordinate
 "
 
 test NutUpsdUsers.upsd_users_lns get upsd_users = 
@@ -77,16 +77,16 @@ test NutUpsdUsers.upsd_users_lns get upsd_users =
 		{ "instcmds" = "test.panel.start" }
 		{ "instcmds" = "test.panel.stop" }
 		{ }  }
-	{ "monmaster"
+	{ "upswired"
 		{ "password" = "blah" }
-		{ "upsmon" = "master" }
+		{ "upsmon" = "manager" }
 		{ }  }
-	{ "monslave"
+	{ "observer"
 		{ "password" = "abcd" }
-		{ "upsmon" = "slave" } }
+		{ "upsmon" = "subordinate" } }
 
 let upsmon_conf = "
-MONITOR testups@localhost 1 monmaster blah master
+MONITOR testups@localhost 1 upswired blah manager
 
 MINSUPPLIES 1
 SHUTDOWNCMD /sbin/shutdown -h +0
@@ -107,9 +107,9 @@ test NutUpsmonConf.upsmon_lns get upsmon_conf =
 		{ "upsname"  = "testups"    }
 		{ "hostname" = "localhost" } }
 		{ "powervalue" = "1"                }
-		{ "username"   = "monmaster"          }
+		{ "username"   = "upswired"          }
 		{ "password"   = "blah"           }
-		{ "type"       = "master"           } }
+		{ "type"       = "manager"           } }
 	{ }
 	{ "MINSUPPLIES"   = "1"  }
 	{ "SHUTDOWNCMD"   = "/sbin/shutdown -h +0" }

--- a/scripts/perl/Nut.pm
+++ b/scripts/perl/Nut.pm
@@ -164,7 +164,7 @@ sub _initialize {
 # Author: Kit Peters
   my $self = shift;
   my %arg = @_;
-  my $host = $arg{HOST}     || 'localhost'; # Host running manager upsd
+  my $host = $arg{HOST}     || 'localhost'; # Host running upsd and probably drivers
   my $port = $arg{PORT}     || '3493'; # 3493 is IANA assigned port for NUT
   my $proto = $arg{PROTO}   || 'tcp'; # use tcp unless user tells us to
   my $user = $arg{USERNAME} || undef; # username passed to upsd
@@ -591,7 +591,7 @@ sub Master { # check for MASTER level access
 # Author: Kit Peters
 # ### changelog: uses the new _send command
 #
-# TODO: API change pending to replace MASTER with MANAGER
+# TODO: API change pending to replace MASTER with PRIMARY
 # (and backwards-compatible alias handling)
   my $self = shift;
 
@@ -843,7 +843,7 @@ It is automatically done if connection closed.
 Use this to find out whether or not we have MASTER privileges for
 this UPS. Returns 1 if we have MASTER privileges, returns 0 otherwise.
 
-TODO: API change pending to replace MASTER with MANAGER
+TODO: API change pending to replace MASTER with PRIMARY
 (and backwards-compatible alias handling)
 
 =item ListVar($variable, ...)

--- a/scripts/perl/Nut.pm
+++ b/scripts/perl/Nut.pm
@@ -164,7 +164,7 @@ sub _initialize {
 # Author: Kit Peters
   my $self = shift;
   my %arg = @_;
-  my $host = $arg{HOST}     || 'localhost'; # Host running master upsd
+  my $host = $arg{HOST}     || 'localhost'; # Host running manager upsd
   my $port = $arg{PORT}     || '3493'; # 3493 is IANA assigned port for NUT
   my $proto = $arg{PROTO}   || 'tcp'; # use tcp unless user tells us to
   my $user = $arg{USERNAME} || undef; # username passed to upsd

--- a/scripts/perl/Nut.pm
+++ b/scripts/perl/Nut.pm
@@ -591,6 +591,8 @@ sub Master { # check for MASTER level access
 # Author: Kit Peters
 # ### changelog: uses the new _send command
 #
+# TODO: API change pending to replace MASTER with MANAGER
+# (and backwards-compatible alias handling)
   my $self = shift;
 
   my $req = "MASTER $self->{name}"; # build request
@@ -840,6 +842,9 @@ It is automatically done if connection closed.
 
 Use this to find out whether or not we have MASTER privileges for
 this UPS. Returns 1 if we have MASTER privileges, returns 0 otherwise.
+
+TODO: API change pending to replace MASTER with MANAGER
+(and backwards-compatible alias handling)
 
 =item ListVar($variable, ...)
 

--- a/scripts/python/app/README
+++ b/scripts/python/app/README
@@ -1,4 +1,4 @@
-NUT-Monitor is a graphical application to access and manager UPSes connected to
+NUT-Monitor is a graphical application to access and manage UPSes connected to
 a NUT (Network UPS Tools) server.
 
 This application (written in Python + GTK) uses the python-pynut class

--- a/scripts/python/module/PyNUT.py
+++ b/scripts/python/module/PyNUT.py
@@ -267,7 +267,7 @@ Returns OK on success or raises an error
 
 Returns OK on success or raises an error
 
-TODO: API change pending to replace MASTER with MANAGER
+TODO: API change pending to replace MASTER with PRIMARY
 (and backwards-compatible alias handling)
         """
 

--- a/scripts/python/module/PyNUT.py
+++ b/scripts/python/module/PyNUT.py
@@ -266,6 +266,9 @@ Returns OK on success or raises an error
         """ Send FSD command
 
 Returns OK on success or raises an error
+
+TODO: API change pending to replace MASTER with MANAGER
+(and backwards-compatible alias handling)
         """
 
         if self.__debug :

--- a/server/netcmds.h
+++ b/server/netcmds.h
@@ -61,6 +61,9 @@ static struct {
 
 	{ "LOGIN",	net_login,	FLAG_USER	},
 	{ "LOGOUT", 	net_logout,	0		},
+	/* FIXME: Protocol update needed to handle master/manager alias
+	 * and probably an API bump also, to rename/alias the routine.
+	 */
 	{ "MASTER",	net_master,	FLAG_USER	},
 
 	{ "FSD",	net_fsd,	FLAG_USER	},

--- a/server/netcmds.h
+++ b/server/netcmds.h
@@ -61,7 +61,7 @@ static struct {
 
 	{ "LOGIN",	net_login,	FLAG_USER	},
 	{ "LOGOUT", 	net_logout,	0		},
-	/* FIXME: Protocol update needed to handle master/manager alias
+	/* FIXME: Protocol update needed to handle master/primary alias
 	 * and probably an API bump also, to rename/alias the routine.
 	 */
 	{ "MASTER",	net_master,	FLAG_USER	},

--- a/server/netuser.c
+++ b/server/netuser.c
@@ -1,4 +1,4 @@
-/* netuser.c - LOGIN/LOGOUT/USERNAME/PASSWORD/MASTER[MANAGER] handlers for upsd
+/* netuser.c - LOGIN/LOGOUT/USERNAME/PASSWORD/MASTER[PRIMARY] handlers for upsd
 
    Copyright (C) 2003  Russell Kroll <rkroll@exploits.org>
 
@@ -84,7 +84,7 @@ void net_logout(nut_ctype_t *client, size_t numarg, const char **arg)
 }
 
 /* MASTER <upsname> */
-/* FIXME: Protocol update needed to handle master/manager alias
+/* FIXME: Protocol update needed to handle master/primary alias
  * and probably an API bump also, to rename/alias the routine.
  */
 void net_master(nut_ctype_t *client, size_t numarg, const char **arg)

--- a/server/netuser.c
+++ b/server/netuser.c
@@ -1,4 +1,4 @@
-/* netuser.c - LOGIN/LOGOUT/USERNAME/PASSWORD/MASTER handlers for upsd
+/* netuser.c - LOGIN/LOGOUT/USERNAME/PASSWORD/MASTER[MANAGER] handlers for upsd
 
    Copyright (C) 2003  Russell Kroll <rkroll@exploits.org>
 
@@ -84,6 +84,9 @@ void net_logout(nut_ctype_t *client, size_t numarg, const char **arg)
 }
 
 /* MASTER <upsname> */
+/* FIXME: Protocol update needed to handle master/manager alias
+ * and probably an API bump also, to rename/alias the routine.
+ */
 void net_master(nut_ctype_t *client, size_t numarg, const char **arg)
 {
 	upstype_t	*ups;

--- a/server/netuser.h
+++ b/server/netuser.h
@@ -1,4 +1,4 @@
-/* netuser.c - LOGIN/LOGOUT/USERNAME/PASSWORD/MASTER[MANAGER] handlers for upsd
+/* netuser.c - LOGIN/LOGOUT/USERNAME/PASSWORD/MASTER[PRIMARY] handlers for upsd
 
    Copyright (C)
 	2003	Russell Kroll <rkroll@exploits.org>
@@ -33,7 +33,7 @@ extern "C" {
 
 void net_login(nut_ctype_t *client, size_t numarg, const char **arg);
 void net_logout(nut_ctype_t *client, size_t numarg, const char **arg);
-/* FIXME: Protocol update needed to handle master/manager alias
+/* FIXME: Protocol update needed to handle master/primary alias
  * and probably an API bump also, to rename/alias the routine.
  */
 void net_master(nut_ctype_t *client, size_t numarg, const char **arg);

--- a/server/netuser.h
+++ b/server/netuser.h
@@ -1,11 +1,11 @@
-/* netuser.c - LOGIN/LOGOUT/USERNAME/PASSWORD/MASTER handlers for upsd
+/* netuser.c - LOGIN/LOGOUT/USERNAME/PASSWORD/MASTER[MANAGER] handlers for upsd
 
    Copyright (C)
 	2003	Russell Kroll <rkroll@exploits.org>
 	2005	Arnaud Quette <arnaud.quette@free.fr>
 	2007	Peter Selinger <selinger@users.sourceforge.net>
 	2013	Emilien Kia <kiae.dev@gmail.com>
-	2020	Jim Klimov <jimklimov@gmail.com>
+	2020-2021	Jim Klimov <jimklimov@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -33,6 +33,9 @@ extern "C" {
 
 void net_login(nut_ctype_t *client, size_t numarg, const char **arg);
 void net_logout(nut_ctype_t *client, size_t numarg, const char **arg);
+/* FIXME: Protocol update needed to handle master/manager alias
+ * and probably an API bump also, to rename/alias the routine.
+ */
 void net_master(nut_ctype_t *client, size_t numarg, const char **arg);
 void net_username(nut_ctype_t *client, size_t numarg, const char **arg);
 void net_password(nut_ctype_t *client, size_t numarg, const char **arg);

--- a/server/user.c
+++ b/server/user.c
@@ -317,19 +317,19 @@ int user_checkaction(const char *un, const char *pw, const char *action)
 	return 0;	/* fail */
 }
 
-/* handle "upsmon master" and "upsmon slave" for nicer configurations */
+/* handle "upsmon manager" and "upsmon subordinate" for nicer configurations */
 static void set_upsmon_type(char *type)
 {
-	/* master: login, master, fsd */
-	if (!strcasecmp(type, "master")) {
+	/* manager: login, master, fsd */
+	if (!strcasecmp(type, "master") || !strcasecmp(type, "manager")) {
 		user_add_action("login");
-		user_add_action("master");
+		user_add_action("master"); /* Note: this is linked to "MASTER" API command permision */
 		user_add_action("fsd");
 		return;
 	}
 
-	/* slave: just login */
-	if (!strcasecmp(type, "slave")) {
+	/* subordinate: just login */
+	if (!strcasecmp(type, "slave") || !strcasecmp(type, "subordinate")) {
 		user_add_action("login");
 		return;
 	}

--- a/server/user.c
+++ b/server/user.c
@@ -317,20 +317,20 @@ int user_checkaction(const char *un, const char *pw, const char *action)
 	return 0;	/* fail */
 }
 
-/* handle "upsmon manager" and "upsmon subordinate" for nicer configurations */
-/* FIXME: Protocol update needed to handle master/manager alias (in action and in protocol) */
+/* handle "upsmon primary" and "upsmon secondary" for nicer configurations */
+/* FIXME: Protocol update needed to handle master/primary alias (in action and in protocol) */
 static void set_upsmon_type(char *type)
 {
-	/* manager: login, master, fsd */
-	if (!strcasecmp(type, "master") || !strcasecmp(type, "manager")) {
+	/* primary: login, master, fsd */
+	if (!strcasecmp(type, "master") || !strcasecmp(type, "primary")) {
 		user_add_action("login");
 		user_add_action("master"); /* Note: this is linked to "MASTER" API command permission */
 		user_add_action("fsd");
 		return;
 	}
 
-	/* subordinate: just login */
-	if (!strcasecmp(type, "slave") || !strcasecmp(type, "subordinate")) {
+	/* secondary: just login */
+	if (!strcasecmp(type, "slave") || !strcasecmp(type, "secondary")) {
 		user_add_action("login");
 		return;
 	}

--- a/server/user.c
+++ b/server/user.c
@@ -318,12 +318,13 @@ int user_checkaction(const char *un, const char *pw, const char *action)
 }
 
 /* handle "upsmon manager" and "upsmon subordinate" for nicer configurations */
+/* FIXME: Protocol update needed to handle master/manager alias (in action and in protocol) */
 static void set_upsmon_type(char *type)
 {
 	/* manager: login, master, fsd */
 	if (!strcasecmp(type, "master") || !strcasecmp(type, "manager")) {
 		user_add_action("login");
-		user_add_action("master"); /* Note: this is linked to "MASTER" API command permision */
+		user_add_action("master"); /* Note: this is linked to "MASTER" API command permission */
 		user_add_action("fsd");
 		return;
 	}


### PR DESCRIPTION
This PR aims to address the bulk of the issue raised in #840.

At the moment of this posting, community discussion is underway to select the replacement terminology, so at the moment this PR serves more as a map of source locations to fix than as a final solution (unless we happen to settle on the words used here).
UPDATE: Terminology was chosen: "primary" and "secondary" modes for upsmon (and eventually possibly NUT protocol aliases)

Even then, there are some more points to consider that were not covered yet:
* documentation sources refer to images, these probably contain the terms being obsoleted and should also be updated when new ones are elected;
* currently there was no change to protocol and to ABI exposed in headers;
* for the protocol in particular, it may be possible to create a backwards compatible solution (so older upsmon's can talk to newer upsd, and older upsd can talk to newer upsmon) which would avoid a required protocol version bump and redeployment of all NUT installations to new code (can be complicated for package users);
* as a bonus, an `upsmon` built from this branch may already support both old and new terms in its configuration to test how that goes (neither built nor tested yet however). It should so far talk the old protocol on the network;
* as highlighted in "docs/history.txt: reflect that slave/master terms were deprecated" committed separately, there is (was?) a precedent using the chosen word for a different purpose: "Manager mode was added to allow changing the value of read/write variables in certain UPS models" but I did not find any related mention of this word in current codebase;
* a few documentation changes that were too cumbersome to backport into "master/slave" terminology have landed here. Most of the documentation and other changes not directly related to the obsoletion of these words for upsmon context are in PRs #989 #990 #991, to keep the change size of this one under control; minor merge conflicts of this PR with those are anticipated and will be addressed when they collide in the PR merges. UPDATE: conflicts handled :)

Note that currently this PR aims to minimally impact the active codebase, only adding the support for "primary" as alias to "master" and "secondary" as alias to "slave" in processing of upsmon configuration, to match contemporary documentation promoting the new words.

Changes to NUT protocol handling and/or public function names may come (and points to modify in code were commented among this PR's changes), but this would be handled in some other PR(s) commanding more thorough testing for unbroken communications across different releases of NUT servers and clients.