### PR TITLE
ci_build.sh: guess the available amount of parallelism for the current system; enable parallel distcheck...

### DIFF
--- a/ci_build.sh
+++ b/ci_build.sh
@@ -658,7 +658,7 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
             # that include DISTCHECK_FLAGS if provided
             DISTCHECK_FLAGS="`for F in "${CONFIG_OPTS[@]}" ; do echo "'$F' " ; done | tr '\n' ' '`"
             export DISTCHECK_FLAGS
-            $CI_TIME $MAKE VERBOSE=1 DISTCHECK_FLAGS="$DISTCHECK_FLAGS" "$BUILD_TGT"
+            $CI_TIME $MAKE VERBOSE=1 DISTCHECK_FLAGS="$DISTCHECK_FLAGS" $PARMAKE_FLAGS "$BUILD_TGT"
 
             echo "=== Are GitIgnores good after '$MAKE $BUILD_TGT'? (should have no output below)"
             git status -s || true

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -105,6 +105,9 @@ esac
 PARMAKE_FLAGS="-j $NPARMAKES"
 if "$MAKE" --version 2>&1 | egrep 'GNU Make|Free Software Foundation' > /dev/null ; then
     PARMAKE_FLAGS="$PARMAKE_FLAGS -l $PARMAKE_LA_LIMIT"
+    echo "Parallel builds would spawn up to $NPARMAKES jobs (detected $NCPUS CPUs), or peak out at $PARMAKE_LA_LIMIT system load average" >&2
+else
+    echo "Parallel builds would spawn up to $NPARMAKES jobs (detected $NCPUS CPUs)" >&2
 fi
 
 # CI builds on Jenkins

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -844,7 +844,9 @@ bindings)
     ./autogen.sh
     #./configure
     ./configure --with-cgi=auto --with-serial=auto --with-dev=auto --with-doc=skip
-    $MAKE all && $MAKE check
+    #$MAKE all && \
+    $MAKE $PARMAKE_FLAGS all && \
+    $MAKE check
     ;;
 *)
     pushd "./builds/${BUILD_TYPE}" && REPO_DIR="$(dirs -l +1)" ./ci_build.sh

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -681,8 +681,10 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
             [ -z "$CI_TIME" ] || echo "`date`: Trying to spellcheck documentation of the currently tested project..."
             # Note: use the root Makefile's spellcheck recipe which goes into
             # sub-Makefiles known to check corresponding directory's doc files.
+            # Note: no PARMAKE_FLAGS here - better have this output readably
+            # ordered in case of issues (in sequential replay below).
             ( echo "`date`: Starting the quiet build attempt for target $BUILD_TYPE..." >&2
-              $CI_TIME $MAKE -s VERBOSE=0 SPELLCHECK_ERROR_FATAL=yes -k spellcheck >/dev/null 2>&1 \
+              $CI_TIME $MAKE -s VERBOSE=0 SPELLCHECK_ERROR_FATAL=yes -k $PARMAKE_FLAGS spellcheck >/dev/null 2>&1 \
               && echo "`date`: SUCCEEDED the spellcheck" >&2
             ) || \
             ( echo "`date`: FAILED something in spellcheck above; re-starting a verbose build attempt to summarize:" >&2
@@ -699,6 +701,8 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
             ### Still, there remains value in also checking the script syntax
             ### by the very version of the shell interpreter that would run
             ### these scripts in production usage of the resulting packages.
+            ### Note: no PARMAKE_FLAGS here - better have this output readably
+            ### ordered in case of issues.
             ( $CI_TIME $MAKE VERBOSE=1 shellcheck check-scripts-syntax )
             exit $?
             ;;
@@ -814,7 +818,7 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
         # that include DISTCHECK_FLAGS if provided
         DISTCHECK_FLAGS="`for F in "${CONFIG_OPTS[@]}" ; do echo "'$F' " ; done | tr '\n' ' '`"
         export DISTCHECK_FLAGS
-        $CI_TIME $MAKE VERBOSE=1 DISTCHECK_FLAGS="$DISTCHECK_FLAGS" distcheck
+        $CI_TIME $MAKE VERBOSE=1 DISTCHECK_FLAGS="$DISTCHECK_FLAGS" $PARMAKE_FLAGS distcheck
 
         echo "=== Are GitIgnores good after '$MAKE distcheck'? (should have no output below)"
         git status -s || true

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -102,12 +102,16 @@ esac
 # some non-trivial LA, so we set the default limit per CPU relatively high.
 [ x"$PARMAKE_LA_LIMIT" = x ] && PARMAKE_LA_LIMIT="`expr $NCPUS '*' 8`".0
 
-PARMAKE_FLAGS="-j $NPARMAKES"
-if "$MAKE" --version 2>&1 | egrep 'GNU Make|Free Software Foundation' > /dev/null ; then
-    PARMAKE_FLAGS="$PARMAKE_FLAGS -l $PARMAKE_LA_LIMIT"
-    echo "Parallel builds would spawn up to $NPARMAKES jobs (detected $NCPUS CPUs), or peak out at $PARMAKE_LA_LIMIT system load average" >&2
-else
-    echo "Parallel builds would spawn up to $NPARMAKES jobs (detected $NCPUS CPUs)" >&2
+# After all the tunable options above, this is the one which takes effect
+# for actual builds with parallel phases. Specify a whitespace to neuter.
+if [ -z "$PARMAKE_FLAGS" ]; then
+    PARMAKE_FLAGS="-j $NPARMAKES"
+    if LANG=C LC_ALL=C "$MAKE" --version 2>&1 | egrep 'GNU Make|Free Software Foundation' > /dev/null ; then
+        PARMAKE_FLAGS="$PARMAKE_FLAGS -l $PARMAKE_LA_LIMIT"
+        echo "Parallel builds would spawn up to $NPARMAKES jobs (detected $NCPUS CPUs), or peak out at $PARMAKE_LA_LIMIT system load average" >&2
+    else
+        echo "Parallel builds would spawn up to $NPARMAKES jobs (detected $NCPUS CPUs)" >&2
+    fi
 fi
 
 # CI builds on Jenkins

--- a/configure.ac
+++ b/configure.ac
@@ -1887,7 +1887,11 @@ dnl we support an explicit --without-valgrind (aka --with-valgrind=no) too.
 AS_IF([test -n "${VALGRIND}"], [
 	AC_MSG_CHECKING([whether valgrind is usable on current platform])
 	AS_IF([( ${VALGRIND} --help >/dev/null 2>/dev/null )],
-		[AC_MSG_RESULT([yes])],
+		[AS_IF([( ${VALGRIND} /bin/sh -c true >/dev/null 2>/dev/null )],
+			[AC_MSG_RESULT([yes])],
+			[AC_MSG_RESULT([no])
+			 VALGRIND="none"
+			])],
 		[AC_MSG_RESULT([no])
 		 VALGRIND="none"
 		])


### PR DESCRIPTION
Also try better in `configure` script to avoid dysfunctional `valgrind` setups (e.g. one crashing with QEMU incomplete CPUs).

After #1154 and #1151, the parallel builds and distchecks are expected to not fail due to recipe side of the equation ;)