### PR TITLE
Add a short sleep between fallback instcmds in usbhid-ups.

### DIFF
--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -566,6 +566,11 @@ int instcmd(const char *cmdname, const char *extradata)
 				return ret;
 			}
 
+			/* Some UPS's (e.g. TrippLive AVR750U w/ 3024 protocol) don't accept
+			 * commands that arrive too rapidly, so add this arbitary wait,
+			 * which has proven to be long enough to avoid this problem in practice */
+			usleep(125000);
+
 			return instcmd("load.off.delay", dstate_getinfo("ups.delay.shutdown"));
 		}
 
@@ -581,6 +586,11 @@ int instcmd(const char *cmdname, const char *extradata)
 			if (ret != STAT_INSTCMD_HANDLED) {
 				return ret;
 			}
+
+			/* Some UPS's (e.g. TrippLive AVR750U w/ 3024 protocol) don't accept
+			 * commands that arrive too rapidly, so add this arbitary wait,
+			 * which has proven to be long enough to avoid this problem in practice */
+			usleep(125000);
 
 			return instcmd("load.off.delay", dstate_getinfo("ups.delay.shutdown"));
 		}


### PR DESCRIPTION
For some devices, missing instcmds are emulated by calling two
instcmds that do exist in sequence. For some devices, when these
commands arrive too quickly, they are not properly processed. (One,
both, or neither of the commands are acted upon.)

Adding a 1/8th-second delay (125,000 microseconds) between the two
instcmds that make up the fallback command has worked to make the
TrippLite AVR750U (new version with the 3024 productId/protocol)
behave consistently when using the fallback commands (shutdown.return
and shutdown.stayoff). This delay is also short enough that it seems
unlikely to cause a problem for any devices which don't exhibit
this issue.