### PR TITLE
Make SNMPv3 multiple auth/priv algo support more flexible in usage() messages

### DIFF
--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -350,10 +350,168 @@ void upsdrv_makevartable(void)
 		"Set the authentication pass phrase used for authenticated SNMPv3 messages (no default)");
 	addvar(VAR_VALUE | VAR_SENSITIVE, SU_VAR_PRIVPASSWD,
 		"Set the privacy pass phrase used for encrypted SNMPv3 messages (no default)");
-	addvar(VAR_VALUE, SU_VAR_AUTHPROT,
-		"Set the authentication protocol (MD5 or SHA) used for authenticated SNMPv3 messages (default=MD5)");
-	addvar(VAR_VALUE, SU_VAR_PRIVPROT,
-		"Set the privacy protocol (DES or AES) used for encrypted SNMPv3 messages (default=DES)");
+
+	/* Construct addvar() for SU_VAR_AUTHPROT: */
+	{ int comma = 0;
+	char tmp_buf[SU_LARGEBUF];
+	char *p = tmp_buf;
+	char *pn; /* proto name to add */
+	size_t remain = sizeof(tmp_buf) - 1;
+	int ret;
+	NUT_UNUSED_VARIABLE(comma); // potentially, if no protocols are available
+
+	tmp_buf[0] = '\0';
+
+	ret = snprintf(p, remain, "%s",
+		"Set the authentication protocol (");
+	if (ret < 0 || (uintmax_t)ret > (uintmax_t)remain) {
+		fatalx(EXIT_FAILURE, "Could not addvar()");
+	}
+	p += ret;
+	remain -= ret;
+
+#if NUT_HAVE_LIBNETSNMP_usmHMACMD5AuthProtocol
+	pn = "MD5";
+	ret = snprintf(p, remain, "%s%s", (comma++ ? ", " : ""), pn );
+	if (ret < 0 || (uintmax_t)ret > (uintmax_t)remain) {
+		fatalx(EXIT_FAILURE, "Could not addvar(%s)", pn);
+	}
+	p += ret;
+	remain -= ret;
+#endif
+#if NUT_HAVE_LIBNETSNMP_usmHMACSHA1AuthProtocol
+	pn = "SHA";
+	ret = snprintf(p, remain, "%s%s", (comma++ ? ", " : ""), pn );
+	if (ret < 0 || (uintmax_t)ret > (uintmax_t)remain) {
+		fatalx(EXIT_FAILURE, "Could not addvar(%s)", pn);
+	}
+	p += ret;
+	remain -= ret;
+#endif
+#if NUT_HAVE_LIBNETSNMP_usmHMAC192SHA256AuthProtocol
+	pn = "SHA256";
+	ret = snprintf(p, remain, "%s%s", (comma++ ? ", " : ""), pn );
+	if (ret < 0 || (uintmax_t)ret > (uintmax_t)remain) {
+		fatalx(EXIT_FAILURE, "Could not addvar(%s)", pn);
+	}
+	p += ret;
+	remain -= ret;
+#endif
+#if NUT_HAVE_LIBNETSNMP_usmHMAC256SHA384AuthProtocol
+	pn = "SHA384";
+	ret = snprintf(p, remain, "%s%s", (comma++ ? ", " : ""), pn );
+	if (ret < 0 || (uintmax_t)ret > (uintmax_t)remain) {
+		fatalx(EXIT_FAILURE, "Could not addvar(%s)", pn);
+	}
+	p += ret;
+	remain -= ret;
+#endif
+#if NUT_HAVE_LIBNETSNMP_usmHMAC384SHA512AuthProtocol
+	pn = "SHA512";
+	ret = snprintf(p, remain, "%s%s", (comma++ ? ", " : ""), pn );
+	if (ret < 0 || (uintmax_t)ret > (uintmax_t)remain) {
+		fatalx(EXIT_FAILURE, "Could not addvar(%s)", pn);
+	}
+	p += ret;
+	remain -= ret;
+#endif
+
+	pn = "none supported";
+	ret = snprintf(p, remain, "%s", (comma++ ? "" : pn) );
+	if (ret < 0 || (uintmax_t)ret > (uintmax_t)remain) {
+		fatalx(EXIT_FAILURE, "Could not addvar(%s)", pn);
+	}
+	p += ret;
+	remain -= ret;
+
+	ret = snprintf(p, remain, "%s",
+		") used for authenticated SNMPv3 messages (default=MD5 if available)");
+	if (ret < 0 || (uintmax_t)ret > (uintmax_t)remain) {
+		fatalx(EXIT_FAILURE, "Could not addvar()");
+	}
+	p += ret;
+	remain -= ret;
+
+	addvar(VAR_VALUE, SU_VAR_AUTHPROT, tmp_buf);
+	} /* Construct addvar() for AUTHPROTO */
+
+	/* Construct addvar() for SU_VAR_PRIVPROT: */
+	{ int comma = 0;
+	char tmp_buf[SU_LARGEBUF];
+	char *p = tmp_buf;
+	char *pn; /* proto name to add */
+	size_t remain = sizeof(tmp_buf) - 1;
+	int ret;
+	NUT_UNUSED_VARIABLE(comma); // potentially, if no protocols are available
+
+	tmp_buf[0] = '\0';
+
+	ret = snprintf(p, remain, "%s",
+		"Set the privacy protocol (");
+	if (ret < 0 || (uintmax_t)ret > (uintmax_t)remain) {
+		fatalx(EXIT_FAILURE, "Could not addvar()");
+	}
+	p += ret;
+	remain -= ret;
+
+#if NUT_HAVE_LIBNETSNMP_usmDESPrivProtocol
+	pn = "DES";
+	ret = snprintf(p, remain, "%s%s", (comma++ ? ", " : ""), pn );
+	if (ret < 0 || (uintmax_t)ret > (uintmax_t)remain) {
+		fatalx(EXIT_FAILURE, "Could not addvar(%s)", pn);
+	}
+	p += ret;
+	remain -= ret;
+#endif
+#if NUT_HAVE_LIBNETSNMP_usmAESPrivProtocol || NUT_HAVE_LIBNETSNMP_usmAES128PrivProtocol
+	pn = "AES";
+	ret = snprintf(p, remain, "%s%s", (comma++ ? ", " : ""), pn );
+	if (ret < 0 || (uintmax_t)ret > (uintmax_t)remain) {
+		fatalx(EXIT_FAILURE, "Could not addvar(%s)", pn);
+	}
+	p += ret;
+	remain -= ret;
+#endif
+#if NETSNMP_DRAFT_BLUMENTHAL_AES_04
+# if NUT_HAVE_LIBNETSNMP_usmAES192PrivProtocol
+	pn = "AES192";
+	ret = snprintf(p, remain, "%s%s", (comma++ ? ", " : ""), pn );
+	if (ret < 0 || (uintmax_t)ret > (uintmax_t)remain) {
+		fatalx(EXIT_FAILURE, "Could not addvar(%s)", pn);
+	}
+	p += ret;
+	remain -= ret;
+# endif
+# if NUT_HAVE_LIBNETSNMP_usmAES256PrivProtocol
+	pn = "AES256";
+	ret = snprintf(p, remain, "%s%s", (comma++ ? ", " : ""), pn );
+	if (ret < 0 || (uintmax_t)ret > (uintmax_t)remain) {
+		fatalx(EXIT_FAILURE, "Could not addvar(%s)", pn);
+	}
+	p += ret;
+	remain -= ret;
+# endif
+#endif /* NETSNMP_DRAFT_BLUMENTHAL_AES_04 */
+
+	pn = "none supported";
+	ret = snprintf(p, remain, "%s", (comma++ ? "" : pn) );
+	if (ret < 0 || (uintmax_t)ret > (uintmax_t)remain) {
+		fatalx(EXIT_FAILURE, "Could not addvar(%s)", pn);
+	}
+	p += ret;
+	remain -= ret;
+
+	ret = snprintf(p, remain, "%s",
+		") used for encrypted SNMPv3 messages (default=DES if available)");
+	if (ret < 0 || (uintmax_t)ret > (uintmax_t)remain) {
+		fatalx(EXIT_FAILURE, "Could not addvar()");
+	}
+	p += ret;
+	remain -= ret;
+
+	addvar(VAR_VALUE, SU_VAR_PRIVPROT, tmp_buf);
+	} /* Construct addvar() for PRIVPROTO */
+
 	addvar(VAR_VALUE, SU_VAR_ONDELAY,
 		"Set start delay time after shutdown");
 	addvar(VAR_VALUE, SU_VAR_OFFDELAY,

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -215,13 +215,85 @@ static void show_usage()
 		printf("\nSNMP v3 specific options:\n");
 		printf("  -l, --secLevel <security level>: Set the securityLevel used for SNMPv3 messages (allowed values: noAuthNoPriv, authNoPriv, authPriv)\n");
 		printf("  -u, --secName <security name>: Set the securityName used for authenticated SNMPv3 messages (mandatory if you set secLevel. No default)\n");
-		printf("  -w, --authProtocol <authentication protocol>: Set the authentication protocol (MD5, SHA, SHA256, SHA384 or SHA512) used for authenticated SNMPv3 messages (default=MD5)\n");
-		printf("  -W, --authPassword <authentication pass phrase>: Set the authentication pass phrase used for authenticated SNMPv3 messages (mandatory if you set secLevel to authNoPriv or authPriv)\n");
-#if NETSNMP_DRAFT_BLUMENTHAL_AES_04
-		printf("  -x, --privProtocol <privacy protocol>: Set the privacy protocol (DES, AES, AES192 or AES256) used for encrypted SNMPv3 messages (default=DES)\n");
-#else
-		printf("  -x, --privProtocol <privacy protocol>: Set the privacy protocol (DES or AES) used for encrypted SNMPv3 messages (default=DES)\n");
+
+		/* Construct help for AUTHPROTO */
+		{ int comma = 0;
+		NUT_UNUSED_VARIABLE(comma); // potentially, if no protocols are available
+		printf("  -w, --authProtocol <authentication protocol>: Set the authentication protocol (");
+#if NUT_HAVE_LIBNETSNMP_usmHMACMD5AuthProtocol
+		printf("%s%s",
+			(comma++ ? ", " : ""),
+			"MD5"
+			);
 #endif
+#if NUT_HAVE_LIBNETSNMP_usmHMACSHA1AuthProtocol
+		printf("%s%s",
+			(comma++ ? ", " : ""),
+			"SHA"
+			);
+#endif
+#if NUT_HAVE_LIBNETSNMP_usmHMAC192SHA256AuthProtocol
+		printf("%s%s",
+			(comma++ ? ", " : ""),
+			"SHA256"
+			);
+#endif
+#if NUT_HAVE_LIBNETSNMP_usmHMAC256SHA384AuthProtocol
+		printf("%s%s",
+			(comma++ ? ", " : ""),
+			"SHA384"
+			);
+#endif
+#if NUT_HAVE_LIBNETSNMP_usmHMAC384SHA512AuthProtocol
+		printf("%s%s",
+			(comma++ ? ", " : ""),
+			"SHA512"
+			);
+#endif
+		printf("%s%s",
+			(comma ? "" : "none supported"),
+			") used for authenticated SNMPv3 messages (default=MD5 if available)\n"
+			);
+		} /* Construct help for AUTHPROTO */
+
+		printf("  -W, --authPassword <authentication pass phrase>: Set the authentication pass phrase used for authenticated SNMPv3 messages (mandatory if you set secLevel to authNoPriv or authPriv)\n");
+
+		/* Construct help for PRIVPROTO */
+		{ int comma = 0;
+		NUT_UNUSED_VARIABLE(comma); // potentially, if no protocols are available
+		printf("  -x, --privProtocol <privacy protocol>: Set the privacy protocol (");
+#if NUT_HAVE_LIBNETSNMP_usmDESPrivProtocol
+		printf("%s%s",
+			(comma++ ? ", " : ""),
+			"DES"
+			);
+#endif
+#if NUT_HAVE_LIBNETSNMP_usmAESPrivProtocol || NUT_HAVE_LIBNETSNMP_usmAES128PrivProtocol
+		printf("%s%s",
+			(comma++ ? ", " : ""),
+			"AES"
+			);
+#endif
+#if NETSNMP_DRAFT_BLUMENTHAL_AES_04
+# if NUT_HAVE_LIBNETSNMP_usmAES192PrivProtocol
+		printf("%s%s",
+			(comma++ ? ", " : ""),
+			"AES192"
+			);
+# endif
+# if NUT_HAVE_LIBNETSNMP_usmAES256PrivProtocol
+		printf("%s%s",
+			(comma++ ? ", " : ""),
+			"AES256"
+			);
+# endif
+#endif /* NETSNMP_DRAFT_BLUMENTHAL_AES_04 */
+		printf("%s%s",
+			(comma ? "" : "none supported"),
+			") used for encrypted SNMPv3 messages (default=DES if available)\n"
+			);
+		} /* Construct help for PRIVPROTO */
+
 		printf("  -X, --privPassword <privacy pass phrase>: Set the privacy pass phrase used for encrypted SNMPv3 messages (mandatory if you set secLevel to authPriv)\n");
 	}
 

--- a/tools/nut-scanner/scan_ipmi.c
+++ b/tools/nut-scanner/scan_ipmi.c
@@ -446,7 +446,7 @@ nutscan_device_t * nutscan_scan_ipmi_device(const char * IPaddr, nutscan_ipmi_t 
 															ipmi_sec->username,
 															ipmi_sec->password,
 															ipmi_sec->K_g_BMC_key,
-???															(ipmi_sec->K_g_BMC_key) ? config->k_g_len : 0,
+/*???*/														(ipmi_sec->K_g_BMC_key) ? config->k_g_len : 0,
 															ipmi_sec->privilege_level,
 															ipmi_sec->cipher_suite_id,
 															IPMI_SESSION_TIMEOUT_LENGTH_DEFAULT,

--- a/tools/nut-scanner/scan_nut.c
+++ b/tools/nut-scanner/scan_nut.c
@@ -232,7 +232,9 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 	pthread_t thread;
 	nutscan_thread_t * thread_array = NULL;
 	int thread_count = 0;
+# if (defined HAVE_PTHREAD_TRYJOIN) || (defined HAVE_SEMAPHORE)
 	size_t  max_threads_scantype = max_threads_oldnut;
+# endif
 
 	pthread_mutex_init(&dev_mutex, NULL);
 

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -869,7 +869,9 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 	pthread_t thread;
 	nutscan_thread_t * thread_array = NULL;
 	int thread_count = 0;
+# if (defined HAVE_PTHREAD_TRYJOIN) || (defined HAVE_SEMAPHORE)
 	size_t  max_threads_scantype = max_threads_netsnmp;
+# endif
 
 	pthread_mutex_init(&dev_mutex, NULL);
 

--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -419,7 +419,9 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 			pthread_t thread;
 			nutscan_thread_t * thread_array = NULL;
 			int thread_count = 0;
+# if (defined HAVE_PTHREAD_TRYJOIN) || (defined HAVE_SEMAPHORE)
 			size_t  max_threads_scantype = max_threads_netxml;
+# endif
 
 			pthread_mutex_init(&dev_mutex, NULL);
 


### PR DESCRIPTION
This should satisfy part of issue #1169, about reporting relevant algo names as supported by a particular build of NUT.