### PR TITLE
Trace snmp-ups MIB-probing better

### DIFF
--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -1724,7 +1724,7 @@ bool_t load_mib2nut(const char *mib)
 	 * (Note: sysOID points the device main MIB entry point) */
 	if (mibIsAuto)
 	{
-		upsdebugx(1, "trying the new match_sysoid() method");
+		upsdebugx(1, "%s: trying the new match_sysoid() method", __func__);
 		/* Retry at most 3 times, to maximise chances */
 		for (i = 0; i < 3 ; i++) {
 			if ((m2n = match_sysoid()) != NULL)
@@ -1741,7 +1741,8 @@ bool_t load_mib2nut(const char *mib)
 				/* "mib" is neither "auto" nor the name in mapping table */
 				continue;
 			}
-			upsdebugx(1, "load_mib2nut: trying classic method with '%s' mib", mib2nut[i]->mib_name);
+			upsdebugx(1, "%s: trying classic method with '%s' mib",
+				__func__, mib2nut[i]->mib_name);
 
 			/* Device might not support this MIB, but we want to
 			 * track that the name string is valid for diags below
@@ -1755,12 +1756,14 @@ bool_t load_mib2nut(const char *mib)
 
 			if (match_model_OID() != TRUE)
 			{
-				upsdebugx(2, "%s: testOID provided and doesn't match MIB '%s'!", __func__, mib2nut[i]->mib_name);
+				upsdebugx(2, "%s: testOID provided and doesn't match MIB '%s'!",
+					__func__, mib2nut[i]->mib_name);
 				snmp_info = NULL;
 				continue;
 			}
 			else
-				upsdebugx(2, "%s: testOID provided and matches MIB '%s'!", __func__, mib2nut[i]->mib_name);
+				upsdebugx(2, "%s: testOID provided and matches MIB '%s'!",
+					__func__, mib2nut[i]->mib_name);
 
 			/* MIB found */
 			m2n = mib2nut[i];

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -1724,7 +1724,8 @@ bool_t load_mib2nut(const char *mib)
 	 * (Note: sysOID points the device main MIB entry point) */
 	if (mibIsAuto)
 	{
-		upsdebugx(2, "%s: trying the new match_sysoid() method", __func__);
+		upsdebugx(2, "%s: trying the new match_sysoid() method with %s",
+			__func__, mib);
 		/* Retry at most 3 times, to maximise chances */
 		for (i = 0; i < 3 ; i++) {
 			if ((m2n = match_sysoid()) != NULL)

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -1712,7 +1712,12 @@ bool_t load_mib2nut(const char *mib)
 	bool_t mibIsAuto = (0 == strcmp(mib, "auto"));
 	bool_t mibSeen = FALSE; /* Did we see the MIB name while walking mib2nut[]? */
 
-	upsdebugx(2, "SNMP UPS driver: entering %s(%s)", __func__, mib);
+	upsdebugx(2, "SNMP UPS driver: entering %s(%s) to detect "
+		"proper MIB for device [%s] (host %s)",
+		__func__, mib,
+		upsname ? upsname : device_name,
+		device_path // the "port" from config section is hostname/IP for networked drivers
+		);
 
 	/* First, try to match against sysOID, if no MIB was provided.
 	 * This should speed up init stage
@@ -1771,7 +1776,9 @@ bool_t load_mib2nut(const char *mib)
 		mibname = m2n->mib_name;
 		mibvers = m2n->mib_version;
 		alarms_info = m2n->alarms_info;
-		upsdebugx(1, "load_mib2nut: using %s mib", mibname);
+		upsdebugx(1, "%s: using %s MIB for device [%s] (host %s)",
+			__func__, mibname,
+			upsname ? upsname : device_name, device_path);
 		return TRUE;
 	}
 
@@ -1779,7 +1786,8 @@ bool_t load_mib2nut(const char *mib)
 	if (!mibIsAuto) {
 		if (mibSeen) {
 			fatalx(EXIT_FAILURE, "Requested 'mibs' value '%s' "
-				"did not match this device", mib);
+				"did not match this device [%s] (host %s)",
+				mib, upsname ? upsname : device_name, device_path);
 		} else {
 			/* String not seen during mib2nut[] walk -
 			 * and if we had no hits, we walked it all
@@ -1787,7 +1795,8 @@ bool_t load_mib2nut(const char *mib)
 			fatalx(EXIT_FAILURE, "Unknown 'mibs' value: %s", mib);
 		}
 	} else {
-		fatalx(EXIT_FAILURE, "No supported device detected");
+		fatalx(EXIT_FAILURE, "No supported device detected at [%s] (host %s)",
+			upsname ? upsname : device_name, device_path);
 	}
 
 	/* Should not get here thanks to fatalx() above, but need to silence a warning */

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -1712,7 +1712,7 @@ bool_t load_mib2nut(const char *mib)
 	bool_t mibIsAuto = (0 == strcmp(mib, "auto"));
 	bool_t mibSeen = FALSE; /* Did we see the MIB name while walking mib2nut[]? */
 
-	upsdebugx(2, "SNMP UPS driver: entering %s(%s) to detect "
+	upsdebugx(1, "SNMP UPS driver: entering %s(%s) to detect "
 		"proper MIB for device [%s] (host %s)",
 		__func__, mib,
 		upsname ? upsname : device_name,
@@ -1724,7 +1724,7 @@ bool_t load_mib2nut(const char *mib)
 	 * (Note: sysOID points the device main MIB entry point) */
 	if (mibIsAuto)
 	{
-		upsdebugx(1, "%s: trying the new match_sysoid() method", __func__);
+		upsdebugx(2, "%s: trying the new match_sysoid() method", __func__);
 		/* Retry at most 3 times, to maximise chances */
 		for (i = 0; i < 3 ; i++) {
 			if ((m2n = match_sysoid()) != NULL)
@@ -1741,7 +1741,7 @@ bool_t load_mib2nut(const char *mib)
 				/* "mib" is neither "auto" nor the name in mapping table */
 				continue;
 			}
-			upsdebugx(1, "%s: trying classic method with '%s' mib",
+			upsdebugx(2, "%s: trying classic method with '%s' mib",
 				__func__, mib2nut[i]->mib_name);
 
 			/* Device might not support this MIB, but we want to
@@ -1756,13 +1756,13 @@ bool_t load_mib2nut(const char *mib)
 
 			if (match_model_OID() != TRUE)
 			{
-				upsdebugx(2, "%s: testOID provided and doesn't match MIB '%s'!",
+				upsdebugx(3, "%s: testOID provided and doesn't match MIB '%s'!",
 					__func__, mib2nut[i]->mib_name);
 				snmp_info = NULL;
 				continue;
 			}
 			else
-				upsdebugx(2, "%s: testOID provided and matches MIB '%s'!",
+				upsdebugx(3, "%s: testOID provided and matches MIB '%s'!",
 					__func__, mib2nut[i]->mib_name);
 
 			/* MIB found */

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -1728,8 +1728,17 @@ bool_t load_mib2nut(const char *mib)
 			__func__, mib);
 		/* Retry at most 3 times, to maximise chances */
 		for (i = 0; i < 3 ; i++) {
+			upsdebugx(3, "%s: trying the new match_sysoid() method: attempt #%d",
+				__func__, (i+1));
 			if ((m2n = match_sysoid()) != NULL)
 				break;
+
+			if (m2n == NULL)
+				upsdebugx(3, "%s: failed with new match_sysoid() method",
+					__func__);
+			else
+				upsdebugx(3, "%s: found something with new match_sysoid() method",
+					__func__);
 		}
 	}
 
@@ -1740,9 +1749,12 @@ bool_t load_mib2nut(const char *mib)
 			/* Is there already a MIB name provided? */
 			if (!mibIsAuto && strcmp(mib, mib2nut[i]->mib_name)) {
 				/* "mib" is neither "auto" nor the name in mapping table */
+				upsdebugx(2, "%s: skip the \"%s\" entry which "
+					" is neither \"auto\" nor a name in the mapping table",
+					__func__, mib);
 				continue;
 			}
-			upsdebugx(2, "%s: trying classic method with '%s' mib",
+			upsdebugx(2, "%s: trying classic sysOID matching method with '%s' mib",
 				__func__, mib2nut[i]->mib_name);
 
 			/* Device might not support this MIB, but we want to


### PR DESCRIPTION
Messages logged by the driver are not always easily actionable, e.g. to cross-check the device accessibility ("oh, which IP was it?") by other tools like ping or snmp-walk. Now the debug trace should offer better visibility for troubleshooting.