### PR TITLE
Improve nut-scanner threadcount limitation with semaphore processing from 42ity fork

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -193,6 +193,28 @@ getrlimit(RLIMIT_NOFILE, &limit);
     )]
 )
 
+AC_CHECK_HEADER([semaphore.h],
+    [AC_DEFINE([HAVE_SEMAPHORE_H], [1],
+        [Define to 1 if you have <sys/semaphore.h>.])
+     AC_MSG_CHECKING([for sem_t, sem_init() and sem_destroy()])
+     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+#include <semaphore.h>
+],
+[sem_t semaphore;
+sem_init(&semaphore, 0, 4);
+sem_destroy(&semaphore);
+/* Do not care about actual return value in this test,
+ * normally check for non-zero meaning to look in errno */
+]
+    )],
+        [AC_DEFINE([HAVE_SEMAPHORE], [1],
+            [Define to 1 if you have <sys/semaphore.h> with usable sem_t sem_init() and sem_destroy().])
+         AC_MSG_RESULT([ok])
+        ],
+        [AC_MSG_RESULT([no])]
+    )]
+)
+
 AC_CHECK_FUNCS(cfsetispeed tcsendbreak)
 AC_CHECK_FUNCS(seteuid setsid getpassphrase)
 AC_CHECK_FUNCS(on_exit strptime setlogmask)

--- a/tools/nut-scanner/Makefile.am
+++ b/tools/nut-scanner/Makefile.am
@@ -72,7 +72,7 @@ libnutscan_la_LDFLAGS = $(SERLIBS) -version-info 1:0:0
 # copies of "nut_debug_level" making fun of our debug-logging attempts.
 # One solution to tackle if needed for those cases would be to make some
 # dynamic/shared libnutcommon (etc.)
-libnutscan_la_LDFLAGS += -export-symbols-regex '^(nutscan_|nut_debug_level|s_upsdebugx)'
+libnutscan_la_LDFLAGS += -export-symbols-regex '^(nutscan_|nut_debug_level|s_upsdebugx|max_threads|curr_threads)'
 libnutscan_la_CFLAGS = -I$(top_srcdir)/clients -I$(top_srcdir)/include $(LIBLTDL_CFLAGS) -I$(top_srcdir)/drivers
 
 nut_scanner_SOURCES = nut-scanner.c

--- a/tools/nut-scanner/README
+++ b/tools/nut-scanner/README
@@ -38,6 +38,8 @@ iteration function to display results:
 		nutscan_options_t * opt;
 		nutscan_device_t *device;
 
+		nutscan-init();
+
 		if ((device = nutscan_scan_usb()) == NULL) {
 			printf("No device found\n");
 			exit(EXIT_FAILURE);

--- a/tools/nut-scanner/nut-scan.h
+++ b/tools/nut-scanner/nut-scan.h
@@ -44,15 +44,21 @@
 
 #ifdef HAVE_PTHREAD
 # include <pthread.h>
-# ifdef HAVE_PTHREAD_TRYJOIN
+
+# ifdef HAVE_SEMAPHORE
+#  include <semaphore.h>
+# endif
+
+# if (defined HAVE_PTHREAD_TRYJOIN) || (defined HAVE_SEMAPHORE)
 extern size_t max_threads, curr_threads, max_threads_netxml, max_threads_oldnut, max_threads_netsnmp;
 extern pthread_mutex_t threadcount_mutex;
 # endif
+
 typedef struct nutscan_thread {
 	pthread_t	thread;
 	int		active;	/* true if the thread was created, false if joined (to not join twice) */
 } nutscan_thread_t;
-#endif
+#endif /* HAVE_PTHREAD */
 
 #ifdef __cplusplus
 /* *INDENT-OFF* */
@@ -126,6 +132,13 @@ nutscan_device_t * nutscan_scan_avahi(long usec_timeout);
 nutscan_device_t * nutscan_scan_ipmi(const char * startIP, const char * stopIP, nutscan_ipmi_t * sec);
 
 nutscan_device_t * nutscan_scan_eaton_serial(const char* ports_list);
+
+#ifdef HAVE_PTHREAD
+# ifdef HAVE_SEMAPHORE
+extern sem_t semaphore;
+sem_t * nutscan_semaphore();
+# endif
+#endif
 
 /* Display functions */
 void nutscan_display_ups_conf(nutscan_device_t * device);

--- a/tools/nut-scanner/nut-scan.h
+++ b/tools/nut-scanner/nut-scan.h
@@ -51,6 +51,9 @@
 
 # if (defined HAVE_PTHREAD_TRYJOIN) || (defined HAVE_SEMAPHORE)
 extern size_t max_threads, curr_threads, max_threads_netxml, max_threads_oldnut, max_threads_netsnmp;
+# endif
+
+# ifdef HAVE_PTHREAD_TRYJOIN
 extern pthread_mutex_t threadcount_mutex;
 # endif
 

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -56,6 +56,8 @@
 
 #include "nut-scan.h"
 
+#define DEFAULT_TIMEOUT 5
+
 #define ERR_BAD_OPTION	(-1)
 
 static const char optstring[] = "?ht:T:s:e:E:c:l:u:W:X:w:x:p:b:B:d:L:CUSMOAm:NPqIVaD";
@@ -110,44 +112,6 @@ static char * serial_ports = NULL;
 
 #ifdef HAVE_PTHREAD
 static pthread_t thread[TYPE_END];
-
-# ifdef HAVE_SEMAPHORE
-sem_t semaphore;
-
-sem_t * nutscan_semaphore() {
-    return &semaphore;
-}
-# endif
-
-# ifdef HAVE_PTHREAD_TRYJOIN
-pthread_mutex_t threadcount_mutex;
-# endif
-
-# if (defined HAVE_PTHREAD_TRYJOIN) || (defined HAVE_SEMAPHORE)
-/* We have 3 networked scan types: nut, snmp, xml,
- * and users typically give their /24 subnet as "-m" arg.
- * With some systems having a 1024 default (u)limit to
- * file descriptors, this should fit if those are involved.
- * On some systems tested, a large amount of not-joined
- * pthreads did cause various crashes; also RAM is limited.
- * Note that each scan may be time consuming to query an
- * IP address and wait for (no) reply, so while these threads
- * are usually not resource-intensive (nor computationally),
- * they spend much wallclock time each so parallelism helps.
- */
-size_t max_threads = 1024;
-size_t curr_threads = 0;
-
-size_t max_threads_netxml = 1021; /* experimental finding, see PR#1158 */
-size_t max_threads_oldnut = 1021;
-size_t max_threads_netsnmp = 0; // 10240;
-	/* per reports in PR#1158, some versions of net-snmp could be limited
-	 * to 1024 threads in the past; this was not found in practice.
-	 * Still, some practical limit can be useful (configurable?)
-	 * Here 0 means to not apply any special limit (beside max_threads).
-	 */
-
-# endif  /* HAVE_PTHREAD_TRYJOIN || HAVE_SEMAPHORE */
 
 static void * run_usb(void *arg)
 {
@@ -627,7 +591,12 @@ display_help:
  * if-else proposition? At least when initializing?
  */
 # ifdef HAVE_SEMAPHORE
-	sem_init(&semaphore, 0, max_threads);
+	/* FIXME: Currently sem_init already done on nutscan-init for lib need.
+	   We need to destroy it before re-init. We currently can't change "sem value"
+	   on lib (need to be thread safe). */
+	sem_t *current_sem = nutscan_semaphore();
+	sem_destroy(current_sem);
+	sem_init(current_sem, 0, max_threads);
 /* # else */
 # endif
 

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -586,10 +586,6 @@ display_help:
 	}
 
 #ifdef HAVE_PTHREAD
-/* TOTHINK: Should semaphores to limit thread count
- * and the more naive but portable methods be an
- * if-else proposition? At least when initializing?
- */
 # ifdef HAVE_SEMAPHORE
 	/* FIXME: Currently sem_init already done on nutscan-init for lib need.
 	   We need to destroy it before re-init. We currently can't change "sem value"
@@ -597,13 +593,7 @@ display_help:
 	sem_t *current_sem = nutscan_semaphore();
 	sem_destroy(current_sem);
 	sem_init(current_sem, 0, max_threads);
-/* # else */
 # endif
-
-#  ifdef HAVE_PTHREAD_TRYJOIN
-	pthread_mutex_init(&threadcount_mutex, NULL);
-#  endif
-/* # endif */
 #endif /* HAVE_PTHREAD */
 
 	if (cidr) {
@@ -825,12 +815,8 @@ display_help:
 	nutscan_free_device(dev[TYPE_EATON_SERIAL]);
 
 #ifdef HAVE_PTHREAD
-/* TOTHINK: See comments near mutex/semaphore init code above */
 # ifdef HAVE_SEMAPHORE
-# endif
-
-# ifdef HAVE_PTHREAD_TRYJOIN
-	pthread_mutex_destroy(&threadcount_mutex);
+	sem_destroy(nutscan_semaphore());
 # endif
 #endif
 

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -35,32 +35,11 @@
 
 #ifdef HAVE_PTHREAD
 # include <pthread.h>
-# ifdef HAVE_PTHREAD_TRYJOIN
+# ifdef HAVE_SEMAPHORE
+#  include <semaphore.h>
+# endif
+# if (defined HAVE_PTHREAD_TRYJOIN) || (defined HAVE_SEMAPHORE)
 #  include "nut_stdint.h"
-pthread_mutex_t threadcount_mutex;
-/* We have 3 networked scan types: nut, snmp, xml,
- * and users typically give their /24 subnet as "-m" arg.
- * With some systems having a 1024 default (u)limit to
- * file descriptors, this should fit if those are involved.
- * On some systems tested, a large amount of not-joined
- * pthreads did cause various crashes; also RAM is limited.
- * Note that each scan may be time consuming to query an
- * IP address and wait for (no) reply, so while these threads
- * are usually not resource-intensive (nor computationally),
- * they spend much wallclock time each so parallelism helps.
- */
-size_t max_threads = 1024;
-size_t curr_threads = 0;
-
-size_t max_threads_netxml = 1021; /* experimental finding, see PR#1158 */
-size_t max_threads_oldnut = 1021;
-size_t max_threads_netsnmp = 0; // 10240;
-	/* per reports in PR#1158, some versions of net-snmp could be limited
-	 * to 1024 threads in the past; this was not found in practice.
-	 * Still, some practical limit can be useful (configurable?)
-	 * Here 0 means to not apply any special limit (beside max_threads).
-	 */
-
 #  ifdef HAVE_SYS_RESOURCE_H
 #   include <sys/resource.h> /* for getrlimit() and struct rlimit */
 #   include <errno.h>
@@ -71,9 +50,9 @@ size_t max_threads_netsnmp = 0; // 10240;
  * and probably means the usual stdin/stdout/stderr triplet
  */
 #   define RESERVE_FD_COUNT 3
-#  endif
-# endif
-#endif
+#  endif /* HAVE_SYS_RESOURCE_H */
+# endif  /* HAVE_PTHREAD_TRYJOIN || HAVE_SEMAPHORE */
+#endif   /* HAVE_PTHREAD */
 
 #include "nut-scan.h"
 
@@ -131,6 +110,44 @@ static char * serial_ports = NULL;
 
 #ifdef HAVE_PTHREAD
 static pthread_t thread[TYPE_END];
+
+# ifdef HAVE_SEMAPHORE
+sem_t semaphore;
+
+sem_t * nutscan_semaphore() {
+    return &semaphore;
+}
+# endif
+
+# ifdef HAVE_PTHREAD_TRYJOIN
+pthread_mutex_t threadcount_mutex;
+# endif
+
+# if (defined HAVE_PTHREAD_TRYJOIN) || (defined HAVE_SEMAPHORE)
+/* We have 3 networked scan types: nut, snmp, xml,
+ * and users typically give their /24 subnet as "-m" arg.
+ * With some systems having a 1024 default (u)limit to
+ * file descriptors, this should fit if those are involved.
+ * On some systems tested, a large amount of not-joined
+ * pthreads did cause various crashes; also RAM is limited.
+ * Note that each scan may be time consuming to query an
+ * IP address and wait for (no) reply, so while these threads
+ * are usually not resource-intensive (nor computationally),
+ * they spend much wallclock time each so parallelism helps.
+ */
+size_t max_threads = 1024;
+size_t curr_threads = 0;
+
+size_t max_threads_netxml = 1021; /* experimental finding, see PR#1158 */
+size_t max_threads_oldnut = 1021;
+size_t max_threads_netsnmp = 0; // 10240;
+	/* per reports in PR#1158, some versions of net-snmp could be limited
+	 * to 1024 threads in the past; this was not found in practice.
+	 * Still, some practical limit can be useful (configurable?)
+	 * Here 0 means to not apply any special limit (beside max_threads).
+	 */
+
+# endif  /* HAVE_PTHREAD_TRYJOIN || HAVE_SEMAPHORE */
 
 static void * run_usb(void *arg)
 {
@@ -282,7 +299,7 @@ int main(int argc, char *argv[])
 	int quiet = 0; /* The debugging level for certain upsdebugx() progress messages; 0 = print always, quiet==1 is to require at least one -D */
 	void (*display_func)(nutscan_device_t * device);
 	int ret_code = EXIT_SUCCESS;
-#if (defined HAVE_PTHREAD) && (defined HAVE_PTHREAD_TRYJOIN) && (defined HAVE_SYS_RESOURCE_H)
+#if (defined HAVE_PTHREAD) && ( (defined HAVE_PTHREAD_TRYJOIN) || (defined HAVE_SEMAPHORE) ) && (defined HAVE_SYS_RESOURCE_H)
 	struct rlimit nofile_limit;
 
 	/* Limit the max scanning thread count by the amount of allowed open
@@ -311,7 +328,7 @@ int main(int argc, char *argv[])
 			}
 		}
 	}
-#endif // HAVE_PTHREAD && HAVE_PTHREAD_TRYJOIN && HAVE_SYS_RESOURCE_H
+#endif /* HAVE_PTHREAD && ( HAVE_PTHREAD_TRYJOIN || HAVE_SEMAPHORE ) && HAVE_SYS_RESOURCE_H */
 
 	memset(&snmp_sec, 0, sizeof(snmp_sec));
 	memset(&ipmi_sec, 0, sizeof(ipmi_sec));
@@ -475,7 +492,7 @@ int main(int argc, char *argv[])
 				port = strdup(optarg);
 				break;
 			case 'T': {
-#if (defined HAVE_PTHREAD) && (defined HAVE_PTHREAD_TRYJOIN)
+#if (defined HAVE_PTHREAD) && ( (defined HAVE_PTHREAD_TRYJOIN) || (defined HAVE_SEMAPHORE) )
 				char* endptr;
 				long val = strtol(optarg, &endptr, 10);
 				/* With endptr we check that no chars were left in optarg
@@ -524,7 +541,7 @@ int main(int argc, char *argv[])
 				fprintf(stderr,
 					"WARNING: Max scanning thread count option "
 					"is not supported in this build, ignored\n");
-#endif
+#endif /* HAVE_PTHREAD && ways to limit the thread count */
 				}
 				break;
 			case 'C':
@@ -604,9 +621,21 @@ display_help:
 		}
 	}
 
-#if (defined HAVE_PTHREAD) && (defined HAVE_PTHREAD_TRYJOIN)
+#ifdef HAVE_PTHREAD
+/* TOTHINK: Should semaphores to limit thread count
+ * and the more naive but portable methods be an
+ * if-else proposition? At least when initializing?
+ */
+# ifdef HAVE_SEMAPHORE
+	sem_init(&semaphore, 0, max_threads);
+/* # else */
+# endif
+
+#  ifdef HAVE_PTHREAD_TRYJOIN
 	pthread_mutex_init(&threadcount_mutex, NULL);
-#endif
+#  endif
+/* # endif */
+#endif /* HAVE_PTHREAD */
 
 	if (cidr) {
 		upsdebugx(1, "Processing CIDR net/mask: %s", cidr);
@@ -826,8 +855,14 @@ display_help:
 	upsdebugx(1, "SCANS DONE: free resources: SERIAL");
 	nutscan_free_device(dev[TYPE_EATON_SERIAL]);
 
-#if (defined HAVE_PTHREAD) && (defined HAVE_PTHREAD_TRYJOIN)
+#ifdef HAVE_PTHREAD
+/* TOTHINK: See comments near mutex/semaphore init code above */
+# ifdef HAVE_SEMAPHORE
+# endif
+
+# ifdef HAVE_PTHREAD_TRYJOIN
 	pthread_mutex_destroy(&threadcount_mutex);
+# endif
 #endif
 
 	upsdebugx(1, "SCANS DONE: free common scanner resources");

--- a/tools/nut-scanner/nutscan-init.c
+++ b/tools/nut-scanner/nutscan-init.c
@@ -88,10 +88,19 @@ size_t max_threads_netsnmp = 0; // 10240;
 void nutscan_init(void)
 {
 #ifdef HAVE_PTHREAD
+/* TOTHINK: Should semaphores to limit thread count
+ * and the more naive but portable methods be an
+ * if-else proposition? At least when initializing?
+ */
 # ifdef HAVE_SEMAPHORE
 	sem_init(&semaphore, 0, max_threads);
 # endif
-#endif
+
+# ifdef HAVE_PTHREAD_TRYJOIN
+	pthread_mutex_init(&threadcount_mutex, NULL);
+# endif
+#endif /* HAVE_PTHREAD */
+
 	char *libname = NULL;
 #ifdef WITH_USB
 	libname = get_libname("libusb-0.1.so");
@@ -162,4 +171,16 @@ void nutscan_free(void)
 	if (nutscan_avail_nut) {
 		lt_dlexit();
 	}
+
+#ifdef HAVE_PTHREAD
+/* TOTHINK: See comments near mutex/semaphore init code above */
+# ifdef HAVE_SEMAPHORE
+	sem_destroy(nutscan_semaphore());
+# endif
+
+# ifdef HAVE_PTHREAD_TRYJOIN
+	pthread_mutex_destroy(&threadcount_mutex);
+# endif
+#endif
+
 }

--- a/tools/nut-scanner/nutscan-init.h
+++ b/tools/nut-scanner/nutscan-init.h
@@ -40,6 +40,8 @@ extern int nutscan_avail_xml_http;
 void nutscan_init(void);
 void nutscan_free(void);
 
+#define DEFAULT_THREAD  512
+
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 }

--- a/tools/nut-scanner/scan_eaton_serial.c
+++ b/tools/nut-scanner/scan_eaton_serial.c
@@ -558,6 +558,9 @@ nutscan_device_t * nutscan_scan_eaton_serial(const char* ports_range)
 # ifdef HAVE_SEMAPHORE
 			/* Wait for all current scans to complete */
 			if (thread_array != NULL) {
+				upsdebugx (2, "%s: Running too many scanning threads, "
+					"waiting until older ones would finish",
+					__func__);
 				for (i = 0; i < thread_count ; i++) {
 					int ret;
 					if (!thread_array[i].active) {

--- a/tools/nut-scanner/scan_eaton_serial.c
+++ b/tools/nut-scanner/scan_eaton_serial.c
@@ -606,7 +606,10 @@ nutscan_device_t * nutscan_scan_eaton_serial(const char* ports_range)
 					__func__, ret);
 			}
 			thread_array[i].active = FALSE;
-# ifdef HAVE_PTHREAD_TRYJOIN
+# ifdef HAVE_SEMAPHORE
+			sem_post(semaphore);
+# else
+#  ifdef HAVE_PTHREAD_TRYJOIN
 			pthread_mutex_lock(&threadcount_mutex);
 			if (curr_threads > 0) {
 				curr_threads --;
@@ -617,7 +620,8 @@ nutscan_device_t * nutscan_scan_eaton_serial(const char* ports_range)
 					"says we are already at 0", __func__);
 			}
 			pthread_mutex_unlock(&threadcount_mutex);
-# endif /* HAVE_PTHREAD_TRYJOIN */
+#  endif /* HAVE_PTHREAD_TRYJOIN */
+# endif /* HAVE_SEMAPHORE */
 		}
 		free(thread_array);
 		upsdebugx(2, "%s: all threads freed", __func__);

--- a/tools/nut-scanner/scan_eaton_serial.c
+++ b/tools/nut-scanner/scan_eaton_serial.c
@@ -391,6 +391,7 @@ static void * nutscan_scan_eaton_serial_device(void * port_arg)
 
 nutscan_device_t * nutscan_scan_eaton_serial(const char* ports_range)
 {
+	bool_t pass = TRUE; /* Track that we may spawn a scanning thread */
 	struct sigaction oldact;
 	int change_action_handler = 0;
 	char *current_port_name = NULL;
@@ -398,12 +399,15 @@ nutscan_device_t * nutscan_scan_eaton_serial(const char* ports_range)
 	int  current_port_nb;
 	int i;
 #ifdef HAVE_PTHREAD
+# ifdef HAVE_SEMAPHORE
+	sem_t * semaphore = nutscan_semaphore();
+# endif
 	pthread_t thread;
 	nutscan_thread_t * thread_array = NULL;
 	int thread_count = 0;
 
 	pthread_mutex_init(&dev_mutex, NULL);
-#endif // HAVE_PTHREAD
+#endif /* HAVE_PTHREAD */
 
 	/* 1) Get ports_list */
 	serial_ports_list = nutscan_get_serial_ports_list(ports_range);
@@ -429,15 +433,33 @@ nutscan_device_t * nutscan_scan_eaton_serial(const char* ports_range)
 	/* port(s) iterator */
 	current_port_nb = 0;
 	while (serial_ports_list[current_port_nb] != NULL) {
-		current_port_name = serial_ports_list[current_port_nb];
-
 #ifdef HAVE_PTHREAD
-# ifdef HAVE_PTHREAD_TRYJOIN
 		/* NOTE: With many enough targets to scan, this can crash
 		 * by spawning too many children; add a limit and loop to
 		 * "reap" some already done with their work. And probably
 		 * account them in thread_array[] as something to not wait
 		 * for below in pthread_join()...
+		 */
+
+# ifdef HAVE_SEMAPHORE
+		/* Just wait for someone to free a semaphored slot,
+		 * if none are available, and then/otherwise grab one
+		 */
+		if (thread_array == NULL) {
+			/* Starting point, or after a wait to complete
+			 * all earlier runners */
+			sem_wait(semaphore);
+			pass = TRUE;
+		} else {
+			pass = (sem_trywait(semaphore) == 0);
+		}
+# else
+#  ifdef HAVE_PTHREAD_TRYJOIN
+		/* A somewhat naive and brute-force solution for
+		 * systems without a semaphore.h. This may suffer
+		 * some off-by-one errors, using a few more threads
+		 * than intended (if we race a bit at the wrong time,
+		 * probably up to one per enabled scanner routine).
 		 */
 
 		/* TOTHINK: Should there be a threadcount_mutex when
@@ -494,36 +516,78 @@ nutscan_device_t * nutscan_scan_eaton_serial(const char* ports_range)
 			}
 			upsdebugx(2, "%s: proceeding with scan", __func__);
 		}
-# endif // HAVE_PTHREAD_TRYJOIN
+		/* NOTE: No change to default "pass" in this ifdef:
+		 * if we got to this line, we have a slot to use */
+#  endif /* HAVE_PTHREAD_TRYJOIN */
+# endif  /* HAVE_SEMAPHORE */
+#endif   /* HAVE_PTHREAD */
 
-		if (pthread_create(&thread, NULL, nutscan_scan_eaton_serial_device, (void*)current_port_name) == 0) {
+		if (pass) {
+			current_port_name = serial_ports_list[current_port_nb];
+
+#ifdef HAVE_PTHREAD
+			if (pthread_create(&thread, NULL, nutscan_scan_eaton_serial_device, (void*)current_port_name) == 0) {
 # ifdef HAVE_PTHREAD_TRYJOIN
-			pthread_mutex_lock(&threadcount_mutex);
-			curr_threads++;
-# endif // HAVE_PTHREAD_TRYJOIN
+				pthread_mutex_lock(&threadcount_mutex);
+				curr_threads++;
+# endif /* HAVE_PTHREAD_TRYJOIN */
 
-			thread_count++;
-			nutscan_thread_t *new_thread_array = realloc(thread_array,
-				thread_count * sizeof(nutscan_thread_t));
-			if (new_thread_array == NULL) {
-				upsdebugx(1, "%s: Failed to realloc thread array", __func__);
-				break;
-			}
-			else {
-				thread_array = new_thread_array;
-			}
-			thread_array[thread_count - 1].thread = thread;
-			thread_array[thread_count - 1].active = TRUE;
+				thread_count++;
+				nutscan_thread_t *new_thread_array = realloc(thread_array,
+					thread_count * sizeof(nutscan_thread_t));
+				if (new_thread_array == NULL) {
+					upsdebugx(1, "%s: Failed to realloc thread array", __func__);
+					break;
+				}
+				else {
+					thread_array = new_thread_array;
+				}
+				thread_array[thread_count - 1].thread = thread;
+				thread_array[thread_count - 1].active = TRUE;
 
 # ifdef HAVE_PTHREAD_TRYJOIN
-			pthread_mutex_unlock(&threadcount_mutex);
-# endif // HAVE_PTHREAD_TRYJOIN
-		}
-#else // not HAVE_PTHREAD
-		nutscan_scan_eaton_serial_device(current_port_name);
-#endif // if HAVE_PTHREAD
-		current_port_nb++;
-	}
+				pthread_mutex_unlock(&threadcount_mutex);
+# endif /* HAVE_PTHREAD_TRYJOIN */
+			}
+#else   /* if not HAVE_PTHREAD */
+			nutscan_scan_eaton_serial_device(current_port_name);
+#endif  /* if HAVE_PTHREAD */
+			current_port_nb++;
+		} else { /* if not pass -- all slots busy */
+#ifdef HAVE_PTHREAD
+# ifdef HAVE_SEMAPHORE
+			/* Wait for all current scans to complete */
+			if (thread_array != NULL) {
+				for (i = 0; i < thread_count ; i++) {
+					int ret;
+					if (!thread_array[i].active) {
+						/* Probably should not get here,
+						 * but handle it just in case */
+						upsdebugx(0, "WARNING: %s: Midway clean-up: did not expect thread %i to be not active",
+							__func__, i);
+						sem_post(semaphore);
+						continue;
+					}
+					thread_array[i].active = FALSE;
+					ret = pthread_join(thread_array[i].thread, NULL);
+					if (ret != 0) {
+						upsdebugx(0, "WARNING: %s: Midway clean-up: pthread_join() returned code %i",
+							__func__, ret);
+					}
+					sem_post(semaphore);
+				}
+				thread_count = 0;
+				free(thread_array);
+				thread_array = NULL;
+			}
+# else
+#  ifdef HAVE_PTHREAD_TRYJOIN
+			/* TODO: Move the wait-loop for TRYJOIN here? */
+#  endif /* HAVE_PTHREAD_TRYJOIN */
+# endif  /* HAVE_SEMAPHORE */
+#endif   /* HAVE_PTHREAD */
+		} /* if: could we "pass" or not? */
+	} /* while */
 
 #ifdef HAVE_PTHREAD
 	if (thread_array != NULL) {
@@ -550,13 +614,13 @@ nutscan_device_t * nutscan_scan_eaton_serial(const char* ports_range)
 					"says we are already at 0", __func__);
 			}
 			pthread_mutex_unlock(&threadcount_mutex);
-# endif // HAVE_PTHREAD_TRYJOIN
+# endif /* HAVE_PTHREAD_TRYJOIN */
 		}
 		free(thread_array);
 		upsdebugx(2, "%s: all threads freed", __func__);
 	}
 	pthread_mutex_destroy(&dev_mutex);
-#endif // HAVE_PTHREAD
+#endif /* HAVE_PTHREAD */
 
 	if (change_action_handler) {
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_STRICT_PROTOTYPES)

--- a/tools/nut-scanner/scan_nut.c
+++ b/tools/nut-scanner/scan_nut.c
@@ -472,7 +472,12 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 					__func__, ret);
 			}
 			thread_array[i].active = FALSE;
-# ifdef HAVE_PTHREAD_TRYJOIN
+# ifdef HAVE_SEMAPHORE
+			sem_post(semaphore);
+			if (max_threads_scantype > 0)
+				sem_post(semaphore_scantype);
+# else
+#  ifdef HAVE_PTHREAD_TRYJOIN
 			pthread_mutex_lock(&threadcount_mutex);
 			if (curr_threads > 0) {
 				curr_threads --;
@@ -483,7 +488,8 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 					"says we are already at 0", __func__);
 			}
 			pthread_mutex_unlock(&threadcount_mutex);
-# endif /* HAVE_PTHREAD_TRYJOIN */
+#  endif /* HAVE_PTHREAD_TRYJOIN */
+# endif /* HAVE_SEMAPHORE */
 		}
 		free(thread_array);
 		upsdebugx(2, "%s: all threads freed", __func__);

--- a/tools/nut-scanner/scan_nut.c
+++ b/tools/nut-scanner/scan_nut.c
@@ -214,6 +214,7 @@ static void * list_nut_devices(void * arg)
 
 nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, const char* port, long usec_timeout)
 {
+	bool_t pass = TRUE; /* Track that we may spawn a scanning thread */
 	nutscan_ip_iter_t ip;
 	char * ip_str = NULL;
 	char * ip_dest = NULL;
@@ -223,12 +224,24 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 	int i;
 	struct scan_nut_arg *nut_arg;
 #ifdef HAVE_PTHREAD
+# ifdef HAVE_SEMAPHORE
+	sem_t * semaphore = nutscan_semaphore();
+	sem_t   semaphore_scantype_inst;
+	sem_t * semaphore_scantype = &semaphore_scantype_inst;
+# endif /* HAVE_SEMAPHORE */
 	pthread_t thread;
 	nutscan_thread_t * thread_array = NULL;
 	int thread_count = 0;
+	size_t  max_threads_scantype = max_threads_oldnut;
 
 	pthread_mutex_init(&dev_mutex, NULL);
-#endif // HAVE_PTHREAD
+
+# ifdef HAVE_SEMAPHORE
+	if (max_threads_scantype > 0)
+		sem_init(semaphore_scantype, 0, max_threads_scantype);
+# endif /* HAVE_SEMAPHORE */
+
+#endif /* HAVE_PTHREAD */
 
 	if (!nutscan_avail_nut) {
 		return NULL;
@@ -251,36 +264,37 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 
 	ip_str = nutscan_ip_iter_init(&ip, startIP, stopIP);
 
-	while (ip_str != NULL)
-	{
-		if (port) {
-			if (ip.type == IPv4) {
-				snprintf(buf, sizeof(buf), "%s:%s", ip_str, port);
-			}
-			else {
-				snprintf(buf, sizeof(buf), "[%s]:%s", ip_str, port);
-			}
-
-			ip_dest = strdup(buf);
-		}
-		else {
-			ip_dest = strdup(ip_str);
-		}
-
-		if ((nut_arg = malloc(sizeof(struct scan_nut_arg))) == NULL) {
-			free(ip_dest);
-			break;
-		}
-
-		nut_arg->timeout = usec_timeout;
-		nut_arg->hostname = ip_dest;
+	while (ip_str != NULL) {
 #ifdef HAVE_PTHREAD
-# ifdef HAVE_PTHREAD_TRYJOIN
 		/* NOTE: With many enough targets to scan, this can crash
 		 * by spawning too many children; add a limit and loop to
 		 * "reap" some already done with their work. And probably
 		 * account them in thread_array[] as something to not wait
 		 * for below in pthread_join()...
+		 */
+
+# ifdef HAVE_SEMAPHORE
+		/* Just wait for someone to free a semaphored slot,
+		 * if none are available, and then/otherwise grab one
+		 */
+		if (thread_array == NULL) {
+			/* Starting point, or after a wait to complete
+			 * all earlier runners */
+			if (max_threads_scantype > 0)
+				sem_wait(semaphore_scantype);
+			sem_wait(semaphore);
+			pass = TRUE;
+		} else {
+			pass = ((max_threads_scantype == 0 || sem_trywait(semaphore_scantype) == 0) &&
+			        sem_trywait(semaphore) == 0);
+		}
+# else
+#  ifdef HAVE_PTHREAD_TRYJOIN
+		/* A somewhat naive and brute-force solution for
+		 * systems without a semaphore.h. This may suffer
+		 * some off-by-one errors, using a few more threads
+		 * than intended (if we race a bit at the wrong time,
+		 * probably up to one per enabled scanner routine).
 		 */
 
 		/* TOTHINK: Should there be a threadcount_mutex when
@@ -289,14 +303,14 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 		 * other protocol scanners...
 		 */
 		if (curr_threads >= max_threads
-		||  curr_threads >= max_threads_oldnut
+		|| (curr_threads >= max_threads_scantype && max_threads_scantype > 0)
 		) {
 			upsdebugx(2, "%s: already running %zu scanning threads "
 				"(launched overall: %d), "
 				"waiting until some would finish",
 				__func__, curr_threads, thread_count);
 			while (curr_threads >= max_threads
-			    || curr_threads >= max_threads_oldnut
+			   || (curr_threads >= max_threads_scantype && max_threads_scantype > 0)
 			) {
 				for (i = 0; i < thread_count ; i++) {
 					int ret;
@@ -336,44 +350,110 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 				}
 
 				if (curr_threads >= max_threads
-				|| curr_threads >= max_threads_oldnut
+				|| (curr_threads >= max_threads_scantype && max_threads_scantype > 0)
 				) {
 					usleep (10000); // microSec's, so 0.01s here
 				}
 			}
 			upsdebugx(2, "%s: proceeding with scan", __func__);
 		}
-# endif // HAVE_PTHREAD_TRYJOIN
+		/* NOTE: No change to default "pass" in this ifdef:
+		 * if we got to this line, we have a slot to use */
+#  endif /* HAVE_PTHREAD_TRYJOIN */
+# endif  /* HAVE_SEMAPHORE */
+#endif   /* HAVE_PTHREAD */
 
-		if (pthread_create(&thread, NULL, list_nut_devices, (void*)nut_arg) == 0) {
-# ifdef HAVE_PTHREAD_TRYJOIN
-			pthread_mutex_lock(&threadcount_mutex);
-			curr_threads++;
-# endif // HAVE_PTHREAD_TRYJOIN
+		if (pass) {
+			if (port) {
+				if (ip.type == IPv4) {
+					snprintf(buf, sizeof(buf), "%s:%s", ip_str, port);
+				}
+				else {
+					snprintf(buf, sizeof(buf), "[%s]:%s", ip_str, port);
+				}
 
-			thread_count++;
-			nutscan_thread_t *new_thread_array = realloc(thread_array,
-				thread_count * sizeof(nutscan_thread_t));
-			if (new_thread_array == NULL) {
-				upsdebugx(1, "%s: Failed to realloc thread array", __func__);
-				break;
+				ip_dest = strdup(buf);
 			}
 			else {
-				thread_array = new_thread_array;
+				ip_dest = strdup(ip_str);
 			}
-			thread_array[thread_count - 1].thread = thread;
-			thread_array[thread_count - 1].active = TRUE;
+
+			if ((nut_arg = malloc(sizeof(struct scan_nut_arg))) == NULL) {
+				free(ip_dest);
+				break;
+			}
+
+			nut_arg->timeout = usec_timeout;
+			nut_arg->hostname = ip_dest;
+
+#ifdef HAVE_PTHREAD
+			if (pthread_create(&thread, NULL, list_nut_devices, (void*)nut_arg) == 0) {
+# ifdef HAVE_PTHREAD_TRYJOIN
+				pthread_mutex_lock(&threadcount_mutex);
+				curr_threads++;
+# endif /* HAVE_PTHREAD_TRYJOIN */
+
+				thread_count++;
+				nutscan_thread_t *new_thread_array = realloc(thread_array,
+					thread_count * sizeof(nutscan_thread_t));
+				if (new_thread_array == NULL) {
+					upsdebugx(1, "%s: Failed to realloc thread array", __func__);
+					break;
+				}
+				else {
+					thread_array = new_thread_array;
+				}
+				thread_array[thread_count - 1].thread = thread;
+				thread_array[thread_count - 1].active = TRUE;
 
 # ifdef HAVE_PTHREAD_TRYJOIN
-			pthread_mutex_unlock(&threadcount_mutex);
-# endif // HAVE_PTHREAD_TRYJOIN
-		}
-#else // not HAVE_PTHREAD
-		list_nut_devices(nut_arg);
-#endif // if HAVE_PTHREAD
-		free(ip_str);
-		ip_str = nutscan_ip_iter_inc(&ip);
-	}
+				pthread_mutex_unlock(&threadcount_mutex);
+# endif /* HAVE_PTHREAD_TRYJOIN */
+			}
+#else  /* not HAVE_PTHREAD */
+			list_nut_devices(nut_arg);
+#endif /* if HAVE_PTHREAD */
+			free(ip_str);
+			ip_str = nutscan_ip_iter_inc(&ip);
+		} else { /* if not pass -- all slots busy */
+#ifdef HAVE_PTHREAD
+# ifdef HAVE_SEMAPHORE
+			/* Wait for all current scans to complete */
+			if (thread_array != NULL) {
+				for (i = 0; i < thread_count ; i++) {
+					int ret;
+					if (!thread_array[i].active) {
+						/* Probably should not get here,
+						 * but handle it just in case */
+						upsdebugx(0, "WARNING: %s: Midway clean-up: did not expect thread %i to be not active",
+							__func__, i);
+						sem_post(semaphore);
+						if (max_threads_scantype > 0)
+							sem_post(semaphore_scantype);
+						continue;
+					}
+					thread_array[i].active = FALSE;
+					ret = pthread_join(thread_array[i].thread, NULL);
+					if (ret != 0) {
+						upsdebugx(0, "WARNING: %s: Midway clean-up: pthread_join() returned code %i",
+							__func__, ret);
+					}
+					sem_post(semaphore);
+					if (max_threads_scantype > 0)
+						sem_post(semaphore_scantype);
+				}
+				thread_count = 0;
+				free(thread_array);
+				thread_array = NULL;
+			}
+# else
+#  ifdef HAVE_PTHREAD_TRYJOIN
+		/* TODO: Move the wait-loop for TRYJOIN here? */
+#  endif /* HAVE_PTHREAD_TRYJOIN */
+# endif  /* HAVE_SEMAPHORE */
+#endif   /* HAVE_PTHREAD */
+		} /* if: could we "pass" or not? */
+	} /* while */
 
 #ifdef HAVE_PTHREAD
 	if (thread_array != NULL) {
@@ -400,13 +480,18 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 					"says we are already at 0", __func__);
 			}
 			pthread_mutex_unlock(&threadcount_mutex);
-# endif // HAVE_PTHREAD_TRYJOIN
+# endif /* HAVE_PTHREAD_TRYJOIN */
 		}
 		free(thread_array);
 		upsdebugx(2, "%s: all threads freed", __func__);
 	}
 	pthread_mutex_destroy(&dev_mutex);
-#endif // HAVE_PTHREAD
+
+# ifdef HAVE_SEMAPHORE
+	if (max_threads_scantype > 0)
+		sem_destroy(semaphore_scantype);
+# endif /* HAVE_SEMAPHORE */
+#endif /* HAVE_PTHREAD */
 
 	if (change_action_handler) {
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_STRICT_PROTOTYPES)

--- a/tools/nut-scanner/scan_nut.c
+++ b/tools/nut-scanner/scan_nut.c
@@ -420,6 +420,9 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 # ifdef HAVE_SEMAPHORE
 			/* Wait for all current scans to complete */
 			if (thread_array != NULL) {
+				upsdebugx (2, "%s: Running too many scanning threads, "
+					"waiting until older ones would finish",
+					__func__);
 				for (i = 0; i < thread_count ; i++) {
 					int ret;
 					if (!thread_array[i].active) {

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -900,6 +900,9 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 # ifdef HAVE_SEMAPHORE
 			/* Wait for all current scans to complete */
 			if (thread_array != NULL) {
+				upsdebugx (2, "%s: Running too many scanning threads, "
+					"waiting until older ones would finish",
+					__func__);
 				for (i = 0; i < thread_count ; i++) {
 					int ret;
 					if (!thread_array[i].active) {

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -952,7 +952,12 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 					__func__, ret);
 			}
 			thread_array[i].active = FALSE;
-# ifdef HAVE_PTHREAD_TRYJOIN
+# ifdef HAVE_SEMAPHORE
+			sem_post(semaphore);
+			if (max_threads_scantype > 0)
+				sem_post(semaphore_scantype);
+# else
+#  ifdef HAVE_PTHREAD_TRYJOIN
 			pthread_mutex_lock(&threadcount_mutex);
 			if (curr_threads > 0) {
 				curr_threads --;
@@ -963,7 +968,8 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 					"says we are already at 0", __func__);
 			}
 			pthread_mutex_unlock(&threadcount_mutex);
-# endif /* HAVE_PTHREAD_TRYJOIN */
+#  endif /* HAVE_PTHREAD_TRYJOIN */
+# endif /* HAVE_SEMAPHORE */
 		}
 		free(thread_array);
 		upsdebugx(2, "%s: all threads freed", __func__);

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -69,6 +69,13 @@
 
 #define SysOID ".1.3.6.1.2.1.1.2.0"
 
+/* use explicit booleans */
+#ifndef FALSE
+typedef enum ebool { FALSE = 0, TRUE } bool_t;
+#else
+typedef int bool_t;
+#endif
+
 static nutscan_device_t * dev_ret = NULL;
 #ifdef HAVE_PTHREAD
 static pthread_mutex_t dev_mutex;
@@ -712,17 +719,30 @@ try_SysOID_free:
 nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip,
                                      long usec_timeout, nutscan_snmp_t * sec)
 {
+	bool_t pass = TRUE; /* Track that we may spawn a scanning thread */
 	int i;
 	nutscan_snmp_t * tmp_sec;
 	nutscan_ip_iter_t ip;
 	char * ip_str = NULL;
 #ifdef HAVE_PTHREAD
+# ifdef HAVE_SEMAPHORE
+	sem_t * semaphore = nutscan_semaphore();
+	sem_t   semaphore_scantype_inst;
+	sem_t * semaphore_scantype = &semaphore_scantype_inst;
+# endif /* HAVE_SEMAPHORE */
 	pthread_t thread;
 	nutscan_thread_t * thread_array = NULL;
 	int thread_count = 0;
+	size_t  max_threads_scantype = max_threads_netsnmp;
 
 	pthread_mutex_init(&dev_mutex, NULL);
-#endif // HAVE_PTHREAD
+
+# ifdef HAVE_SEMAPHORE
+	if (max_threads_scantype > 0)
+		sem_init(semaphore_scantype, 0, max_threads_scantype);
+# endif /* HAVE_SEMAPHORE */
+
+#endif /* HAVE_PTHREAD */
 
 	if (!nutscan_avail_snmp) {
 		return NULL;
@@ -742,17 +762,36 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 	ip_str = nutscan_ip_iter_init(&ip, start_ip, stop_ip);
 
 	while (ip_str != NULL) {
-		tmp_sec = malloc(sizeof(nutscan_snmp_t));
-		memcpy(tmp_sec, sec, sizeof(nutscan_snmp_t));
-		tmp_sec->peername = ip_str;
-
 #ifdef HAVE_PTHREAD
-# ifdef HAVE_PTHREAD_TRYJOIN
 		/* NOTE: With many enough targets to scan, this can crash
 		 * by spawning too many children; add a limit and loop to
 		 * "reap" some already done with their work. And probably
 		 * account them in thread_array[] as something to not wait
 		 * for below in pthread_join()...
+		 */
+
+# ifdef HAVE_SEMAPHORE
+		/* Just wait for someone to free a semaphored slot,
+		 * if none are available, and then/otherwise grab one
+		 */
+		if (thread_array == NULL) {
+			/* Starting point, or after a wait to complete
+			 * all earlier runners */
+			if (max_threads_scantype > 0)
+				sem_wait(semaphore_scantype);
+			sem_wait(semaphore);
+			pass = TRUE;
+		} else {
+			pass = ((max_threads_scantype == 0 || sem_trywait(semaphore_scantype) == 0) &&
+			        sem_trywait(semaphore) == 0);
+		}
+# else
+#  ifdef HAVE_PTHREAD_TRYJOIN
+		/* A somewhat naive and brute-force solution for
+		 * systems without a semaphore.h. This may suffer
+		 * some off-by-one errors, using a few more threads
+		 * than intended (if we race a bit at the wrong time,
+		 * probably up to one per enabled scanner routine).
 		 */
 
 		/* TOTHINK: Should there be a threadcount_mutex when
@@ -761,14 +800,14 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 		 * other protocol scanners...
 		 */
 		if (curr_threads >= max_threads
-		|| (curr_threads >= max_threads_netsnmp && max_threads_netsnmp > 0)
+		|| (curr_threads >= max_threads_scantype && max_threads_scantype > 0)
 		) {
 			upsdebugx(2, "%s: already running %zu scanning threads "
 				"(launched overall: %d), "
 				"waiting until some would finish",
 				__func__, curr_threads, thread_count);
 			while (curr_threads >= max_threads
-			   || (curr_threads >= max_threads_netsnmp && max_threads_netsnmp > 0)
+			   || (curr_threads >= max_threads_scantype && max_threads_scantype > 0)
 			) {
 				for (i = 0; i < thread_count ; i++) {
 					int ret;
@@ -808,43 +847,93 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 				}
 
 				if (curr_threads >= max_threads
-				|| (curr_threads >= max_threads_netsnmp && max_threads_netsnmp > 0)
+				|| (curr_threads >= max_threads_scantype && max_threads_scantype > 0)
 				) {
 					usleep (10000); // microSec's, so 0.01s here
 				}
 			}
 			upsdebugx(2, "%s: proceeding with scan", __func__);
 		}
-# endif // HAVE_PTHREAD_TRYJOIN
+		/* NOTE: No change to default "pass" in this ifdef:
+		 * if we got to this line, we have a slot to use */
+#  endif /* HAVE_PTHREAD_TRYJOIN */
+# endif  /* HAVE_SEMAPHORE */
+#endif   /* HAVE_PTHREAD */
 
-		if (pthread_create(&thread, NULL, try_SysOID, (void*)tmp_sec) == 0) {
+		if (pass) {
+			tmp_sec = malloc(sizeof(nutscan_snmp_t));
+			memcpy(tmp_sec, sec, sizeof(nutscan_snmp_t));
+			tmp_sec->peername = ip_str;
+
+#ifdef HAVE_PTHREAD
+			if (pthread_create(&thread, NULL, try_SysOID, (void*)tmp_sec) == 0) {
 # ifdef HAVE_PTHREAD_TRYJOIN
-			pthread_mutex_lock(&threadcount_mutex);
-			curr_threads++;
-# endif // HAVE_PTHREAD_TRYJOIN
+				pthread_mutex_lock(&threadcount_mutex);
+				curr_threads++;
+# endif /* HAVE_PTHREAD_TRYJOIN */
 
-			thread_count++;
-			nutscan_thread_t *new_thread_array = realloc(thread_array,
-				thread_count * sizeof(nutscan_thread_t));
-			if (new_thread_array == NULL) {
-				upsdebugx(1, "%s: Failed to realloc thread array", __func__);
-				break;
-			}
-			else {
-				thread_array = new_thread_array;
-			}
-			thread_array[thread_count - 1].thread = thread;
-			thread_array[thread_count - 1].active = TRUE;
+				thread_count++;
+				nutscan_thread_t *new_thread_array = realloc(thread_array,
+					thread_count * sizeof(nutscan_thread_t));
+				if (new_thread_array == NULL) {
+					upsdebugx(1, "%s: Failed to realloc thread array", __func__);
+					break;
+				}
+				else {
+					thread_array = new_thread_array;
+				}
+				thread_array[thread_count - 1].thread = thread;
+				thread_array[thread_count - 1].active = TRUE;
 
 # ifdef HAVE_PTHREAD_TRYJOIN
-			pthread_mutex_unlock(&threadcount_mutex);
-# endif // HAVE_PTHREAD_TRYJOIN
-		}
-#else // not HAVE_PTHREAD
-		try_SysOID((void *)tmp_sec);
-#endif // if HAVE_PTHREAD
-		ip_str = nutscan_ip_iter_inc(&ip);
-	}
+				pthread_mutex_unlock(&threadcount_mutex);
+# endif /* HAVE_PTHREAD_TRYJOIN */
+			}
+#else   /* not HAVE_PTHREAD */
+			try_SysOID((void *)tmp_sec);
+#endif  /* if HAVE_PTHREAD */
+/*			free(ip_str); */ /* Do not free() here - seems to cause a double-free instead */
+			ip_str = nutscan_ip_iter_inc(&ip);
+/*			free(tmp_sec); */
+		} else { /* if not pass -- all slots busy */
+#ifdef HAVE_PTHREAD
+# ifdef HAVE_SEMAPHORE
+			/* Wait for all current scans to complete */
+			if (thread_array != NULL) {
+				for (i = 0; i < thread_count ; i++) {
+					int ret;
+					if (!thread_array[i].active) {
+						/* Probably should not get here,
+						 * but handle it just in case */
+						upsdebugx(0, "WARNING: %s: Midway clean-up: did not expect thread %i to be not active",
+							__func__, i);
+						sem_post(semaphore);
+						if (max_threads_scantype > 0)
+							sem_post(semaphore_scantype);
+						continue;
+					}
+					thread_array[i].active = FALSE;
+					ret = pthread_join(thread_array[i].thread, NULL);
+					if (ret != 0) {
+						upsdebugx(0, "WARNING: %s: Midway clean-up: pthread_join() returned code %i",
+							__func__, ret);
+					}
+					sem_post(semaphore);
+					if (max_threads_scantype > 0)
+						sem_post(semaphore_scantype);
+				}
+				thread_count = 0;
+				free(thread_array);
+				thread_array = NULL;
+			}
+# else
+#  ifdef HAVE_PTHREAD_TRYJOIN
+		/* TODO: Move the wait-loop for TRYJOIN here? */
+#  endif /* HAVE_PTHREAD_TRYJOIN */
+# endif  /* HAVE_SEMAPHORE */
+#endif   /* HAVE_PTHREAD */
+		} /* if: could we "pass" or not? */
+	} /* while */
 
 #ifdef HAVE_PTHREAD
 	if (thread_array != NULL) {
@@ -871,18 +960,26 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 					"says we are already at 0", __func__);
 			}
 			pthread_mutex_unlock(&threadcount_mutex);
-# endif // HAVE_PTHREAD_TRYJOIN
+# endif /* HAVE_PTHREAD_TRYJOIN */
 		}
 		free(thread_array);
 		upsdebugx(2, "%s: all threads freed", __func__);
 	}
 	pthread_mutex_destroy(&dev_mutex);
-#endif // HAVE_PTHREAD
+
+# ifdef HAVE_SEMAPHORE
+	if (max_threads_scantype > 0)
+		sem_destroy(semaphore_scantype);
+# endif /* HAVE_SEMAPHORE */
+#endif /* HAVE_PTHREAD */
+
 	nutscan_device_t * result = nutscan_rewind_device(dev_ret);
 	dev_ret = NULL;
 	return result;
 }
+
 #else /* WITH_SNMP */
+
 nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip,
                                      long usec_timeout, nutscan_snmp_t * sec)
 {
@@ -892,4 +989,5 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 	NUT_UNUSED_VARIABLE(sec);
 	return NULL;
 }
+
 #endif /* WITH_SNMP */

--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -578,6 +578,9 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 # ifdef HAVE_SEMAPHORE
 					/* Wait for all current scans to complete */
 					if (thread_array != NULL) {
+				upsdebugx (2, "%s: Running too many scanning threads, "
+					"waiting until older ones would finish",
+					__func__);
 						for (i = 0; i < thread_count ; i++) {
 							int ret;
 							if (!thread_array[i].active) {

--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -388,6 +388,7 @@ end:
 
 nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char * end_ip, long usec_timeout, nutscan_xml_t * sec)
 {
+	bool_t pass = TRUE; /* Track that we may spawn a scanning thread */
 	nutscan_xml_t * tmp_sec = NULL;
 	nutscan_device_t * result = NULL;
 	int i;
@@ -410,28 +411,29 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 			nutscan_ip_iter_t ip;
 			char * ip_str = NULL;
 #ifdef HAVE_PTHREAD
+# ifdef HAVE_SEMAPHORE
+			sem_t * semaphore = nutscan_semaphore();
+			sem_t   semaphore_scantype_inst;
+			sem_t * semaphore_scantype = &semaphore_scantype_inst;
+# endif /* HAVE_SEMAPHORE */
 			pthread_t thread;
 			nutscan_thread_t * thread_array = NULL;
 			int thread_count = 0;
+			size_t  max_threads_scantype = max_threads_netxml;
 
 			pthread_mutex_init(&dev_mutex, NULL);
-#endif // HAVE_PTHREAD
+
+# ifdef HAVE_SEMAPHORE
+			if (max_threads_scantype > 0)
+				sem_init(semaphore_scantype, 0, max_threads_scantype);
+# endif /* HAVE_SEMAPHORE */
+
+#endif /* HAVE_PTHREAD */
 
 			ip_str = nutscan_ip_iter_init(&ip, start_ip, end_ip);
 
 			while (ip_str != NULL) {
-				tmp_sec = malloc(sizeof(nutscan_xml_t));
-				if (tmp_sec == NULL) {
-					fprintf(stderr,
-						"Memory allocation error\n");
-					return NULL;
-				}
-				memcpy(tmp_sec, sec, sizeof(nutscan_xml_t));
-				tmp_sec->peername = ip_str;
-				if (tmp_sec->usec_timeout < 0) tmp_sec->usec_timeout = usec_timeout;
-
 #ifdef HAVE_PTHREAD
-# ifdef HAVE_PTHREAD_TRYJOIN
 				/* NOTE: With many enough targets to scan, this can crash
 				 * by spawning too many children; add a limit and loop to
 				 * "reap" some already done with their work. And probably
@@ -439,21 +441,45 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 				 * for below in pthread_join()...
 				 */
 
+# ifdef HAVE_SEMAPHORE
+				/* Just wait for someone to free a semaphored slot,
+				 * if none are available, and then/otherwise grab one
+				 */
+				if (thread_array == NULL) {
+					/* Starting point, or after a wait to complete
+					 * all earlier runners */
+			if (max_threads_scantype > 0)
+				sem_wait(semaphore_scantype);
+					sem_wait(semaphore);
+					pass = TRUE;
+				} else {
+			pass = ((max_threads_scantype == 0 || sem_trywait(semaphore_scantype) == 0) &&
+			        sem_trywait(semaphore) == 0);
+				}
+# else
+#  ifdef HAVE_PTHREAD_TRYJOIN
+				/* A somewhat naive and brute-force solution for
+				 * systems without a semaphore.h. This may suffer
+				 * some off-by-one errors, using a few more threads
+				 * than intended (if we race a bit at the wrong time,
+				 * probably up to one per enabled scanner routine).
+				 */
+
 				/* TOTHINK: Should there be a threadcount_mutex when
 				 * we just read the value in if() and while() below?
 				 * At worst we would overflow the limit a bit due to
 				 * other protocol scanners...
 				 */
-				if (curr_threads >= max_threads
-				||  curr_threads >= max_threads_netxml
-				) {
+		if (curr_threads >= max_threads
+		|| (curr_threads >= max_threads_scantype && max_threads_scantype > 0)
+		) {
 					upsdebugx(2, "%s: already running %zu scanning threads "
 						"(launched overall: %d), "
 						"waiting until some would finish",
 						__func__, curr_threads, thread_count);
-					while (curr_threads >= max_threads
-					    || curr_threads >= max_threads_netxml
-					) {
+			while (curr_threads >= max_threads
+			   || (curr_threads >= max_threads_scantype && max_threads_scantype > 0)
+			) {
 						for (i = 0; i < thread_count ; i++) {
 							int ret;
 
@@ -491,46 +517,101 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 							pthread_mutex_unlock(&threadcount_mutex);
 						}
 
-						if (curr_threads >= max_threads
-						||  curr_threads >= max_threads_netxml
-						) {
+				if (curr_threads >= max_threads
+				|| (curr_threads >= max_threads_scantype && max_threads_scantype > 0)
+				) {
 							usleep (10000); // microSec's, so 0.01s here
 						}
 					}
 					upsdebugx(2, "%s: proceeding with scan", __func__);
 				}
-# endif // HAVE_PTHREAD_TRYJOIN
+				/* NOTE: No change to default "pass" in this ifdef:
+				 * if we got to this line, we have a slot to use */
+#  endif /* HAVE_PTHREAD_TRYJOIN */
+# endif  /* HAVE_SEMAPHORE */
+#endif   /* HAVE_PTHREAD */
 
-				if (pthread_create(&thread, NULL, nutscan_scan_xml_http_generic, (void *)tmp_sec) == 0) {
-# ifdef HAVE_PTHREAD_TRYJOIN
-					pthread_mutex_lock(&threadcount_mutex);
-					curr_threads++;
-# endif // HAVE_PTHREAD_TRYJOIN
-
-					thread_count++;
-					nutscan_thread_t *new_thread_array = realloc(thread_array,
-						thread_count*sizeof(nutscan_thread_t));
-					if (new_thread_array == NULL) {
-						upsdebugx(1, "%s: Failed to realloc thread array", __func__);
-						break;
+				if (pass) {
+					tmp_sec = malloc(sizeof(nutscan_xml_t));
+					if (tmp_sec == NULL) {
+						fprintf(stderr,
+							"Memory allocation error\n");
+						return NULL;
 					}
-					else {
-						thread_array = new_thread_array;
-					}
-					thread_array[thread_count - 1].thread = thread;
-					thread_array[thread_count - 1].active = TRUE;
+					memcpy(tmp_sec, sec, sizeof(nutscan_xml_t));
+					tmp_sec->peername = ip_str;
+					if (tmp_sec->usec_timeout < 0) tmp_sec->usec_timeout = usec_timeout;
+
+#ifdef HAVE_PTHREAD
+					if (pthread_create(&thread, NULL, nutscan_scan_xml_http_generic, (void *)tmp_sec) == 0) {
+# ifdef HAVE_PTHREAD_TRYJOIN
+						pthread_mutex_lock(&threadcount_mutex);
+						curr_threads++;
+# endif /* HAVE_PTHREAD_TRYJOIN */
+
+						thread_count++;
+						nutscan_thread_t *new_thread_array = realloc(thread_array,
+							thread_count*sizeof(nutscan_thread_t));
+						if (new_thread_array == NULL) {
+							upsdebugx(1, "%s: Failed to realloc thread array", __func__);
+							break;
+						}
+						else {
+							thread_array = new_thread_array;
+						}
+						thread_array[thread_count - 1].thread = thread;
+						thread_array[thread_count - 1].active = TRUE;
 
 # ifdef HAVE_PTHREAD_TRYJOIN
-					pthread_mutex_unlock(&threadcount_mutex);
-# endif // HAVE_PTHREAD_TRYJOIN
-				}
-#else // not HAVE_PTHREAD
-				nutscan_scan_xml_http_generic((void *)tmp_sec);
-#endif // if HAVE_PTHREAD
-/*				free(ip_str); */ /* One of these free()s seems to cause a double-free */
-				ip_str = nutscan_ip_iter_inc(&ip);
-/*				free(tmp_sec); */
-			}
+							pthread_mutex_unlock(&threadcount_mutex);
+# endif /* HAVE_PTHREAD_TRYJOIN */
+					}
+#else /* not HAVE_PTHREAD */
+					nutscan_scan_xml_http_generic((void *)tmp_sec);
+#endif /* if HAVE_PTHREAD */
+
+/*					free(ip_str); */ /* One of these free()s seems to cause a double-free instead */
+					ip_str = nutscan_ip_iter_inc(&ip);
+/*					free(tmp_sec); */
+				} else { /* if not pass -- all slots busy */
+#ifdef HAVE_PTHREAD
+# ifdef HAVE_SEMAPHORE
+					/* Wait for all current scans to complete */
+					if (thread_array != NULL) {
+						for (i = 0; i < thread_count ; i++) {
+							int ret;
+							if (!thread_array[i].active) {
+								/* Probably should not get here,
+								 * but handle it just in case */
+								upsdebugx(0, "WARNING: %s: Midway clean-up: did not expect thread %i to be not active",
+									__func__, i);
+								sem_post(semaphore);
+								if (max_threads_scantype > 0)
+									sem_post(semaphore_scantype);
+								continue;
+							}
+							thread_array[i].active = FALSE;
+							ret = pthread_join(thread_array[i].thread, NULL);
+							if (ret != 0) {
+								upsdebugx(0, "WARNING: %s: Midway clean-up: pthread_join() returned code %i",
+									__func__, ret);
+							}
+							sem_post(semaphore);
+							if (max_threads_scantype > 0)
+								sem_post(semaphore_scantype);
+							}
+						thread_count = 0;
+						free(thread_array);
+						thread_array = NULL;
+					}
+# else
+#  ifdef HAVE_PTHREAD_TRYJOIN
+				/* TODO: Move the wait-loop for TRYJOIN here? */
+#  endif /* HAVE_PTHREAD_TRYJOIN */
+# endif  /* HAVE_SEMAPHORE */
+#endif   /* HAVE_PTHREAD */
+				} /* if: could we "pass" or not? */
+			} /* while */
 
 #ifdef HAVE_PTHREAD
 			if (thread_array != NULL) {
@@ -557,13 +638,19 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 							"says we are already at 0", __func__);
 					}
 					pthread_mutex_unlock(&threadcount_mutex);
-# endif // HAVE_PTHREAD_TRYJOIN
+# endif /* HAVE_PTHREAD_TRYJOIN */
 				}
 				free(thread_array);
 				upsdebugx(2, "%s: all threads freed", __func__);
 			}
 			pthread_mutex_destroy(&dev_mutex);
-#endif // HAVE_PTHREAD
+
+# ifdef HAVE_SEMAPHORE
+	if (max_threads_scantype > 0)
+		sem_destroy(semaphore_scantype);
+# endif /* HAVE_SEMAPHORE */
+#endif /* HAVE_PTHREAD */
+
 			result = nutscan_rewind_device(dev_ret);
 			dev_ret = NULL;
 			return result;
@@ -594,7 +681,9 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 	free(tmp_sec);
 	return result;
 }
+
 #else /* WITH_NEON */
+
 nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char * end_ip, long usec_timeout, nutscan_xml_t * sec)
 {
 	NUT_UNUSED_VARIABLE(start_ip);
@@ -603,4 +692,5 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 	NUT_UNUSED_VARIABLE(sec);
 	return NULL;
 }
+
 #endif /* WITH_NEON */

--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -630,7 +630,12 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 							__func__, ret);
 					}
 					thread_array[i].active = FALSE;
-# ifdef HAVE_PTHREAD_TRYJOIN
+# ifdef HAVE_SEMAPHORE
+			sem_post(semaphore);
+			if (max_threads_scantype > 0)
+				sem_post(semaphore_scantype);
+# else
+#  ifdef HAVE_PTHREAD_TRYJOIN
 					pthread_mutex_lock(&threadcount_mutex);
 					if (curr_threads > 0) {
 						curr_threads --;
@@ -641,7 +646,8 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 							"says we are already at 0", __func__);
 					}
 					pthread_mutex_unlock(&threadcount_mutex);
-# endif /* HAVE_PTHREAD_TRYJOIN */
+#  endif /* HAVE_PTHREAD_TRYJOIN */
+# endif /* HAVE_SEMAPHORE */
 				}
 				free(thread_array);
 				upsdebugx(2, "%s: all threads freed", __func__);


### PR DESCRIPTION
The 42ITy fork of NUT developed a way to limit parallel nut-scanner thread counts back in 2017. It was not as granular as the solution recently merged to NUT master (which can try to wait for some threads to complete, instead of requiring that each and all earlier launched threads for this scanner type have finished), but it relied on standard semaphores (where available) instead of "naive" integer counters used in the recent PR. Also, it worked for earlier glibc versions where `pthread_tryjoin_np()` was not introduced yet.