### PR TITLE
Obsoletion notices in Megatec/Qx legacy driver sources in favor of common nutdrv_qx core and subdrivers

### DIFF
--- a/drivers/bestups.c
+++ b/drivers/bestups.c
@@ -1,5 +1,10 @@
 /* bestups.c - model specific routines for Best-UPS Fortress models
 
+   OBSOLETION WARNING: Please to not base new development on this
+   codebase, instead create a new subdriver for nutdrv_qx which
+   generally covers all Megatec/Qx protocol family and aggregates
+   device support from such legacy drivers over time.
+
    Copyright (C) 1999  Russell Kroll <rkroll@exploits.org>
 
    ID config option by Jason White <jdwhite@jdwhite.org>

--- a/drivers/blazer.c
+++ b/drivers/blazer.c
@@ -1,6 +1,11 @@
 /*
  * blazer.c: driver core for Megatec/Q1 protocol based UPSes
  *
+ * OBSOLETION WARNING: Please to not base new development on this
+ * codebase, instead create a new subdriver for nutdrv_qx which
+ * generally covers all Megatec/Qx protocol family and aggregates
+ * device support from such legacy drivers over time.
+ *
  * A document describing the protocol implemented by this driver can be
  * found online at http://www.networkupstools.org/ups-protocols/megatec.html
  *

--- a/drivers/blazer.h
+++ b/drivers/blazer.h
@@ -1,6 +1,11 @@
 /*
  * blazer.h: defines/macros for Megatec/Q1 protocol based UPSes
  *
+ * OBSOLETION WARNING: Please to not base new development on this
+ * codebase, instead create a new subdriver for nutdrv_qx which
+ * generally covers all Megatec/Qx protocol family and aggregates
+ * device support from such legacy drivers over time.
+ *
  * A document describing the protocol implemented by this driver can be
  * found online at "http://www.networkupstools.org/protocols/megatec.html".
  *

--- a/drivers/blazer_ser.c
+++ b/drivers/blazer_ser.c
@@ -1,6 +1,11 @@
 /*
  * blazer_ser.c: support for Megatec/Q1 serial protocol based UPSes
  *
+ * OBSOLETION WARNING: Please to not base new development on this
+ * codebase, instead create a new subdriver for nutdrv_qx which
+ * generally covers all Megatec/Qx protocol family and aggregates
+ * device support from such legacy drivers over time.
+ *
  * A document describing the protocol implemented by this driver can be
  * found online at "http://www.networkupstools.org/protocols/megatec.html".
  *

--- a/drivers/blazer_usb.c
+++ b/drivers/blazer_usb.c
@@ -1,6 +1,11 @@
 /*
  * blazer_usb.c: support for Megatec/Q1 USB protocol based UPSes
  *
+ * OBSOLETION WARNING: Please to not base new development on this
+ * codebase, instead create a new subdriver for nutdrv_qx which
+ * generally covers all Megatec/Qx protocol family and aggregates
+ * device support from such legacy drivers over time.
+ *
  * A document describing the protocol implemented by this driver can be
  * found online at "http://www.networkupstools.org/protocols/megatec.html".
  *

--- a/tools/nut-usbinfo.pl
+++ b/tools/nut-usbinfo.pl
@@ -305,6 +305,12 @@ sub find_usbdevs
 			else {
 				die "Unknown driver type: $nameFile";
 			}
+			if ($vendor{$VendorID}{$ProductID}{"driver"} && $ENV{"DEBUG"}) {
+				print STDERR "nut-usbinfo.pl: VendorID=$VendorID ProductID=$ProductID " .
+					"was already related to driver '" .
+					$vendor{$VendorID}{$ProductID}{"driver"} .
+					"' and changing to '$driver'\n";
+			}
 			$vendor{$VendorID}{$ProductID}{"driver"}=$driver;
 		}
 	}


### PR DESCRIPTION
Based on a recent discussion due to PR#979, we realized it was not clear for new contributors to NUT where to add support for their new Qx devices. Unfortunately, there is little indication easy to find that some drivers are heading to end-of-life after being superseded by nutdrv_qx, with the UPGRADING document mentioning that for bestups, blazer_ser and blazer_usb.

I suppose @zykh would best explain the current situation with what other older drivers can also be tagged this way (if any), and perhaps which are not ported yet (if any). At the moment I can see drawing a graph of comments "this was copied and 75% adapted from that" so I suppose a majority of *_usb drivers may be siblings, but maybe that is just about the generic skeleton and not actual protocols and logic.

That said, I am not currently sure how even the newer drivers fit together - e.g. nutdrv_qx.c does list an "ATCL FOR UPS" as a "fuji" subdriver, but there is also a new-style `nutdrv_atcl_usb` source and binary for the same IDs... (UPDATE: although docs/man/nutdrv_atcl_usb.txt clarifies that "these USB identifiers (including the iManufacturer string) have also been seen on devices that are supported by the `fuji` subdriver of linkman:nutdrv_qx[8]" with a generic USB chip used in different devices and different ways)

And conversely, while there are 10 subdrivers listed in `subdriver_list` of `nutdrv_qx.c`, there are also several implemented directly in the file and mapped in `qx_usb_id` list... Can I assume they are a monolithic blazer legacy? Or are these two orthogonal dimensions, one for hardware related issues (commands supported, maths needed for data conversion...) vs. protocol variants (language, syntax...) as by default guessed per USB VendorID+ProductID? I see `upsdrv_initups()` tapping into both, and a comment on "USB communication subdrivers" confirming one guess...

What is a proper starting point and way to lay out code changes for new contributors then, as it got confused in #979?

Finally, just in case: is it correct to say that nutdrv_qx covers both Serial and (Serial-over-)USB connections for such devices (but e.g. not USB-HID)? Should contributors code something twice to handle both connections if that is on the market, or the shared core handles that already and they just have to interpret the higher-level protocol once?