### PR TITLE
docs/ci-farm-lxc-setup.txt: clarify how to find defined LXC templates and install CentOS on Debian host

### DIFF
--- a/docs/ci-farm-lxc-setup.txt
+++ b/docs/ci-farm-lxc-setup.txt
@@ -132,12 +132,12 @@ further options for each "template" by invoking its help action, e.g.:
    Otherwise, you risk seeing something like this:
 +
 ------
-root@debian:~# lxc-create -n jenkins-centos7-x86_64 -P /srv/libvirt/rootfs \
+root@debian:~# lxc-create -n jenkins-centos7-x86-64 -P /srv/libvirt/rootfs \
     -t centos -- -R 7 -a x86_64
 Host CPE ID from /etc/os-release: 
 'yum' command is missing
-lxc-create: jenkins-centos7-x86_64: lxccontainer.c: create_run_template: 1616 Failed to create container from template
-lxc-create: jenkins-centos7-x86_64: tools/lxc_create.c: main: 319 Failed to create container jenkins-centos7-x86_64
+lxc-create: jenkins-centos7-x86-64: lxccontainer.c: create_run_template: 1616 Failed to create container from template
+lxc-create: jenkins-centos7-x86-64: tools/lxc_create.c: main: 319 Failed to create container jenkins-centos7-x86-64
 ------
 +
    Note also that with such "third-party" distributions you may face other
@@ -146,9 +146,13 @@ lxc-create: jenkins-centos7-x86_64: tools/lxc_create.c: main: 319 Failed to crea
    (as found by trial and error, and comparison to other `config` files):
 +
 ------
-lxc.uts.name = jenkins-centos7-x86_64
+lxc.uts.name = jenkins-centos7-x86-64
 lxc.arch = x86_64
 ------
++
+   Also note the container/system naming without underscore in "x86_64" --
+   the deployed system discards the character when assigning its hostname.
+   Using "amd64" is another reasonable choice here.
 
 * Add the "name,IP" line for this container to `/etc/lxc/dnsmasq-hosts.conf`
   on the host, e.g.:

--- a/docs/ci-farm-lxc-setup.txt
+++ b/docs/ci-farm-lxc-setup.txt
@@ -260,7 +260,6 @@ Shepherd the herd
 ------
 :; for ALTROOT in /srv/libvirt/rootfs/*/rootfs/ ; do \
     echo "=== $ALTROOT :" >&2; \
-    chroot "$ALTROOT" apt-get install sudo bash ; \
     grep eth0 "$ALTROOT/etc/issue" || ( echo '\S{NAME} \S{VERSION_ID} \n \l@\b ; Current IP(s): \4{eth0} \4{eth1} \4{eth2} \4{eth3}' >> "$ALTROOT/etc/issue" ) ; \
     grep eth0 "$ALTROOT/etc/issue.net" || ( echo '\S{NAME} \S{VERSION_ID} \n \l@\b ; Current IP(s): \4{eth0} \4{eth1} \4{eth2} \4{eth3}' >> "$ALTROOT/etc/issue.net" ) ; \
     groupadd -R "$ALTROOT" -g 399 abuild ; \
@@ -318,9 +317,14 @@ may be not yet configured or still struggling to access the Internet):
 ------
 :; for ALTROOT in /srv/libvirt/rootfs/*/rootfs/ ; do \
     echo "=== $ALTROOT :" ; \
-    chroot "$ALTROOT" apt-get install vim mc p7zip p7zip-full pigz pbzip2 git \
+    chroot "$ALTROOT" apt-get install \
+        sudo bash vim mc p7zip p7zip-full pigz pbzip2 git \
    ; done
 ------
+
+Similarly for `yum`-managed systems (CentOS and relatives), though specific
+package names can differ, and additional package repositories may need to
+be enabled first (see link:config-prereqs.txt for details).
 
 Note that technically `(sudo) chroot ...` can also be used from the CI worker
 account on the host system to build in the prepared filesystems without the

--- a/docs/ci-farm-lxc-setup.txt
+++ b/docs/ci-farm-lxc-setup.txt
@@ -127,7 +127,8 @@ further options for each "template" by invoking its help action, e.g.:
 ** For distributions with a different packaging mechanism from that on the
    LXC host system, you may need to install corresponding tools (e.g. `yum4`,
    `rpm` and `dnf` on Debian hosts for installing CentOS and related guests).
-   You may also need to pepper with symlinks to taste (e.g. `yum => yum4`).
+   You may also need to pepper with symlinks to taste (e.g. `yum => yum4`),
+   or find a `pacman` build to install Arch Linux or derivative, etc.
    Otherwise, you risk seeing something like this:
 +
 ------

--- a/docs/ci-farm-lxc-setup.txt
+++ b/docs/ci-farm-lxc-setup.txt
@@ -231,6 +231,14 @@ Shepherd the herd
    done
 ------
 
+* Verify that unique MAC addresses were defined (e.g. `00:16:3e:00:00:01`
+  tends to pop up often, while `52:54:00:xx:xx:xx` are assigned to other
+  containers); edit the domain definitions to randomize, if needed:
++
+------
+:; grep 'mac add' /etc/libvirt/lxc/*.xml | awk '{print $NF" "$1}' | sort
+------
+
 * Make sure at least one console device exists (end of file, under the
   network interface definition tags), e.g.:
 +

--- a/docs/ci-farm-lxc-setup.txt
+++ b/docs/ci-farm-lxc-setup.txt
@@ -139,6 +139,16 @@ Host CPE ID from /etc/os-release:
 lxc-create: jenkins-centos7-i686: lxccontainer.c: create_run_template: 1616 Failed to create container from template
 lxc-create: jenkins-centos7-i686: tools/lxc_create.c: main: 319 Failed to create container jenkins-centos7-i686
 ------
++
+   Note also that with such "third-party" distributions you may face other
+   issues; for example, the CentOS helper did not generate some fields in
+   the `config` file that were needed for conversion into libvirt "domxml"
+   (as found by trial and error, and comparison to other `config` files):
++
+------
+lxc.uts.name = jenkins-centos7-i686
+lxc.arch = i686
+------
 
 * Add the "name,IP" line for this container to `/etc/lxc/dnsmasq-hosts.conf`
   on the host, e.g.:

--- a/docs/ci-farm-lxc-setup.txt
+++ b/docs/ci-farm-lxc-setup.txt
@@ -132,12 +132,12 @@ further options for each "template" by invoking its help action, e.g.:
    Otherwise, you risk seeing something like this:
 +
 ------
-root@debian:~# lxc-create -n jenkins-centos7-i686 -P /srv/libvirt/rootfs \
-    -t centos -- -R 7 -a i686
+root@debian:~# lxc-create -n jenkins-centos7-x86_64 -P /srv/libvirt/rootfs \
+    -t centos -- -R 7 -a x86_64
 Host CPE ID from /etc/os-release: 
 'yum' command is missing
-lxc-create: jenkins-centos7-i686: lxccontainer.c: create_run_template: 1616 Failed to create container from template
-lxc-create: jenkins-centos7-i686: tools/lxc_create.c: main: 319 Failed to create container jenkins-centos7-i686
+lxc-create: jenkins-centos7-x86_64: lxccontainer.c: create_run_template: 1616 Failed to create container from template
+lxc-create: jenkins-centos7-x86_64: tools/lxc_create.c: main: 319 Failed to create container jenkins-centos7-x86_64
 ------
 +
    Note also that with such "third-party" distributions you may face other
@@ -146,8 +146,8 @@ lxc-create: jenkins-centos7-i686: tools/lxc_create.c: main: 319 Failed to create
    (as found by trial and error, and comparison to other `config` files):
 +
 ------
-lxc.uts.name = jenkins-centos7-i686
-lxc.arch = i686
+lxc.uts.name = jenkins-centos7-x86_64
+lxc.arch = x86_64
 ------
 
 * Add the "name,IP" line for this container to `/etc/lxc/dnsmasq-hosts.conf`

--- a/docs/ci-farm-lxc-setup.txt
+++ b/docs/ci-farm-lxc-setup.txt
@@ -346,6 +346,24 @@ This can be achieved with e.g.:
 TODO: Test and document a working NAT and firewall setup for this, to allow
 SSH access to the containers via dedicated TCP ports exposed on the host.
 
+Troubleshooting
+~~~~~~~~~~~~~~~
+
+Q: Container won't start, its `virsh console` says something like:
++
+------
+Failed to create symlink /sys/fs/cgroup/net_cls: Operation not permitted
+------
+
+A: According to https://bugzilla.redhat.com/show_bug.cgi?id=1770763
+(skip to the end for summary) this can happen when a newer Linux host system
+with cgroupsv2 runs an older guest distro that only knows about cgroupsv1,
+such as CentOS 7. One workaround is to ensure that the guest systemd does
+not try to join host facilities, by setting an explicit empty list:
++
+------
+:; echo 'JoinControllers=' >> "$ALTROOT/etc/systemd/system.conf"
+------
 
 Connecting Jenkins to the containers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/ci-farm-lxc-setup.txt
+++ b/docs/ci-farm-lxc-setup.txt
@@ -124,6 +124,20 @@ further options for each "template" by invoking its help action, e.g.:
 :; lxc-create -n jenkins-ubuntu1804-s390x -P /srv/libvirt/rootfs -t ubuntu -- \
     -r bionic -a s390x
 ------
+** For distributions with a different packaging mechanism from that on the
+   LXC host system, you may need to install corresponding tools (e.g. `yum4`,
+   `rpm` and `dnf` on Debian hosts for installing CentOS and related guests).
+   You may also need to pepper with symlinks to taste (e.g. `yum => yum4`).
+   Otherwise, you risk seeing something like this:
++
+------
+root@debian:~# lxc-create -n jenkins-centos7-i686 -P /srv/libvirt/rootfs \
+    -t centos -- -R 7 -a i686
+Host CPE ID from /etc/os-release: 
+'yum' command is missing
+lxc-create: jenkins-centos7-i686: lxccontainer.c: create_run_template: 1616 Failed to create container from template
+lxc-create: jenkins-centos7-i686: tools/lxc_create.c: main: 319 Failed to create container jenkins-centos7-i686
+------
 
 * Add the "name,IP" line for this container to `/etc/lxc/dnsmasq-hosts.conf`
   on the host, e.g.:

--- a/docs/ci-farm-lxc-setup.txt
+++ b/docs/ci-farm-lxc-setup.txt
@@ -83,6 +83,15 @@ deletes the directories after failure, it shows the pathname where it
 writes the log (also deleted). Before re-trying the container creation, this
 file can be watched with e.g. `tail -F /var/cache/lxc/.../debootstrap.log`
 
+NOTE: You can find the list of LXC "template" definitions on your system
+by looking at the contents of the `/usr/share/lxc/templates/` directory,
+e.g. a script named `lxc-debian` for the "debian" template. You can see
+further options for each "template" by invoking its help action, e.g.:
++
+------
+:; lxc-create -t debian -h
+------
+
 * Install containers like this:
 +
 ------
@@ -114,11 +123,6 @@ file can be watched with e.g. `tail -F /var/cache/lxc/.../debootstrap.log`
 ------
 :; lxc-create -n jenkins-ubuntu1804-s390x -P /srv/libvirt/rootfs -t ubuntu -- \
     -r bionic -a s390x
-------
-** See further options for the "template" with its help, e.g.:
-+
-------
-:; lxc-create -t debian -h
 ------
 
 * Add the "name,IP" line for this container to `/etc/lxc/dnsmasq-hosts.conf`

--- a/docs/config-prereqs.txt
+++ b/docs/config-prereqs.txt
@@ -147,7 +147,8 @@ complete environments):
 ----
 
 NOTE: For Jenkins agents, also need to `apt-get install openjdk-11-jdk-headless`
-(technically, needs at least JRE 8+).
+(technically, needs at least JRE 8+). You may have to ensure `/proc` is mounted
+in the target chroot (or do this from the running container).
 
 FreeBSD 12.2
 ~~~~~~~~~~~~

--- a/docs/config-prereqs.txt
+++ b/docs/config-prereqs.txt
@@ -150,6 +150,103 @@ NOTE: For Jenkins agents, also need to `apt-get install openjdk-11-jdk-headless`
 (technically, needs at least JRE 8+). You may have to ensure `/proc` is mounted
 in the target chroot (or do this from the running container).
 
+CentOS 7
+~~~~~~~~
+
+CentOS is another popular baseline among Linux distributions, being a free
+derivative of the RedHat Linux, upon which many other distros are based as
+well. These systems typically use the RPM package manager, using directly
+`rpm` command, or `yum` or `dnf` front-ends depending on their generation.
+
+For CentOS 7 it seems that not all repositories are equally good; some of
+the software below is only served by EPEL (Extra Packages for Enterprise
+Linux), as detailed at:
+* https://docs.fedoraproject.org/en-US/epel/
+* https://www.redhat.com/en/blog/whats-epel-and-how-do-i-use-it
+* https://pkgs.org/download/epel-release
+
+You may have to specify a mirror as the `baseurl` in a `/etc/yum.repos.d/...`
+file (as the aged distributions become less served by mirrors), such as:
+* https://www.mirrorservice.org/sites/dl.fedoraproject.org/pub/epel/7/x86_64/
++
+------
+# e.g. for CentOS7 currently:
+:; yum install https://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm
+
+# And edit /etc/yum.repos.d/epel.repo to uncomment and set the baseurl=...
+# lines, and comment away the mirrorlist= lines (if yum hiccups otherwise)
+------
+
+General developer system helpers mentioned in `ci-farm-lxc-setup.txt`:
+------
+:; yum update
+
+:; yum install \
+    sudo vim mc p7zip pigz pbzip2
+------
+
+NOTE: Below we request to install generic `python` per system defaults.
+You may request specifically `python2` or `python3` (or both): NUT should
+be compatible with both (2.7+ at least).
+
+NOTE: On CentOS, `libusb` means 0.1.x and `libusbx` means 1.x.x API version.
+
+NOTE: On CentOS, it seems that development against libi2c/smbus is not
+supported. Neither the suitable devel packages were found, nor i2c-based
+drivers in distro packaging of NUT. Resolution and doc PRs are welcome.
+
+NOTE: `busybox` is not packaged for CentOS 7 release; a static binary can
+be downloaded if needed. For more details, see
+https://unix.stackexchange.com/questions/475584/cannot-install-busybox-on-centos
+
+------
+:; yum install \
+    ccache time \
+    file systemd-devel \
+    git python curl \
+    make autoconf automake libtool-ltdl-devel libtool \
+    valgrind \
+    cppcheck \
+    pkgconfig \
+    gcc gcc-c++ clang \
+    asciidoc source-highlight python-pygments dblatex aspell \
+    gd-devel
+
+:; yum install \
+    cppunit-devel \
+    openssl-devel nss-devel \
+    augeas augeas-devel \
+    libusb-devel libusbx-devel \
+    i2c-tools \
+    libmodbus-devel \
+    net-snmp-devel \
+    powerman-devel \
+    freeipmi-devel \
+    avahi-devel \
+    neon-devel
+#?# is python-augeas needed? exists at least...
+#?# no (lib)i2c-devel ...
+#?# no (lib)ipmimonitoring-devel ... would "freeipmi-ipmidetectd" cut it at least for run-time?
+
+# Some NUT code related to lua may be currently limited to lua-5.1
+# or possibly 5.2; the former is default in CentOS 7 releases...
+:; yum install \
+    lua-devel
+
+:; yum install \
+    bash dash ksh
+----
+
+CentOS packaging for 64-bit systems delivers the directory for dispatching
+compiler symlinks as `/usr/lib64/ccache`. You can set it up same way as for
+other described environments by adding a symlink `/usr/lib/ccache`:
+----
+:; ln -s ../lib64/ccache/ "$ALTROOT"/usr/lib/
+----
+
+NOTE: For Jenkins agents, also need to `yum install java-11-openjdk-headless`
+(technically, needs at least JRE 8+).
+
 FreeBSD 12.2
 ~~~~~~~~~~~~
 

--- a/docs/config-prereqs.txt
+++ b/docs/config-prereqs.txt
@@ -236,7 +236,11 @@ OpenBSD delivers many versions of numerous packages, you should specify
 your pick interactively or as part of package name (e.g. `autoconf-2.69p2`).
 
 During builds, you may have to tell system dispatcher scripts which version
-to use, e.g.: `export AUTOCONF_VERSION=2.69 AUTOMAKE_VERSION=1.10`
+to use (which feels inconvenient, but on the up-side for CI -- this system
+allows to test many versions of auto-tools in the same agent), e.g.:
+------
+:; export AUTOCONF_VERSION=2.69 AUTOMAKE_VERSION=1.10
+------
 
 To use the `ci_build.sh` don't forget `bash` which is not part of OpenBSD
 base installation. It is not required for "legacy" builds arranged by just

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 2814 utf-8
+personal_ws-1.1 en 2817 utf-8
 AAS
 ACFAIL
 ACFREQ
@@ -488,6 +488,7 @@ JavaScript
 Javadoc
 Javascript
 Jenkinsfile
+JoinControllers
 Joon
 Jumpered
 KNutClient
@@ -1492,6 +1493,7 @@ cflags
 cgi
 cgipath
 cgroup
+cgroupsv
 chargedvbattery
 chargermode
 chargetime
@@ -1519,6 +1521,7 @@ clearlogs
 clearpassword
 clepple
 clicky
+cls
 clueful
 cmd
 cmdline

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 2806 utf-8
+personal_ws-1.1 en 2814 utf-8
 AAS
 ACFAIL
 ACFREQ
@@ -286,6 +286,7 @@ ENDFOR
 ENV
 EOF
 EOLed
+EPEL
 EPERM
 EPO
 EPS
@@ -1396,6 +1397,7 @@ backport
 backported
 backupspro
 badpassword
+baseurl
 batchable
 batt
 battcap
@@ -1887,6 +1889,8 @@ ip
 ipE
 ipF
 ipmi
+ipmidetectd
+ipmimonitoring
 ipmipsu
 ippon
 ipv
@@ -1959,6 +1963,7 @@ libtool
 libupsclient
 libusb
 libusbugen
+libusbx
 libvirt
 libwrap
 libxslt
@@ -1999,6 +2004,7 @@ lowvoltsout
 lposix
 lr
 lsusb
+ltdl
 lu
 lua
 lv
@@ -2068,6 +2074,7 @@ minvalue
 minvi
 minvo
 mips
+mirrorlist
 mis
 misconfigured
 mkdir
@@ -2454,6 +2461,7 @@ slavesync
 slewrate
 sm
 smartups
+smbus
 sms
 sn
 snailmail

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 2801 utf-8
+personal_ws-1.1 en 2805 utf-8
 AAS
 ACFAIL
 ACFREQ
@@ -175,6 +175,7 @@ COMMOK
 CONFILE
 CONTEXTs
 CPAN
+CPE
 CPM
 CPP
 CPPFLAGS
@@ -1466,6 +1467,7 @@ cblimit
 ccache
 cd
 cdc
+centos
 cerr
 certfile
 certname
@@ -1623,6 +1625,7 @@ dl
 dll
 dlopen
 dmesg
+dnf
 dnl
 dnsmasq
 docbook
@@ -2002,6 +2005,7 @@ lv
 lvo
 lxc
 lxcbr
+lxccontainer
 lxml
 lxyz
 mA

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 2805 utf-8
+personal_ws-1.1 en 2806 utf-8
 AAS
 ACFAIL
 ACFREQ
@@ -2214,6 +2214,7 @@ ostream
 otherprotocols
 outliers
 pF
+pacman
 paramkeywords
 parsable
 parseconf


### PR DESCRIPTION
Documenting a few discoveries about running a CentOS 7 guest container on a Debian 11 host.
For some reason, LXC installer for CentOS 8 did not work...