### PR TITLE
nut-common.tmpfiles.in: fix systemd magic vs autoconf magic

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -10,7 +10,7 @@ queries:
 
 extraction:
   python:
-    python_setup: 
+    python_setup:
       # Is there a way to LGTM both 2 and 3?..
       version: 2
       setup_py: false
@@ -18,10 +18,3 @@ extraction:
       filters:
         - include: "**/*.py.in"
         - include: "**/NUT-Monitor.in"
-#          - include: ./tools/nut-snmpinfo.py.in
-#          - include: ./tools/gitlog2changelog.py.in
-#          - include: ./scripts/python/app/NUT-Monitor.in
-#          - include: ./scripts/python/module/test_nutclient.py.in
-#          - include: ./scripts/python/module/PyNUT.py.in
-#          - include: ./scripts/augeas/gen-nutupsconf-aug.py.in
-#          - include: ./scripts/Solaris/precheck.py.in

--- a/autogen.sh
+++ b/autogen.sh
@@ -61,7 +61,7 @@ then
 fi
 
 if [ ! -e scripts/systemd/nut-common.tmpfiles.in ]; then
-    echo '# autoconf requires this file exists before generating configure script' > scripts/systemd/nut-common.tmpfiles.in
+	echo '# autoconf requires this file exists before generating configure script; it will be overwritten by configure during a build' > scripts/systemd/nut-common.tmpfiles.in
 fi
 
 # now we can safely call autoreconf

--- a/autogen.sh
+++ b/autogen.sh
@@ -51,7 +51,7 @@ then
 			./nut-usbinfo.pl || exit 1
 			cd ..
 		}
-	else 
+	else
 		echo "----------------------------------------------------------------------"
 		echo "Error: Perl is not available."
 		echo "Unable to regenerate USB helper files."
@@ -67,6 +67,6 @@ fi
 # now we can safely call autoreconf
 echo "Calling autoreconf..."
 autoreconf -iv && {
-    sh -n configure 2>/dev/null >/dev/null \
-    || { echo "FAILED: configure script did not pass shell interpreter syntax checks" >&2 ; exit 1; }
+	sh -n configure 2>/dev/null >/dev/null \
+	|| { echo "FAILED: configure script did not pass shell interpreter syntax checks" >&2 ; exit 1; }
 }

--- a/configure.ac
+++ b/configure.ac
@@ -2165,29 +2165,45 @@ AC_MSG_RESULT(["${nut_enable_Werror}"])
 dnl Finally restore warnings settings that the caller might have provided in CFLAGS etc
 NUT_POP_WARNINGS
 
-dnl Due to possibly repetitive content, generate unique settings:
+dnl Due to possibly repetitive content, generate unique settings
+dnl relative to the top_builddir (distcheck and all):
+AC_MSG_CHECKING([for top build dir for this configure run])
+TOP_BUILDDIR=""
+AS_IF([test -n "${ac_abs_top_builddir}" && test -d "${ac_abs_top_builddir}"],
+    [TOP_BUILDDIR="${ac_abs_top_builddir}"],
+    [AS_IF([test -n "${ac_pwd}" && test -d "${ac_pwd}"],
+        [TOP_BUILDDIR="${ac_pwd}"],
+        [TOP_BUILDDIR="`dirname "$0"`"
+         TOP_BUILDDIR="`cd "$TOP_BUILDDIR" && pwd`"]
+    )]
+)
+AC_MSG_RESULT(["${TOP_BUILDDIR}"])
+
+AC_MSG_CHECKING([whether to customize ${TOP_BUILDDIR}/scripts/systemd/nut-common.tmpfiles.in for this system])
 AS_IF([test -n "$systemdtmpfilesdir"],
-    [cat > scripts/systemd/nut-common.tmpfiles.in << EOF
+    [mkdir -p "${TOP_BUILDDIR}"/scripts/systemd
+     cat > "${TOP_BUILDDIR}"/scripts/systemd/nut-common.tmpfiles.in << EOF
 # State file (e.g. upsd to driver) and pidfile location for NUT:
 d @STATEPATH@/nut 0770 @RUN_AS_USER@ @RUN_AS_GROUP@ - -
 X @STATEPATH@/nut
 EOF
     AS_IF([test "$STATEPATH" != "$PIDPATH"],
-        [cat >> scripts/systemd/nut-common.tmpfiles.in << EOF
+        [cat >> "${TOP_BUILDDIR}"/scripts/systemd/nut-common.tmpfiles.in << EOF
 d @PIDPATH@/nut 0770 @RUN_AS_USER@ @RUN_AS_GROUP@ - -
 X @PIDPATH@/nut
 EOF])
     AS_IF([test -n "$ALTPIDPATH" && test "$STATEPATH" != "$ALTPIDPATH" && test "$PIDPATH" != "$ALTPIDPATH"],
-        [cat >> scripts/systemd/nut-common.tmpfiles.in << EOF
+        [cat >> "${TOP_BUILDDIR}"/scripts/systemd/nut-common.tmpfiles.in << EOF
 d @ALTPIDPATH@/nut 0770 @RUN_AS_USER@ @RUN_AS_GROUP@ - -
 X @ALTPIDPATH@/nut
 EOF])
     AS_IF([test -n "$ALTSTATEPATH" && test "$STATEPATH" != "$ALTSTATEPATH" && test "$ALTSTATEPATH" != "$ALTPIDPATH" && test "$PIDPATH" != "$ALTSTATEPATH"],
-        [cat >> scripts/systemd/nut-common.tmpfiles.in << EOF
+        [cat >> "${TOP_BUILDDIR}"/scripts/systemd/nut-common.tmpfiles.in << EOF
 d @ALTSTATEPATH@/nut 0770 @RUN_AS_USER@ @RUN_AS_GROUP@ - -
 X @ALTSTATEPATH@/nut
 EOF])
 ])
+AC_MSG_RESULT([done])
 
 AC_MSG_NOTICE([Generating "data" files from templates, see below for executable scripts])
 AC_CONFIG_FILES([

--- a/scripts/systemd/Makefile.am
+++ b/scripts/systemd/Makefile.am
@@ -24,8 +24,10 @@ sbin_SCRIPTS = ../upsdrvsvcctl/upsdrvsvcctl
 
 else
 EXTRA_DIST += \
-	nut-common.tmpfiles.in nut-driver@.service.in nut-monitor.service.in \
+	nut-driver@.service.in nut-monitor.service.in \
 	nut-server.service.in nutshutdown.in nut-driver.target nut.target \
 	nut-driver-enumerator.path.in nut-driver-enumerator.service.in
+
+# NOTE: Do not EXTRA_DIST nut-common.tmpfiles.in - it is generated per build
 endif
 


### PR DESCRIPTION
Follows up from PR #1037 for issue #1030 to let the trick work for distcheck and similar out-of-tree builds.

Also piggy-backs a little cleanup into CI