### PR TITLE
Fix sanity-checking of the ability to run CppUnit tests

### DIFF
--- a/clients/Makefile.am
+++ b/clients/Makefile.am
@@ -9,7 +9,7 @@ AM_CXXFLAGS = -DHAVE_NUTCOMMON=1 -I$(top_srcdir)/include
 # Make sure out-of-dir dependencies exist (especially when dev-building parts):
 $(top_builddir)/common/libcommon.la \
 $(top_builddir)/common/libcommonclient.la \
-$(top_builddir)/common/libparseconf.la:
+$(top_builddir)/common/libparseconf.la: dummy
 	@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
 # by default, link programs in this directory with libcommon.a
@@ -94,6 +94,8 @@ libnutclientstub_la_LIBADD = libnutclient.la
 else
 EXTRA_DIST += nutclientmem.h nutclientmem.cpp
 endif
+
+dummy:
 
 MAINTAINERCLEANFILES = Makefile.in
 

--- a/clients/nutclient.cpp
+++ b/clients/nutclient.cpp
@@ -1522,6 +1522,11 @@ extern "C" {
 strarr strarr_alloc(size_t count)
 {
 	strarr arr = static_cast<strarr>(xcalloc(count+1, sizeof(char*)));
+
+	if (arr == nullptr) {
+		throw nut::NutException("Out of memory");
+	}
+
 	arr[count] = nullptr;
 	return arr;
 }

--- a/clients/nutclient.h
+++ b/clients/nutclient.h
@@ -57,7 +57,7 @@ class NutException : public std::exception
 public:
 	NutException(const std::string& msg):_msg(msg){}
 	NutException(const NutException&) = default;
-    NutException& operator=(NutException& rhs) = default;
+	NutException& operator=(NutException& rhs) = default;
 	virtual ~NutException();
 	virtual const char * what() const noexcept {return this->_msg.c_str();}
 	virtual std::string str() const noexcept {return this->_msg;}
@@ -73,7 +73,7 @@ class SystemException : public NutException
 public:
 	SystemException();
 	SystemException(const SystemException&) = default;
-    SystemException& operator=(SystemException& rhs) = default;
+	SystemException& operator=(SystemException& rhs) = default;
 	virtual ~SystemException();
 private:
 	static std::string err();
@@ -88,7 +88,7 @@ class IOException : public NutException
 public:
 	IOException(const std::string& msg):NutException(msg){}
 	IOException(const IOException&) = default;
-    IOException& operator=(IOException& rhs) = default;
+	IOException& operator=(IOException& rhs) = default;
 	virtual ~IOException();
 };
 
@@ -100,7 +100,7 @@ class UnknownHostException : public IOException
 public:
 	UnknownHostException():IOException("Unknown host"){}
 	UnknownHostException(const UnknownHostException&) = default;
-    UnknownHostException& operator=(UnknownHostException& rhs) = default;
+	UnknownHostException& operator=(UnknownHostException& rhs) = default;
 	virtual ~UnknownHostException();
 };
 
@@ -112,7 +112,7 @@ class NotConnectedException : public IOException
 public:
 	NotConnectedException():IOException("Not connected"){}
 	NotConnectedException(const NotConnectedException&) = default;
-    NotConnectedException& operator=(NotConnectedException& rhs) = default;
+	NotConnectedException& operator=(NotConnectedException& rhs) = default;
 	virtual ~NotConnectedException();
 };
 
@@ -124,7 +124,7 @@ class TimeoutException : public IOException
 public:
 	TimeoutException():IOException("Timeout"){}
 	TimeoutException(const TimeoutException&) = default;
-    TimeoutException& operator=(TimeoutException& rhs) = default;
+	TimeoutException& operator=(TimeoutException& rhs) = default;
 	virtual ~TimeoutException();
 };
 

--- a/configure.ac
+++ b/configure.ac
@@ -1697,6 +1697,12 @@ AS_IF([test x"$have_PKG_CONFIG" = xyes],
 )
 AC_MSG_RESULT(${have_cppunit})
 
+dnl On some systems, CppUnit inexplicably fails with trivial assertions
+dnl so it should not be enabled with those environments, corrupting the
+dnl test results with misleading errors.
+dnl Tracked in https://github.com/networkupstools/nut/issues/1126
+dnl One such situation was e.g. "clang++ + arm64(QEMU) + -m64" while
+dnl this was not seen with other compilers or bitness on same system.
 AS_IF([test "${have_cppunit}" = "yes"],
     [AC_MSG_CHECKING([if current toolkit can build and run cppunit tests (e.g. no ABI issues, related segfaults, etc.)])
      dnl Code below is largely a stripped variant of our tests/example.cpp and cpputest.cpp
@@ -1723,7 +1729,8 @@ void ExampleTest::testOne()
   int i = 1;
   float f = 1.0;
   int cast = static_cast<int>(f);
-  CPPUNIT_ASSERT_EQUAL_MESSAGE("Casted float is not the expected int", i, cast );
+  CPPUNIT_ASSERT_EQUAL_MESSAGE("Casted float is not the expected int (assert_eq)", i, cast );
+  CPPUNIT_ASSERT_MESSAGE("Casted float is not the expected int (assert)", (i == cast) );
 }
 '
 

--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -3,7 +3,7 @@
 # Make sure out-of-dir dependencies exist (especially when dev-building parts):
 $(top_builddir)/common/libcommon.la \
 $(top_builddir)/common/libparseconf.la \
-$(top_builddir)/clients/libupsclient.la:
+$(top_builddir)/clients/libupsclient.la: dummy
 	@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
 # by default, link programs in this directory with libcommon.la
@@ -332,6 +332,8 @@ libdummy_la_SOURCES = main.c dstate.c
 libdummy_la_LDFLAGS = -no-undefined -static
 libdummy_serial_la_SOURCES = serial.c
 libdummy_serial_la_LDFLAGS = -no-undefined -static
+
+dummy:
 
 CLEANFILES = $(EXTRA_LTLIBRARIES) $(EXTRA_PROGRAMS)
 MAINTAINERCLEANFILES = Makefile.in

--- a/server/Makefile.am
+++ b/server/Makefile.am
@@ -2,7 +2,7 @@
 
 # Make sure out-of-dir dependencies exist (especially when dev-building parts):
 $(top_builddir)/common/libcommon.la \
-$(top_builddir)/common/libparseconf.la:
+$(top_builddir)/common/libparseconf.la: dummy
 	@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
 # Avoid per-target CFLAGS, because this will prevent re-use of object
@@ -33,6 +33,8 @@ upsd_SOURCES = upsd.c user.c conf.c netssl.c sstate.c desc.c		\
  upstype.h user-data.h user.h
 
 sockdebug_SOURCES = sockdebug.c
+
+dummy:
 
 MAINTAINERCLEANFILES = Makefile.in
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -51,9 +51,6 @@ check-local: $(check_PROGRAMS)
 	RES=0; for P in $^ ; do $(VALGRIND) ./$$P || { RES=$$? ; echo "FAILED: $(VALGRIND) ./$$P" >&2; }; done; exit $$RES
 endif
 
-# TODO: This relies on orderly build from the top directory, otherwise we see:
-#   gmake: *** No rule to make target '../clients/libnutclient.la', needed by 'cppunittest'.
-#   gmake: *** No rule to make target '../clients/libnutclientstub.la', needed by 'cppunittest'.
 cppunittest_CXXFLAGS = $(AM_CXXFLAGS) $(CPPUNIT_CFLAGS) $(CPPUNIT_CXXFLAGS) $(CPPUNIT_NUT_CXXFLAGS) $(CXXFLAGS)
 cppunittest_LDFLAGS = $(CPPUNIT_LIBS)
 cppunittest_LDADD = $(top_builddir)/clients/libnutclient.la $(top_builddir)/clients/libnutclientstub.la

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -28,7 +28,7 @@ nodist_getvaluetest_SOURCES = $(builddir)/hidparser.c
 getvaluetest_LDADD = $(top_builddir)/common/libcommon.la
 
 # Make sure out-of-dir dependencies exist (especially when dev-building parts):
-$(top_builddir)/common/libcommon.la:
+$(top_builddir)/common/libcommon.la: dummy
 	@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
 ### Optional tests which can not be built everywhere
@@ -58,7 +58,8 @@ cppunittest_SOURCES = $(CPPUNITTESTSRC) $(CPPUNITTESTERSRC)
 
 # Make sure out-of-dir C++ dependencies exist (especially when dev-building
 # only some parts of NUT):
-$(top_builddir)/clients/libnutclient.la $(top_builddir)/clients/libnutclientstub.la:
+$(top_builddir)/clients/libnutclient.la \
+$(top_builddir)/clients/libnutclientstub.la: dummy
 	@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
 else !HAVE_CPPUNIT
@@ -74,6 +75,8 @@ else !HAVE_CXX11
 EXTRA_DIST += example.cpp cpputest.cpp
 
 endif !HAVE_CXX11
+
+dummy:
 
 BUILT_SOURCES = $(LINKED_SOURCE_FILES)
 CLEANFILES += $(LINKED_SOURCE_FILES)

--- a/tests/nutclienttest.cpp
+++ b/tests/nutclienttest.cpp
@@ -1,7 +1,7 @@
 /* nutclienttest - CppUnit nutclient unit test
 
    Copyright (C) 2016  Emilien Kia <emilien.kia@gmail.com>
-   Copyright (C) 2020  Jim Klimov <jimklimov@gmail.com>
+   Copyright (C) 2020 - 2021  Jim Klimov <jimklimov@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -107,7 +107,9 @@ void NutClientTest::test_stringset_to_strarr()
 	strset.insert("world");
 
 	strarr arr = stringset_to_strarr(strset);
-	CPPUNIT_ASSERT_MESSAGE("stringset_to_strarr(...) result is null", arr != nullptr);
+	CPPUNIT_ASSERT_MESSAGE(
+		"stringset_to_strarr(...) result is null",
+		arr != nullptr);
 
 	std::set<std::string> res;
 
@@ -118,10 +120,18 @@ void NutClientTest::test_stringset_to_strarr()
 		ptr++;
 	}
 
-	CPPUNIT_ASSERT_EQUAL_MESSAGE("stringset_to_strarr(...) result has not 3 items", static_cast<size_t>(3), res.size());
-	CPPUNIT_ASSERT_MESSAGE("stringset_to_strarr(...) result has not item \"test\"", res.find("test")!=res.end());
-	CPPUNIT_ASSERT_MESSAGE("stringset_to_strarr(...) result has not item \"hello\"", res.find("hello")!=res.end());
-	CPPUNIT_ASSERT_MESSAGE("stringset_to_strarr(...) result has not item \"world\"", res.find("world")!=res.end());
+	CPPUNIT_ASSERT_EQUAL_MESSAGE(
+		"stringset_to_strarr(...) result has not 3 items",
+		static_cast<size_t>(3), res.size());
+	CPPUNIT_ASSERT_MESSAGE(
+		"stringset_to_strarr(...) result has not item \"test\"",
+		res.find("test")  != res.end());
+	CPPUNIT_ASSERT_MESSAGE(
+		"stringset_to_strarr(...) result has not item \"hello\"",
+		res.find("hello") != res.end());
+	CPPUNIT_ASSERT_MESSAGE(
+		"stringset_to_strarr(...) result has not item \"world\"",
+		res.find("world") != res.end());
 
 	strarr_free(arr);
 }
@@ -134,21 +144,31 @@ void NutClientTest::test_stringvector_to_strarr()
 	strset.push_back("world");
 
 	strarr arr = stringvector_to_strarr(strset);
-	CPPUNIT_ASSERT_MESSAGE("stringvector_to_strarr(...) result is null", arr != nullptr);
+	CPPUNIT_ASSERT_MESSAGE(
+		"stringvector_to_strarr(...) result is null",
+		arr != nullptr);
 
 	char** ptr = arr;
-	CPPUNIT_ASSERT_EQUAL_MESSAGE("stringvector_to_strarr(...) result has not item 0==\"test\"", std::string("test"), std::string(*ptr));
+	CPPUNIT_ASSERT_EQUAL_MESSAGE(
+		"stringvector_to_strarr(...) result has not item 0==\"test\"",
+		std::string("test"), std::string(*ptr));
 	++ptr;
-	CPPUNIT_ASSERT_EQUAL_MESSAGE("stringvector_to_strarr(...) result has not item 1==\"hello\"", std::string("hello"), std::string(*ptr));
+	CPPUNIT_ASSERT_EQUAL_MESSAGE(
+		"stringvector_to_strarr(...) result has not item 1==\"hello\"",
+		std::string("hello"), std::string(*ptr));
 	++ptr;
-	CPPUNIT_ASSERT_EQUAL_MESSAGE("stringvector_to_strarr(...) result has not item 2==\"world\"", std::string("world"), std::string(*ptr));
+	CPPUNIT_ASSERT_EQUAL_MESSAGE(
+		"stringvector_to_strarr(...) result has not item 2==\"world\"",
+		std::string("world"), std::string(*ptr));
 	++ptr;
 
 	/* https://stackoverflow.com/a/12565009/4715872
 	 * Can not compare nullptr_t and another data type (char*)
 	 * with CPPUNIT template assertEquals()
 	 */
-	CPPUNIT_ASSERT_MESSAGE("stringvector_to_strarr(...) result has not only 3 items", nullptr == *ptr);
+	CPPUNIT_ASSERT_MESSAGE(
+		"stringvector_to_strarr(...) result has not only 3 items",
+		nullptr == *ptr);
 
 	strarr_free(arr);
 }
@@ -158,7 +178,9 @@ void NutClientTest::test_copy_constructor_dev() {
 	nut::Device i(&c, "ups1");
 	nut::Device j(i);
 
-	CPPUNIT_ASSERT_EQUAL_MESSAGE("Failed to assign value of Device variable j by initializing from i", i, j);
+	CPPUNIT_ASSERT_EQUAL_MESSAGE(
+		"Failed to assign value of Device variable j by initializing from i",
+		i, j);
 }
 
 void NutClientTest::test_copy_assignment_dev() {
@@ -166,11 +188,15 @@ void NutClientTest::test_copy_assignment_dev() {
 	nut::Device i(&c, "ups1");
 	nut::Device j(nullptr, "ups2");
 
-	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("Device variables i and j were initialized differently but claim to be equal",
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE(
+		"Device variables i and j were initialized differently "
+		"but claim to be equal",
 		CPPUNIT_ASSERT_EQUAL(i, j) );
 
 	j = i;
-	CPPUNIT_ASSERT_EQUAL_MESSAGE("Failed to assign value of Device Command j by equating to i", i, j);
+	CPPUNIT_ASSERT_EQUAL_MESSAGE(
+		"Failed to assign value of Device Command j by equating to i",
+		i, j);
 }
 
 void NutClientTest::test_copy_constructor_cmd() {
@@ -180,7 +206,9 @@ void NutClientTest::test_copy_constructor_cmd() {
 	nut::Command i(&d, "cmd1");
 	nut::Command j(i);
 
-	CPPUNIT_ASSERT_EQUAL_MESSAGE("Failed to assign value of Command variable j by initializing from i", i, j);
+	CPPUNIT_ASSERT_EQUAL_MESSAGE(
+		"Failed to assign value of Command variable j by initializing from i",
+		i, j);
 }
 
 void NutClientTest::test_copy_assignment_cmd() {
@@ -190,11 +218,15 @@ void NutClientTest::test_copy_assignment_cmd() {
 	nut::Command i(&d, "var1");
 	nut::Command j(nullptr, "var2");
 
-	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("Command variables i and j were initialized differently but claim to be equal",
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE(
+		"Command variables i and j were initialized differently "
+		"but claim to be equal",
 		CPPUNIT_ASSERT_EQUAL(i, j) );
 
 	j = i;
-	CPPUNIT_ASSERT_EQUAL_MESSAGE("Failed to assign value of Command variable j by equating to i", i, j);
+	CPPUNIT_ASSERT_EQUAL_MESSAGE(
+		"Failed to assign value of Command variable j by equating to i",
+		i, j);
 }
 
 void NutClientTest::test_copy_constructor_var() {
@@ -204,7 +236,9 @@ void NutClientTest::test_copy_constructor_var() {
 	nut::Variable i(&d, "var1");
 	nut::Variable j(i);
 
-	CPPUNIT_ASSERT_EQUAL_MESSAGE("Failed to assign value of Variable variable j by initializing from i", i, j);
+	CPPUNIT_ASSERT_EQUAL_MESSAGE(
+		"Failed to assign value of Variable variable j by initializing from i",
+		i, j);
 }
 
 void NutClientTest::test_copy_assignment_var() {
@@ -214,11 +248,15 @@ void NutClientTest::test_copy_assignment_var() {
 	nut::Variable i(&d, "var1");
 	nut::Variable j(nullptr, "var2");
 
-	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("Variable variables i and j were initialized differently but claim to be equal",
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE(
+		"Variable variables i and j were initialized differently "
+		"but claim to be equal",
 		CPPUNIT_ASSERT_EQUAL(i, j) );
 
 	j = i;
-	CPPUNIT_ASSERT_EQUAL_MESSAGE("Failed to assign value of Variable variable j by equating to i", i, j);
+	CPPUNIT_ASSERT_EQUAL_MESSAGE(
+		"Failed to assign value of Variable variable j by equating to i",
+		i, j);
 }
 
 void NutClientTest::test_nutclientstub_dev() {
@@ -232,77 +270,128 @@ void NutClientTest::test_nutclientstub_dev() {
 		c.setDeviceVariable("ups_1", "name_1", "value_1");
 		// get mono value
 		ListValue values = c.getDeviceVariableValue("ups_1", "name_1");
-		CPPUNIT_ASSERT_MESSAGE("Failed stub tcp client: mono wrong values number", values.size() == 1);
-		CPPUNIT_ASSERT_MESSAGE("Failed stub tcp client: mono bad value", values[0] == std::string("value_1"));
+		CPPUNIT_ASSERT_MESSAGE(
+			"Failed stub tcp client: mono wrong values number",
+			values.size() == 1);
+		CPPUNIT_ASSERT_MESSAGE(
+			"Failed stub tcp client: mono bad value",
+			values[0] == std::string("value_1"));
+
 		// set multi value
 		ListValue values_multi = { "multi_1", "multi_2" };
 		c.setDeviceVariable("ups_1", "name_multi_1", values_multi);
 		// get multi value
 		values = c.getDeviceVariableValue("ups_1", "name_multi_1");
-		CPPUNIT_ASSERT_MESSAGE("Failed stub tcp client: multi wrong values number", values.size() == 2);
-		CPPUNIT_ASSERT_MESSAGE("Failed stub tcp client: multi first bad value", values[0] == std::string("multi_1"));
-		CPPUNIT_ASSERT_MESSAGE("Failed stub tcp client: multi second bad value", values[1] == std::string("multi_2"));
+		CPPUNIT_ASSERT_MESSAGE(
+			"Failed stub tcp client: multi wrong values number",
+			values.size() == 2);
+		CPPUNIT_ASSERT_MESSAGE(
+			"Failed stub tcp client: multi first bad value",
+			values[0] == std::string("multi_1"));
+		CPPUNIT_ASSERT_MESSAGE(
+			"Failed stub tcp client: multi second bad value",
+			values[1] == std::string("multi_2"));
+
 		// get object values
 		ListObject objects = c.getDeviceVariableValues("ups_1");
-		CPPUNIT_ASSERT_MESSAGE("Failed stub tcp client: objects wrong values number", objects.size() == 2);
-		CPPUNIT_ASSERT_MESSAGE("Failed stub tcp client: objects mono wrong values number", objects["name_1"].size() == 1);
-		CPPUNIT_ASSERT_MESSAGE("Failed stub tcp client: objects mono bad value", objects["name_1"][0] == std::string("value_1"));
-		CPPUNIT_ASSERT_MESSAGE("Failed stub tcp client: objects multi wrong values number", objects["name_multi_1"].size() == 2);
-		CPPUNIT_ASSERT_MESSAGE("Failed stub tcp client: objects mono bad value", objects["name_multi_1"][0] == std::string("multi_1"));
-		CPPUNIT_ASSERT_MESSAGE("Failed stub tcp client: objects mono bad value", objects["name_multi_1"][1] == std::string("multi_2"));
+		CPPUNIT_ASSERT_MESSAGE(
+			"Failed stub tcp client: objects wrong values number",
+			objects.size() == 2);
+		CPPUNIT_ASSERT_MESSAGE(
+			"Failed stub tcp client: objects mono wrong values number",
+			objects["name_1"].size() == 1);
+		CPPUNIT_ASSERT_MESSAGE(
+			"Failed stub tcp client: objects mono bad value",
+			objects["name_1"][0] == std::string("value_1"));
+		CPPUNIT_ASSERT_MESSAGE(
+			"Failed stub tcp client: objects multi wrong values number",
+			objects["name_multi_1"].size() == 2);
+		CPPUNIT_ASSERT_MESSAGE(
+			"Failed stub tcp client: objects mono bad value",
+			objects["name_multi_1"][0] == std::string("multi_1"));
+		CPPUNIT_ASSERT_MESSAGE(
+			"Failed stub tcp client: objects mono bad value",
+			objects["name_multi_1"][1] == std::string("multi_2"));
+
 		// get device values
 		std::set<std::string> devices_name = { "ups_1" };
 		ListDevice devices = c.getDevicesVariableValues(devices_name);
-		CPPUNIT_ASSERT_MESSAGE("Failed stub tcp client: devices wrong values number", devices.size() == 1);
-		CPPUNIT_ASSERT_MESSAGE("Failed stub tcp client: devices mono wrong values number", devices["ups_1"]["name_1"].size() == 1);
-		CPPUNIT_ASSERT_MESSAGE("Failed stub tcp client: devices mono bad value", devices["ups_1"]["name_1"][0] == std::string("value_1"));
-		CPPUNIT_ASSERT_MESSAGE("Failed stub tcp client: devices multi wrong values number", devices["ups_1"]["name_multi_1"].size() == 2);
-		CPPUNIT_ASSERT_MESSAGE("Failed stub tcp client: devices mono bad value", devices["ups_1"]["name_multi_1"][0] == std::string("multi_1"));
-		CPPUNIT_ASSERT_MESSAGE("Failed stub tcp client: devices mono bad value", devices["ups_1"]["name_multi_1"][1] == std::string("multi_2"));
+		CPPUNIT_ASSERT_MESSAGE(
+			"Failed stub tcp client: devices wrong values number",
+			devices.size() == 1);
+		CPPUNIT_ASSERT_MESSAGE(
+			"Failed stub tcp client: devices mono wrong values number",
+			devices["ups_1"]["name_1"].size() == 1);
+		CPPUNIT_ASSERT_MESSAGE(
+			"Failed stub tcp client: devices mono bad value",
+			devices["ups_1"]["name_1"][0] == std::string("value_1"));
+		CPPUNIT_ASSERT_MESSAGE(
+			"Failed stub tcp client: devices multi wrong values number",
+			devices["ups_1"]["name_multi_1"].size() == 2);
+		CPPUNIT_ASSERT_MESSAGE(
+			"Failed stub tcp client: devices mono bad value",
+			devices["ups_1"]["name_multi_1"][0] == std::string("multi_1"));
+		CPPUNIT_ASSERT_MESSAGE(
+			"Failed stub tcp client: devices mono bad value",
+			devices["ups_1"]["name_multi_1"][1] == std::string("multi_2"));
 	}
 	catch(nut::NutException& ex)
 	{
 		NUT_UNUSED_VARIABLE(ex);
 		noException = false;
 	}
-	CPPUNIT_ASSERT_MESSAGE("Failed stub tcp client: throw exception", noException);
+	CPPUNIT_ASSERT_MESSAGE(
+		"Failed stub tcp client: throw exception",
+		noException);
 
 	// List of functions not implemented (should return exception)
 	noException = true;
 	try {
 		std::set<std::string> cmd = c.getDeviceCommandNames("ups-1");
-		CPPUNIT_ASSERT_MESSAGE("Variable not use", cmd.size() == 0);
+		CPPUNIT_ASSERT_MESSAGE(
+			"Variable not use",
+			cmd.size() == 0);
 	}
 	catch(nut::NutException& ex)
 	{
 		NUT_UNUSED_VARIABLE(ex);
 		noException = false;
 	}
-	CPPUNIT_ASSERT_MESSAGE("Failed stub tcp client: throw no exception", !noException);
+	CPPUNIT_ASSERT_MESSAGE(
+		"Failed stub tcp client: throw no exception",
+		!noException);
 
 	noException = true;
 	try {
 		std::string desc = c.getDeviceCommandDescription("ups-1", "cmd-1");
-		CPPUNIT_ASSERT_MESSAGE("Variable not use", desc.empty());
+		CPPUNIT_ASSERT_MESSAGE(
+			"Variable not use",
+			desc.empty());
 	}
 	catch(nut::NutException& ex)
 	{
 		NUT_UNUSED_VARIABLE(ex);
 		noException = false;
 	}
-	CPPUNIT_ASSERT_MESSAGE("Failed stub tcp client: throw no exception", !noException);
+	CPPUNIT_ASSERT_MESSAGE(
+		"Failed stub tcp client: throw no exception",
+		!noException);
 
 	noException = true;
 	try {
 		TrackingID id = c.executeDeviceCommand("ups-1", "cmd-1", "param-1");
-		CPPUNIT_ASSERT_MESSAGE("Variable not use", id.empty());
+		CPPUNIT_ASSERT_MESSAGE(
+			"Variable not use",
+			id.empty());
 	}
 	catch(nut::NutException& ex)
 	{
 		NUT_UNUSED_VARIABLE(ex);
 		noException = false;
 	}
-	CPPUNIT_ASSERT_MESSAGE("Failed stub tcp client: throw no exception", !noException);
+	CPPUNIT_ASSERT_MESSAGE(
+		"Failed stub tcp client: throw no exception",
+		!noException);
 
 	noException = true;
 	try {
@@ -313,7 +402,9 @@ void NutClientTest::test_nutclientstub_dev() {
 		NUT_UNUSED_VARIABLE(ex);
 		noException = false;
 	}
-	CPPUNIT_ASSERT_MESSAGE("Failed stub tcp client: throw no exception", !noException);
+	CPPUNIT_ASSERT_MESSAGE(
+		"Failed stub tcp client: throw no exception",
+		!noException);
 
 	noException = true;
 	try {
@@ -324,7 +415,9 @@ void NutClientTest::test_nutclientstub_dev() {
 		NUT_UNUSED_VARIABLE(ex);
 		noException = false;
 	}
-	CPPUNIT_ASSERT_MESSAGE("Failed stub tcp client: throw no exception", !noException);
+	CPPUNIT_ASSERT_MESSAGE(
+		"Failed stub tcp client: throw no exception",
+		!noException);
 
 	noException = true;
 	try {
@@ -335,7 +428,9 @@ void NutClientTest::test_nutclientstub_dev() {
 		NUT_UNUSED_VARIABLE(ex);
 		noException = false;
 	}
-	CPPUNIT_ASSERT_MESSAGE("Failed stub tcp client: throw no exception", !noException);
+	CPPUNIT_ASSERT_MESSAGE(
+		"Failed stub tcp client: throw no exception",
+		!noException);
 
 	noException = true;
 	try {
@@ -346,31 +441,41 @@ void NutClientTest::test_nutclientstub_dev() {
 		NUT_UNUSED_VARIABLE(ex);
 		noException = false;
 	}
-	CPPUNIT_ASSERT_MESSAGE("Failed stub tcp client: throw no exception", !noException);
+	CPPUNIT_ASSERT_MESSAGE(
+		"Failed stub tcp client: throw no exception",
+		!noException);
 
 	noException = true;
 	try {
 		TrackingResult result = c.getTrackingResult("track-1");
-		CPPUNIT_ASSERT_MESSAGE("Variable not use", result == TrackingResult::SUCCESS);
+		CPPUNIT_ASSERT_MESSAGE(
+			"Variable not use",
+			result == TrackingResult::SUCCESS);
 	}
 	catch(nut::NutException& ex)
 	{
 		NUT_UNUSED_VARIABLE(ex);
 		noException = false;
 	}
-	CPPUNIT_ASSERT_MESSAGE("Failed stub tcp client: throw no exception", !noException);
+	CPPUNIT_ASSERT_MESSAGE(
+		"Failed stub tcp client: throw no exception",
+		!noException);
 
 	noException = true;
 	try {
 		bool status = c.isFeatureEnabled(Feature("feature-1"));
-		CPPUNIT_ASSERT_MESSAGE("Variable not use", !status);
+		CPPUNIT_ASSERT_MESSAGE(
+			"Variable not use",
+			!status);
 	}
 	catch(nut::NutException& ex)
 	{
 		NUT_UNUSED_VARIABLE(ex);
 		noException = false;
 	}
-	CPPUNIT_ASSERT_MESSAGE("Failed stub tcp client: throw no exception", !noException);
+	CPPUNIT_ASSERT_MESSAGE(
+		"Failed stub tcp client: throw no exception",
+		!noException);
 
 	noException = true;
 	try {
@@ -381,7 +486,9 @@ void NutClientTest::test_nutclientstub_dev() {
 		NUT_UNUSED_VARIABLE(ex);
 		noException = false;
 	}
-	CPPUNIT_ASSERT_MESSAGE("Failed stub tcp client: throw no exception", !noException);
+	CPPUNIT_ASSERT_MESSAGE(
+		"Failed stub tcp client: throw no exception",
+		!noException);
 }
 
 } // namespace nut {}

--- a/tests/nutclienttest.cpp
+++ b/tests/nutclienttest.cpp
@@ -38,6 +38,7 @@ namespace nut {
 class NutClientTest : public CppUnit::TestFixture
 {
 	CPPUNIT_TEST_SUITE( NutClientTest );
+		CPPUNIT_TEST( test_strarr_alloc );
 		CPPUNIT_TEST( test_stringset_to_strarr );
 		CPPUNIT_TEST( test_stringvector_to_strarr );
 
@@ -57,6 +58,7 @@ public:
 	void setUp();
 	void tearDown();
 
+	void test_strarr_alloc();
 	void test_stringset_to_strarr();
 	void test_stringvector_to_strarr();
 
@@ -97,6 +99,31 @@ void NutClientTest::setUp()
 
 void NutClientTest::tearDown()
 {
+}
+
+void NutClientTest::test_strarr_alloc()
+{
+	bool noException = true;
+
+	strarr arr = nullptr;
+
+	try {
+		arr = strarr_alloc(5);
+	}
+	catch(nut::NutException& ex)
+	{
+		NUT_UNUSED_VARIABLE(ex);
+		noException = false;
+	}
+	CPPUNIT_ASSERT_MESSAGE(
+		"Failed strarr_alloc(...): throw exception",
+		noException);
+
+	CPPUNIT_ASSERT_MESSAGE(
+		"Failed strarr_alloc(...): result is null",
+		arr != nullptr);
+
+	strarr_free(arr);
 }
 
 void NutClientTest::test_stringset_to_strarr()

--- a/tools/nut-scanner/Makefile.am
+++ b/tools/nut-scanner/Makefile.am
@@ -11,11 +11,11 @@ CLEANFILES = $(BUILT_SOURCES)
 
 # Make sure we have the freshest files (no-op if built earlier and then
 # no driver sources and other dependencies were edited by a developer)
-$(NUT_SCANNER_DEPS):
+$(NUT_SCANNER_DEPS): dummy
 	@cd .. && $(MAKE) $(AM_MAKEFLAGS) nut-scanner-deps
 
 # Make sure out-of-dir dependencies exist (especially when dev-building parts):
-$(top_builddir)/common/libcommon.la:
+$(top_builddir)/common/libcommon.la: dummy
 	@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
 # do not hard depend on '../include/nut_version.h', since it blocks
@@ -107,6 +107,8 @@ if WITH_DEV
 else
  dist_noinst_HEADERS += nut-scan.h nutscan-device.h nutscan-ip.h nutscan-init.h nutscan-serial.h
 endif
+
+dummy:
 
 CLEANFILES += *-spellchecked
 MAINTAINERCLEANFILES = Makefile.in


### PR DESCRIPTION
During investigation for #1126 it was discovered that some bug lurks in CppUnit which in some of our NUT CI farm build environments causes assertions to fail regardless of argument value. These cases should now be better visible (if some new similar situation arises) by doing some more test cases - so trivial that they should not fail - and it now impacts auto-detection in `configure` script of the ability to run CppUnit tests. Faulty environments would not pollute our CI verdicts anymore :)