### PR TITLE
data/driver.list.in and drivers/salicru-hid.c: add known compatibility for Salicru TWIN (PRO2, PRO3, RT3...)

### DIFF
--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -951,6 +951,10 @@
 "Rucelf"	"ups"	"2"	"Rucelf UPOII-3000-96-EL"	""	"blazer_ser" # http://www.rucelf.ua/en/catalog/upoii-3000-96-el/
 
 "Salicru"	"ups"	"2"	"SPS 650/850 HOME"	"usb"	"usbhid-ups (experimental)"
+"Salicru"	"ups"	"2"	"SLC TWIN PRO2"	"usb"	"usbhid-ups (experimental)" # https://github.com/networkupstools/nut/issues/450
+"Salicru"	"ups"	"2"	"SLC-1500-TWIN PRO3"	"usb"	"usbhid-ups (experimental)" # https://github.com/networkupstools/nut/issues/1142
+"Salicru"	"ups"	"2"	"SLC TWINPRO3"	"usb"	"usbhid-ups (experimental)"
+"Salicru"	"ups"	"2"	"SLC TWIN RT3"	"usb"	"usbhid-ups (experimental)"
 
 "Siemens"	"ups"	"4"	"SITOP UPS500"	"serial"	"nutdrv_siemens_sitop (experimental, untested)"
 "Siemens"	"ups"	"4"	"SITOP UPS500"	"USB"	"nutdrv_siemens_sitop (experimental)"

--- a/drivers/salicru-hid.c
+++ b/drivers/salicru-hid.c
@@ -30,7 +30,7 @@
 #include "main.h"	/* for getval() */
 #include "usb-common.h"
 
-#define SALICRU_HID_VERSION	"Salicru HID 0.1"
+#define SALICRU_HID_VERSION	"Salicru HID 0.2"
 /* FIXME: experimental flag to be put in upsdrv_info */
 
 /* Salicru */
@@ -38,8 +38,14 @@
 
 /* USB IDs device table */
 static usb_device_id_t salicru_usb_device_table[] = {
-	/* Salicru SPS 850 HOME */
-        /* https://www.salicru.com/sps-home.html */
+	/* TWINPRO3/TWINRT3 (SLC-1500-TWIN PRO3) per https://github.com/networkupstools/nut/issues/1142 */
+	/* SLC TWIN PRO2<=3KVA per https://github.com/networkupstools/nut/issues/450 */
+	{ USB_DEVICE(SALICRU_VENDORID, 0x0201), NULL },
+	{ USB_DEVICE(SALICRU_VENDORID, 0x0202), NULL },
+	{ USB_DEVICE(SALICRU_VENDORID, 0x0203), NULL },
+
+	/* Salicru SPS 850 HOME per https://github.com/networkupstools/nut/pull/1199 */
+	/* https://www.salicru.com/sps-home.html */
 	{ USB_DEVICE(SALICRU_VENDORID, 0x0300), NULL },
 
 	/* Terminating entry */

--- a/scripts/upower/95-upower-hid.rules
+++ b/scripts/upower/95-upower-hid.rules
@@ -168,6 +168,9 @@ ATTRS{idVendor}=="2A03", ATTRS{idProduct}=="8040", ENV{UPOWER_BATTERY_TYPE}="ups
 ATTRS{idVendor}=="2b2d", ATTRS{idProduct}=="ffff", ENV{UPOWER_BATTERY_TYPE}="ups"
 
 # Salicru
+ATTRS{idVendor}=="2e66", ATTRS{idProduct}=="0201", ENV{UPOWER_BATTERY_TYPE}="ups"
+ATTRS{idVendor}=="2e66", ATTRS{idProduct}=="0202", ENV{UPOWER_BATTERY_TYPE}="ups"
+ATTRS{idVendor}=="2e66", ATTRS{idProduct}=="0203", ENV{UPOWER_BATTERY_TYPE}="ups"
 ATTRS{idVendor}=="2e66", ATTRS{idProduct}=="0300", ENV{UPOWER_BATTERY_TYPE}="ups"
 
 # Powervar


### PR DESCRIPTION
See also issues #450 and #1142 and #999, PR #1199 and NUT-DDL PR https://github.com/networkupstools/nut-ddl/pull/17

СС @CindyZhan19891207 : can you please check if a build from this branch would detect your UPS "out of the box" as desired?