### PR TITLE
Huawei UPS2000: Update Man Page, Change Logic for "load.on" command

### DIFF
--- a/docs/man/huawei-ups2000.txt
+++ b/docs/man/huawei-ups2000.txt
@@ -30,16 +30,20 @@ UPS with the following characteristics.
 newer kernels, read the section *Cabling* carefully).
 
 The UPS2000 series has two variants: UPS2000-A with a tower chassis,
-and UPS2000-G with a rack-mount chassis. Only the UPS2000-A variant
-has been tested, but UPS2000-G units are probably also supported.
+and UPS2000-G with a rack-mount chassis. Both should be equally supported,
+but more testers are needed.
 
-It has been tested on the following models.
+Currently, it has been tested on the following models.
 
 * UPS2000-A-1KTTS (firmware: V2R1C1SPC40, P1.0-D1.0)
 * UPS2000-A-2KTTS (firmware: V2R1C1SPC50, P1.0-D1.0)
+* UPS2000-G-3KRTS (firmware: V2R1C1SPC40, P1.0-D1.0)
 
-We encourage users of other models to report your successful or
-unsuccessful results to the bug tracker or the mailing list.
+If your model is not in the list, we encourage you to report successful
+or unsuccessful results to the bug tracker or the mailing list.
+Make sure to include the full model number of your UPS manually
+in your report, because the firmware only reports "UPS2000-A"
+for all models, including the G series.
 
 huawei-ups2000 uses the libmodbus project, for Modbus implementation.
 

--- a/docs/man/huawei-ups2000.txt
+++ b/docs/man/huawei-ups2000.txt
@@ -300,7 +300,7 @@ Serial port becomes unresponsive
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Some malformed commands are known to lock up the serial port (including
-USB, which a USB to serial device) Upon receiving them, UPS2000 stops
+USB, which is a USB-to-serial device). Upon receiving them, UPS2000 stops
 all serial communications. The result is a completely unresponsive UPS,
 regardless of what you do - restarting NUT, rebooting the computer -
 cannot restore connectivity, as if someone has unplugged the RS-232 cable.
@@ -328,7 +328,7 @@ requires a device-specific driver, which is only available on Linux
 
 On an unsupported system, the USB device can still be recognized as a
 USB ACM device, but in reality, communication is impossible. It can
-only be fixed by implementing a driver for your system nothing can
+only be fixed by implementing a driver for your system, nothing can
 be done within NUT.
 
 Finally, in the unlike scenario that you are using NUT on Microsoft

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -492,6 +492,7 @@ KNutClient
 KNutSetting
 KOLFF
 KRT
+KRTS
 KTTS
 Kain
 Kaminski


### PR DESCRIPTION
This commit introduces three minor changes after #954 merge.

* Thanks to the user report by @whc2001 in #1066, we finally have a beta tester with a UPS2000-G model with positive result. This commit adds UPS2000-G-3KRTS to the list of tested model in the man page, with slightly updated instructions for submitting new user reports. Two minor typos in the man page are also fixed.
* Currently the driver prevents the user from executing `load.on` when the UPS is already on, and reports a `STAT_INSTCMD_FAILED` with error logs. While executing "load.on" when the UPS is already in "normal-mode on" has no effect, it's still a legal command and should not be rejected arbitrarily, which can potentially confuse downstream applications and users (Update: But we still need to do this if the UPS is in bypass mode, because the UPS would otherwise enter normal mode - "load.on" is not supposed to do that).
* The previous driver also contains two misleading typos in the error logs: (1) it incorrectly suggests `bypass.off` instead of `bypass.stop`, and (2) reports `failed: reason unknown.` when the reason is simply an already-on UPS.

    This commit allows `load.on` to execute when it's already on, and changes the log messages from errors to warnings. Typos in the log messages are also fixed.
