### PR TITLE
clients/nutclient.{h,cpp}: explicitly request copy constructor generation…

### DIFF
--- a/clients/nutclient.cpp
+++ b/clients/nutclient.cpp
@@ -98,7 +98,13 @@ std::string SystemException::err()
 	}
 }
 
-/* Implemented out-of-line to avoid "Weak vtables" warnings and related overheads */
+/* Implemented out-of-line to avoid "Weak vtables" warnings and related overheads
+ * But now with clang-9 C++11 linter (though not C++17) they complain with
+ *   error: definition of implicit copy constructor for 'NutException'
+ *          is deprecated because it has a user-declared destructor
+ * This is fixed in header with declarations like:
+ *   NutException(const NutException&) = default;
+ */
 NutException::~NutException() {}
 SystemException::~SystemException() {}
 IOException::~IOException() {}

--- a/clients/nutclient.cpp
+++ b/clients/nutclient.cpp
@@ -104,6 +104,9 @@ std::string SystemException::err()
  *          is deprecated because it has a user-declared destructor
  * This is fixed in header with declarations like:
  *   NutException(const NutException&) = default;
+ * and assignment operator to accompany the copy constructor, per
+ * https://lgtm.com/rules/2165180572/ like:
+ *   NutException& operator=(NutException& rhs) = default;
  */
 NutException::~NutException() {}
 SystemException::~SystemException() {}

--- a/clients/nutclient.h
+++ b/clients/nutclient.h
@@ -51,6 +51,7 @@ class NutException : public std::exception
 {
 public:
 	NutException(const std::string& msg):_msg(msg){}
+	NutException(const NutException&) = default;
 	virtual ~NutException();
 	virtual const char * what() const noexcept {return this->_msg.c_str();}
 	virtual std::string str() const noexcept {return this->_msg;}
@@ -65,6 +66,7 @@ class SystemException : public NutException
 {
 public:
 	SystemException();
+	SystemException(const SystemException&) = default;
 	virtual ~SystemException();
 private:
 	static std::string err();
@@ -78,6 +80,7 @@ class IOException : public NutException
 {
 public:
 	IOException(const std::string& msg):NutException(msg){}
+	IOException(const IOException&) = default;
 	virtual ~IOException();
 };
 
@@ -88,6 +91,7 @@ class UnknownHostException : public IOException
 {
 public:
 	UnknownHostException():IOException("Unknown host"){}
+	UnknownHostException(const UnknownHostException&) = default;
 	virtual ~UnknownHostException();
 };
 
@@ -98,6 +102,7 @@ class NotConnectedException : public IOException
 {
 public:
 	NotConnectedException():IOException("Not connected"){}
+	NotConnectedException(const NotConnectedException&) = default;
 	virtual ~NotConnectedException();
 };
 
@@ -108,6 +113,7 @@ class TimeoutException : public IOException
 {
 public:
 	TimeoutException():IOException("Timeout"){}
+	TimeoutException(const TimeoutException&) = default;
 	virtual ~TimeoutException();
 };
 

--- a/clients/nutclient.h
+++ b/clients/nutclient.h
@@ -52,6 +52,7 @@ class NutException : public std::exception
 public:
 	NutException(const std::string& msg):_msg(msg){}
 	NutException(const NutException&) = default;
+    NutException& operator=(NutException& rhs) = default;
 	virtual ~NutException();
 	virtual const char * what() const noexcept {return this->_msg.c_str();}
 	virtual std::string str() const noexcept {return this->_msg;}
@@ -67,6 +68,7 @@ class SystemException : public NutException
 public:
 	SystemException();
 	SystemException(const SystemException&) = default;
+    SystemException& operator=(SystemException& rhs) = default;
 	virtual ~SystemException();
 private:
 	static std::string err();
@@ -81,6 +83,7 @@ class IOException : public NutException
 public:
 	IOException(const std::string& msg):NutException(msg){}
 	IOException(const IOException&) = default;
+    IOException& operator=(IOException& rhs) = default;
 	virtual ~IOException();
 };
 
@@ -92,6 +95,7 @@ class UnknownHostException : public IOException
 public:
 	UnknownHostException():IOException("Unknown host"){}
 	UnknownHostException(const UnknownHostException&) = default;
+    UnknownHostException& operator=(UnknownHostException& rhs) = default;
 	virtual ~UnknownHostException();
 };
 
@@ -103,6 +107,7 @@ class NotConnectedException : public IOException
 public:
 	NotConnectedException():IOException("Not connected"){}
 	NotConnectedException(const NotConnectedException&) = default;
+    NotConnectedException& operator=(NotConnectedException& rhs) = default;
 	virtual ~NotConnectedException();
 };
 
@@ -114,6 +119,7 @@ class TimeoutException : public IOException
 public:
 	TimeoutException():IOException("Timeout"){}
 	TimeoutException(const TimeoutException&) = default;
+    TimeoutException& operator=(TimeoutException& rhs) = default;
 	virtual ~TimeoutException();
 };
 


### PR DESCRIPTION
…for exception classes

Balancing the compiler warnings seen in some test cases. Follows up from effort at #823.