### PR TITLE
Extend CI_OS_NAME in ci_build.sh; fix 32/64 pkg-config builds against Mozilla NSS on illumos/Solaris

### DIFF
--- a/ci_build.sh
+++ b/ci_build.sh
@@ -89,6 +89,7 @@ if [ -z "$CI_OS_NAME" ]; then
         "-") ;;
         *)  echo "WARNING: Could not recognize CI_OS_NAME from '$OS_FAMILY'-'$OS_DISTRO', update './ci_build.sh' if needed" >&2 ;;
     esac
+    [ -z "$CI_OS_NAME" ] || echo "INFO: Detected CI_OS_NAME='$CI_OS_NAME'" >&2
 fi
 
 # CI builds on Travis

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -61,7 +61,11 @@ done
 if [ -z "$CI_OS_NAME" ]; then
     # Check for dynaMatrix node labels support and map into a simple
     # classification styled after (compatible with) that in Travis CI
-    case "`echo "$OS_FAMILY-$OS_DISTRO" | tr 'A-Z' 'a-z'`" in
+    for CI_OS_HINT in "$OS_FAMILY-$OS_DISTRO" "`uname -o`" "`uname -s -r -v`" "`uname -a`" ; do
+        [ -z "$CI_OS_HINT" -o "$CI_OS_HINT" = "-" ] || break
+    done
+
+    case "`echo "$CI_OS_HINT" | tr 'A-Z' 'a-z'`" in
         *freebsd*)
             CI_OS_NAME="freebsd" ;;
         *debian*|*linux*)

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -61,7 +61,7 @@ done
 if [ -z "$CI_OS_NAME" ]; then
     # Check for dynaMatrix node labels support and map into a simple
     # classification styled after (compatible with) that in Travis CI
-    case "$OS_FAMILY-$OS_DISTRO" in
+    case "`echo "$OS_FAMILY-$OS_DISTRO" | tr 'A-Z' 'a-z'`" in
         *freebsd*)
             CI_OS_NAME="freebsd" ;;
         *debian*|*linux*)
@@ -78,6 +78,10 @@ if [ -z "$CI_OS_NAME" ]; then
             CI_OS_NAME="bsd" ;;
         *illumos*)
             CI_OS_NAME="illumos" ;;
+        *solaris*)
+            CI_OS_NAME="solaris" ;;
+        *sunos*)
+            CI_OS_NAME="sunos" ;;
         "-") ;;
         *)  echo "WARNING: Could not recognize CI_OS_NAME from '$OS_FAMILY'-'$OS_DISTRO', update './ci_build.sh' if needed" >&2 ;;
     esac

--- a/configure.ac
+++ b/configure.ac
@@ -1079,6 +1079,7 @@ dnl # they use code like below to detect library paths:
 dnl #   if test yes = "$GCC"; then ... lt_search_path_spec=`$CC -print-search-dirs | ...
 dnl # which explodes when non-default architecture is used for the build,
 dnl # where e.g. "CC=gcc" and "CFLAGS=-m32" on a 64-bit capable system.
+dnl # And similarly for compilation-checks to link third-party libraries.
 SAVED_GCC="$GCC"
 SAVED_CC="$CC"
 if ( test "${GCC}" = "yes" )

--- a/m4/nut_check_libnss.m4
+++ b/m4/nut_check_libnss.m4
@@ -13,6 +13,16 @@ if test -z "${nut_have_libnss_seen}"; then
 	LIBS_ORIG="${LIBS}"
 	REQUIRES_ORIG="${REQUIRES}"
 
+	SAVED_GCC="$GCC"
+	SAVED_CC="$CC"
+	if ( test "${GCC}" = "yes" )
+	then
+		case "$CFLAGS$LDFLAGS" in
+			*-m32*) CC="$CC -m32" ;;
+			*-m64*) CC="$CC -m64" ;;
+		esac
+	fi
+
 	AC_MSG_CHECKING(for Mozilla NSS version via pkg-config)
 	NSS_VERSION="`pkg-config --silence-errors --modversion nss 2>/dev/null`"
 	if test "$?" = "0" -a -n "${NSS_VERSION}"; then
@@ -66,7 +76,7 @@ if test -z "${nut_have_libnss_seen}"; then
 	AC_CHECK_FUNCS(NSS_Init, [nut_have_libnss=yes], [nut_have_libnss=no])
 	dnl libc6 also provides an nss.h file, so also check for ssl.h
 	AC_CHECK_HEADERS([nss.h ssl.h], [], [nut_have_libnss=no], [AC_INCLUDES_DEFAULT])
-	
+
 	if test "${nut_have_libnss}" = "yes"; then
 		nut_with_ssl="yes"
 		nut_ssl_lib="(Mozilla NSS)"
@@ -81,5 +91,7 @@ if test -z "${nut_have_libnss_seen}"; then
 	CFLAGS="${CFLAGS_ORIG}"
 	LIBS="${LIBS_ORIG}"
 	REQUIRES="${REQUIRES_ORIG}"
+	GCC="$SAVED_GCC"
+	CC="$SAVED_CC"
 fi
 ])


### PR DESCRIPTION
On Solaris-legacy systems, NSS is historically delivered to /usr/lib/mps or /usr/lib/mps/(amd)64 and the automated smarts of the system to substitute "lib" to match 32 or 64 bit dependencies as appropriate do not kick in. So for CI (and workstation) builds to test this reliably, we have to tell pkg-config which version of the "nss.pc" to expose depending on bitness we build for. Otherwise it tends to report data from "/usr/lib/pkgconfig/nss.pc" which embeds paths to 32-bit libs, and that breaks for 64-bit builds.

Also, the link checks done in the m4 script did not take into account the bitness of the build (which failed for the non-standard paths pattern detailed above), so now this is explicitly set for gcc-compatible tooling.