### PR TITLE
Update snmp-ups authproto/privproto docs

### DIFF
--- a/docs/man/nut-scanner.txt
+++ b/docs/man/nut-scanner.txt
@@ -116,13 +116,13 @@ Set the 'security level' used for SNMPv3 messages. Allowed values are: noAuthNoP
 Set the 'security name' used for authenticated SNMPv3 messages. This parameter is mandatory if you set 'security level'.
 
 *-w* | *--authProtocol* 'authentication protocol'::
-Set the 'authentication protocol' used for authenticated SNMPv3 messages. Allowed values are MD5 or SHA. Default value is MD5.
+Set the 'authentication protocol' used for authenticated SNMPv3 messages. Allowed values are MD5, SHA, SHA256, SHA384 or SHA512. Default value is MD5.
 
 *-W* | *--authPassword* 'authentication pass phrase'::
 Set the 'authentication pass phrase' used for authenticated SNMPv3 messages. This parameter is mandatory if you set 'security level' to authNoPriv or authPriv.
 
 *-x* | *--privProtocol* 'privacy protocol'::
-Set the 'privacy protocol' used for encrypted SNMPv3 messages. Allowed values are DES or AES. Default value is DES.
+Set the 'privacy protocol' used for encrypted SNMPv3 messages. Allowed values are DES, AES, AES192 or AES256. Default value is DES.
 
 *-X* | *--privPassword* 'privacy pass phrase'::
 Set the 'privacy pass phrase' used for encrypted SNMPv3 messages. This parameter is mandatory if you set 'security level' to authPriv.

--- a/docs/man/nut-scanner.txt
+++ b/docs/man/nut-scanner.txt
@@ -116,13 +116,13 @@ Set the 'security level' used for SNMPv3 messages. Allowed values are: noAuthNoP
 Set the 'security name' used for authenticated SNMPv3 messages. This parameter is mandatory if you set 'security level'.
 
 *-w* | *--authProtocol* 'authentication protocol'::
-Set the 'authentication protocol' used for authenticated SNMPv3 messages. Allowed values are MD5, SHA, SHA256, SHA384 or SHA512. Default value is MD5.
+Set the 'authentication protocol' used for authenticated SNMPv3 messages. Allowed values are MD5, SHA, SHA256, SHA384 or SHA512 (depending on Net-SNMP library capabilities; check help of the `nut-scanner` binary program for the run-time supported list). Default value is MD5.
 
 *-W* | *--authPassword* 'authentication pass phrase'::
 Set the 'authentication pass phrase' used for authenticated SNMPv3 messages. This parameter is mandatory if you set 'security level' to authNoPriv or authPriv.
 
 *-x* | *--privProtocol* 'privacy protocol'::
-Set the 'privacy protocol' used for encrypted SNMPv3 messages. Allowed values are DES, AES, AES192 or AES256. Default value is DES.
+Set the 'privacy protocol' used for encrypted SNMPv3 messages. Allowed values are DES, AES, AES192 or AES256 (depending on Net-SNMP library capabilities; check help of the `nut-scanner` binary program for the run-time supported list). Default value is DES.
 
 *-X* | *--privPassword* 'privacy pass phrase'::
 Set the 'privacy pass phrase' used for encrypted SNMPv3 messages. This parameter is mandatory if you set 'security level' to authPriv.

--- a/docs/man/snmp-ups.txt
+++ b/docs/man/snmp-ups.txt
@@ -137,11 +137,15 @@ Set the privacy pass phrase used for encrypted SNMPv3 messages (no default)
 
 *authProtocol*='value'::
 Set the authentication protocol (MD5, SHA, SHA256, SHA384 or SHA512) used for
-authenticated SNMPv3 messages (default=MD5)
+authenticated SNMPv3 messages (default=MD5). Note that the exact protocol list
+depends on Net-SNMP library capabilities; check help of the `snmp-ups` binary
+program for the run-time supported list.
 
 *privProtocol*='value'::
 Set the privacy protocol (DES, AES, AES192 or AES256) used for encrypted SNMPv3
-messages (default=DES)
+messages (default=DES). Note that the exact protocol list depends on Net-SNMP
+library capabilities; check help of the `snmp-ups` binary program for the
+run-time supported list.
 
 REQUIREMENTS
 ------------

--- a/docs/man/snmp-ups.txt
+++ b/docs/man/snmp-ups.txt
@@ -136,12 +136,12 @@ Set the authentication pass phrase used for authenticated SNMPv3 messages
 Set the privacy pass phrase used for encrypted SNMPv3 messages (no default)
 
 *authProtocol*='value'::
-Set the authentication protocol (MD5 or SHA) used for authenticated SNMPv3
-messages (default=MD5)
+Set the authentication protocol (MD5, SHA, SHA256, SHA384 or SHA512) used for
+authenticated SNMPv3 messages (default=MD5)
 
 *privProtocol*='value'::
-Set the privacy protocol (DES or AES) used for encrypted SNMPv3 messages
-(default=DES)
+Set the privacy protocol (DES, AES, AES192 or AES256) used for encrypted SNMPv3
+messages (default=DES)
 
 REQUIREMENTS
 ------------


### PR DESCRIPTION
Apply https://github.com/42ity/nut/pull/160 to list the protocols recently added with PRs #1165 and #1172 (and mention their availability depends on build conditions - libnetsnmp version)