### PR TITLE
Jenkinsfile-dynamatrix: reduce the amount of build combos by careful use of dynamatrixAxesCommonEnv

### DIFF
--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -72,7 +72,7 @@ import org.nut.dynamatrix.*;
     dynacfgBase['commonLabelExpr'] = 'nut-builder'
     dynacfgBase['dynamatrixAxesLabels'] = //[~/^OS_.+/]
         ['OS_FAMILY', 'OS_DISTRO', '${COMPILER}VER', 'ARCH${ARCH_BITS}']
-    dynacfgBase['dynamatrixAxesCommonEnv'] = [ ['LANG=C', 'TZ=UTC'] ]
+    dynacfgBase['dynamatrixAxesCommonEnv'] = [ ['LANG=C', 'LC_ALL=C', 'TZ=UTC'] ]
 
     dynacfgPipeline.stashnameSrc = 'nut-ci-src'
 
@@ -198,10 +198,10 @@ set | sort -n """
                     'CSTDVARIANT': ['gnu']
                     ],
 
-                mergeMode: [ 'dynamatrixAxesVirtualLabelsMap': 'replace', 'excludeCombos': 'merge' ],
+                mergeMode: [ 'dynamatrixAxesVirtualLabelsMap': 'replace', 'excludeCombos': 'merge', 'dynamatrixAxesCommonEnv': 'replace' ],
                 dynamatrixAxesCommonEnv: [
-                    //['LANG=C','LC_ALL=C'], [ 'CFLAGS=-Wall\\ -Wextra\\ -Werror', 'CXXFLAGS=-Wall\\ -Wextra\\ -Werror']
-                    ['LANG=C','LC_ALL=C'], [ 'CFLAGS=-Wall', 'CXXFLAGS=-Wall']
+                    //['LANG=C','LC_ALL=C','TZ=UTC', 'CFLAGS=-Wall\\ -Wextra\\ -Werror', 'CXXFLAGS=-Wall\\ -Wextra\\ -Werror']
+                    ['LANG=C','LC_ALL=C','TZ=UTC', 'CFLAGS=-Wall', 'CXXFLAGS=-Wall']
                 ],
                 allowedFailure: [ [~/OS_FAMILY=windows/], [~/CSTDVARIANT=c/], [~/C.*FLAGS=.+Werror/] ],
                 runAllowedFailure: true,
@@ -230,11 +230,13 @@ set | sort -n """
                     // BUILD_TYPE=default-tgt:distcheck-light + NO_PKG_CONFIG=true
                     ],
                 dynamatrixAxesCommonEnv: [
-                    ['LANG=C','LC_ALL=C'], //'BUILD_WARNFATAL=yes','BUILD_WARNOPT=hard']
+                    ['LANG=C','LC_ALL=C','TZ=UTC'
+                     //,'BUILD_WARNFATAL=yes','BUILD_WARNOPT=hard'
+                    ]
                 ],
                 allowedFailure: [ [~/OS_FAMILY=windows/] ],
                 runAllowedFailure: true,
-                mergeMode: [ 'excludeCombos': 'merge' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
+                mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
                 // So far allow-failure (or avoid C++11 +) on OpenIndiana (cppcheck pkg seems flawed, at least in various versions of GCC builds) and BSD (also just for GCC)
                 excludeCombos: [ [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/], [~/CSTDVARIANT=c/], [~/OS_DISTRO=(openindiana|freebsd).*/, ~/CSTDVERSION_cxx=[12].+/, ~/COMPILER=GCC/] ]
                 ], body)
@@ -259,12 +261,14 @@ set | sort -n """
                     'BUILD_TYPE': ['default-alldrv']
                     ],
                 dynamatrixAxesCommonEnv: [
-                    ['LANG=C','LC_ALL=C'], //'BUILD_WARNFATAL=yes','BUILD_WARNOPT=hard']
+                    ['LANG=C','LC_ALL=C','TZ=UTC'
+                     //,'BUILD_WARNFATAL=yes','BUILD_WARNOPT=hard'
+                    ]
                 ],
                 // On some systems, pkg-config for net-snmp includes CFLAGS values not supported by gcc-4.9 and older
                 allowedFailure: [ [~/OS_FAMILY=windows/], [~/GCCVER=[01234].+/, ~/BUILD_TYPE=default-alldrv/] ],
                 runAllowedFailure: true,
-                mergeMode: [ 'excludeCombos': 'merge' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
+                mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
                 excludeCombos: [ [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/], [~/CSTDVARIANT=c/] ] //, [~/OS_DISTRO=openindiana/] ]
                 ], body)
             }, // getParStages
@@ -288,12 +292,14 @@ set | sort -n """
                     'BUILD_TYPE': ['default-alldrv']
                     ],
                 dynamatrixAxesCommonEnv: [
-                    ['LANG=C','LC_ALL=C', 'BUILD_WARNFATAL=yes','BUILD_WARNOPT=hard']
+                    ['LANG=C','LC_ALL=C','TZ=UTC',
+                     'BUILD_WARNFATAL=yes','BUILD_WARNOPT=hard'
+                    ]
                 ],
                 // On some systems, pkg-config for net-snmp includes CFLAGS values not supported by gcc-4.9 and older
                 allowedFailure: [ [~/OS_FAMILY=windows/], [~/BUILD_WARNOPT=hard/], [~/GCCVER=[01234].+/, ~/BUILD_TYPE=default-alldrv/] ],
                 runAllowedFailure: true,
-                mergeMode: [ 'excludeCombos': 'merge' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
+                mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
                 excludeCombos: [ [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/], [~/CSTDVARIANT=c/], [~/OS_DISTRO=(openindiana|freebsd).*/, ~/CSTDVERSION_cxx=[12].+/, ~/COMPILER=GCC/] ]
                 ], body)
             }, // getParStages
@@ -318,11 +324,13 @@ set | sort -n """
                     'BUILD_TYPE': ['default-withdoc']
                     ],
                 dynamatrixAxesCommonEnv: [
-                    ['LANG=C','LC_ALL=C', 'BUILD_WARNFATAL=no','BUILD_WARNOPT=minimal']
+                    ['LANG=C','LC_ALL=C','TZ=UTC',
+                     'BUILD_WARNFATAL=no','BUILD_WARNOPT=minimal'
+                    ]
                 ],
                 allowedFailure: [ [~/OS_FAMILY=windows/] ],
                 runAllowedFailure: true,
-                mergeMode: [ 'excludeCombos': 'merge' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
+                mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
                 excludeCombos: [ [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/], [~/CSTDVARIANT=c/], [~/OS_DISTRO=(openindiana|freebsd).*/, ~/CSTDVERSION_cxx=[12].+/, ~/COMPILER=GCC/] ]
                 ], body)
             }, // getParStages
@@ -347,11 +355,13 @@ set | sort -n """
                     'BUILD_TYPE': ['default-withdoc:man']
                     ],
                 dynamatrixAxesCommonEnv: [
-                    ['LANG=C','LC_ALL=C', 'BUILD_WARNFATAL=no','BUILD_WARNOPT=minimal']
+                    ['LANG=C','LC_ALL=C','TZ=UTC',
+                     'BUILD_WARNFATAL=no','BUILD_WARNOPT=minimal'
+                    ]
                 ],
                 allowedFailure: [ [~/OS_FAMILY=windows/], [~/BUILD_TYPE=default-withdoc:man/] ],
                 runAllowedFailure: true,
-                mergeMode: [ 'excludeCombos': 'merge' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
+                mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
                 excludeCombos: [ [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/], [~/CSTDVARIANT=c/], [~/OS_DISTRO=(openindiana|freebsd).*/, ~/CSTDVERSION_cxx=[12].+/, ~/COMPILER=GCC/] ]
                 ], body)
             }, // getParStages
@@ -373,11 +383,14 @@ set | sort -n """
                     'CSTDVARIANT': ['gnu'],
                     ],
                 dynamatrixAxesCommonEnv: [
-                    ['LANG=C','LC_ALL=C', 'BUILD_TYPE=default-all-errors', 'BUILD_WARNFATAL=no','BUILD_WARNOPT=auto']
+                    ['LANG=C','LC_ALL=C','TZ=UTC',
+                     'BUILD_TYPE=default-all-errors',
+                     'BUILD_WARNFATAL=no','BUILD_WARNOPT=auto'
+                    ]
                 ],
                 allowedFailure: [ [~/OS_FAMILY=windows/] ],
                 runAllowedFailure: true,
-                mergeMode: [ 'excludeCombos': 'merge' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
+                mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
                 excludeCombos: [ [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/], [~/CSTDVARIANT=c/], [~/OS_DISTRO=(openindiana|freebsd).*/, ~/CSTDVERSION_cxx=[12].+/, ~/COMPILER=GCC/] ]
                 ], body)
             }, // getParStages
@@ -399,11 +412,14 @@ set | sort -n """
                     'CSTDVARIANT': ['gnu'],
                     ],
                 dynamatrixAxesCommonEnv: [
-                    ['LANG=C','LC_ALL=C', 'BUILD_TYPE=default-all-errors', 'BUILD_WARNFATAL=yes','BUILD_WARNOPT=hard']
+                    ['LANG=C','LC_ALL=C','TZ=UTC',
+                     'BUILD_TYPE=default-all-errors',
+                     'BUILD_WARNFATAL=yes','BUILD_WARNOPT=hard'
+                    ]
                 ],
                 allowedFailure: [ [~/OS_FAMILY=windows/], [~/BUILD_WARNOPT=hard/] ],
                 runAllowedFailure: true,
-                mergeMode: [ 'excludeCombos': 'merge' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
+                mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
                 excludeCombos: [
                     [~/BITS=32/, ~/ARCH_BITS=64/],
                     [~/BITS=64/, ~/ARCH_BITS=32/],
@@ -431,11 +447,14 @@ set | sort -n """
                     'CSTDVARIANT': ['gnu'],
                     ],
                 dynamatrixAxesCommonEnv: [
-                    ['LANG=C','LC_ALL=C', 'BUILD_TYPE=default-all-errors', 'BUILD_WARNFATAL=yes','BUILD_WARNOPT=hard']
+                    ['LANG=C','LC_ALL=C','TZ=UTC',
+                     'BUILD_TYPE=default-all-errors',
+                     'BUILD_WARNFATAL=yes','BUILD_WARNOPT=hard'
+                    ]
                 ],
                 allowedFailure: [ [~/OS_FAMILY=windows/] ],
                 runAllowedFailure: true,
-                mergeMode: [ 'excludeCombos': 'merge' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
+                mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
                 excludeCombos: [ [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/], [~/CSTDVARIANT=c/],
                     [~/COMPILER=(?!GCC)/],
                     [~/OS_DISTRO=(openindiana|freebsd).*/, ~/CSTDVERSION_cxx=[12].+/, ~/COMPILER=GCC/]
@@ -461,12 +480,12 @@ set | sort -n """
                     ],
                 dynamatrixAxesCommonEnv: [],
                 dynamatrixAxesCommonEnvCartesian: [
-                    ['LANG=C','LC_ALL=C', 'BUILD_TYPE=default-all-errors'],
+                    ['LANG=C','LC_ALL=C','TZ=UTC', 'BUILD_TYPE=default-all-errors'],
                     [ ['BUILD_WARNFATAL=yes','BUILD_WARNOPT=hard'], ['BUILD_WARNFATAL=no','BUILD_WARNOPT=minimal'] ]
                 ],
                 allowedFailure: [ [~/CSTDVARIANT=c/], [~/BUILD_WARNOPT=hard/] ],
                 runAllowedFailure: true,
-                mergeMode: [ 'excludeCombos': 'merge' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
+                mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
                 excludeCombos: [ [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/], [~/CSTDVARIANT=gnu/], [~/OS_FAMILY=windows/],
                     [~/OS_DISTRO=(openindiana|freebsd).*/, ~/CSTDVERSION_cxx=[12].+/, ~/COMPILER=GCC/]
                     ]
@@ -489,9 +508,16 @@ set | sort -n """
                     'CSTDVERSION_${KEY}': [ ['c': '99', 'cxx': '98'], ['c': '99', 'cxx': '11'], ['c': '17', 'cxx': '17'] ],
                     'CSTDVARIANT': ['c', 'gnu'],
                     ],
-                dynamatrixAxesCommonEnv: [ ['LANG=C','LC_ALL=C', 'BUILD_TYPE=default-all-errors', 'BUILD_WARNFATAL=yes','BUILD_WARNOPT=hard', 'CPPFLAGS=-fms-extensions'] ] ,
+                dynamatrixAxesCommonEnv: [
+                    ['LANG=C','LC_ALL=C','TZ=UTC',
+                     'BUILD_TYPE=default-all-errors',
+                     'BUILD_WARNFATAL=yes','BUILD_WARNOPT=hard',
+                     'CPPFLAGS=-fms-extensions'
+                    ]
+                ],
                 allowedFailure: [ [~/CSTDVARIANT=c/], [~/OS_FAMILY=windows/], [~/BUILD_WARNOPT=hard/] ],
                 runAllowedFailure: true,
+                mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
                 excludeCombos: [ [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/], [~/OS_FAMILY=(?!windows)/] ]
                 ], body)
             }, // getParStages

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -92,8 +92,8 @@ if [ -z "${CANBUILD_LIBGD_CGI-}" ]; then
     [[ "$CI_OS_NAME" = "windows" ]] && CANBUILD_LIBGD_CGI=no
 
     # NUT CI farm with Jenkins can build it; Travis could not
-    #[[ "$CI_OS_NAME" = "freebsd" ]] && CANBUILD_LIBGD_CGI=no
-    [[ "$TRAVIS_OS_NAME" = "freebsd" ]] && CANBUILD_LIBGD_CGI=no
+    [[ "$CI_OS_NAME" = "freebsd" ]] && CANBUILD_LIBGD_CGI=yes \
+    || [[ "$TRAVIS_OS_NAME" = "freebsd" ]] && CANBUILD_LIBGD_CGI=no
 fi
 
 configure_nut() {

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -264,7 +264,7 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
     || ( [ "${CANBUILD_CPPUNIT_TESTS-}" = "no-clang" ] && [ "$COMPILER_FAMILY" = "CLANG" ] ) \
     ; then
         echo "WARNING: Build agent says it can't build or run libcppunit tests, adding configure option to skip them" >&2
-        CONFIG_OPTS+=("--with-cppunit=no")
+        CONFIG_OPTS+=("--enable-cppunit=no")
     fi
 
     DO_DISTCHECK=yes

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -246,6 +246,11 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
             # configure-time checks of libgd; newer compilers fare okay.
             # Feel free to revise this if the distro packages are fixed
             # (or the way configure script and further build uses them).
+            # UPDATE: Per https://github.com/networkupstools/nut/pull/1089
+            # This is a systems issue (in current OpenIndiana 2021.04 built
+            # with a newer GCC version, the older GCC is not ABI compatible
+            # with the libgd shared object file). Maybe this warrants later
+            # caring about not just the CI_OS_NAME but also CI_OS_RELEASE...
             if [[ "$COMPILER_FAMILY" = "GCC" ]]; then
                 case "`LANG=C $CC --version | head -1`" in
                     *[\ -][01234].*)

--- a/configure.ac
+++ b/configure.ac
@@ -1583,6 +1583,57 @@ AS_IF([test x"$have_PKG_CONFIG" = xyes],
 )
 AC_MSG_RESULT(${have_cppunit})
 
+AS_IF([test "${have_cppunit}" = "yes"],
+    [AC_MSG_CHECKING([if current toolkit can build and run cppunit tests (e.g. no ABI issues, related segfaults, etc.)])
+     dnl Code below is largely a stripped variant of our tests/example.cpp and cpputest.cpp
+     CPLUSPLUS_DECL='
+#include <stdexcept>
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/CompilerOutputter.h>
+#include <cppunit/extensions/TestFactoryRegistry.h>
+#include <cppunit/ui/text/TestRunner.h>
+
+class ExampleTest : public CppUnit::TestFixture
+{
+  CPPUNIT_TEST_SUITE( ExampleTest );
+    CPPUNIT_TEST( testOne );
+  CPPUNIT_TEST_SUITE_END();
+public:
+  void setUp() {};
+  void tearDown() {};
+  void testOne();
+};
+CPPUNIT_TEST_SUITE_REGISTRATION( ExampleTest );
+void ExampleTest::testOne()
+{
+  int i = 1;
+  float f = 1.0;
+  int cast = static_cast<int>(f);
+  CPPUNIT_ASSERT_EQUAL_MESSAGE("Casted float is not the expected int", i, cast );
+}
+'
+
+     CPLUSPLUS_MAIN='
+CppUnit::Test *suite = CppUnit::TestFactoryRegistry::getRegistry().makeTest();
+CppUnit::TextUi::TestRunner runner;
+runner.addTest( suite );
+runner.setOutputter( new CppUnit::CompilerOutputter( &runner.result(), std::cerr ) );
+bool res = runner.run();
+return res ? 0 : 1;
+'
+
+     my_CXXFLAGS="$CXXFLAGS"
+     CXXFLAGS="$myCXXFLAGS $pkg_cv_CPPUNIT_CFLAGS $pkg_cv_CPPUNIT_LIBS"
+     AC_LANG_PUSH([C++])
+     AC_RUN_IFELSE([AC_LANG_PROGRAM([[${CPLUSPLUS_DECL}]], [[${CPLUSPLUS_MAIN}]])],
+        [have_cppunit=yes], [have_cppunit=no])
+     CXXFLAGS="$my_CXXFLAGS"
+     AC_LANG_POP([C++])
+     unset CPLUSPLUS_MAIN
+     unset CPLUSPLUS_DECL
+     ])
+AC_MSG_RESULT(${have_cppunit})
+
 dnl # By default keep the originally detected have_cppunit value
 AC_MSG_CHECKING(for impact from --enable-cppunit option - should we build cppunit tests?)
 AC_ARG_ENABLE(cppunit,

--- a/tests/cpputest.cpp
+++ b/tests/cpputest.cpp
@@ -20,15 +20,30 @@
 */
 
 #include <stdexcept>
+#include <cppunit/TestResult.h>
 #include <cppunit/CompilerOutputter.h>
+#include <cppunit/TextTestProgressListener.h>
 #include <cppunit/extensions/TestFactoryRegistry.h>
 #include <cppunit/ui/text/TestRunner.h>
 #include "common.h"
 
+// Inspired by https://stackoverflow.com/a/66702001
+class MyCustomProgressTestListener : public CppUnit::TextTestProgressListener {
+  public:
+    virtual void startTest(CppUnit::Test *test) {
+      //fprintf(stderr, "starting test %s\n", test->getName().c_str());
+      std::cerr << "starting test " << test->getName() << std::endl;
+    }
+};
+
 int main(int argc, char* argv[])
 {
-  NUT_UNUSED_VARIABLE(argc);
-  NUT_UNUSED_VARIABLE(argv);
+  bool verbose = false;
+  if (argc > 1) {
+    if (strcmp("-v", argv[1]) == 0 || strcmp("--verbose", argv[1]) == 0 ) {
+      verbose = true;
+    }
+  }
 
   /* Get the top level suite from the registry */
   std::cerr << "D: Getting test suite..." << std::endl;
@@ -43,6 +58,13 @@ int main(int argc, char* argv[])
   std::cerr << "D: Setting test runner outputter..." << std::endl;
   runner.setOutputter( new CppUnit::CompilerOutputter( &runner.result(),
                                                        std::cerr ) );
+
+  if (verbose) {
+    /* Add a listener to report test names */
+    std::cerr << "D: Setting test runner listener for test names..." << std::endl;
+    MyCustomProgressTestListener progress;
+    runner.eventManager().addListener(&progress);
+  }
 
   /* Run the tests. */
   bool wasSucessful = false;


### PR DESCRIPTION
Note: code includes #1089 to avoid already addressed CI-farm build errors.

After revising the recipe bundles, it seems plausible that CI was scheduling a number of nearly identical runs with different envvars set - and not even competing values of those. Gotta bome leftover of early experiments with the new dynamatrix, ashes on my old head!

Hopefully this also solves the "strange" builds for "ci_build.sh" method that did not get any "BUILD_TYPE" value set, and so produced unexpected faults beside the extra compute load.