### PR TITLE
Fightwarn with libusb-1.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -403,8 +403,13 @@ dnl the usual builds can pass by default on systems without asciidoc.
 NUT_ARG_WITH([docs], [build and install documentation (alias to --with-doc)], [man=auto])
 NUT_ARG_WITH([doc], [build and install documentation (see docs/configure.txt for many variants of the option)], [${nut_with_docs}])
 
-NUT_ARG_ENABLE([warnings], [enable warning presets that were picked as useful in maintainership and CI practice (variants include gcc-minimal, gcc-medium, gcc-hard, clang-minimal, clang-medium, clang-hard, all; auto-choosers: hard, medium, minimal, yes=auto='gcc or clang or all at hardcoded default difficulty')], [legacy])
-NUT_ARG_ENABLE([Werror], [fail the build if compiler emits any warnings (treat them as errors)], [no])
+dnl NOTE: Until X-Mas 2021, the default was "legacy" (now "medium")
+NUT_ARG_ENABLE([warnings],
+    [enable warning presets that were picked as useful in maintainership and CI practice (variants include gcc-minimal, gcc-medium, gcc-hard, clang-minimal, clang-medium, clang-hard, all; auto-choosers: hard, medium, minimal, yes=auto='gcc or clang or all at hardcoded default difficulty')],
+    [medium])
+NUT_ARG_ENABLE([Werror],
+    [fail the build if compiler emits any warnings (treat them as errors)],
+    [no])
 
 dnl ----------------------------------------------------------------------
 dnl Check for presence and compiler flags of various libraries
@@ -2187,7 +2192,8 @@ dnl least-surprise default if caller did not specify any --enable-warnings.
 dnl Note: Currently the "gcc-minimal" mode below adapts to builds with
 dnl C89/C90/ANSI mode to be less noisy. Keep this in mind if changing the
 dnl default "nut_warning_difficulty" and/or the case handling below.
-nut_warning_difficulty="minimal"
+dnl NOTE: Until X-Mas 2021, the default was "minimal" (now "medium")
+nut_warning_difficulty="medium"
 AC_MSG_CHECKING([whether to pre-set warnings])
 AS_CASE(["${nut_enable_warnings}"],
     [no|all|gcc-legacy|gcc-minimal|clang-minimal|gcc-medium|clang-medium|gcc-hard|clang-hard], [],

--- a/drivers/hidparser.c
+++ b/drivers/hidparser.c
@@ -35,6 +35,9 @@ static const uint8_t ItemSize[4] = { 0, 1, 2, 4 };
 /*
  * HIDParser struct
  * -------------------------------------------------------------------------- */
+/* FIXME? Should this structure remain with reasonable fixed int types,
+ * or changed to align with libusb API version and usb_ctrl_* typedefs?
+ */
 typedef struct {
 	const unsigned char	*ReportDesc;		/* Report Descriptor		*/
 	size_t			ReportDescSize;		/* Size of Report Descriptor	*/
@@ -547,14 +550,31 @@ void SetValue(const HIDData_t *pData, unsigned char *Buf, long Value)
    Output: parsed data structure. Returns allocated HIDDesc structure
    on success, NULL on failure with errno set. Note: the value
    returned by this function must be freed with Free_ReportDesc(). */
-HIDDesc_t *Parse_ReportDesc(const unsigned char *ReportDesc, const size_t n)
+HIDDesc_t *Parse_ReportDesc(const usb_ctrl_charbuf ReportDesc, const usb_ctrl_charbufsize n)
 {
 	int		ret = 0;
 	HIDDesc_t	*pDesc;
 	HIDParser_t	*parser;
 
 	pDesc = calloc(1, sizeof(*pDesc));
-	if (!pDesc) {
+	if (!pDesc
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS
+# pragma GCC diagnostic ignored "-Wtype-limits"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE
+# pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE
+# pragma GCC diagnostic ignored "-Wtautological-unsigned-zero-compare"
+#endif
+	|| n < 0 || (uintmax_t)n > SIZE_MAX
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
+# pragma GCC diagnostic pop
+#endif
+	) {
 		return NULL;
 	}
 
@@ -570,8 +590,8 @@ HIDDesc_t *Parse_ReportDesc(const unsigned char *ReportDesc, const size_t n)
 		return NULL;
 	}
 
-	parser->ReportDesc = ReportDesc;
-	parser->ReportDescSize = n;
+	parser->ReportDesc = (const unsigned char *)ReportDesc;
+	parser->ReportDescSize = (const size_t)n;
 
 	for (pDesc->nitems = 0; pDesc->nitems < MAX_REPORT; pDesc->nitems += (size_t)ret) {
 		uint8_t	id;

--- a/drivers/hidparser.c
+++ b/drivers/hidparser.c
@@ -557,7 +557,6 @@ HIDDesc_t *Parse_ReportDesc(const usb_ctrl_charbuf ReportDesc, const usb_ctrl_ch
 	HIDParser_t	*parser;
 
 	pDesc = calloc(1, sizeof(*pDesc));
-	if (!pDesc
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
 # pragma GCC diagnostic push
 #endif
@@ -570,13 +569,14 @@ HIDDesc_t *Parse_ReportDesc(const usb_ctrl_charbuf ReportDesc, const usb_ctrl_ch
 #ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE
 # pragma GCC diagnostic ignored "-Wtautological-unsigned-zero-compare"
 #endif
+	if (!pDesc
 	|| n < 0 || (uintmax_t)n > SIZE_MAX
-#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
-# pragma GCC diagnostic pop
-#endif
 	) {
 		return NULL;
 	}
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
+# pragma GCC diagnostic pop
+#endif
 
 	pDesc->item = calloc(MAX_REPORT, sizeof(*pDesc->item));
 	if (!pDesc->item) {

--- a/drivers/hidparser.h
+++ b/drivers/hidparser.h
@@ -35,10 +35,19 @@ extern "C" {
 #include "config.h"
 #include "hidtypes.h"
 
+/* Include "usb-common.h" or "libshut.h" as appropriate, to define the 
+ * usb_ctrl_* types used below according to the backend USB API version
+ */
+#ifdef SHUT_MODE
+# include "libshut.h"
+#else
+# include "usb-common.h"
+#endif
+
 /*
  * Parse_ReportDesc
  * -------------------------------------------------------------------------- */
-HIDDesc_t *Parse_ReportDesc(const unsigned char *ReportDesc, const size_t n);
+HIDDesc_t *Parse_ReportDesc(const usb_ctrl_charbuf ReportDesc, const usb_ctrl_charbufsize n);
 
 /*
  * Free_ReportDesc

--- a/drivers/libhid.h
+++ b/drivers/libhid.h
@@ -40,7 +40,7 @@
 	#include "libshut.h"
 	typedef SHUTDevice_t                   HIDDevice_t;
 	typedef char                           HIDDeviceMatcher_t;
-	typedef int                            hid_dev_handle_t;
+	typedef usb_dev_handle                 hid_dev_handle_t;
 	typedef shut_communication_subdriver_t communication_subdriver_t;
 #else
 	#include "nut_libusb.h" /* includes usb-common.h */

--- a/drivers/libshut.c
+++ b/drivers/libshut.c
@@ -1145,10 +1145,10 @@ static int shut_control_msg(
 	||  index < 0 || (uintmax_t)index > UINT16_MAX
 	||  (uintmax_t)size > UINT16_MAX
 	||  (uintmax_t)timeout > UINT32_MAX
+	) {
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
 # pragma GCC diagnostic pop
 #endif
-	) {
 		upsdebugx (1, "%s: input values out of range", __func__);
 		return -1;
 	}

--- a/drivers/libshut.c
+++ b/drivers/libshut.c
@@ -180,16 +180,51 @@ struct my_hid_descriptor {
 /*!
  * SHUT functions for HID marshalling
  */
-static int shut_get_descriptor(int upsfd, unsigned char type,
-			unsigned char index, void *buf, int size);
-static int shut_get_string_simple(int upsfd, int index,
-			   char *buf, size_t buflen);
-static int libshut_get_report(int upsfd, int ReportId,
-			   unsigned char *raw_buf, int ReportSize );
-static int libshut_set_report(int upsfd, int id, unsigned char *pkt, int reportlen);
-static int libshut_get_interrupt(int upsfd, unsigned char *buf,
-			   int bufsize, int timeout);
-static void libshut_close(int upsfd);
+/* Expected evaluated types for the API after typedefs:
+ * static int shut_get_descriptor(int upsfd, unsigned char type,
+ *			   unsigned char index, void *buf, int size);
+ * static int shut_get_string_simple(int upsfd, int index,
+ *			   char *buf, size_t buflen);
+ * static int libshut_get_report(int upsfd, int ReportId,
+ *			   unsigned char *raw_buf, int ReportSize );
+ * static int libshut_set_report(int upsfd, int id, unsigned char *pkt,
+ *             int reportlen);
+ * static int libshut_get_interrupt(int upsfd, unsigned char *buf,
+ *			   int bufsize, int timeout);
+ * static void libshut_close(int upsfd);
+ */
+static int shut_get_descriptor(
+	usb_dev_handle upsfd,
+	usb_ctrl_requesttype type,
+	usb_ctrl_descindex index,
+	void *buf,
+	usb_ctrl_charbufsize size);
+
+static int shut_get_string_simple(
+	usb_dev_handle upsfd,
+	usb_ctrl_strindex index,
+	char *buf,
+	usb_ctrl_charbufsize buflen);
+
+static int libshut_get_report(
+	usb_dev_handle upsfd,
+	usb_ctrl_repindex ReportId,
+	usb_ctrl_charbuf raw_buf,
+	usb_ctrl_charbufsize ReportSize);
+
+static int libshut_set_report(
+	usb_dev_handle upsfd,
+	usb_ctrl_repindex id,
+	usb_ctrl_charbuf pkt,
+	usb_ctrl_charbufsize reportlen);
+
+static int libshut_get_interrupt(
+	usb_dev_handle upsfd,
+	usb_ctrl_charbuf buf,
+	usb_ctrl_charbufsize bufsize,
+	usb_ctrl_timeout_msec timeout);
+
+static void libshut_close(usb_dev_handle upsfd);
 
 /* FIXME */
 static const char * shut_strerror(void) { return ""; }
@@ -261,6 +296,7 @@ typedef union device_desc_data_t {
 #endif
 
 /* Low level SHUT (Serial HID UPS Transfer) routines  */
+/* Expected evaluated types for the API after typedefs:
 static void setline(int upsfd, int set);
 static int shut_synchronise(int upsfd);
 static int shut_wait_ack(int upsfd);
@@ -268,6 +304,31 @@ static int shut_interrupt_read(int upsfd, int ep, unsigned char *bytes,
                         int size, int timeout);
 static int shut_control_msg(int upsfd, int requesttype, int request, int value,
                         int index, unsigned char *bytes, int size, int timeout);
+ */
+static void setline(
+	usb_dev_handle upsfd,
+	int set);
+
+static int shut_synchronise(usb_dev_handle upsfd);
+
+static int shut_wait_ack(usb_dev_handle upsfd);
+
+static int shut_interrupt_read(
+	usb_dev_handle upsfd,
+	usb_ctrl_endpoint ep,
+	usb_ctrl_charbuf bytes,
+	usb_ctrl_charbufsize size,
+	usb_ctrl_timeout_msec timeout);
+
+static int shut_control_msg(
+	usb_dev_handle upsfd,
+	usb_ctrl_requesttype requesttype,
+	usb_ctrl_request request,
+	usb_ctrl_msgvalue value,
+	usb_ctrl_repindex index,
+	usb_ctrl_charbuf bytes,
+	usb_ctrl_charbufsize size,
+	usb_ctrl_timeout_msec timeout);
 
 /* Data portability */
 /* realign packet data according to Endianess */
@@ -284,6 +345,12 @@ static void align_request(struct shut_ctrltransfer_s *ctrl)
 #endif
 }
 
+#if (!defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_INSIDEFUNC) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS_BESIDEFUNC)
+# pragma GCC diagnostic ignored "-Wtype-limits"
+#endif
+#if (!defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_INSIDEFUNC) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE_BESIDEFUNC)
+# pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"
+#endif
 /* On success, fill in the curDevice structure and return the report
  * descriptor length. On failure, return -1.
  * Note: When callback is not NULL, the report descriptor will be
@@ -291,9 +358,17 @@ static void align_request(struct shut_ctrltransfer_s *ctrl)
  * information. This callback should return a value > 0 if the device
  * is accepted, or < 1 if not.
  */
-static int libshut_open(int *arg_upsfd, SHUTDevice_t *curDevice, char *arg_device_path,
-                 int (*callback)(int arg_upsfd, SHUTDevice_t *hd,
-                 unsigned char *rdbuf, int rdlen))
+/* Expected evaluated types for the API after typedefs:
+ * static int libshut_open(int *arg_upsfd, SHUTDevice_t *curDevice, char *arg_device_path,
+ *                  int (*callback)(int arg_upsfd, SHUTDevice_t *hd,
+ *                  unsigned char *rdbuf, int rdlen))
+ */
+static int libshut_open(
+	usb_dev_handle *arg_upsfd,
+	SHUTDevice_t *curDevice,
+	char *arg_device_path,
+	int (*callback)(usb_dev_handle arg_upsfd, SHUTDevice_t *hd,
+		            usb_ctrl_charbuf rdbuf, usb_ctrl_charbufsize rdlen))
 {
 	int ret, res;
 	/* Below we cast this buffer as sometimes containing entried of type
@@ -301,18 +376,18 @@ static int libshut_open(int *arg_upsfd, SHUTDevice_t *curDevice, char *arg_devic
 	 * Currently both of these are sized "2", and I don't see a way
 	 * to require a "max()" of such sizes to align for generally.
 	 */
-	unsigned char buf[20] __attribute__((aligned(4)));
+	usb_ctrl_char buf[20] __attribute__((aligned(4)));
 	char string[MAX_STRING_SIZE];
 	struct my_hid_descriptor *desc;
 	struct device_descriptor_s *dev_descriptor;
 
 	/* report descriptor */
-	unsigned char	rdbuf[MAX_REPORT_SIZE];
-	int		rdlen;
+	usb_ctrl_char	rdbuf[MAX_REPORT_SIZE];
+	usb_ctrl_charbufsize			rdlen;
 	/* All devices use HID descriptor at index 0. However, some newer
 	 * Eaton units have a light HID descriptor at index 0, and the full
 	 * version is at index 1 (in which case, bcdDevice == 0x0202) */
-	int hid_desc_index = 0;
+	usb_ctrl_descindex	hid_desc_index = 0;
 
 	upsdebugx(2, "libshut_open: using port %s", arg_device_path);
 
@@ -454,8 +529,32 @@ static int libshut_open(int *arg_upsfd, SHUTDevice_t *curDevice, char *arg_devic
 
 	rdlen = desc->wDescriptorLength;
 
-	if (rdlen > (int)sizeof(rdbuf)) {
-		upsdebugx(2, "HID descriptor too long %d (max %d)", rdlen, (int)sizeof(rdbuf));
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS
+# pragma GCC diagnostic ignored "-Wtype-limits"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE
+# pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"
+#endif
+/* Older CLANG (e.g. clang-3.4) seems to not support the GCC pragmas above */
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#pragma clang diagnostic ignored "-Wtautological-constant-out-of-range-compare"
+#endif
+	if (rdlen > sizeof(rdbuf) || rdlen > INT_MAX) {
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) )
+# pragma GCC diagnostic pop
+#endif
+		upsdebugx(2,
+			"HID descriptor too long %" PRI_NUT_USB_CTRL_CHARBUFSIZE
+			" (max %zu)",
+			rdlen, sizeof(rdbuf));
 		return -1;
 	}
 
@@ -464,7 +563,28 @@ static int libshut_open(int *arg_upsfd, SHUTDevice_t *curDevice, char *arg_devic
 	/* res = shut_control_msg(devp, USB_ENDPOINT_IN+1, USB_REQ_GET_DESCRIPTOR,
 				(USB_DT_REPORT << 8) + 0, 0, ReportDesc,
 			desc->wDescriptorLength, SHUT_TIMEOUT); */
-	if (res == rdlen)
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS
+# pragma GCC diagnostic ignored "-Wtype-limits"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE
+# pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"
+#endif
+/* Older CLANG (e.g. clang-3.4) seems to not support the GCC pragmas above */
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#pragma clang diagnostic ignored "-Wtautological-constant-out-of-range-compare"
+#endif
+	if (res >= 0 && (uintmax_t)res < (uintmax_t)SIZE_MAX && (size_t)res == rdlen)
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) )
+# pragma GCC diagnostic pop
+#endif
 	{
 		res = callback(*arg_upsfd, curDevice, rdbuf, rdlen);
 		if (res < 1) {
@@ -472,11 +592,13 @@ static int libshut_open(int *arg_upsfd, SHUTDevice_t *curDevice, char *arg_devic
 			return -1;
 		}
 
-		upsdebugx(2, "Report descriptor retrieved (Reportlen = %d)", rdlen);
+		upsdebugx(2,
+			"Report descriptor retrieved (Reportlen = %"
+			PRI_NUT_USB_CTRL_CHARBUFSIZE ")", rdlen);
 		upsdebugx(2, "Found HID device");
 		fflush(stdout);
 
-		return rdlen;
+		return (int)rdlen;
 	}
 
 	if (res < 0)
@@ -485,7 +607,10 @@ static int libshut_open(int *arg_upsfd, SHUTDevice_t *curDevice, char *arg_devic
 	}
 	else
 	{
-		upsdebugx(2, "Report descriptor too short (expected %d, got %d)", rdlen, res);
+		upsdebugx(2,
+			"Report descriptor too short (expected %"
+			PRI_NUT_USB_CTRL_CHARBUFSIZE ", got %d)",
+			rdlen, res);
 	}
 
 	upsdebugx(2, "libshut: No appropriate HID device found");
@@ -493,8 +618,14 @@ static int libshut_open(int *arg_upsfd, SHUTDevice_t *curDevice, char *arg_devic
 
 	return -1;
 }
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_BESIDEFUNC) && (!defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_INSIDEFUNC) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS_BESIDEFUNC) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE_BESIDEFUNC) )
+# pragma GCC diagnostic pop
+#endif
 
-static void libshut_close(int arg_upsfd)
+/* Expected evaluated types for the API after typedefs:
+ * static void libshut_close(int arg_upsfd)
+ */
+static void libshut_close(usb_dev_handle arg_upsfd)
 {
 	if (arg_upsfd < 1) {
 		return;
@@ -506,8 +637,15 @@ static void libshut_close(int arg_upsfd)
 /* return the report of ID=type in report
  * return -1 on failure, report length on success
  */
-static int libshut_get_report(int arg_upsfd, int ReportId,
-                       unsigned char *raw_buf, int ReportSize )
+/* Expected evaluated types for the API after typedefs:
+ * static int libshut_get_report(int arg_upsfd, int ReportId,
+ *                      unsigned char *raw_buf, int ReportSize)
+ */
+static int libshut_get_report(
+	usb_dev_handle arg_upsfd,
+	usb_ctrl_repindex ReportId,
+	usb_ctrl_charbuf raw_buf,
+	usb_ctrl_charbufsize ReportSize)
 {
 	if (arg_upsfd < 1) {
 		return 0;
@@ -524,8 +662,15 @@ static int libshut_get_report(int arg_upsfd, int ReportId,
 }
 
 /* return ReportSize upon success ; -1 otherwise */
-static int libshut_set_report(int arg_upsfd, int ReportId,
-                       unsigned char *raw_buf, int ReportSize )
+/* Expected evaluated types for the API after typedefs:
+ * static int libshut_set_report(int arg_upsfd, int ReportId,
+ *                     unsigned char *raw_buf, int ReportSize)
+ */
+static int libshut_set_report(
+	usb_dev_handle arg_upsfd,
+	usb_ctrl_repindex ReportId,
+	usb_ctrl_charbuf raw_buf,
+	usb_ctrl_charbufsize ReportSize)
 {
 	int ret;
 
@@ -533,8 +678,15 @@ static int libshut_set_report(int arg_upsfd, int ReportId,
 		return 0;
 	}
 
-	upsdebugx(1, "Entering libshut_set_report (report %x, len %i)",
+	upsdebugx(1,
+		"Entering libshut_set_report (report %x, "
+		"len %" PRI_NUT_USB_CTRL_CHARBUFSIZE ")",
 		ReportId, ReportSize);
+
+	if ((uintmax_t)ReportSize > (uintmax_t)INT_MAX) {
+		upsdebugx(1, "%s: ReportSize exceeds INT_MAX", __func__);
+		return -1;
+	}
 
 	upsdebug_hex (4, "==> Report after set", raw_buf, ReportSize);
 
@@ -545,10 +697,18 @@ static int libshut_set_report(int arg_upsfd, int ReportId,
 		ReportId+(0x03<<8), /* HID_REPORT_TYPE_FEATURE */
 		0, raw_buf, ReportSize, SHUT_TIMEOUT);
 
-	return ((ret == 0) ? ReportSize : ret);
+	return ((ret == 0) ? (int)ReportSize : ret);
 }
 
-static int libshut_get_string(int arg_upsfd, int StringIdx, char *buf, size_t buflen)
+/* Expected evaluated types for the API after typedefs:
+ * static int libshut_get_string(int arg_upsfd,
+ *                          int StringIdx, char *buf, size_t buflen)
+ */
+static int libshut_get_string(
+	usb_dev_handle arg_upsfd,
+	usb_ctrl_strindex StringIdx,
+	char *buf,
+	usb_ctrl_charbufsize buflen)
 {
 	int ret;
 
@@ -565,8 +725,15 @@ static int libshut_get_string(int arg_upsfd, int StringIdx, char *buf, size_t bu
 	return ret;
 }
 
-static int libshut_get_interrupt(int arg_upsfd, unsigned char *buf,
-                          int bufsize, int timeout)
+/* Expected evaluated types for the API after typedefs:
+ * static int libshut_get_interrupt(int arg_upsfd, unsigned char *buf,
+ *                        int bufsize, int timeout)
+ */
+static int libshut_get_interrupt(
+	usb_dev_handle arg_upsfd,
+	usb_ctrl_charbuf buf,
+	usb_ctrl_charbufsize bufsize,
+	usb_ctrl_timeout_msec timeout)
 {
 	int ret;
 
@@ -605,7 +772,10 @@ shut_communication_subdriver_t shut_subdriver = {
  * set : 1 to set comm
  * set : 0 to stop commupsh.
  */
-void setline(int arg_upsfd, int set)
+/* Expected evaluated types for the API after typedefs:
+ * void setline(int arg_upsfd, int set)
+ */
+void setline(usb_dev_handle arg_upsfd, int set)
 {
 	if (arg_upsfd < 1) {
 		return;
@@ -630,7 +800,10 @@ void setline(int arg_upsfd, int set)
  * return TRUE on success, FALSE on failure
  *
  *****************************************************************************/
-int shut_synchronise(int arg_upsfd)
+/* Expected evaluated types for the API after typedefs:
+ * int shut_synchronise(int arg_upsfd)
+ */
+int shut_synchronise(usb_dev_handle arg_upsfd)
 {
 	int retCode = 0;
 	unsigned char c = SHUT_SYNC_OFF, reply;
@@ -679,9 +852,14 @@ int shut_synchronise(int arg_upsfd)
 /*!
  * Compute a SHUT checksum for the packet "buf"
  */
-static unsigned char shut_checksum(const unsigned char *buf, int bufsize)
+/* Expected evaluated types for the API after typedefs:
+ * static unsigned char shut_checksum(const unsigned char *buf, int bufsize)
+ */
+static unsigned char shut_checksum(
+	const usb_ctrl_charbuf buf,
+	usb_ctrl_charbufsize bufsize)
 {
-	int i;
+	usb_ctrl_charbufsize i;
 	unsigned char chk=0;
 
 	for(i=0; i<bufsize; i++)
@@ -691,8 +869,13 @@ static unsigned char shut_checksum(const unsigned char *buf, int bufsize)
 	return chk;
 }
 
-
-static int shut_packet_recv(int arg_upsfd, unsigned char *Buf, int datalen)
+/* Expected evaluated types for the API after typedefs:
+ * static int shut_packet_recv(int arg_upsfd, unsigned char *Buf, int datalen)
+ */
+static int shut_packet_recv(
+	usb_dev_handle arg_upsfd,
+	usb_ctrl_charbuf Buf,
+	usb_ctrl_charbufsize datalen)
 {
 	unsigned char   Start[2];
 	unsigned char   Frame[8];
@@ -704,7 +887,9 @@ static int shut_packet_recv(int arg_upsfd, unsigned char *Buf, int datalen)
 	/* FIXME: use this
 	 * shut_data_t   sdata; */
 
-	upsdebugx (4, "entering shut_packet_recv (%i)", datalen);
+	upsdebugx (4,
+		"entering shut_packet_recv (%" PRI_NUT_USB_CTRL_CHARBUFSIZE ")",
+		datalen);
 
 	while(datalen>0 && Retry<3)
 	{
@@ -733,7 +918,9 @@ static int shut_packet_recv(int arg_upsfd, unsigned char *Buf, int datalen)
 					upsdebug_hex(4, "Receive", Start, 2);
 					Size=Start[1]&0x0F;
 					if( Size > 8 ) {
-						upsdebugx (4, "shut_packet_recv: invalid frame size = %d", Size);
+						upsdebugx (4,
+							"shut_packet_recv: invalid frame size = %d",
+							Size);
 						ser_send_char(arg_upsfd, SHUT_NOK);
 						Retry++;
 						break;
@@ -777,7 +964,9 @@ static int shut_packet_recv(int arg_upsfd, unsigned char *Buf, int datalen)
 							}
 						}
 						else
-							upsdebugx (4, "need more data (%i)!", datalen);
+							upsdebugx (4,
+								"need more data (%" PRI_NUT_USB_CTRL_CHARBUFSIZE ")!",
+								datalen);
 					}
 					else
 					{
@@ -801,8 +990,17 @@ static int shut_packet_recv(int arg_upsfd, unsigned char *Buf, int datalen)
 }
 
 /**********************************************************************/
-static int shut_interrupt_read(int arg_upsfd, int ep, unsigned char *bytes, int size,
-                        int timeout)
+/* Expected evaluated types for the API after typedefs:
+ * static int shut_interrupt_read(int arg_upsfd, int ep,
+ *                      unsigned char *bytes, int size,
+ *                      int timeout)
+ */
+static int shut_interrupt_read(
+	usb_dev_handle arg_upsfd,
+	usb_ctrl_endpoint ep,
+	usb_ctrl_charbuf bytes,
+	usb_ctrl_charbufsize size,
+	usb_ctrl_timeout_msec timeout)
 {
 /*
 	usleep(timeout * 1000);
@@ -817,10 +1015,17 @@ static int shut_interrupt_read(int arg_upsfd, int ep, unsigned char *bytes, int 
 }
 
 /**********************************************************************/
-static int shut_get_string_simple(int arg_upsfd, int index,
-                           char *buf, size_t buflen)
+/* Expected evaluated types for the API after typedefs:
+ * static int shut_get_string_simple(int arg_upsfd, int index,
+ *                          char *buf, size_t buflen)
+ */
+static int shut_get_string_simple(
+	usb_dev_handle arg_upsfd,
+	usb_ctrl_strindex index,
+	char *buf,
+	usb_ctrl_charbufsize buflen)
 {
-	unsigned char tbuf[255];       /* Some devices choke on size > 255 */
+	usb_ctrl_char tbuf[255];       /* Some devices choke on size > 255 */
 	int ret, si, di;
 
 	ret = shut_control_msg(arg_upsfd, USB_ENDPOINT_IN, USB_REQ_GET_DESCRIPTOR,
@@ -855,7 +1060,7 @@ static int shut_get_string_simple(int arg_upsfd, int index,
  *********************************************************************/
 
 /**********************************************************************
- * shut_get_descriptor(int desctype, unsigned char *pkt)
+ * shut_get_descriptor(int desctype, usb_ctrl_charbuf pkt)
  *
  * get descriptor specified by DescType and return it in Buf
  *
@@ -865,24 +1070,46 @@ static int shut_get_string_simple(int arg_upsfd, int index,
  * return 0 on success, -1 on failure, -2 on NACK
  *
  *********************************************************************/
-static int shut_get_descriptor(int arg_upsfd, unsigned char type,
-                        unsigned char index, void *buf, int size)
+/* Expected evaluated types for the API after typedefs:
+ * static int shut_get_descriptor(int arg_upsfd, unsigned char type,
+ *                        unsigned char index, void *buf, int size)
+ */
+static int shut_get_descriptor(
+	usb_dev_handle arg_upsfd,
+	usb_ctrl_requesttype type,
+	usb_ctrl_descindex index,
+	void *buf,
+	usb_ctrl_charbufsize size)
 {
 	memset(buf, 0, size);
 
-	upsdebugx (2, "entering shut_get_descriptor(n %02x, %i)", type, size);
+	upsdebugx (2,
+		"entering shut_get_descriptor(n %02x, %" PRI_NUT_USB_CTRL_CHARBUFSIZE ")",
+		type, size);
 
 	return shut_control_msg(arg_upsfd, USB_ENDPOINT_IN+(type>=USB_DT_HID?1:0),
 				 USB_REQ_GET_DESCRIPTOR, (type << 8) + index, 0, buf, size, SHUT_TIMEOUT);
 }
 
 /* Take care of a SHUT transfer (sending and receiving data) */
-static int shut_control_msg(int arg_upsfd, int requesttype, int request,
-                     int value, int index, unsigned char *bytes, int size, int timeout)
+/* Expected evaluated types for the API after typedefs:
+ * static int shut_control_msg(int arg_upsfd, int requesttype, int request,
+ *                    int value, int index, unsigned char *bytes, int size,
+ *                    int timeout)
+ */
+static int shut_control_msg(
+	usb_dev_handle arg_upsfd,
+	usb_ctrl_requesttype requesttype,
+	usb_ctrl_request request,
+	usb_ctrl_msgvalue value,
+	usb_ctrl_repindex index,
+	usb_ctrl_charbuf bytes,
+	usb_ctrl_charbufsize size,
+	usb_ctrl_timeout_msec timeout)
 {
 	unsigned char shut_pkt[11];
 	short Retry=1, set_pass = -1;
-	short data_size, remaining_size = size;
+	usb_ctrl_charbufsize data_size, remaining_size = size;
 	int i;
 	struct shut_ctrltransfer_s ctrl;
 	int ret = 0;
@@ -897,12 +1124,30 @@ static int shut_control_msg(int arg_upsfd, int requesttype, int request,
 		remaining_size+= 8;
 	}
 
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS
+# pragma GCC diagnostic ignored "-Wtype-limits"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE
+# pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE
+# pragma GCC diagnostic ignored "-Wtautological-unsigned-zero-compare"
+#endif
+	/* Note: checking against limits of protocol struct fields,
+	 * not against USB_CTRL_REQUEST_MAX et al, which are mostly int
+	 */
 	if (requesttype < 0 || (uintmax_t)requesttype > UINT8_MAX
 	||  request < 0 || (uintmax_t)request > UINT8_MAX
 	||  value < 0 || (uintmax_t)value > UINT16_MAX
 	||  index < 0 || (uintmax_t)index > UINT16_MAX
 	||  (uintmax_t)size > UINT16_MAX
 	||  (uintmax_t)timeout > UINT32_MAX
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
+# pragma GCC diagnostic pop
+#endif
 	) {
 		upsdebugx (1, "%s: input values out of range", __func__);
 		return -1;
@@ -1023,7 +1268,10 @@ static int shut_control_msg(int arg_upsfd, int requesttype, int request,
  * returns 0 on success, -1 on error, -2 on NACK, -3 on NOTIFICATION
  *
  *********************************************************************/
-int shut_wait_ack(int arg_upsfd)
+/* Expected evaluated types for the API after typedefs:
+ * int shut_wait_ack(int arg_upsfd)
+ */
+int shut_wait_ack(usb_dev_handle arg_upsfd)
 {
 	int retCode = -1;
 	unsigned char c = '\0';

--- a/drivers/libshut.c
+++ b/drivers/libshut.c
@@ -1184,14 +1184,31 @@ static int shut_control_msg(
 
 		/* Forge the SHUT Frame */
 		shut_pkt[0] = SHUT_TYPE_REQUEST + ( ((requesttype == REQUEST_TYPE_SET_REPORT) && (remaining_size>8))? 0 : SHUT_PKT_LAST);
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS
+# pragma GCC diagnostic ignored "-Wtype-limits"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE
+# pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE
+# pragma GCC diagnostic ignored "-Wtautological-unsigned-zero-compare"
+#endif
 		if (data_size < 0 || data_size > UCHAR_MAX) {
-			upsdebugx(1, "%s: ERROR: data_size %i is out of range for SHUT packet",
-					__func__, data_size);
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
+# pragma GCC diagnostic pop
+#endif
+			upsdebugx(1, "%s: ERROR: data_size %" PRI_NUT_USB_CTRL_CHARBUFSIZE
+				" is out of range for SHUT packet",
+				__func__, data_size);
 			return -1;
 		}
 		if (data_size > 0x0F) {
-			upsdebugx(1, "%s: WARNING: data_size %i may be too large for SHUT packet?",
-					__func__, data_size);
+			upsdebugx(1, "%s: WARNING: data_size %" PRI_NUT_USB_CTRL_CHARBUFSIZE
+				" may be too large for SHUT packet?",
+				__func__, data_size);
 			// Do not abort here - maybe there is intentional maths
 			// in the protocol with overlapping/shifted-away numbers?
 		}

--- a/drivers/libshut.h
+++ b/drivers/libshut.h
@@ -97,6 +97,16 @@ typedef int usb_ctrl_timeout_msec;	/* in milliseconds */
 #define USB_CTRL_TIMEOUTMSEC_MIN	INT_MIN
 #define USB_CTRL_TIMEOUTMSEC_MAX	INT_MAX
 
+/* Same error-code definitions as in usb-common.h for libusb-0.1 API */
+#define ERROR_ACCESS		-EACCES
+#define ERROR_BUSY			-EBUSY
+#define ERROR_IO			-EIO
+#define ERROR_NO_DEVICE		-ENODEV
+#define ERROR_NOT_FOUND		-ENOENT
+#define ERROR_OVERFLOW		-EOVERFLOW
+#define ERROR_PIPE			-EPIPE
+#define ERROR_TIMEOUT		-ETIMEDOUT
+
 /*!
  * SHUTDevice_t: Describe a SHUT device. This structure contains exactly
  * the 5 pieces of information by which a SHUT device identifies

--- a/drivers/libusb0.c
+++ b/drivers/libusb0.c
@@ -622,7 +622,6 @@ static int libusb_get_string(
 {
 	int ret;
 
-	if (!udev
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
 # pragma GCC diagnostic push
 #endif
@@ -639,12 +638,13 @@ static int libusb_get_string(
 	 * usb.h:int  usb_get_string_simple(usb_dev_handle *dev, int index,
 	 * usb.h-         char *buf, size_t buflen);
 	 */
+	if (!udev
 	|| StringIdx < 0 || (uintmax_t)StringIdx > INT_MAX
 	|| buflen < 0 || (uintmax_t)buflen > (uintmax_t)SIZE_MAX
+	) {
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
 # pragma GCC diagnostic pop
 #endif
-	) {
 		return -1;
 	}
 

--- a/drivers/libusb1.c
+++ b/drivers/libusb1.c
@@ -116,7 +116,8 @@ static int nut_usb_set_altinterface(libusb_device_handle *udev)
 		upslogx(LOG_NOTICE, "%s: libusb_set_interface_alt_setting() should not be necessary - "
 			"please email the nut-upsdev list with information about your UPS.", __func__);
 	} else {
-		upsdebugx(3, "%s: skipped libusb_set_interface_alt_setting(udev, 0, 0)", __func__);
+		upsdebugx(3, "%s: skipped libusb_set_interface_alt_setting(udev, 0, 0)",
+			__func__);
 	}
 	return ret;
 }
@@ -141,7 +142,7 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 	int rdlen1, rdlen2; /* report descriptor length, method 1+2 */
 	USBDeviceMatcher_t *m;
 	libusb_device **devlist;
-	ssize_t devcount = 0;
+	ssize_t	devcount = 0;
 	struct libusb_device_descriptor dev_desc;
 	struct libusb_config_descriptor *conf_desc = NULL;
 	const struct libusb_interface_descriptor *if_desc;
@@ -574,7 +575,7 @@ static int nut_libusb_strerror(const int ret, const char *desc)
 
 /* Expected evaluated types for the API:
  * static int nut_libusb_get_report(libusb_device_handle *udev,
- *	int ReportId, unsigned char *raw_buf, int ReportSize )
+ *	int ReportId, unsigned char *raw_buf, int ReportSize)
  */
 static int nut_libusb_get_report(
 	libusb_device_handle *udev,
@@ -626,7 +627,7 @@ static int nut_libusb_get_report(
 
 /* Expected evaluated types for the API:
  * static int nut_libusb_set_report(libusb_device_handle *udev,
- *	int ReportId, unsigned char *raw_buf, int ReportSize )
+ *	int ReportId, unsigned char *raw_buf, int ReportSize)
  */
 static int nut_libusb_set_report(
 	libusb_device_handle *udev,

--- a/drivers/libusb1.c
+++ b/drivers/libusb1.c
@@ -4,6 +4,7 @@
  *
  * @author Copyright (C) 2016 Eaton
  *         Copyright (C) 2016 Arnaud Quette <aquette.dev@gmail.com>
+ *         Copyright (C) 2021 Jim Klimov <jimklimov+nut@gmail.com>
  *
  *      The logic of this file is ripped from mge-shut driver (also from
  *      Arnaud Quette), which is a "HID over serial link" UPS driver for
@@ -131,7 +132,7 @@ static int nut_usb_set_altinterface(libusb_device_handle *udev)
 static int nut_libusb_open(libusb_device_handle **udevp,
 	USBDevice_t *curDevice, USBDeviceMatcher_t *matcher,
 	int (*callback)(libusb_device_handle *udev,
-		USBDevice_t *hd, unsigned char *rdbuf, int rdlen)
+		USBDevice_t *hd, usb_ctrl_charbuf rdbuf, usb_ctrl_charbufsize rdlen)
 	)
 {
 #if (defined HAVE_LIBUSB_DETACH_KERNEL_DRIVER) || (defined HAVE_LIBUSB_DETACH_KERNEL_DRIVER_NP)
@@ -274,7 +275,9 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 
 
 		upsdebugx(2, "Reading first configuration descriptor");
-		ret = libusb_get_config_descriptor(device, usb_subdriver.hid_rep_index, &conf_desc);
+		ret = libusb_get_config_descriptor(device,
+			(uint8_t)usb_subdriver.hid_rep_index,
+			&conf_desc);
 		/*ret = libusb_get_active_config_descriptor(device, &conf_desc);*/
 		if (ret < 0)
 			upsdebugx(2, "result: %i (%s)",
@@ -438,7 +441,7 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 			goto next_device;
 		}
 
-#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) )
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
 # pragma GCC diagnostic push
 #endif
 #ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS
@@ -447,8 +450,11 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 #ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE
 # pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"
 #endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE
+# pragma GCC diagnostic ignored "-Wtautological-unsigned-zero-compare"
+#endif
 		if ((uintmax_t)rdlen > UINT16_MAX) {
-#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) )
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
 # pragma GCC diagnostic pop
 #endif
 			upsdebugx(2, "HID descriptor too long %d (max %u)",
@@ -477,7 +483,18 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 			rdlen = res; /* correct rdlen if necessary */
 		}
 
-		res = callback(udev, curDevice, rdbuf, rdlen);
+		if (rdlen < USB_CTRL_CHARBUFSIZE_MIN
+		||  (uintmax_t)rdlen > (uintmax_t)USB_CTRL_CHARBUFSIZE_MAX
+		) {
+			upsdebugx(2,
+				"Report descriptor length is out of range on this device: "
+				"should be %ji < %d < %ju",
+					(intmax_t)USB_CTRL_CHARBUFSIZE_MIN, rdlen,
+					(uintmax_t)USB_CTRL_CHARBUFSIZE_MAX);
+			goto next_device;
+		}
+
+		res = callback(udev, curDevice, rdbuf, (usb_ctrl_charbufsize)rdlen);
 		if (res < 1) {
 			upsdebugx(2, "Caller doesn't like this device");
 			goto next_device;
@@ -555,14 +572,39 @@ static int nut_libusb_strerror(const int ret, const char *desc)
  * return -1 on failure, report length on success
  */
 
-static int nut_libusb_get_report(libusb_device_handle *udev,
-	int ReportId, unsigned char *raw_buf, int ReportSize )
+/* Expected evaluated types for the API:
+ * static int nut_libusb_get_report(libusb_device_handle *udev,
+ *	int ReportId, unsigned char *raw_buf, int ReportSize )
+ */
+static int nut_libusb_get_report(
+	libusb_device_handle *udev,
+	usb_ctrl_repindex ReportId,
+	usb_ctrl_charbuf raw_buf,
+	usb_ctrl_charbufsize ReportSize)
 {
 	int	ret;
 
 	upsdebugx(4, "Entering libusb_get_report");
 
-	if (!udev) {
+	if (!udev
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS
+# pragma GCC diagnostic ignored "-Wtype-limits"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE
+# pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE
+# pragma GCC diagnostic ignored "-Wtautological-unsigned-zero-compare"
+#endif
+	|| ReportId < 0 || (uintmax_t)ReportId > UINT16_MAX
+	|| ReportSize < 0 || (uintmax_t)ReportSize > UINT16_MAX
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
+# pragma GCC diagnostic pop
+#endif
+	) {
 		return 0;
 	}
 
@@ -570,9 +612,9 @@ static int nut_libusb_get_report(libusb_device_handle *udev,
 	ret = libusb_control_transfer(udev,
 		LIBUSB_ENDPOINT_IN|LIBUSB_REQUEST_TYPE_CLASS|LIBUSB_RECIPIENT_INTERFACE,
 		0x01, /* HID_REPORT_GET */
-		ReportId+(0x03<<8), /* HID_REPORT_TYPE_FEATURE */
+		(uint16_t)ReportId + (0x03<<8), /* HID_REPORT_TYPE_FEATURE */
 		usb_subdriver.hid_rep_index,
-		raw_buf, ReportSize, USB_TIMEOUT);
+		raw_buf, (uint16_t)ReportSize, USB_TIMEOUT);
 
 	/* Ignore "protocol stall" (for unsupported request) on control endpoint */
 	if (ret == LIBUSB_ERROR_PIPE) {
@@ -582,12 +624,37 @@ static int nut_libusb_get_report(libusb_device_handle *udev,
 	return nut_libusb_strerror(ret, __func__);
 }
 
-static int nut_libusb_set_report(libusb_device_handle *udev,
-	int ReportId, unsigned char *raw_buf, int ReportSize )
+/* Expected evaluated types for the API:
+ * static int nut_libusb_set_report(libusb_device_handle *udev,
+ *	int ReportId, unsigned char *raw_buf, int ReportSize )
+ */
+static int nut_libusb_set_report(
+	libusb_device_handle *udev,
+	usb_ctrl_repindex ReportId,
+	usb_ctrl_charbuf raw_buf,
+	usb_ctrl_charbufsize ReportSize)
 {
 	int	ret;
 
-	if (!udev) {
+	if (!udev
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS
+# pragma GCC diagnostic ignored "-Wtype-limits"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE
+# pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE
+# pragma GCC diagnostic ignored "-Wtautological-unsigned-zero-compare"
+#endif
+	|| ReportId < 0 || (uintmax_t)ReportId > UINT16_MAX
+	|| ReportSize < 0 || (uintmax_t)ReportSize > UINT16_MAX
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
+# pragma GCC diagnostic pop
+#endif
+	) {
 		return 0;
 	}
 
@@ -595,9 +662,9 @@ static int nut_libusb_set_report(libusb_device_handle *udev,
 	ret = libusb_control_transfer(udev,
 		LIBUSB_ENDPOINT_OUT|LIBUSB_REQUEST_TYPE_CLASS|LIBUSB_RECIPIENT_INTERFACE,
 		0x09, /* HID_REPORT_SET = 0x09*/
-		ReportId+(0x03<<8), /* HID_REPORT_TYPE_FEATURE */
+		(uint16_t)ReportId + (0x03<<8), /* HID_REPORT_TYPE_FEATURE */
 		usb_subdriver.hid_rep_index,
-		raw_buf, ReportSize, USB_TIMEOUT);
+		raw_buf, (uint16_t)ReportSize, USB_TIMEOUT);
 
 	/* Ignore "protocol stall" (for unsupported request) on control endpoint */
 	if (ret == LIBUSB_ERROR_PIPE) {
@@ -607,35 +674,94 @@ static int nut_libusb_set_report(libusb_device_handle *udev,
 	return nut_libusb_strerror(ret, __func__);
 }
 
-static int nut_libusb_get_string(libusb_device_handle *udev,
-	int StringIdx, char *buf, size_t buflen)
+/* Expected evaluated types for the API:
+ * static int nut_libusb_get_string(libusb_device_handle *udev,
+ *	int StringIdx, char *buf, int buflen)
+ */
+static int nut_libusb_get_string(
+	libusb_device_handle *udev,
+	usb_ctrl_strindex StringIdx,
+	char *buf,
+	usb_ctrl_charbufsize buflen)
 {
 	int ret;
 
-	if (!udev) {
+	if (!udev
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS
+# pragma GCC diagnostic ignored "-Wtype-limits"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE
+# pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE
+# pragma GCC diagnostic ignored "-Wtautological-unsigned-zero-compare"
+#endif
+	|| StringIdx < 0 || (uintmax_t)StringIdx > UINT8_MAX
+	|| buflen < 0 || (uintmax_t)buflen > (uintmax_t)INT_MAX
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
+# pragma GCC diagnostic pop
+#endif
+	) {
 		return -1;
 	}
 
-	ret = libusb_get_string_descriptor_ascii(udev, StringIdx,
-		(unsigned char*)buf, buflen);
+	ret = libusb_get_string_descriptor_ascii(udev, (uint8_t)StringIdx,
+		(unsigned char*)buf, (int)buflen);
 
 	return nut_libusb_strerror(ret, __func__);
 }
 
-static int nut_libusb_get_interrupt(libusb_device_handle *udev,
-	unsigned char *buf, int bufsize, int timeout)
+/* Expected evaluated types for the API:
+ * static int nut_libusb_get_interrupt(libusb_device_handle *udev,
+ *	unsigned char *buf, int bufsize, int timeout)
+ */
+static int nut_libusb_get_interrupt(
+	libusb_device_handle *udev,
+	usb_ctrl_charbuf buf,
+	usb_ctrl_charbufsize bufsize,
+	usb_ctrl_timeout_msec timeout)
 {
-	int ret;
+	int ret, tmpbufsize;
 
-	if (!udev) {
+	if (!udev
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS
+# pragma GCC diagnostic ignored "-Wtype-limits"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE
+# pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE
+# pragma GCC diagnostic ignored "-Wtautological-unsigned-zero-compare"
+#endif
+	||  bufsize < 0 || (uintmax_t)bufsize > (uintmax_t)INT_MAX
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
+# pragma GCC diagnostic pop
+#endif
+	) {
 		return -1;
 	}
+
+	/* NOTE: With all the fuss about word sized arguments,
+	 * the libusb_interrupt_transfer() lengths are about ints:
+	 * int LIBUSB_CALL libusb_interrupt_transfer(libusb_device_handle *dev_handle,
+	 *	unsigned char endpoint, unsigned char *data, int length,
+	 *	int *actual_length, unsigned int timeout);
+	 */
+	tmpbufsize = (int)bufsize;
 
 	/* FIXME: hardcoded interrupt EP => need to get EP descr for IF descr */
 	/* ret = libusb_interrupt_transfer(udev, 0x81, buf, bufsize, &bufsize, timeout); */
 	/* libusb0: ret = usb_interrupt_read(udev, USB_ENDPOINT_IN + usb_subdriver.hid_ep_in, (char *)buf, bufsize, timeout); */
 	/* Interrupt EP is LIBUSB_ENDPOINT_IN with offset defined in hid_ep_in, which is 0 by default, unless overridden in subdriver. */
-	ret = libusb_interrupt_transfer(udev, LIBUSB_ENDPOINT_IN + usb_subdriver.hid_ep_in, (unsigned char *)buf, bufsize, &bufsize, timeout);
+	ret = libusb_interrupt_transfer(udev,
+		LIBUSB_ENDPOINT_IN + usb_subdriver.hid_ep_in,
+		(unsigned char *)buf, tmpbufsize, &tmpbufsize, timeout);
 
 	/* Clear stall condition */
 	if (ret == LIBUSB_ERROR_PIPE) {
@@ -644,7 +770,12 @@ static int nut_libusb_get_interrupt(libusb_device_handle *udev,
 
 	/* In case of success, return the operation size, as done with libusb 0.1 */
 	if (ret == LIBUSB_SUCCESS) {
-		ret = bufsize;
+		if (tmpbufsize < 0
+		||  (uintmax_t)tmpbufsize > (uintmax_t)USB_CTRL_CHARBUFSIZE_MAX
+		) {
+			return -1;
+		}
+		ret = (usb_ctrl_charbufsize)bufsize;
 	}
 
 	return nut_libusb_strerror(ret, __func__);

--- a/drivers/libusb1.c
+++ b/drivers/libusb1.c
@@ -587,7 +587,6 @@ static int nut_libusb_get_report(
 
 	upsdebugx(4, "Entering libusb_get_report");
 
-	if (!udev
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
 # pragma GCC diagnostic push
 #endif
@@ -600,12 +599,13 @@ static int nut_libusb_get_report(
 #ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE
 # pragma GCC diagnostic ignored "-Wtautological-unsigned-zero-compare"
 #endif
+	if (!udev
 	|| ReportId < 0 || (uintmax_t)ReportId > UINT16_MAX
 	|| ReportSize < 0 || (uintmax_t)ReportSize > UINT16_MAX
+	) {
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
 # pragma GCC diagnostic pop
 #endif
-	) {
 		return 0;
 	}
 
@@ -637,7 +637,6 @@ static int nut_libusb_set_report(
 {
 	int	ret;
 
-	if (!udev
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
 # pragma GCC diagnostic push
 #endif
@@ -650,12 +649,13 @@ static int nut_libusb_set_report(
 #ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE
 # pragma GCC diagnostic ignored "-Wtautological-unsigned-zero-compare"
 #endif
+	if (!udev
 	|| ReportId < 0 || (uintmax_t)ReportId > UINT16_MAX
 	|| ReportSize < 0 || (uintmax_t)ReportSize > UINT16_MAX
+	) {
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
 # pragma GCC diagnostic pop
 #endif
-	) {
 		return 0;
 	}
 
@@ -687,7 +687,6 @@ static int nut_libusb_get_string(
 {
 	int ret;
 
-	if (!udev
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
 # pragma GCC diagnostic push
 #endif
@@ -700,12 +699,13 @@ static int nut_libusb_get_string(
 #ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE
 # pragma GCC diagnostic ignored "-Wtautological-unsigned-zero-compare"
 #endif
+	if (!udev
 	|| StringIdx < 0 || (uintmax_t)StringIdx > UINT8_MAX
 	|| buflen < 0 || (uintmax_t)buflen > (uintmax_t)INT_MAX
+	) {
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
 # pragma GCC diagnostic pop
 #endif
-	) {
 		return -1;
 	}
 
@@ -727,7 +727,6 @@ static int nut_libusb_get_interrupt(
 {
 	int ret, tmpbufsize;
 
-	if (!udev
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
 # pragma GCC diagnostic push
 #endif
@@ -740,11 +739,12 @@ static int nut_libusb_get_interrupt(
 #ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE
 # pragma GCC diagnostic ignored "-Wtautological-unsigned-zero-compare"
 #endif
+	if (!udev
 	||  bufsize < 0 || (uintmax_t)bufsize > (uintmax_t)INT_MAX
+	) {
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
 # pragma GCC diagnostic pop
 #endif
-	) {
 		return -1;
 	}
 

--- a/drivers/nut_libusb.h
+++ b/drivers/nut_libusb.h
@@ -56,21 +56,22 @@ typedef struct usb_communication_subdriver_s {
 		USBDevice_t *curDevice,		/* device matching USBDeviceMatcher_t	*/
 		USBDeviceMatcher_t *matcher,
 		int (*callback)(usb_dev_handle *udev, USBDevice_t *hd,
-			unsigned char *rdbuf, int rdlen));
+			usb_ctrl_charbuf rdbuf, usb_ctrl_charbufsize rdlen));
 
 	void (*close)(usb_dev_handle *sdev);
 
-	int (*get_report)(usb_dev_handle *sdev, int ReportId,
-		unsigned char *raw_buf, int ReportSize);
+	int (*get_report)(usb_dev_handle *sdev, usb_ctrl_repindex ReportId,
+		usb_ctrl_charbuf raw_buf, usb_ctrl_charbufsize ReportSize);
 
-	int (*set_report)(usb_dev_handle *sdev, int ReportId,
-		unsigned char *raw_buf, int ReportSize);
+	int (*set_report)(usb_dev_handle *sdev, usb_ctrl_repindex ReportId,
+		usb_ctrl_charbuf raw_buf, usb_ctrl_charbufsize ReportSize);
 
 	int (*get_string)(usb_dev_handle *sdev,
-		int StringIdx, char *buf, size_t buflen);
+		usb_ctrl_strindex StringIdx, char *buf, usb_ctrl_charbufsize buflen);
 
 	int (*get_interrupt)(usb_dev_handle *sdev,
-		unsigned char *buf, int bufsize, int timeout);
+		usb_ctrl_charbuf buf, usb_ctrl_charbufsize bufsize,
+		usb_ctrl_timeout_msec timeout);
 
 	/* Used for Powervar UPS or similar cases to make sure
 	 * we use the right interface in the Composite device.

--- a/drivers/nutdrv_atcl_usb.c
+++ b/drivers/nutdrv_atcl_usb.c
@@ -263,7 +263,7 @@ static int usb_device_open(usb_dev_handle **handlep, USBDevice_t *device, USBDev
 		libusb_exit(NULL);
 		fatal_with_errno(EXIT_FAILURE, "Failed to init libusb 1.0");
 	}
-#else
+#else  /* => WITH_LIBUSB_0_1 */
 	usb_init();
 	usb_find_busses();
 	usb_find_devices();
@@ -293,7 +293,7 @@ static int usb_device_open(usb_dev_handle **handlep, USBDevice_t *device, USBDev
 		libusb_get_device_descriptor(dev, &dev_desc);
 		ret = libusb_open(dev, &handle);
 		*handlep = handle;
-#else
+#else  /* => WITH_LIBUSB_0_1 */
 	struct usb_bus	*bus;
 	for (bus = usb_busses; bus; bus = bus->next) {
 
@@ -343,7 +343,7 @@ static int usb_device_open(usb_dev_handle **handlep, USBDevice_t *device, USBDev
 			iManufacturer = dev_desc.iManufacturer;
 			iProduct = dev_desc.iProduct;
 			iSerialNumber = dev_desc.iSerialNumber;
-#else
+#else  /* => WITH_LIBUSB_0_1 */
 			device->VendorID = dev->descriptor.idVendor;
 			device->ProductID = dev->descriptor.idProduct;
 			device->Bus = strdup(bus->dirname);
@@ -439,7 +439,8 @@ static int usb_device_open(usb_dev_handle **handlep, USBDevice_t *device, USBDev
 				} else {
 					upsdebugx(4, "detached kernel driver from USB device...");
 				}
-#elif HAVE_LIBUSB_DETACH_KERNEL_DRIVER
+#else
+# ifdef HAVE_LIBUSB_DETACH_KERNEL_DRIVER
 				if ((ret = libusb_detach_kernel_driver(udev, 0)) < 0) {
 					upsdebugx(4,
 						"failed to detach kernel driver from USB device: %s",
@@ -447,7 +448,8 @@ static int usb_device_open(usb_dev_handle **handlep, USBDevice_t *device, USBDev
 				} else {
 					upsdebugx(4, "detached kernel driver from USB device...");
 				}
-#elif HAVE_LIBUSB_DETACH_KERNEL_DRIVER_NP
+# else
+#  ifdef HAVE_LIBUSB_DETACH_KERNEL_DRIVER_NP
 				if ((ret = libusb_detach_kernel_driver_np(udev, 0)) < 0) {
 					upsdebugx(4,
 						"failed to detach kernel driver from USB device: %s",
@@ -455,6 +457,8 @@ static int usb_device_open(usb_dev_handle **handlep, USBDevice_t *device, USBDev
 				} else {
 					upsdebugx(4, "detached kernel driver from USB device...");
 				}
+#  endif /* HAVE_LIBUSB_DETACH_KERNEL_DRIVER_NP */
+# endif /* HAVE_LIBUSB_DETACH_KERNEL_DRIVER */
 #endif /* HAVE_USB_DETACH_KERNEL_DRIVER_NP or HAVE_LIBUSB_DETACH_KERNEL_DRIVER or HAVE_LIBUSB_DETACH_KERNEL_DRIVER_NP */
 			}
 
@@ -465,7 +469,7 @@ static int usb_device_open(usb_dev_handle **handlep, USBDevice_t *device, USBDev
 
 		next_device:
 			usb_close(handle);
-#if (!WITH_LIBUSB_1_0)
+#if (!WITH_LIBUSB_1_0)  /* => WITH_LIBUSB_0_1 */
 		}
 #endif /* WITH_LIBUSB_1_0 */
 	}

--- a/drivers/richcomm_usb.c
+++ b/drivers/richcomm_usb.c
@@ -310,7 +310,7 @@ static int usb_device_open(usb_dev_handle **handlep, USBDevice_t *device, USBDev
 		libusb_exit(NULL);
 		fatal_with_errno(EXIT_FAILURE, "Failed to init libusb 1.0");
 	}
-#else
+#else  /* => WITH_LIBUSB_0_1 */
 	usb_init();
 	usb_find_busses();
 	usb_find_devices();
@@ -340,7 +340,7 @@ static int usb_device_open(usb_dev_handle **handlep, USBDevice_t *device, USBDev
 		libusb_get_device_descriptor(dev, &dev_desc);
 		ret = libusb_open(dev, &handle);
 		*handlep = handle;
-#else
+#else  /* => WITH_LIBUSB_0_1 */
 	struct usb_bus	*bus;
 	for (bus = usb_busses; bus; bus = bus->next) {
 
@@ -390,7 +390,7 @@ static int usb_device_open(usb_dev_handle **handlep, USBDevice_t *device, USBDev
 			iManufacturer = dev_desc.iManufacturer;
 			iProduct = dev_desc.iProduct;
 			iSerialNumber = dev_desc.iSerialNumber;
-#else
+#else  /* => WITH_LIBUSB_0_1 */
 			device->VendorID = dev->descriptor.idVendor;
 			device->ProductID = dev->descriptor.idProduct;
 			device->Bus = strdup(bus->dirname);
@@ -487,7 +487,8 @@ static int usb_device_open(usb_dev_handle **handlep, USBDevice_t *device, USBDev
 				} else {
 					upsdebugx(4, "detached kernel driver from USB device...");
 				}
-#elif HAVE_LIBUSB_DETACH_KERNEL_DRIVER
+#else
+# ifdef HAVE_LIBUSB_DETACH_KERNEL_DRIVER
 				if ((ret = libusb_detach_kernel_driver(udev, 0)) < 0) {
 					upsdebugx(4,
 						"failed to detach kernel driver from USB device: %s",
@@ -495,7 +496,8 @@ static int usb_device_open(usb_dev_handle **handlep, USBDevice_t *device, USBDev
 				} else {
 					upsdebugx(4, "detached kernel driver from USB device...");
 				}
-#elif HAVE_LIBUSB_DETACH_KERNEL_DRIVER_NP
+# else
+#  ifdef HAVE_LIBUSB_DETACH_KERNEL_DRIVER_NP
 				if ((ret = libusb_detach_kernel_driver_np(udev, 0)) < 0) {
 					upsdebugx(4,
 						"failed to detach kernel driver from USB device: %s",
@@ -503,6 +505,8 @@ static int usb_device_open(usb_dev_handle **handlep, USBDevice_t *device, USBDev
 				} else {
 					upsdebugx(4, "detached kernel driver from USB device...");
 				}
+#  endif /* HAVE_LIBUSB_DETACH_KERNEL_DRIVER_NP */
+# endif /* HAVE_LIBUSB_DETACH_KERNEL_DRIVER */
 #endif /* HAVE_USB_DETACH_KERNEL_DRIVER_NP or HAVE_LIBUSB_DETACH_KERNEL_DRIVER or HAVE_LIBUSB_DETACH_KERNEL_DRIVER_NP */
 			}
 
@@ -512,7 +516,7 @@ static int usb_device_open(usb_dev_handle **handlep, USBDevice_t *device, USBDev
 
 		next_device:
 			usb_close(handle);
-#if (!WITH_LIBUSB_1_0)
+#if (!WITH_LIBUSB_1_0)   /* => WITH_LIBUSB_0_1 */
 		}
 #endif /* WITH_LIBUSB_1_0 */
 	}

--- a/drivers/riello_ser.c
+++ b/drivers/riello_ser.c
@@ -31,8 +31,13 @@
 #include "main.h"
 #include "serial.h"
 #include "timehead.h"
+/*
+// The serial driver has no need for HID structures/code currently
+// (maybe there is/was a plan for sharing something between siblings).
+// Note that HID is tied to libusb or libshut definitions at the moment.
 #include "hidparser.h"
 #include "hidtypes.h"
+*/
 #include "common.h" /* for upsdebugx() etc */
 #include "riello.h"
 

--- a/drivers/riello_usb.c
+++ b/drivers/riello_usb.c
@@ -306,7 +306,7 @@ static USBDeviceMatcher_t device_matcher = {
  * caller, don't do this here. Return < 0 on error, 0 or higher on
  * success.
  */
-static int driver_callback(usb_dev_handle *handle, USBDevice_t *device, unsigned char *rdbuf, int rdlen)
+static int driver_callback(usb_dev_handle *handle, USBDevice_t *device, usb_ctrl_charbuf rdbuf, usb_ctrl_charbufsize rdlen)
 {
 	int ret = 0;
 	NUT_UNUSED_VARIABLE(device);

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -613,11 +613,13 @@ static int send_cmd(const unsigned char *msg, size_t msg_len, unsigned char *rep
 	for(send_try=0; !done && send_try < MAX_SEND_TRIES; send_try++) {
 		upsdebugx(6, "send_cmd send_try %d", send_try+1);
 
-		ret = comm_driver->set_report(udev, 0, buffer_out, sizeof(buffer_out));
+		ret = comm_driver->set_report(udev, 0,
+			(usb_ctrl_charbuf)buffer_out,
+			(usb_ctrl_charbufsize)sizeof(buffer_out));
 
 		if(ret != sizeof(buffer_out)) {
-			upslogx(1, "libusb_set_report() returned %d instead of %u",
-				ret, (unsigned)(sizeof(buffer_out)));
+			upslogx(1, "libusb_set_report() returned %d instead of %zu",
+				ret, sizeof(buffer_out));
 			return ret;
 		}
 
@@ -627,7 +629,10 @@ static int send_cmd(const unsigned char *msg, size_t msg_len, unsigned char *rep
 
 		for(recv_try=0; !done && recv_try < MAX_RECV_TRIES; recv_try++) {
 			upsdebugx(7, "send_cmd recv_try %d", recv_try+1);
-			ret = comm_driver->get_interrupt(udev, reply, sizeof(buffer_out), RECV_WAIT_MSEC);
+			ret = comm_driver->get_interrupt(udev,
+				(usb_ctrl_charbuf)reply,
+				(usb_ctrl_charbufsize)sizeof(buffer_out),
+				RECV_WAIT_MSEC);
 			if(ret != sizeof(buffer_out)) {
 				upslogx(1, "libusb_get_interrupt() returned %d instead of %u while sending %s",
 					ret, (unsigned)(sizeof(buffer_out)),

--- a/drivers/usb-common.h
+++ b/drivers/usb-common.h
@@ -84,19 +84,62 @@
  /* Structures */
  /* #define usb_dev_handle libusb_device_handle */
  typedef libusb_device_handle usb_dev_handle;
+/* These typedefs are also named in libshut.h, so we can consistenly
+ * handle the "ifdef SHUT_MODE" handling in libhid.c and some drivers.
+ * These symbolic names are used in all the headers and are expected to
+ * match binary code of object files at (monolithic) driver build time.
+ *
+ * The MIN/MAX definitions here are primarily to generalize range-check
+ * code (especially if anything is done outside the libraries).
+ * FIXME: It may make sense to constrain the limits to lowest common
+ * denominator that should fit alll of libusb-0.1, libusb-1.0 and libshut,
+ * so that any build of the practical (driver) code knows to not exceed
+ * any use-case.
+ */
  typedef uint8_t usb_ctrl_requesttype;
+ #define USB_CTRL_REQUESTTYPE_MIN	0
+ #define USB_CTRL_REQUESTTYPE_MAX	UINT8_MAX
+
  typedef uint8_t usb_ctrl_request;
+ #define USB_CTRL_REQUEST_MIN	0
+ #define USB_CTRL_REQUEST_MAX	UINT8_MAX
+
  typedef unsigned char usb_ctrl_endpoint;
+ #define USB_CTRL_ENDPOINT_MIN	0
+ #define USB_CTRL_ENDPOINT_MAX	UCHAR_MAX
+
  typedef uint16_t usb_ctrl_msgvalue;
+ #define USB_CTRL_MSGVALUE_MIN	0
+ #define USB_CTRL_MSGVALUE_MAX	UINT16_MAX
+
  typedef uint16_t usb_ctrl_repindex;
+ #define USB_CTRL_REPINDEX_MIN	0
+ #define USB_CTRL_REPINDEX_MAX	UINT16_MAX
+
  typedef uint8_t usb_ctrl_strindex;
+ #define USB_CTRL_STRINDEX_MIN	0
+ #define USB_CTRL_STRINDEX_MAX	UINT8_MAX
+
  typedef uint8_t usb_ctrl_descindex;
+ #define USB_CTRL_DESCINDEX_MIN	0
+ #define USB_CTRL_DESCINDEX_MAX	UINT8_MAX
+
  typedef unsigned char* usb_ctrl_charbuf;
+ typedef unsigned char usb_ctrl_char;
+ #define USB_CTRL_CHAR_MIN	0
+ #define USB_CTRL_CHAR_MAX	UCHAR_MAX
+
+ /* Here MIN/MAX should not matter much, type mostly used for casting */
  typedef uint16_t usb_ctrl_charbufsize;
+ #define USB_CTRL_CHARBUFSIZE_MIN	0
+ #define USB_CTRL_CHARBUFSIZE_MAX	UINT16_MAX
  #define PRI_NUT_USB_CTRL_CHARBUFSIZE PRIu16
+
  typedef unsigned int usb_ctrl_timeout_msec;	/* in milliseconds */
 	/* Note: there does not seem to be a standard type
 	 * for milliseconds, like there is an useconds_t */
+ #define USB_CTRL_TIMEOUTMSEC_MIN	0
+ #define USB_CTRL_TIMEOUTMSEC_MAX	UINT_MAX
 
  /* defines */
  #define USB_CLASS_PER_INTERFACE	LIBUSB_CLASS_PER_INTERFACE
@@ -319,18 +362,57 @@
 #if WITH_LIBUSB_0_1
 # include <usb.h>
  /* Structures */
+ /* See detailed comments above, in libusb-1.0 definitions
+  * FIXME: It may make sense to constrain the limits to lowest common
+  * denominator that should fit alll of libusb-0.1, libusb-1.0 and libshut,
+  * so that any build of the practical (driver) code knows to not exceed
+  * any use-case.
+  */
+ /* no typedef for usb_dev_handle - part of libusb-0.1 API names */
+
  typedef int usb_ctrl_requesttype;
+ #define USB_CTRL_REQUESTTYPE_MIN	INT_MIN
+ #define USB_CTRL_REQUESTTYPE_MAX	INT_MAX
+
  typedef int usb_ctrl_request;
+ #define USB_CTRL_REQUEST_MIN	INT_MIN
+ #define USB_CTRL_REQUEST_MAX	INT_MAX
+
  typedef int usb_ctrl_endpoint;
+ #define USB_CTRL_ENDPOINT_MIN	INT_MIN
+ #define USB_CTRL_ENDPOINT_MAX	INT_MAX
+
  typedef int usb_ctrl_msgvalue;
+ #define USB_CTRL_MSGVALUE_MIN	INT_MIN
+ #define USB_CTRL_MSGVALUE_MAX	INT_MAX
+
  typedef int usb_ctrl_repindex;
+ #define USB_CTRL_REPINDEX_MIN	INT_MIN
+ #define USB_CTRL_REPINDEX_MAX	INT_MAX
+
  typedef int usb_ctrl_strindex;
+ #define USB_CTRL_STRINDEX_MIN	INT_MIN
+ #define USB_CTRL_STRINDEX_MAX	INT_MAX
+
  typedef int usb_ctrl_descindex;
+ #define USB_CTRL_DESCINDEX_MIN	INT_MIN
+ #define USB_CTRL_DESCINDEX_MAX	INT_MAX
+
+ /* Here MIN/MAX should not matter much, type mostly used for casting */
  typedef char* usb_ctrl_charbuf;
+ typedef char usb_ctrl_char;
+ #define USB_CTRL_CHAR_MIN	CHAR_MIN
+ #define USB_CTRL_CHAR_MAX	CHAR_MAX
+
  typedef int usb_ctrl_charbufsize;
+ #define USB_CTRL_CHARBUFSIZE_MIN	INT_MIN
+ #define USB_CTRL_CHARBUFSIZE_MAX	INT_MAX
  /* There is no PRIi :) So we define directly by spec */
  #define PRI_NUT_USB_CTRL_CHARBUFSIZE "i"
+
  typedef int usb_ctrl_timeout_msec;	/* in milliseconds */
+ #define USB_CTRL_TIMEOUTMSEC_MIN	INT_MIN
+ #define USB_CTRL_TIMEOUTMSEC_MAX	INT_MAX
 
  /* defines */
  #define ERROR_ACCESS		-EACCES

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -1175,9 +1175,25 @@ static int callback(
 	int ret;
 #endif
 	upsdebugx(2, "Report Descriptor size = %" PRI_NUT_USB_CTRL_CHARBUFSIZE, rdlen);
+
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS
+# pragma GCC diagnostic ignored "-Wtype-limits"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE
+# pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE
+# pragma GCC diagnostic ignored "-Wtautological-unsigned-zero-compare"
+#endif
 	if ((uintmax_t)rdlen < (uintmax_t)SIZE_MAX) {
 		upsdebug_hex(3, "Report Descriptor", rdbuf, (size_t)rdlen);
 	}
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
+# pragma GCC diagnostic pop
+#endif
 
 	/* Save the global "hd" for this driver instance */
 	hd = arghd;

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -156,7 +156,8 @@ static void ups_status_set(void);
 static bool_t hid_ups_walk(walkmode_t mode);
 static int reconnect_ups(void);
 static int ups_infoval_set(hid_info_t *item, double value);
-static int callback(hid_dev_handle_t argudev, HIDDevice_t *arghd, unsigned char *rdbuf, int rdlen);
+static int callback(hid_dev_handle_t argudev, HIDDevice_t *arghd,
+					usb_ctrl_charbuf rdbuf, usb_ctrl_charbufsize rdlen);
 #ifdef DEBUG
 static double interval(void);
 #endif
@@ -1162,15 +1163,21 @@ static void process_boolean_info(const char *nutvalue)
 	upsdebugx(5, "Warning: %s not in list of known values", nutvalue);
 }
 
-static int callback(hid_dev_handle_t argudev, HIDDevice_t *arghd, unsigned char *rdbuf, int rdlen)
+static int callback(
+	hid_dev_handle_t argudev,
+	HIDDevice_t *arghd,
+	usb_ctrl_charbuf rdbuf,
+	usb_ctrl_charbufsize rdlen)
 {
 	int i;
 	const char *mfr = NULL, *model = NULL, *serial = NULL;
 #ifndef SHUT_MODE
 	int ret;
 #endif
-	upsdebugx(2, "Report Descriptor size = %d", rdlen);
-	upsdebug_hex(3, "Report Descriptor", rdbuf, (size_t)rdlen);
+	upsdebugx(2, "Report Descriptor size = %" PRI_NUT_USB_CTRL_CHARBUFSIZE, rdlen);
+	if ((uintmax_t)rdlen < (uintmax_t)SIZE_MAX) {
+		upsdebug_hex(3, "Report Descriptor", rdbuf, (size_t)rdlen);
+	}
 
 	/* Save the global "hd" for this driver instance */
 	hd = arghd;


### PR DESCRIPTION
This PR updates the libusb-1.0 branch with "fightwarn" considerations (following up from effort in #823 to get the NUT codebase CI-tested and free from more and more classes of warnings, so we can enable non-regression testing for them with future iterations), allowing to proceed with issue #300 to get libusb 1.0 API supported by NUT officially. In fact, this PR would complete the current definition of "medium" level warnings, allowing to set them as default requirement.

One important change here, that was questionable to myself but got "rationalized", is the step back from fixed C-standard fixed-size numeric value types like `size_t`, to `typedef ... usb_ctrl_...` with types defined by respective backend API for libusb-1.0, libusb-0.1, libhid, libshut and some drivers. For statically linked drivers this should not matter in fact, and this change does not preclude (and even helps) later efforts to re-define those typedefs identically for all backends, and add more range-checks and casts to make the complete codebase build with that.

This PR also reduces duplication of code (libusb 0.1 vs 1.0 definitions were repeated in many drivers and libs) offloading that to usb-common.h

At least, such is the theory - testing against real hardware would be very helpful; if you do - please comment the good, the bad and the ugly outcomes in #300.

Sibling PR #1241 addresses similar refresh for the newer libusb-1.0+0.1 branch, which incorporates and builds upon this one and is planned to become part of NUT master codebase when the dust settles.