### PR TITLE
A few recipe improvements for baby-steps on Windows builds

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -65,6 +65,16 @@ if [ ! -e scripts/systemd/nut-common.tmpfiles.in ]; then
 fi
 
 # now we can safely call autoreconf
+if ! ( dos2unix < configure.ac | cmp - configure.ac ) 2>/dev/null >/dev/null ; then
+	echo "WARNING: Did not confirm that configure.ac has Unix EOL markers;"
+	echo "this may cause issues for m4 parsing with autotools below."
+	if [ -e .git ] ; then
+		echo "You may want to enforce that Git uses 'lf' line endings and re-checkout:"
+		echo "    :; git config core.autocrlf false && git config core.eol lf"
+	fi
+	echo ""
+fi >&2
+
 echo "Calling autoreconf..."
 autoreconf -iv && {
 	sh -n configure 2>/dev/null >/dev/null \

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -712,14 +712,15 @@ bindings)
     pushd "./bindings/${BINDING}" && ./ci_build.sh
     ;;
 "")
-    echo "ERROR: No BUILD_TYPE was specified, doing a minimal default ritual without any options" >&2
+    echo "ERROR: No BUILD_TYPE was specified, doing a minimal default ritual without any required options" >&2
     if [ -n "${BUILD_WARNOPT}${BUILD_WARNFATAL}" ]; then
         echo "WARNING: BUILD_WARNOPT and BUILD_WARNFATAL settings are ignored in this mode" >&2
         sleep 5
     fi
     echo ""
     ./autogen.sh
-    ./configure
+    #./configure
+    ./configure --with-cgi=auto --with-serial=auto --with-dev=auto
     $MAKE all && $MAKE check
     ;;
 *)

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -87,7 +87,11 @@ if [ -z "$CI_OS_NAME" ]; then
         *sunos*)
             CI_OS_NAME="sunos" ;;
         "-") ;;
-        *)  echo "WARNING: Could not recognize CI_OS_NAME from '$OS_FAMILY'-'$OS_DISTRO', update './ci_build.sh' if needed" >&2 ;;
+        *)  echo "WARNING: Could not recognize CI_OS_NAME from CI_OS_HINT='$CI_OS_HINT', update './ci_build.sh' if needed" >&2
+            if [ "$OS_FAMILY-$OS_DISTRO" != "-" ]; then
+                echo "WARNING: I was told that OS_FAMILY='$OS_FAMILY' and OS_DISTRO='$OS_DISTRO'" >&2
+            fi
+            ;;
     esac
     [ -z "$CI_OS_NAME" ] || echo "INFO: Detected CI_OS_NAME='$CI_OS_NAME'" >&2
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -297,7 +297,7 @@ dnl All current systems provide time.h; it need not be checked for.
 dnl Not all systems provide sys/time.h, but those that do, all allow
 dnl you to include it and time.h simultaneously.
 dnl NUT codebase provides the include/timehead.h to wrap these nuances.
-AC_CHECK_HEADERS_ONCE([sys/time.h])
+AC_CHECK_HEADERS_ONCE([sys/time.h sys/types.h sys/socket.h netdb.h])
 AS_IF([test "$ac_cv_header_sys_time_h" = yes],
     [AC_DEFINE([TIME_WITH_SYS_TIME],[1],[Define to 1 if you can safely include both <sys/time.h>
 	     and <time.h>.  This macro is deemed obsolete by autotools.])


### PR DESCRIPTION
With a Git-Bash build environment, I ended up mixing some of:
* Git-Bash SDK at https://github.com/git-for-windows/build-extra/releases/latest
* "Just" Git-Bash at https://gitforwindows.org/
* Python for Windows at https://www.python.org/downloads/windows/
* PERL for Windows at https://strawberryperl.com/

...and fixes from this PR -- and I got the ./ci_build.sh with defaults to generate and pass the `./configure` script.

NOTE: This is a long shot from getting current NUT actually built (more headers differ, more ifdefs may be due, etc.), and MSys/Cygwin/MinGW etc. are a very different environment from making a "native" Windows build. But at least this can help get somebody started.

Caveats:
* The shell-script driven autotools environment is known to be very slow due to lots of sub-processes and performance differences of POSIX forking and Windows processes; passing `configure` takes about 10 minutes.
* While many tools in the toolkit are okay with CRLF endings, `autoreconf` had an issue with the dangling opening line `AC_CONFIG_FILES([` (we have another wrapped by `m4_foreach_w`) since it is seen to define the `^M` character named file twice; checking out with Unix EOL mode rectifies that.