### PR TITLE
Add CyberPower RMCARD205 which is already supported

### DIFF
--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -229,6 +229,7 @@
 "Cyber Power Systems"	"ups"	"3"	"RMCARD100"	""	"snmp-ups"
 "Cyber Power Systems"	"ups"	"3"	"RMCARD201"	""	"snmp-ups"
 "Cyber Power Systems"	"ups"	"3"	"RMCARD202"	""	"snmp-ups"
+"Cyber Power Systems"	"ups"	"3"	"RMCARD205"	""	"snmp-ups"
 "Cyber Power Systems"	"ups"	"3"	"RMCARD301"	""	"snmp-ups"
 
 "Cyclades"	"pdu"	"1"	"PM8"	"8 outlets"	"powerman-pdu (experimental)"


### PR DESCRIPTION
Support for CyberPower RMCARD205 was added in #686 and #793.

This pull request simply adds the card to the Hardware compatibility list

Thank you to everyone involved in making this awesome application 