### PR TITLE
Revise nut-scanner logging

### DIFF
--- a/clients/upsclient.c
+++ b/clients/upsclient.c
@@ -1121,24 +1121,24 @@ int upscli_tryconnect(UPSCONN_t *ups, const char *host, int port, int flags,stru
 	if (tryssl || forcessl) {
 		ret = upscli_sslinit(ups, certverify);
 		if (forcessl && ret != 1) {
-			upslogx(LOG_ERR, "Can not connect to %s in SSL, disconnect", host);
+			upslogx(LOG_ERR, "Can not connect to NUT server %s in SSL, disconnect", host);
 			ups->upserror = UPSCLI_ERR_SSLFAIL;
 			upscli_disconnect(ups);
 			return -1;
 		} else if (tryssl && ret == -1) {
-			upslogx(LOG_NOTICE, "Error while connecting to %s, disconnect", host);
+			upslogx(LOG_NOTICE, "Error while connecting to NUT server %s, disconnect", host);
 			upscli_disconnect(ups);
 			return -1;
 		} else if (tryssl && ret == 0) {
 			if (certverify != 0) {
-				upslogx(LOG_NOTICE, "Can not connect to %s in SSL and "
+				upslogx(LOG_NOTICE, "Can not connect to NUT server %s in SSL and "
 				"certificate is needed, disconnect", host);
 				upscli_disconnect(ups);
 				return -1;
 			}
-			upsdebugx(3, "Can not connect to %s in SSL, continue unencrypted", host);
+			upsdebugx(3, "Can not connect to NUT server %s in SSL, continue unencrypted", host);
 		} else {
-			upslogx(LOG_INFO, "Connected to %s in SSL", host);
+			upslogx(LOG_INFO, "Connected to NUT server %s in SSL", host);
 			if (certverify == 0) {
 				/* you REALLY should set CERTVERIFY to 1 if using SSL... */
 				upslogx(LOG_WARNING, "Certificate verification is disabled");

--- a/tools/nut-scanner/scan_ipmi.c
+++ b/tools/nut-scanner/scan_ipmi.c
@@ -397,7 +397,7 @@ nutscan_device_t * nutscan_scan_ipmi_device(const char * IPaddr, nutscan_ipmi_t 
 	if (!(ipmi_ctx = (*nut_ipmi_ctx_create) ()))
 	{
 		/* we have to force cleanup, since exit handler is not yet installed */
-		fprintf(stderr, "ipmi_ctx_create\n");
+		fprintf(stderr, "Failed to ipmi_ctx_create\n");
 		return NULL;
 	}
 
@@ -419,7 +419,7 @@ nutscan_device_t * nutscan_scan_ipmi_device(const char * IPaddr, nutscan_ipmi_t 
 					0  /* flags */
 					)) < 0)
 		{
-			fprintf(stderr, "ipmi_ctx_find_inband: %s\n",
+			upsdebugx(2, "ipmi_ctx_find_inband (local scan): %s",
 				(*nut_ipmi_ctx_errormsg) (ipmi_ctx));
 			return NULL;
 		}
@@ -454,7 +454,11 @@ nutscan_device_t * nutscan_scan_ipmi_device(const char * IPaddr, nutscan_ipmi_t 
 															ipmi_dev->workaround_flags,
 															flags) < 0)
 			{
-				IPMI_MONITORING_DEBUG (("ipmi_ctx_open_outofband_2_0: %s", ipmi_ctx_errormsg (c->ipmi_ctx)));
+				upsdebugx(2, "nut_ipmi_ctx_open_outofband_2_0 (%s): %s",
+					IPaddr, (*nut_ipmi_ctx_errormsg) (c->ipmi_ctx));
+				IPMI_MONITORING_DEBUG (("ipmi_ctx_open_outofband_2_0 (%s): %s",
+					IPaddr, ipmi_ctx_errormsg (c->ipmi_ctx)));
+
 				if (ipmi_ctx_errnum (c->ipmi_ctx) == IPMI_ERR_USERNAME_INVALID)
 					c->errnum = IPMI_MONITORING_ERR_USERNAME_INVALID;
 				else if (ipmi_ctx_errnum (c->ipmi_ctx) == IPMI_ERR_PASSWORD_INVALID)
@@ -501,17 +505,17 @@ nutscan_device_t * nutscan_scan_ipmi_device(const char * IPaddr, nutscan_ipmi_t 
 		if (ipmi_sec->authentication_type < 0
 		    || (unsigned int)ipmi_sec->authentication_type > UINT8_MAX
 		) {
-			fprintf(stderr,
-				"nutscan_scan_ipmi_device: authentication_type=%d is out of range!\n",
-				ipmi_sec->authentication_type);
+			upsdebugx(2, "nutscan_scan_ipmi_device (%s): "
+				"authentication_type=%d is out of range!",
+				IPaddr, ipmi_sec->authentication_type);
 			return 0;
 		}
 		if (ipmi_sec->privilege_level < 0
 		    || (unsigned int)ipmi_sec->privilege_level > UINT8_MAX
 		) {
-			fprintf(stderr,
-				"nutscan_scan_ipmi_device: privilege_level=%d is out of range!\n",
-				ipmi_sec->privilege_level);
+			upsdebugx(2, "nutscan_scan_ipmi_device (%s): "
+				"privilege_level=%d is out of range!",
+				IPaddr, ipmi_sec->privilege_level);
 			return 0;
 		}
 		if ((ret = (*nut_ipmi_ctx_open_outofband) (ipmi_ctx,
@@ -537,8 +541,8 @@ nutscan_device_t * nutscan_scan_ipmi_device(const char * IPaddr, nutscan_ipmi_t 
 			  || (*nut_ipmi_ctx_errnum) (ipmi_ctx) == IPMI_ERR_CONNECTION_TIMEOUT) { */
 
 				/* FIXME: don't log timeout errors */
-				fprintf(stderr, "nut_ipmi_ctx_open_outofband: %s\n",
-					(*nut_ipmi_ctx_errormsg) (ipmi_ctx));
+				upsdebugx(2, "nut_ipmi_ctx_open_outofband (%s): %s",
+					IPaddr, (*nut_ipmi_ctx_errormsg) (ipmi_ctx));
 				return NULL;
 			/*}*/
 		}

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -337,6 +337,7 @@ int nutscan_load_snmp_library(const char *libname_path)
 #endif /* NUT_HAVE_LIBNETSNMP_usmHMAC384SHA512AuthProtocol */
 
 	return 1;
+
 err:
 	fprintf(stderr, "Cannot load SNMP library (%s) : %s. SNMP search disabled.\n",
 		libname_path, dl_error);
@@ -475,7 +476,7 @@ static void try_all_oid(void * arg, const char * mib_found)
 	int index = 0;
 	nutscan_snmp_t * sec = (nutscan_snmp_t *)arg;
 
-	upsdebugx(2, "%s", __func__);
+	upsdebugx(2, "Entering %s for %s", __func__, sec->peername);
 
 	while (snmp_device_table[index].mib != NULL) {
 
@@ -779,7 +780,7 @@ static void * try_SysOID(void * arg)
 	int index = 0;
 	char *mib_found = NULL;
 
-	upsdebugx(2, "%s", __func__);
+	upsdebugx(2, "Entering %s for %s", __func__, sec->peername);
 
 	/* Initialize session */
 	if (!init_session(&snmp_sess, sec)) {
@@ -795,16 +796,17 @@ static void * try_SysOID(void * arg)
 	/* Open the session */
 	handle = (*nut_snmp_sess_open)(&snmp_sess); /* establish the session */
 	if (handle == NULL) {
-		fprintf(stderr,
-			"Failed to open SNMP session for %s.\n",
+		upsdebugx(2,
+			"Failed to open SNMP session for %s",
 			sec->peername);
 		goto try_SysOID_free;
 	}
 
 	/* create and send request. */
 	if (!(*nut_snmp_parse_oid)(SysOID, name, &name_len)) {
-		fprintf(stderr,
-			"SNMP errors: %s\n",
+		upsdebugx(2,
+			"SNMP errors for %s: %s",
+			sec->peername,
 			(*nut_snmp_api_errstring)((*nut_snmp_errno)));
 		(*nut_snmp_sess_close)(handle);
 		goto try_SysOID_free;


### PR DESCRIPTION
While testing nut-scanner with large subnets and many protocols enabled, I found the output rather messy (some timestamped `[D#]` logs, and some plaintext) so replaced the majority of non-system error reports from unconditional `fprintf(stderr, ...)` to manageable `upsdebugx()` (arbitrarily starting at level 2) in SNMP and IPMI scanners. This allows to optionally not flood the console with info about unresponsive devices.

There is also a bit of impact outside nut-scanner codebase - in the upsclient.c to clarify the messages seen in nut-scanner for "Old NUT" protocol:
````
Error while connecting to X.X.X.X, disconnect
````
changed to
````
Error while connecting to NUT server X.X.X.X, disconnect
````
