### PR TITLE
Fightwarn: huawei-ups2000

### DIFF
--- a/drivers/huawei-ups2000.c
+++ b/drivers/huawei-ups2000.c
@@ -348,8 +348,15 @@ static void ups2000_device_identification(void)
 		}
 
 		/* step 3: check response CRC-16 */
-		crc16_recv = ident_response_end[0] << 8 | ident_response_end[1];
-		crc16_calc = crc16(ident_response, ident_response_len - IDENT_RESPONSE_CRC_LEN);
+		crc16_recv = (uint16_t)((uint16_t)(ident_response_end[0]) << 8) | (uint16_t)(ident_response_end[1]);
+		if (ident_response_len < IDENT_RESPONSE_CRC_LEN
+		|| (((uintmax_t)(ident_response_len) - IDENT_RESPONSE_CRC_LEN) > UINT16_MAX)
+		) {
+			fatalx(EXIT_FAILURE, "response header shorter than CRC "
+					     "or longer than UINT16_MAX!");
+		}
+
+		crc16_calc = crc16(ident_response, (uint16_t)(ident_response_len - IDENT_RESPONSE_CRC_LEN));
 		if (crc16_recv == crc16_calc) {
 			crc16_fail = 0;
 			break;

--- a/drivers/huawei-ups2000.c
+++ b/drivers/huawei-ups2000.c
@@ -412,10 +412,11 @@ static void ups2000_device_identification(void)
 		/* only one device is supported */
 		if (ups2000_ident[i].type == 0x87) {
 			/* so we assume 0x87 must be 1 */
-			ups_count = ups2000_ident[i].val[0] << 24 |
-				    ups2000_ident[i].val[1] << 16 |
-				    ups2000_ident[i].val[2] << 8  |
-				    ups2000_ident[i].val[3];
+			ups_count =
+				(uint32_t)(ups2000_ident[i].val[0]) << 24 |
+				(uint32_t)(ups2000_ident[i].val[1]) << 16 |
+				(uint32_t)(ups2000_ident[i].val[2]) << 8  |
+				(uint32_t)(ups2000_ident[i].val[3]);
 		}
 		if (ups2000_ident[i].type == 0x88) {
 			/*

--- a/drivers/huawei-ups2000.c
+++ b/drivers/huawei-ups2000.c
@@ -913,7 +913,7 @@ static struct {
 		"UPS has shutdown, bypass output was overload and exceeded "
 		"time limit.",
 	},
-	{ false, -1, -1, -1, -1, -1, -1, NULL, NULL, NULL }
+	{ false, 0, -1, -1, -1, -1, -1, NULL, NULL, NULL }
 };
 
 

--- a/drivers/huawei-ups2000.c
+++ b/drivers/huawei-ups2000.c
@@ -1871,14 +1871,17 @@ static size_t ups2000_read_serial(uint8_t *buf, size_t buf_len)
 
 	while (buf_len > 0) {
 		bytes = ser_get_buf(upsfd, buf, buf_len, 1, 0);
-		if (bytes == -1)
+		if (bytes < 0)
 			return 0;      /* read failure */
 		else if (bytes == 0)
 			return total;  /* nothing to read */
 
-		total += bytes;        /* increment byte counter */
-		buf += bytes;          /* advance buffer position */
-		buf_len -= bytes;      /* decrement limiter */
+		total += (size_t)bytes;        /* increment byte counter */
+		buf += bytes;                  /* advance buffer position */
+		if ((size_t)bytes > buf_len) {
+			fatalx(EXIT_FAILURE, "ups2000_read_serial() read too much!");
+		}
+		buf_len -= (size_t)bytes;      /* decrement limiter */
 	}
 	return 0;  /* buffer exhaustion */
 }

--- a/drivers/huawei-ups2000.c
+++ b/drivers/huawei-ups2000.c
@@ -602,8 +602,8 @@ static int ups2000_update_info(void)
 
 	for (i = 0; ups2000_var[i].name != NULL; i++) {
 		uint16_t reg_id = ups2000_var[i].reg;
-		uint8_t page = reg_id / 1000 - 1;
-		uint8_t idx = reg_id % 1000;
+		uint8_t page = (uint8_t)(reg_id / 1000 - 1);
+		uint8_t idx =  (uint8_t)(reg_id % 1000);
 		uint32_t val;
 		bool invalid = 0;
 

--- a/drivers/huawei-ups2000.c
+++ b/drivers/huawei-ups2000.c
@@ -163,7 +163,7 @@ static int ups2000_update_status(void);
 static int ups2000_update_alarm(void);
 static int ups2000_update_timers(void);
 static void ups2000_device_identification(void);
-static int ups2000_read_serial(uint8_t *buf, size_t buf_len);
+static size_t ups2000_read_serial(uint8_t *buf, size_t buf_len);
 static int ups2000_read_registers(modbus_t *ctx, int addr, int nb, uint16_t *dest);
 static int ups2000_write_register(modbus_t *ctx, int addr, uint16_t val);
 static int ups2000_write_registers(modbus_t *ctx, int addr, int nb, uint16_t *src);
@@ -1853,7 +1853,7 @@ static time_t time_seek(time_t t, int seconds)
  * ser_get_buf_let() requires a precalculated length, necessiates
  * our own read function.
  */
-static int ups2000_read_serial(uint8_t *buf, size_t buf_len)
+static size_t ups2000_read_serial(uint8_t *buf, size_t buf_len)
 {
 	ssize_t bytes = 0;
 	size_t total = 0;

--- a/drivers/huawei-ups2000.c
+++ b/drivers/huawei-ups2000.c
@@ -639,8 +639,20 @@ static int ups2000_update_info(void)
 			return 1;
 		}
 
+#ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_NONLITERAL
+#pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_FORMAT_NONLITERAL
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_FORMAT_SECURITY
+#pragma GCC diagnostic ignored "-Wformat-security"
+#endif
 		dstate_setinfo(ups2000_var[i].name, ups2000_var[i].fmt,
 			       (float) val / ups2000_var[i].scaling);
+#ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_NONLITERAL
+#pragma GCC diagnostic pop
+#endif
 	}
 	return 0;
 }

--- a/drivers/huawei-ups2000.c
+++ b/drivers/huawei-ups2000.c
@@ -301,14 +301,14 @@ static void ups2000_device_identification(void)
 		0x2B, 0x0E, 0x03, 0x03, 0x00, 0x00, 0x02,
 	};
 
-	bool serial_fail;  /* unable to read from serial */
+	bool serial_fail = 0;  /* unable to read from serial */
 	uint16_t crc16_recv, crc16_calc;  /* resp CRC */
-	bool crc16_fail;  /* resp CRC failure */
+	bool crc16_fail = 0;  /* resp CRC failure */
 	uint32_t ups_count = 0;  /* number of UPS in the resp list */
 	uint8_t ident_response[IDENT_RESPONSE_MAX_LEN];  /* resp buf */
 	size_t ident_response_len;    /* buf len */
-	uint8_t *ident_response_end;  /* buf end marker (excluding CRC) */
-	uint8_t *ptr;  /* buf iteratior */
+	uint8_t *ident_response_end = NULL;  /* buf end marker (excluding CRC) */
+	uint8_t *ptr = NULL;  /* buf iteratior */
 
 	/* a desc string copied from ups2000_ident[] */
 	char *ups2000_ident_desc = NULL;
@@ -1906,7 +1906,7 @@ static int retry_status = RETRY_ENABLE;
 static int ups2000_read_registers(modbus_t *ctx, int addr, int nb, uint16_t *dest)
 {
 	int i;
-	int r;
+	int r = -1;
 
 	if (addr < 10000)
 		upslogx(LOG_ERR, "Invalid register read from %04d detected. "
@@ -1951,7 +1951,7 @@ static int ups2000_read_registers(modbus_t *ctx, int addr, int nb, uint16_t *des
 static int ups2000_write_registers(modbus_t *ctx, int addr, int nb, uint16_t *src)
 {
 	int i;
-	int r;
+	int r = -1;
 
 	if (addr < 10000)
 		upslogx(LOG_ERR, "Invalid register write to %04d detected. "

--- a/drivers/huawei-ups2000.c
+++ b/drivers/huawei-ups2000.c
@@ -1495,13 +1495,18 @@ static int instcmd(const char *cmd, const char *extra)
 
 	if (cmd_action->handler_func) {
 		/* handled by a function */
-		status = cmd_action->handler_func(cmd_action->reg1);
+		if (cmd_action->reg1 < 0) {
+			upslogx(LOG_WARNING, "instcmd: command [%s] reg1 is negative", cmd);
+			return STAT_INSTCMD_UNKNOWN;
+		} else {
+			status = cmd_action->handler_func((uint16_t)cmd_action->reg1);
+		}
 	}
-	else if (cmd_action->reg1 != -1 && cmd_action->val1 != -1) {
+	else if (cmd_action->reg1 >= 0 && cmd_action->val1 >= 0) {
 		/* handled by a register write */
 		int r = ups2000_write_register(modbus_ctx,
 					       10000 + cmd_action->reg1,
-					       cmd_action->val1);
+					       (uint16_t)cmd_action->val1);
 		if (r == 1)
 			status = STAT_INSTCMD_HANDLED;
 		else
@@ -1511,10 +1516,10 @@ static int instcmd(const char *cmd, const char *extra)
 		 * if the previous write succeeds and there is an additional
 		 * register to write.
 		 */
-		if (r == 1 && cmd_action->reg2 != -1 && cmd_action->val2 != -1) {
+		if (r == 1 && cmd_action->reg2 >= 0 && cmd_action->val2 >= 0) {
 			r = ups2000_write_register(modbus_ctx,
 						   10000 + cmd_action->reg2,
-						   cmd_action->val2);
+						   (uint16_t)cmd_action->val2);
 			if (r == 1)
 				status = STAT_INSTCMD_HANDLED;
 			else

--- a/drivers/huawei-ups2000.c
+++ b/drivers/huawei-ups2000.c
@@ -625,8 +625,8 @@ static int ups2000_update_info(void)
 				invalid = 1;
 			break;
 		case REG_UINT32:
-			val  = reg[page][idx] << 16;
-			val |= reg[page][idx + 1];
+			val  = (uint32_t)(reg[page][idx]) << 16;
+			val |= (uint32_t)(reg[page][idx + 1]);
 			if (val == REG_UINT32_INVALID)
 				invalid = 1;
 			break;

--- a/drivers/huawei-ups2000.c
+++ b/drivers/huawei-ups2000.c
@@ -96,7 +96,7 @@ static const char *supported_model[] = {
 #define UPS2000_IDENT_MAX_FIELDS 9
 #define UPS2000_IDENT_MAX_LEN 128
 #define UPS2000_IDENT_OFFSET
-struct {
+static struct {
 	uint8_t type;
 	uint8_t len;
 	uint8_t val[UPS2000_IDENT_MAX_LEN];
@@ -125,10 +125,10 @@ enum {
 	UPS2000_DESC_DEVICE_ID,    /* currently unused */
 	UPS2000_DESC_PARALLEL_ID   /* currently unused */
 };
-char ups2000_desc[UPS2000_DESC_MAX_FIELDS][UPS2000_DESC_MAX_LEN] = { { 0 } };
+static char ups2000_desc[UPS2000_DESC_MAX_FIELDS][UPS2000_DESC_MAX_LEN] = { { 0 } };
 
 /* global variable for modbus communication */
-modbus_t *modbus_ctx = NULL;
+static modbus_t *modbus_ctx = NULL;
 
 /*
  * How many seconds to wait before switching off/on/reboot the UPS?
@@ -1892,7 +1892,7 @@ enum {
 	RETRY_ENABLE,
 	RETRY_DISABLE_TEMPORARY
 };
-int retry_status = RETRY_ENABLE;
+static int retry_status = RETRY_ENABLE;
 
 
 /*

--- a/drivers/huawei-ups2000.c
+++ b/drivers/huawei-ups2000.c
@@ -313,7 +313,7 @@ static void ups2000_device_identification(void)
 	/* a desc string copied from ups2000_ident[] */
 	char *ups2000_ident_desc = NULL;
 	int i;
-	int r;
+	ssize_t r;
 
 	/* attempt to obtain a response header with valid CRC. */
 	for (i = 0; i < 3; i++) {

--- a/drivers/huawei-ups2000.c
+++ b/drivers/huawei-ups2000.c
@@ -2075,5 +2075,5 @@ static uint16_t crc16(uint8_t * buffer, uint16_t buffer_length)
 		crc_lo = table_crc_lo[i];
 	}
 
-	return (crc_hi << 8 | crc_lo);
+	return ((uint16_t)((uint16_t)(crc_hi) << 8) | (uint16_t)crc_lo);
 }


### PR DESCRIPTION
CC @biergaizi (so split from #1215 and earlier PRs with other similar fixes): Fixing CI warnings for the new huawei-ups2000 driver from PR #1198 and #954 for issue #1017 

````
$ (cd drivers/ && make -k huawei-ups2000.o)
depbase=`echo huawei-ups2000.o | sed 's|[^/]*$|.deps/&|;s|\.o$||'`;\
/usr/lib/ccache/clang-9 -DHAVE_CONFIG_H -I. -I../include   -I/export/home/jim/nut-DMF/tmp/include -I../include  -I/usr/include/neon   -I/usr/include/modbus -I/export/home/jim/nut-DMF/tmp/include -std=gnu17 -m64 -Wno-unknown-warning-option -D_REENTRANT -ferror-limit=0 -Wall -Wextra -Weverything -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -Wno-documentation -Wno-cast-qual -pedantic -Wno-float-conversion -Wno-double-promotion -Wno-implicit-float-conversion -Werror -MT huawei-ups2000.o -MD -MP -MF $depbase.Tpo -c -o huawei-ups2000.o huawei-ups2000.c &&\
mv -f $depbase.Tpo $depbase.Po
huawei-ups2000.c:128:6: error: no previous extern declaration for non-static variable 'ups2000_desc' [-Werror,-Wmissing-variable-declarations]
char ups2000_desc[UPS2000_DESC_MAX_FIELDS][UPS2000_DESC_MAX_LEN] = { { 0 } };
     ^
huawei-ups2000.c:128:1: note: declare 'static' if the variable is not intended to be used outside of this translation unit
char ups2000_desc[UPS2000_DESC_MAX_FIELDS][UPS2000_DESC_MAX_LEN] = { { 0 } };
^
huawei-ups2000.c:131:11: error: no previous extern declaration for non-static variable 'modbus_ctx' [-Werror,-Wmissing-variable-declarations]
modbus_t *modbus_ctx = NULL;
          ^
huawei-ups2000.c:131:1: note: declare 'static' if the variable is not intended to be used outside of this translation unit
modbus_t *modbus_ctx = NULL;
^
huawei-ups2000.c:329:24: error: implicit conversion changes signedness: 'int' to 'size_t' (aka 'unsigned long') [-Werror,-Wsign-conversion]
                ident_response_len = ups2000_read_serial(ident_response, IDENT_RESPONSE_MAX_LEN);
                                   ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
huawei-ups2000.c:351:43: error: implicit conversion loses integer precision: 'int' to 'uint16_t' (aka 'unsigned short') [-Werror,-Wimplicit-int-conversion]
                crc16_recv = ident_response_end[0] << 8 | ident_response_end[1];
                           ~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
huawei-ups2000.c:352:57: error: implicit conversion loses integer precision: 'unsigned long' to 'uint16_t' (aka 'unsigned short') [-Werror,-Wimplicit-int-conversion]
                crc16_calc = crc16(ident_response, ident_response_len - IDENT_RESPONSE_CRC_LEN);
                             ~~~~~                 ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
huawei-ups2000.c:410:39: error: implicit conversion changes signedness: 'int' to 'uint32_t' (aka 'unsigned int') [-Werror,-Wsign-conversion]
                                    ups2000_ident[i].val[2] << 8  |
                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
huawei-ups2000.c:324:7: error: implicit conversion loses integer precision: 'ssize_t' (aka 'long') to 'int' [-Werror,-Wshorten-64-to-32]
                r = ser_send_buf(upsfd, ident_req, IDENT_REQUEST_LEN);
                  ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
huawei-ups2000.c:371:2: error: variable 'ptr' may be uninitialized when used here [-Werror,-Wconditional-uninitialized]
        ptr += IDENT_RESPONSE_HEADER_LEN;
        ^~~
huawei-ups2000.c:311:14: note: initialize the variable 'ptr' to silence this warning
        uint8_t *ptr;  /* buf iteratior */
                    ^
                     = NULL
huawei-ups2000.c:378:17: error: variable 'ident_response_end' may be uninitialized when used here [-Werror,-Wconditional-uninitialized]
                if (ptr + 2 > ident_response_end)
                              ^~~~~~~~~~~~~~~~~~
huawei-ups2000.c:310:29: note: initialize the variable 'ident_response_end' to silence this warning
        uint8_t *ident_response_end;  /* buf end marker (excluding CRC) */
                                   ^
                                    = NULL
huawei-ups2000.c:364:6: error: variable 'crc16_fail' may be uninitialized when used here [-Werror,-Wconditional-uninitialized]
        if (crc16_fail)
            ^~~~~~~~~~
huawei-ups2000.c:306:17: note: initialize the variable 'crc16_fail' to silence this warning
        bool crc16_fail;  /* resp CRC failure */
                       ^
                        = false
huawei-ups2000.c:361:6: error: variable 'serial_fail' may be uninitialized when used here [-Werror,-Wconditional-uninitialized]
        if (serial_fail)
            ^~~~~~~~~~~
huawei-ups2000.c:304:18: note: initialize the variable 'serial_fail' to silence this warning
        bool serial_fail;  /* unable to read from serial */
                        ^
                         = false
huawei-ups2000.c:598:24: error: implicit conversion loses integer precision: 'int' to 'uint8_t' (aka 'unsigned char') [-Werror,-Wimplicit-int-conversion]
                uint8_t idx = reg_id % 1000;
                        ~~~   ~~~~~~~^~~~~~
huawei-ups2000.c:620:26: error: implicit conversion changes signedness: 'int' to 'uint32_t' (aka 'unsigned int') [-Werror,-Wsign-conversion]
                        val  = reg[page][idx] << 16;
                             ~ ~~~~~~~~~~~~~~~^~~~~
huawei-ups2000.c:634:39: error: format string is not a string literal [-Werror,-Wformat-nonliteral]
                dstate_setinfo(ups2000_var[i].name, ups2000_var[i].fmt,
                                                    ^~~~~~~~~~~~~~~~~~
huawei-ups2000.c:916:11: error: implicit conversion changes signedness: 'int' to 'uint16_t' (aka 'unsigned short') [-Werror,-Wsign-conversion]
        { false, -1, -1, -1, -1, -1, -1, NULL, NULL, NULL }
        ~        ^~
huawei-ups2000.c:968:22: error: implicit conversion changes signedness: 'int' to 'unsigned long' [-Werror,-Wsign-conversion]
                        all_alarms_len += snprintf(alarm_buf, 128, "(ID %02d/%02d): %s!",
                                       ~~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
huawei-ups2000.c:1045:21: error: implicit conversion changes signedness: 'int' to 'unsigned long' [-Werror,-Wsign-conversion]
                all_alarms_len += snprintf(alarm_buf, 128, "Check log for details!");
                               ~~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
huawei-ups2000.c:1465:49: error: implicit conversion changes signedness: 'const int16_t' (aka 'const short') to 'uint16_t' (aka 'unsigned short') [-Werror,-Wsign-conversion]
                status = cmd_action->handler_func(cmd_action->reg1);
                         ~~~~~~~~~~               ~~~~~~~~~~~~^~~~
huawei-ups2000.c:1471:25: error: implicit conversion changes signedness: 'const int16_t' (aka 'const short') to 'uint16_t' (aka 'unsigned short') [-Werror,-Wsign-conversion]
                                               cmd_action->val1);
                                               ~~~~~~~~~~~~^~~~
huawei-ups2000.c:1484:22: error: implicit conversion changes signedness: 'const int16_t' (aka 'const short') to 'uint16_t' (aka 'unsigned short') [-Werror,-Wsign-conversion]
                                                   cmd_action->val2);
                                                   ~~~~~~~~~~~~^~~~
huawei-ups2000.c:1871:12: error: implicit conversion changes signedness: 'ssize_t' (aka 'long') to 'unsigned long' [-Werror,-Wsign-conversion]
                total += bytes;        /* increment byte counter */
                      ~~ ^~~~~
huawei-ups2000.c:1873:14: error: implicit conversion changes signedness: 'ssize_t' (aka 'long') to 'unsigned long' [-Werror,-Wsign-conversion]
                buf_len -= bytes;      /* decrement limiter */
                        ~~ ^~~~~
huawei-ups2000.c:1869:11: error: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int' [-Werror,-Wshorten-64-to-32]
                        return total;  /* nothing to read */
                        ~~~~~~ ^~~~~
huawei-ups2000.c:1895:5: error: no previous extern declaration for non-static variable 'retry_status' [-Werror,-Wmissing-variable-declarations]
int retry_status = RETRY_ENABLE;
    ^
huawei-ups2000.c:1895:1: note: declare 'static' if the variable is not intended to be used outside of this translation unit
int retry_status = RETRY_ENABLE;
^
huawei-ups2000.c:1947:9: error: variable 'r' may be uninitialized when used here [-Werror,-Wconditional-uninitialized]
        return r;
               ^
huawei-ups2000.c:1909:7: note: initialize the variable 'r' to silence this warning
        int r;
             ^
              = 0
huawei-ups2000.c:1978:9: error: variable 'r' may be uninitialized when used here [-Werror,-Wconditional-uninitialized]
        return r;
               ^
huawei-ups2000.c:1954:7: note: initialize the variable 'r' to silence this warning
        int r;
             ^
              = 0
huawei-ups2000.c:2078:22: error: implicit conversion loses integer precision: 'int' to 'uint16_t' (aka 'unsigned short') [-Werror,-Wimplicit-int-conversion]
        return (crc_hi << 8 | crc_lo);
        ~~~~~~  ~~~~~~~~~~~~^~~~~~~~
huawei-ups2000.c:103:3: error: no previous extern declaration for non-static variable 'ups2000_ident' [-Werror,-Wmissing-variable-declarations]
} ups2000_ident[UPS2000_IDENT_MAX_FIELDS];
  ^
huawei-ups2000.c:99:1: note: declare 'static' if the variable is not intended to be used outside of this translation unit
struct {
^
28 errors generated.
make: *** [Makefile:1756: huawei-ups2000.o] Error 1
````

I don't agree that all of those make sense (e.g. initialization of variables does seem like a false-positive alert), but many of those do point to mismatches.

Anyhow, these warnings would be a blocker after dialing up the default level of warnings in CI, which I'm getting close to for the goals of "Fightwarn effort" #823, so gotta get fixed or quiesced otherwise.