### PR TITLE
Redefine bit-flag map values for snmp-ups.h

### DIFF
--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -212,14 +212,14 @@ void upsdrv_initinfo(void)
 	for (su_info_p = &snmp_info[0]; (su_info_p != NULL && su_info_p->info_type != NULL) ; su_info_p++)
 	{
 		if (su_info_p->flags == 0UL) {
-			upsdebugx(0,
+			upsdebugx(4,
 				"SNMP UPS driver: %s: MIB2NUT mapping '%s' (OID '%s') did not define flags bits. "
-				"Please report as a bug to the NUT maintainers.",
+				"Entry would be treated as SU_FLAG_OK if available in returned data.",
 				__func__,
 				(su_info_p->info_type ? su_info_p->info_type : "<null>"),
 				(su_info_p->OID ? su_info_p->OID : "<null>")
 				);
-			/* FIXME? Bail out of driver here? Ignore the entry? */
+			/* Treat as OK if avail, otherwise discarded */
 		}
 
 		su_info_p->flags |= SU_FLAG_OK;

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -211,6 +211,17 @@ void upsdrv_initinfo(void)
 	 * outlet (and groups) commands are processed later, during initial walk */
 	for (su_info_p = &snmp_info[0]; (su_info_p != NULL && su_info_p->info_type != NULL) ; su_info_p++)
 	{
+		if (su_info_p->flags == 0UL) {
+			upsdebugx(0,
+				"SNMP UPS driver: %s: MIB2NUT mapping '%s' (OID '%s') did not define flags bits. "
+				"Please report as a bug to the NUT maintainers.",
+				__func__,
+				(su_info_p->info_type ? su_info_p->info_type : "<null>"),
+				(su_info_p->OID ? su_info_p->OID : "<null>")
+				);
+			/* FIXME? Bail out of driver here? Ignore the entry? */
+		}
+
 		su_info_p->flags |= SU_FLAG_OK;
 		if ((SU_TYPE(su_info_p) == SU_TYPE_CMD)
 			&& !(su_info_p->flags & SU_OUTLET)

--- a/drivers/snmp-ups.h
+++ b/drivers/snmp-ups.h
@@ -219,8 +219,8 @@ typedef struct {
 /* "flags" bits 21..23 */
 #define SU_TYPE_DAISY_1		(1UL << 21)	/* Daisychain index is the 1st specifier */
 #define SU_TYPE_DAISY_2		(1UL << 22)	/* Daisychain index is the 2nd specifier */
-#define SU_TYPE_DAISY(t)	((t)->flags & (7UL << 21))	/* FIXME? Mask with 7 or 3 here? */
-#define SU_DAISY			(1UL << 23)	/* Daisychain template definition */
+#define SU_TYPE_DAISY(t)	((t)->flags & (3UL << 21))	/* Mask the 2 SU_TYPE_DAISY_* but not SU_DAISY */
+#define SU_DAISY			(1UL << 23)	/* Daisychain template definition - set at run-time for devices with detected "device.count" over 1 */
 /* NOTE: Previously SU_DAISY had same bit-flag value as SU_TYPE_DAISY_2*/
 
 /* status string components

--- a/drivers/snmp-ups.h
+++ b/drivers/snmp-ups.h
@@ -149,6 +149,8 @@ typedef struct {
 	                           * NOTE that some *-mib.c mappings can specify
 	                           * a zero in this field... better fix that in
 	                           * favor of explicit values with a meaning!
+	                           * Current code treats such zero values as
+	                           * "OK if avail, otherwise discarded".
 	                           * NOTE: With C99+ a "long" is guaranteed to be
 	                           * at least 4 bytes; consider "unsigned long long"
 	                           * when/if we get more than 32 flag values.

--- a/drivers/snmp-ups.h
+++ b/drivers/snmp-ups.h
@@ -174,7 +174,9 @@ typedef struct {
 #define SU_FLAG_NAINVALID	(1UL << 7)	/* Invalid if "N/A" value */
 #define SU_CMD_OFFSET		(1UL << 8)	/* Add +1 to the OID index */
 
-/* Reserved slot (1UL << 9) -- to import SU_FLAG_FUNCTION from DMF branch codebase */
+/* Reserved slot -- to import from DMF branch codebase:
+//#define SU_FLAG_SEMI_STATIC	(1UL << 9)*/	/* Refresh this entry once in several walks
+// * (for R/W values user can set on device, like descriptions or contacts) */
 
 /* Notes on outlet templates usage:
  * - outlet.count MUST exist and MUST be declared before any outlet template
@@ -216,24 +218,36 @@ typedef struct {
  * in the formatting string. This is useful when considering daisychain with
  * templates, such as outlets / outlets groups, which already have a format
  * string specifier */
-/* "flags" bits 21..23 */
+/* "flags" bits 21..23 (and 24 reserved for DMF) */
 #define SU_TYPE_DAISY_1		(1UL << 21)	/* Daisychain index is the 1st specifier */
 #define SU_TYPE_DAISY_2		(1UL << 22)	/* Daisychain index is the 2nd specifier */
 #define SU_TYPE_DAISY(t)	((t)->flags & (3UL << 21))	/* Mask the 2 SU_TYPE_DAISY_* but not SU_DAISY */
 #define SU_DAISY			(1UL << 23)	/* Daisychain template definition - set at run-time for devices with detected "device.count" over 1 */
 /* NOTE: Previously SU_DAISY had same bit-flag value as SU_TYPE_DAISY_2*/
+/* Reserved slot -- to import from DMF branch codebase
+// (and change SU_TYPE_DAISY to 11UL<<21 for the 3 types then):
+//#define SU_TYPE_DAISY_MASTER_ONLY	(1UL << 24)*/	/* Only valid for daisychain master (device.1) */
+
+/* Free slot: (1UL << 25) */
+
+/* Reserved slot -- to import from DMF branch codebase:
+//#define SU_AMBIENT_TEMPLATE	(1UL << 26)*/	/* ambient template definition */
+
+/* Reserved slot -- to import from DMF branch codebase:
+//#define SU_FLAG_FUNCTION	(1UL << 27)
+*/
 
 /* status string components
  * FIXME: these should be removed, since there is no added value.
  * Ie, this can be guessed from info->type! */
 
-/* "flags" bits 24..27 */
-#define SU_STATUS_PWR		(1UL << 24)	/* indicates power status element */
-#define SU_STATUS_BATT		(1UL << 25)	/* indicates battery status element */
-#define SU_STATUS_CAL		(1UL << 26)	/* indicates calibration status element */
-#define SU_STATUS_RB		(1UL << 27)	/* indicates replace battery status element */
+/* "flags" bits 28..31 */
+#define SU_STATUS_PWR		(1UL << 28)	/* indicates power status element */
+#define SU_STATUS_BATT		(1UL << 29)	/* indicates battery status element */
+#define SU_STATUS_CAL		(1UL << 30)	/* indicates calibration status element */
+#define SU_STATUS_RB		(1UL << 31)	/* indicates replace battery status element */
 #define SU_STATUS_NUM_ELEM	4			/* Obsolete? No references found in codebase */
-#define SU_STATUS_INDEX(t)	(((unsigned long)(t) >> 24) & 15UL)
+#define SU_STATUS_INDEX(t)	(((unsigned long)(t) >> 28) & 15UL)
 
 /* Despite similar names, definitons below are not among the bit-flags ;) */
 #define SU_VAR_COMMUNITY	"community"

--- a/drivers/snmp-ups.h
+++ b/drivers/snmp-ups.h
@@ -168,53 +168,44 @@ typedef struct {
 #define SU_FLAG_UNIQUE		(1UL << 5)	/* There can be only be one
 						 				 * provider of this info,
 						 				 * disable the other providers */
-/* Free slot
+/* Note: older releases defined the following flag, but removed it by 2.7.5:
  * #define SU_FLAG_SETINT	(1UL << 6)*/	/* save value */
-#define SU_OUTLET			(1UL << 7)	/* outlet template definition */
+#define SU_FLAG_ZEROINVALID	(1UL << 6)	/* Invalid if "0" value */
+#define SU_FLAG_NAINVALID	(1UL << 7)	/* Invalid if "N/A" value */
 #define SU_CMD_OFFSET		(1UL << 8)	/* Add +1 to the OID index */
+
+/* Reserved slot (1UL << 9) -- to import SU_FLAG_FUNCTION from DMF branch codebase */
+
 /* Notes on outlet templates usage:
  * - outlet.count MUST exist and MUST be declared before any outlet template
  * Otherwise, the driver will try to determine it by itself...
  * - the first outlet template MUST NOT be a server side variable (ie MUST have
  *   a valid OID) in order to detect the base SNMP index (0 or 1)
  */
-/* Reserved slot (1UL << 9) -- to import from DMF branch codebase */
-
-/* status string components
- * FIXME: these should be removed, since there is no added value.
- * Ie, this can be guessed from info->type! */
-
-/* "flags" value 0, or bits 8..9, or "8 and 9" */
-#define SU_STATUS_PWR		(0UL << 8)	/* indicates power status element */
-#define SU_STATUS_BATT		(1UL << 8)	/* indicates battery status element */
-#define SU_STATUS_CAL		(2UL << 8)	/* indicates calibration status element */
-#define SU_STATUS_RB		(3UL << 8)	/* indicates replace battery status element */
-#define SU_STATUS_NUM_ELEM	4			/* Obsolete? No references found in codebase */
-#define SU_STATUS_INDEX(t)	(((unsigned long)(t) >> 8) & 7UL)
 
 /* "flags" bit 10 */
 #define SU_OUTLET_GROUP		(1UL << 10)	/* outlet group template definition */
+#define SU_OUTLET			(1UL << 11)	/* outlet template definition */
 
 /* Phase specific data */
 /* "flags" bits 12..17 */
-#define SU_PHASES		(0x0000003F << 12)
-#define SU_INPHASES		(0x00000003 << 12)
-#define SU_INPUT_1		(1UL << 12)	/* only if 1 input phase */
-#define SU_INPUT_3		(1UL << 13)	/* only if 3 input phases */
-#define SU_OUTPHASES	(0x00000003 << 14)
-#define SU_OUTPUT_1		(1UL << 14)	/* only if 1 output phase */
-#define SU_OUTPUT_3		(1UL << 15)	/* only if 3 output phases */
-#define SU_BYPPHASES	(0x00000003 << 16)
-#define SU_BYPASS_1		(1UL << 16)	/* only if 1 bypass phase */
-#define SU_BYPASS_3		(1UL << 17)	/* only if 3 bypass phases */
+#define SU_PHASES			(0x0000003F << 12)
+#define SU_INPHASES			(0x00000003 << 12)
+#define SU_INPUT_1			(1UL << 12)	/* only if 1 input phase */
+#define SU_INPUT_3			(1UL << 13)	/* only if 3 input phases */
+#define SU_OUTPHASES		(0x00000003 << 14)
+#define SU_OUTPUT_1			(1UL << 14)	/* only if 1 output phase */
+#define SU_OUTPUT_3			(1UL << 15)	/* only if 3 output phases */
+#define SU_BYPPHASES		(0x00000003 << 16)
+#define SU_BYPASS_1			(1UL << 16)	/* only if 1 bypass phase */
+#define SU_BYPASS_3			(1UL << 17)	/* only if 3 bypass phases */
 /* FIXME: use input.phases and output.phases to replace this */
 
 /* hints for su_ups_set, applicable only to rw vars */
-/* "flags" value 0, or bits 18..19, or "18 and 19" */
-#define SU_TYPE_INT			(0UL << 18)	/* cast to int when setting value */
-/* Free slot                (1UL << 18) */
-#define SU_TYPE_TIME		(2UL << 18)	/* cast to int */
-#define SU_TYPE_CMD			(3UL << 18)	/* instant command */
+/* "flags" bits 18..20 */
+#define SU_TYPE_INT			(1UL << 18)	/* cast to int when setting value */
+#define SU_TYPE_TIME		(1UL << 19)	/* cast to int */
+#define SU_TYPE_CMD			(1UL << 20)	/* instant command */
 /* The following helper macro is used like:
  *   if (SU_TYPE(su_info_p) == SU_TYPE_CMD) { ... }
  */
@@ -225,16 +216,26 @@ typedef struct {
  * in the formatting string. This is useful when considering daisychain with
  * templates, such as outlets / outlets groups, which already have a format
  * string specifier */
-/* "flags" bits 19..20, and 20 again */
-#define SU_TYPE_DAISY_1		(1UL << 19)	/* Daisychain index is the 1st specifier */
-#define SU_TYPE_DAISY_2		(2UL << 19)	/* Daisychain index is the 2nd specifier */
-#define SU_TYPE_DAISY(t)	((t)->flags & (7UL << 19))
-#define SU_DAISY			(2UL << 19)	/* Daisychain template definition */
+/* "flags" bits 21..23 */
+#define SU_TYPE_DAISY_1		(1UL << 21)	/* Daisychain index is the 1st specifier */
+#define SU_TYPE_DAISY_2		(1UL << 22)	/* Daisychain index is the 2nd specifier */
+#define SU_TYPE_DAISY(t)	((t)->flags & (7UL << 21))	/* FIXME? Mask with 7 or 3 here? */
+#define SU_DAISY			(1UL << 23)	/* Daisychain template definition */
+/* NOTE: Previously SU_DAISY had same bit-flag value as SU_TYPE_DAISY_2*/
 
-/* "flags" bits 20..21 */
-#define SU_FLAG_ZEROINVALID	(1UL << 20)	/* Invalid if "0" value */
-#define SU_FLAG_NAINVALID	(1UL << 21)	/* Invalid if "N/A" value */
+/* status string components
+ * FIXME: these should be removed, since there is no added value.
+ * Ie, this can be guessed from info->type! */
 
+/* "flags" bits 24..27 */
+#define SU_STATUS_PWR		(1UL << 24)	/* indicates power status element */
+#define SU_STATUS_BATT		(1UL << 25)	/* indicates battery status element */
+#define SU_STATUS_CAL		(1UL << 26)	/* indicates calibration status element */
+#define SU_STATUS_RB		(1UL << 27)	/* indicates replace battery status element */
+#define SU_STATUS_NUM_ELEM	4			/* Obsolete? No references found in codebase */
+#define SU_STATUS_INDEX(t)	(((unsigned long)(t) >> 24) & 15UL)
+
+/* Despite similar names, definitons below are not among the bit-flags ;) */
 #define SU_VAR_COMMUNITY	"community"
 #define SU_VAR_VERSION		"snmp_version"
 #define SU_VAR_RETRIES		"snmp_retries"


### PR DESCRIPTION
This PR follows up from findings of PRs #1147 and #1177, and aims to just redefine the bit-flags used to identify nuances of data points in MIB2NUT mappings.

Given that many value ranges had to move around and expand to avoid overlapping/conflicts (several macros had zero values, a few had different numbers shifted by different offsets to same result, etc.), some defined values were relocated considerably to group them better.