### PR TITLE
Jenkinsfile-dynamatrix + developers.txt: rearrange for GNU89 support

### DIFF
--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -552,7 +552,7 @@ set | sort -n """
 
                 dynamatrixAxesVirtualLabelsMap: [
                     'BITS': [32, 64],
-                    'CSTDVERSION_${KEY}': [ ['c': '99', 'cxx': '98'], ['c': '99', 'cxx': '11'], ['c': '11', 'cxx': '11'], ['c': '17', 'cxx': '17'] ],
+                    'CSTDVERSION_${KEY}': [ ['c': '89', 'cxx': '98'], ['c': '99', 'cxx': '11'], ['c': '11', 'cxx': '11'], ['c': '17', 'cxx': '17'] ],
                     'CSTDVARIANT': ['gnu'],
                     ],
                 dynamatrixAxesCommonEnv: [
@@ -576,7 +576,7 @@ set | sort -n """
         'bodyParStages': dynacfgPipeline.slowBuildDefaultBody_ci_build
         ] // one slowBuild filter configuration
 
-        ,[name: 'GNU C standard builds with fatal warnings, without distcheck and docs (allowed to fail with non-GCC, and for GCC with gnu89 builds)',
+        ,[name: 'GNU C standard builds with fatal warnings, without distcheck and docs (allowed to fail with non-GCC compilers)',
          disabled: dynacfgPipeline.disableSlowBuildCIBuildExperimental,
          branchRegexSource: ~/^(PR-.+|.*fightwarn.*)$/,
          branchRegexTarget: ~/fightwarn/,
@@ -586,9 +586,56 @@ set | sort -n """
                 requiredNodelabels: [],
                 excludedNodelabels: [],
 
+                // NOTE: C89 not included here as its warnings are quite
+                // noisy as in "not relevant for more modern revisions".
+                // It has a separate slowBuild filter configuration below.
                 dynamatrixAxesVirtualLabelsMap: [
                     'BITS': [32, 64],
-                    'CSTDVERSION_${KEY}': [ ['c': '89', 'cxx': '98'], ['c': '99', 'cxx': '98'], ['c': '99', 'cxx': '11'], ['c': '11', 'cxx': '11'], ['c': '17', 'cxx': '17'] ],
+                    'CSTDVERSION_${KEY}': [ ['c': '99', 'cxx': '98'], ['c': '99', 'cxx': '11'], ['c': '11', 'cxx': '11'], ['c': '17', 'cxx': '17'] ],
+                    'CSTDVARIANT': ['gnu'],
+                    ],
+                dynamatrixAxesCommonEnv: [
+                    ['LANG=C','LC_ALL=C','TZ=UTC',
+                     'BUILD_TYPE=default-all-errors',
+                     'BUILD_WARNFATAL=yes','BUILD_WARNOPT=hard'
+                    ]
+                    ],
+                allowedFailure: [
+                    [~/OS_FAMILY=windows/],
+                    [~/BUILD_WARNOPT=hard/]
+                    ],
+                runAllowedFailure: true,
+                mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
+                excludeCombos: [
+                    [~/BITS=32/, ~/ARCH_BITS=64/],
+                    [~/BITS=64/, ~/ARCH_BITS=32/],
+                    [~/CSTDVARIANT=c/],
+                    //[~/COMPILER=GCC/, ~/CSTDVERSION_KEY=(?!89)/],
+                    [~/OS_DISTRO=(openindiana|freebsd).*/, ~/CSTDVERSION_cxx=[12].+/, ~/COMPILER=GCC/]
+                    ]
+                ], body)
+            }, // getParStages
+        'bodyParStages': dynacfgPipeline.slowBuildDefaultBody_ci_build
+        ] // one slowBuild filter configuration
+
+        ,[name: 'GNU C89 standard builds with fatal warnings with non-GCC compilers, without distcheck and docs (allowed to fail)',
+         // NOTE: This build scenario is quite noisy with regard to warnings
+         // analysis and not too beneficial unless someone looking at the
+         // logs is actively fixing the C89 compatibility. So off by default,
+         // and would only run for a PR against a "fightwarn.*89.*" named
+         // branch or for a build of such branch.
+         disabled: dynacfgPipeline.disableSlowBuildCIBuildExperimental,
+         branchRegexSource: ~/^(PR-.+|.*fightwarn.*89.*)$/,
+         branchRegexTarget: ~/fightwarn.*89.*/,
+         appliesToChangedFilesRegex: dynacfgPipeline.appliesToChangedFilesRegex_C,
+         'getParStages': { dynamatrix, Closure body ->
+            return dynamatrix.generateBuild([
+                requiredNodelabels: [],
+                excludedNodelabels: [],
+
+                dynamatrixAxesVirtualLabelsMap: [
+                    'BITS': [32, 64],
+                    'CSTDVERSION_${KEY}': [ ['c': '89', 'cxx': '98'] ],
                     'CSTDVARIANT': ['gnu'],
                     ],
                 dynamatrixAxesCommonEnv: [

--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -390,7 +390,7 @@ set | sort -n """
 
                 dynamatrixAxesVirtualLabelsMap: [
                     'BITS': [32, 64],
-                    'CSTDVERSION_${KEY}': [ ['c': '17', 'cxx': '17'] ],
+                    'CSTDVERSION_${KEY}': [ ['c': '89', 'cxx': '98'], ['c': '17', 'cxx': '17'] ],
                     'CSTDVARIANT': ['gnu'],
                     'BUILD_TYPE': ['default-alldrv:no-distcheck']
                     ],

--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -200,7 +200,7 @@ set | sort -n """
      * directly and ci_build.sh with stricter warnings, in particular.
      */
     dynacfgPipeline.slowBuild = [
-        [name: 'Default autotools driven build',
+        [name: 'Default autotools driven build with default warning levels (gnu99/gnu++11)',
          disabled: dynacfgPipeline.disableSlowBuildAutotools,
          branchRegexSource: ~/^(PR-.+|fightwarn.*)$/,
          //branchRegexTarget: ~/^(master|main|stable)$/,
@@ -240,9 +240,9 @@ set | sort -n """
                 ], body)
             }, // getParStages
         //'bodyParStages': {}
-        ] // one slowBuild filter configuration
+        ] // one slowBuild filter configuration, autotools-minimal
 
-        ,[name: 'Default autotools driven build with max warnings (allowed to fail)',
+        ,[name: 'Default autotools driven build with max warnings and varied C/C++ revisions (allowed to fail)',
          disabled: dynacfgPipeline.disableSlowBuildAutotools,
          branchRegexSource: ~/^(PR-.+|fightwarn.*)$/,
          //branchRegexTarget: ~/^(master|main|stable)$/,
@@ -286,9 +286,9 @@ set | sort -n """
                 ], body)
             }, // getParStages
         //'bodyParStages': {}
-        ] // one slowBuild filter configuration
+        ] // one slowBuild filter configuration, autotools-Wall
 
-        ,[name: 'Various non-docs target builds (must pass on all platforms)',
+        ,[name: 'Various non-docs distchecked target builds with main and ~newest supported C/C++ revisions (must pass on all platforms)',
          disabled: dynacfgPipeline.disableSlowBuildCIBuild,
          //branchRegexSource: ~/^(PR-.+|fightwarn.*)$/,
          //branchRegexTarget: ~/^(master|main|stable)$/,
@@ -331,7 +331,8 @@ set | sort -n """
         ,[name: 'A build with all driver types on capable systems with distcheck for main supported C/C++ revision (must pass)',
          // NOTE: Here we constrain distcheck builds (more CI stress load)
          // to run as few combos as possible; arguably this filter config
-         // is more about recipes than about codebase quality
+         // is more about recipes distributing those drivers than about
+         // directly codebase quality.
          disabled: dynacfgPipeline.disableSlowBuildCIBuild,
          //branchRegexSource: ~/^(PR-.+|fightwarn.*)$/,
          //branchRegexTarget: ~/^(master|main|stable)$/,
@@ -344,7 +345,8 @@ set | sort -n """
 
                 dynamatrixAxesVirtualLabelsMap: [
                     // TODO: Find a way to constrain these builds to one
-                    // per OS type, whatever bitness(es) supported there
+                    // per OS type, whatever bitness(es) supported there,
+                    // so we really primarily only test the dist-ability.
                     'BITS': [32, 64],
                     'CSTDVERSION_${KEY}': [ ['c': '99', 'cxx': '98'] ],
                     'CSTDVARIANT': ['gnu'],
@@ -372,7 +374,7 @@ set | sort -n """
         'bodyParStages': dynacfgPipeline.slowBuildDefaultBody_ci_build
         ] // one slowBuild filter configuration
 
-        ,[name: 'A build with all driver types on capable systems without distcheck for more C/C++ revisions (must pass)',
+        ,[name: 'A build with all driver types on capable systems without distcheck for other C/C++ revisions (must pass)',
          // NOTE: We reduce the build load here since the Makefile recipes
          // (for distcheck part) are deemed tested above with the supported
          // C/C++ standard revision

--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -223,11 +223,20 @@ set | sort -n """
                     ],
 
                 mergeMode: [ 'dynamatrixAxesVirtualLabelsMap': 'merge', 'excludeCombos': 'merge' ],
-                allowedFailure: [ [~/OS_FAMILY=windows/], [~/CSTDVARIANT=c/] ],
+                allowedFailure: [
+                    [~/OS_FAMILY=windows/],
+                    [~/CSTDVARIANT=c/]
+                    ],
                 runAllowedFailure: true,
                 //dynamatrixAxesLabels: ['OS_FAMILY', 'OS_DISTRO', '${COMPILER}VER', 'ARCH${ARCH_BITS}'],
                 //dynamatrixAxesLabels: [~/^OS/, '${COMPILER}VER', 'ARCH${ARCH_BITS}'],
-                excludeCombos: [ [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/], [~/OS_DISTRO=(openindiana|freebsd).*/, ~/CSTDVERSION_cxx=[12].+/, ~/COMPILER=GCC/] ]
+                excludeCombos: [
+                    // Avoid mix-up of bitness-related requests and abilities
+                    [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/],
+                    // These platforms do not serve a functional cppunit for gcc,
+                    // so a diverse C++ build matrix on them is pointless:
+                    [~/OS_DISTRO=(openindiana|freebsd).*/, ~/CSTDVERSION_cxx=[12].+/, ~/COMPILER=GCC/]
+                    ]
                 ], body)
             }, // getParStages
         //'bodyParStages': {}
@@ -261,12 +270,19 @@ set | sort -n """
                 dynamatrixAxesCommonEnv: [
                     //['LANG=C','LC_ALL=C','TZ=UTC', 'CFLAGS=-Wall\\ -Wextra\\ -Werror', 'CXXFLAGS=-Wall\\ -Wextra\\ -Werror']
                     ['LANG=C','LC_ALL=C','TZ=UTC', 'CFLAGS=-Wall', 'CXXFLAGS=-Wall']
-                ],
-                allowedFailure: [ [~/OS_FAMILY=windows/], [~/CSTDVARIANT=c/], [~/C.*FLAGS=.+Werror/] ],
+                    ],
+                allowedFailure: [
+                    [~/OS_FAMILY=windows/],
+                    [~/CSTDVARIANT=c/],
+                    [~/C.*FLAGS=.+Werror/]
+                    ],
                 runAllowedFailure: true,
                 //dynamatrixAxesLabels: ['OS_FAMILY', 'OS_DISTRO', '${COMPILER}VER', 'ARCH${ARCH_BITS}'],
                 //dynamatrixAxesLabels: [~/^OS/, '${COMPILER}VER', 'ARCH${ARCH_BITS}'],
-                excludeCombos: [ [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/], [~/OS_DISTRO=(openindiana|freebsd).*/, ~/CSTDVERSION_cxx=[12].+/, ~/COMPILER=GCC/] ]
+                excludeCombos: [
+                    [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/],
+                    [~/OS_DISTRO=(openindiana|freebsd).*/, ~/CSTDVERSION_cxx=[12].+/, ~/COMPILER=GCC/]
+                    ]
                 ], body)
             }, // getParStages
         //'bodyParStages': {}
@@ -295,12 +311,18 @@ set | sort -n """
                     ['LANG=C','LC_ALL=C','TZ=UTC'
                      //,'BUILD_WARNFATAL=yes','BUILD_WARNOPT=hard'
                     ]
-                ],
-                allowedFailure: [ [~/OS_FAMILY=windows/] ],
+                    ],
+                allowedFailure: [
+                    [~/OS_FAMILY=windows/]
+                    ],
                 runAllowedFailure: true,
                 mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
                 // So far allow-failure (or avoid C++11 +) on OpenIndiana (cppcheck pkg seems flawed, at least in various versions of GCC builds) and BSD (also just for GCC)
-                excludeCombos: [ [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/], [~/CSTDVARIANT=c/], [~/OS_DISTRO=(openindiana|freebsd).*/, ~/CSTDVERSION_cxx=[12].+/, ~/COMPILER=GCC/] ]
+                excludeCombos: [
+                    [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/],
+                    [~/CSTDVARIANT=c/],
+                    [~/OS_DISTRO=(openindiana|freebsd).*/, ~/CSTDVERSION_cxx=[12].+/, ~/COMPILER=GCC/]
+                    ]
                 ], body)
             }, // getParStages
         'bodyParStages': dynacfgPipeline.slowBuildDefaultBody_ci_build
@@ -332,12 +354,19 @@ set | sort -n """
                     ['LANG=C','LC_ALL=C','TZ=UTC'
                      //,'BUILD_WARNFATAL=yes','BUILD_WARNOPT=hard'
                     ]
-                ],
+                    ],
                 // On some systems, pkg-config for net-snmp includes CFLAGS values not supported by gcc-4.9 and older
-                allowedFailure: [ [~/OS_FAMILY=windows/], [~/GCCVER=[01234].+/, ~/BUILD_TYPE=default-alldrv/] ],
+                allowedFailure: [
+                    [~/OS_FAMILY=windows/],
+                    [~/GCCVER=[01234].+/, ~/BUILD_TYPE=default-alldrv/]
+                    ],
                 runAllowedFailure: true,
                 mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
-                excludeCombos: [ [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/], [~/CSTDVARIANT=c/] ] //, [~/OS_DISTRO=openindiana/] ]
+                excludeCombos: [
+                    [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/],
+                    //[~/OS_DISTRO=openindiana/],
+                    [~/CSTDVARIANT=c/]
+                    ]
                 ], body)
             }, // getParStages
         'bodyParStages': dynacfgPipeline.slowBuildDefaultBody_ci_build
@@ -367,12 +396,19 @@ set | sort -n """
                     ['LANG=C','LC_ALL=C','TZ=UTC'
                      //,'BUILD_WARNFATAL=yes','BUILD_WARNOPT=hard'
                     ]
-                ],
+                    ],
                 // On some systems, pkg-config for net-snmp includes CFLAGS values not supported by gcc-4.9 and older
-                allowedFailure: [ [~/OS_FAMILY=windows/], [~/GCCVER=[01234].+/, ~/BUILD_TYPE=default-alldr(v|v:no-distcheck)/] ],
+                allowedFailure: [
+                    [~/OS_FAMILY=windows/],
+                    [~/GCCVER=[01234].+/, ~/BUILD_TYPE=default-alldr(v|v:no-distcheck)/]
+                    ],
                 runAllowedFailure: true,
                 mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
-                excludeCombos: [ [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/], [~/CSTDVARIANT=c/] ] //, [~/OS_DISTRO=openindiana/] ]
+                excludeCombos: [
+                    [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/],
+                    //[~/OS_DISTRO=openindiana/],
+                    [~/CSTDVARIANT=c/]
+                    ]
                 ], body)
             }, // getParStages
         'bodyParStages': dynacfgPipeline.slowBuildDefaultBody_ci_build
@@ -399,12 +435,20 @@ set | sort -n """
                     ['LANG=C','LC_ALL=C','TZ=UTC',
                      'BUILD_WARNFATAL=yes','BUILD_WARNOPT=hard'
                     ]
-                ],
+                    ],
                 // On some systems, pkg-config for net-snmp includes CFLAGS values not supported by gcc-4.9 and older
-                allowedFailure: [ [~/OS_FAMILY=windows/], [~/BUILD_WARNOPT=hard/], [~/GCCVER=[01234].+/, ~/BUILD_TYPE=default-alldrv/] ],
+                allowedFailure: [
+                    [~/OS_FAMILY=windows/],
+                    [~/BUILD_WARNOPT=hard/],
+                    [~/GCCVER=[01234].+/, ~/BUILD_TYPE=default-alldrv/]
+                    ],
                 runAllowedFailure: true,
                 mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
-                excludeCombos: [ [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/], [~/CSTDVARIANT=c/], [~/OS_DISTRO=(openindiana|freebsd).*/, ~/CSTDVERSION_cxx=[12].+/, ~/COMPILER=GCC/] ]
+                excludeCombos: [
+                    [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/],
+                    [~/CSTDVARIANT=c/],
+                    [~/OS_DISTRO=(openindiana|freebsd).*/, ~/CSTDVERSION_cxx=[12].+/, ~/COMPILER=GCC/]
+                    ]
                 ], body)
             }, // getParStages
         'bodyParStages': dynacfgPipeline.slowBuildDefaultBody_ci_build
@@ -436,11 +480,17 @@ set | sort -n """
                     ['LANG=C','LC_ALL=C','TZ=UTC',
                      'BUILD_WARNFATAL=no','BUILD_WARNOPT=minimal'
                     ]
-                ],
-                allowedFailure: [ [~/OS_FAMILY=windows/] ],
+                    ],
+                allowedFailure: [
+                    [~/OS_FAMILY=windows/]
+                    ],
                 runAllowedFailure: true,
                 mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesLabels': 'replace', 'commonLabelExpr': 'replace', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
-                excludeCombos: [ [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/], [~/CSTDVARIANT=c/], [~/OS_DISTRO=(openindiana|freebsd).*/, ~/CSTDVERSION_cxx=[12].+/, ~/COMPILER=GCC/] ]
+                excludeCombos: [
+                    [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/],
+                    [~/CSTDVARIANT=c/],
+                    [~/OS_DISTRO=(openindiana|freebsd).*/, ~/CSTDVERSION_cxx=[12].+/, ~/COMPILER=GCC/]
+                    ]
                 ], body)
             }, // getParStages
         'bodyParStages': dynacfgPipeline.slowBuildDefaultBody_ci_build
@@ -471,11 +521,18 @@ set | sort -n """
                     ['LANG=C','LC_ALL=C','TZ=UTC',
                      'BUILD_WARNFATAL=no','BUILD_WARNOPT=minimal'
                     ]
-                ],
-                allowedFailure: [ [~/OS_FAMILY=windows/], [~/BUILD_TYPE=default-withdoc:man/] ],
+                    ],
+                allowedFailure: [
+                    [~/OS_FAMILY=windows/],
+                    [~/BUILD_TYPE=default-withdoc:man/]
+                    ],
                 runAllowedFailure: true,
                 mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesLabels': 'replace', 'commonLabelExpr': 'replace', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
-                excludeCombos: [ [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/], [~/CSTDVARIANT=c/], [~/OS_DISTRO=(openindiana|freebsd).*/, ~/CSTDVERSION_cxx=[12].+/, ~/COMPILER=GCC/] ]
+                excludeCombos: [
+                    [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/],
+                    [~/CSTDVARIANT=c/],
+                    [~/OS_DISTRO=(openindiana|freebsd).*/, ~/CSTDVERSION_cxx=[12].+/, ~/COMPILER=GCC/]
+                    ]
                 ], body)
             }, // getParStages
         'bodyParStages': dynacfgPipeline.slowBuildDefaultBody_ci_build
@@ -501,11 +558,17 @@ set | sort -n """
                      'BUILD_TYPE=default-all-errors',
                      'BUILD_WARNFATAL=no','BUILD_WARNOPT=auto'
                     ]
-                ],
-                allowedFailure: [ [~/OS_FAMILY=windows/] ],
+                    ],
+                allowedFailure: [
+                    [~/OS_FAMILY=windows/]
+                    ],
                 runAllowedFailure: true,
                 mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
-                excludeCombos: [ [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/], [~/CSTDVARIANT=c/], [~/OS_DISTRO=(openindiana|freebsd).*/, ~/CSTDVERSION_cxx=[12].+/, ~/COMPILER=GCC/] ]
+                excludeCombos: [
+                    [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/],
+                    [~/CSTDVARIANT=c/],
+                    [~/OS_DISTRO=(openindiana|freebsd).*/, ~/CSTDVERSION_cxx=[12].+/, ~/COMPILER=GCC/]
+                    ]
                 ], body)
             }, // getParStages
         'bodyParStages': dynacfgPipeline.slowBuildDefaultBody_ci_build
@@ -531,8 +594,11 @@ set | sort -n """
                      'BUILD_TYPE=default-all-errors',
                      'BUILD_WARNFATAL=yes','BUILD_WARNOPT=hard'
                     ]
-                ],
-                allowedFailure: [ [~/OS_FAMILY=windows/], [~/BUILD_WARNOPT=hard/] ],
+                    ],
+                allowedFailure: [
+                    [~/OS_FAMILY=windows/],
+                    [~/BUILD_WARNOPT=hard/]
+                    ],
                 runAllowedFailure: true,
                 mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
                 excludeCombos: [
@@ -567,8 +633,10 @@ set | sort -n """
                      'BUILD_TYPE=default-all-errors',
                      'BUILD_WARNFATAL=yes','BUILD_WARNOPT=hard'
                     ]
-                ],
-                allowedFailure: [ [~/OS_FAMILY=windows/] ],
+                    ],
+                allowedFailure: [
+                    [~/OS_FAMILY=windows/]
+                    ],
                 runAllowedFailure: true,
                 mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
                 excludeCombos: [ [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/], [~/CSTDVARIANT=c/],
@@ -599,11 +667,17 @@ set | sort -n """
                 dynamatrixAxesCommonEnvCartesian: [
                     ['LANG=C','LC_ALL=C','TZ=UTC', 'BUILD_TYPE=default-all-errors'],
                     [ ['BUILD_WARNFATAL=yes','BUILD_WARNOPT=hard'], ['BUILD_WARNFATAL=no','BUILD_WARNOPT=minimal'] ]
-                ],
-                allowedFailure: [ [~/CSTDVARIANT=c/], [~/BUILD_WARNOPT=hard/] ],
+                    ],
+                allowedFailure: [
+                    [~/CSTDVARIANT=c/],
+                    [~/BUILD_WARNOPT=hard/]
+                    ],
                 runAllowedFailure: true,
                 mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
-                excludeCombos: [ [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/], [~/CSTDVARIANT=gnu/], [~/OS_FAMILY=windows/],
+                excludeCombos: [
+                    [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/],
+                    [~/CSTDVARIANT=gnu/],
+                    [~/OS_FAMILY=windows/],
                     [~/OS_DISTRO=(openindiana|freebsd).*/, ~/CSTDVERSION_cxx=[12].+/, ~/COMPILER=GCC/]
                     ]
                 ], body)
@@ -632,11 +706,18 @@ set | sort -n """
                      'BUILD_WARNFATAL=yes','BUILD_WARNOPT=hard',
                      'CPPFLAGS=-fms-extensions'
                     ]
-                ],
-                allowedFailure: [ [~/CSTDVARIANT=c/], [~/OS_FAMILY=windows/], [~/BUILD_WARNOPT=hard/] ],
+                    ],
+                allowedFailure: [
+                    [~/CSTDVARIANT=c/],
+                    [~/OS_FAMILY=windows/],
+                    [~/BUILD_WARNOPT=hard/]
+                    ],
                 runAllowedFailure: true,
                 mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
-                excludeCombos: [ [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/], [~/OS_FAMILY=(?!windows)/] ]
+                excludeCombos: [
+                    [~/BITS=32/, ~/ARCH_BITS=64/], [~/BITS=64/, ~/ARCH_BITS=32/],
+                    [~/OS_FAMILY=(?!windows)/]
+                    ]
                 ], body)
             }, // getParStages
         'bodyParStages': dynacfgPipeline.slowBuildDefaultBody_ci_build

--- a/docs/developers.txt
+++ b/docs/developers.txt
@@ -140,13 +140,22 @@ function do_stuff(void)
 }
 --------------------------------------------------------------------------------
 
-At this point NUT is expected to work correctly when built with a C99
-(or GNU99 on Linux) or newer standard.
+TIP: At this point NUT is expected to work correctly when built with a
+C99 (or rather GNU99 on many systems) or newer standard.
 
 The NUT codebase may build in a mode without warnings made fatal on C89
 (GNU89), but the emitted warnings indicate that those binaries may crash.
 If somebody in the community requires to build and run NUT on systems
 that old, pull requests to fix the offending coding issues are welcome.
+
+Note also that the NUT codebase currently relies on certain features,
+such as the printf format modifiers for `(s)size_t`, that a pedantic C90
+mode compilation warns is not part of the standard but a GNU extension
+(and part of C99 and newer standard revisions).
+
+That said, the NUT CI farm does run non-regression builds with GNU C89
+standard revision and minimal warnings level, to ensure that codebase
+remains at least basically compliant.
 
 Continuous Integration and Automated Builds
 -------------------------------------------

--- a/docs/developers.txt
+++ b/docs/developers.txt
@@ -272,6 +272,12 @@ deliberately missed by default warnings levels in "master" branch builds
 (the bar moves over time, as some classes of warnings become extinct from
 our codebase).
 
+Further special handling for branches named like `fightwarn.*89.*` regex
+enables more intensive warning levels for a GNU89 build specifically (which
+are otherwise disabled as noisy yet not useful for supported C99+ builds),
+and is intended to help develop fixes for support of this older language
+revision, if anyone would dare.
+
 Many of those unsuccessful build stages are precisely the focus of the
 "fightwarn" effort, and are currently marked as "may fail", so they end
 up as "UNSTABLE" (seen as orange bubbles in the Jenkins BlueOcean UI, or

--- a/docs/developers.txt
+++ b/docs/developers.txt
@@ -254,6 +254,65 @@ by running a Jenkins Swarm agent with certain labels, which would dial
 into https://ci.networkupstools.org/ controller. Please contact the NUT
 maintainer if you want to participate in this manner.
 
+The `Jenkinsfile-dynamatrix` recipe allows NUT CI farm to run different sets
+of build scenarios based on various conditions, such as the name of branch
+being built (or PR'ed against), changed files (e.g. C/C++ sources vs. just
+docs), and some build combinations may be not required to succeed.
+
+For example, the main development branch and pull requests against it must
+cleanly pass all specified builds and tests on various platforms with the
+default level of warnings specified in the `configure` script. These are
+balanced to not run too many build scenarios overall, but just a quick and
+sufficiently representative set.
+
+As another example, there is special handling for "fightwarn" pattern in
+the branch names to run many more builds with varying warning levels and
+more variants of intermediate language revisions, and so expose concerns
+deliberately missed by default warnings levels in "master" branch builds
+(the bar moves over time, as some classes of warnings become extinct from
+our codebase).
+
+Many of those unsuccessful build stages are precisely the focus of the
+"fightwarn" effort, and are currently marked as "may fail", so they end
+up as "UNSTABLE" (seen as orange bubbles in the Jenkins BlueOcean UI, or
+orange cells in the tabular list of stages in the legacy UI), rather than
+as "FAILURE" (red bubbles) for build scenarios that were not expected to
+fail and usually represent higher-priority problems that would block a PR.
+
+Developers whose PR builds (or attempts to fix warnings) did not succeed in
+some cell of such build matrix, can look at the individual logs of that cell.
+Beside indication from the compiler about the failure, the end of log text
+includes the command which was executed by CI worker and can be reproduced
+locally by the developer, e.g.:
+----
+22:26:01  FINISHED with exit-code 2 cmd:  (
+22:26:01  [ -x ./ci_build.sh ] || exit
+22:26:01
+22:26:01  eval BUILD_TYPE="default-alldrv" BUILD_WARNOPT="hard" \
+    BUILD_WARNFATAL="yes" MAKE="make"  CC=gcc-10 CXX=g++-10 \
+    CPP=cpp-10 CFLAGS='-std=gnu99 -m64' CXXFLAGS='-std=gnu++11 -m64' \
+    LDFLAGS='-m64' ./ci_build.sh
+22:26:01  )
+----
+or for autotools-driven scenarios (which prep, configure, build and test
+in separate stages -- so for reproducing a failed build you should also
+look at its configuration step separately):
+----
+22:28:18  FINISHED with exit-code 0 cmd:  ( [ -x configure ] || exit; \
+    eval  CC=clang-9 CXX=clang++-9 CPP=clang-cpp-9 CFLAGS='-std=c11 -m64' \
+    CXXFLAGS='-std=c++11 -m64' LDFLAGS='-m64' time ./configure )
+----
+
+To re-run such scenario locally, you can copy the line from `eval` (but
+without the `eval` keyword itself) up to and including the executed script
+or tool, into your shell. Depending on locally available compilers, you
+may have to tweak the `CC`, `CXX` and `CPP` arguments; note that a `CPP`
+may be specified as `/path/to/CC -E` for GCC and CLANG based toolkits
+at least, if they lack a standalone preprocessor program (e.g. IntelCC).
+
+NOTE: While NUT recipes do not currently recognize a separate `CXXCPP`,
+it would follow similar semantics.
+
 Some further details about the NUT CI farm workers are available in
 link:config-prereqs.txt and link:ci-farm-lxc-setup.txt documents.
 

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 2740 utf-8
+personal_ws-1.1 en 2745 utf-8
 AAS
 ACFAIL
 ACFREQ
@@ -129,6 +129,7 @@ BigServers
 BlaXwan
 BlackOut
 BladeUPS
+BlueOcean
 Bo
 Bohe
 Borns
@@ -455,6 +456,7 @@ IZ
 Infosec
 Innova
 Integrators
+IntelCC
 InvCDly
 InvCPol
 InvMin
@@ -776,6 +778,7 @@ PPDn
 PPDnnn
 PPP
 PPPPPPPPPP
+PR'ed
 PRs
 PSA
 PSD
@@ -1294,6 +1297,7 @@ alarmtest
 alertset
 alioth
 alist
+alldrv
 alloc
 allowfrom
 altinterface
@@ -1660,6 +1664,7 @@ et
 etapro
 eth
 ev
+eval
 everups
 everyone's
 everything's


### PR DESCRIPTION
Do run low-warning GNU89 scenarios even for master, but don't run them with high warning levels even in usual "fightwarn" branch cases (support a separate "fightwarn-c89" to suffer the noise intentionally).