### PR TITLE
docs: fix use of "link:" tag in asciidoc (issue #1111)

### DIFF
--- a/docs/developers.txt
+++ b/docs/developers.txt
@@ -329,7 +329,8 @@ NOTE: While NUT recipes do not currently recognize a separate `CXXCPP`,
 it would follow similar semantics.
 
 Some further details about the NUT CI farm workers are available in
-link:config-prereqs.txt and link:ci-farm-lxc-setup.txt documents.
+link:config-prereqs.txt[config-prereqs.txt] and
+link:ci-farm-lxc-setup.txt[ci-farm-lxc-setup.txt] documents.
 
 Travis CI
 ^^^^^^^^^

--- a/docs/documentation.txt
+++ b/docs/documentation.txt
@@ -59,7 +59,8 @@ ifndef::website[]
 endif::website[]
 script from the main NUT codebase, and reported on the NUT mailing list or
 via link:https://github.com/networkupstools/nut/issues[NUT issues on GitHub]
-or as a pull request against link:https://github.com/networkupstools/nut-ddl
+or as a pull request against the
+link:https://github.com/networkupstools/nut-ddl[NUT Devices Dumps Library]
 following the naming and other rules described in the DDL documentation page.
 
 Offsite Links

--- a/docs/man/dummy-ups.txt
+++ b/docs/man/dummy-ups.txt
@@ -65,11 +65,13 @@ only to modify values of these variables), and has the same format as an
 linkman:upsc[8] dump (`<varname>: <value>`). So you can easily create
 definition files from an existing UPS using `upsc > file.dev`.
 
-Note that the Network UPS project provides a DDL (Devices Dumps Library) at
-link:https://networkupstools.org/ddl/index.html with files which can be used
-for modelling real devices. Entries for the DDL library are prepared with the
-`./tools/nut-ddl-dump.sh` script from NUT sources instead of plain `upsc` to
-provide some other data points from other NUT clients as well.
+Note that the Network UPS project provides a
+link:https://networkupstools.org/ddl/index.html[DDL (Devices Dumps Library)]
+with files which can be used for modelling real devices.
+Entries for the DDL library are best prepared with the
+link:https://github.com/networkupstools/nut/blob/master/tools/nut-ddl-dump.sh[`nut-ddl-dump.sh`]
+script from NUT sources instead of plain `upsc`, to provide some additional
+data points from other NUT clients as well.
 
 The file can also be empty, in which case only a basic set of data is
 available: `device.*`, `driver.*`, `ups.mfr`, `ups.model`, `ups.status`

--- a/docs/nut-names.txt
+++ b/docs/nut-names.txt
@@ -57,8 +57,10 @@ negative offsets):
 * by appending the complete "hours:minutes" positive or negative time
   offsets from UTC (e.g. "YYYY-MM-DDThh:mm+03:00").
 
-For more details see examples at link:https://en.wikipedia.org/wiki/ISO_8601
-and the publicly available RFC at link:http://tools.ietf.org/html/rfc3339
+For more details see examples at
+link:https://en.wikipedia.org/wiki/ISO_8601[Wikipedia page on ISO 8601]
+and the publicly available RFC at
+link:http://tools.ietf.org/html/rfc3339[RFC 3339].
 
 Other representations from those specifications are not necessarily supported.
 


### PR DESCRIPTION
Offenders found with `grep`:
````
$ git grep -E  'link:[^ \[]*( |$)' | egrep -v '\.(svg|ac)'
docs/developers.txt:link:config-prereqs.txt and link:ci-farm-lxc-setup.txt documents.
docs/documentation.txt:or as a pull request against link:https://github.com/networkupstools/nut-ddl
docs/man/dummy-ups.txt:link:https://networkupstools.org/ddl/index.html with files which can be used
docs/nut-names.txt:For more details see examples at link:https://en.wikipedia.org/wiki/ISO_8601
docs/nut-names.txt:and the publicly available RFC at link:http://tools.ietf.org/html/rfc3339
````