### PR TITLE
RFC: clarify and complete battery dates

### DIFF
--- a/docs/nut-names.txt
+++ b/docs/nut-names.txt
@@ -403,7 +403,10 @@ battery: Any battery details
 | battery.runtime.restart      | Minimum battery runtime for UPS
                                  restart after power-off (seconds)   | 120
 | battery.alarm.threshold      | Battery alarm threshold             | 0 (immediate)
-| battery.date                 | Battery change date (opaque string) | 11/14/00
+| battery.date                 | Battery installation or last change
+                                 date (opaque string)                | 11/14/20
+| battery.date.maintenance     | Battery next change or maintenance
+                                 date (opaque string)                | 11/13/24
 | battery.mfr.date             | Battery manufacturing date
                                  (opaque string)                     | 2005/04/02
 | battery.packs                | Number of battery packs             | 001


### PR DESCRIPTION
The existing battery.date means the installation or last
replacement date, as it seems to be implemented by various
drivers.

Add an additional battery.date.maintenance for the next
replacement or maintenance date

Signed-off-by: Arnaud Quette <ArnaudQuette@eaton.com>