### PR TITLE
Fix issue #439 Incorrect Output Voltage on CPS*EFPCLCD, including libusb-1.0 branch

### DIFF
--- a/drivers/apc-hid.c
+++ b/drivers/apc-hid.c
@@ -507,4 +507,5 @@ subdriver_t apc_subdriver = {
 	apc_format_model,
 	apc_format_mfr,
 	apc_format_serial,
+	fix_report_desc,
 };

--- a/drivers/arduino-hid.c
+++ b/drivers/arduino-hid.c
@@ -142,4 +142,5 @@ subdriver_t arduino_subdriver = {
 	arduino_format_model,
 	arduino_format_mfr,
 	arduino_format_serial,
+	fix_report_desc,
 };

--- a/drivers/belkin-hid.c
+++ b/drivers/belkin-hid.c
@@ -641,4 +641,5 @@ subdriver_t belkin_subdriver = {
 	belkin_format_model,
 	belkin_format_mfr,
 	belkin_format_serial,
+	fix_report_desc,
 };

--- a/drivers/delta_ups-hid.c
+++ b/drivers/delta_ups-hid.c
@@ -317,4 +317,5 @@ subdriver_t delta_ups_subdriver = {
 	delta_ups_format_model,
 	delta_ups_format_mfr,
 	delta_ups_format_serial,
+	fix_report_desc,
 };

--- a/drivers/explore-hid.c
+++ b/drivers/explore-hid.c
@@ -74,4 +74,5 @@ subdriver_t explore_subdriver = {
 	explore_format_model,
 	explore_format_mfr,
 	explore_format_serial,
+	fix_report_desc,
 };

--- a/drivers/hidtypes.h
+++ b/drivers/hidtypes.h
@@ -91,6 +91,12 @@ extern "C" {
 #define ATTR_DATA_CST			0x01
 #define ATTR_NVOL_VOL			0x80
 
+/* Usage Pages */
+#define PAGE_POWER_DEVICE		0x84
+
+/* Usages */
+#define USAGE_HIGHVOLTAGETRANSFER	0x54
+#define USAGE_VOLTAGE			0x30
 /*
  * HIDNode_t struct
  *

--- a/drivers/idowell-hid.c
+++ b/drivers/idowell-hid.c
@@ -166,4 +166,5 @@ subdriver_t idowell_subdriver = {
 	idowell_format_model,
 	idowell_format_mfr,
 	idowell_format_serial,
+	fix_report_desc,
 };

--- a/drivers/liebert-hid.c
+++ b/drivers/liebert-hid.c
@@ -148,4 +148,5 @@ subdriver_t liebert_subdriver = {
 	liebert_format_model,
 	liebert_format_mfr,
 	liebert_format_serial,
+	fix_report_desc,
 };

--- a/drivers/mge-hid.c
+++ b/drivers/mge-hid.c
@@ -1591,4 +1591,5 @@ subdriver_t mge_subdriver = {
 	mge_format_model,
 	mge_format_mfr,
 	mge_format_serial,
+	fix_report_desc,
 };

--- a/drivers/openups-hid.c
+++ b/drivers/openups-hid.c
@@ -393,4 +393,5 @@ subdriver_t openups_subdriver = {
 	openups_format_model,
 	openups_format_mfr,
 	openups_format_serial,
+	fix_report_desc,
 };

--- a/drivers/powercom-hid.c
+++ b/drivers/powercom-hid.c
@@ -550,4 +550,5 @@ subdriver_t powercom_subdriver = {
 	powercom_format_model,
 	powercom_format_mfr,
 	powercom_format_serial,
+	fix_report_desc,
 };

--- a/drivers/powervar-hid.c
+++ b/drivers/powervar-hid.c
@@ -141,4 +141,5 @@ subdriver_t powervar_subdriver = {
 	powervar_format_model,
 	powervar_format_mfr,
 	powervar_format_serial,
+	fix_report_desc,
 };

--- a/drivers/salicru-hid.c
+++ b/drivers/salicru-hid.c
@@ -245,4 +245,5 @@ subdriver_t salicru_subdriver = {
 	salicru_format_model,
 	salicru_format_mfr,
 	salicru_format_serial,
+	fix_report_desc,
 };

--- a/drivers/tripplite-hid.c
+++ b/drivers/tripplite-hid.c
@@ -562,4 +562,5 @@ subdriver_t tripplite_subdriver = {
 	tripplite_format_model,
 	tripplite_format_mfr,
 	tripplite_format_serial,
+	fix_report_desc,
 };

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -1208,6 +1208,9 @@ static int callback(hid_dev_handle_t argudev, HIDDevice_t *arghd, unsigned char 
 
 	upslogx(2, "Using subdriver: %s", subdriver->name);
 
+	if (subdriver->fix_report_desc(arghd, pDesc)) {
+		upsdebugx(2, "Report Descriptor Fixed");
+	}
 	HIDDumpTree(udev, arghd, subdriver->utab);
 
 #ifndef SHUT_MODE
@@ -1266,6 +1269,12 @@ static double interval(void)
 	return ret;
 }
 #endif
+
+/* default subdriver function which doesnt attempt to fix any issues in the parsed HID Report Descriptor */
+int fix_report_desc(HIDDevice_t *pDev, HIDDesc_t *pDesc) {
+	return 0;
+}
+
 
 /* walk ups variables and set elements of the info array. */
 static bool_t hid_ups_walk(walkmode_t mode)

--- a/drivers/usbhid-ups.h
+++ b/drivers/usbhid-ups.h
@@ -208,6 +208,7 @@ typedef struct {
 	const char *(*format_model)(HIDDevice_t *hd);  /* driver-specific methods */
 	const char *(*format_mfr)(HIDDevice_t *hd);    /* for preparing human-    */
 	const char *(*format_serial)(HIDDevice_t *hd); /* readable information    */
+	int	(*fix_report_desc)(HIDDevice_t *pDev, HIDDesc_t *pDesc);		/* Function called to potentially remedy defects in the parsed Report Descriptor caused by buggy HID contents*/
 } subdriver_t;
 
 /* the following functions are exported for the benefit of subdrivers */
@@ -216,4 +217,5 @@ int setvar(const char *varname, const char *val);
 
 void possibly_supported(const char *mfr, HIDDevice_t *hd);
 
+int fix_report_desc(HIDDevice_t *pDev, HIDDesc_t *pDesc);
 #endif /* USBHID_UPS_H */


### PR DESCRIPTION
This fixes the problem whereby the Output Voltage on Cyberpower CPS*EPFCLCD UPS's is masked.
The root cause is due to a legal but inappropriate Report Descriptor published as part of the HID.
Specifically it looks liike Report ID 17 was deleted (ie Report 16 is followed by Report 18) with the result that there was no attempt to reset the LogMin and LogMax values from those used by the HighVoltageTransfer Item for those used by the Output Voltage.  

The fix conditionally corrects the Report Descriptor structure by applying the same LogMin and LogMax values used by the Input Voltage Item after first checking the issue exists.  

The fix creates a generic framework for fixing Report Descriptors that can be used for different manufacturers by adding code to the appropriate subdriver rather than polluting the main code with UPS specific exceptions.

This version is identical to PR #1245 but is for the libusb-1.0 branch. 