### PR TITLE
Fix the web of Makefile cross-references across subdirs

### DIFF
--- a/ci_build.sh
+++ b/ci_build.sh
@@ -749,7 +749,7 @@ bindings)
     echo ""
     ./autogen.sh
     #./configure
-    ./configure --with-cgi=auto --with-serial=auto --with-dev=auto
+    ./configure --with-cgi=auto --with-serial=auto --with-dev=auto --with-doc=skip
     $MAKE all && $MAKE check
     ;;
 *)

--- a/clients/Makefile.am
+++ b/clients/Makefile.am
@@ -6,8 +6,14 @@ EXTRA_DIST =
 # was never triggered in fact, not until pushed through command line like this:
 AM_CXXFLAGS = -DHAVE_NUTCOMMON=1 -I$(top_srcdir)/include
 
+# Make sure out-of-dir dependencies exist (especially when dev-building parts):
+$(top_builddir)/common/libcommon.la \
+$(top_builddir)/common/libcommonclient.la \
+$(top_builddir)/common/libparseconf.la:
+	@cd $(@D) && $(MAKE) -s $(@F)
+
 # by default, link programs in this directory with libcommon.a
-LDADD = ../common/libcommon.la libupsclient.la $(NETLIBS)
+LDADD = $(top_builddir)/common/libcommon.la libupsclient.la $(NETLIBS)
 if WITH_SSL
   LDADD += $(LIBSSL_LIBS)
 endif
@@ -45,7 +51,7 @@ upslog_SOURCES = upslog.c upsclient.h upslog.h
 upsmon_SOURCES = upsmon.c upsmon.h upsclient.h
 
 upssched_SOURCES = upssched.c upssched.h
-upssched_LDADD = ../common/libcommon.la ../common/libparseconf.la $(NETLIBS)
+upssched_LDADD = $(top_builddir)/common/libcommon.la $(top_builddir)/common/libparseconf.la $(NETLIBS)
 
 upsimage_cgi_SOURCES = upsimage.c upsclient.h upsimagearg.h cgilib.c cgilib.h
 upsimage_cgi_LDADD = $(LDADD) $(LIBGD_LDFLAGS)
@@ -56,7 +62,7 @@ upsstats_cgi_SOURCES = upsstats.c upsclient.h status.h upsstats.h	\
 
 # not LDADD.
 libupsclient_la_SOURCES = upsclient.c upsclient.h
-libupsclient_la_LIBADD = ../common/libcommonclient.la
+libupsclient_la_LIBADD = $(top_builddir)/common/libcommonclient.la
 if WITH_SSL
   libupsclient_la_LIBADD += $(LIBSSL_LIBS)
 endif

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -9,6 +9,11 @@ libparseconf_la_SOURCES = parseconf.c
 # 'dist', and is only required for actual build, in which case
 # BUILT_SOURCES (in ../include) will ensure nut_version.h will
 # be built before anything else
+common.c: $(top_builddir)/include/nut_version.h
+
+$(top_builddir)/include/nut_version.h:
+	@cd $(@D) && $(MAKE) -s $(@F)
+
 libcommon_la_SOURCES = common.c state.c str.c upsconf.c
 libcommonclient_la_SOURCES = common.c state.c str.c
 # ensure inclusion of local implementation of missing systems functions

--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -1,9 +1,15 @@
 # Network UPS Tools: drivers
 
+# Make sure out-of-dir dependencies exist (especially when dev-building parts):
+$(top_builddir)/common/libcommon.la \
+$(top_builddir)/common/libparseconf.la \
+$(top_builddir)/clients/libupsclient.la:
+	@cd $(@D) && $(MAKE) -s $(@F)
+
 # by default, link programs in this directory with libcommon.la
 # (libtool version of the static lib, in order to access LTLIBOBJS)
 #FIXME: SERLIBS is only useful for LDADD_DRIVERS_SERIAL not for LDADD_COMMON
-LDADD_COMMON = ../common/libcommon.la ../common/libparseconf.la
+LDADD_COMMON = $(top_builddir)/common/libcommon.la $(top_builddir)/common/libparseconf.la
 LDADD_DRIVERS = libdummy.la $(LDADD_COMMON)
 LDADD_DRIVERS_SERIAL = libdummy_serial.la $(LDADD_DRIVERS) $(SERLIBS)
 
@@ -155,7 +161,7 @@ riello_ser_LDADD = $(LDADD) -lm
 # dummy
 dummy_ups_SOURCES = dummy-ups.c
 dummy_ups_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/clients
-dummy_ups_LDADD = $(LDADD_DRIVERS) ../clients/libupsclient.la
+dummy_ups_LDADD = $(LDADD_DRIVERS) $(top_builddir)/clients/libupsclient.la
 if WITH_SSL
   dummy_ups_CFLAGS += $(LIBSSL_CFLAGS)
   dummy_ups_LDADD += $(LIBSSL_LIBS)

--- a/server/Makefile.am
+++ b/server/Makefile.am
@@ -1,5 +1,10 @@
 # Network UPS Tools: server
 
+# Make sure out-of-dir dependencies exist (especially when dev-building parts):
+$(top_builddir)/common/libcommon.la \
+$(top_builddir)/common/libparseconf.la:
+	@cd $(@D) && $(MAKE) -s $(@F)
+
 # Avoid per-target CFLAGS, because this will prevent re-use of object
 # files. In any case, CFLAGS are only -I options, so there is no harm,
 # but only add them if we really use the target.
@@ -10,7 +15,7 @@ endif
 if WITH_SSL
   AM_CFLAGS += $(LIBSSL_CFLAGS)
 endif
-LDADD = ../common/libcommon.la ../common/libparseconf.la $(NETLIBS)
+LDADD = $(top_builddir)/common/libcommon.la $(top_builddir)/common/libparseconf.la $(NETLIBS)
 if WITH_WRAP
    LDADD += $(LIBWRAP_LIBS)
 endif

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -17,6 +17,10 @@ nutlogtest_LDADD = $(top_builddir)/common/libcommon.la
 getvaluetest_SOURCES = getvaluetest.c $(top_srcdir)/drivers/hidparser.c
 getvaluetest_LDADD = $(top_builddir)/common/libcommon.la
 
+# Make sure out-of-dir dependencies exist (especially when dev-building parts):
+$(top_builddir)/common/libcommon.la:
+	@cd $(@D) && $(MAKE) -s $(@F)
+
 ### Optional tests which can not be built everywhere
 # List of src files for CppUnit tests
 CPPUNITTESTSRC = example.cpp nutclienttest.cpp
@@ -42,6 +46,11 @@ cppunittest_CXXFLAGS = $(AM_CXXFLAGS) $(CPPUNIT_CFLAGS) $(CPPUNIT_CXXFLAGS) $(CP
 cppunittest_LDFLAGS = $(CPPUNIT_LIBS)
 cppunittest_LDADD = $(top_builddir)/clients/libnutclient.la $(top_builddir)/clients/libnutclientstub.la
 cppunittest_SOURCES = $(CPPUNITTESTSRC) $(CPPUNITTESTERSRC)
+
+# Make sure out-of-dir C++ dependencies exist (especially when dev-building
+# only some parts of NUT):
+$(top_builddir)/clients/libnutclient.la $(top_builddir)/clients/libnutclientstub.la:
+	@cd $(@D) && $(MAKE) -s $(@F)
 
 else !HAVE_CPPUNIT
 # Just redistribute test source into tarball

--- a/tools/nut-scanner/Makefile.am
+++ b/tools/nut-scanner/Makefile.am
@@ -13,6 +13,10 @@ BUILT_SOURCES = $(NUT_SCANNER_DEPS)
 $(NUT_SCANNER_DEPS):
 	cd ..; $(MAKE) $(AM_MAKEFLAGS) nut-scanner-deps
 
+# Make sure out-of-dir dependencies exist (especially when dev-building parts):
+$(top_builddir)/common/libcommon.la:
+	@cd $(@D) && $(MAKE) -s $(@F)
+
 # Only build nut-scanner, and its library, if libltdl was found (required!)
 if WITH_LIBLTDL
  bin_PROGRAMS = nut-scanner
@@ -38,7 +42,7 @@ libnutscan_la_CFLAGS = -I$(top_srcdir)/clients -I$(top_srcdir)/include $(LIBLTDL
 
 nut_scanner_SOURCES = nut-scanner.c
 nut_scanner_CFLAGS = -I$(top_srcdir)/clients -I$(top_srcdir)/include
-nut_scanner_LDADD = ../../common/libcommon.la libnutscan.la
+nut_scanner_LDADD = $(top_builddir)/common/libcommon.la libnutscan.la
 
 if WITH_SSL
   libnutscan_la_CFLAGS += $(LIBSSL_CFLAGS)

--- a/tools/nut-scanner/Makefile.am
+++ b/tools/nut-scanner/Makefile.am
@@ -17,6 +17,15 @@ $(NUT_SCANNER_DEPS):
 $(top_builddir)/common/libcommon.la:
 	@cd $(@D) && $(MAKE) -s $(@F)
 
+# do not hard depend on '../include/nut_version.h', since it blocks
+# 'dist', and is only required for actual build, in which case
+# BUILT_SOURCES (in ../include) will ensure nut_version.h will
+# be built before anything else
+$(top_srcdir)/common/common.c nut-scanner.c: $(top_builddir)/include/nut_version.h
+
+$(top_builddir)/include/nut_version.h:
+	@cd $(@D) && $(MAKE) -s $(@F)
+
 # Only build nut-scanner, and its library, if libltdl was found (required!)
 if WITH_LIBLTDL
  bin_PROGRAMS = nut-scanner

--- a/tools/nut-scanner/Makefile.am
+++ b/tools/nut-scanner/Makefile.am
@@ -26,9 +26,9 @@ libnutscan_la_SOURCES = scan_nut.c scan_ipmi.c \
 			nutscan-device.c nutscan-ip.c nutscan-display.c \
 			nutscan-init.c scan_usb.c scan_snmp.c scan_xml_http.c \
 			scan_avahi.c scan_eaton_serial.c nutscan-serial.c \
-			../../drivers/serial.c \
-			../../drivers/bcmxcp_ser.c \
-			../../common/common.c ../../common/str.c
+			$(top_srcdir)/drivers/serial.c \
+			$(top_srcdir)/drivers/bcmxcp_ser.c \
+			$(top_srcdir)/common/common.c $(top_srcdir)/common/str.c
 libnutscan_la_LIBADD = $(NETLIBS) $(LIBLTDL_LIBS)
 #
 # Below we set API versions of public libraries


### PR DESCRIPTION
* We had issues (links welcome) with builds of parts of codebase from sub-directories, rather than builds arranged normally from the root directory. Large part of the mess was the absence of dependencies on files (e.g. `*.la` archives) located in other sub-directories, so those were not automatically built when we wanted to e.g. `configure && cd tests && make`. Now such situations should resolve correctly.