### PR TITLE
configure.ac: avoid syntax errors if pkg-config is not installed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,7 @@ AC_PATH_PROG(dummy_PKG_CONFIG, pkg-config)
 AS_IF([test x"$dummy_PKG_CONFIG" = xno || test -z "$dummy_PKG_CONFIG"],
     [have_PKG_CONFIG=no],
     [AC_MSG_NOTICE([checking for autoconf macro support of pkg-config])
+     have_PKG_CONFIG=no
      dummy_RES=0
      ifdef([PKG_PROG_PKG_CONFIG], [], [dummy_RES=1])
      ifdef([PKG_CHECK_MODULES], [], [dummy_RES=2])
@@ -41,10 +42,12 @@ AS_IF([test x"$dummy_PKG_CONFIG" = xno || test -z "$dummy_PKG_CONFIG"],
         [AC_MSG_NOTICE([checking for autoconf macro support of pkg-config module checker])
          dnl The m4 macro below may be not defined if pkg-config package is not
          dnl installed. Use of ifdef (here and below for e.g. CPPUNIT check)
-         dnl allows to avoid shell syntax errors in generated configure script.
-         ifdef([PKG_CHECK_MODULES], [PKG_CHECK_MODULES ([dummy_PKG_CONFIG], [pkg-config], [have_PKG_CONFIG=yes], [have_PKG_CONFIG=no])], [have_PKG_CONFIG=no])
-        ], [have_PKG_CONFIG=no])]
-)
+         dnl allows to avoid shell syntax errors in generated configure script
+         dnl by defining a dummy macro in-place.
+         ifdef([PKG_CHECK_MODULES], [], [AC_DEFUN([PKG_CHECK_MODULES], [false])])
+         PKG_CHECK_MODULES([dummy_PKG_CONFIG], [pkg-config], [have_PKG_CONFIG=yes])
+        ])
+])
 AS_IF([test x"$have_PKG_CONFIG" = xno],
     [AC_MSG_WARN([pkg-config is needed to look for further dependencies (will be skipped)])])
 

--- a/configure.ac
+++ b/configure.ac
@@ -34,12 +34,15 @@ AC_PATH_PROG(dummy_PKG_CONFIG, pkg-config)
 AS_IF([test x"$dummy_PKG_CONFIG" = xno || test -z "$dummy_PKG_CONFIG"],
     [have_PKG_CONFIG=no],
     [AC_MSG_NOTICE([checking for autoconf macro support of pkg-config])
-     PKG_PROG_PKG_CONFIG
-     dummy_RES=$?
-     AS_IF([test $dummy_RES = 0],
+     dummy_RES=0
+     ifdef([PKG_PROG_PKG_CONFIG], [], [dummy_RES=1])
+     ifdef([PKG_CHECK_MODULES], [], [dummy_RES=2])
+     AS_IF([test "${dummy_RES}" = 0],
         [AC_MSG_NOTICE([checking for autoconf macro support of pkg-config module checker])
-         PKG_CHECK_MODULES([dummy_PKG_CONFIG], [pkg-config],
-            [], [have_PKG_CONFIG=no])
+         dnl The m4 macro below may be not defined if pkg-config package is not
+         dnl installed. Use of ifdef (here and below for e.g. CPPUNIT check)
+         dnl allows to avoid shell syntax errors in generated configure script.
+         ifdef([PKG_CHECK_MODULES], [PKG_CHECK_MODULES ([dummy_PKG_CONFIG], [pkg-config], [have_PKG_CONFIG=yes], [have_PKG_CONFIG=no])], [have_PKG_CONFIG=no])
         ], [have_PKG_CONFIG=no])]
 )
 AS_IF([test x"$have_PKG_CONFIG" = xno],
@@ -1530,7 +1533,7 @@ have_cppunit="no"
 CPPUNIT_NUT_CXXFLAGS=""
 AS_IF([test x"$have_PKG_CONFIG" = xyes],
     [AS_IF([test x"${have_cxx11}" = xyes],
-        [PKG_CHECK_MODULES(CPPUNIT, cppunit, have_cppunit=yes, have_cppunit=no)
+        [ifdef([PKG_CHECK_MODULES], [PKG_CHECK_MODULES(CPPUNIT, cppunit, have_cppunit=yes, have_cppunit=no)], [have_cppunit=no])
          AS_IF([test "${have_cppunit}" != "yes"],
             [AC_MSG_WARN([libcppunit not found - those C++ tests will not be built.])
              have_cppunit=no],


### PR DESCRIPTION
...Then m4 macros we use are not defined, so autotools pastes their lines verbatim and shell syntax is botched. Luckily it has `ifdef` macro just for such cases.