### PR TITLE
Fix nut-scanner subnet/mask handling

### DIFF
--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -300,6 +300,7 @@ int main(int argc, char *argv[])
 				break;
 			case 'm':
 				cidr = strdup(optarg);
+				upsdebugx(5, "Got CIDR net/mask: %s", cidr);
 				break;
 			case 'D':
 				/* nothing to do, here */
@@ -475,7 +476,9 @@ display_help:
 	}
 
 	if (cidr) {
+		upsdebugx(1, "Processing CIDR net/mask: %s", cidr);
 		nutscan_cidr_to_ip(cidr, &start_ip, &end_ip);
+		upsdebugx(1, "Extracted IP address range from CIDR net/mask: %s => %s", start_ip, end_ip);
 	}
 
 	if (!allow_usb && !allow_snmp && !allow_xml && !allow_oldnut &&

--- a/tools/nut-scanner/nutscan-ip.c
+++ b/tools/nut-scanner/nutscan-ip.c
@@ -288,6 +288,16 @@ int nutscan_cidr_to_ip(const char * cidr, char ** start_ip, char ** stop_ip)
 	upsdebugx(5, "%s: parsed mask value %d",
 		__func__, mask_val);
 
+	/* NOTE: Sanity-wise, some larger number also makes sense
+	 * as the maximum subnet size we would scan. But at least,
+	 * this helps avoid scanning the whole Internet just due
+	 * to string-parsing errors.
+	 */
+	if (mask_val < 1) {
+		fatalx(EXIT_FAILURE, "Bad netmask: %s", mask);
+	}
+
+	/* Note: this freeing invalidates "mask" and "saveptr" pointer targets */
 	free(cidr_tok);
 
 	/* Detecting IPv4 vs IPv6 */

--- a/tools/nut-scanner/nutscan-ip.c
+++ b/tools/nut-scanner/nutscan-ip.c
@@ -269,15 +269,23 @@ int nutscan_cidr_to_ip(const char * cidr, char ** start_ip, char ** stop_ip)
 	first_ip = strdup(strtok_r(cidr_tok, "/", &saveptr));
 	free(cidr_tok);
 	if (first_ip == NULL) {
+		upsdebugx(0, "WARNING: %s failed to parse first_ip from cidr=%s",
+			__func__, cidr);
 		return 0;
 	}
 	mask = strtok_r(NULL, "/", &saveptr);
 	if (mask == NULL) {
+		upsdebugx(0, "WARNING: %s failed to parse mask from cidr=%s (first_ip=%s)",
+			__func__, cidr, first_ip);
 		free (first_ip);
 		return 0;
 	}
+	upsdebugx(0, "%s: parsed cidr=%s into first_ip=%s and mask=%s",
+		__func__, cidr, first_ip, mask);
 
 	mask_val = atoi(mask);
+	upsdebugx(0, "%s: parsed mask value %d",
+		__func__, mask_val);
 
 	/* Detecting IPv4 vs IPv6 */
 	memset(&hints, 0, sizeof(struct addrinfo));

--- a/tools/nut-scanner/nutscan-ip.c
+++ b/tools/nut-scanner/nutscan-ip.c
@@ -267,10 +267,10 @@ int nutscan_cidr_to_ip(const char * cidr, char ** start_ip, char ** stop_ip)
 
 	cidr_tok = strdup(cidr);
 	first_ip = strdup(strtok_r(cidr_tok, "/", &saveptr));
-	free(cidr_tok);
 	if (first_ip == NULL) {
 		upsdebugx(0, "WARNING: %s failed to parse first_ip from cidr=%s",
 			__func__, cidr);
+		free(cidr_tok);
 		return 0;
 	}
 	mask = strtok_r(NULL, "/", &saveptr);
@@ -278,6 +278,7 @@ int nutscan_cidr_to_ip(const char * cidr, char ** start_ip, char ** stop_ip)
 		upsdebugx(0, "WARNING: %s failed to parse mask from cidr=%s (first_ip=%s)",
 			__func__, cidr, first_ip);
 		free (first_ip);
+		free(cidr_tok);
 		return 0;
 	}
 	upsdebugx(0, "%s: parsed cidr=%s into first_ip=%s and mask=%s",
@@ -286,6 +287,8 @@ int nutscan_cidr_to_ip(const char * cidr, char ** start_ip, char ** stop_ip)
 	mask_val = atoi(mask);
 	upsdebugx(0, "%s: parsed mask value %d",
 		__func__, mask_val);
+
+	free(cidr_tok);
 
 	/* Detecting IPv4 vs IPv6 */
 	memset(&hints, 0, sizeof(struct addrinfo));

--- a/tools/nut-scanner/nutscan-ip.c
+++ b/tools/nut-scanner/nutscan-ip.c
@@ -281,11 +281,11 @@ int nutscan_cidr_to_ip(const char * cidr, char ** start_ip, char ** stop_ip)
 		free(cidr_tok);
 		return 0;
 	}
-	upsdebugx(0, "%s: parsed cidr=%s into first_ip=%s and mask=%s",
+	upsdebugx(5, "%s: parsed cidr=%s into first_ip=%s and mask=%s",
 		__func__, cidr, first_ip, mask);
 
 	mask_val = atoi(mask);
-	upsdebugx(0, "%s: parsed mask value %d",
+	upsdebugx(5, "%s: parsed mask value %d",
 		__func__, mask_val);
 
 	free(cidr_tok);


### PR DESCRIPTION
Seems that builds in recent OSes exposed that we manipulated free'd memory to parse CIDR string (indirectly - by saved pointers to sub-string contents behind `cidr_tok`, such as `mask` and `saveptr`), and this no longer "happens to work".

Freeing of `cidr_tok` should happen as late as it is appropriate.