### PR TITLE
Detect $PYTHON versions instead of hardcoding a "python" string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,11 +20,13 @@ Makefile.in
 /config.log
 /config.status
 /config.sub
+/config.h
 /config.cache
 /configure
 /conf_nut_report_feature
 /conf??????/
 /dir.??????/
+/dir?.???????/
 /configure-test*/
 /cscope.*
 /depcomp

--- a/Makefile.am
+++ b/Makefile.am
@@ -116,10 +116,12 @@ GITLOG_START_POINT=v2.6.0
 
 # Force ChangeLog regeneration upon make dist (due to nonexistant 'dummy-stamp'),
 # in case it has already been generated previously
+# Note that the script is hard-coded to generate "ChangeLog" in the current dir
 dummy-stamp:
 ChangeLog: tools/gitlog2changelog.py dummy-stamp
-	$(top_srcdir)/tools/gitlog2changelog.py $(GITLOG_START_POINT) || \
-		echo "gitlog2changelog.py failed to generate the ChangeLog. See https://github.com/networkupstools/nut/commits/master" > $@
+	cd $(top_builddir) && \
+	    ./tools/gitlog2changelog.py $(GITLOG_START_POINT) || \
+	    { echo "gitlog2changelog.py failed to generate the ChangeLog. See https://github.com/networkupstools/nut/commits/master" > $@ ; }
 
 nut_version.h include/nut_version.h:
 	cd $(abs_top_builddir)/include && $(MAKE) nut_version.h

--- a/autogen.sh
+++ b/autogen.sh
@@ -29,7 +29,9 @@ then
 	if [ -n "${PYTHON-}" ] && $PYTHON -c "import re,glob,codecs"; then
 		echo "Regenerating Augeas ups.conf lens with '$PYTHON'..."
 		cd scripts/augeas && {
-			$PYTHON ./gen-nutupsconf-aug.py || exit 1
+			# That script is templated; assume @PYTHON@ is the only
+			# road-bump there
+			$PYTHON ./gen-nutupsconf-aug.py.in || exit 1
 			cd ../..
 		}
 	else

--- a/autogen.sh
+++ b/autogen.sh
@@ -3,19 +3,39 @@
 # Autoreconf wrapper script to ensure that the source tree is
 # in a buildable state
 
+if [ -n "${PYTHON-}" ] ; then
+	# May be a name/path of binary, or one with args - check both
+	(command -v "$PYTHON") \
+	|| $PYTHON -c "import re,glob,codecs" \
+	|| {
+		echo "----------------------------------------------------------------------"
+		echo "WARNING: Caller-specified PYTHON='$PYTHON' is not available."
+		echo "----------------------------------------------------------------------"
+		# Do not die just here, we may not need the interpreter
+	}
+else
+	PYTHON=""
+	for P in python python3 python2 ; do
+		if (command -v "$P" >/dev/null) && $P -c "import re,glob,codecs" ; then
+			PYTHON="$P"
+			break
+		fi
+	done
+fi
+
 # re-generate files needed by configure, and created otherwise at 'dist' time
 if [ ! -f scripts/augeas/nutupsconf.aug.in ]
 then
-	if python -c "import re,glob,codecs"; then
-		echo "Regenerating Augeas ups.conf lens..."
+	if [ -n "${PYTHON-}" ] && $PYTHON -c "import re,glob,codecs"; then
+		echo "Regenerating Augeas ups.conf lens with '$PYTHON'..."
 		cd scripts/augeas && {
-			./gen-nutupsconf-aug.py || exit 1
+			$PYTHON ./gen-nutupsconf-aug.py || exit 1
 			cd ../..
 		}
 	else
 		echo "----------------------------------------------------------------------"
 		echo "Error: Python is not available."
-		echo "Unable to regenerate Augeas ups.conf lens."
+		echo "Unable to regenerate Augeas lens for ups.conf parsing."
 		echo "----------------------------------------------------------------------"
 		exit 1
 	fi

--- a/autogen.sh
+++ b/autogen.sh
@@ -28,12 +28,11 @@ if [ ! -f scripts/augeas/nutupsconf.aug.in ]
 then
 	if [ -n "${PYTHON-}" ] && $PYTHON -c "import re,glob,codecs"; then
 		echo "Regenerating Augeas ups.conf lens with '$PYTHON'..."
-		cd scripts/augeas && {
-			# That script is templated; assume @PYTHON@ is the only
-			# road-bump there
-			$PYTHON ./gen-nutupsconf-aug.py.in || exit 1
-			cd ../..
-		}
+		(   # That script is templated; assume @PYTHON@ is the only
+		    # road-bump there
+		    cd scripts/augeas \
+		    && $PYTHON ./gen-nutupsconf-aug.py.in
+		) || exit 1
 	else
 		echo "----------------------------------------------------------------------"
 		echo "Error: Python is not available."

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -316,6 +316,11 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
     CONFIG_OPTS+=("--with-devd-dir=${BUILD_PREFIX}/etc/devd")
     CONFIG_OPTS+=("--with-hotplug-dir=${BUILD_PREFIX}/etc/hotplug")
 
+    if [ -n "${PYTHON-}" ]; then
+        # WARNING: Watch out for whitespaces, not handled here!
+        CONFIG_OPTS+=("--with-python=${PYTHON}")
+    fi
+
     # Some OSes have broken cppunit support, it crashes either build/link
     # or at run-time. While distros take time to figure out fixes, we can
     # skip the case...

--- a/configure.ac
+++ b/configure.ac
@@ -317,6 +317,13 @@ NUT_TYPE_SOCKLEN_T
 NUT_FUNC_GETNAMEINFO_ARGTYPES
 
 dnl ----------------------------------------------------------------------
+dnl Check for python binary program names per language version
+dnl to embed into scripts and Make rules
+NUT_CHECK_PYTHON
+NUT_CHECK_PYTHON2
+NUT_CHECK_PYTHON3
+
+dnl ----------------------------------------------------------------------
 dnl check for --with-all (or --without-all, or --with-all=auto) flag
 
 AC_MSG_CHECKING(for --with-all)

--- a/configure.ac
+++ b/configure.ac
@@ -2213,6 +2213,7 @@ AC_CONFIG_FILES([
  lib/Makefile
  scripts/Aix/nut-aix.spec
  scripts/augeas/Makefile
+ scripts/augeas/gen-nutupsconf-aug.py
  scripts/augeas/nutnutconf.aug
  scripts/augeas/nutupsconf.aug
  scripts/augeas/nutupsdconf.aug
@@ -2230,6 +2231,9 @@ AC_CONFIG_FILES([
  scripts/HP-UX/nut.psf
  scripts/HP-UX/postinstall
  scripts/python/Makefile
+ scripts/python/app/NUT-Monitor
+ scripts/python/module/PyNUT.py
+ scripts/python/module/test_nutclient.py
  scripts/upsdrvsvcctl/Makefile
  scripts/upsdrvsvcctl/nut-driver-enumerator.sh
  scripts/upsdrvsvcctl/upsdrvsvcctl
@@ -2250,6 +2254,7 @@ AC_CONFIG_FILES([
  scripts/Solaris/svc-nut-monitor
  scripts/Solaris/Makefile
  scripts/Solaris/pkginfo
+ scripts/Solaris/precheck.py
  scripts/Solaris/preinstall
  scripts/Solaris/postinstall
  scripts/Solaris/preremove
@@ -2264,6 +2269,8 @@ AC_CONFIG_FILES([
  scripts/Makefile
  server/Makefile
  tools/Makefile
+ tools/gitlog2changelog.py
+ tools/nut-snmpinfo.py
  tools/nut-scanner/Makefile
  tests/Makefile
  Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -2189,6 +2189,7 @@ X @ALTSTATEPATH@/nut
 EOF])
 ])
 
+AC_MSG_NOTICE([Generating "data" files from templates, see below for executable scripts])
 AC_CONFIG_FILES([
  clients/Makefile
  common/Makefile
@@ -2213,7 +2214,6 @@ AC_CONFIG_FILES([
  lib/Makefile
  scripts/Aix/nut-aix.spec
  scripts/augeas/Makefile
- scripts/augeas/gen-nutupsconf-aug.py
  scripts/augeas/nutnutconf.aug
  scripts/augeas/nutupsconf.aug
  scripts/augeas/nutupsdconf.aug
@@ -2227,16 +2227,10 @@ AC_CONFIG_FILES([
  scripts/devd/nut-usb.conf
  scripts/hotplug/Makefile
  scripts/hotplug/libhidups
- scripts/Aix/nut.init
  scripts/HP-UX/nut.psf
- scripts/HP-UX/postinstall
  scripts/python/Makefile
- scripts/python/app/NUT-Monitor
  scripts/python/module/PyNUT.py
- scripts/python/module/test_nutclient.py
  scripts/upsdrvsvcctl/Makefile
- scripts/upsdrvsvcctl/nut-driver-enumerator.sh
- scripts/upsdrvsvcctl/upsdrvsvcctl
  scripts/systemd/Makefile
  scripts/systemd/nut-common.tmpfiles
  scripts/systemd/nut-driver@.service
@@ -2244,23 +2238,13 @@ AC_CONFIG_FILES([
  scripts/systemd/nut-server.service
  scripts/systemd/nut-driver-enumerator.service
  scripts/systemd/nut-driver-enumerator.path
- scripts/systemd/nutshutdown
  scripts/Solaris/nut-driver-enumerator.xml
  scripts/Solaris/nut-driver.xml
  scripts/Solaris/nut-monitor.xml
  scripts/Solaris/nut-server.xml
  scripts/Solaris/nut.xml
- scripts/Solaris/svc-nut-server
- scripts/Solaris/svc-nut-monitor
  scripts/Solaris/Makefile
  scripts/Solaris/pkginfo
- scripts/Solaris/precheck.py
- scripts/Solaris/preinstall
- scripts/Solaris/postinstall
- scripts/Solaris/preremove
- scripts/Solaris/postremove
- scripts/Solaris/preproto.pl
- scripts/Solaris/nut
  scripts/udev/Makefile
  scripts/udev/nut-ipmipsu.rules
  scripts/udev/nut-usbups.rules
@@ -2269,12 +2253,39 @@ AC_CONFIG_FILES([
  scripts/Makefile
  server/Makefile
  tools/Makefile
- tools/gitlog2changelog.py
- tools/nut-snmpinfo.py
  tools/nut-scanner/Makefile
  tests/Makefile
  Makefile
 ])
+
+AC_MSG_NOTICE([Generating templated script files that should be marked executable])
+m4_foreach_w([SCRIPTFILE], [
+ scripts/Aix/nut.init
+ scripts/HP-UX/postinstall
+ scripts/python/app/NUT-Monitor
+ scripts/augeas/gen-nutupsconf-aug.py
+ scripts/python/module/test_nutclient.py
+ scripts/upsdrvsvcctl/nut-driver-enumerator.sh
+ scripts/upsdrvsvcctl/upsdrvsvcctl
+ scripts/systemd/nutshutdown
+ scripts/Solaris/svc-nut-server
+ scripts/Solaris/svc-nut-monitor
+ scripts/Solaris/precheck.py
+ scripts/Solaris/preinstall
+ scripts/Solaris/postinstall
+ scripts/Solaris/preremove
+ scripts/Solaris/postremove
+ scripts/Solaris/preproto.pl
+ scripts/Solaris/nut
+ tools/gitlog2changelog.py
+ tools/nut-snmpinfo.py
+], [
+ dnl Autoconf substitutes the token above specified in plain text,
+ dnl e.g. the brace below is empty and bracket gives verbatim varname
+ dnl AC_MSG_NOTICE([Script: SCRIPTFILE brace:(${SCRIPTFILE}) bracket:([SCRIPTFILE])])
+ AC_CONFIG_FILES(SCRIPTFILE, chmod +x "SCRIPTFILE")
+])
+
 AC_OUTPUT
 
 NUT_PRINT_FEATURE_REPORT

--- a/m4/nut_check_python.m4
+++ b/m4/nut_check_python.m4
@@ -1,0 +1,125 @@
+dnl Check for python binary program names per language version
+dnl to embed into scripts and Make rules
+
+AC_DEFUN([NUT_CHECK_PYTHON],
+[
+    AS_IF([test -z "${nut_with_python}"], [
+        NUT_ARG_WITH([python], [Use a particular program name of the python interpeter], [auto])
+
+        PYTHON=""
+        AS_CASE([${nut_with_python}],
+            [auto|yes|""], [AC_CHECK_PROGS([PYTHON], [python python3 python2], [_python_runtime])],
+            [no], [PYTHON="no"],
+            [PYTHON="${nut_with_python}"]
+        )
+
+        dnl Default to calling a basename from PATH, only use a specific full pathname
+        dnl if provided by the caller:
+        AS_CASE([${PYTHON}],
+            [_python_runtime], [
+                PYTHON="/usr/bin/env python"
+                AC_MSG_WARN([A python program name was not detected during configuration, will default to '$PYTHON' (scripts will fail if that is not in PATH at run time)])],
+            [no], [],
+            [/*" "*" "*], [
+                AC_MSG_WARN([A python program name is not a single token (was specified with more than one argument?), so shebangs can be not reliable])
+                ],
+            [/*], [],
+            [*" "*" "*], [
+                AC_MSG_WARN([A python program name is not a single token (was specified with more than one argument?), so shebangs can be not reliable])
+                PYTHON="/usr/bin/env ${PYTHON}"
+                ],
+            [*" "*], [
+                AC_MSG_WARN([A python program name is not a single token (was specified with an argument?), so /usr/bin/env shebangs can be not reliable])
+                PYTHON="/usr/bin/env ${PYTHON}"
+                ],
+            [*], [PYTHON="/usr/bin/env ${PYTHON}"]
+        )
+
+        AC_MSG_CHECKING([python interpeter to call])
+        AC_MSG_RESULT([${PYTHON}])
+        AC_SUBST([PYTHON], [${PYTHON}])
+        AM_CONDITIONAL([HAVE_PYTHON], [test "${PYTHON}" != "no"])
+    ])
+])
+
+AC_DEFUN([NUT_CHECK_PYTHON2],
+[
+    AS_IF([test -z "${nut_with_python2}"], [
+        NUT_ARG_WITH([python2], [Use a particular program name of the python2 interpeter for code that needs that version and is not compatible with python3], [auto])
+
+        PYTHON2=""
+        AS_CASE([${nut_with_python2}],
+            [auto|yes|""], [AC_CHECK_PROGS([PYTHON2], [python2 python], [_python2_runtime])],
+            [no], [PYTHON2="no"],
+            [PYTHON2="${nut_with_python2}"]
+        )
+
+        dnl Default to calling a basename from PATH, only use a specific full pathname
+        dnl if provided by the caller:
+        AS_CASE([${PYTHON2}],
+            [_python2_runtime], [
+                PYTHON2="/usr/bin/env python2"
+                AC_MSG_WARN([A python2 program name was not detected during configuration, will default to '$PYTHON2' (scripts will fail if that is not in PATH at run time)])],
+            [no], [],
+            [/*" "*" "*], [
+                AC_MSG_WARN([A python2 program name is not a single token (was specified with more than one argument?), so shebangs can be not reliable])
+                ],
+            [/*], [],
+            [*" "*" "*], [
+                AC_MSG_WARN([A python2 program name is not a single token (was specified with more than one argument?), so shebangs can be not reliable])
+                PYTHON2="/usr/bin/env ${PYTHON2}"
+                ],
+            [*" "*], [
+                AC_MSG_WARN([A python2 program name is not a single token (was specified with an argument?), so /usr/bin/env shebangs can be not reliable])
+                PYTHON2="/usr/bin/env ${PYTHON2}"
+                ],
+            [*], [PYTHON2="/usr/bin/env ${PYTHON2}"]
+        )
+
+        AC_MSG_CHECKING([python2 interpeter to call])
+        AC_MSG_RESULT([${PYTHON2}])
+        AC_SUBST([PYTHON2], [${PYTHON2}])
+        AM_CONDITIONAL([HAVE_PYTHON2], [test "${PYTHON2}" != "no"])
+    ])
+])
+
+AC_DEFUN([NUT_CHECK_PYTHON3],
+[
+    AS_IF([test -z "${nut_with_python3}"], [
+        NUT_ARG_WITH([python3], [Use a particular program name of the python3 interpeter for code that needs that version and is not compatible with python2], [auto])
+
+        PYTHON3=""
+        AS_CASE([${nut_with_python3}],
+            [auto|yes|""], [AC_CHECK_PROGS([PYTHON3], [python3 python], [_python3_runtime])],
+            [no], [PYTHON3="no"],
+            [PYTHON3="${nut_with_python3}"]
+        )
+
+        dnl Default to calling a basename from PATH, only use a specific full pathname
+        dnl if provided by the caller:
+        AS_CASE([${PYTHON3}],
+            [_python3_runtime], [
+                PYTHON3="/usr/bin/env python3"
+                AC_MSG_WARN([A python3 program name was not detected during configuration, will default to '$PYTHON3' (scripts will fail if that is not in PATH at run time)])],
+            [no], [],
+            [/*" "*" "*], [
+                AC_MSG_WARN([A python3 program name is not a single token (was specified with more than one argument?), so shebangs can be not reliable])
+                ],
+            [/*], [],
+            [*" "*" "*], [
+                AC_MSG_WARN([A python3 program name is not a single token (was specified with more than one argument?), so shebangs can be not reliable])
+                PYTHON3="/usr/bin/env ${PYTHON3}"
+                ],
+            [*" "*], [
+                AC_MSG_WARN([A python3 program name is not a single token (was specified with an argument?), so /usr/bin/env shebangs can be not reliable])
+                PYTHON3="/usr/bin/env ${PYTHON3}"
+                ],
+            [*], [PYTHON3="/usr/bin/env ${PYTHON3}"]
+        )
+
+        AC_MSG_CHECKING([python3 interpeter to call])
+        AC_MSG_RESULT([${PYTHON3}])
+        AC_SUBST([PYTHON3], [${PYTHON3}])
+        AM_CONDITIONAL([HAVE_PYTHON3], [test "${PYTHON3}" != "no"])
+    ])
+])

--- a/scripts/Solaris/.gitignore
+++ b/scripts/Solaris/.gitignore
@@ -4,6 +4,7 @@
 /postinstall
 /preremove
 /postremove
+/precheck.py
 /preproto.pl
 /svc-nut-server
 /svc-nut-monitor

--- a/scripts/Solaris/Makefile.am
+++ b/scripts/Solaris/Makefile.am
@@ -1,6 +1,7 @@
-EXTRA_DIST = makelocal.sh README
+EXTRA_DIST = makelocal.sh precheck.py.in preproto.pl.in README
 PROTOTYPE_DIR = $(DESTDIR)@prefix@
 SOLARIS_CHECK_TARGETS =
+PYTHON = @PYTHON@
 
 SOLARIS_SMF_MANIFESTS = \
 	nut.xml \
@@ -60,7 +61,9 @@ package-solaris-svr4: $(SOLARIS_PACKAGE_SVR4_HELPERSCRIPTS) $(SOLARIS_PACKAGE_SV
 	cp $(SOLARIS_PACKAGE_SVR4_HELPERSCRIPTS) $(SOLARIS_PACKAGE_SVR4_INSTALLSCRIPTS) $(SOLARIS_PACKAGE_SVR4_INSTALLDATA) $(PROTOTYPE_DIR)
 	cd $(PROTOTYPE_DIR) && chmod +x $(SOLARIS_PACKAGE_SVR4_HELPERSCRIPTS) $(SOLARIS_PACKAGE_SVR4_INSTALLSCRIPTS)
 	cd $(PROTOTYPE_DIR) && perl preproto.pl
-	cd $(PROTOTYPE_DIR) && python precheck.py
+if HAVE_PYTHON
+	cd $(PROTOTYPE_DIR) && $(PYTHON) precheck.py
+endif
 	cd $(PROTOTYPE_DIR) && rm -f prototype1
 	cd $(PROTOTYPE_DIR) && ./makelocal.sh
 	cp $(PROTOTYPE_DIR)/*.gz $(builddir)

--- a/scripts/Solaris/precheck.py.in
+++ b/scripts/Solaris/precheck.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!@PYTHON@
 
 import sys
 

--- a/scripts/augeas/.gitignore
+++ b/scripts/augeas/.gitignore
@@ -1,2 +1,3 @@
 /*.aug
 /nutupsconf.aug.in
+/gen-nutupsconf-aug.py

--- a/scripts/augeas/Makefile.am
+++ b/scripts/augeas/Makefile.am
@@ -5,12 +5,13 @@ EXTRA_DIST = gen-nutupsconf-aug.py.in nutupsconf.aug.tpl \
 PYTHON = @PYTHON@
 
 # only call the script to generate Augeas ups.conf lens upon "make dist",
-# and if Python is present; the gen-nutupsconf-aug.py is assumed generated
-# from gen-nutupsconf-aug.py.in template by the configure script
+# and if Python is present; the distributed gen-nutupsconf-aug.py.in template
+# is assumed to only differ from a generated gen-nutupsconf-aug.py by the
+# @PYTHON@ shebang.
 dist-hook:
 	@if [ -n "$(PYTHON)" ] && $(PYTHON) -c "import re,glob,codecs"; then \
 		echo "Regenerating Augeas ups.conf lens with '$(PYTHON)'."; \
-		$(PYTHON) $(distdir)/gen-nutupsconf-aug.py $(distdir)/; \
+		$(PYTHON) $(distdir)/gen-nutupsconf-aug.py.in $(distdir)/; \
 	else \
 		echo "----------------------------------------------------------------------"; \
 		echo "Warning: Python is not available."; \

--- a/scripts/augeas/Makefile.am
+++ b/scripts/augeas/Makefile.am
@@ -1,17 +1,19 @@
 
-EXTRA_DIST = gen-nutupsconf-aug.py nutupsconf.aug.tpl \
+EXTRA_DIST = gen-nutupsconf-aug.py.in nutupsconf.aug.tpl \
 	README tests/test_nut.aug
+
+PYTHON = @PYTHON@
 
 # only call the script to generate Augeas ups.conf lens upon "make dist",
 # and if Python is present
 dist-hook:
-	@if python -c "import re,glob,codecs"; then \
-		echo "Regenerating Augeas ups.conf lens."; \
-		$(distdir)/gen-nutupsconf-aug.py $(distdir)/; \
+	@if [ -n "$(PYTHON)" ] && $(PYTHON) -c "import re,glob,codecs"; then \
+		echo "Regenerating Augeas ups.conf lens with '$(PYTHON)'."; \
+		$(PYTHON) $(distdir)/gen-nutupsconf-aug.py $(distdir)/; \
 	else \
 		echo "----------------------------------------------------------------------"; \
 		echo "Warning: Python is not available."; \
-		echo "Skipping Augeas ups.conf lens regeneration."; \
+		echo "Skipping regeneration of Augeas lens for ups.conf parsing." ; \
 		echo "----------------------------------------------------------------------"; \
 	fi
 

--- a/scripts/augeas/Makefile.am
+++ b/scripts/augeas/Makefile.am
@@ -5,7 +5,8 @@ EXTRA_DIST = gen-nutupsconf-aug.py.in nutupsconf.aug.tpl \
 PYTHON = @PYTHON@
 
 # only call the script to generate Augeas ups.conf lens upon "make dist",
-# and if Python is present
+# and if Python is present; the gen-nutupsconf-aug.py is assumed generated
+# from gen-nutupsconf-aug.py.in template by the configure script
 dist-hook:
 	@if [ -n "$(PYTHON)" ] && $(PYTHON) -c "import re,glob,codecs"; then \
 		echo "Regenerating Augeas ups.conf lens with '$(PYTHON)'."; \

--- a/scripts/augeas/gen-nutupsconf-aug.py.in
+++ b/scripts/augeas/gen-nutupsconf-aug.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!@PYTHON@
 #   Copyright (C) 2010 - Arnaud Quette <arnaud.quette@gmail.com>
 #
 #   This program is free software; you can redistribute it and/or modify

--- a/scripts/python/Makefile.am
+++ b/scripts/python/Makefile.am
@@ -2,7 +2,7 @@
 
 EXTRA_DIST = README \
 			 app/gui-1.3.glade \
-			 app/NUT-Monitor \
+			 app/NUT-Monitor.in \
 			 app/nut-monitor.appdata.xml \
 			 app/nut-monitor.desktop \
 			 app/icons/48x48/nut-monitor.png \
@@ -17,6 +17,6 @@ EXTRA_DIST = README \
 			 app/pixmaps/var-ro.png \
 			 app/locale/fr/LC_MESSAGES/NUT-Monitor.mo \
 			 app/locale/it/LC_MESSAGES/NUT-Monitor.mo \
-			 module/PyNUT.py \
-			 module/test_nutclient.py
+			 module/PyNUT.py.in \
+			 module/test_nutclient.py.in
 

--- a/scripts/python/app/.gitignore
+++ b/scripts/python/app/.gitignore
@@ -1,0 +1,1 @@
+/NUT-Monitor

--- a/scripts/python/app/NUT-Monitor.in
+++ b/scripts/python/app/NUT-Monitor.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!@PYTHON@
 # -*- coding: utf-8 -*-
 
 # 2009-12-27 David Goncalves - Version 1.2

--- a/scripts/python/module/.gitignore
+++ b/scripts/python/module/.gitignore
@@ -1,0 +1,2 @@
+/PyNUT.py
+/test_nutclient.py

--- a/scripts/python/module/PyNUT.py.in
+++ b/scripts/python/module/PyNUT.py.in
@@ -38,6 +38,11 @@
 # 2014-06-03 george2 - Version 1.3.0
 #            Added custom exception class, fixed minor bug, added Python 3 support.
 #
+# 2021-09-27 Jim Klimov <jimklimov+nut@gmail.com> - Version 1.4.0
+#            Revise strings used to be byte sequences as required by telnetlib
+#            in Python 3.9, by spelling out b"STR" or str.encode('ascii');
+#            the change was also tested to work with Python 2.7, 3.4, 3.5 and
+#            3.7 (to the extent of accompanying test_nutclient.py at least).
 
 import telnetlib
 
@@ -56,8 +61,8 @@ class PyNUTClient :
     __timeout     = None
     __srv_handler = None
 
-    __version     = "1.3.0"
-    __release     = "2014-06-03"
+    __version     = "1.4.0"
+    __release     = "2021-09-27"
 
 
     def __init__( self, host="127.0.0.1", port=3493, login=None, password=None, debug=False, timeout=5 ) :
@@ -89,7 +94,7 @@ timeout  : Timeout used to wait for network response
     def __del__( self ) :
         """ Class destructor method """
         try :
-            self.__srv_handler.write( "LOGOUT\n" )
+            self.__srv_handler.write( b"LOGOUT\n" )
         except :
             pass
 
@@ -105,16 +110,16 @@ if something goes wrong.
         self.__srv_handler = telnetlib.Telnet( self.__host, self.__port )
 
         if self.__login != None :
-            self.__srv_handler.write( "USERNAME %s\n" % self.__login )
-            result = self.__srv_handler.read_until( "\n", self.__timeout )
-            if result[:2] != "OK" :
-                raise PyNUTError( result.replace( "\n", "" ) )
+            self.__srv_handler.write( ("USERNAME %s\n" % self.__login).encode('ascii') )
+            result = self.__srv_handler.read_until( b"\n", self.__timeout )
+            if result[:2] != b"OK" :
+                raise PyNUTError( result.replace( b"\n", b"" ) )
 
         if self.__password != None :
-            self.__srv_handler.write( "PASSWORD %s\n" % self.__password )
-            result = self.__srv_handler.read_until( "\n", self.__timeout )
-            if result[:2] != "OK" :
-                raise PyNUTError( result.replace( "\n", "" ) )
+            self.__srv_handler.write( ("PASSWORD %s\n" % self.__password).encode('ascii') )
+            result = self.__srv_handler.read_until( b"\n", self.__timeout )
+            if result[:2] != b"OK" :
+                raise PyNUTError( result.replace( b"\n", b"" ) )
 
     def GetUPSList( self ) :
         """ Returns the list of available UPS from the NUT server
@@ -124,18 +129,18 @@ The result is a dictionary containing 'key->val' pairs of 'UPSName' and 'UPS Des
         if self.__debug :
             print( "[DEBUG] GetUPSList from server" )
 
-        self.__srv_handler.write( "LIST UPS\n" )
-        result = self.__srv_handler.read_until( "\n" )
-        if result != "BEGIN LIST UPS\n" :
-            raise PyNUTError( result.replace( "\n", "" ) )
+        self.__srv_handler.write( b"LIST UPS\n" )
+        result = self.__srv_handler.read_until( b"\n" )
+        if result != b"BEGIN LIST UPS\n" :
+            raise PyNUTError( result.replace( b"\n", b"" ) )
 
-        result = self.__srv_handler.read_until( "END LIST UPS\n" )
+        result = self.__srv_handler.read_until( b"END LIST UPS\n" )
         ups_list = {}
 
-        for line in result.split( "\n" ) :
-            if line[:3] == "UPS" :
-                ups, desc = line[4:-1].split( '"' )
-                ups_list[ ups.replace( " ", "" ) ] = desc
+        for line in result.split( b"\n" ) :
+            if line[:3] == b"UPS" :
+                ups, desc = line[4:-1].split( b'"' )
+                ups_list[ ups.replace( b" ", b"" ) ] = desc
 
         return( ups_list )
 
@@ -148,19 +153,19 @@ available vars.
         if self.__debug :
             print( "[DEBUG] GetUPSVars called..." )
 
-        self.__srv_handler.write( "LIST VAR %s\n" % ups )
-        result = self.__srv_handler.read_until( "\n" )
-        if result != "BEGIN LIST VAR %s\n" % ups :
-            raise PyNUTError( result.replace( "\n", "" ) )
+        self.__srv_handler.write( ("LIST VAR %s\n" % ups).encode('ascii') )
+        result = self.__srv_handler.read_until( b"\n" )
+        if result != ("BEGIN LIST VAR %s\n" % ups).encode('ascii') :
+            raise PyNUTError( result.replace( b"\n", b"" ) )
 
         ups_vars   = {}
-        result     = self.__srv_handler.read_until( "END LIST VAR %s\n" % ups )
-        offset     = len( "VAR %s " % ups )
-        end_offset = 0 - ( len( "END LIST VAR %s\n" % ups ) + 1 )
+        result     = self.__srv_handler.read_until( ("END LIST VAR %s\n" % ups).encode('ascii') )
+        offset     = len( ("VAR %s " % ups ).encode('ascii') )
+        end_offset = 0 - ( len( ("END LIST VAR %s\n" % ups).encode('ascii') ) + 1 )
 
-        for current in result[:end_offset].split( "\n" ) :
-            var  = current[ offset: ].split( '"' )[0].replace( " ", "" )
-            data = current[ offset: ].split( '"' )[1]
+        for current in result[:end_offset].split( b"\n" ) :
+            var  = current[ offset: ].split( b'"' )[0].replace( b" ", b"" )
+            data = current[ offset: ].split( b'"' )[1]
             ups_vars[ var ] = data
 
         return( ups_vars )
@@ -174,28 +179,28 @@ of the command as value
         if self.__debug :
             print( "[DEBUG] GetUPSCommands called..." )
 
-        self.__srv_handler.write( "LIST CMD %s\n" % ups )
-        result = self.__srv_handler.read_until( "\n" )
-        if result != "BEGIN LIST CMD %s\n" % ups :
-            raise PyNUTError( result.replace( "\n", "" ) )
+        self.__srv_handler.write( ("LIST CMD %s\n" % ups).encode('ascii') )
+        result = self.__srv_handler.read_until( b"\n" )
+        if result != ("BEGIN LIST CMD %s\n" % ups).encode('ascii') :
+            raise PyNUTError( result.replace( b"\n", b"" ) )
 
         ups_cmds   = {}
-        result     = self.__srv_handler.read_until( "END LIST CMD %s\n" % ups )
-        offset     = len( "CMD %s " % ups )
-        end_offset = 0 - ( len( "END LIST CMD %s\n" % ups ) + 1 )
+        result     = self.__srv_handler.read_until( ("END LIST CMD %s\n" % ups).encode('ascii') )
+        offset     = len( ("CMD %s " % ups).encode('ascii') )
+        end_offset = 0 - ( len( ("END LIST CMD %s\n" % ups).encode('ascii') ) + 1 )
 
-        for current in result[:end_offset].split( "\n" ) :
-            var  = current[ offset: ].split( '"' )[0].replace( " ", "" )
+        for current in result[:end_offset].split( b"\n" ) :
+            var  = current[ offset: ].split( b'"' )[0].replace( b" ", b"" )
 
             # For each var we try to get the available description
             try :
-                self.__srv_handler.write( "GET CMDDESC %s %s\n" % ( ups, var ) )
-                temp = self.__srv_handler.read_until( "\n" )
-                if temp[:7] != "CMDDESC" :
+                self.__srv_handler.write( ("GET CMDDESC %s %s\n" % ( ups, var )).encode('ascii') )
+                temp = self.__srv_handler.read_until( b"\n" )
+                if temp[:7] != b"CMDDESC" :
                     raise PyNUTError
                 else :
-                    off  = len( "CMDDESC %s %s " % ( ups, var ) )
-                    desc = temp[off:-1].split('"')[1]
+                    off  = len( ("CMDDESC %s %s " % ( ups, var )).encode('ascii') )
+                    desc = temp[off:-1].split(b'"')[1]
             except :
                 desc = var
 
@@ -211,20 +216,20 @@ The result is presented as a dictionary containing 'key->val' pairs
         if self.__debug :
             print( "[DEBUG] GetUPSVars from '%s'..." % ups )
 
-        self.__srv_handler.write( "LIST RW %s\n" % ups )
-        result = self.__srv_handler.read_until( "\n" )
-        if ( result != "BEGIN LIST RW %s\n" % ups ) :
-            raise PyNUTError( result.replace( "\n",  "" ) )
+        self.__srv_handler.write( ("LIST RW %s\n" % ups).encode('ascii') )
+        result = self.__srv_handler.read_until( b"\n" )
+        if ( result != ("BEGIN LIST RW %s\n" % ups).encode('ascii') ) :
+            raise PyNUTError( result.replace( b"\n", b"" ) )
 
-        result     = self.__srv_handler.read_until( "END LIST RW %s\n" % ups )
-        offset     = len( "VAR %s" % ups )
-        end_offset = 0 - ( len( "END LIST RW %s\n" % ups ) + 1 )
+        result     = self.__srv_handler.read_until( ("END LIST RW %s\n" % ups).encode('ascii') )
+        offset     = len( ("VAR %s" % ups).encode('ascii') )
+        end_offset = 0 - ( len( ("END LIST RW %s\n" % ups).encode('ascii') ) + 1 )
         rw_vars    = {}
 
         try :
-            for current in result[:end_offset].split( "\n" ) :
-                var  = current[ offset: ].split( '"' )[0].replace( " ", "" )
-                data = current[ offset: ].split( '"' )[1]
+            for current in result[:end_offset].split( b"\n" ) :
+                var  = current[ offset: ].split( b'"' )[0].replace( b" ", b"" )
+                data = current[ offset: ].split( b'"' )[1]
                 rw_vars[ var ] = data
 
         except :
@@ -239,9 +244,9 @@ The variable must be a writable value (cf GetRWVars) and you must have the prope
 rights to set it (maybe login/password).
         """
 
-        self.__srv_handler.write( "SET VAR %s %s %s\n" % ( ups, var, value ) )
-        result = self.__srv_handler.read_until( "\n" )
-        if ( result == "OK\n" ) :
+        self.__srv_handler.write( ("SET VAR %s %s %s\n" % ( ups, var, value )).encode('ascii') )
+        result = self.__srv_handler.read_until( b"\n" )
+        if ( result == b"OK\n" ) :
             return( "OK" )
         else :
             raise PyNUTError( result )
@@ -255,12 +260,12 @@ Returns OK on success or raises an error
         if self.__debug :
             print( "[DEBUG] RunUPSCommand called..." )
 
-        self.__srv_handler.write( "INSTCMD %s %s\n" % ( ups, command ) )
-        result = self.__srv_handler.read_until( "\n" )
-        if ( result == "OK\n" ) :
+        self.__srv_handler.write( ("INSTCMD %s %s\n" % ( ups, command )).encode('ascii') )
+        result = self.__srv_handler.read_until( b"\n" )
+        if ( result == b"OK\n" ) :
             return( "OK" )
         else :
-            raise PyNUTError( result.replace( "\n", "" ) )
+            raise PyNUTError( result.replace( b"\n", b"" ) )
 
     def FSD( self, ups="") :
         """ Send FSD command
@@ -274,19 +279,19 @@ TODO: API change pending to replace MASTER with PRIMARY
         if self.__debug :
             print( "[DEBUG] MASTER called..." )
 
-        self.__srv_handler.write( "MASTER %s\n" % ups )
-        result = self.__srv_handler.read_until( "\n" )
-        if ( result != "OK MASTER-GRANTED\n" ) :
+        self.__srv_handler.write( ("MASTER %s\n" % ups).encode('ascii') )
+        result = self.__srv_handler.read_until( b"\n" )
+        if ( result != b"OK MASTER-GRANTED\n" ) :
             raise PyNUTError( ( "Master level function are not available", "" ) )
 
         if self.__debug :
             print( "[DEBUG] FSD called..." )
-        self.__srv_handler.write( "FSD %s\n" % ups )
-        result = self.__srv_handler.read_until( "\n" )
-        if ( result == "OK FSD-SET\n" ) :
+        self.__srv_handler.write( ("FSD %s\n" % ups).encode('ascii') )
+        result = self.__srv_handler.read_until( b"\n" )
+        if ( result == b"OK FSD-SET\n" ) :
             return( "OK" )
         else :
-            raise PyNUTError( result.replace( "\n", "" ) )
+            raise PyNUTError( result.replace( b"\n", b"" ) )
 
     def help(self) :
         """ Send HELP command
@@ -295,8 +300,8 @@ TODO: API change pending to replace MASTER with PRIMARY
         if self.__debug :
             print( "[DEBUG] HELP called..." )
 
-        self.__srv_handler.write( "HELP\n")
-        return self.__srv_handler.read_until( "\n" )
+        self.__srv_handler.write( b"HELP\n" )
+        return self.__srv_handler.read_until( b"\n" )
 
     def ver(self) :
         """ Send VER command
@@ -305,8 +310,8 @@ TODO: API change pending to replace MASTER with PRIMARY
         if self.__debug :
             print( "[DEBUG] VER called..." )
 
-        self.__srv_handler.write( "VER\n")
-        return self.__srv_handler.read_until( "\n" )
+        self.__srv_handler.write( b"VER\n" )
+        return self.__srv_handler.read_until( b"\n" )
 
     def ListClients( self, ups = None ) :
         """ Returns the list of connected clients from the NUT server
@@ -320,20 +325,20 @@ The result is a dictionary containing 'key->val' pairs of 'UPSName' and a list o
             raise PyNUTError( "%s is not a valid UPS" % ups )
 
         if ups:
-            self.__srv_handler.write( "LIST CLIENTS %s\n" % ups)
+            self.__srv_handler.write( ("LIST CLIENTS %s\n" % ups).encode('ascii') )
         else:
-            self.__srv_handler.write( "LIST CLIENTS\n" )
-        result = self.__srv_handler.read_until( "\n" )
-        if result != "BEGIN LIST CLIENTS\n" :
-            raise PyNUTError( result.replace( "\n", "" ) )
+            self.__srv_handler.write( b"LIST CLIENTS\n" )
+        result = self.__srv_handler.read_until( b"\n" )
+        if result != b"BEGIN LIST CLIENTS\n" :
+            raise PyNUTError( result.replace( b"\n", b"" ) )
 
-        result = self.__srv_handler.read_until( "END LIST CLIENTS\n" )
+        result = self.__srv_handler.read_until( b"END LIST CLIENTS\n" )
         ups_list = {}
 
-        for line in result.split( "\n" ):
-            if line[:6] == "CLIENT" :
-                host, ups = line[7:].split(' ')
-                ups.replace(' ', '')
+        for line in result.split( b"\n" ):
+            if line[:6] == b"CLIENT" :
+                host, ups = line[7:].split(b' ')
+                ups.replace(b' ', b'')
                 if not ups in ups_list:
                     ups_list[ups] = []
                 ups_list[ups].append(host)

--- a/scripts/python/module/PyNUT.py.in
+++ b/scripts/python/module/PyNUT.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!@PYTHON@
 # -*- coding: utf-8 -*-
 
 #   Copyright (C) 2008 David Goncalves <david@lestat.st>

--- a/scripts/python/module/test_nutclient.py.in
+++ b/scripts/python/module/test_nutclient.py.in
@@ -16,7 +16,11 @@ if __name__ == "__main__" :
     result = nut.GetUPSList( )
     print( "\033[01;33m%s\033[0m\n" % result )
 
-    print( 80*"-" + "\nTesting 'GetUPSVars' :")
+    # [dummy]
+    # driver = dummy-ups
+    # desc = "Test device"
+    # port = /src/nut/data/evolution500.seq
+    print( 80*"-" + "\nTesting 'GetUPSVars' for 'dummy' (should be registered in upsd.conf) :")
     result = nut.GetUPSVars( "dummy" )
     print( "\033[01;33m%s\033[0m\n" % result )
 

--- a/scripts/python/module/test_nutclient.py.in
+++ b/scripts/python/module/test_nutclient.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!@PYTHON@
 # -*- coding: utf-8 -*-
 
 # This source code is provided for testing/debuging purpose ;)

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,2 @@
+/gitlog2changelog.py
+/nut-snmpinfo.py

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -41,12 +41,14 @@ nut-scanner-deps: $(GENERATED_SNMP_FILES) $(GENERATED_USB_FILES)
 nut-scanner-deps-snmpinfo: $(GENERATED_SNMP_FILES)
 nut-scanner-deps-usb: $(GENERATED_USB_FILES)
 
+# The distributed nut-snmpinfo.py.in template is assumed to only differ from
+# a generated nut-snmpinfo.py by the @PYTHON@ shebang.
 $(GENERATED_SNMP_FILES): $(top_srcdir)/drivers/*-mib.c
 	@if [ -n "$(PYTHON)" ] && $(PYTHON) -c 1; then \
 		echo "Regenerating the SNMP helper files in SRC dir with '$(PYTHON)'."; \
 		TOP_SRCDIR="$(top_srcdir)" ; export TOP_SRCDIR; \
 		TOP_BUILDDIR="$(top_builddir)" ; export TOP_BUILDDIR; \
-		cd $(builddir) && $(PYTHON) $(top_srcdir)/tools/nut-snmpinfo.py; \
+		cd $(builddir) && $(PYTHON) $(top_srcdir)/tools/nut-snmpinfo.py.in; \
 	else \
 		echo "----------------------------------------------------------------------"; \
 		echo "Warning: Python is not available."; \
@@ -74,12 +76,14 @@ $(GENERATED_USB_FILES): $(top_srcdir)/drivers/*-hid.c $(top_srcdir)/drivers/*usb
 # NOTE: Beware that current working directory for the script should be builddir
 # so it may write the files in "dist" case (read-only sources), but the script
 # is called from the distdir where its copy is present.
+# The distributed nut-snmpinfo.py.in template is assumed to only differ from
+# a generated nut-snmpinfo.py by the @PYTHON@ shebang.
 dist-hook:
 	@if [ -n "$(PYTHON)" ] && $(PYTHON) -c 1; then \
 		echo "Regenerating the SNMP helper files in DIST dir with '$(PYTHON)'."; \
 		TOP_SRCDIR="$(top_srcdir)" ; export TOP_SRCDIR; \
 		TOP_BUILDDIR="$(top_builddir)" ; export TOP_BUILDDIR; \
-		$(PYTHON) $(distdir)/nut-snmpinfo.py; \
+		$(PYTHON) $(distdir)/nut-snmpinfo.py.in; \
 	else \
 		echo "----------------------------------------------------------------------"; \
 		echo "Warning: Python is not available."; \

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -11,8 +11,10 @@
 # make, to handle developer workflow (editing the *.c sources this uses).
 SUBDIRS = . nut-scanner
 
+PYTHON = @PYTHON@
+
 EXTRA_DIST = nut-usbinfo.pl nut-recorder.sh nut-ddl-dump.sh \
-  gitlog2changelog.py nut-snmpinfo.py driver-list-format.sh
+  gitlog2changelog.py.in nut-snmpinfo.py.in driver-list-format.sh
 
 GENERATED_SNMP_FILES = nut-scanner/nutscan-snmp.h
 
@@ -40,11 +42,11 @@ nut-scanner-deps-snmpinfo: $(GENERATED_SNMP_FILES)
 nut-scanner-deps-usb: $(GENERATED_USB_FILES)
 
 $(GENERATED_SNMP_FILES): $(top_srcdir)/drivers/*-mib.c
-	@if python -c 1; then \
-		echo "Regenerating the SNMP helper files in SRC dir."; \
+	@if [ -n "$(PYTHON)" ] && $(PYTHON) -c 1; then \
+		echo "Regenerating the SNMP helper files in SRC dir with '$(PYTHON)'."; \
 		TOP_SRCDIR="$(top_srcdir)" ; export TOP_SRCDIR; \
 		TOP_BUILDDIR="$(top_builddir)" ; export TOP_BUILDDIR; \
-		cd $(builddir) && $(top_srcdir)/tools/nut-snmpinfo.py; \
+		cd $(builddir) && $(PYTHON) $(top_srcdir)/tools/nut-snmpinfo.py; \
 	else \
 		echo "----------------------------------------------------------------------"; \
 		echo "Warning: Python is not available."; \
@@ -73,11 +75,11 @@ $(GENERATED_USB_FILES): $(top_srcdir)/drivers/*-hid.c $(top_srcdir)/drivers/*usb
 # so it may write the files in "dist" case (read-only sources), but the script
 # is called from the distdir where its copy is present.
 dist-hook:
-	@if python -c 1; then \
-		echo "Regenerating the SNMP helper files in DIST dir."; \
+	@if [ -n "$(PYTHON)" ] && $(PYTHON) -c 1; then \
+		echo "Regenerating the SNMP helper files in DIST dir with '$(PYTHON)'."; \
 		TOP_SRCDIR="$(top_srcdir)" ; export TOP_SRCDIR; \
 		TOP_BUILDDIR="$(top_builddir)" ; export TOP_BUILDDIR; \
-		$(distdir)/nut-snmpinfo.py; \
+		$(PYTHON) $(distdir)/nut-snmpinfo.py; \
 	else \
 		echo "----------------------------------------------------------------------"; \
 		echo "Warning: Python is not available."; \

--- a/tools/gitlog2changelog.py.in
+++ b/tools/gitlog2changelog.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!@PYTHON@
 # Copyright 2008 Marcus D. Hanwell <marcus@cryos.org>
 # Minor changes for NUT by Charles Lepple
 # Distributed under the terms of the GNU General Public License v2 or later

--- a/tools/nut-snmpinfo.py.in
+++ b/tools/nut-snmpinfo.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!@PYTHON@
 #   Copyright (C) 2011-2021 Eaton
 # 		Authors:	Frederic Bohe <FredericBohe@Eaton.com>
 #   				Arnaud Quette <ArnaudQuette@Eaton.com>


### PR DESCRIPTION
Some distros do not deliver a "python" at all now, going for more explicit "python2" and/or "python3" symlinks to the implementation like `python2.7` or `python-3.9` whichever way they would name it.

Detect one of those 3 basic options from the build operating environment, or use the value specified by caller (in PYTHON envvar for autogen.sh, and proper `--with-python=...` for configure script).

For generalization, this also adds support to explicitly specify a `PYTHON2` and `PYTHON3`, if we (or NUT forks) identify any scripts that are not compatible with the other version.

Respective `HAVE_PYTHON{,2,3}` automake macros can be used in the Makefiles to optionalize certain actions.

Also updates the `PyNUT.py` library to work with both generations of the interpreter (checked by the nearby test script against Python 2.7, 3.4, 3.5, 3.7 and 3.9).

The `NUT-Monitor` UI script was tested to work with both generations of the interpreter.