### PR TITLE
Fightwarn: short global variable names and other minor alerts from LGTM.com

### DIFF
--- a/ci_build.sh
+++ b/ci_build.sh
@@ -889,6 +889,8 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
                 esac || {
                     RES=$?
                     FAILED="${FAILED} NUT_SSL_VARIANT=${NUT_SSL_VARIANT}[configure]"
+                    # TOTHINK: Do we want to try clean-up if we likely have no Makefile?
+                    BUILDSTODO="`expr $BUILDSTODO - 1`" || [ "$BUILDSTODO" = "0" ]
                     continue
                 }
 

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -856,6 +856,7 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
             for NUT_SSL_VARIANT in $NUT_SSL_VARIANTS ; do
                 BUILDSTODO="`expr $BUILDSTODO + 1`"
             done
+            BUILDSTODO_INITIAL="$BUILDSTODO"
 
             #echo "=== Will loop now with $BUILDSTODO build variants..."
             for NUT_SSL_VARIANT in $NUT_SSL_VARIANTS ; do
@@ -947,6 +948,11 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
             if [ "$RES" != 0 ]; then
                 # Leading space is included in FAILED
                 echo "FAILED build(s) with:${FAILED}" >&2
+            fi
+
+            echo "Initially estimated ${BUILDSTODO_INITIAL} variations for BUILD_TYPE='$BUILD_TYPE'" >&2
+            if [ "$BUILDSTODO" -gt 0 ]; then
+                echo "(and missed the mark: ${BUILDSTODO} variations remain - did anything crash early above?)" >&2
             fi
 
             exit $RES

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -894,6 +894,7 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
                     continue
                 }
 
+                echo "=== Configured NUT_SSL_VARIANT='$NUT_SSL_VARIANT', $BUILDSTODO build variants (including this one) remaining to complete; trying to build..."
                 build_to_only_catch_errors && {
                     SUCCEEDED="${SUCCEEDED} NUT_SSL_VARIANT=${NUT_SSL_VARIANT}[build]"
                 } || {

--- a/drivers/bcmxcp_ser.c
+++ b/drivers/bcmxcp_ser.c
@@ -31,7 +31,7 @@ pw_baud_rate_t pw_baud_rates[] = {
 };
 
 /* NOT static: also used from nut-scanner, so extern'ed via bcmxcp_ser.h */
-unsigned char AUT[4] = {0xCF, 0x69, 0xE8, 0xD5}; /* Authorisation command */
+unsigned char BCMXCP_AUTHCMD[4] = {0xCF, 0x69, 0xE8, 0xD5}; /* Authorisation command */
 
 static void send_command(unsigned char *command, size_t command_length)
 {
@@ -356,7 +356,7 @@ static void pw_comm_setup(const char *port)
 		ser_set_speed(upsfd, device_path, mybaud);
 		ser_send_char(upsfd, 0x1d); /* send ESC to take it out of menu */
 		usleep(90000);
-		send_write_command(AUT, 4);
+		send_write_command(BCMXCP_AUTHCMD, 4);
 		usleep(500000);
 		ret = command_sequence(&command, 1, answer);
 		if (ret <= 0) {
@@ -382,7 +382,7 @@ static void pw_comm_setup(const char *port)
 		ser_set_speed(upsfd, device_path, pw_baud_rates[i].rate);
 		ser_send_char(upsfd, 0x1d); /* send ESC to take it out of menu */
 		usleep(90000);
-		send_write_command(AUT, 4);
+		send_write_command(BCMXCP_AUTHCMD, 4);
 		usleep(500000);
 		ret = command_sequence(&command, 1, answer);
 		if (ret <= 0) {

--- a/drivers/bcmxcp_ser.h
+++ b/drivers/bcmxcp_ser.h
@@ -10,7 +10,7 @@
 /* This header is needed for this line, to avoid warnings about it not
  * being static in C file (can't hide, is also needed by nut-scanner)
  */
-extern unsigned char AUT[4];
+extern unsigned char BCMXCP_AUTHCMD[4];
 
 typedef struct {
 	speed_t rate;	/* Value like B19200 defined in termios.h; note: NOT the bitrate numerically */

--- a/drivers/bcmxcp_usb.c
+++ b/drivers/bcmxcp_usb.c
@@ -272,7 +272,7 @@ int get_answer(unsigned char *data, unsigned char command)
 			my_buf = memmove(&buf[0], my_buf + length + PW_HEADER_SIZE, (size_t)tail);
 		else if (tail == 0)
 			my_buf = &buf[0];
-		else if (tail < 0) {
+		else /* if (tail < 0) */ {
 			upsdebugx(1, "get_answer(): did not expect to get negative tail size: %d", tail);
 			return -1;
 		}

--- a/drivers/bestfortress.c
+++ b/drivers/bestfortress.c
@@ -204,6 +204,13 @@ static int upssend(const char *fmt,...) {
 		if (write(upsfd, p, 1) != 1)
 			return -1;
 
+		/* Note: LGTM.com analysis warns that here
+		 * "Comparison is always true because d_usec >= 2"
+		 * since we initialize with UPSDELAY above.
+		 * Do not remove this check just in case that
+		 * initialization changes, or run-time value
+		 * becomes modified, in later iterations.
+		 */
 		if (d_usec > 0)
 			usleep((useconds_t)d_usec);
 

--- a/drivers/phoenixcontact_modbus.c
+++ b/drivers/phoenixcontact_modbus.c
@@ -30,7 +30,7 @@
 #define MODBUS_SLAVE_ID 192
 
 /* Variables */
-modbus_t *ctx = NULL;
+modbus_t *modbus_ctx = NULL;
 int errcount = 0;
 
 static int mrir(modbus_t * arg_ctx, int addr, int nb, uint16_t * dest);
@@ -63,7 +63,7 @@ void upsdrv_updateinfo(void)
 
 	uint16_t tab_reg[64];
 
-	mrir(ctx, 29697, 3, tab_reg);
+	mrir(modbus_ctx, 29697, 3, tab_reg);
 
 	status_init();
 
@@ -80,14 +80,14 @@ void upsdrv_updateinfo(void)
 		status_set("LB");	/* LB is actually called "shutdown event" on this ups */
 	}
 
-	mrir(ctx, 29745, 1, tab_reg);
+	mrir(modbus_ctx, 29745, 1, tab_reg);
 	dstate_setinfo("output.voltage", "%d", (int) (tab_reg[0] / 1000));
 
-	mrir(ctx, 29749, 5, tab_reg);
+	mrir(modbus_ctx, 29749, 5, tab_reg);
 	dstate_setinfo("battery.charge", "%d", tab_reg[0]);
 	/* dstate_setinfo("battery.runtime",tab_reg[1]*60); */ /* also reported on this address, but less accurately */
 
-	mrir(ctx, 29792, 10, tab_reg);
+	mrir(modbus_ctx, 29792, 10, tab_reg);
 	dstate_setinfo("battery.voltage", "%f", (double) (tab_reg[0]) / 1000.0);
 	dstate_setinfo("battery.temperature", "%d", tab_reg[1] - 273);
 	dstate_setinfo("battery.runtime", "%d", tab_reg[3]);
@@ -95,7 +95,7 @@ void upsdrv_updateinfo(void)
 	dstate_setinfo("output.current", "%f", (double) (tab_reg[6]) / 1000.0);
 
 	/* ALARMS */
-	mrir(ctx, 29840, 1, tab_reg);
+	mrir(modbus_ctx, 29840, 1, tab_reg);
 	alarm_init();
 	if (CHECK_BIT(tab_reg[0], 4) && CHECK_BIT(tab_reg[0], 5))
 		alarm_set("End of life (Resistance)");
@@ -150,18 +150,18 @@ void upsdrv_initups(void)
 	int r;
 	upsdebugx(2, "upsdrv_initups");
 
-	ctx = modbus_new_rtu(device_path, 115200, 'E', 8, 1);
-	if (ctx == NULL)
+	modbus_ctx = modbus_new_rtu(device_path, 115200, 'E', 8, 1);
+	if (modbus_ctx == NULL)
 		fatalx(EXIT_FAILURE, "Unable to create the libmodbus context");
 
-	r = modbus_set_slave(ctx, MODBUS_SLAVE_ID);	/* slave ID */
+	r = modbus_set_slave(modbus_ctx, MODBUS_SLAVE_ID);	/* slave ID */
 	if (r < 0) {
-		modbus_free(ctx);
+		modbus_free(modbus_ctx);
 		fatalx(EXIT_FAILURE, "Invalid modbus slave ID %d",MODBUS_SLAVE_ID);
 	}
 
-	if (modbus_connect(ctx) == -1) {
-		modbus_free(ctx);
+	if (modbus_connect(modbus_ctx) == -1) {
+		modbus_free(modbus_ctx);
 		fatalx(EXIT_FAILURE, "modbus_connect: unable to connect: %s", modbus_strerror(errno));
 	}
 
@@ -170,9 +170,9 @@ void upsdrv_initups(void)
 
 void upsdrv_cleanup(void)
 {
-	if (ctx != NULL) {
-		modbus_close(ctx);
-		modbus_free(ctx);
+	if (modbus_ctx != NULL) {
+		modbus_close(modbus_ctx);
+		modbus_free(modbus_ctx);
 	}
 }
 

--- a/tools/nut-scanner/scan_eaton_serial.c
+++ b/tools/nut-scanner/scan_eaton_serial.c
@@ -56,7 +56,7 @@
 
 /* BCMXCP header defines these externs now: */
 /*
-extern unsigned char AUT[4];
+extern unsigned char BCMXCP_AUTHCMD[4];
 extern struct pw_baud_rate {
 	int rate;
 	int name;
@@ -232,7 +232,7 @@ static nutscan_device_t * nutscan_scan_eaton_serial_xcp(const char* port_name)
 				break;
 
 			usleep(90000);
-			send_write_command(AUT, 4);
+			send_write_command(BCMXCP_AUTHCMD, 4);
 			usleep(500000);
 
 			/* Discovery with Baud Hunting (XCP protocol spec. §4.1.2)


### PR DESCRIPTION
This PR follows up from #823 and addresses some warnings from LGTM.com analyses that are easy to address.

Some would likely remain reported until we find a way to quiesce the alerts (similar to GCC pragmas that seem ignored by that analyzer), like where we check numeric types and ranges that differ between platforms. A few of these are already (or with this PR) commented as non-issues at least.

Another case that would likely stay until further research is the names of mib2nut mapping tables ("apc" and "mge" are too short for comfy globals).

Also this PR adds some improvements to `ci_build.sh` script trace messages.