### PR TITLE
Hotfix for drivers/hidparser.c losing the link with incorrect HID data

### DIFF
--- a/drivers/hidparser.c
+++ b/drivers/hidparser.c
@@ -450,6 +450,10 @@ void GetValue(const unsigned char *Buf, HIDData_t *pData, long *pValue)
 	if (range <= 0) {
 		/* makes no sense, give up */
 		*pValue = value;
+		/* Discussion: https://github.com/networkupstools/nut/pull/1138 */
+		upslogx(LOG_ERR, "ERROR in %s: LogMin is greater than LogMax, "
+			"possibly vendor HID is incorrect on device side; "
+			"skipping evaluation of these constraints", __func__);
 		return;
 	}
 


### PR DESCRIPTION
Follows up from #1138 and #1040

Thanks to @blecher-at for noticing the recent regression against some devices, and for proposing/testing the hotfix (reviving a workaround from retired codebase).