### PR TITLE
ci_build.sh/Jenkinsfile-dynamatrix: constrain the sprawl of build cases (doc/distcheck)

### DIFF
--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -244,7 +244,10 @@ set | sort -n """
         'bodyParStages': dynacfgPipeline.slowBuildDefaultBody_ci_build
         ] // one slowBuild filter configuration
 
-        ,[name: 'A build with all driver types on capable systems (must pass)',
+        ,[name: 'A build with all driver types on capable systems with distcheck for main supported C/C++ revision (must pass)',
+         // NOTE: Here we constrain distcheck builds (more CI stress load)
+         // to run as few combos as possible; arguably this filter config
+         // is more about recipes than about codebase quality
          disabled: dynacfgPipeline.disableSlowBuildCIBuild,
          //branchRegexSource: ~/^(PR-.+|fightwarn.*)$/,
          //branchRegexTarget: ~/^(master|main|stable)$/,
@@ -255,8 +258,10 @@ set | sort -n """
                 excludedNodelabels: [],
 
                 dynamatrixAxesVirtualLabelsMap: [
+                    // TODO: Find a way to constrain these builds to one
+                    // per OS type, whatever bitness(es) supported there
                     'BITS': [32, 64],
-                    'CSTDVERSION_${KEY}': [ ['c': '99', 'cxx': '98'], ['c': '17', 'cxx': '17'] ],
+                    'CSTDVERSION_${KEY}': [ ['c': '99', 'cxx': '98'] ],
                     'CSTDVARIANT': ['gnu'],
                     'BUILD_TYPE': ['default-alldrv']
                     ],
@@ -275,7 +280,41 @@ set | sort -n """
         'bodyParStages': dynacfgPipeline.slowBuildDefaultBody_ci_build
         ] // one slowBuild filter configuration
 
-        ,[name: 'A build with all driver types on capable systems with fatal warnings (allowed to fail)',
+        ,[name: 'A build with all driver types on capable systems without distcheck for more C/C++ revisions (must pass)',
+         // NOTE: We reduce the build load here since the Makefile recipes
+         // (for distcheck part) are deemed tested above with the supported
+         // C/C++ standard revision
+         disabled: dynacfgPipeline.disableSlowBuildCIBuild,
+         //branchRegexSource: ~/^(PR-.+|fightwarn.*)$/,
+         //branchRegexTarget: ~/^(master|main|stable)$/,
+         'getParStages': { dynamatrix, Closure body ->
+            return dynamatrix.generateBuild([
+                //commonLabelExpr: "nut-builder:alldrv",
+                requiredNodelabels: ["(NUT_BUILD_CAPS=drivers:all||nut-builder:alldrv)"],
+                excludedNodelabels: [],
+
+                dynamatrixAxesVirtualLabelsMap: [
+                    'BITS': [32, 64],
+                    'CSTDVERSION_${KEY}': [ ['c': '17', 'cxx': '17'] ],
+                    'CSTDVARIANT': ['gnu'],
+                    'BUILD_TYPE': ['default-alldrv:no-distcheck']
+                    ],
+                dynamatrixAxesCommonEnv: [
+                    ['LANG=C','LC_ALL=C','TZ=UTC'
+                     //,'BUILD_WARNFATAL=yes','BUILD_WARNOPT=hard'
+                    ]
+                ],
+                // On some systems, pkg-config for net-snmp includes CFLAGS values not supported by gcc-4.9 and older
+                allowedFailure: [ [~/OS_FAMILY=windows/], [~/GCCVER=[01234].+/, ~/BUILD_TYPE=default-alldr(v|v:no-distcheck)/] ],
+                runAllowedFailure: true,
+                mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
+                excludeCombos: [ [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/], [~/CSTDVARIANT=c/] ] //, [~/OS_DISTRO=openindiana/] ]
+                ], body)
+            }, // getParStages
+        'bodyParStages': dynacfgPipeline.slowBuildDefaultBody_ci_build
+        ] // one slowBuild filter configuration
+
+        ,[name: 'A build with all driver types on capable systems with distcheck and fatal warnings (allowed to fail)',
          disabled: dynacfgPipeline.disableSlowBuildCIBuildExperimental,
          branchRegexSource: ~/^(PR-.+|.*fightwarn.*)$/,
          branchRegexTarget: ~/fightwarn/,

--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -146,6 +146,17 @@ set | sort -n """
 
     dynacfgPipeline.slowBuildDefaultBody = dynacfgPipeline.slowBuildDefaultBody_autotools
 
+    /* By default, the master/main/stable branch and PRs against it
+     * is built with as few scenarios as possible, allowing for fast
+     * turnaround and avoiding redundant work (e.g. documentation
+     * rendering, distchecks that are more about recipes than code),
+     * and stricter warnings that current codebase would fail so far.
+     * In particular, this saves CI farm resources - allowing more
+     * PRs per day to be checked in practice.
+     * Conversely, a branch with "fightwarn" in the name (or PR to it)
+     * would enjoy many more build scenarios, covering both autotools
+     * directly and ci_build.sh with stricter warnings, in particular.
+     */
     dynacfgPipeline.slowBuild = [
         [name: 'Default autotools driven build',
          disabled: dynacfgPipeline.disableSlowBuildAutotools,

--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -213,7 +213,7 @@ set | sort -n """
         //'bodyParStages': {}
         ] // one slowBuild filter configuration
 
-        ,[name: 'Various target builds (must pass)',
+        ,[name: 'Various target builds (must pass on all platforms)',
          disabled: dynacfgPipeline.disableSlowBuildCIBuild,
          //branchRegexSource: ~/^(PR-.+|fightwarn.*)$/,
          //branchRegexTarget: ~/^(master|main|stable)$/,
@@ -226,8 +226,10 @@ set | sort -n """
                     'BITS': [32, 64],
                     'CSTDVERSION_${KEY}': [ ['c': '99', 'cxx': '98'], ['c': '17', 'cxx': '17'] ],
                     'CSTDVARIANT': ['gnu'],
-                    'BUILD_TYPE': ['default-nodoc', 'default', 'default-tgt:distcheck-light', 'default-tgt:distcheck-valgrind', 'default-withdoc:man']
-                    // BUILD_TYPE=default-tgt:distcheck-light + NO_PKG_CONFIG=true
+                    'BUILD_TYPE': ['default-nodoc', 'default', 'default-tgt:distcheck-valgrind']
+                    // BUILD_TYPE=default-withdoc:man
+                    // BUILD_TYPE=default-tgt:distcheck-light == --with-all=auto --with-ssl=auto --with-doc=auto
+                    // BUILD_TYPE=default-tgt:distcheck-light + NO_PKG_CONFIG=true ?
                     ],
                 dynamatrixAxesCommonEnv: [
                     ['LANG=C','LC_ALL=C','TZ=UTC'

--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -1,3 +1,6 @@
+#!/usr/bin/env groovy
+// ^^^ For syntax highlighters
+
 /* Typical Keep this build description formula for custom replayed builds (see below):
 
 Kept for reference: build of commit https://github.com/networkupstools/nut/commit/86a32237c7df45c5aba640746f7afc4de09505a1

--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -407,7 +407,7 @@ set | sort -n """
         'bodyParStages': dynacfgPipeline.slowBuildDefaultBody_ci_build
         ] // one slowBuild filter configuration
 
-        ,[name: 'GNU C standard builds with non-fatal warnings (must pass)',
+        ,[name: 'GNU C standard builds with non-fatal warnings, without distcheck and docs (must pass)',
          disabled: dynacfgPipeline.disableSlowBuildCIBuild,
          //branchRegexSource: ~/^(PR-.+|fightwarn.*)$/,
          //branchRegexTarget: ~/^(master|main|stable)$/,
@@ -436,7 +436,7 @@ set | sort -n """
         'bodyParStages': dynacfgPipeline.slowBuildDefaultBody_ci_build
         ] // one slowBuild filter configuration
 
-        ,[name: 'GNU C standard builds with fatal warnings (allowed to fail with non-GCC, and for GCC with gnu89 builds)',
+        ,[name: 'GNU C standard builds with fatal warnings, without distcheck and docs (allowed to fail with non-GCC, and for GCC with gnu89 builds)',
          disabled: dynacfgPipeline.disableSlowBuildCIBuildExperimental,
          branchRegexSource: ~/^(PR-.+|.*fightwarn.*)$/,
          branchRegexTarget: ~/fightwarn/,
@@ -471,7 +471,7 @@ set | sort -n """
         'bodyParStages': dynacfgPipeline.slowBuildDefaultBody_ci_build
         ] // one slowBuild filter configuration
 
-        ,[name: 'GNU C standard builds with fatal warnings with GCC (must pass)',
+        ,[name: 'GNU C standard builds with fatal warnings with GCC, without distcheck and docs (must pass)',
          disabled: dynacfgPipeline.disableSlowBuildCIBuild,
          //branchRegexSource: ~/^(PR-.+|fightwarn.*)$/,
          //branchRegexTarget: ~/^(master|main|stable)$/,
@@ -503,7 +503,7 @@ set | sort -n """
         'bodyParStages': dynacfgPipeline.slowBuildDefaultBody_ci_build
         ] // one slowBuild filter configuration
 
-        ,[name: 'Strict C standard builds on non-Windows platforms (allowed to fail)',
+        ,[name: 'Strict C standard builds on non-Windows platforms, without distcheck and docs (allowed to fail)',
          disabled: dynacfgPipeline.disableSlowBuildCIBuildExperimental,
          branchRegexSource: ~/^(PR-.+|.*fightwarn.*)$/,
          branchRegexTarget: ~/fightwarn/,
@@ -533,7 +533,7 @@ set | sort -n """
         'bodyParStages': dynacfgPipeline.slowBuildDefaultBody_ci_build
         ] // one slowBuild filter configuration
 
-        ,[name: 'Strict C and GNU standard builds on Windows platforms (allowed to fail)',
+        ,[name: 'Strict C and GNU standard builds on Windows platforms, without distcheck and docs (allowed to fail)',
          disabled: dynacfgPipeline.disableSlowBuildCIBuildExperimental,
          branchRegexSource: ~/^(PR-.+|.*fightwarn.*)$/,
          branchRegexTarget: ~/fightwarn/,

--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -348,6 +348,9 @@ set | sort -n """
         ] // one slowBuild filter configuration
 
         ,[name: 'A build with all docs types on capable systems (must pass)',
+         // TODO: This is a recipe (and target OS) test for ability to build
+         // the docs without error; it should not iterate compilers (maybe
+         // iterate docs tools though, if we were to support many backends?)
          disabled: dynacfgPipeline.disableSlowBuildCIBuild,
          //branchRegexSource: ~/^(PR-.+|fightwarn.*)$/,
          //branchRegexTarget: ~/^(master|main|stable)$/,
@@ -378,7 +381,9 @@ set | sort -n """
         'bodyParStages': dynacfgPipeline.slowBuildDefaultBody_ci_build
         ] // one slowBuild filter configuration
 
-        ,[name: 'A build with manpage docs on all systems (allowed to fail - e.g. no tools even for that)',
+        ,[name: 'A build with manpage docs on all systems that did not build "all docs" (allowed to fail - e.g. no tools even for that)',
+         // TODO: This is a recipe (and target OS) test for ability to build
+         // the docs without error; it should not iterate compilers; see above
          disabled: dynacfgPipeline.disableSlowBuildCIBuild,
          //branchRegexSource: ~/^(PR-.+|fightwarn.*)$/,
          //branchRegexTarget: ~/^(master|main|stable)$/,
@@ -386,8 +391,8 @@ set | sort -n """
             return dynamatrix.generateBuild([
                 //commonLabelExpr: dynacfgBase.commonLabelExpr + " && doc-builder",
                 //commonLabelExpr: infra.labelDocumentationWorker(),
-                requiredNodelabels: ["(NUT_BUILD_CAPS=docs:all||NUT_BUILD_CAPS=docs:man)"],
-                excludedNodelabels: [],
+                requiredNodelabels: ["NUT_BUILD_CAPS=docs:man"],
+                excludedNodelabels: ["NUT_BUILD_CAPS=docs:all"],
 
                 dynamatrixAxesVirtualLabelsMap: [
                     //'BITS': [32, 64],

--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -372,6 +372,7 @@ set | sort -n """
             return dynamatrix.generateBuild([
                 //commonLabelExpr: dynacfgBase.commonLabelExpr + " && doc-builder",
                 //commonLabelExpr: infra.labelDocumentationWorker(),
+                dynamatrixAxesLabels: ['OS_FAMILY', 'OS_DISTRO'],
                 requiredNodelabels: ["NUT_BUILD_CAPS=docs:all"],
                 excludedNodelabels: [],
 
@@ -388,7 +389,7 @@ set | sort -n """
                 ],
                 allowedFailure: [ [~/OS_FAMILY=windows/] ],
                 runAllowedFailure: true,
-                mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
+                mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesLabels': 'replace', 'commonLabelExpr': 'replace', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
                 excludeCombos: [ [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/], [~/CSTDVARIANT=c/], [~/OS_DISTRO=(openindiana|freebsd).*/, ~/CSTDVERSION_cxx=[12].+/, ~/COMPILER=GCC/] ]
                 ], body)
             }, // getParStages
@@ -405,6 +406,7 @@ set | sort -n """
             return dynamatrix.generateBuild([
                 //commonLabelExpr: dynacfgBase.commonLabelExpr + " && doc-builder",
                 //commonLabelExpr: infra.labelDocumentationWorker(),
+                dynamatrixAxesLabels: ['OS_FAMILY', 'OS_DISTRO'],
                 requiredNodelabels: ["NUT_BUILD_CAPS=docs:man"],
                 excludedNodelabels: ["NUT_BUILD_CAPS=docs:all"],
 
@@ -421,7 +423,7 @@ set | sort -n """
                 ],
                 allowedFailure: [ [~/OS_FAMILY=windows/], [~/BUILD_TYPE=default-withdoc:man/] ],
                 runAllowedFailure: true,
-                mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
+                mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesLabels': 'replace', 'commonLabelExpr': 'replace', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
                 excludeCombos: [ [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/], [~/CSTDVARIANT=c/], [~/OS_DISTRO=(openindiana|freebsd).*/, ~/CSTDVERSION_cxx=[12].+/, ~/COMPILER=GCC/] ]
                 ], body)
             }, // getParStages

--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -1,4 +1,4 @@
-/* Typical Keep this build description for custom replayed builds (see below):
+/* Typical Keep this build description formula for custom replayed builds (see below):
 
 Kept for reference: build of commit https://github.com/networkupstools/nut/commit/86a32237c7df45c5aba640746f7afc4de09505a1
 PR https://github.com/networkupstools/nut/pull/1047
@@ -347,7 +347,7 @@ set | sort -n """
         'bodyParStages': dynacfgPipeline.slowBuildDefaultBody_ci_build
         ] // one slowBuild filter configuration
 
-        ,[name: 'A build with all docs types on capable systems (must pass)',
+        ,[name: 'A build with all docs types on capable systems, and a distcheck (must pass)',
          // TODO: This is a recipe (and target OS) test for ability to build
          // the docs without error; it should not iterate compilers (maybe
          // iterate docs tools though, if we were to support many backends?)
@@ -381,7 +381,7 @@ set | sort -n """
         'bodyParStages': dynacfgPipeline.slowBuildDefaultBody_ci_build
         ] // one slowBuild filter configuration
 
-        ,[name: 'A build with manpage docs on all systems that did not build "all docs" (allowed to fail - e.g. no tools even for that)',
+        ,[name: 'A build with manpage docs on all systems that did not build "all docs", and a distcheck (allowed to fail - e.g. no tools even for that)',
          // TODO: This is a recipe (and target OS) test for ability to build
          // the docs without error; it should not iterate compilers; see above
          disabled: dynacfgPipeline.disableSlowBuildCIBuild,

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -521,27 +521,84 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
             exit $?
             ;;
         "default-all-errors")
+            # Try to run various build scenarios to collect build errors
+            # (no checks here) as configured further by caller's choice
+            # of BUILD_WARNFATAL and/or BUILD_WARNOPT envvars above.
+            # Note this is one scenario where we did not configure_nut()
+            # in advance.
             RES=0
-            if pkg-config --exists nss && pkg-config --exists openssl && [ "${BUILD_SSL_ONCE-}" != "true" ] ; then
-                # Try builds for both cases as they are ifdef-ed
+            FAILED=""
+            SUCCEEDED=""
 
-                echo "=== Building with SSL=openssl..."
-                ( CONFIG_OPTS+=("--with-openssl")
-                  configure_nut
-                  build_to_only_catch_errors ) || RES=$?
+            # Technically, let caller provide this setting explicitly
+            if [ -z "$NUT_SSL_VARIANTS" ] ; then
+                NUT_SSL_VARIANTS="auto"
+                if pkg-config --exists nss && pkg-config --exists openssl && [ "${BUILD_SSL_ONCE-}" != "true" ] ; then
+                    # Try builds for both cases as they are ifdef-ed
+                    # TODO: Extend if we begin to care about different
+                    # major versions of openssl (with their APIs), etc.
+                    NUT_SSL_VARIANTS="openssl nss"
+                else
+                    if [ "${BUILD_SSL_ONCE-}" != "true" ]; then
+                        pkg-config --exists nss 2>/dev/null && NUT_SSL_VARIANTS="nss"
+                        pkg-config --exists openssl 2>/dev/null && NUT_SSL_VARIANTS="openssl"
+                    fi  # else leave at "auto", if we skipped building
+                        # two variants while having two possibilities
+                fi
 
+                # Consider also a build --without-ssl to test that codepath?
+                if [ "$NUT_SSL_VARIANTS" != auto ] && [ "${BUILD_SSL_ONCE-}" != "true" ]; then
+                    NUT_SSL_VARIANTS="$NUT_SSL_VARIANTS no"
+                fi
+            fi
+
+            for NUT_SSL_VARIANT in $NUT_SSL_VARIANTS ; do
                 echo "=== Clean the sandbox..."
                 $MAKE distclean -k || true
 
-                echo "=== Building with SSL=nss..."
-                ( CONFIG_OPTS+=("--with-nss")
-                  configure_nut
-                  build_to_only_catch_errors ) || RES=$?
-            else
-                # Build what we can configure
-                configure_nut
-                build_to_only_catch_errors || RES=$?
+                case "$NUT_SSL_VARIANT" in
+                    ""|auto|default)
+                        # Quietly build one scenario, whatever we can (or not)
+                        # configure regarding SSL and other features
+                        NUT_SSL_VARIANT=auto
+                        configure_nut
+                        ;;
+                    no)
+                        echo "=== Building without SSL support..."
+                        ( CONFIG_OPTS+=("--without-ssl")
+                          configure_nut
+                        )
+                        ;;
+                    *)
+                        echo "=== Building with NUT_SSL_VARIANT='${NUT_SSL_VARIANT}' ..."
+                        ( CONFIG_OPTS+=("--with-${NUT_SSL_VARIANT}")
+                          configure_nut
+                        )
+                        ;;
+                esac || {
+                    RES=$?
+                    FAILED="${FAILED} NUT_SSL_VARIANT=${NUT_SSL_VARIANT}[configure]"
+                    continue
+                }
+
+                build_to_only_catch_errors && {
+                    SUCCEEDED="${SUCCEEDED} NUT_SSL_VARIANT=${NUT_SSL_VARIANT}"
+                } || {
+                    RES=$?
+                    FAILED="${FAILED} NUT_SSL_VARIANT=${NUT_SSL_VARIANT}[build]"
+                }
+            done
+            # TODO: Similar loops for other variations like TESTING,
+            # MGE SHUT vs other serial protocols, libusb version...
+
+            if [ -n "$SUCCEEDED" ]; then
+                echo "SUCCEEDED build(s) with:${SUCCEEDED}" >&2
             fi
+            if [ "$RES" != 0 ]; then
+                # Leading space is included in FAILED
+                echo "FAILED build(s) with:${FAILED}" >&2
+            fi
+
             exit $RES
             ;;
     esac

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -291,6 +291,8 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
         CONFIG_OPTS+=("--enable-cppunit=no")
     fi
 
+    # This flag is primarily linked with (lack of) docs generation enabled
+    # (or not) in some BUILD_TYPE scenarios or workers
     DO_DISTCHECK=yes
     case "$BUILD_TYPE" in
         "default-nodoc")
@@ -370,11 +372,13 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
                 CONFIG_OPTS+=("--with-all=yes")
             fi
             ;;
-        "default"|*)
+        "default"|"default-tgt:"*|*)
             # Do not build the docs and tell distcheck it is okay
             CONFIG_OPTS+=("--with-doc=skip")
             ;;
     esac
+    # NOTE: The case "$BUILD_TYPE" above was about setting CONFIG_OPTS.
+    # There is another below for running actual scenarios.
 
     if [ "$HAVE_CCACHE" = yes ] && [ "${COMPILER_FAMILY}" = GCC -o "${COMPILER_FAMILY}" = CLANG ]; then
         PATH="/usr/lib/ccache:$PATH"
@@ -466,8 +470,13 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
         configure_nut
     fi
 
+    # NOTE: There is also a case "$BUILD_TYPE" above for setting CONFIG_OPTS
+    # This case runs some specially handled BUILD_TYPEs and exists; support
+    # for all other scenarios proceeds.below.
     case "$BUILD_TYPE" in
         "default-tgt:"*) # Hook for matrix of custom distchecks primarily
+            # e.g. distcheck-light, distcheck-valgrind, maybe others later,
+            # as defined in Makefile.am:
             BUILD_TGT="`echo "$BUILD_TYPE" | sed 's,^default-tgt:,,'`"
             echo "`date`: Starting the sequential build attempt for singular target $BUILD_TGT..."
 

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -139,7 +139,7 @@ build_to_only_catch_errors() {
 
 echo "Processing BUILD_TYPE='${BUILD_TYPE}' ..."
 case "$BUILD_TYPE" in
-default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|default-nodoc|default-withdoc|default-withdoc:man|"default-tgt:"*)
+default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-spellcheck|default-shellcheck|default-nodoc|default-withdoc|default-withdoc:man|"default-tgt:"*)
     LANG=C
     LC_ALL=C
     export LANG LC_ALL
@@ -362,11 +362,17 @@ default|default-alldrv|default-all-errors|default-spellcheck|default-shellcheck|
                 CONFIG_OPTS+=("--with-cgi=auto")
             fi
             ;;
+        "default-alldrv:no-distcheck")
+            DO_DISTCHECK=no
+            ;& # fall through
         "default-alldrv")
             # Do not build the docs and make possible a distcheck below
             CONFIG_OPTS+=("--with-doc=skip")
             if [ "${CANBUILD_DRIVERS_ALL-}" = no ]; then
                 echo "WARNING: Build agent says it can't build 'all' driver types; will ask for what we can build" >&2
+                if [ "$DO_DISTCHECK" != no ]; then
+                    echo "WARNING: this is effectively default-tgt:distcheck-light then" >&2
+                fi
                 CONFIG_OPTS+=("--with-all=auto")
             else
                 CONFIG_OPTS+=("--with-all=yes")

--- a/clients/upsclient.c
+++ b/clients/upsclient.c
@@ -429,6 +429,11 @@ int upscli_init(int certverify, const char *certpath,
 		nsscertpasswd = xstrdup(certpasswd);
 	}
 	verify_certificate = certverify;
+#else
+	/* Note: historically we do not return with error here,
+	 * just fall through to below and treat as initialized.
+	 */
+	upslogx(LOG_ERR, "upscli_init called but SSL wasn't compiled in");
 #endif /* WITH_OPENSSL | WITH_NSS */
 
 	upscli_initialized = 1;

--- a/clients/upsclient.c
+++ b/clients/upsclient.c
@@ -315,6 +315,8 @@ int upscli_init(int certverify, const char *certpath,
 #elif defined(WITH_NSS) /* WITH_OPENSSL */
 	SECStatus	status;
 #else
+	NUT_UNUSED_VARIABLE(certverify);
+	NUT_UNUSED_VARIABLE(certpath);
 	NUT_UNUSED_VARIABLE(certname);
 	NUT_UNUSED_VARIABLE(certpasswd);
 #endif /* WITH_OPENSSL | WITH_NSS */
@@ -927,6 +929,9 @@ static int upscli_sslinit(UPSCONN_t *ups, int verifycert)
 
 static int upscli_sslinit(UPSCONN_t *ups, int verifycert)
 {
+	NUT_UNUSED_VARIABLE(ups);
+	NUT_UNUSED_VARIABLE(verifycert);
+
 	return 0;	/* not supported */
 }
 

--- a/server/netssl.c
+++ b/server/netssl.c
@@ -64,18 +64,30 @@ static int	ssl_initialized = 0;
 /* stubs for non-ssl compiles */
 void net_starttls(nut_ctype_t *client, size_t numarg, const char **arg)
 {
+	NUT_UNUSED_VARIABLE(client);
+	NUT_UNUSED_VARIABLE(numarg);
+	NUT_UNUSED_VARIABLE(arg);
+
 	send_err(client, NUT_ERR_FEATURE_NOT_SUPPORTED);
 	return;
 }
 
 ssize_t ssl_write(nut_ctype_t *client, const char *buf, size_t buflen)
 {
+	NUT_UNUSED_VARIABLE(client);
+	NUT_UNUSED_VARIABLE(buf);
+	NUT_UNUSED_VARIABLE(buflen);
+
 	upslogx(LOG_ERR, "ssl_write called but SSL wasn't compiled in");
 	return -1;
 }
 
 ssize_t ssl_read(nut_ctype_t *client, char *buf, size_t buflen)
 {
+	NUT_UNUSED_VARIABLE(client);
+	NUT_UNUSED_VARIABLE(buf);
+	NUT_UNUSED_VARIABLE(buflen);
+
 	upslogx(LOG_ERR, "ssl_read called but SSL wasn't compiled in");
 	return -1;
 }


### PR DESCRIPTION
Our two most expensive build types are distchecks and especially builds with docs. Notably, these are less about code quality and more about recipe quality vs. available non-compiler tools provided on the build workers (make implementation, asciidoc and friends) so we do not need to run them as many times as we have various compiler versions.

This PR aims to reign them in, reducing the redundant builds and those that bring little value for much CPU churn, and revising/documenting what different BUILD_TYPE scenario names do.

At the moment of posting, it does not yet address the calling of (docs-included) builds once per target OS, which is a separate goal that may come later in this or future PR.

Partially helps address https://github.com/networkupstools/jenkins-dynamatrix/issues/4 as well, by refactoring ci_build.sh with that needed direction in mind. This does however bring in some more churn to BUILD_TYPE=default-all-errors by building not only openssl and/or nss implementations, but also without-ssl which exposed some minor faults fixed below.