### PR TITLE
Replace strcmp() and strcasecmp() use-cases for short fixed string args…

### DIFF
--- a/clients/upsclient.c
+++ b/clients/upsclient.c
@@ -1418,8 +1418,8 @@ int upscli_list_next(UPSCONN_t *ups, unsigned int numq, const char **query,
 
 	/* see if this is the end */
 	if (ups->pc_ctx.numargs >= 2) {
-		if ((!strcmp(ups->pc_ctx.arglist[0], "END")) &&
-			(!strcmp(ups->pc_ctx.arglist[1], "LIST")))
+		if ((!strncmp(ups->pc_ctx.arglist[0], "END", 3)) &&
+			(!strncmp(ups->pc_ctx.arglist[1], "LIST", 4)))
 			return 0;
 	}
 

--- a/clients/upslog.c
+++ b/clients/upslog.c
@@ -488,7 +488,7 @@ int main(int argc, char **argv)
 		fprintf(stderr, "Warning: initial connect failed: %s\n",
 			upscli_strerror(&ups));
 
-	if (strcmp(logfn, "-") == 0)
+	if (strncmp(logfn, "-", 1) == 0)
 		logfile = stdout;
 	else
 		logfile = fopen(logfn, "a");

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -1591,19 +1591,19 @@ static void parse_status(utype_t *ups, char *status)
 
 		upsdebugx(3, "parsing: [%s]", statword);
 
-		if (!strcasecmp(statword, "OL"))
+		if (!strncasecmp(statword, "OL", 2))
 			ups_on_line(ups);
-		if (!strcasecmp(statword, "OB"))
+		if (!strncasecmp(statword, "OB", 2))
 			ups_on_batt(ups);
-		if (!strcasecmp(statword, "LB"))
+		if (!strncasecmp(statword, "LB", 2))
 			ups_low_batt(ups);
-		if (!strcasecmp(statword, "RB"))
+		if (!strncasecmp(statword, "RB", 2))
 			upsreplbatt(ups);
-		if (!strcasecmp(statword, "CAL"))
+		if (!strncasecmp(statword, "CAL", 3))
 			ups_cal(ups);
 
 		/* do it last to override any possible OL */
-		if (!strcasecmp(statword, "FSD"))
+		if (!strncasecmp(statword, "FSD", 3))
 			ups_fsd(ups);
 
 		update_crittimer(ups);

--- a/clients/upsrw.c
+++ b/clients/upsrw.c
@@ -523,7 +523,7 @@ static void do_type(const char *varname)
 		}
 
 		/* ignore this one */
-		if (!strcasecmp(answer[i], "RW")) {
+		if (!strncasecmp(answer[i], "RW", 2)) {
 			continue;
 		}
 

--- a/clients/upssched.c
+++ b/clients/upssched.c
@@ -802,7 +802,7 @@ static void parse_at(const char *ntype, const char *un, const char *cmd,
 
 	/* check upsname: does this apply to us? */
 	if (strcmp(upsname, un) != 0)
-		if (strcmp(un, "*") != 0)
+		if (strncmp(un, "*", 1) != 0)
 			return;		/* not for us, and not the wildcard */
 
 	/* see if the current notify type matches the one from the .conf */
@@ -864,7 +864,7 @@ static int conf_arg(size_t numargs, char **arg)
 		return 0;
 
 	/* AT <notifytype> <upsname> <command> <cmdarg1> [<cmdarg2>] */
-	if (!strcmp(arg[0], "AT")) {
+	if (!strncmp(arg[0], "AT", 2)) {
 
 		/* don't use arg[5] unless we have it... */
 		if (numargs > 5)

--- a/clients/upsset.c
+++ b/clients/upsset.c
@@ -759,7 +759,7 @@ static void do_type(const char *varname)
 		}
 
 		/* ignore this one */
-		if (!strcasecmp(answer[i], "RW"))
+		if (!strncasecmp(answer[i], "RW", 2))
 			continue;
 
 		printf("Unrecognized\n");

--- a/common/state.c
+++ b/common/state.c
@@ -422,7 +422,7 @@ void state_setflags(st_tree_t *root, const char *var, size_t numflags, char **fl
 
 	for (i = 0; i < numflags; i++) {
 
-		if (!strcasecmp(flag[i], "RW")) {
+		if (!strncasecmp(flag[i], "RW", 2)) {
 			sttmp->flags |= ST_FLAG_RW;
 			continue;
 		}

--- a/common/upsconf.c
+++ b/common/upsconf.c
@@ -54,7 +54,7 @@ static void conf_args(size_t numargs, char **arg)
 		return;
 
 	/* handle 'foo = bar', 'foo=bar', 'foo =bar' or 'foo= bar' forms */
-	if (!strcmp(arg[1], "=")) {
+	if (!strncmp(arg[1], "=", 1)) {
 		do_upsconf_args(ups_section, arg[0], arg[2]);
 		return;
 	}

--- a/docs/developers.txt
+++ b/docs/developers.txt
@@ -21,6 +21,13 @@ Don't use `strcat()`.  We have a neat wrapper for `snprintf()` called
 `snprintfcat()` that allows you to append to `char *` with a format
 string and all the usual string length checking of `snprintf()` routine.
 
+Some systems define `strcmp()` and `strcasecmp()` as macros or inline
+functions optimized for aligned memory access in a way that some compilers
+complain about array out-of-bounds access when comparing fixed short strings.
+For this reason, we compare strings with length 3 chars and less ("", "x",
+"on", "VAL") with fixed-length methods `strncmp()` and `strncasecmp()`,
+e.g. `strncmp(buf, "VAL", 3)`.
+
 Error reporting
 ~~~~~~~~~~~~~~~
 

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 2775 utf-8
+personal_ws-1.1 en 2792 utf-8
 AAS
 ACFAIL
 ACFREQ
@@ -2490,11 +2490,14 @@ strarr
 strcasecmp
 strcat
 strchr
+strcmp
 strcpy
 strdup
 strerror
 strftime
 strlen
+strncasecmp
+strncmp
 struct
 structs
 sts

--- a/drivers/apcsmart-old.c
+++ b/drivers/apcsmart-old.c
@@ -237,7 +237,7 @@ static int poll_data(apc_vartab_t *vt)
 	}
 
 	/* no longer supported by the hardware somehow */
-	if (!strcmp(tmp, "NA")) {
+	if (!strncmp(tmp, "NA", 2)) {
 		dstate_delinfo(vt->name);
 		return 1;
 	}
@@ -291,7 +291,7 @@ static int query_ups(const char *var, int first)
 
 	ser_comm_good();
 
-	if ((ret < 1) || (!strcmp(temp, "NA")))		/* not supported */
+	if ((ret < 1) || (!strncmp(temp, "NA", 2)))		/* not supported */
 		return 0;
 
 	vt->flags |= APC_PRESENT;
@@ -330,7 +330,7 @@ static void do_capabilities(void)
 	ret = ser_get_line(upsfd, temp, sizeof(temp), ENDCHAR,
 		MINIGNCHARS, SER_WAIT_SEC, SER_WAIT_USEC);
 
-	if ((ret < 1) || (!strcmp(temp, "NA"))) {
+	if ((ret < 1) || (!strncmp(temp, "NA", 2))) {
 
 		/* Early Smart-UPS, not as smart as later ones */
 		/* This should never happen since we only call
@@ -434,7 +434,7 @@ static int update_status(void)
 
 	ret = read_buf(buf, sizeof(buf));
 
-	if ((ret < 1) || (!strcmp(buf, "NA"))) {
+	if ((ret < 1) || (!strncmp(buf, "NA", 2))) {
 		dstate_datastale();
 		return 0;
 	}
@@ -554,7 +554,7 @@ static int firmware_table_lookup(void)
 	 * Some UPSes support both 'V' and 'b'. As 'b' doesn't always return
 	 * firmware version, we attempt that only if 'V' doesn't work.
 	 */
-	if ((ret < 1) || (!strcmp(buf, "NA"))) {
+	if ((ret < 1) || (!strncmp(buf, "NA", 2))) {
 		upsdebugx(1, "Attempting firmware lookup using command 'b'");
 		ret = ser_send_char(upsfd, 'b');
 
@@ -633,7 +633,7 @@ static void getbaseinfo(void)
 	ret = ser_get_line(upsfd, temp, sizeof(temp), ENDCHAR, IGNCHARS,
 		SER_WAIT_SEC, SER_WAIT_USEC);
 
-	if ((ret < 1) || (!strcmp(temp, "NA"))) {
+	if ((ret < 1) || (!strncmp(temp, "NA", 2))) {
 		/* We have an old dumb UPS - go to specific code for old stuff */
 		oldapcsetup();
 		return;
@@ -684,7 +684,7 @@ static int do_cal(int start)
 	ret = read_buf(temp, sizeof(temp));
 
 	/* if we can't check the current calibration status, bail out */
-	if ((ret < 1) || (!strcmp(temp, "NA")))
+	if ((ret < 1) || (!strncmp(temp, "NA", 2)))
 		return STAT_INSTCMD_HANDLED;		/* FUTURE: failure */
 
 	tval = strtol(temp, 0, 16);
@@ -709,7 +709,7 @@ static int do_cal(int start)
 
 		ret = read_buf(temp, sizeof(temp));
 
-		if ((ret < 1) || (!strcmp(temp, "NA")) || (!strcmp(temp, "NO"))) {
+		if ((ret < 1) || (!strncmp(temp, "NA", 2)) || (!strncmp(temp, "NO", 2))) {
 			upslogx(LOG_WARNING, "Stop calibration failed: %s",
 				temp);
 			return STAT_INSTCMD_HANDLED;	/* FUTURE: failure */
@@ -736,7 +736,7 @@ static int do_cal(int start)
 
 	ret = read_buf(temp, sizeof(temp));
 
-	if ((ret < 1) || (!strcmp(temp, "NA")) || (!strcmp(temp, "NO"))) {
+	if ((ret < 1) || (!strncmp(temp, "NA", 2)) || (!strncmp(temp, "NO", 2))) {
 		upslogx(LOG_WARNING, "Start calibration failed: %s", temp);
 		return STAT_INSTCMD_HANDLED;	/* FUTURE: failure */
 	}
@@ -763,7 +763,7 @@ static int smartmode(void)
 			IGNCHARS, SER_WAIT_SEC, SER_WAIT_USEC);
 
 		if (ret > 0)
-			if (!strcmp(temp, "SM"))
+			if (!strncmp(temp, "SM", 2))
 				return 1;	/* success */
 
 		sleep(1);	/* wait before trying again */
@@ -795,7 +795,7 @@ static int sdok(void)
 	ser_get_line(upsfd, temp, sizeof(temp), ENDCHAR, IGNCHARS, SER_WAIT_SEC, SER_WAIT_USEC);
 	upsdebugx(4, "sdok: got \"%s\"", temp);
 
-	if (!strcmp(temp, "*") || !strcmp(temp, "OK")) {
+	if (!strncmp(temp, "*", 1) || !strncmp(temp, "OK", 2)) {
 		upsdebugx(4, "Last issued shutdown command succeeded");
 		return 1;
 	}
@@ -1057,7 +1057,7 @@ void upsdrv_shutdown(void)
 		status = APC_STAT_LB | APC_STAT_OB;
 	}
 
-	if (testvar("advorder") && strcasecmp(getval("advorder"), "no"))
+	if (testvar("advorder") && strncasecmp(getval("advorder"), "no", 2))
 		upsdrv_shutdown_advanced(status);
 	else
 		upsdrv_shutdown_simple(status);
@@ -1123,7 +1123,7 @@ static int setvar_enum(apc_vartab_t *vt, const char *val)
 
 	ret = read_buf(orig, sizeof(orig));
 
-	if ((ret < 1) || (!strcmp(orig, "NA")))
+	if ((ret < 1) || (!strncmp(orig, "NA", 2)))
 		return STAT_SET_HANDLED;	/* FUTURE: failed */
 
 	ptr = convert_data(vt, orig);
@@ -1147,13 +1147,13 @@ static int setvar_enum(apc_vartab_t *vt, const char *val)
 		/* this should return either OK (if rotated) or NO (if not) */
 		ret = read_buf(temp, sizeof(temp));
 
-		if ((ret < 1) || (!strcmp(temp, "NA")))
+		if ((ret < 1) || (!strncmp(temp, "NA", 2)))
 			return STAT_SET_HANDLED;	/* FUTURE: failed */
 
 		/* sanity checks */
-		if (!strcmp(temp, "NO"))
+		if (!strncmp(temp, "NO", 2))
 			return STAT_SET_HANDLED;	/* FUTURE: failed */
-		if (strcmp(temp, "OK") != 0)
+		if (strncmp(temp, "OK", 2) != 0)
 			return STAT_SET_HANDLED;	/* FUTURE: failed */
 
 		/* see what it rotated onto */
@@ -1166,7 +1166,7 @@ static int setvar_enum(apc_vartab_t *vt, const char *val)
 
 		ret = read_buf(temp, sizeof(temp));
 
-		if ((ret < 1) || (!strcmp(temp, "NA")))
+		if ((ret < 1) || (!strncmp(temp, "NA", 2)))
 			return STAT_SET_HANDLED;	/* FUTURE: failed */
 
 		ptr = convert_data(vt, temp);
@@ -1217,7 +1217,7 @@ static int setvar_string(apc_vartab_t *vt, const char *val)
 
 	ret = read_buf(temp, sizeof(temp));
 
-	if ((ret < 1) || (!strcmp(temp, "NA")))
+	if ((ret < 1) || (!strncmp(temp, "NA", 2)))
 		return STAT_SET_HANDLED;	/* FUTURE: failed */
 
 	/* suppress redundant changes - easier on the eeprom */
@@ -1267,7 +1267,7 @@ static int setvar_string(apc_vartab_t *vt, const char *val)
 		return STAT_SET_HANDLED;	/* FUTURE: failed */
 	}
 
-	if (!strcmp(temp, "NO")) {
+	if (!strncmp(temp, "NO", 2)) {
 		upslogx(LOG_ERR, "setvar_string: got NO at final read");
 		return STAT_SET_HANDLED;	/* FUTURE: failed */
 	}
@@ -1335,7 +1335,7 @@ static int do_cmd(apc_cmdtab_t *ct)
 	if (ret < 1)
 		return STAT_INSTCMD_HANDLED;		/* FUTURE: failed */
 
-	if (strcmp(buf, "OK") != 0) {
+	if (strncmp(buf, "OK", 2) != 0) {
 		upslogx(LOG_WARNING, "Got [%s] after command [%s]",
 			buf, ct->name);
 

--- a/drivers/apcupsd-ups.c
+++ b/drivers/apcupsd-ups.c
@@ -64,7 +64,7 @@ static void process(char *item,char *data)
 		else if(!strcmp(data,"SELFTEST"))status_set("OB");
 		else for(;(data=strtok(data," "));data=NULL)
 		{
-			if(!strcmp(data,"CAL"))status_set("CAL");
+			if(!strncmp(data, "CAL", 3))status_set("CAL");
 			else if(!strcmp(data,"TRIM"))status_set("TRIM");
 			else if(!strcmp(data,"BOOST"))status_set("BOOST");
 			else if(!strcmp(data,"ONLINE"))status_set("OL");

--- a/drivers/belkin.c
+++ b/drivers/belkin.c
@@ -510,7 +510,7 @@ void upsdrv_initinfo(void)
 	/* deal with stupid firmware that breaks RAT */
 	send_belkin_command(STATUS, RATING, "");
 
-	if (!strcmp(temp, "001")) {
+	if (!strncmp(temp, "001", 3)) {
 		res = do_broken_rat(temp);
 	} else {
 		res = get_belkin_reply(temp);

--- a/drivers/belkinunv.c
+++ b/drivers/belkinunv.c
@@ -1269,10 +1269,10 @@ static int setvar(const char *varname, const char *val)
 	} else if (!strcasecmp(varname, "ups.beeper.status")) {
 		if (!strcasecmp(val, "disabled")) {
 			i=1;
-		} else if (!strcasecmp(val, "on") ||
+		} else if (!strncasecmp(val, "on", 2) ||
 			   !strcasecmp(val, "enabled")) {
 			i=2;
-		} else if (!strcasecmp(val, "off") ||
+		} else if (!strncasecmp(val, "off", 3) ||
 			   !strcasecmp(val, "muted")) {
 			i=3;
 		} else {

--- a/drivers/bestups.c
+++ b/drivers/bestups.c
@@ -53,57 +53,57 @@ static	int	inverted_bypass_bit = 0;
 
 static void model_set(const char *abbr, const char *rating)
 {
-	if (!strcmp(abbr, "FOR")) {
+	if (!strncmp(abbr, "FOR", 3)) {
 		dstate_setinfo("ups.mfr", "%s", "Best Power");
 		dstate_setinfo("ups.model", "Fortress %s", rating);
 		return;
 	}
 
-	if (!strcmp(abbr, "FTC")) {
+	if (!strncmp(abbr, "FTC", 3)) {
 		dstate_setinfo("ups.mfr", "%s", "Best Power");
 		dstate_setinfo("ups.model", "Fortress Telecom %s", rating);
 		return;
 	}
 
-	if (!strcmp(abbr, "PRO")) {
+	if (!strncmp(abbr, "PRO", 3)) {
 		dstate_setinfo("ups.mfr", "%s", "Best Power");
 		dstate_setinfo("ups.model", "Patriot Pro %s", rating);
 		inverted_bypass_bit = 1;
 		return;
 	}
 
-	if (!strcmp(abbr, "PR2")) {
+	if (!strncmp(abbr, "PR2", 3)) {
 		dstate_setinfo("ups.mfr", "%s", "Best Power");
 		dstate_setinfo("ups.model", "Patriot Pro II %s", rating);
 		inverted_bypass_bit = 1;
 		return;
 	}
 
-	if (!strcmp(abbr, "325")) {
+	if (!strncmp(abbr, "325", 3)) {
 		dstate_setinfo("ups.mfr", "%s", "Sola Australia");
 		dstate_setinfo("ups.model", "Sola 325 %s", rating);
 		return;
 	}
 
-	if (!strcmp(abbr, "520")) {
+	if (!strncmp(abbr, "520", 3)) {
 		dstate_setinfo("ups.mfr", "%s", "Sola Australia");
 		dstate_setinfo("ups.model", "Sola 520 %s", rating);
 		return;
 	}
 
-	if (!strcmp(abbr, "610")) {
+	if (!strncmp(abbr, "610", 3)) {
 		dstate_setinfo("ups.mfr", "%s", "Best Power");
 		dstate_setinfo("ups.model", "610 %s", rating);
 		return;
 	}
 
-	if (!strcmp(abbr, "620")) {
+	if (!strncmp(abbr, "620", 3)) {
 		dstate_setinfo("ups.mfr", "%s", "Sola Australia");
 		dstate_setinfo("ups.model", "Sola 620 %s", rating);
 		return;
 	}
 
-	if (!strcmp(abbr, "AX1")) {
+	if (!strncmp(abbr, "AX1", 3)) {
 		dstate_setinfo("ups.mfr", "%s", "Best Power");
 		dstate_setinfo("ups.model", "Axxium Rackmount %s", rating);
 		return;

--- a/drivers/clone-outlet.c
+++ b/drivers/clone-outlet.c
@@ -124,7 +124,7 @@ static int parse_args(size_t numargs, char **arg)
 		}
 
 		if (!strcasecmp(arg[1], prefix.status)) {
-			outlet.status = strcasecmp(arg[2], "off");
+			outlet.status = strncasecmp(arg[2], "off", 3);
 		}
 
 		if (!strcasecmp(arg[1], "ups.status")) {

--- a/drivers/clone.c
+++ b/drivers/clone.c
@@ -356,11 +356,11 @@ static int instcmd(const char *cmdname, const char *extra)
 
 	val = dstate_getinfo(getval("load.status"));
 	if (val) {
-		if (!strcasecmp(val, "off") || !strcasecmp(val, "no")) {
+		if (!strncasecmp(val, "off", 3) || !strncasecmp(val, "no", 2)) {
 			outlet = 0;
 		}
 
-		if (!strcasecmp(val, "on") || !strcasecmp(val, "yes")) {
+		if (!strncasecmp(val, "on", 2) || !strncasecmp(val, "yes", 3)) {
 			outlet = 1;
 		}
 	}

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -473,7 +473,7 @@ static int sock_arg(conn_t *conn, size_t numarg, char **arg)
 	}
 
 	/* SET <var> <value> [TRACKING <id>] */
-	if (!strcasecmp(arg[0], "SET")) {
+	if (!strncasecmp(arg[0], "SET", 3)) {
 		int ret;
 		char *setid = NULL;
 
@@ -1002,7 +1002,7 @@ void status_init(void)
 /* add a status element */
 void status_set(const char *buf)
 {
-	if (ignorelb && !strcasecmp(buf, "LB")) {
+	if (ignorelb && !strncasecmp(buf, "LB", 2)) {
 		upsdebugx(2, "%s: ignoring LB flag from device", __func__);
 		return;
 	}

--- a/drivers/gamatronic.c
+++ b/drivers/gamatronic.c
@@ -167,31 +167,31 @@ static void update_pseudovars( void )
 {
 	status_init();
 
-	if(strcmp(sec_varlist[9].value,"1")== 0) {
+	if(strncmp(sec_varlist[9].value, "1", 1)== 0) {
 		status_set("OFF");
 	}
-	if(strcmp(sec_varlist[76].value,"0")== 0) {
+	if(strncmp(sec_varlist[76].value, "0", 1)== 0) {
 		status_set("OL");
 	}
-	if(strcmp(sec_varlist[76].value,"1")== 0) {
+	if(strncmp(sec_varlist[76].value, "1", 1)== 0) {
 		status_set("OB");
 	}
-	if(strcmp(sec_varlist[76].value,"2")== 0) {
+	if(strncmp(sec_varlist[76].value, "2", 1)== 0) {
 		status_set("BYPASS");
 	}
-	if(strcmp(sec_varlist[76].value,"3")== 0) {
+	if(strncmp(sec_varlist[76].value, "3", 1)== 0) {
 		status_set("TRIM");
 	}
-	if(strcmp(sec_varlist[76].value,"4")== 0) {
+	if(strncmp(sec_varlist[76].value, "4", 1)== 0) {
 		status_set("BOOST");
 	}
-	if(strcmp(sec_varlist[10].value,"1")== 0) {
+	if(strncmp(sec_varlist[10].value, "1", 1)== 0) {
 		status_set("OVER");
 	}
-	if(strcmp(sec_varlist[22].value,"1")== 0) {
+	if(strncmp(sec_varlist[22].value, "1", 1)== 0) {
 		status_set("LB");
 	}
-	if(strcmp(sec_varlist[19].value,"2")== 0) {
+	if(strncmp(sec_varlist[19].value, "2", 1)== 0) {
 		status_set("RB");
 	}
 
@@ -245,7 +245,7 @@ static void sec_poll ( int pollflag ) {
 				}
 
 				/* If SEC VAR is alarm and it's on, add it to the alarm property */
-				if (sec_varlist[sqv(q,f)].flags & FLAG_ALARM && strcmp(r,"1")== 0) {
+				if (sec_varlist[sqv(q,f)].flags & FLAG_ALARM && strncmp(r, "1", 1)== 0) {
 					alarm_set(sec_varlist[sqv(q,f)].name);
 				}
 			}

--- a/drivers/huawei-ups2000.c
+++ b/drivers/huawei-ups2000.c
@@ -1232,9 +1232,9 @@ static int ups2000_autostart_set(const uint16_t reg, const char *string)
 	uint16_t val;
 	int r;
 
-	if (!strcasecmp(string, "yes"))
+	if (!strncasecmp(string, "yes", 3))
 		val = 1;
-	else if (!strcasecmp(string, "no"))
+	else if (!strncasecmp(string, "no", 2))
 		val = 0;
 	else
 		return STAT_SET_INVALID;

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -304,10 +304,10 @@ static int main_arg(char *var, char *val)
 
 	/* allow per-driver overrides of the global setting */
 	if (!strcmp(var, "synchronous")) {
-		if (!strcmp(val, "yes"))
-			do_synchronous=1;
+		if (!strncmp(val, "yes", 3))
+			do_synchronous = 1;
 		else
-			do_synchronous=0;
+			do_synchronous = 0;
 
 		return 1;	/* handled */
 	}
@@ -343,10 +343,10 @@ static void do_global_args(const char *var, const char *val)
 	}
 
 	if (!strcmp(var, "synchronous")) {
-		if (!strcmp(val, "yes"))
-			do_synchronous=1;
+		if (!strncmp(val, "yes", 3))
+			do_synchronous = 1;
 		else
-			do_synchronous=0;
+			do_synchronous = 0;
 	}
 
 

--- a/drivers/masterguard.c
+++ b/drivers/masterguard.c
@@ -412,7 +412,7 @@ static ssize_t ups_ident( void )
 			printf( "Old (broken) WH found\n" );
 		parseOldWH( buf );
 	}
-	else if( ret == 3 && strcmp(buf, "NAK") == 0 )
+	else if( ret == 3 && strncmp(buf, "NAK", 3) == 0 )
 	{
 		if( DEBUG )
 			printf( "WH was NAKed\n" );

--- a/drivers/mge-utalk.c
+++ b/drivers/mge-utalk.c
@@ -181,7 +181,7 @@ void upsdrv_initups(void)
 		mge_ups.LowBatt = atoi (getval ("lowbatt"));
 		/* Set the value in the UPS */
 		mge_command(buf, sizeof(buf), "Bl %d",  mge_ups.LowBatt);
-		if(!strcmp(buf, "OK"))
+		if(!strncmp(buf, "OK", 2))
 			upsdebugx(1, "Low Battery Level set to %d%%", mge_ups.LowBatt);
 		else
 			upsdebugx(1, "initups: Low Battery Level cannot be set");
@@ -193,7 +193,7 @@ void upsdrv_initups(void)
 		mge_ups.OnDelay = atoi (getval ("ondelay"));
 		/* Set the value in the UPS */
 		mge_command(buf, sizeof(buf), "Sm %d",  mge_ups.OnDelay);
-		if(!strcmp(buf, "OK"))
+		if(!strncmp(buf, "OK", 2))
 			upsdebugx(1, "ON delay set to %d min", mge_ups.OnDelay);
 		else
 			upsdebugx(1, "initups: OnDelay unavailable");
@@ -205,7 +205,7 @@ void upsdrv_initups(void)
 		mge_ups.OffDelay = atoi (getval ("offdelay"));
 		/* Set the value in the UPS */
 		mge_command(buf, sizeof(buf), "Sn %d",  mge_ups.OffDelay);
-		if(!strcmp(buf, "OK"))
+		if(!strncmp(buf, "OK", 2))
 			upsdebugx(1, "OFF delay set to %d sec", mge_ups.OffDelay);
 		else
 			upsdebugx(1, "initups: OffDelay unavailable");
@@ -474,13 +474,13 @@ void upsdrv_shutdown(void)
 
 	/* Only call the effective shutoff if restart is ok */
 	/* or if we need only a stayoff... */
-	if (!strcmp(buf, "OK") || (sdtype == SD_STAYOFF)) {
+	if (!strncmp(buf, "OK", 2) || (sdtype == SD_STAYOFF)) {
 		/* shutdown UPS */
 		mge_command(buf, sizeof(buf), "Sx 0");
 
 		upslogx(LOG_INFO, "UPS response to Shutdown was %s", buf);
 	}
-/*	if(strcmp(buf, "OK")) */
+/*	if(strncmp(buf, "OK", 2)) */
 
 	/* call the cleanup to disable/close the comm link */
 	upsdrv_cleanup();
@@ -507,7 +507,7 @@ int instcmd(const char *cmdname, const char *extra)
 		mge_command(temp, sizeof(temp), "Bx 1");
 		upsdebugx(2, "UPS response to %s was %s", cmdname, temp);
 
-		if(strcmp(temp, "OK"))
+		if(strncmp(temp, "OK", 2))
 			return STAT_INSTCMD_UNKNOWN;
 		else
 			return STAT_INSTCMD_HANDLED;
@@ -519,7 +519,7 @@ int instcmd(const char *cmdname, const char *extra)
 		mge_command(temp, sizeof(temp), "Sx 129");
 		upsdebugx(2, "UPS response to %s was %s", cmdname, temp);
 
-		if(strcmp(temp, "OK"))
+		if(strncmp(temp, "OK", 2))
 			return STAT_INSTCMD_UNKNOWN;
 		else
 			return STAT_INSTCMD_HANDLED;
@@ -545,13 +545,13 @@ int instcmd(const char *cmdname, const char *extra)
 		mge_command(temp, sizeof(temp), "Wy 65535");
 		upsdebugx(2, "UPS response to Select All Plugs was %s", temp);
 
-		if(strcmp(temp, "OK"))
+		if(strncmp(temp, "OK", 2))
 			return STAT_INSTCMD_UNKNOWN;
 		else
 		{
 			mge_command(temp, sizeof(temp), "Wx 0");
 			upsdebugx(2, "UPS response to %s was %s", cmdname, temp);
-			if(strcmp(temp, "OK"))
+			if(strncmp(temp, "OK", 2))
 				return STAT_INSTCMD_UNKNOWN;
 			else
 				return STAT_INSTCMD_HANDLED;
@@ -565,13 +565,13 @@ int instcmd(const char *cmdname, const char *extra)
 		mge_command(temp, sizeof(temp), "Wy 65535");
 		upsdebugx(2, "UPS response to Select All Plugs was %s", temp);
 
-		if(strcmp(temp, "OK"))
+		if(strncmp(temp, "OK", 2))
 			return STAT_INSTCMD_UNKNOWN;
 		else
 		{
 			mge_command(temp, sizeof(temp), "Wx 1");
 			upsdebugx(2, "UPS response to %s was %s", cmdname, temp);
-			if(strcmp(temp, "OK"))
+			if(strncmp(temp, "OK", 2))
 				return STAT_INSTCMD_UNKNOWN;
 			else
 				return STAT_INSTCMD_HANDLED;
@@ -599,7 +599,7 @@ int instcmd(const char *cmdname, const char *extra)
 
 			upsdebugx(2, "UPS response to %s was %s", cmdname, temp);
 
-			if(strcmp(temp, "OK"))
+			if(strncmp(temp, "OK", 2))
 				return STAT_INSTCMD_UNKNOWN;
 			else
 				return STAT_INSTCMD_HANDLED;

--- a/drivers/mge-xml.c
+++ b/drivers/mge-xml.c
@@ -1229,7 +1229,7 @@ static int mge_xml_startelm_cb(void *userdata, int parent, const char *nspace, c
 			/* url="upsprop.xml" or url="ws/summary.xml" */
 			int	i;
 			for (i = 0; atts[i] && atts[i+1]; i += 2) {
-				if (!strcasecmp(atts[i], "url")) {
+				if (!strncasecmp(atts[i], "url", 3)) {
 					free(mge_xml_subdriver.summary);
 					mge_xml_subdriver.summary = strdup(url_convert(atts[i+1]));
 				}
@@ -1241,7 +1241,7 @@ static int mge_xml_startelm_cb(void *userdata, int parent, const char *nspace, c
 			/* url="config.xml" */
 			int	i;
 			for (i = 0; atts[i] && atts[i+1]; i += 2) {
-				if (!strcasecmp(atts[i], "url")) {
+				if (!strncasecmp(atts[i], "url", 3)) {
 					free(mge_xml_subdriver.configure);
 					mge_xml_subdriver.configure = strdup(url_convert(atts[i+1]));
 				}
@@ -1261,7 +1261,7 @@ static int mge_xml_startelm_cb(void *userdata, int parent, const char *nspace, c
 			/* url="subscribe.cgi" security="basic" */
 			int	i;
 			for (i = 0; atts[i] && atts[i+1]; i += 2) {
-				if (!strcasecmp(atts[i], "url")) {
+				if (!strncasecmp(atts[i], "url", 3)) {
 					free(mge_xml_subdriver.subscribe);
 					mge_xml_subdriver.subscribe = strdup(url_convert(atts[i+1]));
 				}
@@ -1299,7 +1299,7 @@ static int mge_xml_startelm_cb(void *userdata, int parent, const char *nspace, c
 			/* url="getvalue.cgi" security="none" */
 			int	i;
 			for (i = 0; atts[i] && atts[i+1]; i += 2) {
-				if (!strcasecmp(atts[i], "url")) {
+				if (!strncasecmp(atts[i], "url", 3)) {
 					free(mge_xml_subdriver.getobject);
 					mge_xml_subdriver.getobject = strdup(url_convert(atts[i+1]));
 				}
@@ -1311,7 +1311,7 @@ static int mge_xml_startelm_cb(void *userdata, int parent, const char *nspace, c
 			/* url="setvalue.cgi" security="ssl" */
 			int	i;
 			for (i = 0; atts[i] && atts[i+1]; i += 2) {
-				if (!strcasecmp(atts[i], "url")) {
+				if (!strncasecmp(atts[i], "url", 3)) {
 					free(mge_xml_subdriver.setobject);
 					mge_xml_subdriver.setobject = strdup(url_convert(atts[i+1]));
 				}

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -3324,7 +3324,7 @@ int	ups_infoval_set(item_t *item)
 		if (item->qxflags & QX_FLAG_TRIM)
 			str_trim_m(value, "# ");
 
-		if (strcasecmp(item->dfl, "%s")) {
+		if (strncasecmp(item->dfl, "%s", 2)) {
 
 			if (strspn(value, "0123456789 .") != strlen(value)) {
 				upsdebugx(2, "%s: non numerical value [%s: %s]", __func__, item->info_type, value);

--- a/drivers/nutdrv_qx_bestups.c
+++ b/drivers/nutdrv_qx_bestups.c
@@ -431,11 +431,11 @@ static int	bestups_manufacturer(item_t *item, char *value, const size_t valuelen
 
 	/* Best Power devices */
 	if (
-		!strcmp(item->value, "AX1") ||
-		!strcmp(item->value, "FOR") ||
-		!strcmp(item->value, "FTC") ||
-		!strcmp(item->value, "PR2") ||
-		!strcmp(item->value, "PRO")
+		!strncmp(item->value, "AX1", 3) ||
+		!strncmp(item->value, "FOR", 3) ||
+		!strncmp(item->value, "FTC", 3) ||
+		!strncmp(item->value, "PR2", 3) ||
+		!strncmp(item->value, "PRO", 3)
 	) {
 		snprintf(value, valuelen, item->dfl, "Best Power");
 		return 0;
@@ -443,9 +443,9 @@ static int	bestups_manufacturer(item_t *item, char *value, const size_t valuelen
 
 	/* Sola Australia devices */
 	if (
-		!strcmp(item->value, "325") ||
-		!strcmp(item->value, "520") ||
-		!strcmp(item->value, "620")
+		!strncmp(item->value, "325", 3) ||
+		!strncmp(item->value, "520", 3) ||
+		!strncmp(item->value, "620", 3)
 	) {
 		snprintf(value, valuelen, item->dfl, "Sola Australia");
 		return 0;
@@ -478,35 +478,35 @@ static int	bestups_model(item_t *item, char *value, const size_t valuelen)
 
 	/* Best Power devices */
 
-	if (!strcmp(item->value, "AX1")) {
+	if (!strncmp(item->value, "AX1", 3)) {
 
 		snprintf(value, valuelen, item->dfl, "Axxium Rackmount");
 
-	} else if (!strcmp(item->value, "FOR")) {
+	} else if (!strncmp(item->value, "FOR", 3)) {
 
 		snprintf(value, valuelen, item->dfl, "Fortress");
 
-	} else if (!strcmp(item->value, "FTC")) {
+	} else if (!strncmp(item->value, "FTC", 3)) {
 
 		snprintf(value, valuelen, item->dfl, "Fortress Telecom");
 
-	} else if (!strcmp(item->value, "PR2")) {
+	} else if (!strncmp(item->value, "PR2", 3)) {
 
 		snprintf(value, valuelen, item->dfl, "Patriot Pro II");
 		inverted_bbb_bit = 1;
 
-	} else if (!strcmp(item->value, "PRO")) {
+	} else if (!strncmp(item->value, "PRO", 3)) {
 
 		snprintf(value, valuelen, item->dfl, "Patriot Pro");
 		inverted_bbb_bit = 1;
 
 	/* Sola Australia devices */
 	} else if (
-		!strcmp(item->value, "320") ||
-		!strcmp(item->value, "325") ||
-		!strcmp(item->value, "520") ||
-		!strcmp(item->value, "525") ||
-		!strcmp(item->value, "620")
+		!strncmp(item->value, "320", 3) ||
+		!strncmp(item->value, "325", 3) ||
+		!strncmp(item->value, "520", 3) ||
+		!strncmp(item->value, "525", 3) ||
+		!strncmp(item->value, "620", 3)
 	) {
 
 		snprintf(value, valuelen, "Sola %s", item->value);
@@ -522,7 +522,7 @@ static int	bestups_model(item_t *item, char *value, const size_t valuelen)
 	/* Unskip qx2nut table's items according to the UPS model */
 
 	/* battery.runtime var is not available on the Patriot Pro/Sola 320 model series: leave it skipped in these cases, otherwise unskip it */
-	if (strcmp(item->value, "PRO") && strcmp(item->value, "320")) {
+	if (strncmp(item->value, "PRO", 3) && strncmp(item->value, "320", 3)) {
 
 		unskip = find_nut_info("battery.runtime", 0, 0);
 
@@ -535,7 +535,7 @@ static int	bestups_model(item_t *item, char *value, const size_t valuelen)
 	}
 
 	/* battery.packs var is available only on the Axxium/Sola 620 model series: unskip it in these cases */
-	if (!strcmp(item->value, "AX1") || !strcmp(item->value, "620")) {
+	if (!strncmp(item->value, "AX1", 3) || !strncmp(item->value, "620", 3)) {
 
 		unskip = find_nut_info("battery.packs", 0, QX_FLAG_SETVAR);
 

--- a/drivers/nutdrv_qx_blazer-common.c
+++ b/drivers/nutdrv_qx_blazer-common.c
@@ -145,13 +145,15 @@ void	blazer_initups(item_t *qx2nut)
 			continue;
 
 		/* norating */
-		if (nr && !strcasecmp(item->command, "F\r")) {
+		if (nr && !strncasecmp(item->command, "F\r", strlen("F\r"))) {
 			upsdebugx(2, "%s: skipping %s", __func__, item->info_type);
 			item->qxflags |= QX_FLAG_SKIP;
 		}
 
 		/* novendor */
-		if (nv && (!strcasecmp(item->command, "I\r") || !strcasecmp(item->command, "FW?\r"))) {
+		if (nv && (!strncasecmp(item->command, "I\r", strlen("I\r"))
+		|| !strncasecmp(item->command, "FW?\r", strlen("FW?\r")))
+		) {
 			upsdebugx(2, "%s: skipping %s", __func__, item->info_type);
 			item->qxflags |= QX_FLAG_SKIP;
 		}

--- a/drivers/nutdrv_qx_voltronic-qs-hex.c
+++ b/drivers/nutdrv_qx_voltronic-qs-hex.c
@@ -318,7 +318,7 @@ static int	voltronic_qs_hex_protocol(item_t *item, char *value, const size_t val
 		{ NULL,				0,		0 }
 	};
 
-	if (strcasecmp(item->value, "P") && strcasecmp(item->value, "T")) {
+	if (strncasecmp(item->value, "P", 1) && strncasecmp(item->value, "T", 1)) {
 		upsdebugx(2, "%s: invalid protocol [%s]", __func__, item->value);
 		return -1;
 	}
@@ -339,7 +339,7 @@ static int	voltronic_qs_hex_protocol(item_t *item, char *value, const size_t val
 
 	/* Unskip items supported only by devices that implement 'T' protocol */
 
-	if (!strcasecmp(item->value, "P"))
+	if (!strncasecmp(item->value, "P", 1))
 		return 0;
 
 	for (i = 0; items_to_be_unskipped[i].info_type; i++) {

--- a/drivers/nutdrv_qx_voltronic-qs.c
+++ b/drivers/nutdrv_qx_voltronic-qs.c
@@ -191,7 +191,7 @@ static void	voltronic_qs_initups(void)
 /* Protocol used by the UPS */
 static int	voltronic_qs_protocol(item_t *item, char *value, const size_t valuelen)
 {
-	if (strcasecmp(item->value, "V")) {
+	if (strncasecmp(item->value, "V", 1)) {
 		upsdebugx(2, "%s: invalid protocol [%s]", __func__, item->value);
 		return -1;
 	}

--- a/drivers/nutdrv_qx_voltronic.c
+++ b/drivers/nutdrv_qx_voltronic.c
@@ -2433,12 +2433,12 @@ static int	voltronic_capability_set(item_t *item, char *value, const size_t valu
 #ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_FORMAT_SECURITY
 #pragma GCC diagnostic ignored "-Wformat-security"
 #endif
-	if (!strcasecmp(value, "yes")) {
+	if (!strncasecmp(value, "yes", 3)) {
 		snprintf(value, valuelen, item->command, "E");
 		return 0;
 	}
 
-	if (!strcasecmp(value, "no")) {
+	if (!strncasecmp(value, "no", 2)) {
 		snprintf(value, valuelen, item->command, "D");
 		return 0;
 	}
@@ -2955,7 +2955,7 @@ static int	voltronic_fault(item_t *item, char *value, const size_t valuelen)
 
 	upslogx(LOG_INFO, "Checking for faults..");
 
-	if (!strcasecmp(item->value, "OK")) {
+	if (!strncasecmp(item->value, "OK", 2)) {
 #ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_NONLITERAL
 #pragma GCC diagnostic push
 #endif

--- a/drivers/oneac.c
+++ b/drivers/oneac.c
@@ -1028,13 +1028,13 @@ int setcmd(const char* varname, const char* setvalue)
 
 	if (!strcasecmp(varname, "ups.start.auto"))
 	{
-		if (!strcasecmp(setvalue, "yes"))
+		if (!strncasecmp(setvalue, "yes", 3))
 		{
 			ser_send(upsfd,"%c0%s",SETX_AUTO_START, COMMAND_END);
 			dstate_setinfo("ups.start.auto", "yes");
 			return STAT_SET_HANDLED;
 		}
-		else if (!strcasecmp(setvalue, "no"))
+		else if (!strncasecmp(setvalue, "no", 2))
 		{
 			ser_send(upsfd,"%c1%s",SETX_AUTO_START, COMMAND_END);
 			dstate_setinfo("ups.start.auto", "no");

--- a/drivers/powercom.c
+++ b/drivers/powercom.c
@@ -429,9 +429,9 @@ static float input_voltage(void)
 	unsigned int model;
 	float tmp=0.0;
 
-	if ( !strcmp(types[type].name, "BNT") && raw_data[MODELNUMBER]%16 > 7 ) {
+	if ( !strncmp(types[type].name, "BNT", 3) && raw_data[MODELNUMBER]%16 > 7 ) {
 		tmp=2.2*raw_data[INPUT_VOLTAGE]-24;
-	} else if ( !strcmp(types[type].name, "KIN")) {
+	} else if ( !strncmp(types[type].name, "KIN", 3)) {
 		model=KINmodels[raw_data[MODELNUMBER]/16];
 		/* Process input voltage, according to line voltage and model rating */
 		if (linevoltage < 200) {
@@ -452,7 +452,7 @@ static float input_voltage(void)
 				tmp = 1.625 * raw_data[INPUT_VOLTAGE];
 			}
 		}
-	} else if ( !strcmp(types[type].name, "IMP") || !strcmp(types[type].name, "OPTI")) {
+	} else if ( !strncmp(types[type].name, "IMP", 3) || !strcmp(types[type].name, "OPTI")) {
 		tmp=raw_data[INPUT_VOLTAGE]*2.0;
 	} else {
 		tmp=linevoltage >= 220 ?
@@ -474,12 +474,12 @@ static float output_voltage(void)
 	static float datay2[]={0,1.73,1.74,1.74,1.77,0.9,0.9,0.9,13.204,13.204,0.88,0.88,0.88,6.645};
 	static float dataz2[]={0,1.15,0.9,0.9,0.75,1.1,1.1,1.1,0.8,0.8,0.86,0.86,0.86,0.7};
 
-	if ( !strcmp(types[type].name, "BNT") || !strcmp(types[type].name, "KIN")) {
+	if ( !strncmp(types[type].name, "BNT", 3) || !strncmp(types[type].name, "KIN", 3)) {
 		statINV=raw_data[STATUS_A] & ONLINE;
 		statAVR=raw_data[STATUS_A] & AVR_ON;
 		statAVRMode=raw_data[STATUS_A] & AVR_MODE;
 	}
-	if ( !strcmp(types[type].name, "BNT") && raw_data[MODELNUMBER]%16 > 7 ) {
+	if ( !strncmp(types[type].name, "BNT", 3) && raw_data[MODELNUMBER]%16 > 7 ) {
 		if (statINV==0) {
 			if (statAVR==0){
 				tmp=2.2*raw_data[OUTPUT_VOLTAGE]-24;
@@ -497,7 +497,7 @@ static float output_voltage(void)
 			else
 				tmp=0.0;
 		}
-	} else if ( !strcmp(types[type].name, "KIN")) {
+	} else if ( !strncmp(types[type].name, "KIN", 3)) {
 		model=KINmodels[raw_data[MODELNUMBER]/16];
 		if (statINV == 0) {
 			if (statAVR == 0) {
@@ -586,7 +586,7 @@ static float output_voltage(void)
 			}
 			// FIXME: may miss a last processing with ErrorVal = 5 | 10
 		}
-	} else if ( !strcmp(types[type].name, "IMP") || !strcmp(types[type].name, "OPTI")) {
+	} else if ( !strncmp(types[type].name, "IMP", 3) || !strcmp(types[type].name, "OPTI")) {
 		tmp=raw_data[OUTPUT_VOLTAGE]*2.0;
 	} else {
 		tmp= linevoltage >= 220 ?
@@ -601,9 +601,9 @@ static float output_voltage(void)
 
 static float input_freq(void)
 {
-	if ( !strcmp(types[type].name, "BNT") || !strcmp(types[type].name, "KIN"))
+	if ( !strncmp(types[type].name, "BNT", 3) || !strncmp(types[type].name, "KIN", 3))
 		return 4807.0/raw_data[INPUT_FREQUENCY];
-	else if ( !strcmp(types[type].name, "IMP") || !strcmp(types[type].name, "OPTI"))
+	else if ( !strncmp(types[type].name, "IMP", 3) || !strcmp(types[type].name, "OPTI"))
 		return raw_data[INPUT_FREQUENCY];
 	return raw_data[INPUT_FREQUENCY] ?
 		1.0 / (types[type].freq[0] *
@@ -613,9 +613,9 @@ static float input_freq(void)
 
 static float output_freq(void)
 {
-	if ( !strcmp(types[type].name, "BNT") || !strcmp(types[type].name, "KIN"))
+	if ( !strncmp(types[type].name, "BNT", 3) || !strncmp(types[type].name, "KIN", 3))
 		return 4807.0/raw_data[OUTPUT_FREQUENCY];
-	else if ( !strcmp(types[type].name, "IMP") || !strcmp(types[type].name, "OPTI"))
+	else if ( !strncmp(types[type].name, "IMP", 3) || !strcmp(types[type].name, "OPTI"))
 		return raw_data[OUTPUT_FREQUENCY];
 	return raw_data[OUTPUT_FREQUENCY] ?
 		1.0 / (types[type].freq[0] *
@@ -644,7 +644,7 @@ static float load_level(void)
 	int load1000i[]={1,1,1,1,1,1,1,1,56,54,52};
 	int load1200i[]={1,1,1,1,1,1,1,1,76,74,72};
 
-	if ( !strcmp(types[type].name, "BNT") && raw_data[MODELNUMBER]%16 > 7 ) {
+	if ( !strncmp(types[type].name, "BNT", 3) && raw_data[MODELNUMBER]%16 > 7 ) {
 		statINV=raw_data[STATUS_A] & ONLINE;
 		voltage=raw_data[MODELNUMBER]%16;
 		model=BNTmodels[raw_data[MODELNUMBER]/16];
@@ -668,7 +668,7 @@ static float load_level(void)
 				case 2000: return raw_data[UPS_LOAD]*110.0/load1000i[voltage];
 			}
 		}
-	} else if (!strcmp(types[type].name, "KIN")) {
+	} else if (!strncmp(types[type].name, "KIN", 3)) {
 		statINV=raw_data[STATUS_A] & ONLINE;
 		voltage=raw_data[MODELNUMBER]%16;
 		model=KINmodels[raw_data[MODELNUMBER]/16];
@@ -685,7 +685,7 @@ static float load_level(void)
 			if (model<2000) return raw_data[UPS_LOAD]*1.66;
 			return raw_data[UPS_LOAD]*110.0/load2ki[voltage];
 		}
-	} else if ( !strcmp(types[type].name, "IMP") || !strcmp(types[type].name, "OPTI")) {
+	} else if ( !strncmp(types[type].name, "IMP", 3) || !strcmp(types[type].name, "OPTI")) {
 		return raw_data[UPS_LOAD];
 	}
 	return (raw_data[STATUS_A] & MAINS_FAILURE) ?
@@ -700,7 +700,7 @@ static float batt_level(void)
 	int bat0,bat29,bat100,model;
 	float battval;
 
-	if ( !strcmp(types[type].name, "BNT") ) {
+	if ( !strncmp(types[type].name, "BNT", 3) ) {
 		bat0=157;
 		bat29=165;
 		bat100=193;
@@ -713,7 +713,7 @@ static float batt_level(void)
 			return 30.0+(battval-bat29)*70.0/(bat100-bat29);
 		return 100.0;
 	}
-	if ( !strcmp(types[type].name, "KIN")) {
+	if ( !strncmp(types[type].name, "KIN", 3)) {
 		model=KINmodels[raw_data[MODELNUMBER]/16];
 		if (model>=800 && model<=2000){
 			battval=(raw_data[BATTERY_CHARGE]-165.0)*2.6;
@@ -741,7 +741,7 @@ static float batt_level(void)
 			return 30.0+(battval-bat29)*70.0/(bat100-bat29);
 		return 100;
 	}
-	if ( !strcmp(types[type].name, "IMP") || !strcmp(types[type].name, "OPTI"))
+	if ( !strncmp(types[type].name, "IMP", 3) || !strcmp(types[type].name, "OPTI"))
 		return raw_data[BATTERY_CHARGE];
 	return (raw_data[STATUS_A] & ONLINE) ? /* Are we on battery power? */
 		/* Yes */
@@ -985,7 +985,7 @@ void upsdrv_initups(void)
 	types[type].flowControl.setup_flow_control();
 
 	/* Setup Model and LineVoltage */
-	if (!strncmp(types[type].name, "BNT",3) || !strcmp(types[type].name, "KIN") || !strcmp(types[type].name, "IMP") || !strcmp(types[type].name, "OPTI")) {
+	if (!strncmp(types[type].name, "BNT",3) || !strncmp(types[type].name, "KIN", 3) || !strncmp(types[type].name, "IMP", 3) || !strcmp(types[type].name, "OPTI")) {
 		if (!ups_getinfo()) return;
 		/* Give "BNT-other" a chance! */
 		if (raw_data[MODELNAME]==0x42 || raw_data[MODELNAME]==0x4B || raw_data[MODELNAME]==0x4F){
@@ -1050,7 +1050,7 @@ void upsdrv_initups(void)
 	            types[type].shutdown_arguments.delay[0],
 	            types[type].shutdown_arguments.delay[1],
 	            types[type].shutdown_arguments.minutesShouldBeUsed);
-	if ( strcmp(types[type].name, "KIN") && strcmp(types[type].name, "BNT") && strcmp(types[type].name, "IMP")) {
+	if ( strncmp(types[type].name, "KIN", 3) && strncmp(types[type].name, "BNT", 3) && strncmp(types[type].name, "IMP", 3)) {
 		upsdebugx(1, " frequency calculation coefficients: '{%f,%f}'",
 		        types[type].freq[0], types[type].freq[1]);
 		upsdebugx(1, " load percentage calculation coefficients: "
@@ -1174,7 +1174,7 @@ void upsdrv_makevartable(void)
 		"Flow control method for UPS: 'dtr0rts1' or 'no_flow_control'");
 	addvar(VAR_VALUE, "validationSequence",
 		"Validation values: ByteIndex, ByteValue x 3");
-	if ( strcmp(types[type].name, "KIN") && strcmp(types[type].name, "BNT") && strcmp(types[type].name, "IMP")) {
+	if ( strncmp(types[type].name, "KIN", 3) && strncmp(types[type].name, "BNT", 3) && strncmp(types[type].name, "IMP", 3)) {
 		addvar(VAR_VALUE, "frequency",
 			"Frequency conversion values: FreqFactor, FreqConst");
 		addvar(VAR_VALUE, "loadPercentage",

--- a/drivers/powerman-pdu.c
+++ b/drivers/powerman-pdu.c
@@ -73,13 +73,13 @@ static int instcmd(const char *cmdname, const char *extra)
 	}
 
 	/* Power on the outlet */
-	if (!strcasecmp(cmdsuffix, "on")) {
+	if (!strncasecmp(cmdsuffix, "on", 2)) {
 		rv = pm_node_on(pm, outletname);
 		return (rv==PM_ESUCCESS)?STAT_INSTCMD_HANDLED:STAT_SET_INVALID;
 	}
 
 	/* Power off the outlet */
-	if (!strcasecmp(cmdsuffix, "off")) {
+	if (!strncasecmp(cmdsuffix, "off", 3)) {
 		rv = pm_node_off(pm, outletname);
 		return (rv==PM_ESUCCESS)?STAT_INSTCMD_HANDLED:STAT_SET_INVALID;
 	}

--- a/drivers/powerp-txt.c
+++ b/drivers/powerp-txt.c
@@ -150,7 +150,7 @@ static int powpan_instcmd(const char *cmdname, const char *extra)
 			continue;
 		}
 
-		if ((powpan_command(cmdtab[i].command) == 2) && (!strcasecmp(powpan_answer, "#0"))) {
+		if ((powpan_command(cmdtab[i].command) == 2) && (!strncasecmp(powpan_answer, "#0", 2))) {
 			return STAT_INSTCMD_HANDLED;
 		}
 
@@ -181,7 +181,7 @@ static int powpan_instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_UNKNOWN;
 	}
 
-	if ((powpan_command(command) == 2) && (!strcasecmp(powpan_answer, "#0"))) {
+	if ((powpan_command(command) == 2) && (!strncasecmp(powpan_answer, "#0", 2))) {
 		return STAT_INSTCMD_HANDLED;
 	}
 
@@ -219,7 +219,7 @@ static int powpan_setvar(const char *varname, const char *val)
 #pragma GCC diagnostic pop
 #endif
 
-		if ((powpan_command(command) == 2) && (!strcasecmp(powpan_answer, "#0"))) {
+		if ((powpan_command(command) == 2) && (!strncasecmp(powpan_answer, "#0", 2))) {
 			dstate_setinfo(varname, "%s", val);
 			return STAT_SET_HANDLED;
 		}

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -790,14 +790,14 @@ void nut_snmp_init(const char *type, const char *hostname)
 		authProtocol = testvar(SU_VAR_AUTHPROT) ? getval(SU_VAR_AUTHPROT) : "MD5";
 
 #if NUT_HAVE_LIBNETSNMP_usmHMACMD5AuthProtocol
-		if (strcmp(authProtocol, "MD5") == 0) {
+		if (strncmp(authProtocol, "MD5", 3) == 0) {
 			g_snmp_sess.securityAuthProto = usmHMACMD5AuthProtocol;
 			g_snmp_sess.securityAuthProtoLen = sizeof(usmHMACMD5AuthProtocol)/sizeof(oid);
 		}
 		else
 #endif
 #if NUT_HAVE_LIBNETSNMP_usmHMACSHA1AuthProtocol
-		if (strcmp(authProtocol, "SHA") == 0) {
+		if (strncmp(authProtocol, "SHA", 3) == 0) {
 			g_snmp_sess.securityAuthProto = usmHMACSHA1AuthProtocol;
 			g_snmp_sess.securityAuthProtoLen = sizeof(usmHMACSHA1AuthProtocol)/sizeof(oid);
 		}
@@ -842,14 +842,14 @@ void nut_snmp_init(const char *type, const char *hostname)
 		privProtocol = testvar(SU_VAR_PRIVPROT) ? getval(SU_VAR_PRIVPROT) : "DES";
 
 #if NUT_HAVE_LIBNETSNMP_usmDESPrivProtocol
-		if (strcmp(privProtocol, "DES") == 0) {
+		if (strncmp(privProtocol, "DES", 3) == 0) {
 			g_snmp_sess.securityPrivProto = usmDESPrivProtocol;
 			g_snmp_sess.securityPrivProtoLen =  sizeof(usmDESPrivProtocol)/sizeof(oid);
 		}
 		else
 #endif
 #if NUT_HAVE_LIBNETSNMP_usmAESPrivProtocol || NUT_HAVE_LIBNETSNMP_usmAES128PrivProtocol
-		if (strcmp(privProtocol, "AES") == 0) {
+		if (strncmp(privProtocol, "AES", 3) == 0) {
 			g_snmp_sess.securityPrivProto = usmAESPrivProtocol;
 			g_snmp_sess.securityPrivProtoLen = NUT_securityPrivProtoLen;
 		}
@@ -3446,7 +3446,7 @@ static int parse_mibconf_args(size_t numargs, char **arg)
 	/* special case for setting some OIDs value at driver startup */
 	if (!strcmp(arg[0], "init")) {
 		/* set value. */
-		if (!strcmp(arg[1], "str")) {
+		if (!strncmp(arg[1], "str", 3)) {
 			ret = nut_snmp_set_str(arg[3], arg[4]);
 		} else {
 			ret = nut_snmp_set_int(arg[3], strtol(arg[4], NULL, 0));

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -926,7 +926,7 @@ static int setvar(const char *varname, const char *val)
 		index = atoi(index_str);
 		upslogx(LOG_DEBUG, "outlet.%d.switch = %s", index, val);
 
-		if(!strcasecmp(val, "on") || !strcmp(val, "1")) {
+		if(!strncasecmp(val, "on", 2) || !strncmp(val, "1", 1)) {
 			state = 1;
 		} else {
 			state = 0;

--- a/drivers/upscode2.c
+++ b/drivers/upscode2.c
@@ -1331,17 +1331,17 @@ static int upsc_simple(const simple_t *sp, const char *var, const char *val)
 				dstate_setinfo(sp->desc, "%s", val);
 				break;
 			case t_status:
-				if (strcmp(val, "00") == 0)
+				if (strncmp(val, "00", 2) == 0)
 					;
-				else if (strcmp(val, "11") == 0)
+				else if (strncmp(val, "11", 2) == 0)
 					status |= sp->status;
 				else
 					upslogx(LOG_ERR, "Unknown status value: '%s' '%s'", var, val);
 				break;
 			case t_alarm:
-				if (strcmp(val, "00") == 0)
+				if (strncmp(val, "00", 2) == 0)
 					;
-				else if (strcmp(val, "11") == 0)
+				else if (strncmp(val, "11", 2) == 0)
 					status |= sp->status;
 				else
 					upslogx(LOG_ERR, "Unknown alarm value: '%s' '%s'", var, val);

--- a/drivers/victronups.c
+++ b/drivers/victronups.c
@@ -244,31 +244,31 @@ void upsdrv_updateinfo(void)
 	if (start_is_datastale)
 	{
 		if (get_data("vDS?",temp)) return;
-		if (strcmp(temp+3,"NA"))
+		if (strncmp(temp+3, "NA", 2))
 			exist_ups_serial=1;
 
 		if (get_data("vBT?",temp)) return;
-		if (strcmp(temp+3,"NA"))
+		if (strncmp(temp+3, "NA", 2))
 			exist_ups_temperature =1;
 
 		if (get_data("vO0I?",temp)) return;
-		if (strcmp(temp+4,"NA"))
+		if (strncmp(temp+4, "NA", 2))
 			exist_output_current =1;
 
 		if (get_data("vBC?",temp)) return;
-		if (strcmp(temp+3,"NA"))
+		if (strncmp(temp+3, "NA", 2))
 			exist_battery_charge = 1;
 
 		if (get_data("vBI?",temp)) return;
-		if (strcmp(temp+3,"NA"))
+		if (strncmp(temp+3, "NA", 2))
 			exist_battery_charge = 1;
 
 		if (get_data("vBT?",temp)) return;
-		if (strcmp(temp+3,"NA"))
+		if (strncmp(temp+3, "NA", 2))
 			exist_battery_temperature = 1;
 
 		if (get_data("vBt?",temp)) return;
-		if (strcmp(temp+3,"NA"))
+		if (strncmp(temp+3, "NA", 2))
 			exist_battery_runtime = 1;
 
 		start_is_datastale = 0;

--- a/server/conf.c
+++ b/server/conf.c
@@ -118,11 +118,11 @@ static void ups_update(const char *fn, const char *name, const char *desc)
  */
 static int parse_boolean(char *arg, int *result)
 {
-	if ( (!strcasecmp(arg, "true")) || (!strcasecmp(arg, "on")) || (!strcasecmp(arg, "yes")) || (!strcasecmp(arg, "1"))) {
+	if ( (!strcasecmp(arg, "true")) || (!strncasecmp(arg, "on", 2)) || (!strncasecmp(arg, "yes", 3)) || (!strncasecmp(arg, "1", 1))) {
 		*result = 1;
 		return 1;
 	}
-	if ( (!strcasecmp(arg, "false")) || (!strcasecmp(arg, "off")) || (!strcasecmp(arg, "no")) || (!strcasecmp(arg, "0"))) {
+	if ( (!strcasecmp(arg, "false")) || (!strncasecmp(arg, "off", 3)) || (!strncasecmp(arg, "no", 2)) || (!strncasecmp(arg, "0", 1))) {
 		*result = 0;
 		return 1;
 	}
@@ -265,7 +265,7 @@ static int parse_upsd_conf_args(size_t numargs, char **arg)
 		return 0;
 
 	/* ACL <aclname> <ip block> */
-	if (!strcmp(arg[0], "ACL")) {
+	if (!strncmp(arg[0], "ACL", 3)) {
 		upslogx(LOG_WARNING, "ACL in upsd.conf is no longer supported - switch to LISTEN");
 		return 1;
 	}

--- a/server/netget.c
+++ b/server/netget.c
@@ -258,7 +258,7 @@ void net_get(nut_ctype_t *client, size_t numarg, const char **arg)
 	}
 
 	/* GET VAR UPS VARNAME */
-	if (!strcasecmp(arg[0], "VAR")) {
+	if (!strncasecmp(arg[0], "VAR", 3)) {
 		get_var(client, arg[1], arg[2]);
 		return;
 	}

--- a/server/netlist.c
+++ b/server/netlist.c
@@ -293,7 +293,7 @@ void net_list(nut_ctype_t *client, size_t numarg, const char **arg)
 	}
 
 	/* LIST UPS */
-	if (!strcasecmp(arg[0], "UPS")) {
+	if (!strncasecmp(arg[0], "UPS", 3)) {
 		list_ups(client);
 		return;
 	}
@@ -304,19 +304,19 @@ void net_list(nut_ctype_t *client, size_t numarg, const char **arg)
 	}
 
 	/* LIST VAR UPS */
-	if (!strcasecmp(arg[0], "VAR")) {
+	if (!strncasecmp(arg[0], "VAR", 3)) {
 		list_var(client, arg[1]);
 		return;
 	}
 
 	/* LIST RW UPS */
-	if (!strcasecmp(arg[0], "RW")) {
+	if (!strncasecmp(arg[0], "RW", 2)) {
 		list_rw(client, arg[1]);
 		return;
 	}
 
 	/* LIST CMD UPS */
-	if (!strcasecmp(arg[0], "CMD")) {
+	if (!strncasecmp(arg[0], "CMD", 3)) {
 		list_cmd(client, arg[1]);
 		return;
 	}

--- a/server/netset.c
+++ b/server/netset.c
@@ -177,7 +177,7 @@ void net_set(nut_ctype_t *client, size_t numarg, const char **arg)
 	}
 
 	/* SET VAR UPS VARNAME VALUE */
-	if (!strcasecmp(arg[0], "VAR")) {
+	if (!strncasecmp(arg[0], "VAR", 3)) {
 		if (numarg < 4) {
 			send_err(client, NUT_ERR_INVALID_ARGUMENT);
 			return;
@@ -195,11 +195,11 @@ void net_set(nut_ctype_t *client, size_t numarg, const char **arg)
 
 	/* SET TRACKING VALUE */
 	if (!strcasecmp(arg[0], "TRACKING")) {
-		if (!strcasecmp(arg[1], "ON")) {
+		if (!strncasecmp(arg[1], "ON", 2)) {
 			/* general enablement along with for this client */
 			client->tracking = tracking_enable();
 		}
-		else if (!strcasecmp(arg[1], "OFF")) {
+		else if (!strncasecmp(arg[1], "OFF", 3)) {
 			/* disable status tracking for this client first */
 			client->tracking = 0;
 			/* then only disable the general one if no other clients use it!

--- a/server/user.c
+++ b/server/user.c
@@ -220,7 +220,7 @@ static int user_matchinstcmd(ulist_t *user, const char * cmd)
 			return 1;	/* good */
 		}
 
-		if (!strcasecmp(tmp->cmd, "all")) {
+		if (!strncasecmp(tmp->cmd, "all", 3)) {
 			return 1;	/* good */
 		}
 	}
@@ -442,7 +442,7 @@ static void user_parse_arg(size_t numargs, char **arg)
 	}
 
 	/* handle 'foo = bar' (split form) */
-	if (!strcmp(arg[1], "=")) {
+	if (!strncmp(arg[1], "=", 1)) {
 
 		/*   0 1   2      3       4  ... */
 		/* foo = bar <rest1> <rest2> ... */

--- a/tests/cpputest.cpp
+++ b/tests/cpputest.cpp
@@ -46,7 +46,7 @@ int main(int argc, char* argv[])
 {
   bool verbose = false;
   if (argc > 1) {
-    if (strcmp("-v", argv[1]) == 0 || strcmp("--verbose", argv[1]) == 0 ) {
+    if (strncmp("-v", argv[1], 2) == 0 || strcmp("--verbose", argv[1]) == 0 ) {
       verbose = true;
     }
   }

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -508,10 +508,10 @@ int main(int argc, char *argv[])
 				else if (!strcmp(optarg, "STRAIGHT_PASSWORD_KEY")) {
 					ipmi_sec.authentication_type = IPMI_AUTHENTICATION_TYPE_STRAIGHT_PASSWORD_KEY;
 				}
-				else if (!strcmp(optarg, "MD2")) {
+				else if (!strncmp(optarg, "MD2", 3)) {
 					ipmi_sec.authentication_type = IPMI_AUTHENTICATION_TYPE_MD2;
 				}
-				else if (!strcmp(optarg, "MD5")) {
+				else if (!strncmp(optarg, "MD5", 3)) {
 					ipmi_sec.authentication_type = IPMI_AUTHENTICATION_TYPE_MD5;
 				}
 				else {

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -588,7 +588,7 @@ static int init_session(struct snmp_session * snmp_sess, nutscan_snmp_t * sec)
 
 		if (sec->authProtocol) {
 #if NUT_HAVE_LIBNETSNMP_usmHMACSHA1AuthProtocol
-			if (strcmp(sec->authProtocol, "SHA") == 0) {
+			if (strncmp(sec->authProtocol, "SHA", 3) == 0) {
 				snmp_sess->securityAuthProto = nut_usmHMACSHA1AuthProtocol;
 				snmp_sess->securityAuthProtoLen =
 					sizeof(usmHMACSHA1AuthProtocol)/
@@ -624,7 +624,7 @@ static int init_session(struct snmp_session * snmp_sess, nutscan_snmp_t * sec)
 			else
 #endif
 #if NUT_HAVE_LIBNETSNMP_usmHMACMD5AuthProtocol
-			if (strcmp(sec->authProtocol, "MD5") != 0) {
+			if (strncmp(sec->authProtocol, "MD5", 3) != 0) {
 #else
 			{
 #endif
@@ -665,7 +665,7 @@ static int init_session(struct snmp_session * snmp_sess, nutscan_snmp_t * sec)
 
 		if (sec->privProtocol) {
 #if NUT_HAVE_LIBNETSNMP_usmAESPrivProtocol || NUT_HAVE_LIBNETSNMP_usmAES128PrivProtocol
-			if (strcmp(sec->privProtocol, "AES") == 0) {
+			if (strncmp(sec->privProtocol, "AES", 3) == 0) {
 				snmp_sess->securityPrivProto = nut_usmAESPrivProtocol;
 				snmp_sess->securityPrivProtoLen =
 					sizeof(usmAESPrivProtocol)/
@@ -694,7 +694,7 @@ static int init_session(struct snmp_session * snmp_sess, nutscan_snmp_t * sec)
 # endif
 #endif /* NETSNMP_DRAFT_BLUMENTHAL_AES_04 */
 #if NUT_HAVE_LIBNETSNMP_usmDESPrivProtocol
-			if (strcmp(sec->privProtocol, "DES") != 0) {
+			if (strncmp(sec->privProtocol, "DES", 3) != 0) {
 #else
 			{
 #endif


### PR DESCRIPTION
…(3 chars or less) by strncmp() and strncasecmp() respectively

Some compilers on some OSes complain due to implem nuances.
Updated docs/developers.txt to make note for posterity.