### PR TITLE
Separate source files of snmp-ups.c (driver core) and snmp-ups-helpers.c (shared mapping tables and funcs)

### DIFF
--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -208,13 +208,24 @@ mge_shut_CFLAGS = $(AM_CFLAGS) -DSHUT_MODE
 mge_shut_LDADD = $(LDADD) -lm
 
 # SNMP
-snmp_ups_SOURCES = snmp-ups.c apc-mib.c baytech-mib.c compaq-mib.c \
+# Please keep the MIB table below sorted roughly alphabetically (incidentally
+# by vendor too) to ease maintenance and codebase fork resynchronisations
+snmp_ups_SOURCES = snmp-ups.c \
+ apc-mib.c apc-pdu-mib.c \
+ baytech-mib.c bestpower-mib.c \
+ compaq-mib.c cyberpower-mib.c \
+ delta_ups-mib.c \
  eaton-pdu-genesis2-mib.c eaton-pdu-marlin-mib.c \
  eaton-pdu-pulizzi-mib.c eaton-pdu-revelation-mib.c \
- ietf-mib.c mge-mib.c netvision-mib.c powerware-mib.c raritan-pdu-mib.c \
- bestpower-mib.c cyberpower-mib.c delta_ups-mib.c xppc-mib.c huawei-mib.c \
- eaton-ats16-nmc-mib.c eaton-ats16-nm2-mib.c apc-ats-mib.c raritan-px2-mib.c eaton-ats30-mib.c \
- apc-pdu-mib.c emerson-avocent-pdu-mib.c hpe-pdu-mib.c
+ eaton-ats16-nmc-mib.c eaton-ats16-nm2-mib.c apc-ats-mib.c eaton-ats30-mib.c \
+ emerson-avocent-pdu-mib.c \
+ hpe-pdu-mib.c huawei-mib.c \
+ ietf-mib.c \
+ mge-mib.c \
+ netvision-mib.c \
+ powerware-mib.c \
+ raritan-pdu-mib.c raritan-px2-mib.c \
+ xppc-mib.c
 snmp_ups_CFLAGS = $(AM_CFLAGS)
 snmp_ups_CFLAGS += $(LIBNETSNMP_CFLAGS)
 snmp_ups_LDADD = $(LDADD_DRIVERS) $(LIBNETSNMP_LIBS)

--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -210,7 +210,7 @@ mge_shut_LDADD = $(LDADD) -lm
 # SNMP
 # Please keep the MIB table below sorted roughly alphabetically (incidentally
 # by vendor too) to ease maintenance and codebase fork resynchronisations
-snmp_ups_SOURCES = snmp-ups.c \
+snmp_ups_SOURCES = snmp-ups.c snmp-ups-helpers.c \
  apc-mib.c apc-pdu-mib.c \
  baytech-mib.c bestpower-mib.c \
  compaq-mib.c cyberpower-mib.c \

--- a/drivers/snmp-ups-helpers.c
+++ b/drivers/snmp-ups-helpers.c
@@ -1,0 +1,69 @@
+/*  snmp-ups-helpers.c - Shared helper functions and data mapping tables
+ *  for NUT Generic SNMP driver core
+ *
+ *  Copyright (C)
+ *	2015 - 2021	Eaton (author: Arnaud Quette <ArnaudQuette@Eaton.com>)
+ *	2016 - 2021	Eaton (author: Jim Klimov <EvgenyKlimov@Eaton.com>)
+ *
+ *  Sponsored by Eaton <http://www.eaton.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ */
+
+#include <ctype.h> /* for isprint() */
+
+/* NUT SNMP common functions */
+#include "main.h"
+#include "nut_float.h"
+#include "nut_stdint.h"
+#include "snmp-ups.h"
+
+/***********************************************************************
+ * Subdrivers shared helpers functions
+ * Code below is primarily used in snmp-ups driver, but may be part
+ * of other compilation units, so separated into a stand-alone file
+ **********************************************************************/
+
+static char su_scratch_buf[255];
+
+/* Convert a US formated date (mm/dd/yyyy) to an ISO 8601 Calendar date (yyyy-mm-dd) */
+const char *su_usdate_to_isodate_info_fun(void *raw_date)
+{
+	const char *usdate = (char *)raw_date;
+	struct tm tm;
+	memset(&tm, 0, sizeof(struct tm));
+	memset(&su_scratch_buf, 0, sizeof(su_scratch_buf));
+
+	upsdebugx(3, "%s: US date = %s", __func__, usdate);
+
+	/* Try to convert from US date string to time */
+	/* Note strptime returns NULL upon failure, and a ptr to the last
+	   null char of the string upon success. Just try blindly the conversion! */
+	strptime(usdate, "%m/%d/%Y", &tm);
+	if (strftime(su_scratch_buf, 254, "%F", &tm) != 0) {
+		upsdebugx(3, "%s: successfully reformated: %s", __func__, su_scratch_buf);
+		return su_scratch_buf;
+	}
+
+	return NULL;
+}
+
+info_lkp_t su_convert_to_iso_date_info[] = {
+	/* array index = FUNMAP_USDATE_TO_ISODATE: */
+	{ 1, "dummy", su_usdate_to_isodate_info_fun, NULL },
+	{ 0, NULL, NULL, NULL }
+};

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -5,7 +5,7 @@
  *  Copyright (C)
  *	2002 - 2014	Arnaud Quette <arnaud.quette@free.fr>
  *	2015 - 2021	Eaton (author: Arnaud Quette <ArnaudQuette@Eaton.com>)
- *	2016 - 2019	Eaton (author: Jim Klimov <EvgenyKlimov@Eaton.com>)
+ *	2016 - 2021	Eaton (author: Jim Klimov <EvgenyKlimov@Eaton.com>)
  *	2002 - 2006	Dmitry Frolov <frolov@riss-telecom.ru>
  *			J.W. Hoogervorst <jeroen@hoogervorst.net>
  *			Niels Baggesen <niels@baggesen.net>
@@ -187,41 +187,6 @@ static void disable_transfer_oids(void);
 bool_t get_and_process_data(int mode, snmp_info_t *su_info_p);
 int extract_template_number(int template_type, const char* varname);
 int get_template_type(const char* varname);
-
-
-/***********************************************************************
- * Subdrivers shared helpers functions
- **********************************************************************/
-
-static char su_scratch_buf[255];
-
-/* Convert a US formated date (mm/dd/yyyy) to an ISO 8601 Calendar date (yyyy-mm-dd) */
-const char *su_usdate_to_isodate_info_fun(void *raw_date)
-{
-	const char *usdate = (char *)raw_date;
-	struct tm tm;
-	memset(&tm, 0, sizeof(struct tm));
-	memset(&su_scratch_buf, 0, sizeof(su_scratch_buf));
-
-	upsdebugx(3, "%s: US date = %s", __func__, usdate);
-
-	/* Try to convert from US date string to time */
-	/* Note strptime returns NULL upon failure, and a ptr to the last
-	   null char of the string upon success. Just try blindly the conversion! */
-	strptime(usdate, "%m/%d/%Y", &tm);
-	if (strftime(su_scratch_buf, 254, "%F", &tm) != 0) {
-		upsdebugx(3, "%s: successfully reformated: %s", __func__, su_scratch_buf);
-		return su_scratch_buf;
-	}
-
-	return NULL;
-}
-
-info_lkp_t su_convert_to_iso_date_info[] = {
-	/* array index = FUNMAP_USDATE_TO_ISODATE: */
-	{ 1, "dummy", su_usdate_to_isodate_info_fun, NULL },
-	{ 0, NULL, NULL, NULL }
-};
 
 /* ---------------------------------------------
  * driver functions implementations

--- a/drivers/snmp-ups.h
+++ b/drivers/snmp-ups.h
@@ -283,6 +283,8 @@ bool_t su_ups_get(snmp_info_t *su_info_p);
 
 bool_t load_mib2nut(const char *mib);
 
+/* Practical logic around lookup functions, see fun_vp2s and nuf_s2l
+ * fields in struct info_lkp_t */
 const char *su_find_infoval(info_lkp_t *oid2info, void *value);
 long su_find_valinfo(info_lkp_t *oid2info, const char* value);
 const char *su_find_strval(info_lkp_t *oid2info, void *value);

--- a/drivers/snmp-ups.h
+++ b/drivers/snmp-ups.h
@@ -289,13 +289,19 @@ const char *su_find_infoval(info_lkp_t *oid2info, void *value);
 long su_find_valinfo(info_lkp_t *oid2info, const char* value);
 const char *su_find_strval(info_lkp_t *oid2info, void *value);
 
-/* Common conversion structs and functions provided by snmp-ups-helpers.c
+/*****************************************************
+ * Common conversion structs and functions provided by snmp-ups-helpers.c
  * so they can be used and so "shared" by different subdrivers
- */
+ *****************************************************/
+
 const char *su_usdate_to_isodate_info_fun(void *raw_date);
 extern info_lkp_t su_convert_to_iso_date_info[];
 /* Name the mapping location in that array for consumers to reference */
 #define FUNMAP_USDATE_TO_ISODATE 0
+
+/*****************************************************
+ * End of Subdrivers shared helpers functions
+ *****************************************************/
 
 int su_setvar(const char *varname, const char *val);
 int su_instcmd(const char *cmdname, const char *extradata);

--- a/drivers/snmp-ups.h
+++ b/drivers/snmp-ups.h
@@ -289,7 +289,9 @@ const char *su_find_infoval(info_lkp_t *oid2info, void *value);
 long su_find_valinfo(info_lkp_t *oid2info, const char* value);
 const char *su_find_strval(info_lkp_t *oid2info, void *value);
 
-/* Common conversion structs (functions) */
+/* Common conversion structs and functions provided by snmp-ups-helpers.c
+ * so they can be used and so "shared" by different subdrivers
+ */
 const char *su_usdate_to_isodate_info_fun(void *raw_date);
 extern info_lkp_t su_convert_to_iso_date_info[];
 /* Name the mapping location in that array for consumers to reference */

--- a/drivers/snmp-ups.h
+++ b/drivers/snmp-ups.h
@@ -4,11 +4,14 @@
  *
  *  Copyright (C)
  *   2002-2010  Arnaud Quette <arnaud.quette@free.fr>
+ *   2015-2021  Eaton (author: Arnaud Quette <ArnaudQuette@Eaton.com>)
+ *   2016-2021  Eaton (author: Jim Klimov <EvgenyKlimov@Eaton.com>)
  *   2002-2006	Dmitry Frolov <frolov@riss-telecom.ru>
-  *  			J.W. Hoogervorst <jeroen@hoogervorst.net>
+ *  			J.W. Hoogervorst <jeroen@hoogervorst.net>
  *  			Niels Baggesen <niels@baggesen.net>
  *
- *  Sponsored by MGE UPS SYSTEMS <http://opensource.mgeups.com/>
+ *  Sponsored by Eaton <http://www.eaton.com>
+ *   and originally by MGE UPS SYSTEMS <http://opensource.mgeups.com/>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
This should help re-usability of the helpers in certain cases