### PR TITLE
configure.ac: AC_LANG_PUSH before AC_COMPILE_IFELSE and similar tests

### DIFF
--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -948,7 +948,16 @@ set | sort -n """
     ]
 
     dynacfgPipeline.notifyHandler = {
-        ircNotify (notificationStrategy:'FAILURE_AND_FIXED')
+        def summary = null
+        try {
+            summary = dynamatrix.toStringStageCountDump()
+        } catch (Throwable t) {}
+
+        if (summary == null || summary == "") {
+            ircNotify (notificationStrategy:'FAILURE_AND_FIXED')
+        } else {
+            ircNotify (notificationStrategy:'FAILURE_AND_FIXED', customMessage: summary)
+        }
     }
 
 @NonCPS

--- a/configure.ac
+++ b/configure.ac
@@ -156,6 +156,7 @@ AC_CHECK_HEADER([limits.h],
 
 AC_CHECK_HEADER([sys/resource.h],
     [AC_MSG_CHECKING([for struct rlimit and getrlimit()])
+     AC_LANG_PUSH([C])
      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
 #include <sys/resource.h>
 ],
@@ -164,19 +165,22 @@ getrlimit(RLIMIT_NOFILE, &limit);
 /* Do not care about actual return value in this test,
  * normally check for non-zero meaning to look in errno */
 ]
-    )],
+        )],
         [AC_DEFINE([HAVE_SYS_RESOURCE_H], [1],
             [Define to 1 if you have <sys/resource.h> with usable struct rlimit and getrlimit().])
          AC_MSG_RESULT([ok])
         ],
         [AC_MSG_RESULT([no])]
-    )]
+     )
+     AC_LANG_POP([C])
+    ]
 )
 
 AC_CHECK_HEADER([semaphore.h],
     [AC_DEFINE([HAVE_SEMAPHORE_H], [1],
         [Define to 1 if you have <sys/semaphore.h>.])
      AC_MSG_CHECKING([for sem_t, sem_init() and sem_destroy()])
+     AC_LANG_PUSH([C])
      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
 #include <semaphore.h>
 ],
@@ -186,13 +190,15 @@ sem_destroy(&semaphore);
 /* Do not care about actual return value in this test,
  * normally check for non-zero meaning to look in errno */
 ]
-    )],
+        )],
         [AC_DEFINE([HAVE_SEMAPHORE], [1],
             [Define to 1 if you have <sys/semaphore.h> with usable sem_t sem_init() and sem_destroy().])
          AC_MSG_RESULT([ok])
         ],
         [AC_MSG_RESULT([no])]
-    )]
+     )
+     AC_LANG_POP([C])
+    ]
 )
 
 AC_CHECK_FUNCS(cfsetispeed tcsendbreak)
@@ -478,6 +484,7 @@ AS_IF([test "${nut_with_serial}" != "no"],
     dnl Don't mind the stupid code below, it just probes the tokens and
     dnl sails around compiler warnings
     AC_MSG_CHECKING([for struct termios and speed_t])
+    AC_LANG_PUSH([C])
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
 #if defined(HAVE_SYS_TERMIOS_H)
 #  include <sys/termios.h>      /* for speed_t */
@@ -499,21 +506,23 @@ getspeed(&baudrate);
         ],
         [AC_MSG_RESULT([no, struct termios and/or speed_t not found in discovered headers])
          nut_have_serial_types=no
+        ]
+     )
+     AC_LANG_POP([C])
+
+     dnl Restore common set-or-discovered CFLAGS
+     CFLAGS="${CFLAGS_SAVED_SERIAL}"
+
+     AC_MSG_CHECKING([whether we can build serial drivers])
+     AS_IF([test "${nut_have_serial_types}" = yes],
+        [AS_IF([test "${nut_with_serial}" = "auto"],[nut_with_serial="yes"])],
+        [AS_IF([test "${nut_with_serial}" = "auto"],[nut_with_serial="no"])
+         AS_IF([test "${nut_with_serial}" = "yes"],[AC_MSG_ERROR([no, and were required to])])
         ])
-
-        dnl Restore common set-or-discovered CFLAGS
-        CFLAGS="${CFLAGS_SAVED_SERIAL}"
-
-        AC_MSG_CHECKING([whether we can build serial drivers])
-        AS_IF([test "${nut_have_serial_types}" = yes],
-            [AS_IF([test "${nut_with_serial}" = "auto"],[nut_with_serial="yes"])],
-            [AS_IF([test "${nut_with_serial}" = "auto"],[nut_with_serial="no"])
-             AS_IF([test "${nut_with_serial}" = "yes"],[AC_MSG_ERROR([no, and were required to])])
-            ])
-        AS_IF([test "${nut_with_serial}" = "yes"],
-            [AC_MSG_RESULT([yes])],
-            [AC_MSG_RESULT([no])])
-    ])
+     AS_IF([test "${nut_with_serial}" = "yes"],
+        [AC_MSG_RESULT([yes])],
+        [AC_MSG_RESULT([no])])
+])
 
 NUT_REPORT_FEATURE([build serial drivers], [${nut_with_serial}], [],
 					[WITH_SERIAL], [Define to enable serial support])

--- a/m4/ax_c___attribute__.m4
+++ b/m4/ax_c___attribute__.m4
@@ -57,6 +57,7 @@
 #serial 9
 
 AC_DEFUN([AX_C___ATTRIBUTE__], [
+  AC_LANG_PUSH([C])
   AC_CACHE_CHECK([for __attribute__((unused)) for function arguments], [ax_cv___attribute__unused_arg],
     [AC_COMPILE_IFELSE(
       [AC_LANG_PROGRAM(
@@ -101,6 +102,7 @@ AC_DEFUN([AX_C___ATTRIBUTE__], [
       [ax_cv___attribute__noreturn=no]
     )
   ])
+  AC_LANG_POP([C])
 
   AC_CACHE_CHECK([for at least some __attribute__ support], [ax_cv___attribute__],
    [if test "$ax_cv___attribute__unused_arg" = "yes" \

--- a/m4/nut_check_headers_windows.m4
+++ b/m4/nut_check_headers_windows.m4
@@ -11,6 +11,7 @@ dnl Check for compilable and valid windows.h header
 
 AC_DEFUN([NUT_CHECK_HEADER_WINDOWS], [
   AC_CACHE_CHECK([for windows.h], [nut_cv_header_windows_h], [
+    AC_LANG_PUSH([C])
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
 #undef inline
@@ -30,6 +31,7 @@ AC_DEFUN([NUT_CHECK_HEADER_WINDOWS], [
     ],[
       nut_cv_header_windows_h="no"
     ])
+    AC_LANG_POP([C])
   ])
   case "$nut_cv_header_windows_h" in
     yes)
@@ -50,6 +52,7 @@ AC_DEFUN([NUT_CHECK_NATIVE_WINDOWS], [
     if test "$nut_cv_header_windows_h" = "no"; then
       nut_cv_native_windows="no"
     else
+      AC_LANG_PUSH([C])
       AC_COMPILE_IFELSE([
         AC_LANG_PROGRAM([[
         ]],[[
@@ -65,6 +68,7 @@ AC_DEFUN([NUT_CHECK_NATIVE_WINDOWS], [
       ],[
         nut_cv_native_windows="no"
       ])
+      AC_LANG_POP([C])
     fi
   ])
   AM_CONDITIONAL(DOING_NATIVE_WINDOWS, test "x$nut_cv_native_windows" = xyes)
@@ -78,6 +82,7 @@ dnl Check for compilable and valid winsock.h header
 AC_DEFUN([NUT_CHECK_HEADER_WINSOCK], [
   AC_REQUIRE([NUT_CHECK_HEADER_WINDOWS])dnl
   AC_CACHE_CHECK([for winsock.h], [nut_cv_header_winsock_h], [
+    AC_LANG_PUSH([C])
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
 #undef inline
@@ -98,6 +103,7 @@ AC_DEFUN([NUT_CHECK_HEADER_WINSOCK], [
     ],[
       nut_cv_header_winsock_h="no"
     ])
+    AC_LANG_POP([C])
   ])
   case "$nut_cv_header_winsock_h" in
     yes)
@@ -115,6 +121,7 @@ dnl Check for compilable and valid winsock2.h header
 AC_DEFUN([NUT_CHECK_HEADER_WINSOCK2], [
   AC_REQUIRE([NUT_CHECK_HEADER_WINDOWS])dnl
   AC_CACHE_CHECK([for winsock2.h], [nut_cv_header_winsock2_h], [
+    AC_LANG_PUSH([C])
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
 #undef inline
@@ -135,6 +142,7 @@ AC_DEFUN([NUT_CHECK_HEADER_WINSOCK2], [
     ],[
       nut_cv_header_winsock2_h="no"
     ])
+    AC_LANG_POP([C])
   ])
   case "$nut_cv_header_winsock2_h" in
     yes)
@@ -152,6 +160,7 @@ dnl Check for compilable and valid ws2tcpip.h header
 AC_DEFUN([NUT_CHECK_HEADER_WS2TCPIP], [
   AC_REQUIRE([NUT_CHECK_HEADER_WINSOCK2])dnl
   AC_CACHE_CHECK([for ws2tcpip.h], [nut_cv_header_ws2tcpip_h], [
+    AC_LANG_PUSH([C])
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
 #undef inline
@@ -173,6 +182,7 @@ AC_DEFUN([NUT_CHECK_HEADER_WS2TCPIP], [
     ],[
       nut_cv_header_ws2tcpip_h="no"
     ])
+    AC_LANG_POP([C])
   ])
   case "$nut_cv_header_ws2tcpip_h" in
     yes)

--- a/m4/nut_check_libnetsnmp.m4
+++ b/m4/nut_check_libnetsnmp.m4
@@ -9,6 +9,7 @@ AC_DEFUN([NUT_CHECK_LIBNETSNMP],
 if test -z "${nut_have_libnetsnmp_seen}"; then
 	nut_have_libnetsnmp_seen=yes
 	NUT_CHECK_PKGCONFIG
+	AC_LANG_PUSH([C])
 
 	dnl save CFLAGS and LIBS
 	CFLAGS_ORIG="${CFLAGS}"
@@ -275,6 +276,7 @@ oid * pProto = usmHMACSHA1AuthProtocol;
 			])
 
 	fi
+	AC_LANG_POP([C])
 
 	dnl restore original CFLAGS and LIBS
 	CFLAGS="${CFLAGS_ORIG}"

--- a/m4/nut_func_getnameinfo_argtypes.m4
+++ b/m4/nut_func_getnameinfo_argtypes.m4
@@ -17,6 +17,7 @@ AC_DEFUN([NUT_FUNC_GETNAMEINFO_ARGTYPES], [
   AC_REQUIRE([NUT_CHECK_HEADER_WS2TCPIP])dnl
   AC_REQUIRE([NUT_TYPE_SOCKLEN_T])dnl
   AC_CHECK_HEADERS(sys/types.h sys/socket.h netdb.h)
+  AC_LANG_PUSH([C])
   AC_CACHE_CHECK([types of arguments for getnameinfo],
     [nut_cv_func_getnameinfo_args], [
     nut_cv_func_getnameinfo_args="unknown"
@@ -75,6 +76,7 @@ AC_DEFUN([NUT_FUNC_GETNAMEINFO_ARGTYPES], [
       done
     done
   ])
+  AC_LANG_POP([C])
   if test "$nut_cv_func_getnameinfo_args" = "unknown"; then
     AC_MSG_WARN([Cannot find proper types to use for getnameinfo args])
   else

--- a/m4/nut_type_socklen_t.m4
+++ b/m4/nut_type_socklen_t.m4
@@ -47,6 +47,7 @@ AC_DEFUN([NUT_TYPE_SOCKLEN_T],
       [
          # Systems have either "struct sockaddr *" or
          # "void *" as the second argument to getpeername
+         AC_LANG_PUSH([C])
          nut_cv_socklen_t_equiv=
          for arg1 in "int" "SOCKET"; do
           for arg2 in "struct sockaddr" void; do
@@ -64,6 +65,7 @@ AC_DEFUN([NUT_TYPE_SOCKLEN_T],
             done
           done
          done
+         AC_LANG_POP([C])
 
          if test "x$nut_cv_socklen_t_equiv" = x; then
             AC_MSG_ERROR([Cannot find a type to use in place of socklen_t])


### PR DESCRIPTION
Avoid failures with default `./configure` run that e.g. enables serial drivers (yes by default) but can't run the compiler to check for headers and so fails.