### PR TITLE
More fixes for builds on older platforms (OpenBSD 6.4)

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -9,7 +9,12 @@ libparseconf_la_SOURCES = parseconf.c
 # 'dist', and is only required for actual build, in which case
 # BUILT_SOURCES (in ../include) will ensure nut_version.h will
 # be built before anything else
-common.c: $(top_builddir)/include/nut_version.h
+# Surprisingly, for some "make" implementations this dependency means
+# that the "common.c" required for builds below will be seeked in the
+# current directory. So for out-of-tree builds like distcheck, we have
+# to symlink the "real" source to build area:
+common.c: $(top_builddir)/include/nut_version.h $(srcdir)/common.c
+	test -s "$@" || ln -s -f "$(top_srcdir)/common/common.c" "$@"
 
 $(top_builddir)/include/nut_version.h:
 	@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -19,8 +19,18 @@ common.c: $(top_builddir)/include/nut_version.h $(srcdir)/common.c
 $(top_builddir)/include/nut_version.h:
 	@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
-libcommon_la_SOURCES = common.c state.c str.c upsconf.c
-libcommonclient_la_SOURCES = common.c state.c str.c
+libcommon_la_SOURCES = state.c str.c upsconf.c
+libcommonclient_la_SOURCES = state.c str.c
+if BUILDING_IN_TREE
+libcommon_la_SOURCES += common.c
+libcommonclient_la_SOURCES += common.c
+else
+nodist_libcommon_la_SOURCES = common.c
+nodist_libcommonclient_la_SOURCES = common.c
+CLEANFILES = $(top_builddir)/common/common.c
+BUILT_SOURCES = common.c
+endif
+
 # ensure inclusion of local implementation of missing systems functions
 # using LTLIBOBJS. Refer to configure.in/.ac -> AC_REPLACE_FUNCS
 libcommon_la_LIBADD = libparseconf.la @LTLIBOBJS@

--- a/configure.ac
+++ b/configure.ac
@@ -929,7 +929,7 @@ if test -z "${abs_srcdir}" ; then
 	case "${srcdir}" in
 		/*) abs_srcdir="${srcdir}";;
 		"") AC_MSG_ERROR([Can not detect 'srcdir']) ;;
-		*)  abs_srcdir="$(cd "${srcdir}" && pwd)" ;;
+		*)  abs_srcdir="$(cd "${srcdir}" && pwd)" || AC_MSG_ERROR([Can not detect 'srcdir']) ;;
 	esac
 fi
 DOCTESTDIR="$(mktemp -d configure-test.docbuild.$$.XXXXXXX)" && \
@@ -2331,10 +2331,14 @@ AS_IF([test -n "${ac_abs_top_builddir}" && test -d "${ac_abs_top_builddir}"],
     [AS_IF([test -n "${ac_pwd}" && test -d "${ac_pwd}"],
         [TOP_BUILDDIR="${ac_pwd}"],
         [TOP_BUILDDIR="`dirname "$0"`"
-         TOP_BUILDDIR="`cd "$TOP_BUILDDIR" && pwd`"]
+         TOP_BUILDDIR="`cd "$TOP_BUILDDIR" && pwd`" || AC_MSG_ERROR([Can not detect TOP_BUILDDIR])]
     )]
 )
 AC_MSG_RESULT(["${TOP_BUILDDIR}"])
+
+ABS_TOP_BUILDDIR="`cd "${TOP_BUILDDIR}" && pwd`" || AC_MSG_ERROR([Can not detect ABS_TOP_BUILDDIR])]
+ABS_TOP_SRCDIR="`cd "${abs_srcdir}" && pwd`" || AC_MSG_ERROR([Can not detect ABS_TOP_SRCDIR])]
+AM_CONDITIONAL([BUILDING_IN_TREE], [test "${ABS_TOP_BUILDDIR}" = "${ABS_TOP_SRCDIR}"])
 
 AC_MSG_CHECKING([whether to customize ${TOP_BUILDDIR}/scripts/systemd/nut-common.tmpfiles.in for this system])
 AS_IF([test -n "$systemdtmpfilesdir"],

--- a/docs/config-prereqs.txt
+++ b/docs/config-prereqs.txt
@@ -266,6 +266,7 @@ networked repository (4.2.x vs 4.9.x)
     cppunit \
     openssl nss \
     augeas \
+    libusb1 \
     neon \
     net-snmp \
     avahi

--- a/docs/config-prereqs.txt
+++ b/docs/config-prereqs.txt
@@ -268,7 +268,6 @@ networked repository (4.2.x vs 4.9.x)
     augeas \
     neon \
     net-snmp \
-    freeipmi \
     avahi
 
 # Select a LUA-5.1 (or possibly 5.2?) version
@@ -277,6 +276,15 @@ networked repository (4.2.x vs 4.9.x)
 
 :; pkg_add \
     bash dash busybox ksh93
+----
+
+NOTE: With OpenBSD 6.4, building against freeipmi failed: its libtool
+recipes referenced `-largp` which did not get installed in the system.
+Maybe some more packages are needed explicitly?
++
+----
+:; pkg_add \
+    freeipmi
 ----
 
 Recommended:

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 2774 utf-8
+personal_ws-1.1 en 2775 utf-8
 AAS
 ACFAIL
 ACFREQ
@@ -1914,6 +1914,7 @@ ktrace
 labcd
 lan
 langid
+largp
 lasaine
 ld
 le


### PR DESCRIPTION
This should complete the fix for #1190 started in PR #1194, addressing a quirk with the `make` implementation on that platform in a way that other systems in CI farm should also be content with.

Buildbot should now be all-green again :)