### PR TITLE
Makefiles: mark every spellchecked text file with a touch-file to not re-test it again needlessly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ Makefile.in
 /missing
 /test-driver
 common/.dirstamp
+*.spellchecked
 /.ci*.log
 /.ci*.log.*
 

--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ Makefile.in
 /missing
 /test-driver
 common/.dirstamp
-*.spellchecked
+*-spellchecked
 /.ci*.log
 /.ci*.log.*
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -52,7 +52,7 @@ distcleancheck:
 	@:
 
 clean-local:
-	rm -f *.spellchecked
+	rm -f *-spellchecked
 
 # Hook the documentation building and validating recipes
 # Note: these are optionally available (as determined during configure runs)

--- a/Makefile.am
+++ b/Makefile.am
@@ -51,6 +51,9 @@ memcheck distcheck-valgrind:
 distcleancheck:
 	@:
 
+clean-local:
+	rm -f *.spellchecked
+
 # Hook the documentation building and validating recipes
 # Note: these are optionally available (as determined during configure runs)
 spellcheck spellcheck-interactive:

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -553,7 +553,7 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
             [ -z "$CI_TIME" ] || echo "`date`: Trying to spellcheck documentation of the currently tested project..."
             # Note: use the root Makefile's spellcheck recipe which goes into
             # sub-Makefiles known to check corresponding directory's doc files.
-            ( echo "`date`: Starting the quiet build attempt for target $BUILD_TGT..." >&2
+            ( echo "`date`: Starting the quiet build attempt for target $BUILD_TYPE..." >&2
               $CI_TIME $MAKE -s VERBOSE=0 SPELLCHECK_ERROR_FATAL=yes -k spellcheck >/dev/null 2>&1 \
               && echo "`date`: SUCCEEDED the spellcheck" >&2
             ) || \

--- a/conf/Makefile.am
+++ b/conf/Makefile.am
@@ -24,13 +24,13 @@ clean-local:
 
 # NOTE: Due to portability, we do not use a GNU percent-wildcard extension:
 #%-spellchecked: % Makefile.am $(top_srcdir)/docs/Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
-#	$(MAKE) -s -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC="$<" SPELLCHECK_DIR="$(srcdir)" $@
+#	$(MAKE) -s -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC_ONE="$<" SPELLCHECK_DIR="$(srcdir)" $@
 
 .sample.sample-spellchecked: Makefile.am $(top_srcdir)/docs/Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
-	$(MAKE) -s -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC="$<" SPELLCHECK_DIR="$(srcdir)" $@
+	$(MAKE) -s -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC_ONE="$<" SPELLCHECK_DIR="$(srcdir)" $@
 
 .in.in-spellchecked: Makefile.am $(top_srcdir)/docs/Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
-	$(MAKE) -s -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC="$<" SPELLCHECK_DIR="$(srcdir)" $@
+	$(MAKE) -s -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC_ONE="$<" SPELLCHECK_DIR="$(srcdir)" $@
 
 spellcheck spellcheck-interactive spellcheck-sortdict:
 	$(MAKE) -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC="$(SPELLCHECK_SRC)" SPELLCHECK_DIR="$(srcdir)" $@

--- a/conf/Makefile.am
+++ b/conf/Makefile.am
@@ -20,9 +20,16 @@ SPELLCHECK_SRC = $(dist_sysconf_DATA) \
  upssched.conf.sample.in upsmon.conf.sample.in
 
 clean-local:
-	rm -f *.pdf *.html *.spellchecked
+	rm -f *.pdf *.html *-spellchecked
 
-%.spellchecked: % Makefile.am $(top_srcdir)/docs/Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
+# NOTE: Due to portability, we do not use a GNU percent-wildcard extension:
+#%-spellchecked: % Makefile.am $(top_srcdir)/docs/Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
+#	$(MAKE) -s -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC="$<" SPELLCHECK_DIR="$(srcdir)" $@
+
+.sample.sample-spellchecked: Makefile.am $(top_srcdir)/docs/Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
+	$(MAKE) -s -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC="$<" SPELLCHECK_DIR="$(srcdir)" $@
+
+.in.in-spellchecked: Makefile.am $(top_srcdir)/docs/Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
 	$(MAKE) -s -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC="$<" SPELLCHECK_DIR="$(srcdir)" $@
 
 spellcheck spellcheck-interactive spellcheck-sortdict:

--- a/conf/Makefile.am
+++ b/conf/Makefile.am
@@ -19,6 +19,9 @@ nodist_sysconf_DATA = upssched.conf.sample upsmon.conf.sample
 SPELLCHECK_SRC = $(dist_sysconf_DATA) \
  upssched.conf.sample.in upsmon.conf.sample.in
 
+clean-local:
+	rm -f *.pdf *.html *.spellchecked
+
 %.spellchecked: % Makefile.am $(top_srcdir)/docs/Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
 	$(MAKE) -s -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC="$<" SPELLCHECK_DIR="$(srcdir)" $@
 

--- a/conf/Makefile.am
+++ b/conf/Makefile.am
@@ -19,5 +19,8 @@ nodist_sysconf_DATA = upssched.conf.sample upsmon.conf.sample
 SPELLCHECK_SRC = $(dist_sysconf_DATA) \
  upssched.conf.sample.in upsmon.conf.sample.in
 
+%.spellchecked: % Makefile.am $(top_srcdir)/docs/Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
+	$(MAKE) -s -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC="$<" SPELLCHECK_DIR="$(srcdir)" $@
+
 spellcheck spellcheck-interactive spellcheck-sortdict:
 	$(MAKE) -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC="$(SPELLCHECK_SRC)" SPELLCHECK_DIR="$(srcdir)" $@

--- a/configure.ac
+++ b/configure.ac
@@ -2190,6 +2190,7 @@ AC_CONFIG_FILES([
  data/Makefile
  data/driver.list
  docs/Makefile
+ docs/cables/Makefile
  docs/docinfo.xml
  docs/man/Makefile
  drivers/Makefile
@@ -2248,6 +2249,7 @@ AC_CONFIG_FILES([
  scripts/udev/Makefile
  scripts/udev/nut-ipmipsu.rules
  scripts/udev/nut-usbups.rules
+ scripts/ufw/Makefile
  scripts/ufw/nut.ufw.profile
  scripts/Makefile
  server/Makefile

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -6,5 +6,8 @@ dist_data_DATA = cmdvartab
 nodist_data_DATA = driver.list
 EXTRA_DIST = evolution500.seq epdu-managed.dev
 
+%.spellchecked: % Makefile.am $(top_srcdir)/docs/Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
+	$(MAKE) -s -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC="$<" SPELLCHECK_DIR="$(srcdir)" $@
+
 spellcheck spellcheck-interactive spellcheck-sortdict:
 	$(MAKE) -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC="cmdvartab" SPELLCHECK_DIR="$(srcdir)" $@

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -6,6 +6,9 @@ dist_data_DATA = cmdvartab
 nodist_data_DATA = driver.list
 EXTRA_DIST = evolution500.seq epdu-managed.dev
 
+clean-local:
+	rm -f *.pdf *.html *.spellchecked
+
 %.spellchecked: % Makefile.am $(top_srcdir)/docs/Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
 	$(MAKE) -s -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC="$<" SPELLCHECK_DIR="$(srcdir)" $@
 

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -7,9 +7,13 @@ nodist_data_DATA = driver.list
 EXTRA_DIST = evolution500.seq epdu-managed.dev
 
 clean-local:
-	rm -f *.pdf *.html *.spellchecked
+	rm -f *.pdf *.html *-spellchecked
 
-%.spellchecked: % Makefile.am $(top_srcdir)/docs/Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
+# NOTE: Due to portability, we do not use a GNU percent-wildcard extension:
+#%-spellchecked: % Makefile.am $(top_srcdir)/docs/Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
+#	$(MAKE) -s -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC="$<" SPELLCHECK_DIR="$(srcdir)" $@
+
+cmdvartab-spellchecked: cmdvartab Makefile.am $(top_srcdir)/docs/Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
 	$(MAKE) -s -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC="$<" SPELLCHECK_DIR="$(srcdir)" $@
 
 spellcheck spellcheck-interactive spellcheck-sortdict:

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -11,10 +11,10 @@ clean-local:
 
 # NOTE: Due to portability, we do not use a GNU percent-wildcard extension:
 #%-spellchecked: % Makefile.am $(top_srcdir)/docs/Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
-#	$(MAKE) -s -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC="$<" SPELLCHECK_DIR="$(srcdir)" $@
+#	$(MAKE) -s -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC_ONE="$<" SPELLCHECK_DIR="$(srcdir)" $@
 
 cmdvartab-spellchecked: cmdvartab Makefile.am $(top_srcdir)/docs/Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
-	$(MAKE) -s -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC="$<" SPELLCHECK_DIR="$(srcdir)" $@
+	$(MAKE) -s -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC_ONE="$<" SPELLCHECK_DIR="$(srcdir)" $@
 
 spellcheck spellcheck-interactive spellcheck-sortdict:
 	$(MAKE) -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC="cmdvartab" SPELLCHECK_DIR="$(srcdir)" $@

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -324,8 +324,9 @@ spellcheck-interactive:
 	 echo "because other systems might not know these words in their system dictionaries)"; \
 	 echo "------------------------------------------------------------------------"
 else !HAVE_ASPELL
-*-spellchecked: Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
-	@echo "  SKIP-ASPELL   Spell checking on $< : Documentation spell check not available since 'aspell' was not found." >&2
+#%-spellchecked: % Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
+*/*-spellchecked *-spellchecked: Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
+	@echo "  SKIP-ASPELL   $@ : Documentation spell check not available since 'aspell' was not found." >&2
 spellcheck:
 	@echo "Documentation spell check not available since 'aspell' was not found."
 spellcheck-interactive:

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -261,7 +261,7 @@ spellcheck:
 		if test "$(SPELLCHECK_ENV_DEBUG)" != no ; then \
 			echo "ASPELL MAKEFILE DEBUG: Will see from `pwd` if '$(SPELLCHECK_DIR)/$${docsrc}-spellchecked' is up to date" >&2; \
 		else true ; fi ; \
-		$(MAKE) -s "$(SPELLCHECK_DIR)/$${docsrc}-spellchecked" \
+		$(MAKE) -s -f "$(top_builddir)/docs/Makefile" "$(SPELLCHECK_DIR)/$${docsrc}-spellchecked" \
 		|| FAILED="$$FAILED $(SPELLCHECK_DIR)/$$docsrc"; \
 	 done ; \
 	 if test -n "$$FAILED" ; then \

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -233,11 +233,15 @@ ASPELL_OUT_NOTERRORS = (^[ \t]*[\*\@]|^$$)
 # Other Makefiles have a relatively simple life, dealing with just a
 # few texts and name/extension patterns in their directories.
 #?#.txt.txt-spellchecked: Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
-%-spellchecked: % Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
+#%-spellchecked: % Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
+#*-spellchecked */*-spellchecked: $(@:-spellchecked=) $(top_srcdir)/docs/Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
+# NOTE: This portable  rule RELIES on just one SPELLCHECK_SRC defined
+# at a time, with an outer Makefile caller ensuring the looping:
+$(SPELLCHECK_DIR)/$(SPELLCHECK_SRC_ONE)-spellchecked: $(SPELLCHECK_DIR)/$(SPELLCHECK_SRC_ONE) $(abs_top_srcdir)/docs/Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
 	@LANG=C; LC_ALL=C; export LANG; export LC_ALL; \
 	 rm -f "$@" || true ; \
-	 echo "  ASPELL   Spell checking on $<"; \
-	 OUT="`sed 's,^\(.*\)$$, \1,' < "$<" | $(ASPELL) -a -t $(ASPELL_NUT_COMMON_ARGS) 2>&1`" \
+	 echo "  ASPELL   Spell checking on $(SPELLCHECK_DIR)/$(SPELLCHECK_SRC_ONE)"; \
+	 OUT="`sed 's,^\(.*\)$$, \1,' < "$(SPELLCHECK_DIR)/$(SPELLCHECK_SRC_ONE)" | $(ASPELL) -a -t $(ASPELL_NUT_COMMON_ARGS) 2>&1`" \
 		&& { if test -n "$$OUT" ; then OUT="`echo "$$OUT" | $(EGREP) -b -v '$(ASPELL_OUT_NOTERRORS)' `" ; fi; \
 		     test -z "$$OUT" ; } \
 		|| { RES=$$? ; \
@@ -262,7 +266,7 @@ spellcheck:
 		if test "$(SPELLCHECK_ENV_DEBUG)" != no ; then \
 			echo "ASPELL MAKEFILE DEBUG: Will see from `pwd` if '$(SPELLCHECK_DIR)/$${docsrc}-spellchecked' is up to date" >&2; \
 		else true ; fi ; \
-		$(MAKE) -s -f "$(top_builddir)/docs/Makefile" "$(SPELLCHECK_DIR)/$${docsrc}-spellchecked" \
+		$(MAKE) -s -f "$(top_builddir)/docs/Makefile" SPELLCHECK_SRC_ONE="$${docsrc}" SPELLCHECK_DIR="$(SPELLCHECK_DIR)" "$(SPELLCHECK_DIR)/$${docsrc}-spellchecked" \
 		|| FAILED="$$FAILED $(SPELLCHECK_DIR)/$$docsrc"; \
 	 done ; \
 	 if test -n "$$FAILED" ; then \
@@ -325,7 +329,7 @@ spellcheck-interactive:
 	 echo "because other systems might not know these words in their system dictionaries)"; \
 	 echo "------------------------------------------------------------------------"
 else !HAVE_ASPELL
-#%-spellchecked: % Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
+# This rule woulf probably just fail; normally with no ASPELL there are no callers for it
 */*-spellchecked *-spellchecked: Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
 	@echo "  SKIP-ASPELL   $@ : Documentation spell check not available since 'aspell' was not found." >&2
 spellcheck:

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -241,7 +241,7 @@ $(SPELLCHECK_DIR)/$(SPELLCHECK_SRC_ONE)-spellchecked: $(SPELLCHECK_DIR)/$(SPELLC
 	@LANG=C; LC_ALL=C; export LANG; export LC_ALL; \
 	 rm -f "$@" || true ; \
 	 echo "  ASPELL   Spell checking on $(SPELLCHECK_DIR)/$(SPELLCHECK_SRC_ONE)"; \
-	 OUT="`sed 's,^\(.*\)$$, \1,' < "$(SPELLCHECK_DIR)/$(SPELLCHECK_SRC_ONE)" | $(ASPELL) -a -t $(ASPELL_NUT_COMMON_ARGS) 2>&1`" \
+	 OUT="`(sed 's,^\(.*\)$$, \1,' | $(ASPELL) -a -t $(ASPELL_NUT_COMMON_ARGS) 2>&1) < "$(SPELLCHECK_DIR)/$(SPELLCHECK_SRC_ONE)"`" \
 		&& { if test -n "$$OUT" ; then OUT="`echo "$$OUT" | $(EGREP) -b -v '$(ASPELL_OUT_NOTERRORS)' `" ; fi; \
 		     test -z "$$OUT" ; } \
 		|| { RES=$$? ; \

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -258,6 +258,9 @@ spellcheck:
 	 else true; fi
 	@FAILED="" ; LANG=C; LC_ALL=C; export LANG; export LC_ALL; \
 	 for docsrc in $(SPELLCHECK_SRC); do \
+		if test "$(SPELLCHECK_ENV_DEBUG)" != no ; then \
+			echo "ASPELL MAKEFILE DEBUG: Will see from `pwd` if '$(SPELLCHECK_DIR)/$${docsrc}-spellchecked' is up to date" >&2; \
+		else true ; fi ; \
 		$(MAKE) -s "$(SPELLCHECK_DIR)/$${docsrc}-spellchecked" \
 		|| FAILED="$$FAILED $(SPELLCHECK_DIR)/$$docsrc"; \
 	 done ; \

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -176,17 +176,24 @@ A2X_COMMON_OPTS = $(ASCIIDOC_VERBOSE) --attribute icons \
 # eventually the POSIX stance would be taken to define a rule for a weird
 # verbatim target file name with prerequisites:
 # ../docs/Makefile:936: warning: ignoring prerequisites on suffix rule definition
-.txt.html: common.xsl xhtml.xsl
+# Changes from ".txt.pdf: docinfo.xml" to "*.pdf: docinfo.xml" = ".txt.pdf:"
+# as done below may be pointless in the end (with regard to a portable way
+# to trigger builds by a changed dependency), but at least predictable and
+# not toxic.
+*.html: common.xsl xhtml.xsl
+.txt.html:
 	@if test -s "${builddir}/docbook-xsl.css" && test -r "${builddir}/docbook-xsl.css" && ! test -w "${builddir}/docbook-xsl.css" ; then chmod u+w "${builddir}/docbook-xsl.css" ; fi
 	@chmod -R u+w .
 	$(A2X) $(A2X_COMMON_OPTS) --attribute=xhtml11_format --format=xhtml --xsl-file=$(srcdir)/xhtml.xsl $<
 
-.txt.chunked: common.xsl chunked.xsl
+*.chunked: common.xsl chunked.xsl
+.txt.chunked:
 	@if test -s "${builddir}/docbook-xsl.css" && test -r "${builddir}/docbook-xsl.css" && ! test -w "${builddir}/docbook-xsl.css" ; then chmod u+w "${builddir}/docbook-xsl.css" ; fi
 	@chmod -R u+w .
 	$(A2X) $(A2X_COMMON_OPTS) --attribute=chunked_format --format=chunked --xsl-file=$(srcdir)/chunked.xsl $<
 
-.txt.pdf: docinfo.xml
+*.pdf: docinfo.xml
+.txt.pdf:
 	@if test -s "${builddir}/docbook-xsl.css" && test -r "${builddir}/docbook-xsl.css" && ! test -w "${builddir}/docbook-xsl.css" ; then chmod u+w "${builddir}/docbook-xsl.css" ; fi
 	@chmod -R u+w .
 	$(A2X) $(A2X_COMMON_OPTS) --attribute=pdf_format --format=pdf -a docinfo1 $<

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -74,7 +74,7 @@ ASCIIDOC_PDF = user-manual.pdf \
 	FAQ.pdf
 
 SUBDIRS = man cables
-SUFFIXES = .txt .html .pdf
+SUFFIXES = .txt .html .pdf -spellchecked
 
 all: doc
 

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -174,7 +174,8 @@ A2X_COMMON_OPTS = $(ASCIIDOC_VERBOSE) --attribute icons \
 # https://www.gnu.org/software/make/manual/html_node/Error-Messages.html
 # says the prerequisites were ignored while a suffix rule was created;
 # eventually the POSIX stance would be taken to define a rule for a weird
-# verbatim target file name with prerequisites.
+# verbatim target file name with prerequisites:
+# ../docs/Makefile:936: warning: ignoring prerequisites on suffix rule definition
 .txt.html: common.xsl xhtml.xsl
 	@if test -s "${builddir}/docbook-xsl.css" && test -r "${builddir}/docbook-xsl.css" && ! test -w "${builddir}/docbook-xsl.css" ; then chmod u+w "${builddir}/docbook-xsl.css" ; fi
 	@chmod -R u+w .

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -266,7 +266,7 @@ spellcheck:
 		if test "$(SPELLCHECK_ENV_DEBUG)" != no ; then \
 			echo "ASPELL MAKEFILE DEBUG: Will see from `pwd` if '$(SPELLCHECK_DIR)/$${docsrc}-spellchecked' is up to date" >&2; \
 		else true ; fi ; \
-		$(MAKE) -s -f "$(top_builddir)/docs/Makefile" SPELLCHECK_SRC_ONE="$${docsrc}" SPELLCHECK_DIR="$(SPELLCHECK_DIR)" "$(SPELLCHECK_DIR)/$${docsrc}-spellchecked" \
+		$(MAKE) -s -f "$(abs_top_builddir)/docs/Makefile" SPELLCHECK_SRC_ONE="$${docsrc}" SPELLCHECK_DIR="$(SPELLCHECK_DIR)" "$(SPELLCHECK_DIR)/$${docsrc}-spellchecked" \
 		|| FAILED="$$FAILED $(SPELLCHECK_DIR)/$$docsrc"; \
 	 done ; \
 	 if test -n "$$FAILED" ; then \

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -218,6 +218,22 @@ ASPELL_NUT_COMMON_ARGS += -d en --lang=en --ignore-accents
 ASPELL_NUT_COMMON_ARGS += --encoding=utf-8
 ASPELL_ENV_LANG = en.UTF-8
 ASPELL_OUT_NOTERRORS = (^[ \t]*[\*\@]|^$$)
+
+%.spellchecked: % Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
+	@LANG=C; LC_ALL=C; export LANG; export LC_ALL; \
+	 rm -f "$@" || true ; \
+	 echo "  ASPELL   Spell checking on $<"; \
+	 OUT="`sed 's,^\(.*\)$$, \1,' < "$<" | $(ASPELL) -a -t $(ASPELL_NUT_COMMON_ARGS) 2>&1`" \
+		&& { if test -n "$$OUT" ; then OUT="`echo "$$OUT" | $(EGREP) -b -v '$(ASPELL_OUT_NOTERRORS)' `" ; fi; \
+		     test -z "$$OUT" ; } \
+		|| { RES=$$? ; \
+		     echo "FAILED : Aspell reported errors here:" >&2 \
+		     && echo "----- vvv" >&2 \
+		     && echo "$$OUT" >&2 \
+		     && echo "----- ^^^" >&2 ; \
+		     exit $$RES; } ; \
+	 touch "$@"
+
 spellcheck: 
 	@if test "$(SPELLCHECK_ENV_DEBUG)" != no ; then \
 		echo "ASPELL DEBUG : information about the setup follows:"; \
@@ -229,12 +245,8 @@ spellcheck:
 	 else true; fi
 	@FAILED="" ; LANG=C; LC_ALL=C; export LANG; export LC_ALL; \
 	 for docsrc in $(SPELLCHECK_SRC); do \
-		echo "  ASPELL   Spell checking on $(SPELLCHECK_DIR)/$$docsrc"; \
-		OUT="`sed 's,^\(.*\)$$, \1,' < $(SPELLCHECK_DIR)/$$docsrc | $(ASPELL) -a -t $(ASPELL_NUT_COMMON_ARGS) 2>&1`" && \
-			{ if test -n "$$OUT" ; then OUT="`echo "$$OUT" | $(EGREP) -b -v '$(ASPELL_OUT_NOTERRORS)' `" ; fi; \
-			  test -z "$$OUT" ; } || \
-			{ echo "FAILED : Aspell reported errors here:" >&2 && echo "----- vvv" >&2 && echo "$$OUT" >&2 && echo "----- ^^^" >&2 && \
-			  FAILED="$$FAILED $(SPELLCHECK_DIR)/$$docsrc"; } ; \
+		$(MAKE) -s $(SPELLCHECK_DIR)/$$docsrc.spellchecked \
+		|| FAILED="$$FAILED $(SPELLCHECK_DIR)/$$docsrc"; \
 	 done ; \
 	 if test -n "$$FAILED" ; then \
 		echo "=====================================================================" ; \
@@ -296,6 +308,8 @@ spellcheck-interactive:
 	 echo "because other systems might not know these words in their system dictionaries)"; \
 	 echo "------------------------------------------------------------------------"
 else !HAVE_ASPELL
+%.spellchecked: % Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
+	@echo "  SKIP-ASPELL   Spell checking on $< : Documentation spell check not available since 'aspell' was not found." >&2
 spellcheck:
 	@echo "Documentation spell check not available since 'aspell' was not found."
 spellcheck-interactive:

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -123,7 +123,7 @@ check-man:
 	cd $(top_builddir)/docs/man/ && $(MAKE) -f Makefile $@
 
 clean-local:
-	rm -f *.pdf *.html *.spellchecked docbook-xsl.css
+	rm -f *.pdf *.html *-spellchecked docbook-xsl.css
 	rm -rf *.chunked *.bak
 
 ### TODO: automatic dependency generation
@@ -219,7 +219,13 @@ ASPELL_NUT_COMMON_ARGS += --encoding=utf-8
 ASPELL_ENV_LANG = en.UTF-8
 ASPELL_OUT_NOTERRORS = (^[ \t]*[\*\@]|^$$)
 
-%.spellchecked: % Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
+# WARNING: The percent wildcard is a GNU extension; otherwise we need
+# a ".txt.txt-spellchecked" type of rule and files like "README" all
+# renamed to *.txt, or lots of rules for files without the extensions
+# Other Makefiles have a relatively simple life, dealing with just a
+# few texts and name/extension patterns in their directories.
+#?#.txt.txt-spellchecked: Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
+%-spellchecked: % Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
 	@LANG=C; LC_ALL=C; export LANG; export LC_ALL; \
 	 rm -f "$@" || true ; \
 	 echo "  ASPELL   Spell checking on $<"; \
@@ -245,7 +251,7 @@ spellcheck:
 	 else true; fi
 	@FAILED="" ; LANG=C; LC_ALL=C; export LANG; export LC_ALL; \
 	 for docsrc in $(SPELLCHECK_SRC); do \
-		$(MAKE) -s $(SPELLCHECK_DIR)/$$docsrc.spellchecked \
+		$(MAKE) -s "$(SPELLCHECK_DIR)/$${docsrc}-spellchecked" \
 		|| FAILED="$$FAILED $(SPELLCHECK_DIR)/$$docsrc"; \
 	 done ; \
 	 if test -n "$$FAILED" ; then \
@@ -308,7 +314,7 @@ spellcheck-interactive:
 	 echo "because other systems might not know these words in their system dictionaries)"; \
 	 echo "------------------------------------------------------------------------"
 else !HAVE_ASPELL
-%.spellchecked: % Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
+*-spellchecked: Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
 	@echo "  SKIP-ASPELL   Spell checking on $< : Documentation spell check not available since 'aspell' was not found." >&2
 spellcheck:
 	@echo "Documentation spell check not available since 'aspell' was not found."

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -168,6 +168,13 @@ A2X_COMMON_OPTS = $(ASCIIDOC_VERBOSE) --attribute icons \
 # (or cause them to produce undefined results if some bad timing happens).
 # As a brutal workaround for the former problem, we chmod. For second one we
 # might try magic with .SEQUENTIAL recipe hints, but that is gmake-dependent.
+
+# PORTABILITY NOTE: POSIX Make forbids the suffix rule definitions with
+# prerequisites like done below, and GNU Make of some versions complains;
+# https://www.gnu.org/software/make/manual/html_node/Error-Messages.html
+# says the prerequisites were ignored while a suffix rule was created;
+# eventually the POSIX stance would be taken to define a rule for a weird
+# verbatim target file name with prerequisites.
 .txt.html: common.xsl xhtml.xsl
 	@if test -s "${builddir}/docbook-xsl.css" && test -r "${builddir}/docbook-xsl.css" && ! test -w "${builddir}/docbook-xsl.css" ; then chmod u+w "${builddir}/docbook-xsl.css" ; fi
 	@chmod -R u+w .

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -73,7 +73,7 @@ ASCIIDOC_PDF = user-manual.pdf \
 	cables.pdf \
 	FAQ.pdf
 
-SUBDIRS = man
+SUBDIRS = man cables
 SUFFIXES = .txt .html .pdf
 
 all: doc
@@ -123,7 +123,7 @@ check-man:
 	cd $(top_builddir)/docs/man/ && $(MAKE) -f Makefile $@
 
 clean-local:
-	rm -f *.pdf *.html docbook-xsl.css
+	rm -f *.pdf *.html *.spellchecked docbook-xsl.css
 	rm -rf *.chunked *.bak
 
 ### TODO: automatic dependency generation

--- a/docs/cables/Makefile.am
+++ b/docs/cables/Makefile.am
@@ -1,2 +1,2 @@
 clean-local:
-	rm -f *.spellchecked
+	rm -f *-spellchecked

--- a/docs/cables/Makefile.am
+++ b/docs/cables/Makefile.am
@@ -1,0 +1,2 @@
+clean-local:
+	rm -f *.spellchecked

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -885,10 +885,14 @@ else !HAVE_ASCIIDOC
 endif !HAVE_ASCIIDOC
 
 clean-local:
-	rm -f *.pdf *.html *.spellchecked
+	rm -f *.pdf *.html *-spellchecked
 	rm -f *.1 *.3 *.5 *.8
 
-%.spellchecked: % Makefile.am $(top_srcdir)/docs/Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
+# NOTE: Due to portability, we do not use a GNU percent-wildcard extension:
+#%-spellchecked: % Makefile.am $(top_srcdir)/docs/Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
+#	$(MAKE) -s -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC="$<" SPELLCHECK_DIR="$(srcdir)" $@
+
+.txt.txt-spellchecked: Makefile.am $(top_srcdir)/docs/Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
 	$(MAKE) -s -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC="$<" SPELLCHECK_DIR="$(srcdir)" $@
 
 spellcheck spellcheck-interactive spellcheck-sortdict:

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -884,6 +884,10 @@ else !HAVE_ASCIIDOC
 
 endif !HAVE_ASCIIDOC
 
+clean-local:
+	rm -f *.pdf *.html *.spellchecked
+	rm -f *.1 *.3 *.5 *.8
+
 %.spellchecked: % Makefile.am $(top_srcdir)/docs/Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
 	$(MAKE) -s -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC="$<" SPELLCHECK_DIR="$(srcdir)" $@
 

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -884,5 +884,8 @@ else !HAVE_ASCIIDOC
 
 endif !HAVE_ASCIIDOC
 
+%.spellchecked: % Makefile.am $(top_srcdir)/docs/Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
+	$(MAKE) -s -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC="$<" SPELLCHECK_DIR="$(srcdir)" $@
+
 spellcheck spellcheck-interactive spellcheck-sortdict:
 	$(MAKE) -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC="$(SRC_ALL_PAGES)" SPELLCHECK_DIR="$(srcdir)" $@

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -890,10 +890,10 @@ clean-local:
 
 # NOTE: Due to portability, we do not use a GNU percent-wildcard extension:
 #%-spellchecked: % Makefile.am $(top_srcdir)/docs/Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
-#	$(MAKE) -s -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC="$<" SPELLCHECK_DIR="$(srcdir)" $@
+#	$(MAKE) -s -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC_ONE="$<" SPELLCHECK_DIR="$(srcdir)" $@
 
-.txt.txt-spellchecked: Makefile.am $(top_srcdir)/docs/Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
-	$(MAKE) -s -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC="$<" SPELLCHECK_DIR="$(srcdir)" $@
+.txt.txt-spellchecked: Makefile.am $(abs_top_srcdir)/docs/Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
+	$(MAKE) -s -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC_ONE="$<" SPELLCHECK_DIR="$(srcdir)" $@
 
 spellcheck spellcheck-interactive spellcheck-sortdict:
 	$(MAKE) -f $(top_builddir)/docs/Makefile SPELLCHECK_SRC="$(SRC_ALL_PAGES)" SPELLCHECK_DIR="$(srcdir)" $@

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -7,3 +7,6 @@ else
  bin_SCRIPTS = libupsclient-config
 endif
 endif
+
+clean-local:
+	rm -f *.spellchecked

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -9,4 +9,4 @@ endif
 endif
 
 clean-local:
-	rm -f *.spellchecked
+	rm -f *-spellchecked

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -25,4 +25,4 @@ EXTRA_DIST = README \
     Windows/halt.c \
     Windows/Makefile
 
-SUBDIRS = augeas devd hotplug python systemd udev Solaris upsdrvsvcctl
+SUBDIRS = augeas devd hotplug python systemd udev ufw Solaris upsdrvsvcctl

--- a/scripts/augeas/Makefile.am
+++ b/scripts/augeas/Makefile.am
@@ -34,4 +34,4 @@ if WITH_AUGLENS
 endif
 
 clean-local:
-	rm -f *.spellchecked
+	rm -f *-spellchecked

--- a/scripts/augeas/Makefile.am
+++ b/scripts/augeas/Makefile.am
@@ -32,3 +32,6 @@ if WITH_AUGLENS
     nuthostsconf.aug  nutupsconf.aug   nutupsdusers.aug   nutupsschedconf.aug \
     nutnutconf.aug    nutupsdconf.aug  nutupsmonconf.aug  nutupssetconf.aug
 endif
+
+clean-local:
+	rm -f *.spellchecked

--- a/scripts/ufw/Makefile.am
+++ b/scripts/ufw/Makefile.am
@@ -1,2 +1,2 @@
 clean-local:
-	rm -f *.spellchecked
+	rm -f *-spellchecked

--- a/scripts/ufw/Makefile.am
+++ b/scripts/ufw/Makefile.am
@@ -1,0 +1,2 @@
+clean-local:
+	rm -f *.spellchecked

--- a/tools/nut-scanner/Makefile.am
+++ b/tools/nut-scanner/Makefile.am
@@ -72,4 +72,4 @@ endif
 CLEANFILES = $(BUILT_SOURCES)
 
 clean-local:
-	rm -f *.spellchecked
+	rm -f *-spellchecked

--- a/tools/nut-scanner/Makefile.am
+++ b/tools/nut-scanner/Makefile.am
@@ -70,3 +70,6 @@ else
 endif
 
 CLEANFILES = $(BUILT_SOURCES)
+
+clean-local:
+	rm -f *.spellchecked


### PR DESCRIPTION
Follows up from #1099 to do implement incremental spellcheck ability and only report the failed files.

Note that for interactive developer use with GNU Make this may come with a cost of some noise (entering/leaving directory for every child make process); this effect is hidden with CI builds however.