### PR TITLE
Add new auth methods to SNMPv3

### DIFF
--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -622,6 +622,18 @@ void nut_snmp_init(const char *type, const char *hostname)
 			g_snmp_sess.securityAuthProto = usmHMACSHA1AuthProtocol;
 			g_snmp_sess.securityAuthProtoLen = sizeof(usmHMACSHA1AuthProtocol)/sizeof(oid);
 		}
+		else if (strcmp(authProtocol, "SHA256") == 0) {
+			g_snmp_sess.securityAuthProto = usmHMAC192SHA256AuthProtocol;
+			g_snmp_sess.securityAuthProtoLen = sizeof(usmHMAC192SHA256AuthProtocol)/sizeof(oid);
+		}
+		else if (strcmp(authProtocol, "SHA384") == 0) {
+			g_snmp_sess.securityAuthProto = usmHMAC256SHA384AuthProtocol;
+			g_snmp_sess.securityAuthProtoLen = sizeof(usmHMAC256SHA384AuthProtocol)/sizeof(oid);
+		}
+		else if (strcmp(authProtocol, "SHA512") == 0) {
+			g_snmp_sess.securityAuthProto = usmHMAC384SHA512AuthProtocol;
+			g_snmp_sess.securityAuthProtoLen = sizeof(usmHMAC384SHA512AuthProtocol)/sizeof(oid);
+		}
 		else
 			fatalx(EXIT_FAILURE, "Bad SNMPv3 authProtocol: %s", authProtocol);
 
@@ -648,6 +660,16 @@ void nut_snmp_init(const char *type, const char *hostname)
 			g_snmp_sess.securityPrivProto = usmAESPrivProtocol;
 			g_snmp_sess.securityPrivProtoLen = NUT_securityPrivProtoLen;
 		}
+#if NETSNMP_DRAFT_BLUMENTHAL_AES_04
+		else if (strcmp(privProtocol, "AES192") == 0) {
+			g_snmp_sess.securityPrivProto = usmAES192PrivProtocol;
+			g_snmp_sess.securityPrivProtoLen = (sizeof(usmAES192PrivProtocol)/sizeof(oid));
+		}
+		else if (strcmp(privProtocol, "AES256") == 0) {
+			g_snmp_sess.securityPrivProto = usmAES256PrivProtocol;
+			g_snmp_sess.securityPrivProtoLen = (sizeof(usmAES256PrivProtocol)/sizeof(oid));
+		}
+#endif
 		else
 			fatalx(EXIT_FAILURE, "Bad SNMPv3 privProtocol: %s", privProtocol);
 

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -614,32 +614,46 @@ void nut_snmp_init(const char *type, const char *hostname)
 		g_snmp_sess.securityAuthKeyLen = USM_AUTH_KU_LEN;
 		authProtocol = testvar(SU_VAR_AUTHPROT) ? getval(SU_VAR_AUTHPROT) : "MD5";
 
+#if NUT_HAVE_LIBNETSNMP_usmHMACMD5AuthProtocol
 		if (strcmp(authProtocol, "MD5") == 0) {
 			g_snmp_sess.securityAuthProto = usmHMACMD5AuthProtocol;
 			g_snmp_sess.securityAuthProtoLen = sizeof(usmHMACMD5AuthProtocol)/sizeof(oid);
 		}
-		else if (strcmp(authProtocol, "SHA") == 0) {
+		else
+#endif
+#if NUT_HAVE_LIBNETSNMP_usmHMACSHA1AuthProtocol
+		if (strcmp(authProtocol, "SHA") == 0) {
 			g_snmp_sess.securityAuthProto = usmHMACSHA1AuthProtocol;
 			g_snmp_sess.securityAuthProtoLen = sizeof(usmHMACSHA1AuthProtocol)/sizeof(oid);
 		}
-		else if (strcmp(authProtocol, "SHA256") == 0) {
+		else
+#endif
+#if NUT_HAVE_LIBNETSNMP_usmHMAC192SHA256AuthProtocol
+		if (strcmp(authProtocol, "SHA256") == 0) {
 			g_snmp_sess.securityAuthProto = usmHMAC192SHA256AuthProtocol;
 			g_snmp_sess.securityAuthProtoLen = sizeof(usmHMAC192SHA256AuthProtocol)/sizeof(oid);
 		}
-		else if (strcmp(authProtocol, "SHA384") == 0) {
+		else
+#endif
+#if NUT_HAVE_LIBNETSNMP_usmHMAC256SHA384AuthProtocol
+		if (strcmp(authProtocol, "SHA384") == 0) {
 			g_snmp_sess.securityAuthProto = usmHMAC256SHA384AuthProtocol;
 			g_snmp_sess.securityAuthProtoLen = sizeof(usmHMAC256SHA384AuthProtocol)/sizeof(oid);
 		}
-		else if (strcmp(authProtocol, "SHA512") == 0) {
+		else
+#endif
+#if NUT_HAVE_LIBNETSNMP_usmHMAC384SHA512AuthProtocol
+		if (strcmp(authProtocol, "SHA512") == 0) {
 			g_snmp_sess.securityAuthProto = usmHMAC384SHA512AuthProtocol;
 			g_snmp_sess.securityAuthProtoLen = sizeof(usmHMAC384SHA512AuthProtocol)/sizeof(oid);
 		}
 		else
+#endif
 			fatalx(EXIT_FAILURE, "Bad SNMPv3 authProtocol: %s", authProtocol);
 
 		/* set the authentication key to a MD5/SHA1 hashed version of our
 		 * passphrase (must be at least 8 characters long) */
-		if(g_snmp_sess.securityLevel != SNMP_SEC_LEVEL_NOAUTH) {
+		if (g_snmp_sess.securityLevel != SNMP_SEC_LEVEL_NOAUTH) {
 			if (generate_Ku(g_snmp_sess.securityAuthProto,
 				g_snmp_sess.securityAuthProtoLen,
 				(const unsigned char *) authPassword, strlen(authPassword),
@@ -652,30 +666,41 @@ void nut_snmp_init(const char *type, const char *hostname)
 
 		privProtocol = testvar(SU_VAR_PRIVPROT) ? getval(SU_VAR_PRIVPROT) : "DES";
 
+#if NUT_HAVE_LIBNETSNMP_usmDESPrivProtocol
 		if (strcmp(privProtocol, "DES") == 0) {
 			g_snmp_sess.securityPrivProto = usmDESPrivProtocol;
 			g_snmp_sess.securityPrivProtoLen =  sizeof(usmDESPrivProtocol)/sizeof(oid);
 		}
-		else if (strcmp(privProtocol, "AES") == 0) {
+		else
+#endif
+#if NUT_HAVE_LIBNETSNMP_usmAESPrivProtocol || NUT_HAVE_LIBNETSNMP_usmAES128PrivProtocol
+		if (strcmp(privProtocol, "AES") == 0) {
 			g_snmp_sess.securityPrivProto = usmAESPrivProtocol;
 			g_snmp_sess.securityPrivProtoLen = NUT_securityPrivProtoLen;
 		}
+		else
+#endif
 #if NETSNMP_DRAFT_BLUMENTHAL_AES_04
-		else if (strcmp(privProtocol, "AES192") == 0) {
+# if NUT_HAVE_LIBNETSNMP_usmAES192PrivProtocol
+		if (strcmp(privProtocol, "AES192") == 0) {
 			g_snmp_sess.securityPrivProto = usmAES192PrivProtocol;
 			g_snmp_sess.securityPrivProtoLen = (sizeof(usmAES192PrivProtocol)/sizeof(oid));
 		}
-		else if (strcmp(privProtocol, "AES256") == 0) {
+		else
+# endif
+# if NUT_HAVE_LIBNETSNMP_usmAES256PrivProtocol
+		if (strcmp(privProtocol, "AES256") == 0) {
 			g_snmp_sess.securityPrivProto = usmAES256PrivProtocol;
 			g_snmp_sess.securityPrivProtoLen = (sizeof(usmAES256PrivProtocol)/sizeof(oid));
 		}
-#endif
 		else
+# endif
+#endif
 			fatalx(EXIT_FAILURE, "Bad SNMPv3 privProtocol: %s", privProtocol);
 
 		/* set the privacy key to a MD5/SHA1 hashed version of our
 		 * passphrase (must be at least 8 characters long) */
-		if(g_snmp_sess.securityLevel == SNMP_SEC_LEVEL_AUTHPRIV) {
+		if (g_snmp_sess.securityLevel == SNMP_SEC_LEVEL_AUTHPRIV) {
 			g_snmp_sess.securityPrivKeyLen = USM_PRIV_KU_LEN;
 			if (generate_Ku(g_snmp_sess.securityAuthProto,
 				g_snmp_sess.securityAuthProtoLen,

--- a/m4/nut_check_libnetsnmp.m4
+++ b/m4/nut_check_libnetsnmp.m4
@@ -98,6 +98,51 @@ oid * pProto = usmAESPrivProtocol;
 		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmAESPrivProtocol, 0, [Variable or macro by this name is not resolvable])
 		])
 
+	AC_MSG_CHECKING([for defined usmHMAC256SHA384AuthProtocol])
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+#include <net-snmp/net-snmp-config.h>
+#include <net-snmp/net-snmp-includes.h>
+oid * pProto = usmHMAC256SHA384AuthProtocol;
+],
+[]
+		)],
+		[AC_MSG_RESULT([yes])
+		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMAC256SHA384AuthProtocol, 1, [Variable or macro by this name is resolvable])
+		],
+		[AC_MSG_RESULT([no])
+		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMAC256SHA384AuthProtocol, 0, [Variable or macro by this name is not resolvable])
+		])
+
+	AC_MSG_CHECKING([for defined usmHMAC384SHA512AuthProtocol])
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+#include <net-snmp/net-snmp-config.h>
+#include <net-snmp/net-snmp-includes.h>
+oid * pProto = usmHMAC384SHA512AuthProtocol;
+],
+[]
+		)],
+		[AC_MSG_RESULT([yes])
+		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMAC384SHA512AuthProtocol, 1, [Variable or macro by this name is resolvable])
+		],
+		[AC_MSG_RESULT([no])
+		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMAC384SHA512AuthProtocol, 0, [Variable or macro by this name is not resolvable])
+		])
+
+	AC_MSG_CHECKING([for defined usmHMAC192SHA256AuthProtocol])
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+#include <net-snmp/net-snmp-config.h>
+#include <net-snmp/net-snmp-includes.h>
+oid * pProto = usmHMAC192SHA256AuthProtocol;
+],
+[]
+		)],
+		[AC_MSG_RESULT([yes])
+		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMAC192SHA256AuthProtocol, 1, [Variable or macro by this name is resolvable])
+		],
+		[AC_MSG_RESULT([no])
+		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMAC192SHA256AuthProtocol, 0, [Variable or macro by this name is not resolvable])
+		])
+
 	fi
 
 	dnl restore original CFLAGS and LIBS

--- a/m4/nut_check_libnetsnmp.m4
+++ b/m4/nut_check_libnetsnmp.m4
@@ -158,6 +158,36 @@ oid * pProto = usmHMAC192SHA256AuthProtocol;
 		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMAC192SHA256AuthProtocol, 0, [Variable or macro by this name is not resolvable])
 		])
 
+	AC_MSG_CHECKING([for defined usmAES192PrivProtocol])
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+#include <net-snmp/net-snmp-config.h>
+#include <net-snmp/net-snmp-includes.h>
+oid * pProto = usmAES192PrivProtocol;
+],
+[]
+		)],
+		[AC_MSG_RESULT([yes])
+		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmAES192PrivProtocol, 1, [Variable or macro by this name is resolvable])
+		],
+		[AC_MSG_RESULT([no])
+		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmAES192PrivProtocol, 0, [Variable or macro by this name is not resolvable])
+		])
+
+	AC_MSG_CHECKING([for defined usmAES256PrivProtocol])
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+#include <net-snmp/net-snmp-config.h>
+#include <net-snmp/net-snmp-includes.h>
+oid * pProto = usmAES256PrivProtocol;
+],
+[]
+		)],
+		[AC_MSG_RESULT([yes])
+		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmAES256PrivProtocol, 1, [Variable or macro by this name is resolvable])
+		],
+		[AC_MSG_RESULT([no])
+		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmAES256PrivProtocol, 0, [Variable or macro by this name is not resolvable])
+		])
+
 	AC_MSG_CHECKING([for defined usmHMACMD5AuthProtocol])
 	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
 #include <net-snmp/net-snmp-config.h>

--- a/m4/nut_check_libnetsnmp.m4
+++ b/m4/nut_check_libnetsnmp.m4
@@ -98,6 +98,21 @@ oid * pProto = usmAESPrivProtocol;
 		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmAESPrivProtocol, 0, [Variable or macro by this name is not resolvable])
 		])
 
+	AC_MSG_CHECKING([for defined usmDESPrivProtocol])
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+#include <net-snmp/net-snmp-config.h>
+#include <net-snmp/net-snmp-includes.h>
+oid * pProto = usmDESPrivProtocol;
+],
+[]
+		)],
+		[AC_MSG_RESULT([yes])
+		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmDESPrivProtocol, 1, [Variable or macro by this name is resolvable])
+		],
+		[AC_MSG_RESULT([no])
+		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmDESPrivProtocol, 0, [Variable or macro by this name is not resolvable])
+		])
+
 	AC_MSG_CHECKING([for defined usmHMAC256SHA384AuthProtocol])
 	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
 #include <net-snmp/net-snmp-config.h>
@@ -141,6 +156,36 @@ oid * pProto = usmHMAC192SHA256AuthProtocol;
 		],
 		[AC_MSG_RESULT([no])
 		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMAC192SHA256AuthProtocol, 0, [Variable or macro by this name is not resolvable])
+		])
+
+	AC_MSG_CHECKING([for defined usmHMACMD5AuthProtocol])
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+#include <net-snmp/net-snmp-config.h>
+#include <net-snmp/net-snmp-includes.h>
+oid * pProto = usmHMACMD5AuthProtocol;
+],
+[]
+		)],
+		[AC_MSG_RESULT([yes])
+		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMACMD5AuthProtocol, 1, [Variable or macro by this name is resolvable])
+		],
+		[AC_MSG_RESULT([no])
+		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMACMD5AuthProtocol, 0, [Variable or macro by this name is not resolvable])
+		])
+
+	AC_MSG_CHECKING([for defined usmHMACSHA1AuthProtocol])
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+#include <net-snmp/net-snmp-config.h>
+#include <net-snmp/net-snmp-includes.h>
+oid * pProto = usmHMACSHA1AuthProtocol;
+],
+[]
+		)],
+		[AC_MSG_RESULT([yes])
+		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMACSHA1AuthProtocol, 1, [Variable or macro by this name is resolvable])
+		],
+		[AC_MSG_RESULT([no])
+		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMACSHA1AuthProtocol, 0, [Variable or macro by this name is not resolvable])
 		])
 
 	fi

--- a/m4/nut_check_libnetsnmp.m4
+++ b/m4/nut_check_libnetsnmp.m4
@@ -98,6 +98,21 @@ oid * pProto = usmAESPrivProtocol;
 		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmAESPrivProtocol, 0, [Variable or macro by this name is not resolvable])
 		])
 
+	AC_MSG_CHECKING([for defined usmAES128PrivProtocol])
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+#include <net-snmp/net-snmp-config.h>
+#include <net-snmp/net-snmp-includes.h>
+oid * pProto = usmAES128PrivProtocol;
+],
+[]
+		)],
+		[AC_MSG_RESULT([yes])
+		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmAES128PrivProtocol, 1, [Variable or macro by this name is resolvable])
+		],
+		[AC_MSG_RESULT([no])
+		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmAES128PrivProtocol, 0, [Variable or macro by this name is not resolvable])
+		])
+
 	AC_MSG_CHECKING([for defined usmDESPrivProtocol])
 	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
 #include <net-snmp/net-snmp-config.h>

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -234,9 +234,13 @@ static void show_usage()
 		printf("\nSNMP v3 specific options:\n");
 		printf("  -l, --secLevel <security level>: Set the securityLevel used for SNMPv3 messages (allowed values: noAuthNoPriv, authNoPriv, authPriv)\n");
 		printf("  -u, --secName <security name>: Set the securityName used for authenticated SNMPv3 messages (mandatory if you set secLevel. No default)\n");
-		printf("  -w, --authProtocol <authentication protocol>: Set the authentication protocol (MD5 or SHA) used for authenticated SNMPv3 messages (default=MD5)\n");
+		printf("  -w, --authProtocol <authentication protocol>: Set the authentication protocol (MD5, SHA, SHA256, SHA384 or SHA512) used for authenticated SNMPv3 messages (default=MD5)\n");
 		printf("  -W, --authPassword <authentication pass phrase>: Set the authentication pass phrase used for authenticated SNMPv3 messages (mandatory if you set secLevel to authNoPriv or authPriv)\n");
+#if NETSNMP_DRAFT_BLUMENTHAL_AES_04
+		printf("  -x, --privProtocol <privacy protocol>: Set the privacy protocol (DES, AES, AES192 or AES256) used for encrypted SNMPv3 messages (default=DES)\n");
+#else
 		printf("  -x, --privProtocol <privacy protocol>: Set the privacy protocol (DES or AES) used for encrypted SNMPv3 messages (default=DES)\n");
+#endif
 		printf("  -X, --privPassword <privacy pass phrase>: Set the privacy pass phrase used for encrypted SNMPv3 messages (mandatory if you set secLevel to authPriv)\n");
 	}
 

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -101,17 +101,35 @@ static const char * (*nut_snmp_api_errstring) (int snmp_errnumber);
 
 /* Variables (not methods) exported by libnet-snmp: */
 static int *nut_snmp_errno;
-static oid *nut_usmAESPrivProtocol;
-static oid *nut_usmHMACMD5AuthProtocol;
-static oid *nut_usmHMACSHA1AuthProtocol;
-static oid *nut_usmDESPrivProtocol;
-#if NETSNMP_DRAFT_BLUMENTHAL_AES_04
-static oid *nut_usmAES192PrivProtocol;
-static oid *nut_usmAES256PrivProtocol;
+#if NUT_HAVE_LIBNETSNMP_usmAESPrivProtocol || NUT_HAVE_LIBNETSNMP_usmAES128PrivProtocol
+static oid *nut_usmAESPrivProtocol; /* might be usmAES128PrivProtocol on some systems */
 #endif
+#if NUT_HAVE_LIBNETSNMP_usmHMACMD5AuthProtocol
+static oid *nut_usmHMACMD5AuthProtocol;
+#endif
+#if NUT_HAVE_LIBNETSNMP_usmHMACSHA1AuthProtocol
+static oid *nut_usmHMACSHA1AuthProtocol;
+#endif
+#if NUT_HAVE_LIBNETSNMP_usmDESPrivProtocol
+static oid *nut_usmDESPrivProtocol;
+#endif
+#if NETSNMP_DRAFT_BLUMENTHAL_AES_04
+# if NUT_HAVE_LIBNETSNMP_usmAES192PrivProtocol
+static oid *nut_usmAES192PrivProtocol;
+# endif
+# if NUT_HAVE_LIBNETSNMP_usmAES256PrivProtocol
+static oid *nut_usmAES256PrivProtocol;
+# endif
+#endif
+#if NUT_HAVE_LIBNETSNMP_usmHMAC192SHA256AuthProtocol
 static oid *nut_usmHMAC192SHA256AuthProtocol;
+#endif
+#if NUT_HAVE_LIBNETSNMP_usmHMAC256SHA384AuthProtocol
 static oid *nut_usmHMAC256SHA384AuthProtocol;
+#endif
+#if NUT_HAVE_LIBNETSNMP_usmHMAC384SHA512AuthProtocol
 static oid *nut_usmHMAC384SHA512AuthProtocol;
+#endif
 
 /* return 0 on error; visible externally */
 int nutscan_load_snmp_library(const char *libname_path);
@@ -230,61 +248,79 @@ int nutscan_load_snmp_library(const char *libname_path)
 		goto err;
 	}
 
+#if NUT_HAVE_LIBNETSNMP_usmAESPrivProtocol || NUT_HAVE_LIBNETSNMP_usmAES128PrivProtocol
 	*(void **) (&nut_usmAESPrivProtocol) = lt_dlsym(dl_handle,
 							USMAESPRIVPROTOCOL);
 	if ((dl_error = lt_dlerror()) != NULL) {
 		goto err;
 	}
+#endif /* NUT_HAVE_LIBNETSNMP_usmAESPrivProtocol || NUT_HAVE_LIBNETSNMP_usmAES128PrivProtocol */
 
+#if NUT_HAVE_LIBNETSNMP_usmHMACMD5AuthProtocol
 	*(void **) (&nut_usmHMACMD5AuthProtocol) = lt_dlsym(dl_handle,
 						"usmHMACMD5AuthProtocol");
 	if ((dl_error = lt_dlerror()) != NULL) {
 		goto err;
 	}
+#endif /* NUT_HAVE_LIBNETSNMP_usmHMACMD5AuthProtocol */
 
+#if NUT_HAVE_LIBNETSNMP_usmHMACSHA1AuthProtocol
 	*(void **) (&nut_usmHMACSHA1AuthProtocol) = lt_dlsym(dl_handle,
 						"usmHMACSHA1AuthProtocol");
 	if ((dl_error = lt_dlerror()) != NULL) {
 		goto err;
 	}
+#endif /* NUT_HAVE_LIBNETSNMP_usmHMACSHA1AuthProtocol */
 
+#if NUT_HAVE_LIBNETSNMP_usmDESPrivProtocol
 	*(void **) (&nut_usmDESPrivProtocol) = lt_dlsym(dl_handle,
 						"usmDESPrivProtocol");
 	if ((dl_error = lt_dlerror()) != NULL) {
 		goto err;
 	}
+#endif /* NUT_HAVE_LIBNETSNMP_usmDESPrivProtocol */
 
 #if NETSNMP_DRAFT_BLUMENTHAL_AES_04
+# if NUT_HAVE_LIBNETSNMP_usmAES192PrivProtocol
 	*(void **) (&nut_usmAES192PrivProtocol) = lt_dlsym(dl_handle,
 						"usmAES192PrivProtocol");
 	if ((dl_error = lt_dlerror()) != NULL) {
 		goto err;
 	}
+# endif /* NUT_HAVE_LIBNETSNMP_usmAES192PrivProtocol */
 
+# if NUT_HAVE_LIBNETSNMP_usmAES256PrivProtocol
 	*(void **) (&nut_usmAES256PrivProtocol) = lt_dlsym(dl_handle,
 						"usmAES256PrivProtocol");
 	if ((dl_error = lt_dlerror()) != NULL) {
 		goto err;
 	}
+# endif /* NUT_HAVE_LIBNETSNMP_usmAES256PrivProtocol */
 #endif /* NETSNMP_DRAFT_BLUMENTHAL_AES_04 */
 
+#if NUT_HAVE_LIBNETSNMP_usmHMAC192SHA256AuthProtocol
 	*(void **) (&nut_usmHMAC192SHA256AuthProtocol) = lt_dlsym(dl_handle,
 						"usmHMAC192SHA256AuthProtocol");
 	if ((dl_error = lt_dlerror()) != NULL) {
 		goto err;
 	}
+#endif /* NUT_HAVE_LIBNETSNMP_usmHMAC192SHA256AuthProtocol */
 
+#if NUT_HAVE_LIBNETSNMP_usmHMAC256SHA384AuthProtocol
 	*(void **) (&nut_usmHMAC256SHA384AuthProtocol) = lt_dlsym(dl_handle,
 						"usmHMAC256SHA384AuthProtocol");
 	if ((dl_error = lt_dlerror()) != NULL) {
 		goto err;
 	}
+#endif /* NUT_HAVE_LIBNETSNMP_usmHMAC256SHA384AuthProtocol */
 
+#if NUT_HAVE_LIBNETSNMP_usmHMAC384SHA512AuthProtocol
 	*(void **) (&nut_usmHMAC384SHA512AuthProtocol) = lt_dlsym(dl_handle,
 						"usmHMAC384SHA512AuthProtocol");
 	if ((dl_error = lt_dlerror()) != NULL) {
 		goto err;
 	}
+#endif /* NUT_HAVE_LIBNETSNMP_usmHMAC384SHA512AuthProtocol */
 
 	return 1;
 err:
@@ -533,44 +569,60 @@ static int init_session(struct snmp_session * snmp_sess, nutscan_snmp_t * sec)
 		/* Process authentication protocol and key */
 		snmp_sess->securityAuthKeyLen = USM_AUTH_KU_LEN;
 
+#if NUT_HAVE_LIBNETSNMP_usmHMACMD5AuthProtocol
 		/* default to MD5 */
 		snmp_sess->securityAuthProto = nut_usmHMACMD5AuthProtocol;
 		snmp_sess->securityAuthProtoLen =
 			sizeof(usmHMACMD5AuthProtocol)/
 			sizeof(oid);
+#endif
 
 		if (sec->authProtocol) {
+#if NUT_HAVE_LIBNETSNMP_usmHMACSHA1AuthProtocol
 			if (strcmp(sec->authProtocol, "SHA") == 0) {
 				snmp_sess->securityAuthProto = nut_usmHMACSHA1AuthProtocol;
 				snmp_sess->securityAuthProtoLen =
 					sizeof(usmHMACSHA1AuthProtocol)/
 					sizeof(oid);
 			}
-			else if (strcmp(sec->authProtocol, "SHA256") == 0) {
+			else
+#endif
+#if NUT_HAVE_LIBNETSNMP_usmHMAC192SHA256AuthProtocol
+			if (strcmp(sec->authProtocol, "SHA256") == 0) {
 				snmp_sess->securityAuthProto = nut_usmHMAC192SHA256AuthProtocol;
 				snmp_sess->securityAuthProtoLen =
 					sizeof(usmHMAC192SHA256AuthProtocol)/
 					sizeof(oid);
 			}
-			else if (strcmp(sec->authProtocol, "SHA384") == 0) {
+			else
+#endif
+#if NUT_HAVE_LIBNETSNMP_usmHMAC256SHA384AuthProtocol
+			if (strcmp(sec->authProtocol, "SHA384") == 0) {
 				snmp_sess->securityAuthProto = nut_usmHMAC256SHA384AuthProtocol;
 				snmp_sess->securityAuthProtoLen =
 					sizeof(usmHMAC256SHA384AuthProtocol)/
 					sizeof(oid);
 			}
-			else if (strcmp(sec->authProtocol, "SHA512") == 0) {
+			else
+#endif
+#if NUT_HAVE_LIBNETSNMP_usmHMAC384SHA512AuthProtocol
+			if (strcmp(sec->authProtocol, "SHA512") == 0) {
 				snmp_sess->securityAuthProto = nut_usmHMAC384SHA512AuthProtocol;
 				snmp_sess->securityAuthProtoLen =
 					sizeof(usmHMAC384SHA512AuthProtocol)/
 					sizeof(oid);
 			}
-			else {
-				if (strcmp(sec->authProtocol, "MD5") != 0) {
-					fprintf(stderr,
-						"Bad SNMPv3 authProtocol: %s\n",
-						sec->authProtocol);
-					return 0;
-				}
+			else
+#endif
+#if NUT_HAVE_LIBNETSNMP_usmHMACMD5AuthProtocol
+			if (strcmp(sec->authProtocol, "MD5") != 0) {
+#else
+			{
+#endif
+				fprintf(stderr,
+					"Bad SNMPv3 authProtocol: %s\n",
+					sec->authProtocol);
+				return 0;
 			}
 		}
 
@@ -595,39 +647,52 @@ static int init_session(struct snmp_session * snmp_sess, nutscan_snmp_t * sec)
 			return 1;
 		}
 
+#if NUT_HAVE_LIBNETSNMP_usmDESPrivProtocol
 		/* default to DES */
 		snmp_sess->securityPrivProto = nut_usmDESPrivProtocol;
 		snmp_sess->securityPrivProtoLen =
 			sizeof(usmDESPrivProtocol)/sizeof(oid);
+#endif
 
 		if (sec->privProtocol) {
+#if NUT_HAVE_LIBNETSNMP_usmAESPrivProtocol || NUT_HAVE_LIBNETSNMP_usmAES128PrivProtocol
 			if (strcmp(sec->privProtocol, "AES") == 0) {
 				snmp_sess->securityPrivProto = nut_usmAESPrivProtocol;
 				snmp_sess->securityPrivProtoLen =
 					sizeof(usmAESPrivProtocol)/
 					sizeof(oid);
 			}
+			else
+#endif
 #if NETSNMP_DRAFT_BLUMENTHAL_AES_04
-			else if (strcmp(sec->privProtocol, "AES192") == 0) {
+# if NUT_HAVE_LIBNETSNMP_usmAES192PrivProtocol
+			if (strcmp(sec->privProtocol, "AES192") == 0) {
 				snmp_sess->securityPrivProto = nut_usmAES192PrivProtocol;
 				snmp_sess->securityPrivProtoLen =
 					sizeof(usmAES192PrivProtocol)/
 					sizeof(oid);
 			}
-			else if (strcmp(sec->privProtocol, "AES256") == 0) {
+			else
+# endif
+# if NUT_HAVE_LIBNETSNMP_usmAES256PrivProtocol
+			if (strcmp(sec->privProtocol, "AES256") == 0) {
 				snmp_sess->securityPrivProto = nut_usmAES256PrivProtocol;
 				snmp_sess->securityPrivProtoLen =
 					sizeof(usmAES256PrivProtocol)/
 					sizeof(oid);
 			}
+			else
+# endif
 #endif /* NETSNMP_DRAFT_BLUMENTHAL_AES_04 */
-			else {
-				if (strcmp(sec->privProtocol, "DES") != 0) {
-					fprintf(stderr,
-						"Bad SNMPv3 privProtocol: %s\n",
-						sec->privProtocol);
-					return 0;
-				}
+#if NUT_HAVE_LIBNETSNMP_usmDESPrivProtocol
+			if (strcmp(sec->privProtocol, "DES") != 0) {
+#else
+			{
+#endif
+				fprintf(stderr,
+					"Bad SNMPv3 privProtocol: %s\n",
+					sec->privProtocol);
+				return 0;
 			}
 		}
 

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -105,8 +105,10 @@ static oid *nut_usmAESPrivProtocol;
 static oid *nut_usmHMACMD5AuthProtocol;
 static oid *nut_usmHMACSHA1AuthProtocol;
 static oid *nut_usmDESPrivProtocol;
+#if NETSNMP_DRAFT_BLUMENTHAL_AES_04
 static oid *nut_usmAES192PrivProtocol;
 static oid *nut_usmAES256PrivProtocol;
+#endif
 static oid *nut_usmHMAC192SHA256AuthProtocol;
 static oid *nut_usmHMAC256SHA384AuthProtocol;
 static oid *nut_usmHMAC384SHA512AuthProtocol;
@@ -251,6 +253,7 @@ int nutscan_load_snmp_library(const char *libname_path)
 	if ((dl_error = lt_dlerror()) != NULL) {
 		goto err;
 	}
+
 #if NETSNMP_DRAFT_BLUMENTHAL_AES_04
 	*(void **) (&nut_usmAES192PrivProtocol) = lt_dlsym(dl_handle,
 						"usmAES192PrivProtocol");
@@ -263,7 +266,7 @@ int nutscan_load_snmp_library(const char *libname_path)
 	if ((dl_error = lt_dlerror()) != NULL) {
 		goto err;
 	}
-#endif
+#endif /* NETSNMP_DRAFT_BLUMENTHAL_AES_04 */
 
 	*(void **) (&nut_usmHMAC192SHA256AuthProtocol) = lt_dlsym(dl_handle,
 						"usmHMAC192SHA256AuthProtocol");
@@ -617,7 +620,7 @@ static int init_session(struct snmp_session * snmp_sess, nutscan_snmp_t * sec)
 					sizeof(usmAES256PrivProtocol)/
 					sizeof(oid);
 			}
-#endif
+#endif /* NETSNMP_DRAFT_BLUMENTHAL_AES_04 */
 			else {
 				if (strcmp(sec->privProtocol, "DES") != 0) {
 					fprintf(stderr,

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -105,6 +105,11 @@ static oid *nut_usmAESPrivProtocol;
 static oid *nut_usmHMACMD5AuthProtocol;
 static oid *nut_usmHMACSHA1AuthProtocol;
 static oid *nut_usmDESPrivProtocol;
+static oid *nut_usmAES192PrivProtocol;
+static oid *nut_usmAES256PrivProtocol;
+static oid *nut_usmHMAC192SHA256AuthProtocol;
+static oid *nut_usmHMAC256SHA384AuthProtocol;
+static oid *nut_usmHMAC384SHA512AuthProtocol;
 
 /* return 0 on error; visible externally */
 int nutscan_load_snmp_library(const char *libname_path);
@@ -243,6 +248,37 @@ int nutscan_load_snmp_library(const char *libname_path)
 
 	*(void **) (&nut_usmDESPrivProtocol) = lt_dlsym(dl_handle,
 						"usmDESPrivProtocol");
+	if ((dl_error = lt_dlerror()) != NULL) {
+		goto err;
+	}
+#if NETSNMP_DRAFT_BLUMENTHAL_AES_04
+	*(void **) (&nut_usmAES192PrivProtocol) = lt_dlsym(dl_handle,
+						"usmAES192PrivProtocol");
+	if ((dl_error = lt_dlerror()) != NULL) {
+		goto err;
+	}
+
+	*(void **) (&nut_usmAES256PrivProtocol) = lt_dlsym(dl_handle,
+						"usmAES256PrivProtocol");
+	if ((dl_error = lt_dlerror()) != NULL) {
+		goto err;
+	}
+#endif
+
+	*(void **) (&nut_usmHMAC192SHA256AuthProtocol) = lt_dlsym(dl_handle,
+						"usmHMAC192SHA256AuthProtocol");
+	if ((dl_error = lt_dlerror()) != NULL) {
+		goto err;
+	}
+
+	*(void **) (&nut_usmHMAC256SHA384AuthProtocol) = lt_dlsym(dl_handle,
+						"usmHMAC256SHA384AuthProtocol");
+	if ((dl_error = lt_dlerror()) != NULL) {
+		goto err;
+	}
+
+	*(void **) (&nut_usmHMAC384SHA512AuthProtocol) = lt_dlsym(dl_handle,
+						"usmHMAC384SHA512AuthProtocol");
 	if ((dl_error = lt_dlerror()) != NULL) {
 		goto err;
 	}
@@ -507,10 +543,28 @@ static int init_session(struct snmp_session * snmp_sess, nutscan_snmp_t * sec)
 					sizeof(usmHMACSHA1AuthProtocol)/
 					sizeof(oid);
 			}
+			else if (strcmp(sec->authProtocol, "SHA256") == 0) {
+				snmp_sess->securityAuthProto = nut_usmHMAC192SHA256AuthProtocol;
+				snmp_sess->securityAuthProtoLen =
+					sizeof(usmHMAC192SHA256AuthProtocol)/
+					sizeof(oid);
+			}
+			else if (strcmp(sec->authProtocol, "SHA384") == 0) {
+				snmp_sess->securityAuthProto = nut_usmHMAC256SHA384AuthProtocol;
+				snmp_sess->securityAuthProtoLen =
+					sizeof(usmHMAC256SHA384AuthProtocol)/
+					sizeof(oid);
+			}
+			else if (strcmp(sec->authProtocol, "SHA512") == 0) {
+				snmp_sess->securityAuthProto = nut_usmHMAC384SHA512AuthProtocol;
+				snmp_sess->securityAuthProtoLen =
+					sizeof(usmHMAC384SHA512AuthProtocol)/
+					sizeof(oid);
+			}
 			else {
 				if (strcmp(sec->authProtocol, "MD5") != 0) {
 					fprintf(stderr,
-						"Bad SNMPv3 authProtocol: %s",
+						"Bad SNMPv3 authProtocol: %s\n",
 						sec->authProtocol);
 					return 0;
 				}
@@ -550,6 +604,20 @@ static int init_session(struct snmp_session * snmp_sess, nutscan_snmp_t * sec)
 					sizeof(usmAESPrivProtocol)/
 					sizeof(oid);
 			}
+#if NETSNMP_DRAFT_BLUMENTHAL_AES_04
+			else if (strcmp(sec->privProtocol, "AES192") == 0) {
+				snmp_sess->securityPrivProto = nut_usmAES192PrivProtocol;
+				snmp_sess->securityPrivProtoLen =
+					sizeof(usmAES192PrivProtocol)/
+					sizeof(oid);
+			}
+			else if (strcmp(sec->privProtocol, "AES256") == 0) {
+				snmp_sess->securityPrivProto = nut_usmAES256PrivProtocol;
+				snmp_sess->securityPrivProtoLen =
+					sizeof(usmAES256PrivProtocol)/
+					sizeof(oid);
+			}
+#endif
 			else {
 				if (strcmp(sec->privProtocol, "DES") != 0) {
 					fprintf(stderr,


### PR DESCRIPTION
Porting an improvement from 42ITy fork of NUT, to support modern SNMPv3 encryption and auth algorithms.