### PR TITLE
Small fixes for CI and developer workflows

### DIFF
--- a/ci_build.sh
+++ b/ci_build.sh
@@ -2,6 +2,11 @@
 
 ################################################################################
 # This file is based on a template used by zproject, but isn't auto-generated. #
+# Its primary use is to automate a number of BUILD_TYPE scenarios for the NUT  #
+# CI farm, but for the same reason it can also be useful to reduce typing for  #
+# reproducible build attempts with NUT development and refactoring workflows.  #
+# Note that it is driven by enviroment variables rather than CLI arguments --  #
+# this approach better suits the practicalities of CI build farm technologies. #
 ################################################################################
 
 set -e

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -59,6 +59,14 @@ case "$CI_TRACE" in
         set -x ;;
 esac
 
+[ -n "${CI_REQUIRE_GOOD_GITIGNORE-}" ] || CI_REQUIRE_GOOD_GITIGNORE="true"
+case "$CI_REQUIRE_GOOD_GITIGNORE" in
+    [Nn][Oo]|[Oo][Ff][Ff]|[Ff][Aa][Ll][Ss][Ee])
+        CI_REQUIRE_GOOD_GITIGNORE="false" ;;
+    [Yy][Ee][Ss]|[Oo][Nn]|[Tt][Rr][Uu][Ee])
+        CI_REQUIRE_GOOD_GITIGNORE="true" ;;
+esac
+
 [ -n "$MAKE" ] || MAKE=make
 [ -n "$GGREP" ] || GGREP=grep
 
@@ -618,7 +626,7 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
             echo "=== Are GitIgnores good after '$MAKE $BUILD_TGT'? (should have no output below)"
             git status -s || true
             echo "==="
-            if git status -s | egrep '\.dmf$' ; then
+            if git status -s | egrep '\.dmf$' && [ "$CI_REQUIRE_GOOD_GITIGNORE" != false ] ; then
                 echo "FATAL: There are changes in DMF files listed above - tracked sources should be updated!" >&2
                 exit 1
             fi
@@ -745,7 +753,7 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
     echo "=== Are GitIgnores good after '$MAKE all'? (should have no output below)"
     git status -s || true
     echo "==="
-    if [ -n "`git status -s`" ]; then
+    if [ -n "`git status -s`" ] && [ "$CI_REQUIRE_GOOD_GITIGNORE" != false ]; then
         echo "FATAL: There are changes in some files listed above - tracked sources should be updated in the PR, and build products should be added to a .gitignore file!" >&2
         git diff || true
         echo "==="

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -79,9 +79,19 @@ SUFFIXES = .txt .html .pdf -spellchecked
 
 all: doc
 
+# This list is defined by configure script choices and options:
 check-local: @DOC_CHECK_LIST@
 
+# This list is defined by configure script choices and options:
 doc: @DOC_BUILD_LIST@
+
+# This target can be called by developers to go around the configure
+# script choices at their risk (e.g. missing tools are possible):
+docs: pdf html-single html-chunked man
+
+all-docs: docs
+
+check-docs: check-pdf check-html-single check-html-chunked check-man
 
 pdf: $(ASCIIDOC_PDF)
 # also build the HTML manpages with these targets
@@ -122,6 +132,9 @@ check-html-chunked: $(ASCIIDOC_HTML_CHUNKED)
 # once as a SUBDIRS child makefile, and once via DOC_CHECK_LIST expansion
 check-man:
 	cd $(top_builddir)/docs/man/ && $(MAKE) -f Makefile $@
+
+man:
+	cd $(top_builddir)/docs/man/ && $(MAKE) -f Makefile all
 
 clean-local:
 	rm -f *.pdf *.html *-spellchecked docbook-xsl.css
@@ -349,4 +362,4 @@ spellcheck-interactive:
 	@echo "Documentation spell check not available since 'aspell' was not found."
 endif !HAVE_ASPELL
 
-.PHONY: html html-single pdf
+.PHONY: html html-chunked html-single pdf man

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -124,9 +124,8 @@ MAN8_CGI_PAGES = \
 endif
 
 if WITH_CGI
- man5_MANS += $(MAN5_CGI_PAGES)
-
- man8_MANS += $(MAN8_CGI_PAGES)
+man5_MANS += $(MAN5_CGI_PAGES)
+man8_MANS += $(MAN8_CGI_PAGES)
 endif
 
 HTML_CGI_MANS = \
@@ -306,10 +305,10 @@ MAN1_DEV_PAGES = \
 endif
 
 if WITH_DEV
- man3_MANS = $(MAN3_DEV_PAGES)
+man3_MANS = $(MAN3_DEV_PAGES)
 
 if !WITH_PKG_CONFIG
- man1_MANS = $(MAN1_DEV_PAGES)
+man1_MANS = $(MAN1_DEV_PAGES)
 endif
 # WITH_DEV
 endif
@@ -364,7 +363,7 @@ HTML_DEV_MANS = \
 
 # (--with-drivers=...)
 if SOME_DRIVERS
- man8_MANS += $(DRIVER_MAN_LIST)
+man8_MANS += $(DRIVER_MAN_LIST)
 
 else
 
@@ -457,7 +456,7 @@ MAN_SERIAL_PAGES = \
 endif
 
 if WITH_SERIAL
-  man8_MANS +=  $(MAN_SERIAL_PAGES)
+man8_MANS +=  $(MAN_SERIAL_PAGES)
 endif
 
 HTML_SERIAL_MANS = \
@@ -509,7 +508,7 @@ MAN_SNMP_PAGES = snmp-ups.8
 endif
 
 if WITH_SNMP
-  man8_MANS += $(MAN_SNMP_PAGES)
+man8_MANS += $(MAN_SNMP_PAGES)
 endif
 
 HTML_SNMP_MANS = snmp-ups.html
@@ -537,7 +536,7 @@ MAN_USB_LIBUSB_PAGES = \
 endif
 
 if WITH_USB
- man8_MANS += $(MAN_USB_LIBUSB_PAGES)
+man8_MANS += $(MAN_USB_LIBUSB_PAGES)
 endif
 
 HTML_USB_LIBUSB_MANS = \
@@ -559,10 +558,10 @@ MAN_SERIAL_USB_PAGES = \
 endif
 
 if WITH_SERIAL
- man8_MANS += $(MAN_SERIAL_USB_PAGES)
+man8_MANS += $(MAN_SERIAL_USB_PAGES)
 else
 if WITH_USB
- man8_MANS += $(MAN_SERIAL_USB_PAGES)
+man8_MANS += $(MAN_SERIAL_USB_PAGES)
 endif
 endif
 
@@ -576,7 +575,7 @@ MAN_NETXML_PAGES = netxml-ups.8
 endif
 
 if WITH_NEON
-   man8_MANS += $(MAN_NETXML_PAGES)
+man8_MANS += $(MAN_NETXML_PAGES)
 endif
 
 HTML_NETXML_MANS = netxml-ups.html
@@ -588,7 +587,7 @@ MAN_POWERMAN_PAGES = powerman-pdu.8
 endif
 
 if WITH_LIBPOWERMAN
-   man8_MANS += $(MAN_POWERMAN_PAGES)
+man8_MANS += $(MAN_POWERMAN_PAGES)
 endif
 
 HTML_POWERMAN_MANS = powerman-pdu.html
@@ -600,7 +599,7 @@ MAN_IPMIPSU_PAGES = nut-ipmipsu.8
 endif
 
 if WITH_IPMI
-   man8_MANS += $(MAN_IPMIPSU_PAGES)
+man8_MANS += $(MAN_IPMIPSU_PAGES)
 endif
 
 HTML_IPMIPSU_MANS = nut-ipmipsu.html
@@ -611,24 +610,24 @@ MAN_MACOSX_PAGES = macosx-ups.8
 endif
 
 if WITH_MACOSX
-   man8_MANS += $(MAN_MACOSX_PAGES)
+man8_MANS += $(MAN_MACOSX_PAGES)
 endif
 
 HTML_MACOSX_MANS = macosx-ups.html
 
 SRC_MODBUS_PAGES = phoenixcontact_modbus.txt \
-		   generic_modbus.txt
+	generic_modbus.txt
 if WITH_MANS
 MAN_MODBUS_PAGES = phoenixcontact_modbus.8 \
-		   generic_modbus.8
+	generic_modbus.8
 endif
 
 if WITH_MODBUS
-   man8_MANS += $(MAN_MODBUS_PAGES)
+man8_MANS += $(MAN_MODBUS_PAGES)
 endif
 
 HTML_MODBUS_MANS = phoenixcontact_modbus.html \
-		   generic_modbus.html
+	generic_modbus.html
 
 SRC_LINUX_I2C_PAGES = asem.txt pijuice.txt
 if WITH_MANS
@@ -636,7 +635,7 @@ MAN_LINUX_I2C_PAGES = asem.8 pijuice.8
 endif
 
 if WITH_LINUX_I2C
-   man8_MANS += $(MAN_LINUX_I2C_PAGES)
+man8_MANS += $(MAN_LINUX_I2C_PAGES)
 endif
 
 HTML_LINUX_I2C_MANS = asem.html pijuice.html


### PR DESCRIPTION
One allows to use `ci_build.sh` in a git workspace with random logs, helper scripts, notes, etc. that are neither git-tracked nor git-ignored (avoid choking on `git status -s` returning not empty).

Another allows to `(cd docs && make docs)` regardless of whether they are enabled or not -- helping with PRs like #1152 