### PR TITLE
Move check for LogMax encoding error to parsing of report description

### DIFF
--- a/drivers/hidparser.c
+++ b/drivers/hidparser.c
@@ -312,20 +312,24 @@ static int HIDParse(HIDParser_t *pParser, HIDData_t *pData)
 
 		case ITEM_LOG_MAX :
 			pParser->Data.LogMax = FormatValue(pParser->Value, ItemSize[pParser->Item & SIZE_MASK]);
-                        /* HACK: If treating the value as signed (FormatValue(...)) results in a LogMax that is
+			/* HACK: If treating the value as signed (FormatValue(...)) results in a LogMax that is
 			 * less than the LogMin value then it is likely that the LogMax value has been
 			 * incorrectly encoded by the UPS firmware (field too short and overflowed into sign
 			 * bit).  In that case, reinterpret it as an unsigned number and log the problem.
 			 * This hack is not correct in the sense that it only looks at the LogMin value for
 			 * this item, whereas the HID spec says that Logical values persist in global state.
 			 */
-                        if (pParser->Data.LogMax < pParser->Data.LogMin) {
-                          upslogx(LOG_WARNING, "%s: LogMax is less than LogMin. "
-                                  "Vendor HID report descriptor may be incorrect; "
-                                  "interpreting LogMax %ld as %u in ReportID: 0x%02x", __func__,
-				  pParser->Data.LogMax, pParser->Value, pParser->Data.ReportID);
-                          pParser->Data.LogMax = (long) pParser->Value;
-                        }
+			if (pParser->Data.LogMax < pParser->Data.LogMin) {
+				upslogx(LOG_WARNING,
+					"%s: LogMax is less than LogMin. "
+					"Vendor HID report descriptor may be incorrect; "
+					"interpreting LogMax %ld as %u in ReportID: 0x%02x",
+					__func__,
+					pParser->Data.LogMax,
+					pParser->Value,
+					pParser->Data.ReportID);
+				pParser->Data.LogMax = (long) pParser->Value;
+			}
 			break;
 
 		case ITEM_PHY_MIN :

--- a/drivers/hidparser.c
+++ b/drivers/hidparser.c
@@ -312,6 +312,20 @@ static int HIDParse(HIDParser_t *pParser, HIDData_t *pData)
 
 		case ITEM_LOG_MAX :
 			pParser->Data.LogMax = FormatValue(pParser->Value, ItemSize[pParser->Item & SIZE_MASK]);
+                        /* HACK: If treating the value as signed (FormatValue(...)) results in a LogMax that is
+			 * less than the LogMin value then it is likely that the LogMax value has been
+			 * incorrectly encoded by the UPS firmware (field too short and overflowed into sign
+			 * bit).  In that case, reinterpret it as an unsigned number and log the problem.
+			 * This hack is not correct in the sense that it only looks at the LogMin value for
+			 * this item, whereas the HID spec says that Logical values persist in global state.
+			 */
+                        if (pParser->Data.LogMax < pParser->Data.LogMin) {
+                          upslogx(LOG_WARNING, "%s: LogMax is less than LogMin. "
+                                  "Vendor HID report descriptor may be incorrect; "
+                                  "interpreting LogMax %ld as %u in ReportID: 0x%02x", __func__,
+				  pParser->Data.LogMax, pParser->Value, pParser->Data.ReportID);
+                          pParser->Data.LogMax = (long) pParser->Value;
+                        }
 			break;
 
 		case ITEM_PHY_MIN :
@@ -438,7 +452,7 @@ void GetValue(const unsigned char *Buf, HIDData_t *pData, long *pValue)
 
 	int	Weight, Bit;
 	unsigned long mask, signbit, magMax, magMin;
-	long	value = 0, range;
+	long	value = 0;
 
 	Bit = pData->Offset + 8;	/* First byte of report is report ID */
 
@@ -448,17 +462,6 @@ void GetValue(const unsigned char *Buf, HIDData_t *pData, long *pValue)
 		if(State) {
 			value += (1L << Weight);
 		}
-	}
-
-	range = pData->LogMax - pData->LogMin + 1;
-	if (range <= 0) {
-		/* makes no sense, give up */
-		*pValue = value;
-		/* Discussion: https://github.com/networkupstools/nut/pull/1138 */
-		upslogx(LOG_ERR, "ERROR in %s: LogMin is greater than LogMax, "
-			"possibly vendor HID is incorrect on device side; "
-			"skipping evaluation of these constraints", __func__);
-		return;
 	}
 
 	/* translate Value into a signed/unsigned value in the range


### PR DESCRIPTION
At least one UPS [APC Back-UPS BX1600MI FW:294201G -302201G] is known
to have encoding errors in its USB HID report description such that a
conforming interpretation of the encoded LogicalMaximum value
indicates that it is -1 and the resulting LogicalMin..LogicalMax range
is 0..-1.

The actual report values read are correctly encoded.  Rather than log
a range error each time a value is read we can detect the encoding
error when the report description is read (once, at startup) and
adjust for the encoding error at that time.

Closes #1208 