### PR TITLE
docs/nut-names.txt: reword the intro paragraphs and define the "experimental.*" namespace

### DIFF
--- a/docs/nut-names.txt
+++ b/docs/nut-names.txt
@@ -3,6 +3,20 @@ NUT variable names and instant commands
 =======================================
 endif::external_title[]
 
+[NOTE]
+.RFC xxxx Recording Document
+====
+This document is defined by (pending) RFC xxxx and is referenced as the
+document of record for the variable names and the instant commands used
+in the protocol described by the RFC.
+
+On behalf of the RFC, this document records the names of variables
+describing the abstracted state of an UPS or similar power distribution
+device, and the instant commands sent to the UPS using command `INSTCMD`,
+as used in commands and messages between the Attachment Daemon (the `upsd`
+in case of NUT implementation of the standard) and the clients.
+====
+
 This document defines the standard names of NUT commands and variables.
 Developers should use the names recorded here, with dstate functions and
 data mappings provided in NUT drivers for interactions with power devices.

--- a/docs/nut-names.txt
+++ b/docs/nut-names.txt
@@ -1,21 +1,30 @@
 ifndef::external_title[]
-NUT command and variable naming scheme
-======================================
+NUT variable names and instant commands
+=======================================
 endif::external_title[]
 
-This is a dump of the standard variables and command names used in NUT.
-Don't use a name with any of the dstate functions unless it exists here.
+This document defines the standard names of NUT commands and variables.
+Developers should use the names recorded here, with dstate functions and
+data mappings provided in NUT drivers for interactions with power devices.
 
-If you need a new variable or command name, contact the Development Team
-first.
+If you need to express a state which cannot be described by any existing
+name, please make a request to the NUT developers' mailing list for
+definition and assignment of a new name.  Clients using unrecorded names
+risk breaking at a future update.  If you wish to experiment with new
+concepts before obtaining your requested variable name, you should use
+a name of the form `experimental.x.y` for those states.
 
-Put another way: if you make up a name that's not in this list and it
-gets into the tree, and then we come up with a better name later, clients
-that use the undocumented variable will break when it is changed.
+Put another way: if you make up a name that is not in this list and it
+gets into the source code tree, and then the NUT community comes up with
+a better name later, clients that already use the undocumented variable
+will break when it is eventually changed.  An explicitly "experimental"
+data point is less surprising in this regard.
 
-NOTE: "opaque" means programs should not attempt to parse the value for
-that variable as it may vary greatly from one UPS to the next. These
-strings are best handled directly by the user.
+NOTE: In the descriptions, "opaque" means programs should not attempt to
+parse the value for that variable as it may vary greatly from one UPS
+(or similar device) to the next.  These strings are best handled directly
+by the user.
+
 
 Variables
 ---------


### PR DESCRIPTION
Credit goes to Roger Price @NUT-RogerPrice for providing the wording for most of the changes.

https://alioth-lists.debian.net/pipermail/nut-upsdev/2021-May/007553.html