### PR TITLE
Fightwarn: fix warnings in codebase of recently added `getvaluetest`

### DIFF
--- a/ci_build.sh
+++ b/ci_build.sh
@@ -6,6 +6,41 @@
 
 set -e
 
+# Quick hijack for interactive development like this:
+#   BUILD_TYPE=fightwarn-clang ./ci_build.sh
+case "$BUILD_TYPE" in
+    fightwarn) ;; # for default compiler
+    fightwarn-gcc)
+        CC="gcc"
+        CXX="g++"
+        CPP="cpp"
+        BUILD_TYPE=fightwarn
+        ;;
+    fightwarn-clang)
+        CC="clang"
+        CXX="clang++"
+        CPP="clang-cpp"
+        BUILD_TYPE=fightwarn
+        ;;
+esac
+
+if [ "$BUILD_TYPE" = fightwarn ]; then
+    # For CFLAGS/CXXFLAGS keep caller or compiler defaults
+    # (including C/C++ revision)
+    BUILD_TYPE=default-all-errors
+    BUILD_WARNFATAL=yes
+
+    # Current fightwarn goal is to have no warnings at preset level below:
+    #[ -n "$BUILD_WARNOPT" ] || BUILD_WARNOPT=hard
+    [ -n "$BUILD_WARNOPT" ] || BUILD_WARNOPT=medium
+
+    # Eventually this constraint would be removed to check all present
+    # SSL implementations since their ifdef-driven codebases differ and
+    # emit varied warnings. But so far would be nice to get the majority
+    # of shared codebase clean first:
+    [ -n "$NUT_SSL_VARIANTS" ] || NUT_SSL_VARIANTS=auto
+fi
+
 # Set this to enable verbose profiling
 [ -n "${CI_TIME-}" ] || CI_TIME=""
 case "$CI_TIME" in

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -201,6 +201,13 @@ build_to_only_catch_errors() {
 }
 
 echo "Processing BUILD_TYPE='${BUILD_TYPE}' ..."
+
+echo "Build host settings:"
+set | egrep '^(CI_.*|CANBUILD_.*|NODE_LABELS|MAKE)=' || true
+uname -a
+echo "LONG_BIT:`getconf LONG_BIT` WORD_BIT:`getconf WORD_BIT`" || true
+if command -v xxd >/dev/null ; then xxd -c 1 -l 6 | tail -1; else if command -v od >/dev/null; then od -N 1 -j 5 -b | head -1 ; else hexdump -s 5 -n 1 -C | head -1; fi; fi < /bin/ls 2>/dev/null | awk '($2 == 1){print "Endianness: LE"}; ($2 == 2){print "Endianness: BE"}' || true
+
 case "$BUILD_TYPE" in
 default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-spellcheck|default-shellcheck|default-nodoc|default-withdoc|default-withdoc:man|"default-tgt:"*)
     LANG=C

--- a/docs/developers.txt
+++ b/docs/developers.txt
@@ -211,6 +211,14 @@ for their build, e.g.:
 	CC=clang-9 CXX=clang++-9 CPP=clang-cpp \
 		./ci_build.sh
 
+Finally, for refactoring effort geared particularly for fighting the
+warnings which exist in current codebase, the script contains some
+presets (which would evolve along with codebase quality improvements)
+as `BUILD_TYPE=fightwarn-gcc`, `BUILD_TYPE=fightwarn-clang` or plain
+`BUILD_TYPE=fightwarn`:
+
+	BUILD_TYPE=fightwarn-clang ./ci_build.sh
+
 As a rule of thumb, new contributions must not emit any warnings when
 built in GNU99 mode with a `minimal` "difficulty" level of warnings.
 Technically they must survive the part of test matrix across the several

--- a/tests/getvaluetest.c
+++ b/tests/getvaluetest.c
@@ -36,7 +36,7 @@
 
 void GetValue(const unsigned char *Buf, HIDData_t *pData, long *pValue);
 
-void Usage(char *name) {
+static void Usage(char *name) {
 	printf("%s [<buf> <offset> <size> <min> <max> <expect>]\n", name);
 	printf("  <buf>     - string of hex digit pairs, space separated\n");
 	printf("  <offset>  - offset of the report item value in bits, typically 0..31\n");
@@ -49,7 +49,7 @@ void Usage(char *name) {
 	printf("\nIf no arguments are given a builtin set of tests are run.\n");
 }
 
-void PrintBufAndData(uint8_t *buf, size_t bufSize, HIDData_t *pData) {
+static void PrintBufAndData(uint8_t *buf, size_t bufSize, HIDData_t *pData) {
 	size_t i;
 
 	printf("buf \"");
@@ -61,7 +61,7 @@ void PrintBufAndData(uint8_t *buf, size_t bufSize, HIDData_t *pData) {
 		pData->Offset, pData->Size, pData->LogMin, pData->LogMin, pData->LogMax, pData->LogMax);
 }
 
-int RunBuiltInTests(char *argv[]) {
+static int RunBuiltInTests(char *argv[]) {
 	NUT_UNUSED_VARIABLE(argv);
 
 	int exitStatus = 0;
@@ -71,6 +71,7 @@ int RunBuiltInTests(char *argv[]) {
 	int bufSize;
 	HIDData_t data;
 	long value;
+
 	static struct {
 		char *buf;		/* item data, starts with report id byte, then remaining report bytes */
 		int Offset;		/* item offset in bits, typically 0..31 */
@@ -125,7 +126,7 @@ int RunBuiltInTests(char *argv[]) {
 	return (exitStatus);
 }
 
-int RunCommandLineTest(char *argv[]) {
+static int RunCommandLineTest(char *argv[]) {
 	uint8_t reportBuf[64];
 	size_t bufSize;
 	char *start, *end;

--- a/tests/getvaluetest.c
+++ b/tests/getvaluetest.c
@@ -68,7 +68,7 @@ static int RunBuiltInTests(char *argv[]) {
 	size_t i;
 	char *next;
 	uint8_t reportBuf[64];
-	int bufSize;
+	size_t bufSize;
 	HIDData_t data;
 	long value;
 

--- a/tests/getvaluetest.c
+++ b/tests/getvaluetest.c
@@ -73,9 +73,9 @@ static int RunBuiltInTests(char *argv[]) {
 	long value;
 
 	static struct {
-		char *buf;		/* item data, starts with report id byte, then remaining report bytes */
-		int Offset;		/* item offset in bits, typically 0..31 */
-		int Size;		/* item size in bits, typically 1..32 */
+		char *buf;			/* item data, starts with report id byte, then remaining report bytes */
+		uint8_t Offset;		/* item offset in bits, typically 0..31 */
+		uint8_t Size;		/* item size in bits, typically 1..32 */
 		long LogMin, LogMax;	/* logical minimum and maximum values */
 		long expectedValue;	/* the expected result of decoding the value in the buffer */
 	} testData[] = {


### PR DESCRIPTION
...and add a couple of helpers in `ci_build.sh`

Follows up from #823 to fight warnings in NUT codebase, and #1040 / #1055 / #1023 about HID parser fixes.

CC @nbriggs 