### PR TITLE
Fightwarn for medium level

### DIFF
--- a/ci_build.sh
+++ b/ci_build.sh
@@ -395,7 +395,7 @@ fi
 echo "Processing BUILD_TYPE='${BUILD_TYPE}' ..."
 
 echo "Build host settings:"
-set | egrep '^(CI_.*|CANBUILD_.*|NODE_LABELS|MAKE)=' || true
+set | egrep '^(CI_.*|CANBUILD_.*|NODE_LABELS|MAKE|C.*FLAGS|LDFLAGS|CC|CXX|DO_.*|BUILD_.*)=' || true
 uname -a
 echo "LONG_BIT:`getconf LONG_BIT` WORD_BIT:`getconf WORD_BIT`" || true
 if command -v xxd >/dev/null ; then xxd -c 1 -l 6 | tail -1; else if command -v od >/dev/null; then od -N 1 -j 5 -b | head -1 ; else hexdump -s 5 -n 1 -C | head -1; fi; fi < /bin/ls 2>/dev/null | awk '($2 == 1){print "Endianness: LE"}; ($2 == 2){print "Endianness: BE"}' || true

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -530,7 +530,7 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
     CONFIG_OPTS+=("CFLAGS=-I${BUILD_PREFIX}/include ${CFLAGS}")
     CONFIG_OPTS+=("CPPFLAGS=-I${BUILD_PREFIX}/include ${CPPFLAGS}")
     CONFIG_OPTS+=("CXXFLAGS=-I${BUILD_PREFIX}/include ${CXXFLAGS}")
-    CONFIG_OPTS+=("LDFLAGS=-L${BUILD_PREFIX}/lib")
+    CONFIG_OPTS+=("LDFLAGS=-L${BUILD_PREFIX}/lib ${LDFLAGS}")
 
     DEFAULT_PKG_CONFIG_PATH="${BUILD_PREFIX}/lib/pkgconfig"
     SYSPKG_CONFIG_PATH="" # Let the OS guess... usually

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -1312,9 +1312,17 @@ bindings)
     if [ -s Makefile ]; then
         ${MAKE} realclean -k || true
     fi
+
     ./autogen.sh
+
+    # NOTE: Default NUT "configure" actually insists on some features,
+    # like serial port support unless told otherwise, or docs if possible.
+    # Below we aim for really fast iterations of C/C++ development so
+    # enable whatever is auto-detectable (except docs), and highlight
+    # any warnings if we can:
     #./configure
     ./configure --enable-Wcolor --with-all=auto --with-cgi=auto --with-serial=auto --with-dev=auto --with-doc=skip
+
     #$MAKE all && \
     $MAKE $PARMAKE_FLAGS all && \
     $MAKE check

--- a/clients/nutclient.h
+++ b/clients/nutclient.h
@@ -58,8 +58,8 @@ public:
 	NutException(const std::string& msg):_msg(msg){}
 	NutException(const NutException&) = default;
 	NutException& operator=(NutException& rhs) = default;
-	virtual ~NutException();
-	virtual const char * what() const noexcept {return this->_msg.c_str();}
+	virtual ~NutException() override;
+	virtual const char * what() const noexcept override {return this->_msg.c_str();}
 	virtual std::string str() const noexcept {return this->_msg;}
 private:
 	std::string _msg;
@@ -74,7 +74,7 @@ public:
 	SystemException();
 	SystemException(const SystemException&) = default;
 	SystemException& operator=(SystemException& rhs) = default;
-	virtual ~SystemException();
+	virtual ~SystemException() override;
 private:
 	static std::string err();
 };
@@ -89,7 +89,7 @@ public:
 	IOException(const std::string& msg):NutException(msg){}
 	IOException(const IOException&) = default;
 	IOException& operator=(IOException& rhs) = default;
-	virtual ~IOException();
+	virtual ~IOException() override;
 };
 
 /**
@@ -101,7 +101,7 @@ public:
 	UnknownHostException():IOException("Unknown host"){}
 	UnknownHostException(const UnknownHostException&) = default;
 	UnknownHostException& operator=(UnknownHostException& rhs) = default;
-	virtual ~UnknownHostException();
+	virtual ~UnknownHostException() override;
 };
 
 /**
@@ -113,7 +113,7 @@ public:
 	NotConnectedException():IOException("Not connected"){}
 	NotConnectedException(const NotConnectedException&) = default;
 	NotConnectedException& operator=(NotConnectedException& rhs) = default;
-	virtual ~NotConnectedException();
+	virtual ~NotConnectedException() override;
 };
 
 /**
@@ -125,7 +125,7 @@ public:
 	TimeoutException():IOException("Timeout"){}
 	TimeoutException(const TimeoutException&) = default;
 	TimeoutException& operator=(TimeoutException& rhs) = default;
-	virtual ~TimeoutException();
+	virtual ~TimeoutException() override;
 };
 
 /**
@@ -368,7 +368,7 @@ public:
 	 * \param port Server port.
 	 */
 	TcpClient(const std::string& host, int port = 3493);
-	~TcpClient();
+	~TcpClient() override;
 
 	/**
 	 * Connect it to the specified server.
@@ -416,38 +416,38 @@ public:
 	 */
 	int getPort()const;
 
-	virtual void authenticate(const std::string& user, const std::string& passwd);
-	virtual void logout();
+	virtual void authenticate(const std::string& user, const std::string& passwd) override;
+	virtual void logout() override;
 
-	virtual Device getDevice(const std::string& name);
-	virtual std::set<std::string> getDeviceNames();
-	virtual std::string getDeviceDescription(const std::string& name);
+	virtual Device getDevice(const std::string& name) override;
+	virtual std::set<std::string> getDeviceNames() override;
+	virtual std::string getDeviceDescription(const std::string& name) override;
 
-	virtual std::set<std::string> getDeviceVariableNames(const std::string& dev);
-	virtual std::set<std::string> getDeviceRWVariableNames(const std::string& dev);
-	virtual std::string getDeviceVariableDescription(const std::string& dev, const std::string& name);
-	virtual std::vector<std::string> getDeviceVariableValue(const std::string& dev, const std::string& name);
-	virtual std::map<std::string,std::vector<std::string> > getDeviceVariableValues(const std::string& dev);
-	virtual std::map<std::string,std::map<std::string,std::vector<std::string> > > getDevicesVariableValues(const std::set<std::string>& devs);
-	virtual TrackingID setDeviceVariable(const std::string& dev, const std::string& name, const std::string& value);
-	virtual TrackingID setDeviceVariable(const std::string& dev, const std::string& name, const std::vector<std::string>& values);
+	virtual std::set<std::string> getDeviceVariableNames(const std::string& dev) override;
+	virtual std::set<std::string> getDeviceRWVariableNames(const std::string& dev) override;
+	virtual std::string getDeviceVariableDescription(const std::string& dev, const std::string& name) override;
+	virtual std::vector<std::string> getDeviceVariableValue(const std::string& dev, const std::string& name) override;
+	virtual std::map<std::string,std::vector<std::string> > getDeviceVariableValues(const std::string& dev) override;
+	virtual std::map<std::string,std::map<std::string,std::vector<std::string> > > getDevicesVariableValues(const std::set<std::string>& devs) override;
+	virtual TrackingID setDeviceVariable(const std::string& dev, const std::string& name, const std::string& value) override;
+	virtual TrackingID setDeviceVariable(const std::string& dev, const std::string& name, const std::vector<std::string>& values) override;
 
-	virtual std::set<std::string> getDeviceCommandNames(const std::string& dev);
-	virtual std::string getDeviceCommandDescription(const std::string& dev, const std::string& name);
-	virtual TrackingID executeDeviceCommand(const std::string& dev, const std::string& name, const std::string& param="");
+	virtual std::set<std::string> getDeviceCommandNames(const std::string& dev) override;
+	virtual std::string getDeviceCommandDescription(const std::string& dev, const std::string& name) override;
+	virtual TrackingID executeDeviceCommand(const std::string& dev, const std::string& name, const std::string& param="") override;
 
-	virtual void deviceLogin(const std::string& dev);
+	virtual void deviceLogin(const std::string& dev) override;
 	/* FIXME: Protocol update needed to handle master/primary alias
 	 * and probably an API bump also, to rename/alias the routine.
 	 */
-	virtual void deviceMaster(const std::string& dev);
-	virtual void deviceForcedShutdown(const std::string& dev);
-	virtual int deviceGetNumLogins(const std::string& dev);
+	virtual void deviceMaster(const std::string& dev) override;
+	virtual void deviceForcedShutdown(const std::string& dev) override;
+	virtual int deviceGetNumLogins(const std::string& dev) override;
 
-	virtual TrackingResult getTrackingResult(const TrackingID& id);
+	virtual TrackingResult getTrackingResult(const TrackingID& id) override;
 
-	virtual bool isFeatureEnabled(const Feature& feature);
-	virtual void setFeature(const Feature& feature, bool status);
+	virtual bool isFeatureEnabled(const Feature& feature) override;
+	virtual void setFeature(const Feature& feature, bool status) override;
 
 protected:
 	std::string sendQuery(const std::string& req);

--- a/clients/nutclientmem.h
+++ b/clients/nutclientmem.h
@@ -43,40 +43,40 @@ public:
 	 * Construct a nut MemClientStub object.
 	 */
 	MemClientStub() {}
-	~MemClientStub() {}
+	~MemClientStub() override {}
 
-	virtual void authenticate(const std::string& user, const std::string& passwd) {
+	virtual void authenticate(const std::string& user, const std::string& passwd) override {
 		NUT_UNUSED_VARIABLE(user);
 		NUT_UNUSED_VARIABLE(passwd);
 	}
-	virtual void logout() {}
+	virtual void logout() override {}
 
-	virtual Device getDevice(const std::string& name);
-	virtual std::set<std::string> getDeviceNames();
-	virtual std::string getDeviceDescription(const std::string& name);
+	virtual Device getDevice(const std::string& name) override;
+	virtual std::set<std::string> getDeviceNames() override;
+	virtual std::string getDeviceDescription(const std::string& name) override;
 
-	virtual std::set<std::string> getDeviceVariableNames(const std::string& dev);
-	virtual std::set<std::string> getDeviceRWVariableNames(const std::string& dev);
-	virtual std::string getDeviceVariableDescription(const std::string& dev, const std::string& name);
-	virtual ListValue getDeviceVariableValue(const std::string& dev, const std::string& name);
-	virtual ListObject getDeviceVariableValues(const std::string& dev);
-	virtual ListDevice getDevicesVariableValues(const std::set<std::string>& devs);
-	virtual TrackingID setDeviceVariable(const std::string& dev, const std::string& name, const std::string& value);
-	virtual TrackingID setDeviceVariable(const std::string& dev, const std::string& name, const ListValue& values);
+	virtual std::set<std::string> getDeviceVariableNames(const std::string& dev) override;
+	virtual std::set<std::string> getDeviceRWVariableNames(const std::string& dev) override;
+	virtual std::string getDeviceVariableDescription(const std::string& dev, const std::string& name) override;
+	virtual ListValue getDeviceVariableValue(const std::string& dev, const std::string& name) override;
+	virtual ListObject getDeviceVariableValues(const std::string& dev) override;
+	virtual ListDevice getDevicesVariableValues(const std::set<std::string>& devs) override;
+	virtual TrackingID setDeviceVariable(const std::string& dev, const std::string& name, const std::string& value) override;
+	virtual TrackingID setDeviceVariable(const std::string& dev, const std::string& name, const ListValue& values) override;
 
-	virtual std::set<std::string> getDeviceCommandNames(const std::string& dev);
-	virtual std::string getDeviceCommandDescription(const std::string& dev, const std::string& name);
-	virtual TrackingID executeDeviceCommand(const std::string& dev, const std::string& name, const std::string& param="");
+	virtual std::set<std::string> getDeviceCommandNames(const std::string& dev) override;
+	virtual std::string getDeviceCommandDescription(const std::string& dev, const std::string& name) override;
+	virtual TrackingID executeDeviceCommand(const std::string& dev, const std::string& name, const std::string& param="") override;
 
- 	virtual void deviceLogin(const std::string& dev);
-	virtual void deviceMaster(const std::string& dev);
-	virtual void deviceForcedShutdown(const std::string& dev);
-	virtual int deviceGetNumLogins(const std::string& dev);
+	virtual void deviceLogin(const std::string& dev) override;
+	virtual void deviceMaster(const std::string& dev) override;
+	virtual void deviceForcedShutdown(const std::string& dev) override;
+	virtual int deviceGetNumLogins(const std::string& dev) override;
 
-	virtual TrackingResult getTrackingResult(const TrackingID& id);
+	virtual TrackingResult getTrackingResult(const TrackingID& id) override;
 
-	virtual bool isFeatureEnabled(const Feature& feature);
-	virtual void setFeature(const Feature& feature, bool status);
+	virtual bool isFeatureEnabled(const Feature& feature) override;
+	virtual void setFeature(const Feature& feature, bool status) override;
 
 private:
 	ListDevice _values;

--- a/common/common.c
+++ b/common/common.c
@@ -225,7 +225,9 @@ struct passwd *get_user_pwent(const char *name)
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunreachable-code"
-#pragma clang diagnostic ignored "-Wunreachable-code-return"
+# ifdef HAVE_PRAGMA_CLANG_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE_RETURN
+#  pragma clang diagnostic ignored "-Wunreachable-code-return"
+# endif
 #endif
 	/* Oh joy, adding unreachable "return" to make one compiler happy,
 	 * and pragmas around to make other compilers happy, all at once! */

--- a/common/common.c
+++ b/common/common.c
@@ -213,15 +213,19 @@ struct passwd *get_user_pwent(const char *name)
 	else
 		fatal_with_errno(EXIT_FAILURE, "getpwnam(%s)", name);
 
-#ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) || (defined HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE_RETURN) )
 #pragma GCC diagnostic push
 #endif
 #ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
 #pragma GCC diagnostic ignored "-Wunreachable-code"
 #endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE_RETURN
+#pragma GCC diagnostic ignored "-Wunreachable-code-return"
+#endif
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunreachable-code"
+#pragma clang diagnostic ignored "-Wunreachable-code-return"
 #endif
 	/* Oh joy, adding unreachable "return" to make one compiler happy,
 	 * and pragmas around to make other compilers happy, all at once! */
@@ -229,7 +233,7 @@ struct passwd *get_user_pwent(const char *name)
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif
-#ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) || (defined HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE_RETURN) )
 #pragma GCC diagnostic pop
 #endif
 }

--- a/configure.ac
+++ b/configure.ac
@@ -2453,7 +2453,7 @@ AC_CHECK_HEADER([string.h],
     [AC_LANG_PUSH([C])
      CFLAGS_SAVED="${CFLAGS}"
      CFLAGS_BUILTIN_STR="-fno-builtin-strchr -fno-builtin-strcmp -fno-builtin-strncmp"
-     CFLAGS="${CFLAGS} -Werror -Wunreachable-code ${LIBNETSNMP_CFLAGS} ${LIBNEON_CFLAGS} ${LIBSSL_CFLAGS}"
+     CFLAGS="${CFLAGS} -Werror -Wunreachable-code ${LIBNETSNMP_CFLAGS} ${LIBLTDL_CFLAGS} ${LIBNEON_CFLAGS} ${LIBSSL_CFLAGS}"
      AC_MSG_CHECKING([whether we should disable string built-ins])
      dnl AC_DEFINE([HAVE_STRING_H], [1], [Define to 1 if you have <string.h>.])
      AC_COMPILE_IFELSE(
@@ -2479,7 +2479,7 @@ if (strchr(s, c) != NULL) return 1
                 ])],
             [CFLAGS="${CFLAGS_BUILTIN_STR} ${CFLAGS_SAVED}"
              AC_MSG_RESULT([yes, this solves a problem])],
-            [CFLAGS="${CFLAGS_SAVED} -Wno-unreachable-code ${LIBNETSNMP_CFLAGS} ${LIBNEON_CFLAGS} ${LIBSSL_CFLAGS}"
+            [CFLAGS="${CFLAGS_SAVED} -Wno-unreachable-code ${LIBNETSNMP_CFLAGS} ${LIBLTDL_CFLAGS} ${LIBNEON_CFLAGS} ${LIBSSL_CFLAGS}"
              AC_COMPILE_IFELSE(
                 [AC_LANG_PROGRAM(
                     [[#include <string.h>
@@ -2496,6 +2496,7 @@ if (strchr(s, c) != NULL) return 1
                 [dnl CFLAGS="${CFLAGS_SAVED} -Wno-unreachable-code"
                  dnl NOTE: Empirically, constrain to just LIBNETSNMP_CFLAGS
                  CFLAGS="${CFLAGS_SAVED}"
+                 LIBLTDL_CFLAGS="${LIBLTDL_CFLAGS} -Wno-unreachable-code"
                  LIBNETSNMP_CFLAGS="${LIBNETSNMP_CFLAGS} -Wno-unreachable-code"
                  AC_MSG_RESULT([no, but -Wno-unreachable-code solves the problem for this compiler])],
                 [CFLAGS="${CFLAGS_SAVED}"
@@ -2515,7 +2516,7 @@ AC_CHECK_HEADER([arpa/inet.h],
     [AC_LANG_PUSH([C])
      CFLAGS_SAVED="${CFLAGS}"
      CFLAGS_BUILTIN_NTOHL="-fno-builtin-htonl -fno-builtin-ntohl"
-     CFLAGS="${CFLAGS} ${LIBNETSNMP_CFLAGS} ${LIBNEON_CFLAGS} ${LIBSSL_CFLAGS}"
+     CFLAGS="${CFLAGS} ${LIBNETSNMP_CFLAGS} ${LIBLTDL_CFLAGS} ${LIBNEON_CFLAGS} ${LIBSSL_CFLAGS}"
      AC_MSG_CHECKING([whether we should disable htonl/ntohl built-ins])
      dnl AC_DEFINE([HAVE_ARPA_INET_H], [1], [Define to 1 if you have <arpa/inet.h>.])
      AC_COMPILE_IFELSE(
@@ -2545,6 +2546,7 @@ sin.s_addr = htonl((ntohl(sin.s_addr) + 1))
 sin.s_addr = htonl((ntohl(sin.s_addr) + 1))
                     ])],
                 [CFLAGS="${CFLAGS_SAVED}"
+                 LIBLTDL_CFLAGS="${LIBLTDL_CFLAGS} -Wno-shadow"
                  LIBNETSNMP_CFLAGS="${LIBNETSNMP_CFLAGS} -Wno-shadow"
                  AC_MSG_RESULT([no, but -Wno-shadow solves the problem for this compiler])],
                 [CFLAGS="${CFLAGS_SAVED}"

--- a/configure.ac
+++ b/configure.ac
@@ -2479,7 +2479,7 @@ if (strchr(s, c) != NULL) return 1
                 ])],
             [CFLAGS="${CFLAGS_BUILTIN_STR} ${CFLAGS_SAVED}"
              AC_MSG_RESULT([yes, this solves a problem])],
-            [CFLAGS="${CFLAGS_SAVED} -Wno-unreachable-code ${LIBNETSNMP_CFLAGS} ${LIBLTDL_CFLAGS} ${LIBNEON_CFLAGS} ${LIBSSL_CFLAGS}"
+            [CFLAGS="${CFLAGS_SAVED} -Werror -Wno-unreachable-code ${LIBNETSNMP_CFLAGS} ${LIBLTDL_CFLAGS} ${LIBNEON_CFLAGS} ${LIBSSL_CFLAGS}"
              AC_COMPILE_IFELSE(
                 [AC_LANG_PROGRAM(
                     [[#include <string.h>
@@ -2538,7 +2538,7 @@ sin.s_addr = htonl((ntohl(sin.s_addr) + 1))
                 ])],
             [CFLAGS="${CFLAGS_BUILTIN_NTOHL} ${CFLAGS_SAVED}"
              AC_MSG_RESULT([yes, this solves a problem])],
-            [CFLAGS="${CFLAGS_SAVED} -Wno-shadow ${LIBNETSNMP_CFLAGS} ${LIBLTDL_CFLAGS} ${LIBNEON_CFLAGS} ${LIBSSL_CFLAGS}"
+            [CFLAGS="${CFLAGS_SAVED} -Werror -Wno-shadow ${LIBNETSNMP_CFLAGS} ${LIBLTDL_CFLAGS} ${LIBNEON_CFLAGS} ${LIBSSL_CFLAGS}"
              AC_COMPILE_IFELSE(
                 [AC_LANG_PROGRAM(
                     [[#include <arpa/inet.h>

--- a/configure.ac
+++ b/configure.ac
@@ -2280,6 +2280,15 @@ AC_SUBST(auglensdir)
 AC_SUBST(hotplugdir)
 AC_SUBST(udevdir)
 
+dnl On a related note to warning setup below, we limit the minimum C and C++
+dnl standard versions to ones we actively strive to support (C99 and C++11,
+dnl GNU dialects tend to work on more systems if supported by compiler there).
+dnl It is assumed that on very old systems whose compilers do not know these
+dnl standards (only support ANSI/C89/C90 or older), as well as for builds
+dnl that explicitly specify a CFLAGS="-std=..." (for GCC/CLANG toolkits),
+dnl nothing should get added to CFLAGS/CXXFLAGS by this method:
+NUT_COMPILER_FAMILY_FLAGS_DEFAULT_STANDARD
+
 dnl Filter through known variants first, so automatic choices can be made.
 dnl Note that clang identifies as gcc-compatible so should be probed first.
 dnl TODO: Flip this default to "hard" when we clear existing codebase.

--- a/configure.ac
+++ b/configure.ac
@@ -2453,7 +2453,7 @@ AC_CHECK_HEADER([string.h],
     [AC_LANG_PUSH([C])
      CFLAGS_SAVED="${CFLAGS}"
      CFLAGS_BUILTIN_STR="-fno-builtin-strchr -fno-builtin-strcmp -fno-builtin-strncmp"
-     CFLAGS="${CFLAGS} ${LIBNETSNMP_CFLAGS} ${LIBNEON_CFLAGS} ${LIBSSL_CFLAGS}"
+     CFLAGS="${CFLAGS} -Werror -Wunreachable-code ${LIBNETSNMP_CFLAGS} ${LIBNEON_CFLAGS} ${LIBSSL_CFLAGS}"
      AC_MSG_CHECKING([whether we should disable string built-ins])
      dnl AC_DEFINE([HAVE_STRING_H], [1], [Define to 1 if you have <string.h>.])
      AC_COMPILE_IFELSE(
@@ -2479,7 +2479,7 @@ if (strchr(s, c) != NULL) return 1
                 ])],
             [CFLAGS="${CFLAGS_BUILTIN_STR} ${CFLAGS_SAVED}"
              AC_MSG_RESULT([yes, this solves a problem])],
-            [CFLAGS="${CFLAGS} -Wno-unreachable-code"
+            [CFLAGS="${CFLAGS_SAVED} -Wno-unreachable-code ${LIBNETSNMP_CFLAGS} ${LIBNEON_CFLAGS} ${LIBSSL_CFLAGS}"
              AC_COMPILE_IFELSE(
                 [AC_LANG_PROGRAM(
                     [[#include <string.h>

--- a/configure.ac
+++ b/configure.ac
@@ -2516,7 +2516,7 @@ AC_CHECK_HEADER([arpa/inet.h],
     [AC_LANG_PUSH([C])
      CFLAGS_SAVED="${CFLAGS}"
      CFLAGS_BUILTIN_NTOHL="-fno-builtin-htonl -fno-builtin-ntohl"
-     CFLAGS="${CFLAGS} ${LIBNETSNMP_CFLAGS} ${LIBLTDL_CFLAGS} ${LIBNEON_CFLAGS} ${LIBSSL_CFLAGS}"
+     CFLAGS="${CFLAGS} -Werror -Wunreachable-code -Wshadow ${LIBNETSNMP_CFLAGS} ${LIBLTDL_CFLAGS} ${LIBNEON_CFLAGS} ${LIBSSL_CFLAGS}"
      AC_MSG_CHECKING([whether we should disable htonl/ntohl built-ins])
      dnl AC_DEFINE([HAVE_ARPA_INET_H], [1], [Define to 1 if you have <arpa/inet.h>.])
      AC_COMPILE_IFELSE(
@@ -2538,7 +2538,7 @@ sin.s_addr = htonl((ntohl(sin.s_addr) + 1))
                 ])],
             [CFLAGS="${CFLAGS_BUILTIN_NTOHL} ${CFLAGS_SAVED}"
              AC_MSG_RESULT([yes, this solves a problem])],
-            [CFLAGS="${CFLAGS} -Wno-shadow"
+            [CFLAGS="${CFLAGS_SAVED} -Wno-shadow ${LIBNETSNMP_CFLAGS} ${LIBLTDL_CFLAGS} ${LIBNEON_CFLAGS} ${LIBSSL_CFLAGS}"
              AC_COMPILE_IFELSE(
                 [AC_LANG_PROGRAM(
                     [[#include <arpa/inet.h>

--- a/docs/config-prereqs.txt
+++ b/docs/config-prereqs.txt
@@ -81,6 +81,14 @@ distros for Raspberry Pi, as well as many others. The package list below
 should largely apply to those as well, however note that some well-known
 package names tend to differ. A few of those are noted below.
 
+NOTE: While Debian distros I've seen (8 to 11) provide a "libusb-dev"
+for libusb-0.1 headers, the binary library package name is specifically
+versioned package by default of the current release (e.g. "libusb-0.1-4"),
+while names of both the library and development packages for libusb-1.0
+must be determined with `apt-cache search 'libusb.*1\.0.*` yielding e.g.
+"libusb-1.0-0-dev" (string name was seen with different actual package
+source versions on both Debian 8 Jessie and Debian 11 Buster).
+
 ----
 :; apt-get update
 
@@ -102,7 +110,7 @@ package names tend to differ. A few of those are noted below.
     libcppunit-dev \
     openssl-dev libnss3-dev \
     augeas-tools libaugeas-dev augeas-lenses \
-    libusb-dev \
+    libusb-dev libusb-1.0-0-dev \
     libi2c-dev \
     libmodbus-dev \
     libsnmp-dev \
@@ -212,6 +220,8 @@ https://unix.stackexchange.com/questions/475584/cannot-install-busybox-on-centos
     asciidoc source-highlight python-pygments dblatex aspell \
     gd-devel
 
+# NOTE: "libusbx" is the CentOS way of naming "libusb-1.0"
+# vs. the older "libusb" as the package with "libusb-0.1"
 :; yum install \
     cppunit-devel \
     openssl-devel nss-devel \

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 2820 utf-8
+personal_ws-1.1 en 2821 utf-8
 AAS
 ACFAIL
 ACFREQ
@@ -2752,6 +2752,7 @@ vc
 vendorid
 verifySourceSig
 versa
+versioned
 victron
 victronups
 vid

--- a/drivers/asem.c
+++ b/drivers/asem.c
@@ -105,7 +105,18 @@ void upsdrv_initinfo(void)
 	__u8 buffer[10];
 	unsigned short year, month, day;
 
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_EXTRA_SEMI_STMT)
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_EXTRA_SEMI_STMT
+# pragma GCC diagnostic ignored "-Wextra-semi-stmt"
+#endif
+	/* Current definition of this macro ends with a brace;
+	 * we keep the useless trailing ";" for readability */
 	ACCESS_DEVICE(upsfd, BQ2060_ADDRESS);
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_EXTRA_SEMI_STMT)
+# pragma GCC diagnostic pop
+#endif
 
 	/* Set capacity mode in mA(h) */
 	i2c_status = i2c_smbus_read_word_data(upsfd, 0x03);
@@ -171,7 +182,18 @@ void upsdrv_updateinfo(void)
 	static __s32 temperature;
 	static __s32 runtime_to_empty;
 
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_EXTRA_SEMI_STMT)
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_EXTRA_SEMI_STMT
+# pragma GCC diagnostic ignored "-Wextra-semi-stmt"
+#endif
+	/* Current definition of this macro ends with a brace;
+	 * we keep the useless trailing ";" for readability */
 	ACCESS_DEVICE(upsfd, CHARGER_ADDRESS);
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_EXTRA_SEMI_STMT)
+# pragma GCC diagnostic pop
+#endif
 	/* Charger only supplies online/offline status */
 	i2c_status = i2c_smbus_read_word_data(upsfd, 0x13);
 	if (i2c_status == -1) {
@@ -182,7 +204,18 @@ void upsdrv_updateinfo(void)
 	online = (i2c_status & 0x8000) != 0;
 	upsdebugx(3, "Charger status 0x%02X, online %d", i2c_status, online);
 
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_EXTRA_SEMI_STMT)
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_EXTRA_SEMI_STMT
+# pragma GCC diagnostic ignored "-Wextra-semi-stmt"
+#endif
+	/* Current definition of this macro ends with a brace;
+	 * we keep the useless trailing ";" for readability */
 	ACCESS_DEVICE(upsfd, BQ2060_ADDRESS);
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_EXTRA_SEMI_STMT)
+# pragma GCC diagnostic pop
+#endif
 	i2c_status = i2c_smbus_read_word_data(upsfd, 0x16);
 	if (i2c_status == -1) {
 		dstate_datastale();
@@ -342,7 +375,18 @@ void upsdrv_initups(void)
 		fatal_with_errno(EXIT_FAILURE, "Could not open device port '%s'", device_path);
 	}
 
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_EXTRA_SEMI_STMT)
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_EXTRA_SEMI_STMT
+# pragma GCC diagnostic ignored "-Wextra-semi-stmt"
+#endif
+	/* Current definition of this macro ends with a brace;
+	 * we keep the useless trailing ";" for readability */
 	ACCESS_DEVICE(upsfd, BQ2060_ADDRESS);
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_EXTRA_SEMI_STMT)
+# pragma GCC diagnostic pop
+#endif
 
 	/* Get ManufacturerName */
 	memset(DeviceName_buffer, 0, 10);

--- a/drivers/asem.c
+++ b/drivers/asem.c
@@ -292,6 +292,9 @@ void upsdrv_updateinfo(void)
 }
 
 void upsdrv_shutdown(void)
+	__attribute__((noreturn));
+
+void upsdrv_shutdown(void)
 {
 	/* tell the UPS to shut down, then return - DO NOT SLEEP HERE */
 

--- a/drivers/nut-libfreeipmi.c
+++ b/drivers/nut-libfreeipmi.c
@@ -528,11 +528,17 @@ static int libfreeipmi_get_board_info (const void *areabuf,
 #pragma clang diagnostic ignored "-Wunreachable-code"
 #endif
 	/* Stay ahead of possible redefinitions... */
-	if (sizeof(mfg_date_time) < sizeof(timetmp))
+	if (sizeof(mfg_date_time) > sizeof(timetmp))
 	{
 		libfreeipmi_cleanup();
-		fatalx(EXIT_FAILURE, "libfreeipmi_get_board_info: mfg_date_time type too large to process");
+		fatalx(EXIT_FAILURE, "libfreeipmi_get_board_info: mfg_date_time type too large to process into a time_t");
 	}
+	/* NOTE: Code until the end of method would also be "unreachable"
+	 * for compilers or static analyzers that care about this, if the
+	 * sizeof() check above fails on some architecture; build warnings
+	 * should expose that so we look for a fix - so do not just blindly
+	 * move the closing pragmas to end of method ;)
+	 */
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -46,8 +46,7 @@
 
 /* note: QX_USB/QX_SERIAL set through Makefile */
 #ifdef QX_USB
-	#include "nut_libusb.h"
-	#include "usb-common.h"
+	#include "nut_libusb.h" /* also includes "usb-common.h" */
 
 	#ifdef QX_SERIAL
 		#define DRIVER_NAME	"Generic Q* USB/Serial driver"

--- a/drivers/snmp-ups.h
+++ b/drivers/snmp-ups.h
@@ -82,6 +82,9 @@
 #include <net-snmp/net-snmp-includes.h>
 
 /* Force numeric OIDs by disabling MIB loading */
+#ifdef DISABLE_MIB_LOADING
+# undef DISABLE_MIB_LOADING
+#endif
 #define DISABLE_MIB_LOADING 1
 
 /* Parameters default values */

--- a/m4/ax_c_pragmas.m4
+++ b/m4/ax_c_pragmas.m4
@@ -563,6 +563,33 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
     AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT_BESIDEFUNC], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wcovered-switch-default" (outside functions)])
   ])
 
+  AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wextra-semi-stmt"],
+    [ax_cv__pragma__gcc__diags_ignored_extra_semi_stmt],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[void func(void) {
+#pragma GCC diagnostic ignored "-Wextra-semi-stmt"
+}
+]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_extra_semi_stmt=yes],
+      [ax_cv__pragma__gcc__diags_ignored_extra_semi_stmt=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_extra_semi_stmt" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_EXTRA_SEMI_STMT], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wextra-semi-stmt"])
+  ])
+
+  AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wextra-semi-stmt" (outside functions)],
+    [ax_cv__pragma__gcc__diags_ignored_extra_semi_stmt_besidefunc],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wextra-semi-stmt"]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_extra_semi_stmt_besidefunc=yes],
+      [ax_cv__pragma__gcc__diags_ignored_extra_semi_stmt_besidefunc=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_extra_semi_stmt_besidefunc" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_EXTRA_SEMI_STMT_BESIDEFUNC], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wextra-semi-stmt" (outside functions)])
+  ])
+
   AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wcast-align"],
     [ax_cv__pragma__gcc__diags_ignored_cast_align],
     [AC_COMPILE_IFELSE(

--- a/m4/ax_c_pragmas.m4
+++ b/m4/ax_c_pragmas.m4
@@ -421,6 +421,33 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
     AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE_BREAK_BESIDEFUNC], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wunreachable-code-break" (outside functions)])
   ])
 
+  AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wunreachable-code-return"],
+    [ax_cv__pragma__gcc__diags_ignored_unreachable_code_return],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[void func(void) {
+#pragma GCC diagnostic ignored "-Wunreachable-code-return"
+}
+]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_unreachable_code_return=yes],
+      [ax_cv__pragma__gcc__diags_ignored_unreachable_code_return=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_unreachable_code_return" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE_RETURN], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wunreachable-code-return"])
+  ])
+
+  AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wunreachable-code-return" (outside functions)],
+    [ax_cv__pragma__gcc__diags_ignored_unreachable_code_return_besidefunc],
+    [AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([[#pragma GCC diagnostic ignored "-Wunreachable-code-return"]], [])],
+      [ax_cv__pragma__gcc__diags_ignored_unreachable_code_return_besidefunc=yes],
+      [ax_cv__pragma__gcc__diags_ignored_unreachable_code_return_besidefunc=no]
+    )]
+  )
+  AS_IF([test "$ax_cv__pragma__gcc__diags_ignored_unreachable_code_return_besidefunc" = "yes"],[
+    AC_DEFINE([HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE_RETURN_BESIDEFUNC], 1, [define if your compiler has #pragma GCC diagnostic ignored "-Wunreachable-code-return" (outside functions)])
+  ])
+
   AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wunreachable-code"],
     [ax_cv__pragma__gcc__diags_ignored_unreachable_code],
     [AC_COMPILE_IFELSE(

--- a/m4/ax_c_pragmas.m4
+++ b/m4/ax_c_pragmas.m4
@@ -109,6 +109,40 @@ dnl ###        [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning"
     AC_DEFINE([HAVE_PRAGMA_CLANG_DIAGNOSTIC_PUSH_POP], 1, [define if your compiler has #pragma clang diagnostic push and pop])
   ])
 
+  dnl Test for some clang-specific pragma support: primarily useful for older
+  dnl clang (3.x) releases, so polluting NUT codebase only when unavoidable.
+  dnl In most cases, GCC pragmas are usable by both; in a few others, direct
+  dnl use of `#ifdef __clang__` suffices.
+  AS_IF([test "${CLANG}" = "yes"], [
+      AC_CACHE_CHECK([for pragma CLANG diagnostic ignored "-Wunreachable-code-return"],
+        [ax_cv__pragma__clang__diags_ignored_unreachable_code_return],
+        [AC_COMPILE_IFELSE(
+          [AC_LANG_PROGRAM([[void func(void) {
+#pragma clang diagnostic ignored "-Wunreachable-code-return"
+}
+    ]], [])],
+          [ax_cv__pragma__clang__diags_ignored_unreachable_code_return=yes],
+          [ax_cv__pragma__clang__diags_ignored_unreachable_code_return=no]
+        )]
+      )
+      AS_IF([test "$ax_cv__pragma__clang__diags_ignored_unreachable_code_return" = "yes"],[
+        AC_DEFINE([HAVE_PRAGMA_CLANG_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE_RETURN], 1, [define if your compiler has #pragma clang diagnostic ignored "-Wunreachable-code-return"])
+      ])
+
+      AC_CACHE_CHECK([for pragma CLANG diagnostic ignored "-Wunreachable-code-return" (outside functions)],
+        [ax_cv__pragma__clang__diags_ignored_unreachable_code_return_besidefunc],
+        [AC_COMPILE_IFELSE(
+          [AC_LANG_PROGRAM([[#pragma clang diagnostic ignored "-Wunreachable-code-return"]], [])],
+          [ax_cv__pragma__clang__diags_ignored_unreachable_code_return_besidefunc=yes],
+          [ax_cv__pragma__clang__diags_ignored_unreachable_code_return_besidefunc=no]
+        )]
+      )
+      AS_IF([test "$ax_cv__pragma__clang__diags_ignored_unreachable_code_return_besidefunc" = "yes"],[
+        AC_DEFINE([HAVE_PRAGMA_CLANG_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE_RETURN_BESIDEFUNC], 1, [define if your compiler has #pragma clang diagnostic ignored "-Wunreachable-code-return" (outside functions)])
+      ])
+  ]) dnl Special pragma support testing for clang
+
+  dnl Test common pragmas for GCC (and compatible) compilers
   AC_CACHE_CHECK([for pragma GCC diagnostic ignored "-Wunused-function"],
     [ax_cv__pragma__gcc__diags_ignored_unused_function],
     [AC_COMPILE_IFELSE(

--- a/m4/ax_c_pragmas.m4
+++ b/m4/ax_c_pragmas.m4
@@ -10,8 +10,8 @@ AC_DEFUN([AX_C_PRAGMAS], [
 
   dnl # This is expected to fail builds with unknown pragma names on GCC or CLANG at least
   AS_IF([test "${CLANG}" = "yes"],
-    [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning-option"
-     CXXFLAGS="${CXXFLAGS_SAVED} -Werror=pragmas -Werror=unknown-warning-option"],
+    [CFLAGS="${CFLAGS_SAVED} -Werror=pragmas -Werror=unknown-pragmas -Werror=unknown-warning-option"
+     CXXFLAGS="${CXXFLAGS_SAVED} -Werror=pragmas -Werror=unknown-pragmas -Werror=unknown-warning-option"],
     [AS_IF([test "${GCC}" = "yes"],
 dnl ### Despite the docs, this dies with lack of (apparently) support for
 dnl ### -Wunknown-warning(-options) on all GCC versions I tried (v5-v10)

--- a/m4/nut_check_libnetsnmp.m4
+++ b/m4/nut_check_libnetsnmp.m4
@@ -125,7 +125,7 @@ if test -z "${nut_have_libnetsnmp_seen}"; then
 	AC_CHECK_HEADERS(net-snmp/net-snmp-config.h, [nut_have_libnetsnmp=yes], [nut_have_libnetsnmp=no], [AC_INCLUDES_DEFAULT])
 	AC_CHECK_FUNCS(init_snmp, [], [nut_have_libnetsnmp=no])
 
-	if test "${nut_have_libnetsnmp}" = "yes"; then
+	AS_IF([test "${nut_have_libnetsnmp}" = "yes"], [
 		LIBNETSNMP_CFLAGS="${CFLAGS}"
 		LIBNETSNMP_LIBS="${LIBS}"
 
@@ -294,7 +294,7 @@ int num = NETSNMP_DRAFT_BLUMENTHAL_AES_04 + 1; /* if defined, NETSNMP_DRAFT_BLUM
 			 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_DRAFT_BLUMENTHAL_AES_04, 0, [Variable or macro by this name is not resolvable])
 			])
 
-	fi
+	])
 	AC_LANG_POP([C])
 
 	dnl restore original CFLAGS and LIBS

--- a/m4/nut_compiler_family.m4
+++ b/m4/nut_compiler_family.m4
@@ -131,6 +131,39 @@ dnl #    AS_IF([test "x$CLANGCC" = xyes -o  "x$GCC" = xyes],
 dnl #        [CFLAGS="-isystem /usr/include -isystem /usr/local/include $CFLAGS"])
 dnl #    AS_IF([test "x$CLANGXX" = xyes -o  "x$GXX" = xyes],
 dnl #        [CXXFLAGS="-isystem /usr/include -isystem /usr/local/include $CXXFLAGS"])
+
+dnl # Default to avoid noisy warnings on older compilers
+dnl # (gcc-4.x, clang-3.x) due to their preference of
+dnl # ANSI C (C89/C90) out of the box. While NUT codebase
+dnl # currently can build in that mode, reliability of
+dnl # results is uncertain - third-party and/or system
+dnl # headers and libs seemingly no longer care for C90
+dnl # on modern systems, and we have no recent data from
+dnl # truly legacy systems which have no choice:
+    AS_IF([test "x$GCC" = xyes -o "x$CLANGCC" = xyes],
+        [AS_CASE(["${CFLAGS}"], [-std=*], [],
+            [AC_LANG_PUSH([C])
+             AX_CHECK_COMPILE_FLAG([-std=c99],
+                [AC_MSG_NOTICE([Defaulting C standard support to C99 on a GCC or CLANG compatible compiler])
+                 CFLAGS="$CFLAGS -std=c99"
+                ], [], [-Werror])
+             AC_LANG_POP([C])
+         ])
+    ])
+
+dnl # Note: this might upset some very old compilers
+dnl # but then by default we wouldn't build C++ parts
+    AS_IF([test "x$GCC" = xyes -o "x$CLANGCC" = xyes],
+        [AS_CASE(["${CXXFLAGS}"], [-std=*], [],
+            [AC_LANG_PUSH([C++])
+             AX_CHECK_COMPILE_FLAG([-std=c++11],
+                [AC_MSG_NOTICE([Defaulting C++ standard support to C++11 on a GCC or CLANG compatible compiler])
+                 CXXFLAGS="$CXXFLAGS -std=c++11"
+                ], [], [-Werror])
+             AC_LANG_POP([C++])
+         ])
+    ])
+
 ])
 
 AC_DEFUN([NUT_COMPILER_FAMILY_FLAGS_DEFAULT_STANDARD],

--- a/m4/nut_compiler_family.m4
+++ b/m4/nut_compiler_family.m4
@@ -139,13 +139,16 @@ dnl # currently can build in that mode, reliability of
 dnl # results is uncertain - third-party and/or system
 dnl # headers and libs seemingly no longer care for C90
 dnl # on modern systems, and we have no recent data from
-dnl # truly legacy systems which have no choice:
+dnl # truly legacy systems which have no choice.
+dnl # Some distributions and platforms also have problems
+dnl # building in "strict C" mode, so for the GNU-compatible
+dnl # compilers we default to the GNU C/C++ dialects.
     AS_IF([test "x$GCC" = xyes -o "x$CLANGCC" = xyes],
         [AS_CASE(["${CFLAGS}"], [*-std=*], [],
             [AC_LANG_PUSH([C])
-             AX_CHECK_COMPILE_FLAG([-std=c99],
-                [AC_MSG_NOTICE([Defaulting C standard support to C99 on a GCC or CLANG compatible compiler])
-                 CFLAGS="$CFLAGS -std=c99"
+             AX_CHECK_COMPILE_FLAG([-std=gnu99],
+                [AC_MSG_NOTICE([Defaulting C standard support to GNU C99 on a GCC or CLANG compatible compiler])
+                 CFLAGS="$CFLAGS -std=gnu99"
                 ], [], [-Werror])
              AC_LANG_POP([C])
          ])
@@ -156,9 +159,9 @@ dnl # but then by default we wouldn't build C++ parts
     AS_IF([test "x$GCC" = xyes -o "x$CLANGCC" = xyes],
         [AS_CASE(["${CXXFLAGS}"], [*-std=*], [],
             [AC_LANG_PUSH([C++])
-             AX_CHECK_COMPILE_FLAG([-std=c++11],
-                [AC_MSG_NOTICE([Defaulting C++ standard support to C++11 on a GCC or CLANG compatible compiler])
-                 CXXFLAGS="$CXXFLAGS -std=c++11"
+             AX_CHECK_COMPILE_FLAG([-std=gnu++11],
+                [AC_MSG_NOTICE([Defaulting C++ standard support to GNU C++11 on a GCC or CLANG compatible compiler])
+                 CXXFLAGS="$CXXFLAGS -std=gnu++11"
                 ], [], [-Werror])
              AC_LANG_POP([C++])
          ])

--- a/m4/nut_compiler_family.m4
+++ b/m4/nut_compiler_family.m4
@@ -131,4 +131,37 @@ dnl #    AS_IF([test "x$CLANGCC" = xyes -o  "x$GCC" = xyes],
 dnl #        [CFLAGS="-isystem /usr/include -isystem /usr/local/include $CFLAGS"])
 dnl #    AS_IF([test "x$CLANGXX" = xyes -o  "x$GXX" = xyes],
 dnl #        [CXXFLAGS="-isystem /usr/include -isystem /usr/local/include $CXXFLAGS"])
+
+dnl # Default to avoid noisy warnings on older compilers
+dnl # (gcc-4.x, clang-3.x) due to their preference of
+dnl # ANSI C (C89/C90) out of the box. While NUT codebase
+dnl # currently can build in that mode, reliability of
+dnl # results is uncertain - third-party and/or system
+dnl # headers and libs seemingly no longer care for C90
+dnl # on modern systems, and we have no recent data from
+dnl # truly legacy systems which have no choice:
+    AS_IF([test "x$GCC" = xyes -o "x$CLANGCC" = xyes],
+        [AS_CASE(["${CFLAGS}"], [*-std=*], [],
+            [AC_LANG_PUSH([C])
+             AX_CHECK_COMPILE_FLAG([-std=c99],
+                [AC_MSG_NOTICE([Defaulting C standard support to C99 on a GCC or CLANG compatible compiler])
+                 CFLAGS="$CFLAGS -std=c99"
+                ], [], [-Werror])
+             AC_LANG_POP([C])
+         ])
+    ])
+
+dnl # Note: this might upset some very old compilers
+dnl # but then by default we wouldn't build C++ parts
+    AS_IF([test "x$GCC" = xyes -o "x$CLANGCC" = xyes],
+        [AS_CASE(["${CXXFLAGS}"], [*-std=*], [],
+            [AC_LANG_PUSH([C++])
+             AX_CHECK_COMPILE_FLAG([-std=c++11],
+                [AC_MSG_NOTICE([Defaulting C++ standard support to C++11 on a GCC or CLANG compatible compiler])
+                 CXXFLAGS="$CXXFLAGS -std=c++11"
+                ], [], [-Werror])
+             AC_LANG_POP([C++])
+         ])
+    ])
+
 ])

--- a/m4/nut_compiler_family.m4
+++ b/m4/nut_compiler_family.m4
@@ -139,13 +139,16 @@ dnl # currently can build in that mode, reliability of
 dnl # results is uncertain - third-party and/or system
 dnl # headers and libs seemingly no longer care for C90
 dnl # on modern systems, and we have no recent data from
-dnl # truly legacy systems which have no choice:
+dnl # truly legacy systems which have no choice.
+dnl # Some distributions and platforms also have problems
+dnl # building in "strict C" mode, so for the GNU-compatible
+dnl # compilers we default to the GNU C/C++ dialects.
     AS_IF([test "x$GCC" = xyes -o "x$CLANGCC" = xyes],
         [AS_CASE(["${CFLAGS}"], [-std=*], [],
             [AC_LANG_PUSH([C])
-             AX_CHECK_COMPILE_FLAG([-std=c99],
-                [AC_MSG_NOTICE([Defaulting C standard support to C99 on a GCC or CLANG compatible compiler])
-                 CFLAGS="$CFLAGS -std=c99"
+             AX_CHECK_COMPILE_FLAG([-std=gnu99],
+                [AC_MSG_NOTICE([Defaulting C standard support to GNU C99 on a GCC or CLANG compatible compiler])
+                 CFLAGS="$CFLAGS -std=gnu99"
                 ], [], [-Werror])
              AC_LANG_POP([C])
          ])
@@ -156,9 +159,9 @@ dnl # but then by default we wouldn't build C++ parts
     AS_IF([test "x$GCC" = xyes -o "x$CLANGCC" = xyes],
         [AS_CASE(["${CXXFLAGS}"], [-std=*], [],
             [AC_LANG_PUSH([C++])
-             AX_CHECK_COMPILE_FLAG([-std=c++11],
-                [AC_MSG_NOTICE([Defaulting C++ standard support to C++11 on a GCC or CLANG compatible compiler])
-                 CXXFLAGS="$CXXFLAGS -std=c++11"
+             AX_CHECK_COMPILE_FLAG([-std=gnu++11],
+                [AC_MSG_NOTICE([Defaulting C++ standard support to GNU C++11 on a GCC or CLANG compatible compiler])
+                 CXXFLAGS="$CXXFLAGS -std=gnu++11"
                 ], [], [-Werror])
              AC_LANG_POP([C++])
          ])

--- a/m4/nut_compiler_family.m4
+++ b/m4/nut_compiler_family.m4
@@ -131,7 +131,10 @@ dnl #    AS_IF([test "x$CLANGCC" = xyes -o  "x$GCC" = xyes],
 dnl #        [CFLAGS="-isystem /usr/include -isystem /usr/local/include $CFLAGS"])
 dnl #    AS_IF([test "x$CLANGXX" = xyes -o  "x$GXX" = xyes],
 dnl #        [CXXFLAGS="-isystem /usr/include -isystem /usr/local/include $CXXFLAGS"])
+])
 
+AC_DEFUN([NUT_COMPILER_FAMILY_FLAGS_DEFAULT_STANDARD],
+[
 dnl # Default to avoid noisy warnings on older compilers
 dnl # (gcc-4.x, clang-3.x) due to their preference of
 dnl # ANSI C (C89/C90) out of the box. While NUT codebase

--- a/tests/cpputest.cpp
+++ b/tests/cpputest.cpp
@@ -30,7 +30,7 @@
 // Inspired by https://stackoverflow.com/a/66702001
 class MyCustomProgressTestListener : public CppUnit::TextTestProgressListener {
     public:
-        virtual void startTest(CppUnit::Test *test);
+        virtual void startTest(CppUnit::Test *test) override;
 };
 
 // Implement out of class declaration to avoid

--- a/tests/example.cpp
+++ b/tests/example.cpp
@@ -41,8 +41,8 @@ class ExampleTest : public CppUnit::TestFixture
   CPPUNIT_TEST_SUITE_END();
 
 public:
-  void setUp();
-  void tearDown();
+  void setUp() override;
+  void tearDown() override;
 
   void testOne();
 };

--- a/tests/nutclienttest.cpp
+++ b/tests/nutclienttest.cpp
@@ -55,8 +55,8 @@ class NutClientTest : public CppUnit::TestFixture
 	CPPUNIT_TEST_SUITE_END();
 
 public:
-	void setUp();
-	void tearDown();
+	void setUp() override;
+	void tearDown() override;
 
 	void test_strarr_alloc();
 	void test_stringset_to_strarr();

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -221,36 +221,41 @@ static void show_usage()
 		{ int comma = 0;
 		NUT_UNUSED_VARIABLE(comma); /* potentially, if no protocols are available */
 		printf("  -w, --authProtocol <authentication protocol>: Set the authentication protocol (");
-#if NUT_HAVE_LIBNETSNMP_usmHMACMD5AuthProtocol
+#if (defined WITH_SNMP) && (defined NUT_HAVE_LIBNETSNMP_usmHMACMD5AuthProtocol)
+/* Note: NUT_HAVE_LIBNETSNMP_* macros are not AC_DEFINE'd when libsnmp was
+ * completely not detected at configure time, so "#if" is not a pedantically
+ * correct test (unknown macro may default to "0" but is not guaranteed to).
+ */
+# if NUT_HAVE_LIBNETSNMP_usmHMACMD5AuthProtocol
 		printf("%s%s",
 			(comma++ ? ", " : ""),
 			"MD5"
 			);
-#endif
-#if NUT_HAVE_LIBNETSNMP_usmHMACSHA1AuthProtocol
+# endif
+# if NUT_HAVE_LIBNETSNMP_usmHMACSHA1AuthProtocol
 		printf("%s%s",
 			(comma++ ? ", " : ""),
 			"SHA"
 			);
-#endif
-#if NUT_HAVE_LIBNETSNMP_usmHMAC192SHA256AuthProtocol
+# endif
+# if NUT_HAVE_LIBNETSNMP_usmHMAC192SHA256AuthProtocol
 		printf("%s%s",
 			(comma++ ? ", " : ""),
 			"SHA256"
 			);
-#endif
-#if NUT_HAVE_LIBNETSNMP_usmHMAC256SHA384AuthProtocol
+# endif
+# if NUT_HAVE_LIBNETSNMP_usmHMAC256SHA384AuthProtocol
 		printf("%s%s",
 			(comma++ ? ", " : ""),
 			"SHA384"
 			);
-#endif
-#if NUT_HAVE_LIBNETSNMP_usmHMAC384SHA512AuthProtocol
+# endif
+# if NUT_HAVE_LIBNETSNMP_usmHMAC384SHA512AuthProtocol
 		printf("%s%s",
 			(comma++ ? ", " : ""),
 			"SHA512"
 			);
-#endif
+# endif
 		printf("%s%s",
 			(comma ? "" : "none supported"),
 			") used for authenticated SNMPv3 messages (default=MD5 if available)\n"
@@ -263,32 +268,33 @@ static void show_usage()
 		{ int comma = 0;
 		NUT_UNUSED_VARIABLE(comma); /* potentially, if no protocols are available */
 		printf("  -x, --privProtocol <privacy protocol>: Set the privacy protocol (");
-#if NUT_HAVE_LIBNETSNMP_usmDESPrivProtocol
+# if NUT_HAVE_LIBNETSNMP_usmDESPrivProtocol
 		printf("%s%s",
 			(comma++ ? ", " : ""),
 			"DES"
 			);
-#endif
-#if NUT_HAVE_LIBNETSNMP_usmAESPrivProtocol || NUT_HAVE_LIBNETSNMP_usmAES128PrivProtocol
+# endif
+# if NUT_HAVE_LIBNETSNMP_usmAESPrivProtocol || NUT_HAVE_LIBNETSNMP_usmAES128PrivProtocol
 		printf("%s%s",
 			(comma++ ? ", " : ""),
 			"AES"
 			);
-#endif
-#if NUT_HAVE_LIBNETSNMP_DRAFT_BLUMENTHAL_AES_04
-# if NUT_HAVE_LIBNETSNMP_usmAES192PrivProtocol
+# endif
+# if NUT_HAVE_LIBNETSNMP_DRAFT_BLUMENTHAL_AES_04
+#  if NUT_HAVE_LIBNETSNMP_usmAES192PrivProtocol
 		printf("%s%s",
 			(comma++ ? ", " : ""),
 			"AES192"
 			);
-# endif
-# if NUT_HAVE_LIBNETSNMP_usmAES256PrivProtocol
+#  endif
+#  if NUT_HAVE_LIBNETSNMP_usmAES256PrivProtocol
 		printf("%s%s",
 			(comma++ ? ", " : ""),
 			"AES256"
 			);
-# endif
-#endif /* NUT_HAVE_LIBNETSNMP_DRAFT_BLUMENTHAL_AES_04 */
+#  endif
+# endif /* NUT_HAVE_LIBNETSNMP_DRAFT_BLUMENTHAL_AES_04 */
+#endif /* built WITH_SNMP */
 		printf("%s%s",
 			(comma ? "" : "none supported"),
 			") used for encrypted SNMPv3 messages (default=DES if available)\n"


### PR DESCRIPTION
Follows up for the "fightwarn effort" per #823 and the raised bar (default warnings sensitivity) with libusb-1.0 support merged in #1255 and a series of PRs before that - to solve most of the issue types that were reported with that level.