### PR TITLE
95-upower-hid.rules script updated for PowerVar USB (catch up to #733)

### DIFF
--- a/ci_build.sh
+++ b/ci_build.sh
@@ -394,6 +394,8 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
     echo "==="
     if [ -n "`git status -s`" ]; then
         echo "FATAL: There are changes in some files listed above - tracked sources should be updated in the PR, and build products should be added to a .gitignore file!" >&2
+        git diff || true
+        echo "==="
         exit 1
     fi
 

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -392,6 +392,10 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
     echo "=== Are GitIgnores good after 'make all'? (should have no output below)"
     git status -s || true
     echo "==="
+    if [ -n "`git status -s`" ]; then
+        echo "FATAL: There are changes in some files listed above - tracked sources should be updated in the PR, and build products should be added to a .gitignore file!" >&2
+        exit 1
+    fi
 
     [ -z "$CI_TIME" ] || echo "`date`: Trying to install the currently tested project into the custom DESTDIR..."
     $CI_TIME make VERBOSE=1 DESTDIR="$INST_PREFIX" install

--- a/scripts/upower/95-upower-hid.rules
+++ b/scripts/upower/95-upower-hid.rules
@@ -35,6 +35,7 @@ ATTRS{idVendor}=="09ae", ENV{UPOWER_VENDOR}="TrippLite"
 ATTRS{idVendor}=="0d9f", ENV{UPOWER_VENDOR}="PowerCOM"
 ATTRS{idVendor}=="10af", ENV{UPOWER_VENDOR}="Liebert"
 ATTRS{idVendor}=="2b2d", ENV{UPOWER_VENDOR}="AEG"
+ATTRS{idVendor}=="4234", ENV{UPOWER_VENDOR}="Powervar"
 
 # Hewlett Packard
 ATTRS{idVendor}=="03f0", ATTRS{idProduct}=="0001", ENV{UPOWER_BATTERY_TYPE}="ups"
@@ -146,5 +147,8 @@ ATTRS{idVendor}=="10af", ATTRS{idProduct}=="0008", ENV{UPOWER_BATTERY_TYPE}="ups
 
 # AEG
 ATTRS{idVendor}=="2b2d", ATTRS{idProduct}=="ffff", ENV{UPOWER_BATTERY_TYPE}="ups"
+
+# Powervar
+ATTRS{idVendor}=="4234", ATTRS{idProduct}=="0002", ENV{UPOWER_BATTERY_TYPE}="ups"
 
 LABEL="up_hid_end"

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -3,3 +3,4 @@
 /cppunittest.trs
 /test-suite.log
 /selftest-rw/*
+/nutlogtest


### PR DESCRIPTION
Signed-off-by: Degott, Francois Regis <FrancoisRegisDegott@eaton.com>

Thanks to Jeff and Arno for bringing up this oversight in CI, missing the need to update the file in source (or perhaps evict it from git and make a dist-only resident).