### PR TITLE
drivers/snmp-ups.c: fix build warnings (with daisy-chain code et al)

### DIFF
--- a/docs/daisychain.txt
+++ b/docs/daisychain.txt
@@ -190,7 +190,7 @@ Two functions are available to handle alarms on daisychain devices in your
 driver:
 
 * device_alarm_init(): clear the current alarm buffer
-* device_alarm_commit(const int device_number): commit the current alarm
+* device_alarm_commit(const size_t device_number): commit the current alarm
 buffer to "device.<device_number>.ups.alarm", and increase the count of
 alarms. If the current alarms buffer is empty, the count of alarm is
 decreased, and the variable "device.<device_number>.ups.alarm" is removed

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -1179,14 +1179,14 @@ void device_alarm_init(void)
 }
 
 /* same as above, but writes to "device.X.ups.alarm" or "ups.alarm" */
-void device_alarm_commit(const int device_number)
+void device_alarm_commit(const size_t device_number)
 {
 	char info_name[20];
 
 	memset(info_name, 0, 20);
 
-	if (device_number != 0) /* would then go into "device.%i.alarm" */
-		snprintf(info_name, 20, "device.%i.ups.alarm", device_number);
+	if (device_number != 0) /* would then go into "device.%zu.alarm" */
+		snprintf(info_name, 20, "device.%zu.ups.alarm", device_number);
 	else /* would then go into "device.alarm" */
 		snprintf(info_name, 20, "ups.alarm");
 

--- a/drivers/dstate.h
+++ b/drivers/dstate.h
@@ -90,7 +90,7 @@ void alarm_init(void);
 void alarm_set(const char *buf);
 void alarm_commit(void);
 void device_alarm_init(void);
-void device_alarm_commit(const int device_number);
+void device_alarm_commit(const size_t device_number);
 
 int dstate_detect_phasecount(
         const char *xput_prefix,

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -866,12 +866,22 @@ static bool_t decode_str(struct snmp_pdu *pdu, char *buf, size_t buf_len, info_l
 			buf[buf_len-1]='\0';
 		}
 		else {
-			len = snprintf(buf, buf_len, "%ld", *pdu->variables->val.integer);
+			int ret = snprintf(buf, buf_len, "%ld", *pdu->variables->val.integer);
+			if (ret < 0)
+				upsdebugx(3, "Failed to retrieve ASN_GAUGE");
+			else
+				len = (size_t)ret;
 		}
 		break;
 	case ASN_TIMETICKS:
 		/* convert timeticks to seconds */
-		len = snprintf(buf, buf_len, "%ld", *pdu->variables->val.integer / 100);
+		{
+			int ret = snprintf(buf, buf_len, "%ld", *pdu->variables->val.integer / 100);
+			if (ret < 0)
+				upsdebugx(3, "Failed to retrieve ASN_TIMETICKS");
+			else
+				len = (size_t)ret;
+		}
 		break;
 	case ASN_OBJECT_ID:
 		snprint_objid (tmp_buf, sizeof(tmp_buf), pdu->variables->val.objid, pdu->variables->val_len / sizeof(oid));

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -1876,7 +1876,9 @@ static bool_t process_template(int mode, const char* type, snmp_info_t *su_info_
 	size_t template_count = 0;
 	size_t base_snmp_index = 0;
 	snmp_info_t cur_info_p;
-	char template_count_var[SU_BUFSIZE];
+	char template_count_var[SU_BUFSIZE * 2];
+	/* Needed *2 to fit a max size_t in snprintf() below,
+	 * even if that should never happen */
 	char tmp_buf[SU_INFOSIZE];
 
 	upsdebugx(1, "%s template definition found (%s)...", type, su_info_p->info_type);

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -185,8 +185,8 @@ static int device_template_offset = -1;
 /* Forward functions declarations */
 static void disable_transfer_oids(void);
 bool_t get_and_process_data(int mode, snmp_info_t *su_info_p);
-int extract_template_number(int template_type, const char* varname);
-int get_template_type(const char* varname);
+int extract_template_number(unsigned long template_type, const char* varname);
+unsigned long get_template_type(const char* varname);
 
 /* ---------------------------------------------
  * driver functions implementations
@@ -1711,7 +1711,7 @@ static int base_snmp_template_index(const snmp_info_t *su_info_p)
 
 	int base_index = -1;
 	char test_OID[SU_INFOSIZE];
-	int template_type = get_template_type(su_info_p->info_type);
+	unsigned long template_type = get_template_type(su_info_p->info_type);
 
 	if (!su_info_p->OID)
 		return base_index;
@@ -2054,7 +2054,7 @@ static bool_t process_template(int mode, const char* type, snmp_info_t *su_info_
 
 /* Return the type of template, according to a variable name.
  * Return: SU_OUTLET_GROUP, SU_OUTLET or 0 if not a template */
-int get_template_type(const char* varname)
+unsigned long get_template_type(const char* varname)
 {
 	if (!strncmp(varname, "outlet.group", 12)) {
 		upsdebugx(4, "outlet.group template");
@@ -2076,7 +2076,7 @@ int get_template_type(const char* varname)
 
 /* Extract the id number of an instantiated template.
  * Example: return '1' for type = 'outlet.1.desc', -1 if unknown */
-int extract_template_number(int template_type, const char* varname)
+int extract_template_number(unsigned long template_type, const char* varname)
 {
 	const char* item_number_ptr = NULL;
 	int item_number = -1;
@@ -2266,7 +2266,7 @@ static int process_phase_data(const char* type, long *nb_phases, snmp_info_t *su
 	char tmpOID[SU_INFOSIZE];
 	char tmpInfo[SU_INFOSIZE];
 	long tmpValue;
-	int phases_flag = 0, single_phase_flag = 0, three_phase_flag = 0;
+	unsigned long phases_flag = 0, single_phase_flag = 0, three_phase_flag = 0;
 
 	/* Phase specific data */
 	if (!strncmp(type, "input", 5)) {
@@ -2841,7 +2841,7 @@ static int su_setOID(int mode, const char *varname, const char *val)
 	int cmd_offset = 0;
 	long value = -1;
 	/* normal (default), outlet, or outlet group variable */
-	int vartype = -1;
+	unsigned long vartype = 0;
 	int daisychain_device_number = -1;
 	/* variable without the potential "device.X" prefix, to find the template */
 	char *tmp_varname = NULL;

--- a/drivers/snmp-ups.h
+++ b/drivers/snmp-ups.h
@@ -199,7 +199,7 @@ typedef struct {
  * string specifier */
 #define SU_TYPE_DAISY_1		(1 << 19)	/* Daisychain index is the 1st specifier */
 #define SU_TYPE_DAISY_2		(2 << 19)	/* Daisychain index is the 2nd specifier */
-#define SU_TYPE_DAISY		((t)->flags & (7 << 19))
+#define SU_TYPE_DAISY(t)	((t)->flags & (7 << 19))
 #define SU_DAISY			(2 << 19)	/* Daisychain template definition */
 #define SU_FLAG_ZEROINVALID	(1 << 20)	/* Invalid if "0" value */
 #define SU_FLAG_NAINVALID	(1 << 21)	/* Invalid if "N/A" value */

--- a/drivers/snmp-ups.h
+++ b/drivers/snmp-ups.h
@@ -130,19 +130,33 @@ typedef struct {
 */
 typedef struct {
 	char         *info_type;  /* INFO_ or CMD_ element */
-	int           info_flags; /* flags to set in addinfo */
-	double        info_len;   /* length of strings if ST_FLAG_STRING, multiplier otherwise. */
+	int           info_flags; /* flags to set in addinfo: see ST_FLAG_*
+	                           * defined in include/extstate.h */
+	double        info_len;   /* length of strings if ST_FLAG_STRING,
+	                           * multiplier otherwise. */
 	char         *OID;        /* SNMP OID or NULL */
 	char         *dfl;        /* default value */
-	unsigned long flags;      /* snmp-ups internal flags */
+	unsigned long flags;      /* snmp-ups internal flags: see SU_* bit-shifts
+	                           * defined below (SU_FLAG*, SU_TYPE*, SU_STATUS*
+	                           * and others for outlets, phases, daisy-chains,
+	                           * etc.)
+	                           * NOTE that some *-mib.c mappings can specify
+	                           * a zero in this field... better fix that in
+	                           * favor of explicit values with a meaning!
+	                           * NOTE: With C99+ a "long" is guaranteed to be
+	                           * at least 4 bytes; consider "unsigned long long"
+	                           * when/if we get more than 32 flag values.
+	                           */
 	info_lkp_t   *oid2info;   /* lookup table between OID and NUT values */
 } snmp_info_t;
 
-#define SU_FLAG_OK			(1UL << 0)	/* show element to upsd - internal to snmp driver */
+#define SU_FLAG_OK			(1UL << 0)	/* show element to upsd -
+										 * internal to snmp driver */
 #define SU_FLAG_STATIC		(1UL << 1)	/* retrieve info only once. */
 #define SU_FLAG_ABSENT		(1UL << 2)	/* data is absent in the device,
 										 * use default value. */
-#define SU_FLAG_STALE		(1UL << 3)	/* data stale, don't try too often - internal to snmp driver */
+#define SU_FLAG_STALE		(1UL << 3)	/* data stale, don't try too often -
+										 * internal to snmp driver */
 #define SU_FLAG_NEGINVALID	(1UL << 4)	/* Invalid if negative value */
 #define SU_FLAG_UNIQUE		(1UL << 5)	/* There can be only be one
 						 				 * provider of this info,

--- a/drivers/snmp-ups.h
+++ b/drivers/snmp-ups.h
@@ -203,13 +203,15 @@ typedef struct {
 #define SU_BYPASS_3		(1 << 17)	/* only if 3 bypass phases */
 /* FIXME: use input.phases and output.phases to replace this */
 
-
 /* hints for su_ups_set, applicable only to rw vars */
 /* "flags" value 0, or bits 18..19, or "18 and 19" */
 #define SU_TYPE_INT			(0 << 18)	/* cast to int when setting value */
 /* Free slot                (1 << 18) */
 #define SU_TYPE_TIME		(2 << 18)	/* cast to int */
 #define SU_TYPE_CMD			(3 << 18)	/* instant command */
+/* The following helper macro is used like:
+ *   if (SU_TYPE(su_info_p) == SU_TYPE_CMD) { ... }
+ */
 #define SU_TYPE(t)			((t)->flags & (7 << 18))
 
 /* Daisychain template definition */

--- a/drivers/snmp-ups.h
+++ b/drivers/snmp-ups.h
@@ -169,7 +169,7 @@ typedef struct {
 #define SU_STATUS_NUM_ELEM	4			/* Obsolete? No references found in codebase */
 #define SU_STATUS_INDEX(t)	(((t) >> 8) & 7)
 
-#define SU_OUTLET_GROUP     (1 << 10)   /* outlet group template definition */
+#define SU_OUTLET_GROUP		(1 << 10)	/* outlet group template definition */
 
 /* Phase specific data */
 #define SU_PHASES		(0x3F << 12)
@@ -197,12 +197,12 @@ typedef struct {
  * in the formatting string. This is useful when considering daisychain with
  * templates, such as outlets / outlets groups, which already have a format
  * string specifier */
-#define SU_TYPE_DAISY_1		(1 << 19) /* Daisychain index is the 1st specifier */
-#define SU_TYPE_DAISY_2		(2 << 19) /* Daisychain index is the 2nd specifier */
+#define SU_TYPE_DAISY_1		(1 << 19)	/* Daisychain index is the 1st specifier */
+#define SU_TYPE_DAISY_2		(2 << 19)	/* Daisychain index is the 2nd specifier */
 #define SU_TYPE_DAISY		((t)->flags & (7 << 19))
-#define SU_DAISY			(2 << 19) /* Daisychain template definition */
-#define SU_FLAG_ZEROINVALID    (1 << 20)       /* Invalid if "0" value */
-#define SU_FLAG_NAINVALID      (1 << 21)       /* Invalid if "N/A" value */
+#define SU_DAISY			(2 << 19)	/* Daisychain template definition */
+#define SU_FLAG_ZEROINVALID	(1 << 20)	/* Invalid if "0" value */
+#define SU_FLAG_NAINVALID	(1 << 21)	/* Invalid if "N/A" value */
 
 #define SU_VAR_COMMUNITY	"community"
 #define SU_VAR_VERSION		"snmp_version"

--- a/drivers/snmp-ups.h
+++ b/drivers/snmp-ups.h
@@ -138,19 +138,19 @@ typedef struct {
 	info_lkp_t   *oid2info;   /* lookup table between OID and NUT values */
 } snmp_info_t;
 
-#define SU_FLAG_OK		(1 << 0)	/* show element to upsd - internal to snmp driver */
-#define SU_FLAG_STATIC		(1 << 1)	/* retrieve info only once. */
-#define SU_FLAG_ABSENT		(1 << 2)	/* data is absent in the device,
+#define SU_FLAG_OK			(1UL << 0)	/* show element to upsd - internal to snmp driver */
+#define SU_FLAG_STATIC		(1UL << 1)	/* retrieve info only once. */
+#define SU_FLAG_ABSENT		(1UL << 2)	/* data is absent in the device,
 										 * use default value. */
-#define SU_FLAG_STALE		(1 << 3)	/* data stale, don't try too often - internal to snmp driver */
-#define SU_FLAG_NEGINVALID	(1 << 4)	/* Invalid if negative value */
-#define SU_FLAG_UNIQUE		(1 << 5)	/* There can be only be one
+#define SU_FLAG_STALE		(1UL << 3)	/* data stale, don't try too often - internal to snmp driver */
+#define SU_FLAG_NEGINVALID	(1UL << 4)	/* Invalid if negative value */
+#define SU_FLAG_UNIQUE		(1UL << 5)	/* There can be only be one
 						 				 * provider of this info,
 						 				 * disable the other providers */
 /* Free slot
- * #define SU_FLAG_SETINT	(1 << 6)*/	/* save value */
-#define SU_OUTLET		(1 << 7)	/* outlet template definition */
-#define SU_CMD_OFFSET		(1 << 8)	/* Add +1 to the OID index */
+ * #define SU_FLAG_SETINT	(1UL << 6)*/	/* save value */
+#define SU_OUTLET			(1UL << 7)	/* outlet template definition */
+#define SU_CMD_OFFSET		(1UL << 8)	/* Add +1 to the OID index */
 /* Notes on outlet templates usage:
  * - outlet.count MUST exist and MUST be declared before any outlet template
  * Otherwise, the driver will try to determine it by itself...

--- a/drivers/snmp-ups.h
+++ b/drivers/snmp-ups.h
@@ -150,6 +150,7 @@ typedef struct {
 	info_lkp_t   *oid2info;   /* lookup table between OID and NUT values */
 } snmp_info_t;
 
+/* "flags" bits 0..8 (and 9 reserved for DMF) */
 #define SU_FLAG_OK			(1UL << 0)	/* show element to upsd -
 										 * internal to snmp driver */
 #define SU_FLAG_STATIC		(1UL << 1)	/* retrieve info only once. */
@@ -171,11 +172,13 @@ typedef struct {
  * - the first outlet template MUST NOT be a server side variable (ie MUST have
  *   a valid OID) in order to detect the base SNMP index (0 or 1)
  */
+/* Reserved slot (1UL << 9) -- to import from DMF branch codebase */
 
 /* status string components
  * FIXME: these should be removed, since there is no added value.
  * Ie, this can be guessed from info->type! */
 
+/* "flags" value 0, or bits 8..9, or "8 and 9" */
 #define SU_STATUS_PWR		(0 << 8)	/* indicates power status element */
 #define SU_STATUS_BATT		(1 << 8)	/* indicates battery status element */
 #define SU_STATUS_CAL		(2 << 8)	/* indicates calibration status element */
@@ -183,9 +186,11 @@ typedef struct {
 #define SU_STATUS_NUM_ELEM	4			/* Obsolete? No references found in codebase */
 #define SU_STATUS_INDEX(t)	(((t) >> 8) & 7)
 
+/* "flags" bit 10 */
 #define SU_OUTLET_GROUP		(1 << 10)	/* outlet group template definition */
 
 /* Phase specific data */
+/* "flags" bits 12..17 */
 #define SU_PHASES		(0x3F << 12)
 #define SU_INPHASES		(0x3 << 12)
 #define SU_INPUT_1		(1 << 12)	/* only if 1 input phase */
@@ -200,6 +205,7 @@ typedef struct {
 
 
 /* hints for su_ups_set, applicable only to rw vars */
+/* "flags" value 0, or bits 18..19, or "18 and 19" */
 #define SU_TYPE_INT			(0 << 18)	/* cast to int when setting value */
 /* Free slot                (1 << 18) */
 #define SU_TYPE_TIME		(2 << 18)	/* cast to int */
@@ -211,10 +217,13 @@ typedef struct {
  * in the formatting string. This is useful when considering daisychain with
  * templates, such as outlets / outlets groups, which already have a format
  * string specifier */
+/* "flags" bits 19..20, and 20 again */
 #define SU_TYPE_DAISY_1		(1 << 19)	/* Daisychain index is the 1st specifier */
 #define SU_TYPE_DAISY_2		(2 << 19)	/* Daisychain index is the 2nd specifier */
 #define SU_TYPE_DAISY(t)	((t)->flags & (7 << 19))
 #define SU_DAISY			(2 << 19)	/* Daisychain template definition */
+
+/* "flags" bits 20..21 */
 #define SU_FLAG_ZEROINVALID	(1 << 20)	/* Invalid if "0" value */
 #define SU_FLAG_NAINVALID	(1 << 21)	/* Invalid if "N/A" value */
 

--- a/drivers/snmp-ups.h
+++ b/drivers/snmp-ups.h
@@ -166,7 +166,7 @@ typedef struct {
 #define SU_STATUS_BATT		(1 << 8)	/* indicates battery status element */
 #define SU_STATUS_CAL		(2 << 8)	/* indicates calibration status element */
 #define SU_STATUS_RB		(3 << 8)	/* indicates replace battery status element */
-#define SU_STATUS_NUM_ELEM	4
+#define SU_STATUS_NUM_ELEM	4			/* Obsolete? No references found in codebase */
 #define SU_STATUS_INDEX(t)	(((t) >> 8) & 7)
 
 #define SU_OUTLET_GROUP     (1 << 10)   /* outlet group template definition */


### PR DESCRIPTION
Follows up from #823 to fight warnings in NUT codebase

CC @aquette about:
* Not sure if the template offsets may be validly negative?
* Also, compiler did not mind but should other `SU_*` macros be forced as `unsigned long`?
* ...And maybe the `snmp_info_t->info_flags` field should also be increased to `unsigned long`... or rather a fixed-bitness type for both sorts of flags?