### PR TITLE
CI/BUILD: avoid directly calling *-config progs from m4 functions

### DIFF
--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -397,6 +397,14 @@ Default is /var/state/ups.
 Things the compiler might need to find
 --------------------------------------
 
+	--with-pkg-config
+
+This option allows to provide a custom program name (in `PATH`) or a
+complete pathname to `pkg-config` which describes `CFLAGS`, `LIBS` and
+possibly other build-time options in `*.pc` files, to use third-party
+libraries. On build systems which support multiple architectures you
+may also want to set `PKG_CONFIG_PATH` to match your current build.
+
 	--with-gd-includes="-I/foo/bar"
 
 If you installed gd in some place where your C preprocessor can't

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -440,13 +440,14 @@ program differently.
 	--with-powerman-includes="-I/foo/bar"
 
 If your system doesn't have pkg-config and support for any of the above
-libraries isn't found (but you know it is installed), you must specify the
-compiler flags that are needed.
+libraries isn't found (but you know it is installed), you must specify
+the compiler flags that are needed.
 
 	--with-ssl-libs, --with-usb-libs, --with-snmp-libs,
 	--with-neon-libs, --with-libltdl-libs
 	--with-powerman-libs="-L/foo/bar -labcd -lxyz"
 
-If system doesn't have pkg-config or it fails to provides hints for some of the
-settings that are needed to set it up properly and the build in defaults are
-not right, you can specify the right variables here.
+If system doesn't have pkg-config or it fails to provides hints for
+some of the settings that are needed to set it up properly and the
+build in defaults are not right, you can specify the correct values
+for your system here.

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -27,7 +27,9 @@ Note that you need to install libsnmp development package or files.
 	--with-net-snmp-config
 
 In addition to the `--with-snmp` option above, this one allows to provide
-a custom program name (in `PATH`) or complete pathname to `net-snmp-config`.
+a custom program name (in `PATH`) or complete pathname to `net-snmp-config`
+(may have copies named per architecture, e.g. `net-snmp-config-32` and
+`net-snmp-config-64`).
 This may be needed on build systems which support multiple architectures,
 or in cases where your distribution names this program differently.
 With a default value of `yes` it would mean preference of this program,

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -418,6 +418,15 @@ a complete pathname to `gdlib-config`. This may be needed on build
 systems which support multiple architectures, or in cases where your
 distribution names this program differently.
 
+	--with-libusb-config
+
+This option allows to provide a custom program name (in `PATH`) or
+a complete pathname to `libusb-config` (usually delivered only for
+libusb-0.1 version, but not for libusb-1.0). This may be needed on
+build systems which support multiple architectures or provide several
+versions of libusb, or in cases where your distribution names this
+program differently.
+
 	--with-ssl-includes, --with-usb-includes, --with-snmp-includes,
 	--with-neon-includes, --with-libltdl-includes,
 	--with-powerman-includes="-I/foo/bar"

--- a/m4/nut_check_libgd.m4
+++ b/m4/nut_check_libgd.m4
@@ -38,7 +38,7 @@ if test -z "${nut_have_libgd_seen}"; then
 		 LIBS="-lgd -lpng -lz -ljpeg -lfreetype -lm -lXpm -lX11"
 
 		 dnl By default seek in PATH
-		 GDLIB_CONFIG=gdlib-config
+		 AC_PATH_PROGS([GDLIB_CONFIG], [gdlib-config], [none])
 		 AC_ARG_WITH(gdlib-config,
 			AS_HELP_STRING([@<:@--with-gdlib-config=/path/to/gdlib-config@:>@],
 				[path to program that reports GDLIB configuration]),
@@ -54,12 +54,15 @@ if test -z "${nut_have_libgd_seen}"; then
 			esac
 		 ])
 
-		 AC_MSG_CHECKING(for gd version via ${GDLIB_CONFIG})
-		 GD_VERSION="`${GDLIB_CONFIG} --version 2>/dev/null`"
-		 if test "$?" != "0" -o -z "${GD_VERSION}"; then
-			GD_VERSION="none"
-		 fi
-		 AC_MSG_RESULT(${GD_VERSION} found)
+		 AS_IF([test x"$GDLIB_CONFIG" != xnone],
+			[AC_MSG_CHECKING(for gd version via ${GDLIB_CONFIG})
+			 GD_VERSION="`${GDLIB_CONFIG} --version 2>/dev/null`"
+			 if test "$?" != "0" -o -z "${GD_VERSION}"; then
+				GD_VERSION="none"
+			 fi
+			 AC_MSG_RESULT(${GD_VERSION} found)
+			], [GD_VERSION="none"]
+		 )
 
 		 case "${GD_VERSION}" in
 		 none)

--- a/m4/nut_check_libgd.m4
+++ b/m4/nut_check_libgd.m4
@@ -12,6 +12,9 @@ if test -z "${nut_have_libgd_seen}"; then
 	CFLAGS_ORIG="${CFLAGS}"
 	LDFLAGS_ORIG="${LDFLAGS}"
 	LIBS_ORIG="${LIBS}"
+	CFLAGS=""
+	LDFLAGS=""
+	LIBS=""
 
 	AS_IF([test x"$have_PKG_CONFIG" = xyes],
 		[AC_MSG_CHECKING(for gd version via pkg-config)

--- a/m4/nut_check_libnetsnmp.m4
+++ b/m4/nut_check_libnetsnmp.m4
@@ -22,12 +22,12 @@ if test -z "${nut_have_libnetsnmp_seen}"; then
 
 	dnl By default seek in PATH, but which variant (if several are provided)?
 	AC_CHECK_SIZEOF([void *])
+	NET_SNMP_CONFIG="none"
 	AS_CASE(["${ac_cv_sizeof_void_p}"],
-		[4],[NET_SNMP_CONFIG=net-snmp-config-32],
-		[8],[NET_SNMP_CONFIG=net-snmp-config-64]
-		)
-	AS_IF([test -n "${NET_SNMP_CONFIG}" && test -n "`command -v "${NET_SNMP_CONFIG}"`"],
-		[], [NET_SNMP_CONFIG=net-snmp-config])
+		[4],[AC_PATH_PROGS([NET_SNMP_CONFIG], [net-snmp-config-32 net-snmp-config], [none])],
+		[8],[AC_PATH_PROGS([NET_SNMP_CONFIG], [net-snmp-config-64 net-snmp-config], [none])],
+		    [AC_PATH_PROGS([NET_SNMP_CONFIG], [net-snmp-config], [none])]
+	)
 
 	prefer_NET_SNMP_CONFIG=false
 	AC_ARG_WITH(net-snmp-config,
@@ -58,6 +58,10 @@ if test -z "${nut_have_libnetsnmp_seen}"; then
 			AC_MSG_RESULT(none found)
 			prefer_NET_SNMP_CONFIG=true
 		fi
+	fi
+
+	if test "$NET_SNMP_CONFIG" = none ; then
+		prefer_NET_SNMP_CONFIG=false
 	fi
 
 	if "${prefer_NET_SNMP_CONFIG}" ; then

--- a/m4/nut_check_libpowerman.m4
+++ b/m4/nut_check_libpowerman.m4
@@ -16,10 +16,16 @@ if test -z "${nut_have_libpowerman_seen}"; then
 	AS_IF([test x"$have_PKG_CONFIG" = xyes],
 		[AC_MSG_CHECKING([for LLNC libpowerman version via pkg-config])
 		 POWERMAN_VERSION="`$PKG_CONFIG --silence-errors --modversion libpowerman 2>/dev/null`"
-		 if test "$?" != "0" -o -z "${POWERMAN_VERSION}"; then
+		 dnl Unlike other pkg-config enabled projects we use,
+		 dnl libpowerman (at least on Debian) delivers an empty
+		 dnl "Version:" tag in /usr/lib/pkgconfig/libpowerman.pc
+		 dnl (and it is the only file in that dir, others going
+		 dnl to /usr/lib/x86_64-linux-gnu/pkgconfig/ or similar
+		 dnl for other architectures). Empty is not an error here!
+		 if test "$?" != "0" ; then # -o -z "${POWERMAN_VERSION}"; then
 		    POWERMAN_VERSION="none"
 		 fi
-		 AC_MSG_RESULT([${POWERMAN_VERSION} found])
+		 AC_MSG_RESULT(['${POWERMAN_VERSION}' found])
 		],
 		[POWERMAN_VERSION="none"
 		 AC_MSG_NOTICE([can not check LLNC libpowerman settings via pkg-config])

--- a/m4/nut_check_libpowerman.m4
+++ b/m4/nut_check_libpowerman.m4
@@ -73,7 +73,18 @@ if test -z "${nut_have_libpowerman_seen}"; then
 
 	dnl check if libpowerman is usable
 	AC_CHECK_HEADERS(libpowerman.h, [nut_have_libpowerman=yes], [nut_have_libpowerman=no], [AC_INCLUDES_DEFAULT])
-	AC_CHECK_FUNCS(pm_connect, [], [nut_have_libpowerman=no])
+	AC_CHECK_FUNCS(pm_connect, [], [
+		dnl Some systems may just have libpowerman in their
+		dnl standard paths, but not the pkg-config data
+		AS_IF([test "${nut_have_libpowerman}" = "yes" && test "$POWERMAN_VERSION" = "none" && test -z "$LIBS"],
+			[AC_MSG_CHECKING([if libpowerman is just present in path])
+			 LIBS="-L/usr/lib -L/usr/local/lib -lpowerman"
+			 unset ac_cv_func_pm_connect || true
+			 AC_CHECK_FUNCS(pm_connect, [], [nut_have_libpowerman=no])
+			 AC_MSG_RESULT([${nut_have_libpowerman}])
+			], [nut_have_libpowerman=no]
+		)]
+	)
 
 	if test "${nut_have_libpowerman}" = "yes"; then
 		LIBPOWERMAN_CFLAGS="${CFLAGS}"

--- a/m4/nut_check_libpowerman.m4
+++ b/m4/nut_check_libpowerman.m4
@@ -7,24 +7,47 @@ AC_DEFUN([NUT_CHECK_LIBPOWERMAN],
 [
 if test -z "${nut_have_libpowerman_seen}"; then
 	nut_have_libpowerman_seen=yes
+	NUT_CHECK_PKGCONFIG
 
 	dnl save CFLAGS and LIBS
 	CFLAGS_ORIG="${CFLAGS}"
 	LIBS_ORIG="${LIBS}"
 
-	AC_MSG_CHECKING(for libpowerman cflags)
+	AS_IF([test x"$have_PKG_CONFIG" = xyes],
+		[AC_MSG_CHECKING([for LLNC libpowerman version via pkg-config])
+		 POWERMAN_VERSION="`$PKG_CONFIG --silence-errors --modversion libpowerman 2>/dev/null`"
+		 if test "$?" != "0" -o -z "${POWERMAN_VERSION}"; then
+		    POWERMAN_VERSION="none"
+		 fi
+		 AC_MSG_RESULT([${POWERMAN_VERSION} found])
+		],
+		[POWERMAN_VERSION="none"
+		 AC_MSG_NOTICE([can not check LLNC libpowerman settings via pkg-config])
+		]
+	)
+
+	AS_IF([test x"$POWERMAN_VERSION" != xnone],
+		[CFLAGS="`$PKG_CONFIG --silence-errors --cflags libpowerman 2>/dev/null`"
+		 LIBS="`$PKG_CONFIG --silence-errors --libs libpowerman 2>/dev/null`"
+		],
+		[CFLAGS=""
+		 LIBS=""
+		]
+	)
+
+	AC_MSG_CHECKING([for libpowerman cflags])
 	AC_ARG_WITH(powerman-includes,
 		AS_HELP_STRING([@<:@--with-powerman-includes=CFLAGS@:>@], [include flags for the libpowerman library]),
 	[
 		case "${withval}" in
 		yes|no)
-			AC_MSG_ERROR(invalid option --with(out)-powerman-includes - see docs/configure.txt)
+			AC_MSG_ERROR([invalid option --with(out)-powerman-includes - see docs/configure.txt])
 			;;
 		*)
 			CFLAGS="${withval}"
 			;;
 		esac
-	], [CFLAGS="`pkg-config --silence-errors --cflags libpowerman 2>/dev/null`"])
+	], [])
 	AC_MSG_RESULT([${CFLAGS}])
 
 	AC_MSG_CHECKING(for libpowerman libs)
@@ -39,7 +62,7 @@ if test -z "${nut_have_libpowerman_seen}"; then
 			LIBS="${withval}"
 			;;
 		esac
-	], [LIBS="`pkg-config --silence-errors --libs libpowerman 2>/dev/null`"])
+	], [])
 	AC_MSG_RESULT([${LIBS}])
 
 	dnl check if libpowerman is usable

--- a/m4/nut_check_libusb.m4
+++ b/m4/nut_check_libusb.m4
@@ -99,7 +99,18 @@ if test -z "${nut_have_libusb_seen}"; then
 
 	dnl check if libusb is usable
 	AC_CHECK_HEADERS(usb.h, [nut_have_libusb=yes], [nut_have_libusb=no], [AC_INCLUDES_DEFAULT])
-	AC_CHECK_FUNCS(usb_init, [], [nut_have_libusb=no])
+	AC_CHECK_FUNCS(usb_init, [], [
+		dnl Some systems may just have libusb in their standard
+		dnl paths, but not the pkg-config or libusb-config data
+		AS_IF([test "${nut_have_libusb}" = "yes" && test "$LIBUSB_VERSION" = "none" && test -z "$LIBS"],
+			[AC_MSG_CHECKING([if libusb is just present in path])
+			 LIBS="-L/usr/lib -L/usr/local/lib -lusb"
+			 unset ac_cv_func_usb_init || true
+			 AC_CHECK_FUNCS(usb_init, [], [nut_have_libusb=no])
+			 AC_MSG_RESULT([${nut_have_libusb}])
+			], [nut_have_libusb=no]
+		)]
+	)
 
 	if test "${nut_have_libusb}" = "yes"; then
 		dnl Check for libusb "force driver unbind" availability

--- a/m4/nut_check_libwrap.m4
+++ b/m4/nut_check_libwrap.m4
@@ -18,6 +18,7 @@ if test -z "${nut_have_libwrap_seen}"; then
 	dnl The line below does not work on Solaris 10.
 	dnl AC_SEARCH_LIBS(request_init, wrap, [], [nut_have_libwrap=no])
 	AC_MSG_CHECKING(for library containing request_init)
+	AC_LANG_PUSH([C])
 	AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 #include <tcpd.h>
 int allow_severity = 0, deny_severity = 0;
@@ -35,6 +36,7 @@ int allow_severity = 0, deny_severity = 0;
 			nut_have_libwrap=no
 		])
 	])
+	AC_LANG_POP([C])
 
 	if test "${nut_have_libwrap}" = "yes"; then
 		AC_DEFINE(HAVE_WRAP, 1, [Define to enable libwrap support])

--- a/m4/nut_check_pkgconfig.m4
+++ b/m4/nut_check_pkgconfig.m4
@@ -25,7 +25,23 @@ AS_IF([test -z "${nut_have_pkg_config_seen}"], [
 		[dnl Some systems have older autotools without direct macro support for PKG_CONF*
 		have_PKG_CONFIG=yes
 		AC_PATH_PROG(dummy_PKG_CONFIG, pkg-config)
-		AC_MSG_CHECKING([whether usable PKG_CONFIG is present in PATH])
+
+		AC_ARG_WITH(pkg-config,
+			AS_HELP_STRING([@<:@--with-pkg-config=/path/to/gdlib-config@:>@],
+				[path to program that reports development package configuration]),
+		[
+			case "${withval}" in
+			"") ;;
+			yes|no)
+				AC_MSG_ERROR(invalid option --with(out)-pkg-config - see docs/configure.txt)
+				;;
+			*)
+				dummy_PKG_CONFIG="${withval}"
+				;;
+			esac
+		])
+
+		AC_MSG_CHECKING([whether usable PKG_CONFIG is present in PATH or was set by caller])
 		AS_IF([test x"$dummy_PKG_CONFIG" = xno || test -z "$dummy_PKG_CONFIG"],
 			[AC_MSG_RESULT([no])
 			 PKG_CONFIG=false


### PR DESCRIPTION
A number of third-party libraries provide their CFLAGS, LIBS and/or LDFLAGS with either `pkg-config` standard files, or with their own `something-config` scripts (which generally are less preferable, especially for multi-arch builds).

We should not assume blindly that a program to call exists in PATH or fail trying to call it, but detect with `AC_CHECK_PROGS` explicitly and go from that knowledge that the program exists. Also this PR augments an ability to `configure --with-something-config=/path/to/something-config` where that was missing, and documents such options.