### PR TITLE
Fightwarn, style and CI recipe revisions

### DIFF
--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -26,6 +26,7 @@ import org.nut.dynamatrix.*;
     dynacfgPipeline.disableSlowBuildAutotools = false
     dynacfgPipeline.disableSlowBuildCIBuild = false
     dynacfgPipeline.disableSlowBuildCIBuildExperimental = false
+    dynacfgPipeline.disableSlowBuildCIBuildExperimentalANSI = true
 
     // The NUT CI farm offers a few other architectures in containers backed
     // by QEMU virtual CPUs. Running builds in these is expensive (takes a
@@ -884,7 +885,42 @@ set | sort -n """
 
                 dynamatrixAxesVirtualLabelsMap: [
                     'BITS': [32, 64],
-                    'CSTDVERSION_${KEY}': [ ['c': '99', 'cxx': '98'], ['c': '99', 'cxx': '11'], ['c': '11', 'cxx': '11'], ['c': '17', 'cxx': '17'], 'ansi' ],
+                    'CSTDVERSION_${KEY}': [ ['c': '99', 'cxx': '98'], ['c': '99', 'cxx': '11'], ['c': '11', 'cxx': '11'], ['c': '17', 'cxx': '17'] ],
+                    'CSTDVARIANT': ['c'],
+                    ],
+                dynamatrixAxesCommonEnv: [],
+                dynamatrixAxesCommonEnvCartesian: [
+                    ['LANG=C','LC_ALL=C','TZ=UTC', 'BUILD_TYPE=default-all-errors'],
+                    [ ['BUILD_WARNFATAL=yes','BUILD_WARNOPT=hard'], ['BUILD_WARNFATAL=no','BUILD_WARNOPT=minimal'] ]
+                    ],
+                allowedFailure: [
+                    dynacfgPipeline.axisCombos_STRICT_C,
+                    [~/BUILD_WARNOPT=hard/]
+                    ],
+                runAllowedFailure: true,
+                mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs language standards as centrally defined!
+                excludeCombos: dynacfgPipeline.excludeCombos_DEFAULT_CPPUNIT + [
+                    dynacfgPipeline.axisCombos_GNU_C,
+                    dynacfgPipeline.axisCombos_WINDOWS
+                    ]
+                ], body)
+            }, // getParStages
+        'bodyParStages': dynacfgPipeline.slowBuildDefaultBody_ci_build
+        ] // one slowBuild filter configuration
+
+        ,[name: 'Strict ANSI C (C89/C90) standard builds on non-Windows platforms, without distcheck and docs (allowed to fail)',
+         disabled: dynacfgPipeline.disableSlowBuildCIBuildExperimentalANSI,
+         branchRegexSource: ~/^(PR-.+|.*fightwarn.*)$/,
+         branchRegexTarget: ~/fightwarn/,
+         appliesToChangedFilesRegex: dynacfgPipeline.appliesToChangedFilesRegex_C,
+         'getParStages': { dynamatrix, Closure body ->
+            return dynamatrix.generateBuild([
+                requiredNodelabels: [],
+                excludedNodelabels: [],
+
+                dynamatrixAxesVirtualLabelsMap: [
+                    'BITS': [32, 64],
+                    'CSTDVERSION_${KEY}': [ 'ansi' ],
                     'CSTDVARIANT': ['c'],
                     ],
                 dynamatrixAxesCommonEnv: [],

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -640,6 +640,9 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
             fi
             ;;
         "default-all-errors")
+            # This mode aims to build as many codepaths (to collect warnings)
+            # as it can, so help it enable (require) as many options as we can.
+
             # Do not build the docs as we are interested in binary code
             CONFIG_OPTS+=("--with-doc=skip")
             # Enable as many binaries to build as current worker setup allows
@@ -860,6 +863,9 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
             exit $?
             ;;
         "default-all-errors")
+            # This mode aims to build as many codepaths (to collect warnings)
+            # as it can, so help it enable (require) as many options as we can.
+
             # Try to run various build scenarios to collect build errors
             # (no checks here) as configured further by caller's choice
             # of BUILD_WARNFATAL and/or BUILD_WARNOPT envvars above.

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -271,7 +271,7 @@ build_to_only_catch_errors_target() {
     fi
 
     ( echo "`date`: Starting the parallel build attempt (quietly to build what we can)..."; \
-      $CI_TIME $MAKE VERBOSE=0 -k $PARMAKE_FLAGS "$@" >/dev/null 2>&1 && echo "`date`: SUCCESS" ; ) || \
+      $CI_TIME $MAKE VERBOSE=0 V=0 -s -k $PARMAKE_FLAGS "$@" >/dev/null 2>&1 && echo "`date`: SUCCESS" ; ) || \
     ( echo "`date`: Starting the sequential build attempt (to list remaining files with errors considered fatal for this build configuration)..."; \
       $CI_TIME $MAKE VERBOSE=1 "$@" -k ) || return $?
     return 0
@@ -281,7 +281,7 @@ build_to_only_catch_errors() {
     build_to_only_catch_errors_target all || return $?
 
     echo "`date`: Starting a '$MAKE check' for quick sanity test of the products built with the current compiler and standards"
-    $CI_TIME $MAKE VERBOSE=0 check \
+    $CI_TIME $MAKE VERBOSE=0 V=0 -s check \
     && echo "`date`: SUCCESS" \
     || return $?
 
@@ -833,14 +833,14 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
             # Note: no PARMAKE_FLAGS here - better have this output readably
             # ordered in case of issues (in sequential replay below).
             ( echo "`date`: Starting the quiet build attempt for target $BUILD_TYPE..." >&2
-              $CI_TIME $MAKE -s VERBOSE=0 SPELLCHECK_ERROR_FATAL=yes -k $PARMAKE_FLAGS spellcheck >/dev/null 2>&1 \
+              $CI_TIME $MAKE -s VERBOSE=0 V=0 -s SPELLCHECK_ERROR_FATAL=yes -k $PARMAKE_FLAGS spellcheck >/dev/null 2>&1 \
               && echo "`date`: SUCCEEDED the spellcheck" >&2
             ) || \
             ( echo "`date`: FAILED something in spellcheck above; re-starting a verbose build attempt to give more context first:" >&2
               $CI_TIME $MAKE -s VERBOSE=1 SPELLCHECK_ERROR_FATAL=yes spellcheck
               # Make end of log useful:
               echo "`date`: FAILED something in spellcheck above; re-starting a non-verbose build attempt to just summarize now:" >&2
-              $CI_TIME $MAKE -s VERBOSE=0 SPELLCHECK_ERROR_FATAL=yes spellcheck
+              $CI_TIME $MAKE -s VERBOSE=0 V=0 SPELLCHECK_ERROR_FATAL=yes spellcheck
             )
             exit $?
             ;;

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -241,8 +241,8 @@ configure_nut() {
       [ -z "${CI_SHELL_IS_FLAKY-}" ] || echo "=== CI_SHELL_IS_FLAKY='$CI_SHELL_IS_FLAKY'"
       $CI_TIME $CONFIGURE_SCRIPT "${CONFIG_OPTS[@]}" \
       && return 0 \
-      || { RES=$?
-        echo "FAILED ($RES) to configure nut, will dump config.log in a second to help troubleshoot CI" >&2
+      || { RES_CFG=$?
+        echo "FAILED ($RES_CFG) to configure nut, will dump config.log in a second to help troubleshoot CI" >&2
         echo "    (or press Ctrl+C to abort now if running interactively)" >&2
         sleep 5
         echo "=========== DUMPING config.log :"
@@ -254,12 +254,12 @@ configure_nut() {
             # Real-life story from the trenches: there are weird systems
             # which fail ./configure in random spots not due to script's
             # quality. Then we'd just loop here.
-            echo "WOULD BE FATAL: FAILED ($RES) to ./configure ${CONFIG_OPTS[*]} -- but asked to loop trying" >&2
+            echo "WOULD BE FATAL: FAILED ($RES_CFG) to ./configure ${CONFIG_OPTS[*]} -- but asked to loop trying" >&2
         else
-            echo "FATAL: FAILED ($RES) to ./configure ${CONFIG_OPTS[*]}" >&2
+            echo "FATAL: FAILED ($RES_CFG) to ./configure ${CONFIG_OPTS[*]}" >&2
             echo "If you are sure this is not a fault of scripting or config option, try" >&2
             echo "    CI_SHELL_IS_FLAKY=true $0"
-            exit $RES
+            exit $RES_CFG
         fi
        }
     done
@@ -871,7 +871,7 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
             # of BUILD_WARNFATAL and/or BUILD_WARNOPT envvars above.
             # Note this is one scenario where we did not configure_nut()
             # in advance.
-            RES=0
+            RES_ALLERRORS=0
             FAILED=""
             SUCCEEDED=""
             BUILDSTODO=0
@@ -937,7 +937,7 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
                         )
                         ;;
                 esac || {
-                    RES=$?
+                    RES_ALLERRORS=$?
                     FAILED="${FAILED} NUT_SSL_VARIANT=${NUT_SSL_VARIANT}[configure]"
                     # TOTHINK: Do we want to try clean-up if we likely have no Makefile?
                     BUILDSTODO="`expr $BUILDSTODO - 1`" || [ "$BUILDSTODO" = "0" ] || break
@@ -948,7 +948,7 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
                 build_to_only_catch_errors && {
                     SUCCEEDED="${SUCCEEDED} NUT_SSL_VARIANT=${NUT_SSL_VARIANT}[build]"
                 } || {
-                    RES=$?
+                    RES_ALLERRORS=$?
                     FAILED="${FAILED} NUT_SSL_VARIANT=${NUT_SSL_VARIANT}[build]"
                 }
 
@@ -972,7 +972,7 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
                                 SUCCEEDED="${SUCCEEDED} NUT_SSL_VARIANT=${NUT_SSL_VARIANT}[dist_clean]"
                             fi
                         } || {
-                            RES=$?
+                            RES_ALLERRORS=$?
                             FAILED="${FAILED} NUT_SSL_VARIANT=${NUT_SSL_VARIANT}[dist_clean]"
                         }
                     else
@@ -981,7 +981,7 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
                                 SUCCEEDED="${SUCCEEDED} NUT_SSL_VARIANT=${NUT_SSL_VARIANT}[maintainer_clean]"
                             fi
                         } || {
-                            RES=$?
+                            RES_ALLERRORS=$?
                             FAILED="${FAILED} NUT_SSL_VARIANT=${NUT_SSL_VARIANT}[maintainer_clean]"
                         }
                     fi
@@ -1005,7 +1005,7 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
                         SUCCEEDED="${SUCCEEDED} [final_maintainer_clean]"
                     fi
                 } || {
-                    RES=$?
+                    RES_ALLERRORS=$?
                     FAILED="${FAILED} [final_maintainer_clean]"
                 }
                 echo "=== Completed sandbox maintainer-cleanup-check after all builds"
@@ -1015,9 +1015,9 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
                 echo "SUCCEEDED build(s) with:${SUCCEEDED}" >&2
             fi
 
-            if [ "$RES" != 0 ]; then
+            if [ "$RES_ALLERRORS" != 0 ]; then
                 # Leading space is included in FAILED
-                echo "FAILED build(s) with:${FAILED}" >&2
+                echo "FAILED build(s) with code ${RES_ALLERRORS}:${FAILED}" >&2
             fi
 
             echo "Initially estimated ${BUILDSTODO_INITIAL} variations for BUILD_TYPE='$BUILD_TYPE'" >&2
@@ -1025,7 +1025,7 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
                 echo "(and missed the mark: ${BUILDSTODO} variations remain - did anything crash early above?)" >&2
             fi
 
-            exit $RES
+            exit $RES_ALLERRORS
             ;;
     esac
 

--- a/common/common.c
+++ b/common/common.c
@@ -48,7 +48,7 @@ const char *UPS_VERSION = NUT_VERSION_MACRO;
 # endif
 #endif
 
-// https://stackoverflow.com/a/12844426/4715872
+/* https://stackoverflow.com/a/12844426/4715872 */
 #include <sys/types.h>
 #include <limits.h>
 #include <stdlib.h>
@@ -57,7 +57,7 @@ pid_t get_max_pid_t()
 	if (sizeof(pid_t) == sizeof(short)) return (pid_t)SHRT_MAX;
 	if (sizeof(pid_t) == sizeof(int)) return (pid_t)INT_MAX;
 	if (sizeof(pid_t) == sizeof(long)) return (pid_t)LONG_MAX;
-#if defined(LLONG_MAX)  // C99
+#if defined(LLONG_MAX)  /* C99 */
 	if (sizeof(pid_t) == sizeof(long long)) return (pid_t)LLONG_MAX;
 #endif
 	abort();
@@ -280,8 +280,8 @@ int sendsignalfn(const char *pidfn, int sig)
 		return -1;
 	}
 
-	{ // scoping
-		intmax_t _pid = strtol(buf, (char **)NULL, 10); // assuming 10 digits for a long
+	{ /* scoping */
+		intmax_t _pid = strtol(buf, (char **)NULL, 10); /* assuming 10 digits for a long */
 		if (_pid <= get_max_pid_t()) {
 			pid = (pid_t)_pid;
 		} else {

--- a/common/common.c
+++ b/common/common.c
@@ -530,6 +530,7 @@ void upslogx(int priority, const char *fmt, ...)
 void s_upsdebug_with_errno(int level, const char *fmt, ...)
 {
 	va_list va;
+	char fmt2[LARGEBUF];
 
 	/* Note: Thanks to macro wrapping, we do not quite need this
 	 * test now, but we still need the "level" value to report
@@ -543,7 +544,6 @@ void s_upsdebug_with_errno(int level, const char *fmt, ...)
  * of logging info he needs to see at the moment. Using '-DDDDD' all the time
  * is too brutal and needed high-level overview can be lost. This [D#] prefix
  * can help limit this debug stream quicker, than experimentally picking ;) */
-	char fmt2[LARGEBUF];
 	if (level > 0) {
 		int ret;
 		ret = snprintf(fmt2, sizeof(fmt2), "[D%d] %s", level, fmt);
@@ -575,12 +575,12 @@ void s_upsdebug_with_errno(int level, const char *fmt, ...)
 void s_upsdebugx(int level, const char *fmt, ...)
 {
 	va_list va;
+	char fmt2[LARGEBUF];
 
 	if (nut_debug_level < level)
 		return;
 
 /* See comments above in upsdebug_with_errno() - they apply here too. */
-	char fmt2[LARGEBUF];
 	if (level > 0) {
 		int ret;
 		ret = snprintf(fmt2, sizeof(fmt2), "[D%d] %s", level, fmt);

--- a/conf/upsmon.conf.sample.in
+++ b/conf/upsmon.conf.sample.in
@@ -156,15 +156,22 @@ SHUTDOWNCMD "/sbin/shutdown -h +0"
 #
 # upsmon calls this to send messages when things happen
 #
-# This command is called with the full text of the message as one argument.
+# This command is called with the full text of the message (from NOTIFYMSG)
+# as one argument.
+#
 # The environment string NOTIFYTYPE will contain the type string of
 # whatever caused this event to happen.
+#
+# The environment string UPSNAME will contain the name of the system/device
+# that generated the change.
 #
 # Note that this is only called for NOTIFY events that have EXEC set with
 # NOTIFYFLAG.  See NOTIFYFLAG below for more details.
 #
-# Making this some sort of shell script might not be a bad idea.  For more
-# information and ideas, see docs/scheduling.txt
+# Making this some sort of shell script might not be a bad idea.
+# Alternately you can use the upssched program as your NOTIFYCMD for some
+# more complex setups (e.g. to ease handling of notification storms).
+# For more information and ideas, see docs/scheduling.txt
 #
 # Example:
 # NOTIFYCMD @BINDIR@/notifyme

--- a/configure.ac
+++ b/configure.ac
@@ -2302,6 +2302,8 @@ AS_CASE(["${nut_enable_warnings}"],
     [gcc-minimal], [
         dnl Builds with C89 (and aliases) are quite noisy for C99+ syntax used
         dnl in NUT. The minimal-warnings should not complain in these builds.
+        dnl To make matters worse, many modern OS and third-party library
+        dnl headers can not be used with "C90 + pedantic" mode of GCC, either.
         CFLAGS="${CFLAGS} -Wall -Wsign-compare"
         CXXFLAGS="${CXXFLAGS} -Wall -Wextra"
         AS_CASE(["${CFLAGS}"],
@@ -2310,8 +2312,12 @@ AS_CASE(["${nut_enable_warnings}"],
         )
         ],
     [gcc-medium|gcc-hard], [
-        CFLAGS="${CFLAGS} -Wall -Wextra -Wsign-compare -pedantic"
+        CFLAGS="${CFLAGS} -Wall -Wextra -Wsign-compare"
         CXXFLAGS="${CXXFLAGS} -Wall -Wextra"
+        AS_CASE(["${CFLAGS}"],
+            [*89*|*90*|*ansi*], [],
+            [CFLAGS="${CFLAGS} -pedantic"]
+        )
         ]
 )
 

--- a/docs/developers.txt
+++ b/docs/developers.txt
@@ -409,8 +409,19 @@ compatibility can enable a few easy warning presets by default. This
 can be avoided with an explicit argument to `--disable-warnings` (or
 `--enable-warnings=no`).
 
-Hopefully this mechanism is extensible enough if we would need to add
-more compilers and/or "difficulty levels" in the future.
+All levels of warnings pre-sets for GCC in particular do not enforce
+the `-pedantic` mode for builds with C89/C90/ANSI standard revision
+(as guesstimated by `CFLAGS` content), because nowadays it complains
+more about the system and third-party library headers, than about NUT
+codebase quality (and "our offenses" are mostly something not worth
+fixing in this era, such as the use of `__func__` in debug commands).
+If there still are practical use-cases that require builds of NUT on
+pre-C99 compiler toolkits, pull requests are of course welcome -- but
+the maintainer team does not intend to spend much time on that.
+
+Hopefully this warnings pre-set mechanism is extensible enough if we
+would need to add more compilers and/or "difficulty levels" in the
+future.
 
 Finally, note that such pre-set warnings can be mixed with options
 passed through `CFLAGS` or `CXXFLAGS` values to your local `configure`

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 2800 utf-8
+personal_ws-1.1 en 2801 utf-8
 AAS
 ACFAIL
 ACFREQ
@@ -1746,6 +1746,7 @@ fsd
 ftdi
 fuji
 fullload
+func
 gamatronic
 gcc
 gcpp

--- a/drivers/hidparser.c
+++ b/drivers/hidparser.c
@@ -37,7 +37,7 @@ static const uint8_t ItemSize[4] = { 0, 1, 2, 4 };
  * -------------------------------------------------------------------------- */
 typedef struct {
 	const unsigned char	*ReportDesc;		/* Report Descriptor		*/
-	int			ReportDescSize;		/* Size of Report Descriptor	*/
+	size_t			ReportDescSize;		/* Size of Report Descriptor	*/
 
 	uint16_t	Pos;				/* Store current pos in descriptor	*/
 	uint8_t		Item;				/* Store current Item		*/
@@ -547,7 +547,7 @@ void SetValue(const HIDData_t *pData, unsigned char *Buf, long Value)
    Output: parsed data structure. Returns allocated HIDDesc structure
    on success, NULL on failure with errno set. Note: the value
    returned by this function must be freed with Free_ReportDesc(). */
-HIDDesc_t *Parse_ReportDesc(const unsigned char *ReportDesc, const int n)
+HIDDesc_t *Parse_ReportDesc(const unsigned char *ReportDesc, const size_t n)
 {
 	int		ret = 0;
 	HIDDesc_t	*pDesc;

--- a/drivers/hidparser.h
+++ b/drivers/hidparser.h
@@ -38,7 +38,7 @@ extern "C" {
 /*
  * Parse_ReportDesc
  * -------------------------------------------------------------------------- */
-HIDDesc_t *Parse_ReportDesc(const unsigned char *ReportDesc, const int n);
+HIDDesc_t *Parse_ReportDesc(const unsigned char *ReportDesc, const size_t n);
 
 /*
  * Free_ReportDesc

--- a/drivers/hidparser.h
+++ b/drivers/hidparser.h
@@ -32,6 +32,7 @@ extern "C" {
 /* *INDENT-ON* */
 #endif /* __cplusplus */
 
+#include "config.h"
 #include "hidtypes.h"
 
 /*

--- a/drivers/libhid.c
+++ b/drivers/libhid.c
@@ -148,7 +148,7 @@ reportbuf_t *new_report_buffer(HIDDesc_t *arg_pDesc)
 /* because buggy firmwares from APC return wrong report size, we either
    ask the report with the found report size or with the whole buffer size
    depending on the max_report_size flag */
-static int refresh_report_buffer(reportbuf_t *rbuf, hid_dev_handle_t udev, HIDData_t *pData, int age)
+static int refresh_report_buffer(reportbuf_t *rbuf, hid_dev_handle_t udev, HIDData_t *pData, time_t age)
 {
 	int	id = pData->ReportID;
 	int	ret;
@@ -187,7 +187,7 @@ static int refresh_report_buffer(reportbuf_t *rbuf, hid_dev_handle_t udev, HIDDa
    conversion is performed. If age>0, the read operation is buffered
    if the item's age is less than "age". On success, return 0 and
    store the answer in *value. On failure, return -1 and set errno. */
-static int get_item_buffered(reportbuf_t *rbuf, hid_dev_handle_t udev, HIDData_t *pData, long *Value, int age)
+static int get_item_buffered(reportbuf_t *rbuf, hid_dev_handle_t udev, HIDData_t *pData, long *Value, time_t age)
 {
 	int id = pData->ReportID;
 	int r;
@@ -383,7 +383,7 @@ char *HIDGetDataItem(const HIDData_t *hiddata, usage_tables_t *utab)
 /* Return the physical value associated with the given HIDData path.
  * return 1 if OK, 0 on fail, -errno otherwise (ie disconnect).
  */
-int HIDGetDataValue(hid_dev_handle_t udev, HIDData_t *hiddata, double *Value, int age)
+int HIDGetDataValue(hid_dev_handle_t udev, HIDData_t *hiddata, double *Value, time_t age)
 {
 	int	r;
 	long	hValue;

--- a/drivers/libhid.h
+++ b/drivers/libhid.h
@@ -124,7 +124,7 @@ char *HIDGetDataItem(const HIDData_t *hiddata, usage_tables_t *utab);
 /*
  * HIDGetDataValue
  * -------------------------------------------------------------------------- */
-int HIDGetDataValue(hid_dev_handle_t udev, HIDData_t *hiddata, double *Value, int age);
+int HIDGetDataValue(hid_dev_handle_t udev, HIDData_t *hiddata, double *Value, time_t age);
 
 /*
  * HIDSetDataValue

--- a/drivers/libshut.h
+++ b/drivers/libshut.h
@@ -58,19 +58,26 @@ typedef struct SHUTDevice_s {
 typedef struct shut_communication_subdriver_s {
 	const char *name;				/* name of this subdriver		*/
 	const char *version;				/* version of this subdriver		*/
+
 	int (*open)(int *upsfd,			/* try to open the next available	*/
 		SHUTDevice_t *curDevice,	/* device matching USBDeviceMatcher_t	*/
 		char *device_path,
-		int (*callback)(int upsfd, SHUTDevice_t *hd, unsigned char *rdbuf, int rdlen));
+		int (*callback)(int upsfd, SHUTDevice_t *hd,
+			unsigned char *rdbuf, int rdlen));
+
 	void (*close)(int upsfd);
+
 	int (*get_report)(int upsfd, int ReportId,
-	unsigned char *raw_buf, int ReportSize );
+		unsigned char *raw_buf, int ReportSize);
+
 	int (*set_report)(int upsfd, int ReportId,
-	unsigned char *raw_buf, int ReportSize );
+		unsigned char *raw_buf, int ReportSize);
+
 	int (*get_string)(int upsfd,
-	int StringIdx, char *buf, size_t buflen);
+		int StringIdx, char *buf, size_t buflen);
+
 	int (*get_interrupt)(int upsfd,
-	unsigned char *buf, int bufsize, int timeout);
+		unsigned char *buf, int bufsize, int timeout);
 } shut_communication_subdriver_t;
 
 extern shut_communication_subdriver_t	shut_subdriver;

--- a/drivers/libusb.h
+++ b/drivers/libusb.h
@@ -37,6 +37,7 @@
 /* libusb header file */
 #include <usb.h>
 
+/* Used in drivers/libusb*.c sources: */
 #define LIBUSB_DEFAULT_INTERFACE        0
 #define LIBUSB_DEFAULT_DESC_INDEX       0
 #define LIBUSB_DEFAULT_HID_EP_IN        1
@@ -51,19 +52,26 @@ extern upsdrv_info_t comm_upsdrv_info;
 typedef struct usb_communication_subdriver_s {
 	const char *name;				/* name of this subdriver		*/
 	const char *version;				/* version of this subdriver		*/
+
 	int (*open)(usb_dev_handle **sdevp,	/* try to open the next available	*/
 		USBDevice_t *curDevice,		/* device matching USBDeviceMatcher_t	*/
 		USBDeviceMatcher_t *matcher,
-		int (*callback)(usb_dev_handle *udev, USBDevice_t *hd, unsigned char *rdbuf, int rdlen));
+		int (*callback)(usb_dev_handle *udev, USBDevice_t *hd,
+			unsigned char *rdbuf, int rdlen));
+
 	void (*close)(usb_dev_handle *sdev);
+
 	int (*get_report)(usb_dev_handle *sdev, int ReportId,
-	unsigned char *raw_buf, int ReportSize );
+		unsigned char *raw_buf, int ReportSize);
+
 	int (*set_report)(usb_dev_handle *sdev, int ReportId,
-	unsigned char *raw_buf, int ReportSize );
+		unsigned char *raw_buf, int ReportSize);
+
 	int (*get_string)(usb_dev_handle *sdev,
-	int StringIdx, char *buf, size_t buflen);
+		int StringIdx, char *buf, size_t buflen);
+
 	int (*get_interrupt)(usb_dev_handle *sdev,
-	unsigned char *buf, int bufsize, int timeout);
+		unsigned char *buf, int bufsize, int timeout);
 
 	/* Used for Powervar UPS or similar cases to make sure
 	 * we use the right interface in the Composite device

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -390,7 +390,7 @@ info_lkp_t on_off_info[] = {
    done with result! */
 static const char *date_conversion_fun(double value)
 {
-	static char buf[20];
+	static char buf[32];
 	long year, month, day;
 
 	if ((long)value == 0) {

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -391,17 +391,21 @@ info_lkp_t on_off_info[] = {
 static const char *date_conversion_fun(double value)
 {
 	static char buf[20];
-	int year, month, day;
+	long year, month, day;
 
 	if ((long)value == 0) {
 		return "not set";
 	}
 
-	year = 1980 + ((long)value >> 9); /* negative value represents pre-1980 date */
+	/* TOTHINK: About the comment below...
+	 * Does bit-shift keep the negativeness on all architectures?
+	 */
+	/* negative value represents pre-1980 date: */
+	year = 1980 + ((long)value >> 9);
 	month = ((long)value >> 5) & 0x0f;
 	day = (long)value & 0x1f;
 
-	snprintf(buf, sizeof(buf), "%04d/%02d/%02d", year, month, day);
+	snprintf(buf, sizeof(buf), "%04ld/%02ld/%02ld", year, month, day);
 
 	return buf;
 }

--- a/include/nut_stdint.h
+++ b/include/nut_stdint.h
@@ -47,4 +47,21 @@
 #define SIZE_MAX ((size_t)(-1LL))
 #endif
 
+/* Printing format for size_t and ssize_t */
+#ifndef PRIsize
+# if defined(__MINGW32__)
+#  define PRIsize "u"
+# else
+#  define PRIsize "zu"
+# endif
+#endif
+
+#ifndef PRIssize
+# if defined(__MINGW32__)
+#  define PRIssize "d"
+# else
+#  define PRIssize "zd"
+# endif
+#endif /* format for size_t and ssize_t */
+
 #endif	/* NUT_STDINT_H_SEEN */

--- a/m4/ax_c_pragmas.m4
+++ b/m4/ax_c_pragmas.m4
@@ -109,6 +109,21 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
     AC_DEFINE([HAVE_PRAGMA_CLANG_DIAGNOSTIC_PUSH_POP], 1, [define if your compiler has #pragma clang diagnostic push and pop])
   ])
 
+  AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wunused-function"],
+    [ax_cv__pragma__gcc__diags_ignored_unused_function],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[void func(void) {
+#pragma GCC diagnostic ignored "-Wunused-function"
+}
+]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_unused_function=yes],
+      [ax_cv__pragma__gcc__diags_ignored_unused_function=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_unused_function" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNUSED_FUNCTION], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wunused-function"])
+  ])
+
   AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wformat-nonliteral"],
     [ax_cv__pragma__gcc__diags_ignored_format_nonliteral],
     [AC_COMPILE_IFELSE(

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -21,6 +21,8 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
+#include "config.h"	/* must be the first header */
+
 #include "upsd.h"
 #include "upstype.h"
 #include "conf.h"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -25,6 +25,8 @@ hidparser.c: $(top_srcdir)/drivers/hidparser.c
 
 getvaluetest_SOURCES = getvaluetest.c
 nodist_getvaluetest_SOURCES = hidparser.c
+# Pull the right include path for chosen libusb version:
+getvaluetest_CFLAGS = $(AM_CFLAGS) $(LIBUSB_CFLAGS)
 getvaluetest_LDADD = $(top_builddir)/common/libcommon.la
 
 # Make sure out-of-dir dependencies exist (especially when dev-building parts):


### PR DESCRIPTION
Follows up from #823 for the fightwarn effort, and offloads some changes that would be relevant for libusb-1.0(+0.1) merge to minimize specific diff of that (and/or that were non-specific changes for libusb API variations, that happened to be made while developing those branches).