### PR TITLE
ci_build.sh: refactor make-verbosity settings and repeated logic

### DIFF
--- a/ci_build.sh
+++ b/ci_build.sh
@@ -1343,6 +1343,9 @@ bindings)
     #./configure
     ./configure --enable-Wcolor --with-all=auto --with-cgi=auto --with-serial=auto --with-dev=auto --with-doc=skip
 
+    # NOTE: Currently parallel builds are expected to succeed (as far
+    # as recipes are concerned), and the builds without a BUILD_TYPE
+    # are aimed at developer iterations so not tweaking verbosity.
     #$MAKE all && \
     $MAKE $PARMAKE_FLAGS all && \
     $MAKE check

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -842,13 +842,17 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
     # include all needed pre-generated files to rely less on OS facilities.
     if [ -s Makefile ]; then
         # Let initial clean-up be at default verbosity
+        echo "=== Starting initial clean-up (from old build products)"
         ${MAKE} maintainer-clean -k -s || ${MAKE} distclean -k -s || true
+        echo "=== Finished initial clean-up"
     fi
+
     if [ "$CI_OS_NAME" = "windows" ] ; then
         $CI_TIME ./autogen.sh || true
     else
         $CI_TIME ./autogen.sh ### 2>/dev/null
     fi
+
     if [ "$NO_PKG_CONFIG" == "true" ] && [ "$CI_OS_NAME" = "linux" ] && (command -v dpkg) ; then
         echo "NO_PKG_CONFIG==true : BUTCHER pkg-config for this test case" >&2
         sudo dpkg -r --force all pkg-config
@@ -1324,7 +1328,9 @@ bindings)
     echo ""
     if [ -s Makefile ]; then
         # Let initial clean-up be at default verbosity
+        echo "=== Starting initial clean-up (from old build products)"
         ${MAKE} realclean -k -s || true
+        echo "=== Finished initial clean-up"
     fi
 
     ./autogen.sh

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -292,7 +292,9 @@ build_to_only_catch_errors_target() {
     ( echo "`date`: Starting the parallel build attempt (quietly to build what we can) for '$@' ..."; \
       ( case "${CI_PARMAKE_VERBOSITY}" in
         silent)
-          $CI_TIME $MAKE $MAKE_FLAGS_QUIET -k $PARMAKE_FLAGS "$@" >/dev/null 2>&1 ;;
+          # Note: stderr would still expose errors and warnings (needed for
+          # e.g. CI analysis of coding issues, even if not treated as fatal)
+          $CI_TIME $MAKE $MAKE_FLAGS_QUIET -k $PARMAKE_FLAGS "$@" >/dev/null ;;
         quiet)
           $CI_TIME $MAKE $MAKE_FLAGS_QUIET -k $PARMAKE_FLAGS "$@" ;;
         silent)

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -843,7 +843,7 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
     if [ -s Makefile ]; then
         # Let initial clean-up be at default verbosity
         echo "=== Starting initial clean-up (from old build products)"
-        ${MAKE} maintainer-clean -k -s || ${MAKE} distclean -k -s || true
+        ${MAKE} maintainer-clean -k || ${MAKE} distclean -k || true
         echo "=== Finished initial clean-up"
     fi
 
@@ -1329,7 +1329,7 @@ bindings)
     if [ -s Makefile ]; then
         # Let initial clean-up be at default verbosity
         echo "=== Starting initial clean-up (from old build products)"
-        ${MAKE} realclean -k -s || true
+        ${MAKE} realclean -k || true
         echo "=== Finished initial clean-up"
     fi
 


### PR DESCRIPTION
Note: similar change applied in jenkins-dynamatrix library for "direct autotools" builds in e.g. `fightwarn` #823 branches.

This should reduce the amount of text printed by default in CI builds, especially when they are successful, reducing the storage consumption and I/O and making human navigation in the log feasible :)