### PR TITLE
Some fixes for nut-scanner

### DIFF
--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -180,19 +180,29 @@ static void show_usage()
 	printf("  -C, --complete_scan: Scan all available devices except serial ports (default).\n");
 	if (nutscan_avail_usb) {
 		printf("  -U, --usb_scan: Scan USB devices.\n");
+	} else {
+		printf("* Options for USB devices scan not enabled: library not detected.\n");
 	}
 	if (nutscan_avail_snmp) {
 		printf("  -S, --snmp_scan: Scan SNMP devices using built-in mapping definitions.\n");
+	} else {
+		printf("* Options for SNMP devices scan not enabled: library not detected.\n");
 	}
 	if (nutscan_avail_xml_http) {
 		printf("  -M, --xml_scan: Scan XML/HTTP devices.\n");
+	} else {
+		printf("* Options for XML/HTTP devices scan not enabled: library not detected.\n");
 	}
 	printf("  -O, --oldnut_scan: Scan NUT devices (old method).\n");
 	if (nutscan_avail_avahi) {
 		printf("  -A, --avahi_scan: Scan NUT devices (avahi method).\n");
+	} else {
+		printf("* Options for NUT devices (avahi method) scan not enabled: library not detected.\n");
 	}
 	if (nutscan_avail_ipmi) {
 		printf("  -I, --ipmi_scan: Scan IPMI devices.\n");
+	} else {
+		printf("* Options for IPMI devices scan not enabled: library not detected.\n");
 	}
 
 	printf("  -E, --eaton_serial <serial ports list>: Scan serial Eaton devices (XCP, SHUT and Q1).\n");

--- a/tools/nut-scanner/scan_usb.c
+++ b/tools/nut-scanner/scan_usb.c
@@ -290,17 +290,29 @@ nutscan_device_t * nutscan_scan_usb()
 				/* open the device */
 #if WITH_LIBUSB_1_0
 				ret = (*nut_usb_open)(dev, &udev);
-				if (!udev) {
-					fprintf(stderr,"Failed to open device, \
-						skipping. (%s)\n",
+				if (!udev || ret != LIBUSB_SUCCESS) {
+					fprintf(stderr,"Failed to open device "
+						"bus '%s', skipping: %s\n",
+						busname,
 						(*nut_usb_strerror)(ret));
+
+					/* Note: closing is not applicable
+					 * it seems, and can even segfault
+					 * (even though an udev is not NULL
+					 * when e.g. permissions problem)
+					 */
+
+					free (busname);
+
 					continue;
 				}
 #else  /* => WITH_LIBUSB_0_1 */
 				udev = (*nut_usb_open)(dev);
 				if (!udev) {
-					fprintf(stderr, "Failed to open device, \
-						skipping. (%s)\n",
+					/* TOTHINK: any errno or similar to test? */
+					fprintf(stderr, "Failed to open device "
+						"bus '%s',skipping: %s\n",
+						busname,
 						(*nut_usb_strerror)());
 					continue;
 				}


### PR DESCRIPTION
* Report in usage() if "library not detected" (rather than silently omitting possible params for that detector)
* Avoid using a not-opened device via libusb-1.0 - accesses (even closing) can segfault on some builds of the library if the device access is denied and not actually opened