### PR TITLE
Fix builds on older platforms

### DIFF
--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -362,7 +362,42 @@ set | sort -n """
                     'BITS': [32, 64],
                     'CSTDVERSION_${KEY}': [ ['c': '99', 'cxx': '98'], ['c': '17', 'cxx': '17'] ],
                     'CSTDVARIANT': ['gnu'],
-                    'BUILD_TYPE': ['default-nodoc', 'default-tgt:distcheck-valgrind']
+                    'BUILD_TYPE': ['default-nodoc']
+                    // BUILD_TYPE=default-withdoc:man
+                    // BUILD_TYPE=default-tgt:distcheck-light == --with-all=auto --with-ssl=auto --with-doc=auto
+                    // BUILD_TYPE=default-tgt:distcheck-light + NO_PKG_CONFIG=true ?
+                    ],
+                dynamatrixAxesCommonEnv: [
+                    ['LANG=C','LC_ALL=C','TZ=UTC'
+                     //,'BUILD_WARNFATAL=yes','BUILD_WARNOPT=hard'
+                    ]
+                    ],
+                allowedFailure: [
+                    dynacfgPipeline.axisCombos_WINDOWS
+                    ],
+                runAllowedFailure: true,
+                mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
+                excludeCombos: dynacfgPipeline.excludeCombos_DEFAULT_CPPUNIT_STRICT_C
+                ], body)
+            }, // getParStages
+        'bodyParStages': dynacfgPipeline.slowBuildDefaultBody_ci_build
+        ] // one slowBuild filter configuration
+
+        ,[name: 'Valgrind+distchecked target builds with main and ~newest supported C/C++ revisions (must pass on all platforms)',
+         disabled: dynacfgPipeline.disableSlowBuildCIBuild,
+         //branchRegexSource: ~/^(PR-.+|fightwarn.*)$/,
+         //branchRegexTarget: dynacfgPipeline.branchStableRegex,
+         appliesToChangedFilesRegex: dynacfgPipeline.appliesToChangedFilesRegex_C,
+         'getParStages': { dynamatrix, Closure body ->
+            return dynamatrix.generateBuild([
+                requiredNodelabels: ["(NUT_BUILD_CAPS=valgrind=yes||NUT_BUILD_CAPS=valgrind)"],
+                excludedNodelabels: ["NUT_BUILD_CAPS=valgrind=no"],
+
+                dynamatrixAxesVirtualLabelsMap: [
+                    'BITS': [32, 64],
+                    'CSTDVERSION_${KEY}': [ ['c': '99', 'cxx': '98'], ['c': '17', 'cxx': '17'] ],
+                    'CSTDVARIANT': ['gnu'],
+                    'BUILD_TYPE': ['default-tgt:distcheck-valgrind']
                     // BUILD_TYPE=default-withdoc:man
                     // BUILD_TYPE=default-tgt:distcheck-light == --with-all=auto --with-ssl=auto --with-doc=auto
                     // BUILD_TYPE=default-tgt:distcheck-light + NO_PKG_CONFIG=true ?

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -283,7 +283,7 @@ optional_maintainer_clean_check() {
         return 0
     fi
 
-    if [ "${DO_MAINTAINER_CLEAN_CHECK-}" = "no" ] ; then
+    if [ "${DO_CLEAN_CHECK-}" = "no" ] || [ "${DO_MAINTAINER_CLEAN_CHECK-}" = "no" ] ; then
         echo "Skipping maintainer-clean check because recipe/developer said so"
     else
         [ -z "$CI_TIME" ] || echo "`date`: Starting maintainer-clean check of currently tested project..."
@@ -320,7 +320,7 @@ optional_dist_clean_check() {
         return 0
     fi
 
-    if [ "${DO_DIST_CLEAN_CHECK-}" = "no" ] ; then
+    if [ "${DO_CLEAN_CHECK-}" = "no" ] || [ "${DO_DIST_CLEAN_CHECK-}" = "no" ] ; then
         echo "Skipping distclean check because recipe/developer said so"
     else
         [ -z "$CI_TIME" ] || echo "`date`: Starting dist-clean check of currently tested project..."

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -296,10 +296,10 @@ optional_maintainer_clean_check() {
             echo "WARNING: Skipping maintainer-clean check because there is no `pwd`/.git anymore" >&2
             return 0
         fi
-        git status --ignored -s || echo "WARNING: Could not query git repo while in `pwd`" >&2
+        git status --ignored -s | egrep -v '^.. \.ci.*\.log.*' || echo "WARNING: Could not query git repo while in `pwd`" >&2
         echo "==="
 
-        if [ -n "`git status --ignored -s`" ] && [ "$CI_REQUIRE_GOOD_GITIGNORE" != false ]; then
+        if [ -n "`git status --ignored -s | egrep -v '^.. \.ci.*\.log.*'`" ] && [ "$CI_REQUIRE_GOOD_GITIGNORE" != false ]; then
             echo "FATAL: There are changes in some files listed above - tracked sources should be updated in the PR, and build products should be added to a .gitignore file, everything made should be cleaned and no tracked files should be removed!" >&2
             git diff || true
             echo "==="

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -296,7 +296,7 @@ optional_maintainer_clean_check() {
             echo "WARNING: Skipping maintainer-clean check because there is no `pwd`/.git anymore" >&2
             return 0
         fi
-        git status --ignored -s || true
+        git status --ignored -s || echo "WARNING: Could not query git repo while in `pwd`" >&2
         echo "==="
 
         if [ -n "`git status --ignored -s`" ] && [ "$CI_REQUIRE_GOOD_GITIGNORE" != false ]; then
@@ -333,7 +333,7 @@ optional_dist_clean_check() {
             echo "WARNING: Skipping distclean check because there is no `pwd`/.git anymore" >&2
             return 0
         fi
-        git status -s || true
+        git status -s || echo "WARNING: Could not query git repo while in `pwd`" >&2
         echo "==="
 
         if [ -n "`git status -s`" ] && [ "$CI_REQUIRE_GOOD_GITIGNORE" != false ]; then
@@ -765,7 +765,7 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
             $CI_TIME $MAKE VERBOSE=1 DISTCHECK_FLAGS="$DISTCHECK_FLAGS" $PARMAKE_FLAGS "$BUILD_TGT"
 
             echo "=== Are GitIgnores good after '$MAKE $BUILD_TGT'? (should have no output below)"
-            git status -s || true
+            git status -s || echo "WARNING: Could not query git repo while in `pwd`" >&2
             echo "==="
             if git status -s | egrep '\.dmf$' && [ "$CI_REQUIRE_GOOD_GITIGNORE" != false ] ; then
                 echo "FATAL: There are changes in DMF files listed above - tracked sources should be updated!" >&2
@@ -950,7 +950,7 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
       $CI_TIME $MAKE VERBOSE=1 all )
 
     echo "=== Are GitIgnores good after '$MAKE all'? (should have no output below)"
-    git status -s || true
+    git status -s || echo "WARNING: Could not query git repo while in `pwd`" >&2
     echo "==="
     if [ -n "`git status -s`" ] && [ "$CI_REQUIRE_GOOD_GITIGNORE" != false ]; then
         echo "FATAL: There are changes in some files listed above - tracked sources should be updated in the PR, and build products should be added to a .gitignore file!" >&2
@@ -976,7 +976,7 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
         $CI_TIME $MAKE VERBOSE=1 DISTCHECK_FLAGS="$DISTCHECK_FLAGS" $PARMAKE_FLAGS distcheck
 
         echo "=== Are GitIgnores good after '$MAKE distcheck'? (should have no output below)"
-        git status -s || true
+        git status -s || echo "WARNING: Could not query git repo while in `pwd`" >&2
         echo "==="
 
         if [ -n "`git status -s`" ] && [ "$CI_REQUIRE_GOOD_GITIGNORE" != false ]; then

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -492,12 +492,18 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
         *openindiana*|*omnios*|*solaris*|*illumos*|*sunos*)
             case "$CC$CXX$CFLAGS$CXXFLAGS$LDFLAGS" in
                 *-m64*)
-                    SYS_PKG_CONFIG_PATH="/usr/lib/64/pkgconfig:/usr/lib/amd64/pkgconfig:/usr/lib/sparcv9/pkgconfig:/usr/lib/amd64/pkgconfig"
+                    SYS_PKG_CONFIG_PATH="/usr/lib/64/pkgconfig:/usr/lib/amd64/pkgconfig:/usr/lib/sparcv9/pkgconfig:/usr/lib/pkgconfig"
+                    ;;
+                *-m32*)
+                    SYS_PKG_CONFIG_PATH="/usr/lib/32/pkgconfig:/usr/lib/pkgconfig:/usr/lib/i86pc/pkgconfig:/usr/lib/i386/pkgconfig:/usr/lib/sparcv7/pkgconfig"
                     ;;
                 *)
                     case "$ARCH$BITS" in
                         *64*)
-                            SYS_PKG_CONFIG_PATH="/usr/lib/64/pkgconfig:/usr/lib/amd64/pkgconfig:/usr/lib/sparcv9/pkgconfig:/usr/lib/amd64/pkgconfig"
+                            SYS_PKG_CONFIG_PATH="/usr/lib/64/pkgconfig:/usr/lib/amd64/pkgconfig:/usr/lib/sparcv9/pkgconfig:/usr/lib/pkgconfig"
+                            ;;
+                        *32*)
+                            SYS_PKG_CONFIG_PATH="/usr/lib/32/pkgconfig:/usr/lib/pkgconfig:/usr/lib/i86pc/pkgconfig:/usr/lib/i386/pkgconfig:/usr/lib/sparcv7/pkgconfig"
                             ;;
                     esac
                     ;;

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -292,6 +292,10 @@ optional_maintainer_clean_check() {
         $CI_TIME $MAKE VERBOSE=1 DISTCHECK_FLAGS="$DISTCHECK_FLAGS" $PARMAKE_FLAGS maintainer-clean || return
 
         echo "=== Are GitIgnores good after '$MAKE maintainer-clean'? (should have no output below)"
+        if [ ! -e .git ]; then
+            echo "WARNING: Skipping maintainer-clean check because there is no `pwd`/.git anymore" >&2
+            return 0
+        fi
         git status --ignored -s || true
         echo "==="
 
@@ -325,6 +329,10 @@ optional_dist_clean_check() {
         $CI_TIME $MAKE VERBOSE=1 DISTCHECK_FLAGS="$DISTCHECK_FLAGS" $PARMAKE_FLAGS distclean || return
 
         echo "=== Are GitIgnores good after '$MAKE distclean'? (should have no output below)"
+        if [ ! -e .git ]; then
+            echo "WARNING: Skipping distclean check because there is no `pwd`/.git anymore" >&2
+            return 0
+        fi
         git status -s || true
         echo "==="
 

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -1568,7 +1568,7 @@ static void parse_status(utype_t *ups, char *status)
 	upsdebugx(2, "%s: [%s]", __func__, status);
 
 	/* empty response is the same as a dead ups */
-	if (!strcmp(status, "")) {
+	if (status == NULL || status[0] == '\0') {
 		ups_is_gone(ups);
 		return;
 	}

--- a/configure.ac
+++ b/configure.ac
@@ -1566,7 +1566,12 @@ AC_ARG_WITH([systemdsystemunitdir],
 [
 	case "${withval}" in
 	yes|auto|"")
-		systemdsystemunitdir="`$PKG_CONFIG --variable=systemdsystemunitdir systemd`"
+		AS_IF([test x"$have_PKG_CONFIG" = xyes],
+			[systemdsystemunitdir="`$PKG_CONFIG --variable=systemdsystemunitdir systemd`"],
+			[AS_IF([test "${withval}" = yes],
+				[AC_MSG_ERROR([--with-systemdsystemunitdir=${withval} was requested, but PKG_CONFIG could not be queried for the system settings])])
+			 systemdsystemunitdir=""
+			])
 		;;
 	no)
 		systemdsystemunitdir=""
@@ -1594,7 +1599,12 @@ dnl Note: this option is enabled only if systemdsystemunitdir is not trivial
 if test -n "${systemdsystemunitdir}"; then
 	case "${systemdshutdowndir}" in
 	yes|auto|"")
-		systemdshutdowndir="`$PKG_CONFIG --variable=systemdshutdowndir systemd`"
+		AS_IF([test x"$have_PKG_CONFIG" = xyes],
+			[systemdshutdowndir="`$PKG_CONFIG --variable=systemdshutdowndir systemd`"],
+			[AS_IF([test "${systemdshutdowndir}" = yes],
+				[AC_MSG_ERROR([--with-systemdshutdowndir=${systemdshutdowndir} was requested, but PKG_CONFIG could not be queried for the system settings])])
+			 systemdshutdowndir=""
+			])
 		;;
 	no)
 		systemdshutdowndir=""
@@ -1618,7 +1628,12 @@ AC_ARG_WITH([systemdtmpfilesdir],
 	[systemdtmpfilesdir=${withval}])
 case "${systemdtmpfilesdir}" in
 	yes|auto|"")
-		systemdtmpfilesdir="`$PKG_CONFIG --variable=tmpfilesdir systemd`"
+		AS_IF([test x"$have_PKG_CONFIG" = xyes],
+			[systemdtmpfilesdir="`$PKG_CONFIG --variable=tmpfilesdir systemd`"],
+			[AS_IF([test "${systemdtmpfilesdir}" = yes],
+				[AC_MSG_ERROR([--with-systemdtmpfilesdir=${systemdtmpfilesdir} was requested, but PKG_CONFIG could not be queried for the system settings])])
+			 systemdtmpfilesdir=""
+			])
 		;;
 	no)
 		systemdtmpfilesdir=""

--- a/configure.ac
+++ b/configure.ac
@@ -318,7 +318,7 @@ dnl All current systems provide time.h; it need not be checked for.
 dnl Not all systems provide sys/time.h, but those that do, all allow
 dnl you to include it and time.h simultaneously.
 dnl NUT codebase provides the include/timehead.h to wrap these nuances.
-AC_CHECK_HEADERS_ONCE([sys/time.h sys/types.h sys/socket.h netdb.h])
+AC_CHECK_HEADERS_ONCE([sys/time.h time.h sys/types.h sys/socket.h netdb.h])
 AS_IF([test "$ac_cv_header_sys_time_h" = yes],
     [AC_DEFINE([TIME_WITH_SYS_TIME],[1],[Define to 1 if you can safely include both <sys/time.h>
 	     and <time.h>.  This macro is deemed obsolete by autotools.])

--- a/configure.ac
+++ b/configure.ac
@@ -31,27 +31,7 @@ dnl in sync after Git updates.
 AM_MAINTAINER_MODE
 
 dnl Some systems have older autotools without direct macro support for PKG_CONF*
-have_PKG_CONFIG=yes
-AC_PATH_PROG(dummy_PKG_CONFIG, pkg-config)
-AS_IF([test x"$dummy_PKG_CONFIG" = xno || test -z "$dummy_PKG_CONFIG"],
-    [have_PKG_CONFIG=no],
-    [AC_MSG_NOTICE([checking for autoconf macro support of pkg-config])
-     have_PKG_CONFIG=no
-     dummy_RES=0
-     ifdef([PKG_PROG_PKG_CONFIG], [], [dummy_RES=1])
-     ifdef([PKG_CHECK_MODULES], [], [dummy_RES=2])
-     AS_IF([test "${dummy_RES}" = 0],
-        [AC_MSG_NOTICE([checking for autoconf macro support of pkg-config module checker])
-         dnl The m4 macro below may be not defined if pkg-config package is not
-         dnl installed. Use of ifdef (here and below for e.g. CPPUNIT check)
-         dnl allows to avoid shell syntax errors in generated configure script
-         dnl by defining a dummy macro in-place.
-         ifdef([PKG_CHECK_MODULES], [], [AC_DEFUN([PKG_CHECK_MODULES], [false])])
-         PKG_CHECK_MODULES([dummy_PKG_CONFIG], [pkg-config], [have_PKG_CONFIG=yes])
-        ])
-])
-AS_IF([test x"$have_PKG_CONFIG" = xno],
-    [AC_MSG_WARN([pkg-config is needed to look for further dependencies (will be skipped)])])
+NUT_CHECK_PKGCONFIG
 
 
 dnl Various version related processing

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -30,6 +30,8 @@ In addition to the `--with-snmp` option above, this one allows to provide
 a custom program name (in `PATH`) or complete pathname to `net-snmp-config`.
 This may be needed on build systems which support multiple architectures,
 or in cases where your distribution names this program differently.
+With a default value of `yes` it would mean preference of this program,
+compared to information from `pkg-config`, if both are available.
 
 	--with-neon
 

--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -254,7 +254,7 @@ if WITH_FREEIPMI
 endif
 # FIXME: Hacky hot-fix for build agents of varying OS generations:
 # Different versions of IPMI libs requested 'unsigned int *' or 'int *' args:
-nut_ipmipsu_CFLAGS = $(AM_CFLAGS) -Wno-pointer-sign
+#nut_ipmipsu_CFLAGS = $(AM_CFLAGS) -Wno-pointer-sign
 nut_ipmipsu_LDADD = $(LDADD) $(LIBIPMI_LIBS)
 
 # Mac OS X metadriver

--- a/drivers/bcmxcp_ser.c
+++ b/drivers/bcmxcp_ser.c
@@ -322,12 +322,21 @@ static void pw_comm_setup(const char *port)
 #ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE
 # pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"
 #endif
+/* Older CLANG (e.g. clang-3.4) seems to not support the GCC pragmas above */
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#pragma clang diagnostic ignored "-Wtautological-constant-out-of-range-compare"
+#endif
 		switch(sizeof(speed_t)) {
 			case 8:	assert (br < INT64_MAX); break;
 			case 4:	assert (br < INT32_MAX); break;
 			case 2:	assert (br < INT16_MAX); break;
 			default:	assert (br < INT_MAX);
 		}
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) )
 # pragma GCC diagnostic pop
 #endif

--- a/drivers/mge-utalk.c
+++ b/drivers/mge-utalk.c
@@ -320,7 +320,7 @@ void upsdrv_initinfo(void)
 			}
 		}
 
-		if ( firmware && strcmp(firmware, ""))
+		if (firmware && firmware[0] != '\0')
 			dstate_setinfo("ups.firmware", "%s", firmware);
 		else
 			dstate_setinfo("ups.firmware", "unknown");

--- a/drivers/nut-ipmi.h
+++ b/drivers/nut-ipmi.h
@@ -29,6 +29,14 @@ typedef enum {
 	PSU_POWER_FAILURE		/* = status OFF */
 } psu_status_t;
 
+#ifdef HAVE_FREEIPMI_11X_12X
+  /* args 8, 9, 10, 11 of ipmi_fru_multirecord_power_supply_information() */
+  typedef int input_voltage_range_t;
+#else
+  /* args 8, 9, 10, 11 of ipmi_fru_parse_multirecord_power_supply_information() */
+  typedef unsigned int input_voltage_range_t;
+#endif
+
 /* Abstract structure to store information */
 typedef struct IPMIDevice_s {
 	int			ipmi_id;				/* FRU ID */
@@ -38,8 +46,8 @@ typedef struct IPMIDevice_s {
 	char*		part;					/* Part Number */
 	char*		date;					/* Manufacturing Date/Time */
 	int			overall_capacity;		/* realpower.nominal? */
-	int			input_minvoltage;
-	int			input_maxvoltage;
+	input_voltage_range_t			input_minvoltage;
+	input_voltage_range_t			input_maxvoltage;
 	int			input_minfreq;
 	int			input_maxfreq;
 	int			voltage;				/* psu.voltage or device.voltage */
@@ -60,4 +68,3 @@ int nut_ipmi_monitoring_init(void);
 int nut_ipmi_get_sensors_status(IPMIDevice_t *ipmi_dev);
 
 #endif /* NUT_IPMI_H */
-

--- a/drivers/nut-ipmipsu.c
+++ b/drivers/nut-ipmipsu.c
@@ -87,10 +87,17 @@ void upsdrv_initinfo(void)
 	if (ipmi_dev.overall_capacity != -1)
 		dstate_setinfo("ups.realpower.nominal", "%i", ipmi_dev.overall_capacity);
 
+	/* FIXME: Did older FreeIPMI with "unsigned int" voltage ranges
+	 * have a way to report invalid readings?
+	 */
+#ifdef HAVE_FREEIPMI_11X_12X
 	if (ipmi_dev.input_minvoltage != -1)
+#endif
 		dstate_setinfo("input.voltage.minimum", "%i", ipmi_dev.input_minvoltage);
 
+#ifdef HAVE_FREEIPMI_11X_12X
 	if (ipmi_dev.input_maxvoltage != -1)
+#endif
 		dstate_setinfo("input.voltage.maximum", "%i", ipmi_dev.input_maxvoltage);
 
 	if (ipmi_dev.input_minfreq != -1)

--- a/drivers/nut-libfreeipmi.c
+++ b/drivers/nut-libfreeipmi.c
@@ -364,8 +364,8 @@ static int libfreeipmi_get_psu_info (const void *areabuf,
 {
 	/* FIXME: directly use ipmi_dev fields */
 	unsigned int overall_capacity;
-	int low_end_input_voltage_range_1;
-	int high_end_input_voltage_range_1;
+	input_voltage_range_t low_end_input_voltage_range_1;
+	input_voltage_range_t high_end_input_voltage_range_1;
 	unsigned int low_end_input_frequency_range;
 	unsigned int high_end_input_frequency_range;
 	unsigned int voltage_1; /* code for conversion into a float */
@@ -374,8 +374,8 @@ static int libfreeipmi_get_psu_info (const void *areabuf,
 	unsigned int peak_va;
 	unsigned int inrush_current;
 	unsigned int inrush_interval;
-	int low_end_input_voltage_range_2;
-	int high_end_input_voltage_range_2;
+	input_voltage_range_t low_end_input_voltage_range_2;
+	input_voltage_range_t high_end_input_voltage_range_2;
 	unsigned int ac_dropout_tolerance;
 	unsigned int predictive_fail_support;
 	unsigned int power_factor_correction;

--- a/drivers/snmp-ups-helpers.c
+++ b/drivers/snmp-ups-helpers.c
@@ -24,7 +24,7 @@
  *
  */
 
-#include <ctype.h> /* for isprint() */
+#include "config.h"
 
 /* NUT SNMP common functions */
 #include "main.h"
@@ -32,6 +32,8 @@
 #include "nut_stdint.h"
 #include "snmp-ups.h"
 #include "timehead.h" /* time.h => strptime() */
+
+#include <ctype.h> /* for isprint() */
 
 /***********************************************************************
  * Subdrivers shared helpers functions

--- a/drivers/snmp-ups-helpers.c
+++ b/drivers/snmp-ups-helpers.c
@@ -31,6 +31,7 @@
 #include "nut_float.h"
 #include "nut_stdint.h"
 #include "snmp-ups.h"
+#include "timehead.h" /* time.h => strptime() */
 
 /***********************************************************************
  * Subdrivers shared helpers functions

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -715,13 +715,13 @@ void nut_snmp_init(const char *type, const char *hostname)
 	/* Retrieve user parameters */
 	version = testvar(SU_VAR_VERSION) ? getval(SU_VAR_VERSION) : "v1";
 
-	if ((strcmp(version, "v1") == 0) || (strcmp(version, "v2c") == 0)) {
-		g_snmp_sess.version = (strcmp(version, "v1") == 0) ? SNMP_VERSION_1 : SNMP_VERSION_2c;
+	if ((strncmp(version, "v1", 3) == 0) || (strncmp(version, "v2c", 3) == 0)) {
+		g_snmp_sess.version = (strncmp(version, "v1", 3) == 0) ? SNMP_VERSION_1 : SNMP_VERSION_2c;
 		community = testvar(SU_VAR_COMMUNITY) ? getval(SU_VAR_COMMUNITY) : "public";
 		g_snmp_sess.community = (unsigned char *)xstrdup(community);
 		g_snmp_sess.community_len = strlen(community);
 	}
-	else if (strcmp(version, "v3") == 0) {
+	else if (strncmp(version, "v3", 3) == 0) {
 		/* SNMP v3 related init */
 		g_snmp_sess.version = SNMP_VERSION_3;
 

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -1451,7 +1451,7 @@ void su_status_set(snmp_info_t *su_info_p, long value)
 
 	if ((info_value = su_find_infoval(su_info_p->oid2info, &value)) != NULL)
 	{
-		if (strcmp(info_value, "")) {
+		if (info_value[0] != '\0') {
 			status_set(info_value);
 		}
 	}

--- a/m4/nut_check_libavahi.m4
+++ b/m4/nut_check_libavahi.m4
@@ -7,25 +7,29 @@ AC_DEFUN([NUT_CHECK_LIBAVAHI],
 [
 if test -z "${nut_have_avahi_seen}"; then
 	nut_have_avahi_seen=yes
+	NUT_CHECK_PKGCONFIG
 
 	dnl save CFLAGS and LIBS
 	CFLAGS_ORIG="${CFLAGS}"
 	LIBS_ORIG="${LIBS}"
 
-	dnl See which version of the avahi library (if any) is installed
-	AC_MSG_CHECKING(for avahi-core version via pkg-config (0.6.30 minimum required))
-	AVAHI_CORE_VERSION="`pkg-config --silence-errors --modversion avahi-core 2>/dev/null`"
-	if test "$?" != "0" -o -z "${AVAHI_CORE_VERSION}"; then
-		AVAHI_CORE_VERSION="none"
-	fi
-	AC_MSG_RESULT(${AVAHI_CORE_VERSION} found)
+	AS_IF([test x"$have_PKG_CONFIG" = xyes],
+		[dnl See which version of the avahi library (if any) is installed
+		 AC_MSG_CHECKING(for avahi-core version via pkg-config (0.6.30 minimum required))
+		 AVAHI_CORE_VERSION="`$PKG_CONFIG --silence-errors --modversion avahi-core 2>/dev/null`"
+		 if test "$?" != "0" -o -z "${AVAHI_CORE_VERSION}"; then
+		    AVAHI_CORE_VERSION="none"
+		 fi
+		 AC_MSG_RESULT(${AVAHI_CORE_VERSION} found)
 
-	AC_MSG_CHECKING(for avahi-client version via pkg-config (0.6.30 minimum required))
-	AVAHI_CLIENT_VERSION="`pkg-config --silence-errors --modversion avahi-client 2>/dev/null`"
-	if test "$?" != "0" -o -z "${AVAHI_CLIENT_VERSION}"; then
-		AVAHI_CLIENT_VERSION="none"
-	fi
-	AC_MSG_RESULT(${AVAHI_CLIENT_VERSION} found)
+		 AC_MSG_CHECKING(for avahi-client version via pkg-config (0.6.30 minimum required))
+		 AVAHI_CLIENT_VERSION="`$PKG_CONFIG --silence-errors --modversion avahi-client 2>/dev/null`"
+		 if test "$?" != "0" -o -z "${AVAHI_CLIENT_VERSION}"; then
+		    AVAHI_CLIENT_VERSION="none"
+		 fi
+		 AC_MSG_RESULT(${AVAHI_CLIENT_VERSION} found)
+		], [AC_MSG_NOTICE([can not check avahi settings via pkg-config])]
+	)
 
 	AC_MSG_CHECKING(for avahi cflags)
 	AC_ARG_WITH(avahi-includes,
@@ -39,7 +43,12 @@ if test -z "${nut_have_avahi_seen}"; then
 			CFLAGS="${withval}"
 			;;
 		esac
-	], [CFLAGS="`pkg-config --silence-errors --cflags avahi-core avahi-client 2>/dev/null`" || CFLAGS="-I/usr/local/include -I/usr/include -L/usr/local/lib -L/usr/lib"])
+	], [
+		AS_IF([test x"$have_PKG_CONFIG" = xyes],
+			[CFLAGS="`$PKG_CONFIG --silence-errors --cflags avahi-core avahi-client 2>/dev/null`" || CFLAGS="-I/usr/local/include -I/usr/include -L/usr/local/lib -L/usr/lib"],
+			[CFLAGS="-I/usr/local/include -I/usr/include -L/usr/local/lib -L/usr/lib"]
+		)]
+	)
 	AC_MSG_RESULT([${CFLAGS}])
 
 	AC_MSG_CHECKING(for avahi ldflags)
@@ -54,7 +63,12 @@ if test -z "${nut_have_avahi_seen}"; then
 			LIBS="${withval}"
 			;;
 		esac
-	], [LIBS="`pkg-config --silence-errors --libs avahi-core avahi-client 2>/dev/null`" || LIBS="-lavahi-core -lavahi-client"])
+	], [
+		AS_IF([test x"$have_PKG_CONFIG" = xyes],
+			[LIBS="`$PKG_CONFIG --silence-errors --libs avahi-core avahi-client 2>/dev/null`" || LIBS="-lavahi-core -lavahi-client"],
+			[LIBS="-lavahi-core -lavahi-client"]
+		)]
+	)
 	AC_MSG_RESULT([${LIBS}])
 
 	dnl check if avahi-core is usable

--- a/m4/nut_check_libfreeipmi.m4
+++ b/m4/nut_check_libfreeipmi.m4
@@ -8,25 +8,36 @@ AC_DEFUN([NUT_CHECK_LIBFREEIPMI],
 [
 if test -z "${nut_have_libfreeipmi_seen}"; then
 	nut_have_libfreeipmi_seen=yes
+	NUT_CHECK_PKGCONFIG
 
 	dnl save CFLAGS and LIBS
 	CFLAGS_ORIG="${CFLAGS}"
 	LIBS_ORIG="${LIBS}"
 
-	AC_MSG_CHECKING(for FreeIPMI version via pkg-config)
-	dnl pkg-config support requires Freeipmi 1.0.5, released on Thu Jun 30 2011
-	dnl but NUT should only require 0.8.5 (for nut-scanner) and 1.0.1 (for
-	dnl nut-ipmipsu) (comment from upstream Al Chu)
-	FREEIPMI_VERSION="`pkg-config --silence-errors --modversion libfreeipmi 2>/dev/null`"
-	if test "$?" = "0" -a -n "${FREEIPMI_VERSION}"; then
-		CFLAGS="`pkg-config --silence-errors --cflags libfreeipmi libipmimonitoring 2>/dev/null`"
-		LIBS="`pkg-config --silence-errors --libs libfreeipmi libipmimonitoring 2>/dev/null`"
-	else
-		FREEIPMI_VERSION="none"
-		CFLAGS=""
-		LIBS="-lfreeipmi -lipmimonitoring"
-	fi
-	AC_MSG_RESULT(${FREEIPMI_VERSION} found)
+	AS_IF([test x"$have_PKG_CONFIG" = xyes],
+		[dnl pkg-config support requires Freeipmi 1.0.5, released on Thu Jun 30 2011
+		 dnl but NUT should only require 0.8.5 (for nut-scanner) and 1.0.1 (for
+		 dnl nut-ipmipsu) (comment from upstream Al Chu)
+		 AC_MSG_CHECKING(for FreeIPMI version via pkg-config)
+		 FREEIPMI_VERSION="`$PKG_CONFIG --silence-errors --modversion libfreeipmi 2>/dev/null`"
+		 if test "$?" != "0" -o -z "${FREEIPMI_VERSION}"; then
+		    FREEIPMI_VERSION="none"
+		 fi
+		 AC_MSG_RESULT(${FREEIPMI_VERSION} found)
+		],
+		[FREEIPMI_VERSION="none"
+		 AC_MSG_NOTICE([can not check FreeIPMI settings via pkg-config])
+		]
+	)
+
+	AS_IF([test x"$FREEIPMI_VERSION" != xnone],
+		[CFLAGS="`$PKG_CONFIG --silence-errors --cflags libfreeipmi libipmimonitoring 2>/dev/null`"
+		 LIBS="`$PKG_CONFIG --silence-errors --libs libfreeipmi libipmimonitoring 2>/dev/null`"
+		],
+		[CFLAGS=""
+		 LIBS="-lfreeipmi -lipmimonitoring"
+		]
+	)
 
 	dnl allow overriding FreeIPMI settings if the user knows best
 	AC_MSG_CHECKING(for FreeIPMI cflags)

--- a/m4/nut_check_libgd.m4
+++ b/m4/nut_check_libgd.m4
@@ -7,35 +7,42 @@ AC_DEFUN([NUT_CHECK_LIBGD],
 [
 if test -z "${nut_have_libgd_seen}"; then
 	nut_have_libgd_seen=yes
+	NUT_CHECK_PKGCONFIG
 
 	CFLAGS_ORIG="${CFLAGS}"
 	LDFLAGS_ORIG="${LDFLAGS}"
 	LIBS_ORIG="${LIBS}"
 
-	AC_MSG_CHECKING(for gd version via pkg-config)
-	GD_VERSION="`pkg-config --silence-errors --modversion gdlib 2>/dev/null`"
-	if test "$?" = "0" -a -n "${GD_VERSION}"; then
-		CFLAGS="`pkg-config --silence-errors --cflags gdlib 2>/dev/null`"
-		LIBS="`pkg-config --silence-errors --libs gdlib 2>/dev/null`"
-	else
-		GD_VERSION="none"
-	fi
-	AC_MSG_RESULT(${GD_VERSION} found)
+	AS_IF([test x"$have_PKG_CONFIG" = xyes],
+		[AC_MSG_CHECKING(for gd version via pkg-config)
+		 GD_VERSION="`$PKG_CONFIG --silence-errors --modversion gdlib 2>/dev/null`"
+		 if test "$?" != "0" -o -z "${GD_VERSION}"; then
+		    GD_VERSION="none"
+		 fi
+		 AC_MSG_RESULT(${GD_VERSION} found)
+		],
+		[GD_VERSION="none"
+		 AC_MSG_NOTICE([can not check libgd settings via pkg-config])
+		]
+	)
 
-	if test "${GD_VERSION}" = "none"; then
-		dnl Initial defaults. These are only used if gdlib-config is
-		dnl unusable and the user fails to pass better values in --with
-		dnl arguments
-		CFLAGS=""
-		LDFLAGS="-L/usr/X11R6/lib"
-		LIBS="-lgd -lpng -lz -ljpeg -lfreetype -lm -lXpm -lX11"
+	AS_IF([test x"$GD_VERSION" != xnone],
+		[CFLAGS="`$PKG_CONFIG --silence-errors --cflags gdlib 2>/dev/null`"
+		 LIBS="`$PKG_CONFIG --silence-errors --libs gdlib 2>/dev/null`"
+		],
+		[dnl Initial defaults. These are only used if gdlib-config is
+		 dnl unusable and the user fails to pass better values in --with
+		 dnl arguments
+		 CFLAGS=""
+		 LDFLAGS="-L/usr/X11R6/lib"
+		 LIBS="-lgd -lpng -lz -ljpeg -lfreetype -lm -lXpm -lX11"
 
-		dnl By default seek in PATH
-		GDLIB_CONFIG=gdlib-config
-		AC_ARG_WITH(gdlib-config,
+		 dnl By default seek in PATH
+		 GDLIB_CONFIG=gdlib-config
+		 AC_ARG_WITH(gdlib-config,
 			AS_HELP_STRING([@<:@--with-gdlib-config=/path/to/gdlib-config@:>@],
 				[path to program that reports GDLIB configuration]),
-		[
+		 [
 			case "${withval}" in
 			"") ;;
 			yes|no)
@@ -45,29 +52,30 @@ if test -z "${nut_have_libgd_seen}"; then
 				GDLIB_CONFIG="${withval}"
 				;;
 			esac
-		])
+		 ])
 
-		AC_MSG_CHECKING(for gd version via ${GDLIB_CONFIG})
-		GD_VERSION=`${GDLIB_CONFIG} --version 2>/dev/null`
-		if test "$?" != "0" -o -z "${GD_VERSION}"; then
+		 AC_MSG_CHECKING(for gd version via ${GDLIB_CONFIG})
+		 GD_VERSION="`${GDLIB_CONFIG} --version 2>/dev/null`"
+		 if test "$?" != "0" -o -z "${GD_VERSION}"; then
 			GD_VERSION="none"
-		fi
-		AC_MSG_RESULT(${GD_VERSION} found)
+		 fi
+		 AC_MSG_RESULT(${GD_VERSION} found)
 
-		case "${GD_VERSION}" in
-		none)
+		 case "${GD_VERSION}" in
+		 none)
 			;;
-		2.0.5 | 2.0.6 | 2.0.7)
+		 2.0.5 | 2.0.6 | 2.0.7)
 			AC_MSG_WARN([[gd ${GD_VERSION} detected, unable to use ${GDLIB_CONFIG} script]])
 			AC_MSG_WARN([[If gd detection fails, upgrade gd or use --with-gd-includes and --with-gd-libs]])
 			;;
-		*)
+		 *)
 			CFLAGS="`${GDLIB_CONFIG} --includes 2>/dev/null`"
 			LDFLAGS="`${GDLIB_CONFIG} --ldflags 2>/dev/null`"
 			LIBS="`${GDLIB_CONFIG} --libs 2>/dev/null`"
 			;;
-		esac
-	fi
+		 esac
+		]
+	)
 
 	dnl Now allow overriding gd settings if the user knows best
 	AC_MSG_CHECKING(for gd include flags)

--- a/m4/nut_check_libmodbus.m4
+++ b/m4/nut_check_libmodbus.m4
@@ -11,18 +11,29 @@ if test -z "${nut_have_libmodbus_seen}"; then
 	dnl save CFLAGS and LIBS
 	CFLAGS_ORIG="${CFLAGS}"
 	LIBS_ORIG="${LIBS}"
+	NUT_CHECK_PKGCONFIG
 
-	AC_MSG_CHECKING(for libmodbus version via pkg-config)
-	LIBMODBUS_VERSION="`pkg-config --silence-errors --modversion libmodbus 2>/dev/null`"
-	if test "$?" = "0" -a -n "${LIBMODBUS_VERSION}"; then
-		CFLAGS="`pkg-config --silence-errors --cflags libmodbus 2>/dev/null`"
-		LIBS="`pkg-config --silence-errors --libs libmodbus 2>/dev/null`"
-	else
-		LIBMODBUS_VERSION="none"
-		CFLAGS="-I/usr/include/modbus"
-		LIBS="-lmodbus"
-	fi
-	AC_MSG_RESULT(${LIBMODBUS_VERSION} found)
+	AS_IF([test x"$have_PKG_CONFIG" = xyes],
+		[AC_MSG_CHECKING(for libmodbus version via pkg-config)
+		 LIBMODBUS_VERSION="`$PKG_CONFIG --silence-errors --modversion libmodbus 2>/dev/null`"
+		 if test "$?" != "0" -o -z "${LIBMODBUS_VERSION}"; then
+		    LIBMODBUS_VERSION="none"
+		 fi
+		 AC_MSG_RESULT(${LIBMODBUS_VERSION} found)
+		],
+		[LIBMODBUS_VERSION="none"
+		 AC_MSG_NOTICE([can not check libmodbus settings via pkg-config])
+		]
+	)
+
+	AS_IF([test x"$LIBMODBUS_VERSION" != xnone],
+		[CFLAGS="`$PKG_CONFIG --silence-errors --cflags libmodbus 2>/dev/null`"
+		 LIBS="`$PKG_CONFIG --silence-errors --libs libmodbus 2>/dev/null`"
+		],
+		[CFLAGS="-I/usr/include/modbus"
+		 LIBS="-lmodbus"
+		]
+	)
 
 	AC_MSG_CHECKING(for libmodbus cflags)
 	AC_ARG_WITH(modbus-includes,

--- a/m4/nut_check_libneon.m4
+++ b/m4/nut_check_libneon.m4
@@ -7,28 +7,27 @@ AC_DEFUN([NUT_CHECK_LIBNEON],
 [
 if test -z "${nut_have_neon_seen}"; then
 	nut_have_neon_seen=yes
+	NUT_CHECK_PKGCONFIG
 
 	dnl save CFLAGS and LIBS
 	CFLAGS_ORIG="${CFLAGS}"
 	LIBS_ORIG="${LIBS}"
 
-	nut_defaulted_neon_version=no
-	nut_defaulted_neon_cflags=no
-	nut_defaulted_neon_libs=no
-
-	dnl See which version of the neon library (if any) is installed
-	dnl FIXME : Support detection of cflags/ldflags below by legacy discovery if pkgconfig is not there
-	AC_MSG_CHECKING(for libneon version via pkg-config (0.25.0 minimum required))
-	NEON_VERSION="`pkg-config --silence-errors --modversion neon 2>/dev/null`"
-	if test "$?" != "0" -o -z "${NEON_VERSION}"; then
-		nut_defaulted_neon_version=yes
-		NEON_VERSION="none"
-	fi
-	AC_MSG_RESULT(${NEON_VERSION} found)
-
-	if test "${nut_defaulted_neon_version}" = "yes" ; then
-		AC_MSG_WARN([could not get pkg-config information for libneon version, using fallback defaults])
-	fi
+	AS_IF([test x"$have_PKG_CONFIG" = xyes],
+		[dnl See which version of the neon library (if any) is installed
+		 dnl FIXME : Support detection of cflags/ldflags below by legacy
+		 dnl discovery if pkgconfig is not there
+		 AC_MSG_CHECKING(for libneon version via pkg-config (0.25.0 minimum required))
+		 NEON_VERSION="`$PKG_CONFIG --silence-errors --modversion neon 2>/dev/null`"
+		 if test "$?" != "0" -o -z "${NEON_VERSION}"; then
+		    NEON_VERSION="none"
+		 fi
+		 AC_MSG_RESULT(${NEON_VERSION} found)
+		],
+		[NEON_VERSION="none"
+		 AC_MSG_NOTICE([can not check libneon settings via pkg-config])
+		]
+	)
 
 	AC_MSG_CHECKING(for libneon cflags)
 	AC_ARG_WITH(neon-includes,
@@ -42,16 +41,13 @@ if test -z "${nut_have_neon_seen}"; then
 			CFLAGS="${withval}"
 			;;
 		esac
-	], [CFLAGS="`pkg-config --silence-errors --cflags neon 2>/dev/null`"
-		if test "$?" != 0 ; then
-			nut_defaulted_neon_cflags=yes
-			CFLAGS="-I/usr/include/neon -I/usr/local/include/neon"
-		fi])
+	], [
+		AS_IF([test x"$have_PKG_CONFIG" = xyes],
+			[CFLAGS="`$PKG_CONFIG --silence-errors --cflags neon 2>/dev/null`" || CFLAGS="-I/usr/include/neon -I/usr/local/include/neon"],
+			[CFLAGS="-I/usr/include/neon -I/usr/local/include/neon"]
+		)]
+	)
 	AC_MSG_RESULT([${CFLAGS}])
-
-	if test "${nut_defaulted_neon_cflags}" = "yes" ; then
-		AC_MSG_WARN([could not get pkg-config information for libneon cflags, using fallback defaults])
-	fi
 
 	AC_MSG_CHECKING(for libneon ldflags)
 	AC_ARG_WITH(neon-libs,
@@ -65,16 +61,13 @@ if test -z "${nut_have_neon_seen}"; then
 			LIBS="${withval}"
 			;;
 		esac
-	], [LIBS="`pkg-config --silence-errors --libs neon 2>/dev/null`"
-		if test "$?" != 0 ; then
-			nut_defaulted_neon_libs=yes
-			LIBS="-lneon"
-		fi])
+	], [
+		AS_IF([test x"$have_PKG_CONFIG" = xyes],
+			[LIBS="`$PKG_CONFIG --silence-errors --libs neon 2>/dev/null`" || LIBS="-lneon"],
+			[LIBS="-lneon"]
+		)]
+	)
 	AC_MSG_RESULT([${LIBS}])
-
-	if test "${nut_defaulted_neon_libs}" = "yes" ; then
-		AC_MSG_WARN([could not get pkg-config information for libneon libs, using fallback defaults])
-	fi
 
 	dnl check if neon is usable
 	AC_CHECK_HEADERS(ne_xmlreq.h, [nut_have_neon=yes], [nut_have_neon=no], [AC_INCLUDES_DEFAULT])

--- a/m4/nut_check_libnetsnmp.m4
+++ b/m4/nut_check_libnetsnmp.m4
@@ -34,9 +34,10 @@ if test -z "${nut_have_libnetsnmp_seen}"; then
 			[path to program that reports Net-SNMP configuration]),
 	[
 		case "${withval}" in
-		"") ;;
-		yes|no)
-			AC_MSG_ERROR(invalid option --with(out)-net-snmp-config - see docs/configure.txt)
+		""|yes) prefer_NET_SNMP_CONFIG=true ;;
+		no)
+			dnl AC_MSG_ERROR(invalid option --with(out)-net-snmp-config - see docs/configure.txt)
+			prefer_NET_SNMP_CONFIG=false
 			;;
 		*)
 			NET_SNMP_CONFIG="${withval}"

--- a/m4/nut_check_libnetsnmp.m4
+++ b/m4/nut_check_libnetsnmp.m4
@@ -1,8 +1,8 @@
 dnl Check for LIBNETSNMP compiler flags. On success, set
 dnl nut_have_libnetsnmp="yes" and set LIBNETSNMP_CFLAGS and
 dnl LIBNETSNMP_LIBS. On failure, set nut_have_libnetsnmp="no".
-dnl This macro can be run multiple times, but will do the checking only
-dnl once.
+dnl This macro can be run multiple times, but will do the
+dnl checking only once.
 
 AC_DEFUN([NUT_CHECK_LIBNETSNMP],
 [
@@ -13,6 +13,11 @@ if test -z "${nut_have_libnetsnmp_seen}"; then
 	CFLAGS_ORIG="${CFLAGS}"
 	LIBS_ORIG="${LIBS}"
 
+	dnl We prefer to get info from pkg-config (for suitable arch/bitness as
+	dnl specified in args for that mechanism), unless (legacy) a particular
+	dnl --with-net-snmp-config=... was requested. If there is no pkg-config
+	dnl info, we fall back to detecting and running a NET_SNMP_CONFIG as well.
+
 	dnl By default seek in PATH, but which variant (if several are provided)?
 	AC_CHECK_SIZEOF([void *])
 	AS_CASE(["${ac_cv_sizeof_void_p}"],
@@ -22,6 +27,7 @@ if test -z "${nut_have_libnetsnmp_seen}"; then
 	AS_IF([test -n "${NET_SNMP_CONFIG}" && test -n "`command -v "${NET_SNMP_CONFIG}"`"],
 		[], [NET_SNMP_CONFIG=net-snmp-config])
 
+	prefer_NET_SNMP_CONFIG=false
 	AC_ARG_WITH(net-snmp-config,
 		AS_HELP_STRING([@<:@--with-net-snmp-config=/path/to/net-snmp-config@:>@],
 			[path to program that reports Net-SNMP configuration]),
@@ -33,17 +39,34 @@ if test -z "${nut_have_libnetsnmp_seen}"; then
 			;;
 		*)
 			NET_SNMP_CONFIG="${withval}"
+			prefer_NET_SNMP_CONFIG=true
 			;;
 		esac
 	])
 
-	dnl See which version of the Net-SNMP library (if any) is installed
-	AC_MSG_CHECKING(for Net-SNMP version via ${NET_SNMP_CONFIG})
-	SNMP_VERSION=`${NET_SNMP_CONFIG} --version 2>/dev/null`
-	if test "$?" != "0" -o -z "${SNMP_VERSION}"; then
-		SNMP_VERSION="none"
+	if ! "${prefer_NET_SNMP_CONFIG}" ; then
+		AC_MSG_CHECKING(for Net-SNMP version via pkg-config)
+		dnl TODO? Loop over possible/historic pkg names, like
+		dnl netsnmp, net-snmp, ucd-snmp, libsnmp, snmp...
+		SNMP_VERSION="`pkg-config --silence-errors --modversion netsnmp 2>/dev/null`"
+		if test "$?" = "0" -a -n "${SNMP_VERSION}" ; then
+			AC_MSG_RESULT(${SNMP_VERSION} found)
+		else
+			AC_MSG_RESULT(none found)
+			prefer_NET_SNMP_CONFIG=true
+		fi
 	fi
-	AC_MSG_RESULT(${SNMP_VERSION} found)
+
+	if "${prefer_NET_SNMP_CONFIG}" ; then
+		dnl See which version of the Net-SNMP library (if any) is installed
+		AC_MSG_CHECKING(for Net-SNMP version via ${NET_SNMP_CONFIG})
+		SNMP_VERSION="`${NET_SNMP_CONFIG} --version 2>/dev/null`"
+		if test "$?" != "0" -o -z "${SNMP_VERSION}"; then
+			SNMP_VERSION="none"
+			prefer_NET_SNMP_CONFIG=false
+		fi
+		AC_MSG_RESULT(${SNMP_VERSION} found)
+	fi
 
 	AC_MSG_CHECKING(for Net-SNMP cflags)
 	AC_ARG_WITH(snmp-includes,
@@ -57,7 +80,10 @@ if test -z "${nut_have_libnetsnmp_seen}"; then
 			CFLAGS="${withval}"
 			;;
 		esac
-	], [CFLAGS="`${NET_SNMP_CONFIG} --base-cflags 2>/dev/null`"])
+	], [AS_IF(["${prefer_NET_SNMP_CONFIG}"],
+		[CFLAGS="`${NET_SNMP_CONFIG} --base-cflags 2>/dev/null`"],
+		[CFLAGS="`pkg-config --silence-errors --cflags netsnmp 2>/dev/null`"]
+	)])
 	AC_MSG_RESULT([${CFLAGS}])
 
 	AC_MSG_CHECKING(for Net-SNMP libs)
@@ -72,7 +98,10 @@ if test -z "${nut_have_libnetsnmp_seen}"; then
 			LIBS="${withval}"
 			;;
 		esac
-	], [LIBS="`${NET_SNMP_CONFIG} --libs 2>/dev/null`"])
+	], [AS_IF(["${prefer_NET_SNMP_CONFIG}"],
+		[LIBS="`${NET_SNMP_CONFIG} --libs 2>/dev/null`"],
+		[LIBS="`pkg-config --silence-errors --libs netsnmp 2>/dev/null`"]
+	)])
 	AC_MSG_RESULT([${LIBS}])
 
 	dnl Check if the Net-SNMP library is usable

--- a/m4/nut_check_libnetsnmp.m4
+++ b/m4/nut_check_libnetsnmp.m4
@@ -112,155 +112,155 @@ if test -z "${nut_have_libnetsnmp_seen}"; then
 		LIBNETSNMP_CFLAGS="${CFLAGS}"
 		LIBNETSNMP_LIBS="${LIBS}"
 
-	AC_MSG_CHECKING([for defined usmAESPrivProtocol])
-	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+		AC_MSG_CHECKING([for defined usmAESPrivProtocol])
+		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/net-snmp-includes.h>
 oid * pProto = usmAESPrivProtocol;
 ],
 []
-		)],
-		[AC_MSG_RESULT([yes])
-		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmAESPrivProtocol, 1, [Variable or macro by this name is resolvable])
-		],
-		[AC_MSG_RESULT([no])
-		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmAESPrivProtocol, 0, [Variable or macro by this name is not resolvable])
-		])
+			)],
+			[AC_MSG_RESULT([yes])
+			 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmAESPrivProtocol, 1, [Variable or macro by this name is resolvable])
+			],
+			[AC_MSG_RESULT([no])
+			 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmAESPrivProtocol, 0, [Variable or macro by this name is not resolvable])
+			])
 
-	AC_MSG_CHECKING([for defined usmAES128PrivProtocol])
-	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+		AC_MSG_CHECKING([for defined usmAES128PrivProtocol])
+		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/net-snmp-includes.h>
 oid * pProto = usmAES128PrivProtocol;
 ],
 []
-		)],
-		[AC_MSG_RESULT([yes])
-		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmAES128PrivProtocol, 1, [Variable or macro by this name is resolvable])
-		],
-		[AC_MSG_RESULT([no])
-		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmAES128PrivProtocol, 0, [Variable or macro by this name is not resolvable])
-		])
+			)],
+			[AC_MSG_RESULT([yes])
+			 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmAES128PrivProtocol, 1, [Variable or macro by this name is resolvable])
+			],
+			[AC_MSG_RESULT([no])
+			 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmAES128PrivProtocol, 0, [Variable or macro by this name is not resolvable])
+			])
 
-	AC_MSG_CHECKING([for defined usmDESPrivProtocol])
-	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+		AC_MSG_CHECKING([for defined usmDESPrivProtocol])
+		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/net-snmp-includes.h>
 oid * pProto = usmDESPrivProtocol;
 ],
 []
-		)],
-		[AC_MSG_RESULT([yes])
-		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmDESPrivProtocol, 1, [Variable or macro by this name is resolvable])
-		],
-		[AC_MSG_RESULT([no])
-		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmDESPrivProtocol, 0, [Variable or macro by this name is not resolvable])
-		])
+			)],
+			[AC_MSG_RESULT([yes])
+			 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmDESPrivProtocol, 1, [Variable or macro by this name is resolvable])
+			],
+			[AC_MSG_RESULT([no])
+			 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmDESPrivProtocol, 0, [Variable or macro by this name is not resolvable])
+			])
 
-	AC_MSG_CHECKING([for defined usmHMAC256SHA384AuthProtocol])
-	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+		AC_MSG_CHECKING([for defined usmHMAC256SHA384AuthProtocol])
+		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/net-snmp-includes.h>
 oid * pProto = usmHMAC256SHA384AuthProtocol;
 ],
 []
-		)],
-		[AC_MSG_RESULT([yes])
-		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMAC256SHA384AuthProtocol, 1, [Variable or macro by this name is resolvable])
-		],
-		[AC_MSG_RESULT([no])
-		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMAC256SHA384AuthProtocol, 0, [Variable or macro by this name is not resolvable])
-		])
+			)],
+			[AC_MSG_RESULT([yes])
+			 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMAC256SHA384AuthProtocol, 1, [Variable or macro by this name is resolvable])
+			],
+			[AC_MSG_RESULT([no])
+			 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMAC256SHA384AuthProtocol, 0, [Variable or macro by this name is not resolvable])
+			])
 
-	AC_MSG_CHECKING([for defined usmHMAC384SHA512AuthProtocol])
-	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+		AC_MSG_CHECKING([for defined usmHMAC384SHA512AuthProtocol])
+		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/net-snmp-includes.h>
 oid * pProto = usmHMAC384SHA512AuthProtocol;
 ],
 []
-		)],
-		[AC_MSG_RESULT([yes])
-		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMAC384SHA512AuthProtocol, 1, [Variable or macro by this name is resolvable])
-		],
-		[AC_MSG_RESULT([no])
-		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMAC384SHA512AuthProtocol, 0, [Variable or macro by this name is not resolvable])
-		])
+			)],
+			[AC_MSG_RESULT([yes])
+			 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMAC384SHA512AuthProtocol, 1, [Variable or macro by this name is resolvable])
+			],
+			[AC_MSG_RESULT([no])
+			 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMAC384SHA512AuthProtocol, 0, [Variable or macro by this name is not resolvable])
+			])
 
-	AC_MSG_CHECKING([for defined usmHMAC192SHA256AuthProtocol])
-	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+		AC_MSG_CHECKING([for defined usmHMAC192SHA256AuthProtocol])
+		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/net-snmp-includes.h>
 oid * pProto = usmHMAC192SHA256AuthProtocol;
 ],
 []
-		)],
-		[AC_MSG_RESULT([yes])
-		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMAC192SHA256AuthProtocol, 1, [Variable or macro by this name is resolvable])
-		],
-		[AC_MSG_RESULT([no])
-		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMAC192SHA256AuthProtocol, 0, [Variable or macro by this name is not resolvable])
-		])
+			)],
+			[AC_MSG_RESULT([yes])
+			 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMAC192SHA256AuthProtocol, 1, [Variable or macro by this name is resolvable])
+			],
+			[AC_MSG_RESULT([no])
+			 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMAC192SHA256AuthProtocol, 0, [Variable or macro by this name is not resolvable])
+			])
 
-	AC_MSG_CHECKING([for defined usmAES192PrivProtocol])
-	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+		AC_MSG_CHECKING([for defined usmAES192PrivProtocol])
+		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/net-snmp-includes.h>
 oid * pProto = usmAES192PrivProtocol;
 ],
 []
-		)],
-		[AC_MSG_RESULT([yes])
-		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmAES192PrivProtocol, 1, [Variable or macro by this name is resolvable])
-		],
-		[AC_MSG_RESULT([no])
-		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmAES192PrivProtocol, 0, [Variable or macro by this name is not resolvable])
-		])
+			)],
+			[AC_MSG_RESULT([yes])
+			 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmAES192PrivProtocol, 1, [Variable or macro by this name is resolvable])
+			],
+			[AC_MSG_RESULT([no])
+			 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmAES192PrivProtocol, 0, [Variable or macro by this name is not resolvable])
+			])
 
-	AC_MSG_CHECKING([for defined usmAES256PrivProtocol])
-	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+		AC_MSG_CHECKING([for defined usmAES256PrivProtocol])
+		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/net-snmp-includes.h>
 oid * pProto = usmAES256PrivProtocol;
 ],
 []
-		)],
-		[AC_MSG_RESULT([yes])
-		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmAES256PrivProtocol, 1, [Variable or macro by this name is resolvable])
-		],
-		[AC_MSG_RESULT([no])
-		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmAES256PrivProtocol, 0, [Variable or macro by this name is not resolvable])
-		])
+			)],
+			[AC_MSG_RESULT([yes])
+			 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmAES256PrivProtocol, 1, [Variable or macro by this name is resolvable])
+			],
+			[AC_MSG_RESULT([no])
+			 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmAES256PrivProtocol, 0, [Variable or macro by this name is not resolvable])
+			])
 
-	AC_MSG_CHECKING([for defined usmHMACMD5AuthProtocol])
-	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+		AC_MSG_CHECKING([for defined usmHMACMD5AuthProtocol])
+		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/net-snmp-includes.h>
 oid * pProto = usmHMACMD5AuthProtocol;
 ],
 []
-		)],
-		[AC_MSG_RESULT([yes])
-		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMACMD5AuthProtocol, 1, [Variable or macro by this name is resolvable])
-		],
-		[AC_MSG_RESULT([no])
-		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMACMD5AuthProtocol, 0, [Variable or macro by this name is not resolvable])
-		])
+			)],
+			[AC_MSG_RESULT([yes])
+			 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMACMD5AuthProtocol, 1, [Variable or macro by this name is resolvable])
+			],
+			[AC_MSG_RESULT([no])
+			 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMACMD5AuthProtocol, 0, [Variable or macro by this name is not resolvable])
+			])
 
-	AC_MSG_CHECKING([for defined usmHMACSHA1AuthProtocol])
-	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+		AC_MSG_CHECKING([for defined usmHMACSHA1AuthProtocol])
+		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/net-snmp-includes.h>
 oid * pProto = usmHMACSHA1AuthProtocol;
 ],
 []
-		)],
-		[AC_MSG_RESULT([yes])
-		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMACSHA1AuthProtocol, 1, [Variable or macro by this name is resolvable])
-		],
-		[AC_MSG_RESULT([no])
-		 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMACSHA1AuthProtocol, 0, [Variable or macro by this name is not resolvable])
-		])
+			)],
+			[AC_MSG_RESULT([yes])
+			 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMACSHA1AuthProtocol, 1, [Variable or macro by this name is resolvable])
+			],
+			[AC_MSG_RESULT([no])
+			 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_usmHMACSHA1AuthProtocol, 0, [Variable or macro by this name is not resolvable])
+			])
 
 	fi
 

--- a/m4/nut_check_libopenssl.m4
+++ b/m4/nut_check_libopenssl.m4
@@ -8,25 +8,36 @@ AC_DEFUN([NUT_CHECK_LIBOPENSSL],
 [
 if test -z "${nut_have_libopenssl_seen}"; then
 	nut_have_libopenssl_seen=yes
+	NUT_CHECK_PKGCONFIG
 
 	dnl save CFLAGS and LIBS
 	CFLAGS_ORIG="${CFLAGS}"
 	LIBS_ORIG="${LIBS}"
 	REQUIRES_ORIG="${REQUIRES}"
 
-	AC_MSG_CHECKING(for OpenSSL version via pkg-config)
-	OPENSSL_VERSION="`pkg-config --silence-errors --modversion openssl 2>/dev/null`"
-	if test "$?" = "0" -a -n "${OPENSSL_VERSION}"; then
-		CFLAGS="`pkg-config --silence-errors --cflags openssl 2>/dev/null`"
-		LIBS="`pkg-config --silence-errors --libs openssl 2>/dev/null`"
-		REQUIRES="openssl"
-	else
-		OPENSSL_VERSION="none"
-		CFLAGS=""
-		LIBS="-lssl -lcrypto"
-		REQUIRES="openssl"
-	fi
-	AC_MSG_RESULT(${OPENSSL_VERSION} found)
+	AS_IF([test x"$have_PKG_CONFIG" = xyes],
+		[AC_MSG_CHECKING(for OpenSSL version via pkg-config)
+		 OPENSSL_VERSION="`$PKG_CONFIG --silence-errors --modversion openssl 2>/dev/null`"
+		 if test "$?" != "0" -o -z "${OPENSSL_VERSION}"; then
+		    OPENSSL_VERSION="none"
+		 fi
+		 AC_MSG_RESULT(${OPENSSL_VERSION} found)
+		],
+		[OPENSSL_VERSION="none"
+		 AC_MSG_NOTICE([can not check OpenSSL settings via pkg-config])
+		]
+	)
+
+	AS_IF([test x"$OPENSSL_VERSION" != xnone],
+		[CFLAGS="`$PKG_CONFIG --silence-errors --cflags openssl 2>/dev/null`"
+		 LIBS="`$PKG_CONFIG --silence-errors --libs openssl 2>/dev/null`"
+		 REQUIRES="openssl"
+		],
+		[CFLAGS=""
+		 LIBS="-lssl -lcrypto"
+		 REQUIRES="openssl"
+		]
+	)
 
 	dnl allow overriding OpenSSL settings if the user knows best
 	AC_MSG_CHECKING(for OpenSSL cflags)

--- a/m4/nut_check_libusb.m4
+++ b/m4/nut_check_libusb.m4
@@ -7,29 +7,42 @@ AC_DEFUN([NUT_CHECK_LIBUSB],
 [
 if test -z "${nut_have_libusb_seen}"; then
 	nut_have_libusb_seen=yes
+	NUT_CHECK_PKGCONFIG
 
 	dnl save CFLAGS and LIBS
 	CFLAGS_ORIG="${CFLAGS}"
 	LIBS_ORIG="${LIBS}"
 
-	AC_MSG_CHECKING(for libusb version via pkg-config)
-	LIBUSB_VERSION="`pkg-config --silence-errors --modversion libusb 2>/dev/null`"
-	if test "$?" = "0" -a -n "${LIBUSB_VERSION}"; then
-		CFLAGS="`pkg-config --silence-errors --cflags libusb 2>/dev/null`"
-		LIBS="`pkg-config --silence-errors --libs libusb 2>/dev/null`"
-	else
-		AC_MSG_CHECKING(via libusb-config)
-		LIBUSB_VERSION="`libusb-config --version 2>/dev/null`"
-		if test "$?" = "0" -a -n "${LIBUSB_VERSION}"; then
+	AS_IF([test x"$have_PKG_CONFIG" = xyes],
+		[AC_MSG_CHECKING(for libusb version via pkg-config)
+		 LIBUSB_VERSION="`$PKG_CONFIG --silence-errors --modversion libusb 2>/dev/null`"
+		 if test "$?" != "0" -o -z "${LIBUSB_VERSION}"; then
+		    LIBUSB_VERSION="none"
+		 fi
+		 AC_MSG_RESULT(${LIBUSB_VERSION} found)
+		],
+		[LIBUSB_VERSION="none"
+		 AC_MSG_NOTICE([can not check libusb settings via pkg-config])
+		]
+	)
+
+	AS_IF([test x"${LIBUSB_VERSION}" != xnone],
+		[CFLAGS="`$PKG_CONFIG --silence-errors --cflags libusb 2>/dev/null`"
+		 LIBS="`$PKG_CONFIG --silence-errors --libs libusb 2>/dev/null`"
+		],
+		[AC_MSG_CHECKING([via libusb-config (if present)])
+		 LIBUSB_VERSION="`libusb-config --version 2>/dev/null`"
+		 if test "$?" = "0" -a -n "${LIBUSB_VERSION}"; then
 			CFLAGS="`libusb-config --cflags 2>/dev/null`"
 			LIBS="`libusb-config --libs 2>/dev/null`"
-		else
+		 else
 			LIBUSB_VERSION="none"
 			CFLAGS=""
 			LIBS="-lusb"
-		fi
-	fi
-	AC_MSG_RESULT(${LIBUSB_VERSION} found)
+		 fi
+		 AC_MSG_RESULT(${LIBUSB_VERSION} found)
+		]
+	)
 
 	AC_MSG_CHECKING(for libusb cflags)
 	AC_ARG_WITH(usb-includes,

--- a/m4/nut_check_pkgconfig.m4
+++ b/m4/nut_check_pkgconfig.m4
@@ -44,9 +44,9 @@ AS_IF([test -z "${nut_have_pkg_config_seen}"], [
 		)]
 	)
 
+	have_PKG_CONFIG_MACROS=no
 	AS_IF([test x"$have_PKG_CONFIG" = xyes],
 		[AC_MSG_NOTICE([checking for autoconf macro support of pkg-config (${PKG_CONFIG})])
-		 have_PKG_CONFIG=no
 		 dummy_RES=0
 		 ifdef([PKG_PROG_PKG_CONFIG], [], [dummy_RES=1])
 		 ifdef([PKG_CHECK_MODULES], [], [dummy_RES=2])
@@ -57,15 +57,18 @@ AS_IF([test -z "${nut_have_pkg_config_seen}"], [
 			 dnl allows to avoid shell syntax errors in generated configure script
 			 dnl by defining a dummy macro in-place.
 			 ifdef([PKG_CHECK_MODULES], [], [AC_DEFUN([PKG_CHECK_MODULES], [false])])
-			 PKG_CHECK_MODULES([dummy_PKG_CONFIG], [pkg-config], [have_PKG_CONFIG=yes])
+			 PKG_CHECK_MODULES([dummy_PKG_CONFIG], [pkg-config], [have_PKG_CONFIG_MACROS=yes])
 			]
 		)]
 	)
 
 	AS_IF([test x"$have_PKG_CONFIG" = xno],
-		[AC_MSG_WARN([pkg-config is needed to look for further dependencies (will be skipped)])
+		[AC_MSG_WARN([pkg-config program is needed to look for further dependencies (will be skipped)])
 		 PKG_CONFIG="false"
-		]
+		],
+		[AS_IF([test x"$have_PKG_CONFIG_MACROS" = xno],
+			[AC_MSG_WARN([pkg-config macros are needed to look for further dependencies, but in some cases pkg-config program can be used directly])]
+		)]
 	)
 
   ]) dnl if nut_have_pkg_config_seen

--- a/m4/nut_check_pkgconfig.m4
+++ b/m4/nut_check_pkgconfig.m4
@@ -1,0 +1,35 @@
+dnl Check for LIBPOWERMAN compiler flags. On success, set nut_have_libpowerman="yes"
+dnl and set LIBPOWERMAN_CFLAGS and LIBPOWERMAN_LIBS. On failure, set
+dnl nut_have_libpowerman="no". This macro can be run multiple times, but will
+dnl do the checking only once.
+
+AC_DEFUN([NUT_CHECK_PKGCONFIG],
+[
+AS_IF([test -z "${nut_have_pkg_config_seen}"], [
+	nut_have_pkg_config_seen=yes
+
+	dnl Some systems have older autotools without direct macro support for PKG_CONF*
+	have_PKG_CONFIG=yes
+	AC_PATH_PROG(dummy_PKG_CONFIG, pkg-config)
+	AS_IF([test x"$dummy_PKG_CONFIG" = xno || test -z "$dummy_PKG_CONFIG"],
+	    [have_PKG_CONFIG=no],
+	    [AC_MSG_NOTICE([checking for autoconf macro support of pkg-config])
+	     have_PKG_CONFIG=no
+	     dummy_RES=0
+	     ifdef([PKG_PROG_PKG_CONFIG], [], [dummy_RES=1])
+	     ifdef([PKG_CHECK_MODULES], [], [dummy_RES=2])
+	     AS_IF([test "${dummy_RES}" = 0],
+	        [AC_MSG_NOTICE([checking for autoconf macro support of pkg-config module checker])
+	         dnl The m4 macro below may be not defined if pkg-config package is not
+	         dnl installed. Use of ifdef (here and below for e.g. CPPUNIT check)
+	         dnl allows to avoid shell syntax errors in generated configure script
+	         dnl by defining a dummy macro in-place.
+	         ifdef([PKG_CHECK_MODULES], [], [AC_DEFUN([PKG_CHECK_MODULES], [false])])
+	         PKG_CHECK_MODULES([dummy_PKG_CONFIG], [pkg-config], [have_PKG_CONFIG=yes])
+	        ])
+	])
+	AS_IF([test x"$have_PKG_CONFIG" = xno],
+	    [AC_MSG_WARN([pkg-config is needed to look for further dependencies (will be skipped)])])
+
+  ]) dnl if nut_have_pkg_config_seen
+])

--- a/m4/nut_check_pkgconfig.m4
+++ b/m4/nut_check_pkgconfig.m4
@@ -8,28 +8,65 @@ AC_DEFUN([NUT_CHECK_PKGCONFIG],
 AS_IF([test -z "${nut_have_pkg_config_seen}"], [
 	nut_have_pkg_config_seen=yes
 
-	dnl Some systems have older autotools without direct macro support for PKG_CONF*
-	have_PKG_CONFIG=yes
-	AC_PATH_PROG(dummy_PKG_CONFIG, pkg-config)
-	AS_IF([test x"$dummy_PKG_CONFIG" = xno || test -z "$dummy_PKG_CONFIG"],
-	    [have_PKG_CONFIG=no],
-	    [AC_MSG_NOTICE([checking for autoconf macro support of pkg-config])
-	     have_PKG_CONFIG=no
-	     dummy_RES=0
-	     ifdef([PKG_PROG_PKG_CONFIG], [], [dummy_RES=1])
-	     ifdef([PKG_CHECK_MODULES], [], [dummy_RES=2])
-	     AS_IF([test "${dummy_RES}" = 0],
-	        [AC_MSG_NOTICE([checking for autoconf macro support of pkg-config module checker])
-	         dnl The m4 macro below may be not defined if pkg-config package is not
-	         dnl installed. Use of ifdef (here and below for e.g. CPPUNIT check)
-	         dnl allows to avoid shell syntax errors in generated configure script
-	         dnl by defining a dummy macro in-place.
-	         ifdef([PKG_CHECK_MODULES], [], [AC_DEFUN([PKG_CHECK_MODULES], [false])])
-	         PKG_CHECK_MODULES([dummy_PKG_CONFIG], [pkg-config], [have_PKG_CONFIG=yes])
-	        ])
-	])
+	dnl Note that PKG_CONFIG may be a filename, path,
+	dnl or either with args - so no quoting here
+	AC_MSG_CHECKING([whether usable PKG_CONFIG was already detected by autoconf])
+	AS_IF([test -n "${PKG_CONFIG-}" && test x"${PKG_CONFIG-}" != x"false" && $PKG_CONFIG --help 2>&1 | grep -E '(--cflags|--libs)' >/dev/null],
+		[AC_MSG_RESULT([yes: ${PKG_CONFIG}])
+		 have_PKG_CONFIG=yes
+		],
+		[AC_MSG_RESULT([no])
+		 PKG_CONFIG=false
+		 have_PKG_CONFIG=no
+		]
+	)
+
+	AS_IF([test x"${PKG_CONFIG-}" = x"false"],
+		[dnl Some systems have older autotools without direct macro support for PKG_CONF*
+		have_PKG_CONFIG=yes
+		AC_PATH_PROG(dummy_PKG_CONFIG, pkg-config)
+		AC_MSG_CHECKING([whether usable PKG_CONFIG is present in PATH])
+		AS_IF([test x"$dummy_PKG_CONFIG" = xno || test -z "$dummy_PKG_CONFIG"],
+			[AC_MSG_RESULT([no])
+			 PKG_CONFIG=false
+			 have_PKG_CONFIG=no
+			],
+			[AS_IF([$dummy_PKG_CONFIG --help 2>&1 | grep -E '(--cflags|--libs)' >/dev/null],
+				[AC_MSG_RESULT([yes: ${dummy_PKG_CONFIG}])
+				 have_PKG_CONFIG=yes
+				 PKG_CONFIG="$dummy_PKG_CONFIG"
+				],
+				[AC_MSG_RESULT([no])
+				 PKG_CONFIG=false
+				 have_PKG_CONFIG=no
+				]
+			)]
+		)]
+	)
+
+	AS_IF([test x"$have_PKG_CONFIG" = xyes],
+		[AC_MSG_NOTICE([checking for autoconf macro support of pkg-config (${PKG_CONFIG})])
+		 have_PKG_CONFIG=no
+		 dummy_RES=0
+		 ifdef([PKG_PROG_PKG_CONFIG], [], [dummy_RES=1])
+		 ifdef([PKG_CHECK_MODULES], [], [dummy_RES=2])
+		 AS_IF([test "${dummy_RES}" = 0],
+			[AC_MSG_NOTICE([checking for autoconf macro support of pkg-config module checker])
+			 dnl The m4 macro below may be not defined if pkg-config package is not
+			 dnl installed. Use of ifdef (here and below for e.g. CPPUNIT check)
+			 dnl allows to avoid shell syntax errors in generated configure script
+			 dnl by defining a dummy macro in-place.
+			 ifdef([PKG_CHECK_MODULES], [], [AC_DEFUN([PKG_CHECK_MODULES], [false])])
+			 PKG_CHECK_MODULES([dummy_PKG_CONFIG], [pkg-config], [have_PKG_CONFIG=yes])
+			]
+		)]
+	)
+
 	AS_IF([test x"$have_PKG_CONFIG" = xno],
-	    [AC_MSG_WARN([pkg-config is needed to look for further dependencies (will be skipped)])])
+		[AC_MSG_WARN([pkg-config is needed to look for further dependencies (will be skipped)])
+		 PKG_CONFIG="false"
+		]
+	)
 
   ]) dnl if nut_have_pkg_config_seen
 ])

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -472,7 +472,9 @@ static void try_all_oid(void * arg, const char * mib_found)
 
 	while (snmp_device_table[index].mib != NULL) {
 
-		if (snmp_device_table[index].oid == NULL || strcmp(snmp_device_table[index].oid, "") == 0) {
+		if (snmp_device_table[index].oid == NULL
+		||  snmp_device_table[index].oid[0] == '\0'
+		) {
 			index++;
 			continue;
 		}
@@ -812,7 +814,7 @@ static void * try_SysOID(void * arg)
 					/* add mib if no complementary oid is present */
 					/* FIXME: No desc defined when add device */
 					if (snmp_device_table[index].oid == NULL
-						|| strcmp(snmp_device_table[index].oid, "") == 0
+					||  snmp_device_table[index].oid[0] == '\0'
 					) {
 						scan_snmp_add_device(sec, NULL, snmp_device_table[index].mib);
 						mib_found = snmp_device_table[index].sysoid;


### PR DESCRIPTION
There were issues building against old or new FreeIPMI (different types in lib headers), avoiding `valgrind` on agents that say they lack it, and using `pkg-config` regardless of its presence.

Also fixes a few mild warnings found by the newly consulted compiler versions.