### PR TITLE
drivers: Fix undefined references with slibtool.

### DIFF
--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -4,8 +4,8 @@
 # (libtool version of the static lib, in order to access LTLIBOBJS)
 #FIXME: SERLIBS is only useful for LDADD_DRIVERS_SERIAL not for LDADD_COMMON
 LDADD_COMMON = ../common/libcommon.la ../common/libparseconf.la
-LDADD_DRIVERS = $(LDADD_COMMON) main.o dstate.o
-LDADD_DRIVERS_SERIAL = $(LDADD_DRIVERS) $(SERLIBS) serial.o
+LDADD_DRIVERS = libdummy.la $(LDADD_COMMON)
+LDADD_DRIVERS_SERIAL = libdummy_serial.la $(LDADD_DRIVERS) $(SERLIBS)
 
 # most targets are drivers, so make this the default
 LDADD = $(LDADD_DRIVERS_SERIAL)
@@ -109,6 +109,7 @@ bcmxcp_LDADD = $(LDADD) -lm
 belkin_SOURCES = belkin.c
 belkinunv_SOURCES = belkinunv.c
 bestfcom_SOURCES = bestfcom.c
+bestfortress_SOURCES = bestfortress.c
 bestuferrups_SOURCES = bestuferrups.c
 bestups_SOURCES = bestups.c
 blazer_ser_SOURCES = blazer.c blazer_ser.c
@@ -198,7 +199,6 @@ richcomm_usb_LDADD = $(LDADD_DRIVERS) $(LIBUSB_LIBS)
 riello_usb_SOURCES = riello.c riello_usb.c libusb.c usb-common.c
 riello_usb_LDADD = $(LDADD_DRIVERS) $(LIBUSB_LIBS) -lm
 
-
 # HID-over-serial
 mge_shut_SOURCES = usbhid-ups.c libshut.c libhid.c hidparser.c mge-hid.c
 # per-target CFLAGS are necessary here
@@ -253,7 +253,7 @@ nutdrv_qx_LDADD = $(LDADD_DRIVERS) -lm
 nutdrv_qx_CFLAGS = $(AM_CFLAGS)
 if WITH_SERIAL
 nutdrv_qx_CFLAGS += -DQX_SERIAL
-nutdrv_qx_LDADD += $(SERLIBS) serial.o
+nutdrv_qx_LDADD += libdummy_serial.la $(SERLIBS)
 endif
 if WITH_USB
 nutdrv_qx_CFLAGS += -DQX_USB
@@ -291,5 +291,8 @@ dist_noinst_HEADERS = apc-mib.h apc-hid.h baytech-mib.h bcmxcp.h bcmxcp_ser.h	\
 
 # Define a dummy library so that Automake builds rules for the
 # corresponding object files.  This library is not actually built,
-EXTRA_LIBRARIES = libdummy.a
-libdummy_a_SOURCES = main.c dstate.c serial.c
+EXTRA_LTLIBRARIES = libdummy.la libdummy_serial.la
+libdummy_la_SOURCES = main.c dstate.c
+libdummy_la_LDFLAGS = -no-undefined -static
+libdummy_serial_la_SOURCES = serial.c
+libdummy_serial_la_LDFLAGS = -no-undefined -static


### PR DESCRIPTION
When building the nut drivers with slibtool (https://dev.midipix.org/cross/slibtool) it fails with the same issues in several places.
```
rdlibtool --tag=CC --mode=link gcc -I../include -I/usr/include/libusb-1.0 -g -O2 -Wall -Wsign-compare -Wno-error -o al175 al175.o ../common/libcommon.la ../common/libparseconf.la main.o dstate.o serial.o -lpthread

rdlibtool: lconf: {.name="libtool"}.
rdlibtool: fdcwd: {.fdcwd=AT_FDCWD, .realpath="/tmp/nut/drivers"}.
rdlibtool: lconf: fstatat(AT_FDCWD,".",...) = 0 {.st_dev = 45, .st_ino = 557816}.
rdlibtool: lconf: openat(AT_FDCWD,"libtool",O_RDONLY,0) = -1 [ENOENT].
rdlibtool: lconf: openat(AT_FDCWD,"../",O_DIRECTORY,0) = 3.
rdlibtool: lconf: fstat(3,...) = 0 {.st_dev = 45, .st_ino = 557467}.
rdlibtool: lconf: openat(3,"libtool",O_RDONLY,0) = 4.
rdlibtool: lconf: found "/tmp/nut/libtool".
rdlibtool: link: gcc al175.o ../common/.libs/libcommon.a ../common/.libs/libparseconf.a main.o dstate.o serial.o -I../include -I/usr/include/libusb-1.0 -g -O2 -Wall -Wsign-compare -Wno-error -lpthread -o .libs/al175
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: main.o: in function `main':
/tmp/nut/drivers/main.c:542: undefined reference to `read_upsconf'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: dstate.o: in function `sock_disconnect':
/tmp/nut/drivers/dstate.c:151: undefined reference to `pconf_finish'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/nut/drivers/dstate.c:151: undefined reference to `pconf_finish'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: dstate.o: in function `sock_read':
/tmp/nut/drivers/dstate.c:534: undefined reference to `pconf_char'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: dstate.o: in function `sock_disconnect':
/tmp/nut/drivers/dstate.c:151: undefined reference to `pconf_finish'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: dstate.o: in function `sock_connect':
/tmp/nut/drivers/dstate.c:291: undefined reference to `pconf_init'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: dstate.o: in function `dstate_setinfo':
/tmp/nut/drivers/dstate.c:718: undefined reference to `state_setinfo'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: dstate.o: in function `dstate_addenum':
/tmp/nut/drivers/dstate.c:749: undefined reference to `state_addenum'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: dstate.o: in function `dstate_setflags':
/tmp/nut/drivers/dstate.c:779: undefined reference to `state_tree_find'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: dstate.o: in function `dstate_addflags':
/tmp/nut/drivers/dstate.c:818: undefined reference to `state_getflags'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: dstate.o: in function `dstate_addrange':
/tmp/nut/drivers/dstate.c:762: undefined reference to `state_addrange'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: dstate.o: in function `dstate_delflags':
/tmp/nut/drivers/dstate.c:836: undefined reference to `state_getflags'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: dstate.o: in function `dstate_setaux':
/tmp/nut/drivers/dstate.c:857: undefined reference to `state_tree_find'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: dstate.o: in function `dstate_addcmd':
/tmp/nut/drivers/dstate.c:883: undefined reference to `state_addcmd'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: dstate.o: in function `dstate_delinfo':
/tmp/nut/drivers/dstate.c:895: undefined reference to `state_delinfo'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: dstate.o: in function `dstate_delenum':
/tmp/nut/drivers/dstate.c:909: undefined reference to `state_delenum'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: dstate.o: in function `dstate_delrange':
/tmp/nut/drivers/dstate.c:923: undefined reference to `state_delrange'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: dstate.o: in function `dstate_delcmd':
/tmp/nut/drivers/dstate.c:937: undefined reference to `state_delcmd'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: dstate.o: in function `dstate_free':
/tmp/nut/drivers/dstate.c:949: undefined reference to `state_infofree'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/nut/drivers/dstate.c:952: undefined reference to `state_cmdfree'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: dstate.o: in function `sock_disconnect':
/tmp/nut/drivers/dstate.c:151: undefined reference to `pconf_finish'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: dstate.o: in function `dstate_getinfo':
/tmp/nut/drivers/dstate.c:876: undefined reference to `state_getinfo'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/nut/drivers/dstate.c:876: undefined reference to `state_getinfo'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/nut/drivers/dstate.c:876: undefined reference to `state_getinfo'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/nut/drivers/dstate.c:876: undefined reference to `state_getinfo'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/nut/drivers/dstate.c:876: undefined reference to `state_getinfo'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: dstate.o: in function `dstate_delinfo':
/tmp/nut/drivers/dstate.c:895: undefined reference to `state_delinfo'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/nut/drivers/dstate.c:895: undefined reference to `state_delinfo'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: dstate.o: in function `dstate_getinfo':
/tmp/nut/drivers/dstate.c:876: undefined reference to `state_getinfo'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/nut/drivers/dstate.c:876: undefined reference to `state_getinfo'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/nut/drivers/dstate.c:876: undefined reference to `state_getinfo'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/nut/drivers/dstate.c:876: undefined reference to `state_getinfo'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/nut/drivers/dstate.c:876: undefined reference to `state_getinfo'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: dstate.o:/tmp/nut/drivers/dstate.c:876: more undefined references to `state_getinfo' follow
collect2: error: ld returned 1 exit status
rdlibtool: exec error upon slbt_exec_link_create_executable(), line 1614: (see child process error messages).
rdlibtool: < returned to > slbt_exec_link(), line 1934.
make[1]: *** [Makefile:1269: al175] Error 2
make[1]: Leaving directory '/tmp/nut/drivers'
make: *** [Makefile:550: install-recursive] Error 1
```
This is because of two reasons.

1. The build is linking directly the `main.o`, `dstate.o` and `serial.o` object files which does not work as reliably as creating the corresponding `.la` files and linking with those.
2. ~~`$(LDADD_COMMON)` is missing from many of the driver's `LDADD` resulting in undefined references. In a few cases just adding `libcommon.la` was enough.~~

GNU libtool is far more permissive and hides these issues...

Also please see this downstream issue: https://bugs.gentoo.org/778584