### PR TITLE
Opti-UPS PS1500E is supported by blazer_usb

### DIFF
--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -804,6 +804,7 @@
 
 "Opti-UPS"	"ups"	"1"	"PowerES"	"420E"	"optiups"
 "Opti-UPS"	"ups"	"1"	"VS 575C"	"type=OPTI"	"powercom"
+"Opti-UPS"	"ups"	"1"	"Power Series"	"PS1500E"	"blazer_usb"
 
 "Orvaldi Power Protection"	"ups"	"2"	"various"	"not 400 or 600"	"blazer_ser"
 "Orvaldi Power Protection"	"ups"	"2"	"750 / 900SP"	""	"blazer_usb"


### PR DESCRIPTION
Opti-UPS PS1500E connects via serial over USB, and is supported
by the blazer_usb driver. This patch updates the compatibility list.

Manufacturer link: https://www.opti-ups.com/index.asp?SCID=SC20060001

Device is automatically detected by nut-scanner
> [nutdev1]
>	driver = "blazer_usb"
>	port = "auto"
>	vendorid = "0665"
>	productid = "5161"
>	bus = "001"

OB status is correctly detected, and other correct values
are displayed when queried:
```
battery.charge: 100
battery.voltage: 27.60
battery.voltage.high: 26.00
battery.voltage.low: 20.80
battery.voltage.nominal: 24.0
device.mfr:
device.model: 1500VA
device.type: ups
driver.name: blazer_usb
driver.parameter.bus: 001
driver.parameter.pollinterval: 2
driver.parameter.port: auto
driver.parameter.productid: 5161
driver.parameter.synchronous: no
driver.parameter.vendorid: 0665
driver.version: 2.7.4
driver.version.internal: 0.12
input.current.nominal: 13.0
input.frequency: 60.0
input.frequency.nominal: 60
input.voltage: 113.9
input.voltage.fault: 111.4
input.voltage.nominal: 110
output.voltage: 113.3
ups.beeper.status: enabled
ups.delay.shutdown: 30
ups.delay.start: 180
ups.firmware:
ups.load: 2
ups.mfr:
ups.model: 1500VA
ups.productid: 5161
ups.status: OL
ups.type: offline / line interactive
ups.vendorid: 0665
```