### PR TITLE
Fightwarn: string format truncation

### DIFF
--- a/clients/upscmd.c
+++ b/clients/upscmd.c
@@ -190,7 +190,19 @@ static void do_cmd(char **argv, const int argc)
 		return;
 	}
 
-	snprintf(tracking_id, sizeof(tracking_id), "%s", buf + strlen("OK TRACKING "));
+#ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION
+#pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#endif
+	/* From the check above, we know that we have exactly UUID4_LEN chars
+	 * (aka sizeof(tracking_id)) in the buf after "OK TRACKING " prefix.
+	 */
+	assert (UUID4_LEN == snprintf(tracking_id, sizeof(tracking_id), "%s", buf + strlen("OK TRACKING ")));
+#ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION
+#pragma GCC diagnostic pop
+#endif
 	time(&start);
 
 	/* send status tracking request, looping if status is PENDING */

--- a/clients/upsrw.c
+++ b/clients/upsrw.c
@@ -115,7 +115,19 @@ static void do_set(const char *varname, const char *newval)
 		return;
 	}
 
-	snprintf(tracking_id, sizeof(tracking_id), "%s", buf + strlen("OK TRACKING "));
+#ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION
+#pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#endif
+	/* From the check above, we know that we have exactly UUID4_LEN chars
+	 * (aka sizeof(tracking_id)) in the buf after "OK TRACKING " prefix.
+	 */
+	assert (UUID4_LEN == snprintf(tracking_id, sizeof(tracking_id), "%s", buf + strlen("OK TRACKING ")));
+#ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION
+#pragma GCC diagnostic pop
+#endif
 	time(&start);
 
 	/* send status tracking request, looping if status is PENDING */

--- a/drivers/bcmxcp.c
+++ b/drivers/bcmxcp.c
@@ -1183,7 +1183,7 @@ void init_config(void)
 		dstate_setinfo("output.voltage.nominal", "%u", voltage);
 
 	/* Nominal Output Frequency */
-	frequency = get_word((answer+BCMXCP_CONFIG_BLOCK_NOMINAL_OUTPUT_FREQ));
+	frequency = get_word((answer + BCMXCP_CONFIG_BLOCK_NOMINAL_OUTPUT_FREQ));
 	if (frequency != 0)
 		dstate_setinfo("output.frequency.nominal", "%u", frequency);
 
@@ -1191,6 +1191,16 @@ void init_config(void)
 	tmp = (uint16_t) *(answer + BCMXCP_CONFIG_BLOCK_BATTERY_DATA_WORD3);
 	if (tmp != 0)
 		dstate_setinfo("battery.packs", "%u", tmp);
+
+#ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION
+#pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#endif
+	/* NOTE: We intentionally limit the amount of characters picked from
+	 * "answer" into "sValue" and "sPartNumber" buffers (16 byte + NUL).
+	 */
 
 	/* UPS serial number */
 	snprintf(sValue, sizeof(sValue), "%s", answer + BCMXCP_CONFIG_BLOCK_SERIAL_NUMBER);
@@ -1201,6 +1211,9 @@ void init_config(void)
 	snprintf(sPartNumber, sizeof(sPartNumber), "%s", answer + BCMXCP_CONFIG_BLOCK_PART_NUMBER);
 	if (sPartNumber[0] != '\0')
 		dstate_setinfo("device.part", "%s", sPartNumber);
+#ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION
+#pragma GCC diagnostic pop
+#endif
 }
 
 void init_limit(void)

--- a/drivers/gamatronic.c
+++ b/drivers/gamatronic.c
@@ -215,8 +215,21 @@ static void sec_poll ( int pollflag ) {
 
 			if (sqv(q,f) > 0) {
 				if (strcmp(sec_varlist[sqv(q,f)].value, r) != 0) {
+#ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION
+#pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#endif
+					/* NOTE: We intentionally limit the amount
+					 * of characters picked from "r" buffer
+					 * into respectively sized "*.value"
+					 */
 					snprintf(sec_varlist[sqv(q,f)].value,
 						sizeof(sec_varlist[sqv(q,f)].value), "%s", r);
+#ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION
+#pragma GCC diagnostic pop
+#endif
 					sec_setinfo(sqv(q,f), r);
 				}
 

--- a/drivers/gamatronic.c
+++ b/drivers/gamatronic.c
@@ -30,6 +30,7 @@
 #include "main.h"
 #include "serial.h"
 #include "gamatronic.h"
+#include "nut_stdint.h"
 
 #define DRIVER_NAME	"Gamatronic UPS driver"
 #define DRIVER_VERSION	"0.02"
@@ -225,8 +226,18 @@ static void sec_poll ( int pollflag ) {
 					 * of characters picked from "r" buffer
 					 * into respectively sized "*.value"
 					 */
-					snprintf(sec_varlist[sqv(q,f)].value,
+					int len = snprintf(sec_varlist[sqv(q,f)].value,
 						sizeof(sec_varlist[sqv(q,f)].value), "%s", r);
+
+					if (len < 0) {
+						upsdebugx(1, "%s: got an error while extracting value", __func__);
+					}
+
+					if ((intmax_t)len > (intmax_t)sizeof(sec_varlist[sqv(q,f)].value)
+					||  (intmax_t)strnlen(r, sizeof(retbuf)) > (intmax_t)sizeof(sec_varlist[sqv(q,f)].value)
+					) {
+						upsdebugx(1, "%s: value was truncated", __func__);
+					}
 #ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION
 #pragma GCC diagnostic pop
 #endif

--- a/drivers/mge-hid.c
+++ b/drivers/mge-hid.c
@@ -1469,7 +1469,17 @@ static char *get_model_name(const char *iProduct, const char *iModel)
 		 * model name by concatenation of iProduct and iModel
 		 */
 		char	buf[SMALLBUF];
+#ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION
+#pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#endif
+		/* NOTE: We intentionally limit the amount of bytes reported */
 		snprintf(buf, sizeof(buf), "%s %s", iProduct, iModel);
+#ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION
+#pragma GCC diagnostic pop
+#endif
 		return strdup(buf);
 	}
 

--- a/drivers/mge-hid.c
+++ b/drivers/mge-hid.c
@@ -1476,7 +1476,21 @@ static char *get_model_name(const char *iProduct, const char *iModel)
 #pragma GCC diagnostic ignored "-Wformat-truncation"
 #endif
 		/* NOTE: We intentionally limit the amount of bytes reported */
-		snprintf(buf, sizeof(buf), "%s %s", iProduct, iModel);
+		int len = snprintf(buf, sizeof(buf), "%s %s", iProduct, iModel);
+
+		if (len < 0) {
+			upsdebugx(1, "%s: got an error while extracting iProduct+iModel value", __func__);
+		}
+
+		/* NOTE: SMALLBUF here comes from mge_format_model()
+		 * buffer definitions below
+		 */
+		if ((intmax_t)len > (intmax_t)sizeof(buf)
+		|| (intmax_t)(strnlen(iProduct, SMALLBUF) + strnlen(iModel, SMALLBUF) + 1 + 1)
+		    > (intmax_t)sizeof(buf)
+		) {
+			upsdebugx(1, "%s: extracted iProduct+iModel value was truncated", __func__);
+		}
 #ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION
 #pragma GCC diagnostic pop
 #endif

--- a/drivers/nutdrv_qx_masterguard.c
+++ b/drivers/nutdrv_qx_masterguard.c
@@ -356,7 +356,7 @@ static int masterguard_output_voltages(item_t *item, char *value, const size_t v
 			upsdebugx(1, "output voltages: allocating #%d failed", n);
 			return -1;
 		}
-		strncpy(masterguard_e_outvolts[n - 1].value, w, SMALLBUF);
+		strncpy(masterguard_e_outvolts[n - 1].value, w, SMALLBUF - 1);
 		masterguard_e_outvolts[n - 1].preprocess = NULL;
 	}
 	/* need to do this seperately in case the loop is run zero times */

--- a/drivers/oneac.c
+++ b/drivers/oneac.c
@@ -368,7 +368,19 @@ void upsdrv_initinfo(void)
 
 		/*UPS Model (full string)*/
 		memset(buffer2, '\0', 32);
-		strncpy(buffer2, buffer+5, 10);
+#ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION
+#pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_STRINGOP_TRUNCATION
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+#endif
+		strncpy(buffer2, buffer + 5, 10);
+#ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION
+#pragma GCC diagnostic pop
+#endif
 		for (i = 9; i >= 0 && buffer2[i] == ' '; --i)
 		{
 			buffer2[i] = '\0';
@@ -416,7 +428,19 @@ void upsdrv_initinfo(void)
 			buffer2[3]='\0';
 			i = atoi(buffer2);		/* Minimum voltage */
 
-			strncpy(buffer2, buffer+4, 3);
+#ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION
+#pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_STRINGOP_TRUNCATION
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+#endif
+			strncpy(buffer2, buffer + 4, 3);
+#ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION
+#pragma GCC diagnostic pop
+#endif
 			j = atoi(buffer2);		/* Maximum voltage */
 
 			strncpy(buffer2, buffer+8, 2);

--- a/m4/ax_c_pragmas.m4
+++ b/m4/ax_c_pragmas.m4
@@ -122,6 +122,33 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
     AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_FORMAT_SECURITY_BESIDEFUNC], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wformat-security" (outside functions)])
   ])
 
+  AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wformat-truncation"],
+    [ax_cv__pragma__gcc__diags_ignored_format_truncation],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[void func(void) {
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+}
+]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_format_truncation=yes],
+      [ax_cv__pragma__gcc__diags_ignored_format_truncation=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_format_truncation" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wformat-truncation"])
+  ])
+
+  AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wformat-truncation" (outside functions)],
+    [ax_cv__pragma__gcc__diags_ignored_format_truncation_besidefunc],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wformat-truncation"]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_format_truncation_besidefunc=yes],
+      [ax_cv__pragma__gcc__diags_ignored_format_truncation_besidefunc=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_format_truncation_besidefunc" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION_BESIDEFUNC], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wformat-truncation" (outside functions)])
+  ])
+
   AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wtype-limits"],
     [ax_cv__pragma__gcc__diags_ignored_type_limits],
     [AC_COMPILE_IFELSE(
@@ -540,6 +567,9 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
     AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_format_security" = "yes" || test "$ax_cv__pragma__gcc__diags_ignored_format_nonliteral" = "yes" ],[
         AC_DEFINE([HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_NONLITERAL], 1, [define if your compiler has pragmas for GCC diagnostic ignored "-Wformat-nonliteral" or "-Wformat-security" and for push-pop support])
     ])
+    AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_format_truncation" = "yes" ],[
+        AC_DEFINE([HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION], 1, [define if your compiler has pragmas for GCC diagnostic ignored "-Wformat-truncation" and for push-pop support])
+    ])
     AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_unreachable_code" = "yes" || test "$ax_cv__pragma__gcc__diags_ignored_unreachable_code_break" = "yes" ],[
         AC_DEFINE([HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE], 1, [define if your compiler has pragmas for GCC diagnostic ignored "-Wunreachable-code(-break)" and for push-pop support])
     ])
@@ -551,6 +581,9 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
   AS_IF([test "$ax_cv__pragma__gcc__diags_push_pop_besidefunc" = "yes"],[
     AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_format_security" = "yes" || test "$ax_cv__pragma__gcc__diags_ignored_format_nonliteral" = "yes" ],[
         AC_DEFINE([HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_NONLITERAL_BESIDEFUNC], 1, [define if your compiler has pragmas for GCC diagnostic ignored "-Wformat-nonliteral" or "-Wformat-security" and for push-pop support (outside function bodies)])
+    ])
+    AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_format_truncation" = "yes" ],[
+        AC_DEFINE([HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION_BESIDEFUNC], 1, [define if your compiler has pragmas for GCC diagnostic ignored "-Wformat-truncation" and for push-pop support (outside function bodies)])
     ])
     AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_unreachable_code" = "yes" || test "$ax_cv__pragma__gcc__diags_ignored_unreachable_code_break" = "yes" ],[
         AC_DEFINE([HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE_BESIDEFUNC], 1, [define if your compiler has pragmas for GCC diagnostic ignored "-Wunreachable-code(-break)" and for push-pop support (outside function bodies)])

--- a/m4/ax_c_pragmas.m4
+++ b/m4/ax_c_pragmas.m4
@@ -149,6 +149,33 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
     AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION_BESIDEFUNC], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wformat-truncation" (outside functions)])
   ])
 
+  AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wstringop-truncation"],
+    [ax_cv__pragma__gcc__diags_ignored_stringop_truncation],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[void func(void) {
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+}
+]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_stringop_truncation=yes],
+      [ax_cv__pragma__gcc__diags_ignored_stringop_truncation=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_stringop_truncation" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_STRINGOP_TRUNCATION], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wstringop-truncation"])
+  ])
+
+  AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wstringop-truncation" (outside functions)],
+    [ax_cv__pragma__gcc__diags_ignored_stringop_truncation_besidefunc],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wstringop-truncation"]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_stringop_truncation_besidefunc=yes],
+      [ax_cv__pragma__gcc__diags_ignored_stringop_truncation_besidefunc=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_stringop_truncation_besidefunc" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_STRINGOP_TRUNCATION_BESIDEFUNC], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wstringop-truncation" (outside functions)])
+  ])
+
   AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wtype-limits"],
     [ax_cv__pragma__gcc__diags_ignored_type_limits],
     [AC_COMPILE_IFELSE(
@@ -567,8 +594,8 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
     AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_format_security" = "yes" || test "$ax_cv__pragma__gcc__diags_ignored_format_nonliteral" = "yes" ],[
         AC_DEFINE([HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_NONLITERAL], 1, [define if your compiler has pragmas for GCC diagnostic ignored "-Wformat-nonliteral" or "-Wformat-security" and for push-pop support])
     ])
-    AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_format_truncation" = "yes" ],[
-        AC_DEFINE([HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION], 1, [define if your compiler has pragmas for GCC diagnostic ignored "-Wformat-truncation" and for push-pop support])
+    AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_format_truncation" = "yes" || test "$ax_cv__pragma__gcc__diags_ignored_stringop_truncation" = "yes" ],[
+        AC_DEFINE([HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION], 1, [define if your compiler has pragmas for GCC diagnostic ignored "-Wformat-truncation" or "-Werror=stringop-truncation" and for push-pop support])
     ])
     AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_unreachable_code" = "yes" || test "$ax_cv__pragma__gcc__diags_ignored_unreachable_code_break" = "yes" ],[
         AC_DEFINE([HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE], 1, [define if your compiler has pragmas for GCC diagnostic ignored "-Wunreachable-code(-break)" and for push-pop support])
@@ -582,8 +609,8 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
     AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_format_security" = "yes" || test "$ax_cv__pragma__gcc__diags_ignored_format_nonliteral" = "yes" ],[
         AC_DEFINE([HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_NONLITERAL_BESIDEFUNC], 1, [define if your compiler has pragmas for GCC diagnostic ignored "-Wformat-nonliteral" or "-Wformat-security" and for push-pop support (outside function bodies)])
     ])
-    AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_format_truncation" = "yes" ],[
-        AC_DEFINE([HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION_BESIDEFUNC], 1, [define if your compiler has pragmas for GCC diagnostic ignored "-Wformat-truncation" and for push-pop support (outside function bodies)])
+    AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_format_truncation" = "yes" || test "$ax_cv__pragma__gcc__diags_ignored_stringop_truncation" = "yes" ],[
+        AC_DEFINE([HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION_BESIDEFUNC], 1, [define if your compiler has pragmas for GCC diagnostic ignored "-Wformat-truncation" or "-Werror=stringop-truncation" and for push-pop support (outside function bodies)])
     ])
     AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_unreachable_code" = "yes" || test "$ax_cv__pragma__gcc__diags_ignored_unreachable_code_break" = "yes" ],[
         AC_DEFINE([HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE_BESIDEFUNC], 1, [define if your compiler has pragmas for GCC diagnostic ignored "-Wunreachable-code(-break)" and for push-pop support (outside function bodies)])


### PR DESCRIPTION
Follows up from #823 "fightwarn" effort to revise the warnings about string format truncation (printing from a buffer potentially too large for the destination to hold) and address accordingly:
* increase the destination,
* reduce the limit of copy/print size,
* ignore the warning by pragmas where tested or "assumed" safe (e.g. if "vendor + model" exceed 512*2 chars, we have some other problem), or dictated by protocol layout ("these 16 bytes from the message buffer are...")