### PR TITLE
ci_build.sh: work around handling cppunit and libgd/cgi faults on NUT CI farm agents

### DIFF
--- a/ci_build.sh
+++ b/ci_build.sh
@@ -92,8 +92,8 @@ if [ -z "${CANBUILD_LIBGD_CGI-}" ]; then
     [[ "$CI_OS_NAME" = "windows" ]] && CANBUILD_LIBGD_CGI=no
 
     # NUT CI farm with Jenkins can build it; Travis could not
-    #[[ "$CI_OS_NAME" = "freebsd" ]] && CANBUILD_LIBGD_CGI=no
-    [[ "$TRAVIS_OS_NAME" = "freebsd" ]] && CANBUILD_LIBGD_CGI=no
+    [[ "$CI_OS_NAME" = "freebsd" ]] && CANBUILD_LIBGD_CGI=yes \
+    || [[ "$TRAVIS_OS_NAME" = "freebsd" ]] && CANBUILD_LIBGD_CGI=no
 fi
 
 configure_nut() {

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -264,7 +264,7 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
     || ( [ "${CANBUILD_CPPUNIT_TESTS-}" = "no-clang" ] && [ "$COMPILER_FAMILY" = "CLANG" ] ) \
     ; then
         echo "WARNING: Build agent says it can't build or run libcppunit tests, adding configure option to skip them" >&2
-        CONFIG_OPTS+=("--with-cppunit=no")
+        CONFIG_OPTS+=("--enable-cppunit=no")
     fi
 
     DO_DISTCHECK=yes

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -246,6 +246,11 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
             # configure-time checks of libgd; newer compilers fare okay.
             # Feel free to revise this if the distro packages are fixed
             # (or the way configure script and further build uses them).
+            # UPDATE: Per https://github.com/networkupstools/nut/pull/1089
+            # This is a systems issue (in current OpenIndiana 2021.04 built
+            # with a newer GCC version, the older GCC is not ABI compatible
+            # with the libgd shared object file). Maybe this warrants later
+            # caring about not just the CI_OS_NAME but also CI_OS_RELEASE...
             if [[ "$COMPILER_FAMILY" = "GCC" ]]; then
                 case "`LANG=C $CC --version | head -1`" in
                     *[\ -][01234].*)

--- a/configure.ac
+++ b/configure.ac
@@ -1583,6 +1583,57 @@ AS_IF([test x"$have_PKG_CONFIG" = xyes],
 )
 AC_MSG_RESULT(${have_cppunit})
 
+AS_IF([test "${have_cppunit}" = "yes"],
+    [AC_MSG_CHECKING([if current toolkit can build and run cppunit tests (e.g. no ABI issues, related segfaults, etc.)])
+     dnl Code below is largely a stripped variant of our tests/example.cpp and cpputest.cpp
+     CPLUSPLUS_DECL='
+#include <stdexcept>
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/CompilerOutputter.h>
+#include <cppunit/extensions/TestFactoryRegistry.h>
+#include <cppunit/ui/text/TestRunner.h>
+
+class ExampleTest : public CppUnit::TestFixture
+{
+  CPPUNIT_TEST_SUITE( ExampleTest );
+    CPPUNIT_TEST( testOne );
+  CPPUNIT_TEST_SUITE_END();
+public:
+  void setUp() {};
+  void tearDown() {};
+  void testOne();
+};
+CPPUNIT_TEST_SUITE_REGISTRATION( ExampleTest );
+void ExampleTest::testOne()
+{
+  int i = 1;
+  float f = 1.0;
+  int cast = static_cast<int>(f);
+  CPPUNIT_ASSERT_EQUAL_MESSAGE("Casted float is not the expected int", i, cast );
+}
+'
+
+     CPLUSPLUS_MAIN='
+CppUnit::Test *suite = CppUnit::TestFactoryRegistry::getRegistry().makeTest();
+CppUnit::TextUi::TestRunner runner;
+runner.addTest( suite );
+runner.setOutputter( new CppUnit::CompilerOutputter( &runner.result(), std::cerr ) );
+bool res = runner.run();
+return res ? 0 : 1;
+'
+
+     my_CXXFLAGS="$CXXFLAGS"
+     CXXFLAGS="$myCXXFLAGS $pkg_cv_CPPUNIT_CFLAGS $pkg_cv_CPPUNIT_LIBS"
+     AC_LANG_PUSH([C++])
+     AC_RUN_IFELSE([AC_LANG_PROGRAM([[${CPLUSPLUS_DECL}]], [[${CPLUSPLUS_MAIN}]])],
+        [have_cppunit=yes], [have_cppunit=no])
+     CXXFLAGS="$my_CXXFLAGS"
+     AC_LANG_POP([C++])
+     unset CPLUSPLUS_MAIN
+     unset CPLUSPLUS_DECL
+     ])
+AC_MSG_RESULT(${have_cppunit})
+
 dnl # By default keep the originally detected have_cppunit value
 AC_MSG_CHECKING(for impact from --enable-cppunit option - should we build cppunit tests?)
 AC_ARG_ENABLE(cppunit,

--- a/tests/cpputest.cpp
+++ b/tests/cpputest.cpp
@@ -20,15 +20,30 @@
 */
 
 #include <stdexcept>
+#include <cppunit/TestResult.h>
 #include <cppunit/CompilerOutputter.h>
+#include <cppunit/TextTestProgressListener.h>
 #include <cppunit/extensions/TestFactoryRegistry.h>
 #include <cppunit/ui/text/TestRunner.h>
 #include "common.h"
 
+// Inspired by https://stackoverflow.com/a/66702001
+class MyCustomProgressTestListener : public CppUnit::TextTestProgressListener {
+  public:
+    virtual void startTest(CppUnit::Test *test) {
+      //fprintf(stderr, "starting test %s\n", test->getName().c_str());
+      std::cerr << "starting test " << test->getName() << std::endl;
+    }
+};
+
 int main(int argc, char* argv[])
 {
-  NUT_UNUSED_VARIABLE(argc);
-  NUT_UNUSED_VARIABLE(argv);
+  bool verbose = false;
+  if (argc > 1) {
+    if (strcmp("-v", argv[1]) == 0 || strcmp("--verbose", argv[1]) == 0 ) {
+      verbose = true;
+    }
+  }
 
   /* Get the top level suite from the registry */
   std::cerr << "D: Getting test suite..." << std::endl;
@@ -43,6 +58,13 @@ int main(int argc, char* argv[])
   std::cerr << "D: Setting test runner outputter..." << std::endl;
   runner.setOutputter( new CppUnit::CompilerOutputter( &runner.result(),
                                                        std::cerr ) );
+
+  if (verbose) {
+    /* Add a listener to report test names */
+    std::cerr << "D: Setting test runner listener for test names..." << std::endl;
+    MyCustomProgressTestListener progress;
+    runner.eventManager().addListener(&progress);
+  }
 
   /* Run the tests. */
   bool wasSucessful = false;


### PR DESCRIPTION
For the first shot, this disables their use in build scenarios known to fail for some systemic reasons.

Next shot, if possible, would be to fix these situation (maybe in NUT, maybe in distro):
* FreeBSD with GCC fails to link cppunit based tests; passes okay with CLANG
* OpenIndiana fails with cppunit (segfaults with GCC)
* OpenIndiana fails libgd => CGI detection in configure script when using gcc-4.9 and gcc-4.4.4-il with either bitness; okay in other GCC and CLANG versions

For cppunit, possibly some shared library should be linked; differences of GCC vs CLANG imply some ABI mismatch though? In any case, a more proper solution would be for configure script to detect if it can build and run a trivial test, not for CI systems to set up exclusions.

For libgd and gcc-4.x, more log digging is needed.