### PR TITLE
Jenkinsfile-dynamatrix: find a way to constrain build scenarios not relevant to the changed files

### DIFF
--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -79,27 +79,32 @@ import org.nut.dynamatrix.*;
 
     dynacfgPipeline.stashnameSrc = 'nut-ci-src'
 
-    // First list the building blocks as lists of files;
-    // final regexes are arranged below:
-    // TODO: Technically the slash should be the Path.Separator,
-    // but at least modern windows can handle a sh step with that
-    // character, so no big deal for NUT supported platforms
-    dynacfgPipeline.appliesToChangedFilesRegex_FILES_PREFIX = ~/^(\/*|.*\/)/
-    dynacfgPipeline.appliesToChangedFilesRegex_FILES_RECIPE = ~/(configure\.ac|.*\.m4|Makefile.am|ci_.*\.sh|\.git.*|Jenkinsfile.*|.*\.groovy)/
-    dynacfgPipeline.appliesToChangedFilesRegex_FILES_C = ~/^(.*\.h|.*\.hpp|.*\.c|.*\.cxx|.*\.cpp)/
-    dynacfgPipeline.appliesToChangedFilesRegex_FILES_TXT = ~/^(.*\.txt|.*\.dict|asciidoc.*|.*\.xsl|.*\.css|AUTHORS.*|CHANGELOG.*|COPYING.*|INSTALL.*|LICENSE.*|MAINT.*|NEWS.*|README.*|TODO.*|UPGRAD.*)/
-    dynacfgPipeline.appliesToChangedFilesRegex_FILES_IMG = ~/^(.*\.svg|.*\.png|.*\.jpg|.*\.jpeg|.*\.gif)/
+    if ( !( env?.BRANCH_NAME ==~ /master|main|stable/ ) ) {
+        // else: For main branches we want all builds,
+        // to keep reference for warnings-ng up to date
 
-    // Recipe changes and C source changes go here:
-    dynacfgPipeline.appliesToChangedFilesRegex_RECIPE = ~/${dynacfgPipeline.appliesToChangedFilesRegex_FILES_PREFIX}${dynacfgPipeline.appliesToChangedFilesRegex_FILES_RECIPE}(|\.in)$/
-    dynacfgPipeline.appliesToChangedFilesRegex_C = ~/${dynacfgPipeline.appliesToChangedFilesRegex_FILES_PREFIX}(${dynacfgPipeline.appliesToChangedFilesRegex_FILES_RECIPE}|${dynacfgPipeline.appliesToChangedFilesRegex_FILES_C})(|\.in)$/
+        // First list the building blocks as lists of files;
+        // final regexes are arranged below:
+        // TODO: Technically the slash should be the Path.Separator,
+        // but at least modern windows can handle a sh step with that
+        // character, so no big deal for NUT supported platforms
+        dynacfgPipeline.appliesToChangedFilesRegex_FILES_PREFIX = ~/^(\/*|.*\/)/
+        dynacfgPipeline.appliesToChangedFilesRegex_FILES_RECIPE = ~/(configure\.ac|.*\.m4|Makefile.am|ci_.*\.sh|\.git.*|Jenkinsfile.*|.*\.groovy)/
+        dynacfgPipeline.appliesToChangedFilesRegex_FILES_C = ~/^(.*\.h|.*\.hpp|.*\.c|.*\.cxx|.*\.cpp)/
+        dynacfgPipeline.appliesToChangedFilesRegex_FILES_TXT = ~/^(.*\.txt|.*\.dict|asciidoc.*|.*\.xsl|.*\.css|AUTHORS.*|CHANGELOG.*|COPYING.*|INSTALL.*|LICENSE.*|MAINT.*|NEWS.*|README.*|TODO.*|UPGRAD.*)/
+        dynacfgPipeline.appliesToChangedFilesRegex_FILES_IMG = ~/^(.*\.svg|.*\.png|.*\.jpg|.*\.jpeg|.*\.gif)/
 
-    // Recipe changes and docs source changes go here:
-    dynacfgPipeline.appliesToChangedFilesRegex_TXT = ~/${dynacfgPipeline.appliesToChangedFilesRegex_FILES_PREFIX}(${dynacfgPipeline.appliesToChangedFilesRegex_FILES_RECIPE}|${dynacfgPipeline.appliesToChangedFilesRegex_FILES_TXT}(|\.in)$)/
-    dynacfgPipeline.appliesToChangedFilesRegex_DOC = ~/${dynacfgPipeline.appliesToChangedFilesRegex_FILES_PREFIX}(${dynacfgPipeline.appliesToChangedFilesRegex_FILES_RECIPE}|${dynacfgPipeline.appliesToChangedFilesRegex_FILES_TXT}|${dynacfgPipeline.appliesToChangedFilesRegex_FILES_IMG})(|\.in)$/
+        // Recipe changes and C source changes go here:
+        dynacfgPipeline.appliesToChangedFilesRegex_RECIPE = ~/${dynacfgPipeline.appliesToChangedFilesRegex_FILES_PREFIX}${dynacfgPipeline.appliesToChangedFilesRegex_FILES_RECIPE}(|\.in)$/
+        dynacfgPipeline.appliesToChangedFilesRegex_C = ~/${dynacfgPipeline.appliesToChangedFilesRegex_FILES_PREFIX}(${dynacfgPipeline.appliesToChangedFilesRegex_FILES_RECIPE}|${dynacfgPipeline.appliesToChangedFilesRegex_FILES_C})(|\.in)$/
 
-    // TODO: Similar for shell files but based on some logic
-    // like in shellcheck to find the script files (not only *.sh)?
+        // Recipe changes and docs source changes go here:
+        dynacfgPipeline.appliesToChangedFilesRegex_TXT = ~/${dynacfgPipeline.appliesToChangedFilesRegex_FILES_PREFIX}(${dynacfgPipeline.appliesToChangedFilesRegex_FILES_RECIPE}|${dynacfgPipeline.appliesToChangedFilesRegex_FILES_TXT}(|\.in)$)/
+        dynacfgPipeline.appliesToChangedFilesRegex_DOC = ~/${dynacfgPipeline.appliesToChangedFilesRegex_FILES_PREFIX}(${dynacfgPipeline.appliesToChangedFilesRegex_FILES_RECIPE}|${dynacfgPipeline.appliesToChangedFilesRegex_FILES_TXT}|${dynacfgPipeline.appliesToChangedFilesRegex_FILES_IMG})(|\.in)$/
+
+        // TODO: Similar for shell files but based on some logic
+        // like in shellcheck to find the script files (not only *.sh)?
+    }
 
     // Do not override DISTCHECK_CONFIGURE_FLAGS as default implem
     // does, that breaks custom proto-dir installs and tries to go

--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -89,7 +89,7 @@ import org.nut.dynamatrix.*;
         // but at least modern windows can handle a sh step with that
         // character, so no big deal for NUT supported platforms
         dynacfgPipeline.appliesToChangedFilesRegex_FILES_PREFIX = ~/^(\/*|.*\/)/
-        dynacfgPipeline.appliesToChangedFilesRegex_FILES_RECIPE = ~/(configure\.ac|.*\.m4|Makefile.am|ci_.*\.sh|\.git.*|Jenkinsfile.*|.*\.groovy)/
+        dynacfgPipeline.appliesToChangedFilesRegex_FILES_RECIPE = ~/(configure\.ac|.*\.m4|C?Make.*|ci_.*\.sh|\.git.*|Jenkinsfile.*|.*\.groovy)/
         dynacfgPipeline.appliesToChangedFilesRegex_FILES_C = ~/^(.*\.h|.*\.hpp|.*\.c|.*\.cxx|.*\.cpp)/
         dynacfgPipeline.appliesToChangedFilesRegex_FILES_TXT = ~/^(.*\.txt|.*\.dict|asciidoc.*|.*\.xsl|.*\.css|AUTHORS.*|CHANGELOG.*|COPYING.*|INSTALL.*|LICENSE.*|MAINT.*|NEWS.*|README.*|TODO.*|UPGRAD.*)/
         dynacfgPipeline.appliesToChangedFilesRegex_FILES_IMG = ~/^(.*\.svg|.*\.png|.*\.jpg|.*\.jpeg|.*\.gif)/

--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -79,14 +79,27 @@ import org.nut.dynamatrix.*;
 
     dynacfgPipeline.stashnameSrc = 'nut-ci-src'
 
+    // First list the building blocks as lists of files;
+    // final regexes are arranged below:
+    // TODO: Technically the slash should be the Path.Separator,
+    // but at least modern windows can handle a sh step with that
+    // character, so no big deal for NUT supported platforms
+    dynacfgPipeline.appliesToChangedFilesRegex_FILES_PREFIX = ~/^(\/*|.*\/)/
+    dynacfgPipeline.appliesToChangedFilesRegex_FILES_RECIPE = ~/(configure\.ac|.*\.m4|Makefile.am|ci_.*\.sh|\.git.*|Jenkinsfile.*|.*\.groovy)/
+    dynacfgPipeline.appliesToChangedFilesRegex_FILES_C = ~/^(.*\.h|.*\.hpp|.*\.c|.*\.cxx|.*\.cpp)/
+    dynacfgPipeline.appliesToChangedFilesRegex_FILES_TXT = ~/^(.*\.txt|.*\.dict|asciidoc.*|.*\.xsl|.*\.css|AUTHORS.*|CHANGELOG.*|COPYING.*|INSTALL.*|LICENSE.*|MAINT.*|NEWS.*|README.*|TODO.*|UPGRAD.*)/
+    dynacfgPipeline.appliesToChangedFilesRegex_FILES_IMG = ~/^(.*\.svg|.*\.png|.*\.jpg|.*\.jpeg|.*\.gif)/
+
     // Recipe changes and C source changes go here:
-    dynacfgPipeline.appliesToChangedFilesRegex_C = ~/^(\/*|.*\/)(configure\.ac|.*\.m4|Makefile.am|ci_.*\.sh|\.git.*|.*\.h|.*\.hpp|.*\.c|.*\.cxx|.*\.cpp)$/
+    dynacfgPipeline.appliesToChangedFilesRegex_RECIPE = ~/${dynacfgPipeline.appliesToChangedFilesRegex_FILES_PREFIX}${dynacfgPipeline.appliesToChangedFilesRegex_FILES_RECIPE}(|\.in)$/
+    dynacfgPipeline.appliesToChangedFilesRegex_C = ~/${dynacfgPipeline.appliesToChangedFilesRegex_FILES_PREFIX}(${dynacfgPipeline.appliesToChangedFilesRegex_FILES_RECIPE}|${dynacfgPipeline.appliesToChangedFilesRegex_FILES_C})(|\.in)$/
+
     // Recipe changes and docs source changes go here:
-    dynacfgPipeline.appliesToChangedFilesRegex_TXT = ~/^(\/*|.*\/)(configure\.ac|.*\.m4|Makefile.am|ci_.*\.sh|\.git.*|.*\.txt|.*\.dict|asciidoc.*|.*\.xsl|AUTHORS.*|CHANGELOG.*|COPYING.*|INSTALL.*|LICENSE.*|MAINT.*|NEWS.*|README.*|TODO.*|UPGRAD.*)$/
-    dynacfgPipeline.appliesToChangedFilesRegex_DOC = ~/^(\/*|.*\/)(configure\.ac|.*\.m4|Makefile.am|ci_.*\.sh|\.git.*|.*\.txt|.*\.dict|asciidoc.*|.*\.xsl|.*\.css|.*\.svg|.*\.png|.*\.jpg|.*\.jpeg|.*\.gif|AUTHORS.*|CHANGELOG.*|COPYING.*|INSTALL.*|LICENSE.*|MAINT.*|NEWS.*|README.*|TODO.*|UPGRAD.*)$/
-    // |Jenkinsfile.*|*.groovy
-    // TODO: modularize the regexes - e.g. repetitive "recipe changes" part...
-    // TODO: Similar for shell files but based on some logic like in shellcheck to find the script files (not only *.sh)?
+    dynacfgPipeline.appliesToChangedFilesRegex_TXT = ~/${dynacfgPipeline.appliesToChangedFilesRegex_FILES_PREFIX}(${dynacfgPipeline.appliesToChangedFilesRegex_FILES_RECIPE}|${dynacfgPipeline.appliesToChangedFilesRegex_FILES_TXT}(|\.in)$)/
+    dynacfgPipeline.appliesToChangedFilesRegex_DOC = ~/${dynacfgPipeline.appliesToChangedFilesRegex_FILES_PREFIX}(${dynacfgPipeline.appliesToChangedFilesRegex_FILES_RECIPE}|${dynacfgPipeline.appliesToChangedFilesRegex_FILES_TXT}|${dynacfgPipeline.appliesToChangedFilesRegex_FILES_IMG})(|\.in)$/
+
+    // TODO: Similar for shell files but based on some logic
+    // like in shellcheck to find the script files (not only *.sh)?
 
     // Do not override DISTCHECK_CONFIGURE_FLAGS as default implem
     // does, that breaks custom proto-dir installs and tries to go

--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -79,6 +79,15 @@ import org.nut.dynamatrix.*;
 
     dynacfgPipeline.stashnameSrc = 'nut-ci-src'
 
+    // Recipe changes and C source changes go here:
+    dynacfgPipeline.appliesToChangedFilesRegex_C = ~/^(\/*|.*\/)(configure\.ac|.*\.m4|Makefile.am|ci_.*\.sh|\.git.*|.*\.h|.*\.hpp|.*\.c|.*\.cxx|.*\.cpp)$/
+    // Recipe changes and docs source changes go here:
+    dynacfgPipeline.appliesToChangedFilesRegex_TXT = ~/^(\/*|.*\/)(configure\.ac|.*\.m4|Makefile.am|ci_.*\.sh|\.git.*|.*\.txt|.*\.dict|asciidoc.*|.*\.xsl|AUTHORS.*|CHANGELOG.*|COPYING.*|INSTALL.*|LICENSE.*|MAINT.*|NEWS.*|README.*|TODO.*|UPGRAD.*)$/
+    dynacfgPipeline.appliesToChangedFilesRegex_DOC = ~/^(\/*|.*\/)(configure\.ac|.*\.m4|Makefile.am|ci_.*\.sh|\.git.*|.*\.txt|.*\.dict|asciidoc.*|.*\.xsl|.*\.css|.*\.svg|.*\.png|.*\.jpg|.*\.jpeg|.*\.gif|AUTHORS.*|CHANGELOG.*|COPYING.*|INSTALL.*|LICENSE.*|MAINT.*|NEWS.*|README.*|TODO.*|UPGRAD.*)$/
+    // |Jenkinsfile.*|*.groovy
+    // TODO: modularize the regexes - e.g. repetitive "recipe changes" part...
+    // TODO: Similar for shell files but based on some logic like in shellcheck to find the script files (not only *.sh)?
+
     // Do not override DISTCHECK_CONFIGURE_FLAGS as default implem
     // does, that breaks custom proto-dir installs and tries to go
     // into (not writeable) system paths:
@@ -163,6 +172,7 @@ set | sort -n """
          branchRegexSource: ~/^(PR-.+|fightwarn.*)$/,
          //branchRegexTarget: ~/^(master|main|stable)$/,
          branchRegexTarget: ~/fightwarn/,
+         appliesToChangedFilesRegex: dynacfgPipeline.appliesToChangedFilesRegex_C,
          'getParStages': { dynamatrix, Closure body ->
             return dynamatrix.generateBuild([
                 //commonLabelExpr: dynacfgBase.commonLabelExpr,
@@ -195,6 +205,8 @@ set | sort -n """
          branchRegexSource: ~/^(PR-.+|fightwarn.*)$/,
          //branchRegexTarget: ~/^(master|main|stable)$/,
          branchRegexTarget: ~/fightwarn/,
+         // NOTE: For fightwarn, we want some schenarios that would always build to test
+         //appliesToChangedFilesRegex: dynacfgPipeline.appliesToChangedFilesRegex_C,
          'getParStages': { dynamatrix, Closure body ->
             return dynamatrix.generateBuild([
                 //commonLabelExpr: dynacfgBase.commonLabelExpr,
@@ -227,10 +239,11 @@ set | sort -n """
         //'bodyParStages': {}
         ] // one slowBuild filter configuration
 
-        ,[name: 'Various target builds (must pass on all platforms)',
+        ,[name: 'Various non-docs target builds (must pass on all platforms)',
          disabled: dynacfgPipeline.disableSlowBuildCIBuild,
          //branchRegexSource: ~/^(PR-.+|fightwarn.*)$/,
          //branchRegexTarget: ~/^(master|main|stable)$/,
+         appliesToChangedFilesRegex: dynacfgPipeline.appliesToChangedFilesRegex_C,
          'getParStages': { dynamatrix, Closure body ->
             return dynamatrix.generateBuild([
                 requiredNodelabels: [],
@@ -267,6 +280,7 @@ set | sort -n """
          disabled: dynacfgPipeline.disableSlowBuildCIBuild,
          //branchRegexSource: ~/^(PR-.+|fightwarn.*)$/,
          //branchRegexTarget: ~/^(master|main|stable)$/,
+         appliesToChangedFilesRegex: dynacfgPipeline.appliesToChangedFilesRegex_C,
          'getParStages': { dynamatrix, Closure body ->
             return dynamatrix.generateBuild([
                 //commonLabelExpr: "nut-builder:alldrv",
@@ -303,6 +317,7 @@ set | sort -n """
          disabled: dynacfgPipeline.disableSlowBuildCIBuild,
          //branchRegexSource: ~/^(PR-.+|fightwarn.*)$/,
          //branchRegexTarget: ~/^(master|main|stable)$/,
+         appliesToChangedFilesRegex: dynacfgPipeline.appliesToChangedFilesRegex_C,
          'getParStages': { dynamatrix, Closure body ->
             return dynamatrix.generateBuild([
                 //commonLabelExpr: "nut-builder:alldrv",
@@ -334,6 +349,7 @@ set | sort -n """
          disabled: dynacfgPipeline.disableSlowBuildCIBuildExperimental,
          branchRegexSource: ~/^(PR-.+|.*fightwarn.*)$/,
          branchRegexTarget: ~/fightwarn/,
+         appliesToChangedFilesRegex: dynacfgPipeline.appliesToChangedFilesRegex_C,
          'getParStages': { dynamatrix, Closure body ->
             return dynamatrix.generateBuild([
                 //commonLabelExpr: "nut-builder:alldrv",
@@ -368,6 +384,7 @@ set | sort -n """
          disabled: dynacfgPipeline.disableSlowBuildCIBuild,
          //branchRegexSource: ~/^(PR-.+|fightwarn.*)$/,
          //branchRegexTarget: ~/^(master|main|stable)$/,
+         appliesToChangedFilesRegex: dynacfgPipeline.appliesToChangedFilesRegex_DOC,
          'getParStages': { dynamatrix, Closure body ->
             return dynamatrix.generateBuild([
                 //commonLabelExpr: dynacfgBase.commonLabelExpr + " && doc-builder",
@@ -402,6 +419,7 @@ set | sort -n """
          disabled: dynacfgPipeline.disableSlowBuildCIBuild,
          //branchRegexSource: ~/^(PR-.+|fightwarn.*)$/,
          //branchRegexTarget: ~/^(master|main|stable)$/,
+         appliesToChangedFilesRegex: dynacfgPipeline.appliesToChangedFilesRegex_TXT,
          'getParStages': { dynamatrix, Closure body ->
             return dynamatrix.generateBuild([
                 //commonLabelExpr: dynacfgBase.commonLabelExpr + " && doc-builder",
@@ -434,6 +452,7 @@ set | sort -n """
          disabled: dynacfgPipeline.disableSlowBuildCIBuild,
          //branchRegexSource: ~/^(PR-.+|fightwarn.*)$/,
          //branchRegexTarget: ~/^(master|main|stable)$/,
+         appliesToChangedFilesRegex: dynacfgPipeline.appliesToChangedFilesRegex_C,
          'getParStages': { dynamatrix, Closure body ->
             return dynamatrix.generateBuild([
                 requiredNodelabels: [],
@@ -463,6 +482,7 @@ set | sort -n """
          disabled: dynacfgPipeline.disableSlowBuildCIBuildExperimental,
          branchRegexSource: ~/^(PR-.+|.*fightwarn.*)$/,
          branchRegexTarget: ~/fightwarn/,
+         appliesToChangedFilesRegex: dynacfgPipeline.appliesToChangedFilesRegex_C,
          'getParStages': { dynamatrix, Closure body ->
             return dynamatrix.generateBuild([
                 requiredNodelabels: [],
@@ -498,6 +518,7 @@ set | sort -n """
          disabled: dynacfgPipeline.disableSlowBuildCIBuild,
          //branchRegexSource: ~/^(PR-.+|fightwarn.*)$/,
          //branchRegexTarget: ~/^(master|main|stable)$/,
+         appliesToChangedFilesRegex: dynacfgPipeline.appliesToChangedFilesRegex_C,
          'getParStages': { dynamatrix, Closure body ->
             return dynamatrix.generateBuild([
                 requiredNodelabels: [],
@@ -530,6 +551,7 @@ set | sort -n """
          disabled: dynacfgPipeline.disableSlowBuildCIBuildExperimental,
          branchRegexSource: ~/^(PR-.+|.*fightwarn.*)$/,
          branchRegexTarget: ~/fightwarn/,
+         appliesToChangedFilesRegex: dynacfgPipeline.appliesToChangedFilesRegex_C,
          'getParStages': { dynamatrix, Closure body ->
             return dynamatrix.generateBuild([
                 requiredNodelabels: [],
@@ -560,6 +582,7 @@ set | sort -n """
          disabled: dynacfgPipeline.disableSlowBuildCIBuildExperimental,
          branchRegexSource: ~/^(PR-.+|.*fightwarn.*)$/,
          branchRegexTarget: ~/fightwarn/,
+         appliesToChangedFilesRegex: dynacfgPipeline.appliesToChangedFilesRegex_C,
          'getParStages': { dynamatrix, Closure body ->
             return dynamatrix.generateBuild([
                 requiredNodelabels: [],
@@ -617,4 +640,3 @@ def stageNameFunc_ShellcheckCustom(DynamatrixSingleBuildConfig dsbc) {
     }
 
 dynamatrixPipeline(dynacfgBase, dynacfgPipeline)
-

--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -266,7 +266,7 @@ set | sort -n """
                     'BITS': [32, 64],
                     'CSTDVERSION_${KEY}': [ ['c': '99', 'cxx': '98'], ['c': '17', 'cxx': '17'] ],
                     'CSTDVARIANT': ['gnu'],
-                    'BUILD_TYPE': ['default-nodoc', 'default', 'default-tgt:distcheck-valgrind']
+                    'BUILD_TYPE': ['default-nodoc', 'default-tgt:distcheck-valgrind']
                     // BUILD_TYPE=default-withdoc:man
                     // BUILD_TYPE=default-tgt:distcheck-light == --with-all=auto --with-ssl=auto --with-doc=auto
                     // BUILD_TYPE=default-tgt:distcheck-light + NO_PKG_CONFIG=true ?


### PR DESCRIPTION
... (e.g. no big rebuilds for a docs-only change)

Should address the issue described at https://github.com/networkupstools/jenkins-dynamatrix/issues/5 and solved in the library by supporting the fields we set in this PR, and a way to get the list of files changed by the tested build and process them against the regexes.