### PR TITLE
Use ci_build.sh for CI spellchecks, and check some more docs files

### DIFF
--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -35,8 +35,17 @@ import org.nut.dynamatrix.*;
     dynacfgPipeline.delayedIssueAnalysis = //false //
         true
 
+    // In modern builds, use the ci_build.sh recipe which first checks
+    // quietly for things that succeed, and summarizes errors in the end
+    dynacfgPipeline['spellcheck_prepconf'] = false
+    dynacfgPipeline['spellcheck_configure'] = false
+    dynacfgPipeline['spellcheck'] = '(BUILD_TYPE=default-spellcheck ./ci_build.sh)'
+
+/*
+    // For older builds, with only autotools in the tree:
     dynacfgPipeline['spellcheck'] = //false //true
-        '( \${MAKE} VERBOSE=1 SPELLCHECK_ERROR_FATAL=yes spellcheck )'
+        // '( \${MAKE} VERBOSE=1 SPELLCHECK_ERROR_FATAL=yes spellcheck )'
+*/
 
     //dynacfgPipeline['shellcheck'] = true
     dynacfgPipeline['shellcheck'] = [

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -510,8 +510,13 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
             [ -z "$CI_TIME" ] || echo "`date`: Trying to spellcheck documentation of the currently tested project..."
             # Note: use the root Makefile's spellcheck recipe which goes into
             # sub-Makefiles known to check corresponding directory's doc files.
-            ( $CI_TIME $MAKE VERBOSE=1 SPELLCHECK_ERROR_FATAL=yes spellcheck )
-            exit 0
+            ( echo "`date`: Starting the quiet build attempt for target $BUILD_TGT..." >&2
+              $CI_TIME $MAKE -s VERBOSE=0 SPELLCHECK_ERROR_FATAL=yes -k spellcheck \
+              && echo "`date`: SUCCEEDED the spellcheck" >&2
+            ) || \
+            ( echo "`date`: FAILED something in spellcheck above; re-starting a verbose build attempt to summarize:" >&2
+              $CI_TIME $MAKE -s VERBOSE=1 SPELLCHECK_ERROR_FATAL=yes spellcheck )
+            exit $?
             ;;
         "default-shellcheck")
             [ -z "$CI_TIME" ] || echo "`date`: Trying to check shell script syntax validity of the currently tested project..."

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -511,7 +511,7 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
             # Note: use the root Makefile's spellcheck recipe which goes into
             # sub-Makefiles known to check corresponding directory's doc files.
             ( echo "`date`: Starting the quiet build attempt for target $BUILD_TGT..." >&2
-              $CI_TIME $MAKE -s VERBOSE=0 SPELLCHECK_ERROR_FATAL=yes -k spellcheck \
+              $CI_TIME $MAKE -s VERBOSE=0 SPELLCHECK_ERROR_FATAL=yes -k spellcheck >/dev/null 2>&1 \
               && echo "`date`: SUCCEEDED the spellcheck" >&2
             ) || \
             ( echo "`date`: FAILED something in spellcheck above; re-starting a verbose build attempt to summarize:" >&2

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -188,11 +188,13 @@ if HAVE_ASPELL
 # This is useful for Buildbot and automated QA processing
 # FIXME: how to present output (std{out,err}, single file or per target)?
 # NOTE: ../ChangeLog is nowadays generated from commit messages, so
-# its spelling (or errors in that) are not fixable and thus irrelevant
+# its spelling (or errors in that) are not fixable and thus irrelevant.
+# Similarly for the ../INSTALL file that is prepared by autoconf and not
+# tracked as a source file by NUT Git repository.
 SPELLCHECK_SRC = $(ALL_TXT_SRC) ../README ../INSTALL.nut ../UPGRADING  ../NEWS \
 	../TODO ../scripts/ufw/README ../scripts/augeas/README ../lib/README \
 	../tools/nut-scanner/README \
-	../INSTALL ../AUTHORS ../COPYING ../LICENSE-GPL2 ../LICENSE-GPL3
+	../AUTHORS ../COPYING ../LICENSE-GPL2 ../LICENSE-GPL3
 
 # Directory SPELLCHECK_SRC files are relative to. Overriden by other Makefiles.
 SPELLCHECK_DIR = $(srcdir)

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -187,9 +187,12 @@ if HAVE_ASPELL
 # Non-interactively spell check all documentation source files.
 # This is useful for Buildbot and automated QA processing
 # FIXME: how to present output (std{out,err}, single file or per target)?
+# NOTE: ../ChangeLog is nowadays generated from commit messages, so
+# its spelling (or errors in that) are not fixable and thus irrelevant
 SPELLCHECK_SRC = $(ALL_TXT_SRC) ../README ../INSTALL.nut ../UPGRADING  ../NEWS \
 	../TODO ../scripts/ufw/README ../scripts/augeas/README ../lib/README \
-	../tools/nut-scanner/README
+	../tools/nut-scanner/README \
+	../INSTALL ../AUTHORS ../COPYING ../LICENSE-GPL2 ../LICENSE-GPL3
 
 # Directory SPELLCHECK_SRC files are relative to. Overriden by other Makefiles.
 SPELLCHECK_DIR = $(srcdir)

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -233,7 +233,7 @@ spellcheck:
 	 done ; \
 	 if test -n "$$FAILED" ; then \
 		echo "=====================================================================" ; \
-		echo "FAILED automatic spellcheck for the following sources: $$FAILED" ; \
+		echo "FAILED automatic spellcheck for the following sources (relative to `pwd`): $$FAILED" ; \
 		echo "=====================================================================" ; \
 		echo "Please 'cd $(abs_top_builddir) && make spellcheck-interactive'"; \
 		echo "to either fix document sources or update the dictionary of accepted"; \
@@ -280,7 +280,7 @@ spellcheck-interactive:
 			FAILED="$$FAILED $(SPELLCHECK_DIR)/$$docsrc"; \
 	done ; \
 	if test -n "$$FAILED" ; then \
-		echo "FAILED interactive spellcheck for the following sources: $$FAILED" >&2 ; \
+		echo "FAILED interactive spellcheck for the following sources (relative to `pwd`): $$FAILED" >&2 ; \
 		exit 1; \
 	fi ; exit 0
 	$(MAKE) spellcheck-sortdict

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 2611 utf-8
+personal_ws-1.1 en 2678 utf-8
 AAS
 ACFAIL
 ACFREQ
@@ -12,8 +12,10 @@ ADDRINFO
 ADK
 ADKK
 AEC
+AEF
 AEG
 AES
+AFE
 AGM
 AIX
 AMETEK
@@ -38,6 +40,7 @@ AWG
 Ablerex
 ActivePower
 AdMiN
+Affero
 Agrain
 AlarmStatus
 AlarmsHelp
@@ -107,6 +110,7 @@ BadPW
 Bads
 Baggesen
 Bakos
+Balker
 Bartek
 BattTstFail
 BatteryA
@@ -178,6 +182,7 @@ CUDA
 CVE
 CXR
 CXX
+CXXCPP
 CXXFLAGS
 Casar
 CentOS
@@ -192,6 +197,7 @@ Chu
 Cichowski
 Claesson
 CodingStyle
+Collver
 Colombier
 Comfo
 ConITm
@@ -222,6 +228,7 @@ DELINFO
 DELRANGE
 DES
 DESTDIR
+DF
 DHEA
 DISCHRG
 DMF
@@ -327,6 +334,7 @@ Feldman
 Ferrups
 Fideltronic
 Fideltronik
+Filipozzi
 Fiskars
 FlossMetrics
 Forza
@@ -349,6 +357,7 @@ GUIs
 GWD
 GXE
 GXT
+Gabeler
 Gabor
 Gammons
 Gandi
@@ -363,6 +372,7 @@ Gilles
 GitHub
 GitHub's
 Gnd
+Gnomovision
 Goebl
 Golang
 Gomes
@@ -535,6 +545,7 @@ LowRntm
 LowRuntime
 Loyer
 Ltr
+Luca
 Lucent
 Lygre
 Lynge
@@ -556,11 +567,13 @@ MMM
 MMMMMMMMMMMMMMM
 MNU
 MONITORed
+MOXA
 MPSU
 MQ
 MSI
 MacKenzie's
 MacOS
+Maccelari
 Magalhaes
 MagalhÃ
 Magalhães
@@ -586,6 +599,7 @@ Metheringham
 Michal
 Michalkiewicz
 MicroDowell
+MicroFerrups
 Microline
 Micropower
 Microsol
@@ -606,9 +620,9 @@ Morioka
 Morozov
 Moskovitch
 Moxa
-MOXA
 Mozilla
 Msg
+MultiLink
 Multiplug
 MyCompany
 MyPasSw
@@ -687,6 +701,7 @@ OMNIVS
 OMNIVSINT
 ONF
 ONV
+OSF
 OSs
 OUTPUTV
 OUTVOLT
@@ -895,6 +910,7 @@ Reinholdtsen
 Remi
 Rene
 René
+Repotec's
 Repoteck
 Richthof
 Rickard
@@ -904,6 +920,7 @@ RntmK
 Rocketfish
 Rodrigues
 Rodríguez
+Rozman
 Rucelf
 RxD
 RxHs
@@ -978,7 +995,10 @@ SXI
 SXL
 SafeNet
 Salvia
+Santinoli
+Savia
 Sawatzky
+Schmier
 Schoch
 Schonefeld
 Schroder
@@ -1026,9 +1046,13 @@ Stanislav
 StatePath
 Stefano
 Stimits
+SuSE
 Suatoni
+Sublicensing
+SunOS
 SuperPower
 Sweex
+Sycon
 Symmetra
 Symmetras
 Synology
@@ -1064,6 +1088,7 @@ TapSwDly
 TapSwPh
 TcpClient
 Technic
+Technorama
 Tecnoware
 Tefft
 TeleCom
@@ -1088,6 +1113,7 @@ Tru
 Tx
 TxD
 TxHS
+UB
 UBD
 UBR
 UDP
@@ -1140,6 +1166,7 @@ VIB
 VMIN
 VMware
 VNC
+VPATH
 VSN
 VTIME
 VV
@@ -1152,6 +1179,7 @@ VendorID
 Viewpower
 Viewsonic
 Viktor
+VirCIO
 Vout
 Václav
 WALKMODE
@@ -1159,6 +1187,7 @@ WARNFATAL
 WARNOPT
 WELI
 WHAD
+WIPO
 WMNut
 WS
 WSE
@@ -1179,6 +1208,7 @@ XCP
 XLA
 XOFF
 XON
+XOPEN
 XP
 XPPC
 XSL
@@ -1199,6 +1229,7 @@ YYYY
 YYYYMMDD
 YZ
 Ygor
+Yoyodyne
 Yukai
 Yunto
 ZZZZZZZZ
@@ -1336,6 +1367,7 @@ beepertone
 belkin
 belkinunv
 bestfcom
+bestferrups
 bestfort
 bestfortress
 bestuferrups
@@ -1455,6 +1487,7 @@ constatus
 contdisplay
 contrib
 contstatus
+copyrightable
 coreutils
 cout
 coverity
@@ -1522,6 +1555,7 @@ dipsw
 dir
 disp
 distcheck
+distclean
 distro
 distros
 dl
@@ -1746,6 +1780,7 @@ initinfo
 initscripts
 initups
 inline
+installcheck
 instcmd
 instcmds
 intercharacter
@@ -1838,12 +1873,15 @@ libusbugen
 libwrap
 libxslt
 libxxx
+licensor
+licensors
 liebert
 liebertgxt
 linesensitivity
 linevoltage
 linkdoc
 linux
+lipo
 listdef
 littleguy
 lk
@@ -1868,6 +1906,7 @@ lowbattery
 lowfrequency
 lowruntime
 lowvoltsout
+lposix
 lr
 lsusb
 lu
@@ -2002,6 +2041,7 @@ nn
 nnn
 noAuthNoPriv
 nobody's
+nodtk
 noflag
 nohang
 noimp
@@ -2012,6 +2052,7 @@ nomacvoltsout
 nombattvolt
 nomdcvolts
 nomfrequency
+noncommercially
 noout
 norating
 noro
@@ -2138,9 +2179,11 @@ powerpanel
 powerup
 powervalue
 powerware
+ppc
 pprint
 ppro
 pre
+prepend
 prepended
 preprocess
 preprocessing
@@ -2160,6 +2203,7 @@ prtconf
 psu
 pw
 pwl
+pwmib
 pwro
 px
 pxgx
@@ -2199,6 +2243,7 @@ refactoring
 referencenominal
 regex
 regtype
+relicensing
 reposurgeon
 repotec
 req
@@ -2301,6 +2346,7 @@ sm
 smartups
 sms
 sn
+snailmail
 snmp
 snmpagent
 snmpv
@@ -2321,6 +2367,7 @@ splitaddr
 splitname
 sr
 src
+srcdir
 srw
 ss
 ssl
@@ -2360,6 +2407,8 @@ subdriver
 subdriver's
 subdrivers
 subdrv
+sublicense
+sublicenses
 submodule
 submodules
 subtree
@@ -2454,6 +2503,7 @@ uD
 uM
 ua
 uc
+ucb
 udev
 udevadm
 ufw
@@ -2573,6 +2623,7 @@ voltronic
 von
 wDescriptorLength
 wakeup
+wchar
 webserver
 wf
 wget


### PR DESCRIPTION
Let the first spellcheck attempt be quiet in the log; only redo the work verbosely if that fails.

NOTE: This was originally part of a PR to track which files were spell-checked, so that retry would only double-check and report the failed documents -- improving the UX for developers who would see all the errors concisely. The first shot at that solution worked well, but only in GNU make, so has to be tracked as a separate effort.