### PR TITLE
drivers/snmp-ups.{c,h}: typedef snmp_info_t::flags and …

### DIFF
--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -185,8 +185,8 @@ static int device_template_offset = -1;
 /* Forward functions declarations */
 static void disable_transfer_oids(void);
 bool_t get_and_process_data(int mode, snmp_info_t *su_info_p);
-int extract_template_number(unsigned long template_type, const char* varname);
-unsigned long get_template_type(const char* varname);
+int extract_template_number(snmp_info_flags_t template_type, const char* varname);
+snmp_info_flags_t get_template_type(const char* varname);
 
 /* ---------------------------------------------
  * driver functions implementations
@@ -1989,7 +1989,7 @@ static int base_snmp_template_index(const snmp_info_t *su_info_p)
 
 	int base_index = -1;
 	char test_OID[SU_INFOSIZE];
-	unsigned long template_type = get_template_type(su_info_p->info_type);
+	snmp_info_flags_t template_type = get_template_type(su_info_p->info_type);
 
 	if (!su_info_p->OID)
 		return base_index;
@@ -2007,6 +2007,11 @@ static int base_snmp_template_index(const snmp_info_t *su_info_p)
 			break;
 		case SU_DAISY:
 			template_index_base = device_template_index_base;
+			break;
+		default:
+			/* we should never fall here! */
+			upsdebugx(3, "%s: unknown template type '%" PRI_SU_FLAGS "' for %s",
+				__func__, template_type, su_info_p->info_type);
 	}
 	base_index = template_index_base;
 
@@ -2334,7 +2339,7 @@ static bool_t process_template(int mode, const char* type, snmp_info_t *su_info_
 
 /* Return the type of template, according to a variable name.
  * Return: SU_OUTLET_GROUP, SU_OUTLET or 0 if not a template */
-unsigned long get_template_type(const char* varname)
+snmp_info_flags_t get_template_type(const char* varname)
 {
 	if (!strncmp(varname, "outlet.group", 12)) {
 		upsdebugx(4, "outlet.group template");
@@ -2356,7 +2361,7 @@ unsigned long get_template_type(const char* varname)
 
 /* Extract the id number of an instantiated template.
  * Example: return '1' for type = 'outlet.1.desc', -1 if unknown */
-int extract_template_number(unsigned long template_type, const char* varname)
+int extract_template_number(snmp_info_flags_t template_type, const char* varname)
 {
 	const char* item_number_ptr = NULL;
 	int item_number = -1;
@@ -2546,7 +2551,7 @@ static int process_phase_data(const char* type, long *nb_phases, snmp_info_t *su
 	char tmpOID[SU_INFOSIZE];
 	char tmpInfo[SU_INFOSIZE];
 	long tmpValue;
-	unsigned long phases_flag = 0, single_phase_flag = 0, three_phase_flag = 0;
+	snmp_info_flags_t phases_flag = 0, single_phase_flag = 0, three_phase_flag = 0;
 
 	/* Phase specific data */
 	if (!strncmp(type, "input", 5)) {
@@ -3121,7 +3126,7 @@ static int su_setOID(int mode, const char *varname, const char *val)
 	int cmd_offset = 0;
 	long value = -1;
 	/* normal (default), outlet, or outlet group variable */
-	unsigned long vartype = 0;
+	snmp_info_flags_t vartype = 0;
 	int daisychain_device_number = -1;
 	/* variable without the potential "device.X" prefix, to find the template */
 	char *tmp_varname = NULL;

--- a/drivers/snmp-ups.h
+++ b/drivers/snmp-ups.h
@@ -128,6 +128,9 @@ typedef struct {
    use sprintf with given format string.  If unit is not NONE, values
    are converted according to the multiplier table
 */
+typedef uint32_t snmp_info_flags_t; /* To extend when 32 bits become too congested */
+#define PRI_SU_FLAGS	PRIu32
+
 typedef struct {
 	char         *info_type;  /* INFO_ or CMD_ element */
 	int           info_flags; /* flags to set in addinfo: see ST_FLAG_*
@@ -136,7 +139,7 @@ typedef struct {
 	                           * multiplier otherwise. */
 	char         *OID;        /* SNMP OID or NULL */
 	char         *dfl;        /* default value */
-	unsigned long flags;      /* snmp-ups internal flags: see SU_* bit-shifts
+	snmp_info_flags_t flags;  /* snmp-ups internal flags: see SU_* bit-shifts
 	                           * defined below (SU_FLAG*, SU_TYPE*, SU_STATUS*
 	                           * and others for outlets, phases, daisy-chains,
 	                           * etc.)


### PR DESCRIPTION
…define its `PRI_SU_FLAGS` format to ease type changes later

Also adds a "default:" to case for template flag handling (from FTY fork)

Follows up from #1177