### PR TITLE
Small docs/ci-farm-lxc-setup.txt and configure.ac fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2083,14 +2083,26 @@ dnl Note that clang identifies as gcc-compatible so should be probed first.
 dnl TODO: Flip this default to "hard" when we clear existing codebase.
 dnl Note: the "gcc-legacy" option is intentionally undocumented, it acts as
 dnl least-surprise default if caller did not specify any --enable-warnings.
+dnl Note: Currently the "gcc-minimal" mode below adapts to builds with
+dnl C89/C90/ANSI mode to be less noisy. Keep this in mind if changing the
+dnl default "nut_warning_difficulty" and/or the case handling below.
 nut_warning_difficulty="minimal"
 AC_MSG_CHECKING([whether to pre-set warnings])
 AS_CASE(["${nut_enable_warnings}"],
     [no|all|gcc-legacy|gcc-minimal|clang-minimal|gcc-medium|clang-medium|gcc-hard|clang-hard], [],
-    [gcc|clang], [nut_enable_warnings="${nut_enable_warnings}-${nut_warning_difficulty}"],
+    [clang], [nut_enable_warnings="${nut_enable_warnings}-${nut_warning_difficulty}"],
+    [gcc], [
+        AS_CASE(["${CFLAGS}"],
+            [*89*|*90*|*ansi*], [nut_enable_warnings="${nut_enable_warnings}-minimal"],
+            [nut_enable_warnings="${nut_enable_warnings}-${nut_warning_difficulty}"]
+        )],
     [yes|auto|""], [
         AS_IF([test "${CLANGCC}" = "yes"], [nut_enable_warnings="clang-${nut_warning_difficulty}"],
-            [AS_IF([test "${GCC}" = "yes"], [nut_enable_warnings="gcc-${nut_warning_difficulty}"], [nut_enable_warnings="all"])
+            [AS_IF([test "${GCC}" = "yes"], [
+                AS_CASE(["${CFLAGS}"],
+                    [*89*|*90*|*ansi*], [nut_enable_warnings="gcc-minimal"],
+                    [nut_enable_warnings="gcc-${nut_warning_difficulty}"]
+                )], [nut_enable_warnings="all"])
             ])
         ],
     [hard|auto-hard|auto=hard], [
@@ -2162,7 +2174,17 @@ AS_CASE(["${nut_enable_warnings}"],
         CXXFLAGS="${CXXFLAGS} -ferror-limit=0 -Wall -Wextra -Wno-documentation"
         ],
     [gcc-legacy], [CFLAGS="${CFLAGS} -Wall -Wsign-compare"],
-    [gcc-minimal|gcc-medium|gcc-hard], [
+    [gcc-minimal], [
+        dnl Builds with C89 (and aliases) are quite noisy for C99+ syntax used
+        dnl in NUT. The minimal-warnings should not complain in these builds.
+        CFLAGS="${CFLAGS} -Wall -Wsign-compare"
+        CXXFLAGS="${CXXFLAGS} -Wall -Wextra"
+        AS_CASE(["${CFLAGS}"],
+            [*89*|*90*|*ansi*], [],
+            [CFLAGS="${CFLAGS} -Wextra -pedantic"]
+        )
+        ],
+    [gcc-medium|gcc-hard], [
         CFLAGS="${CFLAGS} -Wall -Wextra -Wsign-compare -pedantic"
         CXXFLAGS="${CXXFLAGS} -Wall -Wextra"
         ]

--- a/configure.ac
+++ b/configure.ac
@@ -1846,6 +1846,25 @@ AC_DEFINE_UNQUOTED(CPU_TYPE, $target_cpu, [Define processor type])
 
 dnl Can use valgrind for memory-leak testing, if present
 AC_PATH_PROGS([VALGRIND], [valgrind], [none])
+dnl Even if the tool is installed, it may be not usable on build platform.
+dnl QEMU may further complicate things, providing CPUs that formally match
+dnl a supported family but crash in practice, or hopefully rejected early:
+dnl valgrind: fatal error: unsupported CPU.
+dnl    Supported CPUs are:
+dnl    * x86 (practically any; Pentium-I or above), AMD Athlon or above)
+dnl    * AMD Athlon64/Opteron
+dnl    * ARM (armv7)
+dnl    * MIPS (mips32 and above; mips64 and above)
+dnl    * PowerPC (most; ppc405 and above)
+dnl    * System z (64bit only - s390x; z990 and above)
+AS_IF([test -n "${VALGRIND}"], [
+	AC_MSG_CHECKING([whether valgrind is usable on current platform])
+	AS_IF([( ${VALGRIND} --help )],
+		[AC_MSG_RESULT([yes])],
+		[AC_MSG_RESULT([no])
+		 VALGRIND="none"
+		])
+])
 with_valgrind="auto"
 AC_MSG_CHECKING(whether to use valgrind for memory-leak testing)
 AC_ARG_WITH(valgrind,

--- a/docs/ci-farm-lxc-setup.txt
+++ b/docs/ci-farm-lxc-setup.txt
@@ -212,7 +212,7 @@ fails to find the group anyway; then we have to "manually" add them.
 * Let the host know names/IPs of containers you assigned:
 +
 ------
-:; grep -v '#' /etc/lxc/dnsmasq.conf  | while IFS=, read N I ; do \
+:; grep -v '#' /etc/lxc/dnsmasq-hosts.conf | while IFS=, read N I ; do \
     getent hosts "$N" >&2 || echo "$I $N" ; \
    done >> /etc/hosts
 ------

--- a/docs/ci-farm-lxc-setup.txt
+++ b/docs/ci-farm-lxc-setup.txt
@@ -232,7 +232,7 @@ may be not yet configured or still struggling to access the Internet):
 ------
 :; for ALTROOT in /srv/libvirt/rootfs/*/rootfs/ ; do \
     echo "=== $ALTROOT :" ; \
-    chroot "$ALTROOT" apt-get install vim mc p7zip p7zip-full pigz pbzip2 \
+    chroot "$ALTROOT" apt-get install vim mc p7zip p7zip-full pigz pbzip2 git \
    ; done
 ------
 

--- a/docs/ci-farm-lxc-setup.txt
+++ b/docs/ci-farm-lxc-setup.txt
@@ -93,6 +93,13 @@ file can be watched with e.g. `tail -F /var/cache/lxc/.../debootstrap.log`
    lxc-create -n jenkins-debian8-s390x -P /srv/libvirt/rootfs -t debian -- \
     -r jessie -a s390x
 ------
+** ...Alternatively, other distributions can be used (as supported by your
+   LXC scripts, typically in `/usr/share/debootstrap/scripts`), e.g. Ubuntu:
++
+------
+:; lxc-create -n jenkins-ubuntu1804-s390x -P /srv/libvirt/rootfs -t ubuntu -- \
+    -r bionic -a s390x
+------
 ** See further options for the "template" with its help, e.g.:
 +
 ------

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 2745 utf-8
+personal_ws-1.1 en 2748 utf-8
 AAS
 ACFAIL
 ACFREQ
@@ -1166,6 +1166,7 @@ UTC
 UTalk
 UUU
 UX
+Ubuntu
 Ulf
 Uncomment
 Unices
@@ -1562,6 +1563,7 @@ ddl
 de
 deUNV
 debian
+debootstrap
 debouncing
 deci
 decrement
@@ -2566,6 +2568,7 @@ uA
 uD
 uM
 ua
+ubuntu
 uc
 ucb
 udev


### PR DESCRIPTION
Recipes:
* do not fail on systems with dysfunctional valgrind (program present but CPU not supported)
* do not complain a lot for C89 builds with "auto" warnings level (mapped to "minimal" for gcc)