### PR TITLE
Limit nut-scanner thread count

### DIFF
--- a/clients/Makefile.am
+++ b/clients/Makefile.am
@@ -10,7 +10,7 @@ AM_CXXFLAGS = -DHAVE_NUTCOMMON=1 -I$(top_srcdir)/include
 $(top_builddir)/common/libcommon.la \
 $(top_builddir)/common/libcommonclient.la \
 $(top_builddir)/common/libparseconf.la:
-	@cd $(@D) && $(MAKE) -s $(@F)
+	@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
 # by default, link programs in this directory with libcommon.a
 LDADD = $(top_builddir)/common/libcommon.la libupsclient.la $(NETLIBS)

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -12,7 +12,7 @@ libparseconf_la_SOURCES = parseconf.c
 common.c: $(top_builddir)/include/nut_version.h
 
 $(top_builddir)/include/nut_version.h:
-	@cd $(@D) && $(MAKE) -s $(@F)
+	@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
 libcommon_la_SOURCES = common.c state.c str.c upsconf.c
 libcommonclient_la_SOURCES = common.c state.c str.c

--- a/configure.ac
+++ b/configure.ac
@@ -307,8 +307,14 @@ AC_CHECK_HEADERS(sys/modem.h stdarg.h varargs.h, [], [], [AC_INCLUDES_DEFAULT])
 
 
 dnl pthread related checks
+dnl Note: pthread_tryjoin_np() should be available since glibc 2.3.3, according
+dnl to https://man7.org/linux/man-pages/man3/pthread_tryjoin_np.3.html
 AC_SEARCH_LIBS([pthread_create], [pthread],
-       [AC_DEFINE(HAVE_PTHREAD, 1, [Define to enable pthread support code])],
+       [AC_DEFINE(HAVE_PTHREAD, 1, [Define to enable pthread support code])
+        AC_SEARCH_LIBS([pthread_tryjoin_np], [pthread],
+               [AC_DEFINE(HAVE_PTHREAD_TRYJOIN, 1, [Define to enable pthread_tryjoin support code])],
+               [])
+       ],
        [])
 
 dnl ----------------------------------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -174,6 +174,25 @@ AC_CHECK_HEADER([limits.h],
     [AC_DEFINE([HAVE_LIMITS_H], [1],
         [Define to 1 if you have <limits.h>.])])
 
+AC_CHECK_HEADER([sys/resource.h],
+    [AC_MSG_CHECKING([for struct rlimit and getrlimit()])
+     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+#include <sys/resource.h>
+],
+[struct rlimit limit;
+getrlimit(RLIMIT_NOFILE, &limit);
+/* Do not care about actual return value in this test,
+ * normally check for non-zero meaning to look in errno */
+]
+    )],
+        [AC_DEFINE([HAVE_SYS_RESOURCE_H], [1],
+            [Define to 1 if you have <sys/resource.h> with usable struct rlimit and getrlimit().])
+         AC_MSG_RESULT([ok])
+        ],
+        [AC_MSG_RESULT([no])]
+    )]
+)
+
 AC_CHECK_FUNCS(cfsetispeed tcsendbreak)
 AC_CHECK_FUNCS(seteuid setsid getpassphrase)
 AC_CHECK_FUNCS(on_exit strptime setlogmask)

--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -4,7 +4,7 @@
 $(top_builddir)/common/libcommon.la \
 $(top_builddir)/common/libparseconf.la \
 $(top_builddir)/clients/libupsclient.la:
-	@cd $(@D) && $(MAKE) -s $(@F)
+	@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
 # by default, link programs in this directory with libcommon.la
 # (libtool version of the static lib, in order to access LTLIBOBJS)

--- a/server/Makefile.am
+++ b/server/Makefile.am
@@ -3,7 +3,7 @@
 # Make sure out-of-dir dependencies exist (especially when dev-building parts):
 $(top_builddir)/common/libcommon.la \
 $(top_builddir)/common/libparseconf.la:
-	@cd $(@D) && $(MAKE) -s $(@F)
+	@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
 # Avoid per-target CFLAGS, because this will prevent re-use of object
 # files. In any case, CFLAGS are only -I options, so there is no harm,

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -19,7 +19,7 @@ getvaluetest_LDADD = $(top_builddir)/common/libcommon.la
 
 # Make sure out-of-dir dependencies exist (especially when dev-building parts):
 $(top_builddir)/common/libcommon.la:
-	@cd $(@D) && $(MAKE) -s $(@F)
+	@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
 ### Optional tests which can not be built everywhere
 # List of src files for CppUnit tests
@@ -50,7 +50,7 @@ cppunittest_SOURCES = $(CPPUNITTESTSRC) $(CPPUNITTESTERSRC)
 # Make sure out-of-dir C++ dependencies exist (especially when dev-building
 # only some parts of NUT):
 $(top_builddir)/clients/libnutclient.la $(top_builddir)/clients/libnutclientstub.la:
-	@cd $(@D) && $(MAKE) -s $(@F)
+	@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
 else !HAVE_CPPUNIT
 # Just redistribute test source into tarball

--- a/tools/nut-scanner/Makefile.am
+++ b/tools/nut-scanner/Makefile.am
@@ -15,7 +15,7 @@ $(NUT_SCANNER_DEPS):
 
 # Make sure out-of-dir dependencies exist (especially when dev-building parts):
 $(top_builddir)/common/libcommon.la:
-	@cd $(@D) && $(MAKE) -s $(@F)
+	@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
 # do not hard depend on '../include/nut_version.h', since it blocks
 # 'dist', and is only required for actual build, in which case
@@ -24,7 +24,7 @@ $(top_builddir)/common/libcommon.la:
 $(top_srcdir)/common/common.c nut-scanner.c: $(top_builddir)/include/nut_version.h
 
 $(top_builddir)/include/nut_version.h:
-	@cd $(@D) && $(MAKE) -s $(@F)
+	@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
 # Only build nut-scanner, and its library, if libltdl was found (required!)
 if WITH_LIBLTDL

--- a/tools/nut-scanner/Makefile.am
+++ b/tools/nut-scanner/Makefile.am
@@ -11,7 +11,7 @@ BUILT_SOURCES = $(NUT_SCANNER_DEPS)
 # Make sure we have the freshest files (no-op if built earlier and then
 # no driver sources and other dependencies were edited by a developer)
 $(NUT_SCANNER_DEPS):
-	cd ..; $(MAKE) $(AM_MAKEFLAGS) nut-scanner-deps
+	@cd .. && $(MAKE) $(AM_MAKEFLAGS) nut-scanner-deps
 
 # Make sure out-of-dir dependencies exist (especially when dev-building parts):
 $(top_builddir)/common/libcommon.la:

--- a/tools/nut-scanner/nut-scan.h
+++ b/tools/nut-scanner/nut-scan.h
@@ -30,12 +30,27 @@
 #ifndef NUT_SCAN_H
 #define NUT_SCAN_H
 
+#include "config.h"
+#include <sys/types.h>
+
 #include <nutscan-init.h>
 #include <nutscan-device.h>
 #include <nutscan-ip.h>
 
 #ifdef WITH_IPMI
 #include <freeipmi/freeipmi.h>
+#endif
+
+#ifdef HAVE_PTHREAD
+# include <pthread.h>
+# ifdef HAVE_PTHREAD_TRYJOIN
+extern size_t max_threads, curr_threads;
+extern pthread_mutex_t threadcount_mutex;
+# endif
+typedef struct nutscan_thread {
+	pthread_t	thread;
+	int		active;	/* true if the thread was created, false if joined (to not join twice) */
+} nutscan_thread_t;
 #endif
 
 #ifdef __cplusplus

--- a/tools/nut-scanner/nut-scan.h
+++ b/tools/nut-scanner/nut-scan.h
@@ -45,7 +45,7 @@
 #ifdef HAVE_PTHREAD
 # include <pthread.h>
 # ifdef HAVE_PTHREAD_TRYJOIN
-extern size_t max_threads, curr_threads;
+extern size_t max_threads, curr_threads, max_threads_netxml, max_threads_oldnut, max_threads_netsnmp;
 extern pthread_mutex_t threadcount_mutex;
 # endif
 typedef struct nutscan_thread {

--- a/tools/nut-scanner/nut-scan.h
+++ b/tools/nut-scanner/nut-scan.h
@@ -3,6 +3,7 @@
  *    2011 - EATON
  *    2012 - Arnaud Quette <arnaud.quette@free.fr>
  *    2016 - EATON - IP addressed XML scan
+ *    2016-2021 - EATON - Various threads-related improvements
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -52,6 +52,15 @@ pthread_mutex_t threadcount_mutex;
 size_t max_threads = 1024;
 size_t curr_threads = 0;
 
+size_t max_threads_netxml = 1021; /* experimental finding, see PR#1158 */
+size_t max_threads_oldnut = 1021;
+size_t max_threads_netsnmp = 0; // 10240;
+	/* per reports in PR#1158, some versions of net-snmp could be limited
+	 * to 1024 threads in the past; this was not found in practice.
+	 * Still, some practical limit can be useful (configurable?)
+	 * Here 0 means to not apply any special limit (beside max_threads).
+	 */
+
 #  ifdef HAVE_SYS_RESOURCE_H
 #   include <sys/resource.h> /* for getrlimit() and struct rlimit */
 #   include <errno.h>

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -35,6 +35,7 @@
 #ifdef HAVE_PTHREAD
 #include <pthread.h>
 #include "nut_stdint.h"
+pthread_mutex_t threadcount_mutex;
 size_t max_threads = 64;
 size_t curr_threads = 0;
 #endif
@@ -501,6 +502,10 @@ display_help:
 		}
 	}
 
+#ifdef HAVE_PTHREAD
+	pthread_mutex_init(&threadcount_mutex, NULL);
+#endif
+
 	if (cidr) {
 		upsdebugx(1, "Processing CIDR net/mask: %s", cidr);
 		nutscan_cidr_to_ip(cidr, &start_ip, &end_ip);
@@ -718,6 +723,10 @@ display_help:
 	display_func(dev[TYPE_EATON_SERIAL]);
 	upsdebugx(1, "SCANS DONE: free resources: SERIAL");
 	nutscan_free_device(dev[TYPE_EATON_SERIAL]);
+
+#ifdef HAVE_PTHREAD
+	pthread_mutex_destroy(&threadcount_mutex);
+#endif
 
 	upsdebugx(1, "SCANS DONE: free common scanner resources");
 	nutscan_free();

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -638,7 +638,7 @@ display_help:
 		upsdebugx(1, "NUT bus (avahi) SCAN: not requested, SKIPPED");
 	}
 
-	if (allow_ipmi  && nutscan_avail_ipmi) {
+	if (allow_ipmi && nutscan_avail_ipmi) {
 		upsdebugx(quiet, "Scanning IPMI bus.");
 #ifdef HAVE_PTHREAD
 		upsdebugx(1, "IPMI SCAN: starting pthread_create with run_ipmi...");

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -300,8 +300,12 @@ int main(int argc, char *argv[])
 		nofile_limit.rlim_cur = 0;
 		nofile_limit.rlim_max = 0;
 	} else {
-		if (max_threads > nofile_limit.rlim_cur) {
-			max_threads = nofile_limit.rlim_cur;
+		if (nofile_limit.rlim_cur > 0
+		&&  nofile_limit.rlim_cur > RESERVE_FD_COUNT
+		&&  (uintmax_t)max_threads > (uintmax_t)(nofile_limit.rlim_cur - RESERVE_FD_COUNT)
+		&&  (uintmax_t)(nofile_limit.rlim_cur) < (uintmax_t)SIZE_MAX
+		) {
+			max_threads = (size_t)nofile_limit.rlim_cur;
 			if (max_threads > (RESERVE_FD_COUNT + 1)) {
 				max_threads -= RESERVE_FD_COUNT;
 			}
@@ -476,8 +480,9 @@ int main(int argc, char *argv[])
 				if (val > 0 && (uintmax_t)val < (uintmax_t)SIZE_MAX) {
 # ifdef HAVE_SYS_RESOURCE_H
 					if (nofile_limit.rlim_cur > 0
+					&&  nofile_limit.rlim_cur > RESERVE_FD_COUNT
 					&& (uintmax_t)nofile_limit.rlim_cur < (uintmax_t)SIZE_MAX
-					&&  val > nofile_limit.rlim_cur
+					&& (uintmax_t)val > (uintmax_t)(nofile_limit.rlim_cur - RESERVE_FD_COUNT)
 					) {
 						upsdebugx(1, "Detected soft limit for "
 							"file descriptor count is %ju",

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -32,12 +32,15 @@
 #include "nut_version.h"
 #include <unistd.h>
 #include <string.h>
+
 #ifdef HAVE_PTHREAD
-#include <pthread.h>
-#include "nut_stdint.h"
+# include <pthread.h>
+# ifdef HAVE_PTHREAD_TRYJOIN
+#  include "nut_stdint.h"
 pthread_mutex_t threadcount_mutex;
 size_t max_threads = 64;
 size_t curr_threads = 0;
+# endif
 #endif
 
 #include "nut-scan.h"
@@ -222,7 +225,7 @@ static void show_usage()
 	printf("  -q, --quiet: Display only scan result. No information on currently scanned bus is displayed.\n");
 	printf("  -D, --nut_debug_level: Raise the debugging level.  Use this multiple times to see more details.\n");
 
-#ifdef HAVE_PTHREAD
+#if (defined HAVE_PTHREAD) && (defined HAVE_PTHREAD_TRYJOIN)
 	printf("  -j, --jobs: Limit the amount of scanning threads running simultaneously (default: %zu).\n", max_threads);
 #else
 	printf("  -j, --jobs: Limit the amount of scanning threads running simultaneously (not implemented in this build: no pthread support)");
@@ -411,7 +414,7 @@ int main(int argc, char *argv[])
 				break;
 			case 'j': {
 				int val = atoi(optarg);
-#ifdef HAVE_PTHREAD
+#if (defined HAVE_PTHREAD) && (defined HAVE_PTHREAD_TRYJOIN)
 				if (val > 0 && (uintmax_t)val < (uintmax_t)SIZE_MAX) {
 					max_threads = (size_t)val;
 				} else {
@@ -502,7 +505,7 @@ display_help:
 		}
 	}
 
-#ifdef HAVE_PTHREAD
+#if (defined HAVE_PTHREAD) && (defined HAVE_PTHREAD_TRYJOIN)
 	pthread_mutex_init(&threadcount_mutex, NULL);
 #endif
 
@@ -724,7 +727,7 @@ display_help:
 	upsdebugx(1, "SCANS DONE: free resources: SERIAL");
 	nutscan_free_device(dev[TYPE_EATON_SERIAL]);
 
-#ifdef HAVE_PTHREAD
+#if (defined HAVE_PTHREAD) && (defined HAVE_PTHREAD_TRYJOIN)
 	pthread_mutex_destroy(&threadcount_mutex);
 #endif
 

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -430,7 +430,8 @@ int main(int argc, char *argv[])
 					max_threads = (size_t)val;
 				} else {
 					fprintf(stderr,
-						"WARNING: Max jobs count %s (%d) is out of range, using default %zu\n",
+						"WARNING: Max jobs count %s (%d) is out of range, "
+						"using default %zu\n",
 						optarg, val, max_threads);
 				}
 #else

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -38,7 +38,18 @@
 # ifdef HAVE_PTHREAD_TRYJOIN
 #  include "nut_stdint.h"
 pthread_mutex_t threadcount_mutex;
-size_t max_threads = 64;
+/* We have 3 networked scan types: nut, snmp, xml,
+ * and users typically give their /24 subnet as "-m" arg.
+ * With some systems having a 1024 default (u)limit to
+ * file descriptors, this should fit if those are involved.
+ * On some systems tested, a large amount of not-joined
+ * pthreads did cause various crashes; also RAM is limited.
+ * Note that each scan may be time consuming to query an
+ * IP address and wait for (no) reply, so while these threads
+ * are usually not resource-intensive (nor computationally),
+ * they spend much wallclock time each so parallelism helps.
+ */
+size_t max_threads = 1024;
 size_t curr_threads = 0;
 # endif
 #endif

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -476,8 +476,15 @@ int main(int argc, char *argv[])
 				break;
 			case 'T': {
 #if (defined HAVE_PTHREAD) && (defined HAVE_PTHREAD_TRYJOIN)
-				int val = atoi(optarg);
-				if (val > 0 && (uintmax_t)val < (uintmax_t)SIZE_MAX) {
+				char* endptr;
+				long val = strtol(optarg, &endptr, 10);
+				/* With endptr we check that no chars were left in optarg
+				 * (that is, pointed-to char -- if reported -- is '\0')
+				 */
+				if ((!endptr || !*endptr)
+				&& val > 0
+				&& (uintmax_t)val < (uintmax_t)SIZE_MAX
+				) {
 # ifdef HAVE_SYS_RESOURCE_H
 					if (nofile_limit.rlim_cur > 0
 					&&  nofile_limit.rlim_cur > RESERVE_FD_COUNT
@@ -497,22 +504,26 @@ int main(int argc, char *argv[])
 						}
 
 						fprintf(stderr,
-							"WARNING: Requested max jobs count %s (%d) "
-							"exceeds current file descriptor count limit "
-							"(minus reservation), constraining to %zu\n",
+							"WARNING: Requested max scanning "
+							"thread count %s (%ld) exceeds the "
+							"current file descriptor count limit "
+							"(minus reservation), constraining "
+							"to %zu\n",
 							optarg, val, max_threads);
 					} else
 # endif /* HAVE_SYS_RESOURCE_H */
 						max_threads = (size_t)val;
 				} else {
 					fprintf(stderr,
-						"WARNING: Max jobs count %s (%d) is out of range, "
+						"WARNING: Requested max scanning "
+						"thread count %s (%ld) is out of range, "
 						"using default %zu\n",
 						optarg, val, max_threads);
 				}
 #else
 				fprintf(stderr,
-					"WARNING: Max jobs count option is not supported in this build, ignored\n");
+					"WARNING: Max scanning thread count option "
+					"is not supported in this build, ignored\n");
 #endif
 				}
 				break;

--- a/tools/nut-scanner/scan_eaton_serial.c
+++ b/tools/nut-scanner/scan_eaton_serial.c
@@ -1,5 +1,6 @@
 /*
  *  Copyright (C) 2012 - EATON
+ *  Copyright (C) 2016-2021 - EATON - Various threads-related improvements
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -19,9 +20,11 @@
 /*! \file scan_eaton_serial.c
     \brief detect Eaton serial XCP, SHUT and Q1 devices
     \author Arnaud Quette <ArnaudQuette@eaton.com>
+    \author Jim Klimov <EvgenyKlimov@eaton.com>
 */
 
 #include "common.h"
+#include "nut-scan.h"
 
 /* Need this on AIX when using xlc to get alloca */
 #ifdef _AIX
@@ -41,16 +44,11 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include "nut-scan.h"
 #include "serial.h"
 #include "bcmxcp_io.h"
 #include "bcmxcp_ser.h"
 #include "bcmxcp.h"
 #include "nutscan-serial.h"
-
-#ifdef HAVE_PTHREAD
-#include <pthread.h>
-#endif
 
 /* SHUT header */
 #define SHUT_SYNC 0x16
@@ -401,11 +399,11 @@ nutscan_device_t * nutscan_scan_eaton_serial(const char* ports_range)
 	int i;
 #ifdef HAVE_PTHREAD
 	pthread_t thread;
-	pthread_t * thread_array = NULL;
+	nutscan_thread_t * thread_array = NULL;
 	int thread_count = 0;
 
 	pthread_mutex_init(&dev_mutex, NULL);
-#endif
+#endif // HAVE_PTHREAD
 
 	/* 1) Get ports_list */
 	serial_ports_list = nutscan_get_serial_ports_list(ports_range);
@@ -432,33 +430,133 @@ nutscan_device_t * nutscan_scan_eaton_serial(const char* ports_range)
 	current_port_nb = 0;
 	while (serial_ports_list[current_port_nb] != NULL) {
 		current_port_name = serial_ports_list[current_port_nb];
+
 #ifdef HAVE_PTHREAD
+# ifdef HAVE_PTHREAD_TRYJOIN
+		/* NOTE: With many enough targets to scan, this can crash
+		 * by spawning too many children; add a limit and loop to
+		 * "reap" some already done with their work. And probably
+		 * account them in thread_array[] as something to not wait
+		 * for below in pthread_join()...
+		 */
+
+		/* TOTHINK: Should there be a threadcount_mutex when
+		 * we just read the value in if() and while() below?
+		 * At worst we would overflow the limit a bit due to
+		 * other protocol scanners...
+		 */
+		if (curr_threads >= max_threads) {
+			upsdebugx(2, "%s: already running %zu scanning threads "
+				"(launched overall: %d), "
+				"waiting until some would finish",
+				__func__, curr_threads, thread_count);
+			while (curr_threads >= max_threads) {
+				for (i = 0; i < thread_count ; i++) {
+					int ret;
+
+					if (!thread_array[i].active) continue;
+
+					pthread_mutex_lock(&threadcount_mutex);
+					upsdebugx(3, "%s: Trying to join thread #%i...", __func__, i);
+					ret = pthread_tryjoin_np(thread_array[i].thread, NULL);
+					switch (ret) {
+						case ESRCH:     // No thread with the ID thread could be found - already "joined"?
+							upsdebugx(5, "%s: Was thread #%i joined earlier?", __func__, i);
+							break;
+						case 0:         // thread exited
+							if (curr_threads > 0) {
+								curr_threads --;
+								upsdebugx(4, "%s: Joined a finished thread #%i", __func__, i);
+							} else {
+								/* threadcount_mutex fault? */
+								upsdebugx(0, "WARNING: %s: Accounting of thread count "
+									"says we are already at 0", __func__);
+							}
+							thread_array[i].active = FALSE;
+							break;
+						case EBUSY:     // actively running
+							upsdebugx(6, "%s: thread #%i still busy (%i)",
+								__func__, i, ret);
+							break;
+						case EDEADLK:   // Errors with thread interactions... bail out?
+						case EINVAL:    // Errors with thread interactions... bail out?
+						default:        // new pthreads abilities?
+							upsdebugx(5, "%s: thread #%i reported code %i",
+								__func__, i, ret);
+							break;
+					}
+					pthread_mutex_unlock(&threadcount_mutex);
+				}
+
+				if (curr_threads >= max_threads) {
+					usleep (10000); // microSec's, so 0.01s here
+				}
+			}
+			upsdebugx(2, "%s: proceeding with scan", __func__);
+		}
+# endif // HAVE_PTHREAD_TRYJOIN
+
 		if (pthread_create(&thread, NULL, nutscan_scan_eaton_serial_device, (void*)current_port_name) == 0) {
+# ifdef HAVE_PTHREAD_TRYJOIN
+			pthread_mutex_lock(&threadcount_mutex);
+			curr_threads++;
+# endif // HAVE_PTHREAD_TRYJOIN
+
 			thread_count++;
-			pthread_t *new_thread_array = realloc(thread_array,
-						thread_count*sizeof(pthread_t));
+			nutscan_thread_t *new_thread_array = realloc(thread_array,
+				thread_count * sizeof(nutscan_thread_t));
 			if (new_thread_array == NULL) {
-				upsdebugx(1, "%s: Failed to realloc thread", __func__);
+				upsdebugx(1, "%s: Failed to realloc thread array", __func__);
 				break;
 			}
 			else {
 				thread_array = new_thread_array;
 			}
-			thread_array[thread_count-1] = thread;
+			thread_array[thread_count - 1].thread = thread;
+			thread_array[thread_count - 1].active = TRUE;
+
+# ifdef HAVE_PTHREAD_TRYJOIN
+			pthread_mutex_unlock(&threadcount_mutex);
+# endif // HAVE_PTHREAD_TRYJOIN
 		}
-#else
+#else // not HAVE_PTHREAD
 		nutscan_scan_eaton_serial_device(current_port_name);
-#endif
+#endif // if HAVE_PTHREAD
 		current_port_nb++;
 	}
 
 #ifdef HAVE_PTHREAD
-	for (i = 0; i < thread_count ; i++) {
-		pthread_join(thread_array[i], NULL);
+	if (thread_array != NULL) {
+		upsdebugx(2, "%s: all planned scans launched, waiting for threads to complete", __func__);
+		for (i = 0; i < thread_count; i++) {
+			int ret;
+
+			if (!thread_array[i].active) continue;
+
+			ret = pthread_join(thread_array[i].thread, NULL);
+			if (ret != 0) {
+				upsdebugx(0, "WARNING: %s: Clean-up: pthread_join() returned code %i",
+					__func__, ret);
+			}
+			thread_array[i].active = FALSE;
+# ifdef HAVE_PTHREAD_TRYJOIN
+			pthread_mutex_lock(&threadcount_mutex);
+			if (curr_threads > 0) {
+				curr_threads --;
+				upsdebugx(5, "%s: Clean-up: Joined a finished thread #%i",
+					__func__, i);
+			} else {
+				upsdebugx(0, "WARNING: %s: Clean-up: Accounting of thread count "
+					"says we are already at 0", __func__);
+			}
+			pthread_mutex_unlock(&threadcount_mutex);
+# endif // HAVE_PTHREAD_TRYJOIN
+		}
+		free(thread_array);
+		upsdebugx(2, "%s: all threads freed", __func__);
 	}
 	pthread_mutex_destroy(&dev_mutex);
-	free(thread_array);
-#endif
+#endif // HAVE_PTHREAD
 
 	if (change_action_handler) {
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_STRICT_PROTOTYPES)

--- a/tools/nut-scanner/scan_nut.c
+++ b/tools/nut-scanner/scan_nut.c
@@ -1,5 +1,6 @@
 /*
  *  Copyright (C) 2011 - EATON
+ *  Copyright (C) 2016-2021 - EATON - Various threads-related improvements
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -19,14 +20,12 @@
 /*! \file scan_nut.c
     \brief detect remote NUT services
     \author Frederic Bohe <fredericbohe@eaton.com>
+    \author Jim Klimov <EvgenyKlimov@eaton.com>
 */
 
 #include "common.h"
 #include "upsclient.h"
 #include "nut-scan.h"
-#ifdef HAVE_PTHREAD
-#include <pthread.h>
-#endif
 #include <ltdl.h>
 
 /* dynamic link library stuff */
@@ -45,6 +44,13 @@ static int (*nut_upscli_disconnect)(UPSCONN_t *ups);
 static nutscan_device_t * dev_ret = NULL;
 #ifdef HAVE_PTHREAD
 static pthread_mutex_t dev_mutex;
+#endif
+
+/* use explicit booleans */
+#ifndef FALSE
+typedef enum ebool { FALSE = 0, TRUE } bool_t;
+#else
+typedef int bool_t;
 #endif
 
 struct scan_nut_arg {
@@ -218,11 +224,11 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 	struct scan_nut_arg *nut_arg;
 #ifdef HAVE_PTHREAD
 	pthread_t thread;
-	pthread_t * thread_array = NULL;
+	nutscan_thread_t * thread_array = NULL;
 	int thread_count = 0;
 
 	pthread_mutex_init(&dev_mutex, NULL);
-#endif
+#endif // HAVE_PTHREAD
 
 	if (!nutscan_avail_nut) {
 		return NULL;
@@ -269,33 +275,132 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 		nut_arg->timeout = usec_timeout;
 		nut_arg->hostname = ip_dest;
 #ifdef HAVE_PTHREAD
+# ifdef HAVE_PTHREAD_TRYJOIN
+		/* NOTE: With many enough targets to scan, this can crash
+		 * by spawning too many children; add a limit and loop to
+		 * "reap" some already done with their work. And probably
+		 * account them in thread_array[] as something to not wait
+		 * for below in pthread_join()...
+		 */
+
+		/* TOTHINK: Should there be a threadcount_mutex when
+		 * we just read the value in if() and while() below?
+		 * At worst we would overflow the limit a bit due to
+		 * other protocol scanners...
+		 */
+		if (curr_threads >= max_threads) {
+			upsdebugx(2, "%s: already running %zu scanning threads "
+				"(launched overall: %d), "
+				"waiting until some would finish",
+				__func__, curr_threads, thread_count);
+			while (curr_threads >= max_threads) {
+				for (i = 0; i < thread_count ; i++) {
+					int ret;
+
+					if (!thread_array[i].active) continue;
+
+					pthread_mutex_lock(&threadcount_mutex);
+					upsdebugx(3, "%s: Trying to join thread #%i...", __func__, i);
+					ret = pthread_tryjoin_np(thread_array[i].thread, NULL);
+					switch (ret) {
+						case ESRCH:     // No thread with the ID thread could be found - already "joined"?
+							upsdebugx(5, "%s: Was thread #%i joined earlier?", __func__, i);
+							break;
+						case 0:         // thread exited
+							if (curr_threads > 0) {
+								curr_threads --;
+								upsdebugx(4, "%s: Joined a finished thread #%i", __func__, i);
+							} else {
+								/* threadcount_mutex fault? */
+								upsdebugx(0, "WARNING: %s: Accounting of thread count "
+									"says we are already at 0", __func__);
+							}
+							thread_array[i].active = FALSE;
+							break;
+						case EBUSY:     // actively running
+							upsdebugx(6, "%s: thread #%i still busy (%i)",
+								__func__, i, ret);
+							break;
+						case EDEADLK:   // Errors with thread interactions... bail out?
+						case EINVAL:    // Errors with thread interactions... bail out?
+						default:        // new pthreads abilities?
+							upsdebugx(5, "%s: thread #%i reported code %i",
+								__func__, i, ret);
+							break;
+					}
+					pthread_mutex_unlock(&threadcount_mutex);
+				}
+
+				if (curr_threads >= max_threads) {
+					usleep (10000); // microSec's, so 0.01s here
+				}
+			}
+			upsdebugx(2, "%s: proceeding with scan", __func__);
+		}
+# endif // HAVE_PTHREAD_TRYJOIN
+
 		if (pthread_create(&thread, NULL, list_nut_devices, (void*)nut_arg) == 0) {
+# ifdef HAVE_PTHREAD_TRYJOIN
+			pthread_mutex_lock(&threadcount_mutex);
+			curr_threads++;
+# endif // HAVE_PTHREAD_TRYJOIN
+
 			thread_count++;
-			pthread_t *new_thread_array = realloc(thread_array,
-						thread_count * sizeof(pthread_t));
+			nutscan_thread_t *new_thread_array = realloc(thread_array,
+				thread_count * sizeof(nutscan_thread_t));
 			if (new_thread_array == NULL) {
-				upsdebugx(1, "%s: Failed to realloc thread", __func__);
+				upsdebugx(1, "%s: Failed to realloc thread array", __func__);
 				break;
 			}
 			else {
 				thread_array = new_thread_array;
 			}
-			thread_array[thread_count-1] = thread;
+			thread_array[thread_count - 1].thread = thread;
+			thread_array[thread_count - 1].active = TRUE;
+
+# ifdef HAVE_PTHREAD_TRYJOIN
+			pthread_mutex_unlock(&threadcount_mutex);
+# endif // HAVE_PTHREAD_TRYJOIN
 		}
-#else
+#else // not HAVE_PTHREAD
 		list_nut_devices(nut_arg);
-#endif
+#endif // if HAVE_PTHREAD
 		free(ip_str);
 		ip_str = nutscan_ip_iter_inc(&ip);
 	}
 
 #ifdef HAVE_PTHREAD
-	for (i = 0; i < thread_count ; i++) {
-		pthread_join(thread_array[i], NULL);
+	if (thread_array != NULL) {
+		upsdebugx(2, "%s: all planned scans launched, waiting for threads to complete", __func__);
+	for (i = 0; i < thread_count; i++) {
+			int ret;
+
+			if (!thread_array[i].active) continue;
+
+			ret = pthread_join(thread_array[i].thread, NULL);
+			if (ret != 0) {
+				upsdebugx(0, "WARNING: %s: Clean-up: pthread_join() returned code %i",
+					__func__, ret);
+			}
+			thread_array[i].active = FALSE;
+# ifdef HAVE_PTHREAD_TRYJOIN
+			pthread_mutex_lock(&threadcount_mutex);
+			if (curr_threads > 0) {
+				curr_threads --;
+				upsdebugx(5, "%s: Clean-up: Joined a finished thread #%i",
+					__func__, i);
+			} else {
+				upsdebugx(0, "WARNING: %s: Clean-up: Accounting of thread count "
+					"says we are already at 0", __func__);
+			}
+			pthread_mutex_unlock(&threadcount_mutex);
+# endif // HAVE_PTHREAD_TRYJOIN
+		}
+		free(thread_array);
+		upsdebugx(2, "%s: all threads freed", __func__);
 	}
 	pthread_mutex_destroy(&dev_mutex);
-	free(thread_array);
-#endif
+#endif // HAVE_PTHREAD
 
 	if (change_action_handler) {
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_STRICT_PROTOTYPES)

--- a/tools/nut-scanner/scan_nut.c
+++ b/tools/nut-scanner/scan_nut.c
@@ -288,12 +288,16 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 		 * At worst we would overflow the limit a bit due to
 		 * other protocol scanners...
 		 */
-		if (curr_threads >= max_threads) {
+		if (curr_threads >= max_threads
+		||  curr_threads >= max_threads_oldnut
+		) {
 			upsdebugx(2, "%s: already running %zu scanning threads "
 				"(launched overall: %d), "
 				"waiting until some would finish",
 				__func__, curr_threads, thread_count);
-			while (curr_threads >= max_threads) {
+			while (curr_threads >= max_threads
+			    || curr_threads >= max_threads_oldnut
+			) {
 				for (i = 0; i < thread_count ; i++) {
 					int ret;
 
@@ -331,7 +335,9 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 					pthread_mutex_unlock(&threadcount_mutex);
 				}
 
-				if (curr_threads >= max_threads) {
+				if (curr_threads >= max_threads
+				|| curr_threads >= max_threads_oldnut
+				) {
 					usleep (10000); // microSec's, so 0.01s here
 				}
 			}

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -722,7 +722,7 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 	int thread_count = 0;
 
 	pthread_mutex_init(&dev_mutex, NULL);
-#endif
+#endif // HAVE_PTHREAD
 
 	if (!nutscan_avail_snmp) {
 		return NULL;
@@ -834,9 +834,9 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 			pthread_mutex_unlock(&threadcount_mutex);
 # endif // HAVE_PTHREAD_TRYJOIN
 		}
-#else
+#else // not HAVE_PTHREAD
 		try_SysOID((void *)tmp_sec);
-#endif
+#endif // if HAVE_PTHREAD
 		ip_str = nutscan_ip_iter_inc(&ip);
 	}
 
@@ -871,7 +871,7 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 		upsdebugx(2, "%s: all threads freed", __func__);
 	}
 	pthread_mutex_destroy(&dev_mutex);
-#endif
+#endif // HAVE_PTHREAD
 	nutscan_device_t * result = nutscan_rewind_device(dev_ret);
 	dev_ret = NULL;
 	return result;

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -748,6 +748,12 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 		tmp_sec->peername = ip_str;
 
 #ifdef HAVE_PTHREAD
+		/* FIXME: With many enough targets to scan, this can crash
+		 * by spawning too many children; add a limit and loop to
+		 * "reap" some already done with their work. And probably
+		 * account them in thread_array[] as something to not wait
+		 * for below in pthread_join()...
+		 */
 		if (pthread_create(&thread, NULL, try_SysOID, (void*)tmp_sec) == 0) {
 			thread_count++;
 			pthread_t *new_thread_array = realloc(thread_array,

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -759,7 +759,7 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 		 * other protocol scanners...
 		 */
 		if (curr_threads >= max_threads) {
-			upsdebugx(0, "%s: already running %zu scanning threads "
+			upsdebugx(2, "%s: already running %zu scanning threads "
 				"(launched overall: %d), "
 				"waiting until some would finish",
 				__func__, curr_threads, thread_count);
@@ -770,16 +770,16 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 					if (!thread_array[i].active) continue;
 
 					pthread_mutex_lock(&threadcount_mutex);
-					upsdebugx(0, "%s: Trying to join thread #%i...", __func__, i);
+					upsdebugx(3, "%s: Trying to join thread #%i...", __func__, i);
 					ret = pthread_tryjoin_np(thread_array[i].thread, NULL);
 					switch (ret) {
 						case ESRCH:     // No thread with the ID thread could be found - already "joined"?
-							upsdebugx(0, "%s: Was thread #%i joined earlier?", __func__, i);
+							upsdebugx(5, "%s: Was thread #%i joined earlier?", __func__, i);
 							break;
 						case 0:         // thread exited
 							if (curr_threads > 0) {
 								curr_threads --;
-								upsdebugx(0, "%s: Joined a finished thread #%i", __func__, i);
+								upsdebugx(4, "%s: Joined a finished thread #%i", __func__, i);
 							} else {
 								/* threadcount_mutex fault? */
 								upsdebugx(0, "WARNING: %s: Accounting of thread count "
@@ -788,13 +788,13 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 							thread_array[i].active = FALSE;
 							break;
 						case EBUSY:     // actively running
-							upsdebugx(0, "%s: thread #%i still busy (%i)",
+							upsdebugx(6, "%s: thread #%i still busy (%i)",
 								__func__, i, ret);
 							break;
 						case EDEADLK:   // Errors with thread interactions... bail out?
 						case EINVAL:    // Errors with thread interactions... bail out?
 						default:        // new pthreads abilities?
-							upsdebugx(0, "%s: thread #%i reported code %i",
+							upsdebugx(5, "%s: thread #%i reported code %i",
 								__func__, i, ret);
 							break;
 					}
@@ -802,7 +802,7 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 				}
 				usleep (10000); // microSec's, so 0.01s here
 			}
-			upsdebugx(0, "%s: proceeding with scan", __func__);
+			upsdebugx(2, "%s: proceeding with scan", __func__);
 		}
 # endif // HAVE_PTHREAD_TRYJOIN
 
@@ -836,7 +836,7 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 	}
 
 #ifdef HAVE_PTHREAD
-	upsdebugx(0, "%s: all planned scans launched, waiting for threads to complete", __func__);
+	upsdebugx(2, "%s: all planned scans launched, waiting for threads to complete", __func__);
 	for (i = 0; i < thread_count ; i++) {
 		int ret;
 
@@ -852,7 +852,7 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 		pthread_mutex_lock(&threadcount_mutex);
 		if (curr_threads > 0) {
 			curr_threads --;
-			upsdebugx(0, "%s: Clean-up: Joined a finished thread #%i",
+			upsdebugx(5, "%s: Clean-up: Joined a finished thread #%i",
 				__func__, i);
 		} else {
 			upsdebugx(0, "WARNING: %s: Clean-up: Accounting of thread count "
@@ -861,7 +861,7 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 		pthread_mutex_unlock(&threadcount_mutex);
 # endif // HAVE_PTHREAD_TRYJOIN
 	}
-	upsdebugx(0, "%s: all threads freed", __func__);
+	upsdebugx(2, "%s: all threads freed", __func__);
 	pthread_mutex_destroy(&dev_mutex);
 	free(thread_array);
 #endif

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -1,5 +1,6 @@
 /*
- *  Copyright (C) 2011-2017 Eaton
+ *  Copyright (C) 2011 - EATON
+ *  Copyright (C) 2016-2021 - EATON - Various threads-related improvements
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -20,6 +21,7 @@
     \brief detect NUT supported SNMP devices
     \author Frederic Bohe <FredericBohe@Eaton.com>
     \author Arnaud Quette <ArnaudQuette@Eaton.com>
+    \author Jim Klimov <EvgenyKlimov@eaton.com>
 */
 
 #include "common.h"
@@ -817,7 +819,7 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 
 			thread_count++;
 			nutscan_thread_t *new_thread_array = realloc(thread_array,
-				thread_count*sizeof(nutscan_thread_t));
+				thread_count * sizeof(nutscan_thread_t));
 			if (new_thread_array == NULL) {
 				upsdebugx(1, "%s: Failed to realloc thread array", __func__);
 				break;
@@ -825,8 +827,8 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 			else {
 				thread_array = new_thread_array;
 			}
-			thread_array[thread_count-1].thread = thread;
-			thread_array[thread_count-1].active = TRUE;
+			thread_array[thread_count - 1].thread = thread;
+			thread_array[thread_count - 1].active = TRUE;
 
 # ifdef HAVE_PTHREAD_TRYJOIN
 			pthread_mutex_unlock(&threadcount_mutex);
@@ -840,7 +842,7 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 
 #ifdef HAVE_PTHREAD
 	upsdebugx(2, "%s: all planned scans launched, waiting for threads to complete", __func__);
-	for (i = 0; i < thread_count ; i++) {
+	for (i = 0; i < thread_count; i++) {
 		int ret;
 
 		if (!thread_array[i].active) continue;

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -760,12 +760,16 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 		 * At worst we would overflow the limit a bit due to
 		 * other protocol scanners...
 		 */
-		if (curr_threads >= max_threads) {
+		if (curr_threads >= max_threads
+		|| (curr_threads >= max_threads_netsnmp && max_threads_netsnmp > 0)
+		) {
 			upsdebugx(2, "%s: already running %zu scanning threads "
 				"(launched overall: %d), "
 				"waiting until some would finish",
 				__func__, curr_threads, thread_count);
-			while (curr_threads >= max_threads) {
+			while (curr_threads >= max_threads
+			   || (curr_threads >= max_threads_netsnmp && max_threads_netsnmp > 0)
+			) {
 				for (i = 0; i < thread_count ; i++) {
 					int ret;
 
@@ -803,7 +807,9 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 					pthread_mutex_unlock(&threadcount_mutex);
 				}
 
-				if (curr_threads >= max_threads) {
+				if (curr_threads >= max_threads
+				|| (curr_threads >= max_threads_netsnmp && max_threads_netsnmp > 0)
+				) {
 					usleep (10000); // microSec's, so 0.01s here
 				}
 			}

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -58,6 +58,7 @@
 #include <net-snmp/net-snmp-includes.h>
 #ifdef HAVE_PTHREAD
 #include <pthread.h>
+extern size_t max_threads, curr_threads;
 #endif
 #include "nutscan-snmp.h"
 

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -800,7 +800,10 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 					}
 					pthread_mutex_unlock(&threadcount_mutex);
 				}
-				usleep (10000); // microSec's, so 0.01s here
+
+				if (curr_threads >= max_threads) {
+					usleep (10000); // microSec's, so 0.01s here
+				}
 			}
 			upsdebugx(2, "%s: proceeding with scan", __func__);
 		}

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -803,7 +803,6 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 # ifdef HAVE_PTHREAD_TRYJOIN
 			pthread_mutex_lock(&threadcount_mutex);
 			curr_threads++;
-			pthread_mutex_unlock(&threadcount_mutex);
 # endif // HAVE_PTHREAD_TRYJOIN
 
 			thread_count++;
@@ -817,6 +816,10 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 				thread_array = new_thread_array;
 			}
 			thread_array[thread_count-1] = thread;
+
+# ifdef HAVE_PTHREAD_TRYJOIN
+			pthread_mutex_unlock(&threadcount_mutex);
+# endif // HAVE_PTHREAD_TRYJOIN
 		}
 #else
 		try_SysOID((void *)tmp_sec);

--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -61,6 +61,13 @@ static nutscan_device_t * dev_ret = NULL;
 static pthread_mutex_t dev_mutex;
 #endif
 
+/* use explicit booleans */
+#ifndef FALSE
+typedef enum ebool { FALSE = 0, TRUE } bool_t;
+#else
+typedef int bool_t;
+#endif
+
 /* return 0 on error; visible externally */
 int nutscan_load_neon_library(const char *libname_path);
 int nutscan_load_neon_library(const char *libname_path)

--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -1,6 +1,7 @@
 /*
  *  Copyright (C) 2011 - EATON
  *  Copyright (C) 2016 - EATON - IP addressed XML scan
+ *  Copyright (C) 2016-2021 - EATON - Various threads-related improvements
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -26,6 +27,7 @@
 
 #include "common.h"
 #include "nut-scan.h"
+
 #ifdef WITH_NEON
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -38,10 +40,6 @@
 #include <errno.h>
 #include <ne_xml.h>
 #include <ltdl.h>
-
-#ifdef HAVE_PTHREAD
-#include <pthread.h>
-#endif
 
 /* dynamic link library stuff */
 static char * libname = "libneon"; /* Note: this is for info messages, not the SONAME */
@@ -406,11 +404,11 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 			char * ip_str = NULL;
 #ifdef HAVE_PTHREAD
 			pthread_t thread;
-			pthread_t * thread_array = NULL;
+			nutscan_thread_t * thread_array = NULL;
 			int thread_count = 0;
 
 			pthread_mutex_init(&dev_mutex, NULL);
-#endif
+#endif // HAVE_PTHREAD
 
 			ip_str = nutscan_ip_iter_init(&ip, start_ip, end_ip);
 
@@ -426,22 +424,96 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 				if (tmp_sec->usec_timeout < 0) tmp_sec->usec_timeout = usec_timeout;
 
 #ifdef HAVE_PTHREAD
+# ifdef HAVE_PTHREAD_TRYJOIN
+				/* NOTE: With many enough targets to scan, this can crash
+				 * by spawning too many children; add a limit and loop to
+				 * "reap" some already done with their work. And probably
+				 * account them in thread_array[] as something to not wait
+				 * for below in pthread_join()...
+				 */
+
+				/* TOTHINK: Should there be a threadcount_mutex when
+				 * we just read the value in if() and while() below?
+				 * At worst we would overflow the limit a bit due to
+				 * other protocol scanners...
+				 */
+				if (curr_threads >= max_threads) {
+					upsdebugx(2, "%s: already running %zu scanning threads "
+						"(launched overall: %d), "
+						"waiting until some would finish",
+						__func__, curr_threads, thread_count);
+					while (curr_threads >= max_threads) {
+						for (i = 0; i < thread_count ; i++) {
+							int ret;
+
+							if (!thread_array[i].active) continue;
+
+							pthread_mutex_lock(&threadcount_mutex);
+							upsdebugx(3, "%s: Trying to join thread #%i...", __func__, i);
+							ret = pthread_tryjoin_np(thread_array[i].thread, NULL);
+							switch (ret) {
+								case ESRCH:     // No thread with the ID thread could be found - already "joined"?
+									upsdebugx(5, "%s: Was thread #%i joined earlier?", __func__, i);
+									break;
+								case 0:         // thread exited
+									if (curr_threads > 0) {
+										curr_threads --;
+										upsdebugx(4, "%s: Joined a finished thread #%i", __func__, i);
+									} else {
+										/* threadcount_mutex fault? */
+										upsdebugx(0, "WARNING: %s: Accounting of thread count "
+											"says we are already at 0", __func__);
+									}
+									thread_array[i].active = FALSE;
+									break;
+								case EBUSY:     // actively running
+									upsdebugx(6, "%s: thread #%i still busy (%i)",
+										__func__, i, ret);
+									break;
+								case EDEADLK:   // Errors with thread interactions... bail out?
+								case EINVAL:    // Errors with thread interactions... bail out?
+								default:        // new pthreads abilities?
+									upsdebugx(5, "%s: thread #%i reported code %i",
+										__func__, i, ret);
+									break;
+							}
+							pthread_mutex_unlock(&threadcount_mutex);
+						}
+
+						if (curr_threads >= max_threads) {
+							usleep (10000); // microSec's, so 0.01s here
+						}
+					}
+					upsdebugx(2, "%s: proceeding with scan", __func__);
+				}
+# endif // HAVE_PTHREAD_TRYJOIN
+
 				if (pthread_create(&thread, NULL, nutscan_scan_xml_http_generic, (void *)tmp_sec) == 0) {
+# ifdef HAVE_PTHREAD_TRYJOIN
+					pthread_mutex_lock(&threadcount_mutex);
+					curr_threads++;
+# endif // HAVE_PTHREAD_TRYJOIN
+
 					thread_count++;
-					pthread_t *new_thread_array = realloc(thread_array,
-						thread_count*sizeof(pthread_t));
+					nutscan_thread_t *new_thread_array = realloc(thread_array,
+						thread_count*sizeof(nutscan_thread_t));
 					if (new_thread_array == NULL) {
-						upsdebugx(1, "%s: Failed to realloc thread", __func__);
+						upsdebugx(1, "%s: Failed to realloc thread array", __func__);
 						break;
 					}
 					else {
 						thread_array = new_thread_array;
 					}
-					thread_array[thread_count - 1] = thread;
+					thread_array[thread_count - 1].thread = thread;
+					thread_array[thread_count - 1].active = TRUE;
+
+# ifdef HAVE_PTHREAD_TRYJOIN
+					pthread_mutex_unlock(&threadcount_mutex);
+# endif // HAVE_PTHREAD_TRYJOIN
 				}
-#else
+#else // not HAVE_PTHREAD
 				nutscan_scan_xml_http_generic((void *)tmp_sec);
-#endif
+#endif // if HAVE_PTHREAD
 /*				free(ip_str); */ /* One of these free()s seems to cause a double-free */
 				ip_str = nutscan_ip_iter_inc(&ip);
 /*				free(tmp_sec); */
@@ -449,13 +521,36 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 
 #ifdef HAVE_PTHREAD
 			if (thread_array != NULL) {
+				upsdebugx(2, "%s: all planned scans launched, waiting for threads to complete", __func__);
 				for (i = 0; i < thread_count; i++) {
-					pthread_join(thread_array[i], NULL);
+					int ret;
+
+					if (!thread_array[i].active) continue;
+
+					ret = pthread_join(thread_array[i].thread, NULL);
+					if (ret != 0) {
+						upsdebugx(0, "WARNING: %s: Clean-up: pthread_join() returned code %i",
+							__func__, ret);
+					}
+					thread_array[i].active = FALSE;
+# ifdef HAVE_PTHREAD_TRYJOIN
+					pthread_mutex_lock(&threadcount_mutex);
+					if (curr_threads > 0) {
+						curr_threads --;
+						upsdebugx(5, "%s: Clean-up: Joined a finished thread #%i",
+							__func__, i);
+					} else {
+						upsdebugx(0, "WARNING: %s: Clean-up: Accounting of thread count "
+							"says we are already at 0", __func__);
+					}
+					pthread_mutex_unlock(&threadcount_mutex);
+# endif // HAVE_PTHREAD_TRYJOIN
 				}
 				free(thread_array);
+				upsdebugx(2, "%s: all threads freed", __func__);
 			}
 			pthread_mutex_destroy(&dev_mutex);
-#endif
+#endif // HAVE_PTHREAD
 			result = nutscan_rewind_device(dev_ret);
 			dev_ret = NULL;
 			return result;

--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -444,12 +444,16 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 				 * At worst we would overflow the limit a bit due to
 				 * other protocol scanners...
 				 */
-				if (curr_threads >= max_threads) {
+				if (curr_threads >= max_threads
+				||  curr_threads >= max_threads_netxml
+				) {
 					upsdebugx(2, "%s: already running %zu scanning threads "
 						"(launched overall: %d), "
 						"waiting until some would finish",
 						__func__, curr_threads, thread_count);
-					while (curr_threads >= max_threads) {
+					while (curr_threads >= max_threads
+					    || curr_threads >= max_threads_netxml
+					) {
 						for (i = 0; i < thread_count ; i++) {
 							int ret;
 
@@ -487,7 +491,9 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 							pthread_mutex_unlock(&threadcount_mutex);
 						}
 
-						if (curr_threads >= max_threads) {
+						if (curr_threads >= max_threads
+						||  curr_threads >= max_threads_netxml
+						) {
 							usleep (10000); // microSec's, so 0.01s here
 						}
 					}


### PR DESCRIPTION
If extremely many threads are spawned, e.g. scanning a very large IP address range, the `nut-scanner` program can crash due to resource exhaustion or hitting some constraints in pthreads implementation (various effects were seen on different generations of OSes) or third-party libraries used in particular scanners.

This PR adds a (CLI-configurable as `--thread N`) limit to amount of threads that would be spawned by different parallelized scanners (snmp, nut, netxml, serial), and if the limit gets hit - it would `pthread_tryjoin_np()` to wait for some of the threads to complete their work, and only then proceed to spawn another.

Note that while there is locking to increase or decrease the overall thread counter, checks are not mutex'ed and I anticipate that small accounting errors are possible (e.g. launching up to +1 "extra" thread for each scan type).

Given that scanning usually means sending a request and waiting if any reply comes within a timeout, the processing load of each item scan is negligible while considerable wall-clock time is spent. Lack of parallelism does add up: in tests, an SNMP scan of a /24 subnet took ~5 seconds without hitting a limit, 20 seconds with a limit of 64 threads, and ~1200 seconds with a limit of 1 thread.

The default limit in this PR is arbitrarily set to 1024 threads overall, to accomodate fast scans of a typical /24 subnet with several protocols at once.
UPDATE1: The default can get reduced if allowed file descriptor `ulimit` is smaller.
UPDATE2: Also individual protocol scanners can be subjected to their own limits; whichever is smaller (and gets hit first) wins.

PS: This is a separate issue from broken netmask processing, addressed in PR #1157