### PR TITLE
Revert strcmp() warnings fixed earlier by strncmp()

### DIFF
--- a/clients/upsclient.c
+++ b/clients/upsclient.c
@@ -1424,8 +1424,8 @@ int upscli_list_next(UPSCONN_t *ups, size_t numq, const char **query,
 
 	/* see if this is the end */
 	if (ups->pc_ctx.numargs >= 2) {
-		if ((!strncmp(ups->pc_ctx.arglist[0], "END", 3)) &&
-			(!strncmp(ups->pc_ctx.arglist[1], "LIST", 4)))
+		if ((!strcmp(ups->pc_ctx.arglist[0], "END")) &&
+			(!strcmp(ups->pc_ctx.arglist[1], "LIST")))
 			return 0;
 	}
 

--- a/clients/upslog.c
+++ b/clients/upslog.c
@@ -488,7 +488,7 @@ int main(int argc, char **argv)
 		fprintf(stderr, "Warning: initial connect failed: %s\n",
 			upscli_strerror(&ups));
 
-	if (strncmp(logfn, "-", 1) == 0)
+	if (strcmp(logfn, "-") == 0)
 		logfile = stdout;
 	else
 		logfile = fopen(logfn, "a");

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -1619,19 +1619,19 @@ static void parse_status(utype_t *ups, char *status)
 
 		upsdebugx(3, "parsing: [%s]", statword);
 
-		if (!strncasecmp(statword, "OL", 2))
+		if (!strcasecmp(statword, "OL"))
 			ups_on_line(ups);
-		if (!strncasecmp(statword, "OB", 2))
+		if (!strcasecmp(statword, "OB"))
 			ups_on_batt(ups);
-		if (!strncasecmp(statword, "LB", 2))
+		if (!strcasecmp(statword, "LB"))
 			ups_low_batt(ups);
-		if (!strncasecmp(statword, "RB", 2))
+		if (!strcasecmp(statword, "RB"))
 			upsreplbatt(ups);
-		if (!strncasecmp(statword, "CAL", 3))
+		if (!strcasecmp(statword, "CAL"))
 			ups_cal(ups);
 
 		/* do it last to override any possible OL */
-		if (!strncasecmp(statword, "FSD", 3))
+		if (!strcasecmp(statword, "FSD"))
 			ups_fsd(ups);
 
 		update_crittimer(ups);

--- a/clients/upsrw.c
+++ b/clients/upsrw.c
@@ -523,7 +523,7 @@ static void do_type(const char *varname)
 		}
 
 		/* ignore this one */
-		if (!strncasecmp(answer[i], "RW", 2)) {
+		if (!strcasecmp(answer[i], "RW")) {
 			continue;
 		}
 

--- a/clients/upssched.c
+++ b/clients/upssched.c
@@ -823,7 +823,7 @@ static void parse_at(const char *ntype, const char *un, const char *cmd,
 
 	/* check upsname: does this apply to us? */
 	if (strcmp(upsname, un) != 0)
-		if (strncmp(un, "*", 1) != 0)
+		if (strcmp(un, "*") != 0)
 			return;		/* not for us, and not the wildcard */
 
 	/* see if the current notify type matches the one from the .conf */
@@ -885,7 +885,7 @@ static int conf_arg(size_t numargs, char **arg)
 		return 0;
 
 	/* AT <notifytype> <upsname> <command> <cmdarg1> [<cmdarg2>] */
-	if (!strncmp(arg[0], "AT", 2)) {
+	if (!strcmp(arg[0], "AT")) {
 
 		/* don't use arg[5] unless we have it... */
 		if (numargs > 5)

--- a/clients/upsset.c
+++ b/clients/upsset.c
@@ -759,7 +759,7 @@ static void do_type(const char *varname)
 		}
 
 		/* ignore this one */
-		if (!strncasecmp(answer[i], "RW", 2))
+		if (!strcasecmp(answer[i], "RW"))
 			continue;
 
 		printf("Unrecognized\n");

--- a/common/state.c
+++ b/common/state.c
@@ -424,7 +424,7 @@ void state_setflags(st_tree_t *root, const char *var, size_t numflags, char **fl
 
 	for (i = 0; i < numflags; i++) {
 
-		if (!strncasecmp(flag[i], "RW", 2)) {
+		if (!strcasecmp(flag[i], "RW")) {
 			sttmp->flags |= ST_FLAG_RW;
 			continue;
 		}

--- a/common/upsconf.c
+++ b/common/upsconf.c
@@ -56,7 +56,7 @@ static void conf_args(size_t numargs, char **arg)
 		return;
 
 	/* handle 'foo = bar', 'foo=bar', 'foo =bar' or 'foo= bar' forms */
-	if (!strncmp(arg[1], "=", 1)) {
+	if (!strcmp(arg[1], "=")) {
 		do_upsconf_args(ups_section, arg[0], arg[2]);
 		return;
 	}

--- a/docs/developers.txt
+++ b/docs/developers.txt
@@ -21,13 +21,6 @@ Don't use `strcat()`.  We have a neat wrapper for `snprintf()` called
 `snprintfcat()` that allows you to append to `char *` with a format
 string and all the usual string length checking of `snprintf()` routine.
 
-Some systems define `strcmp()` and `strcasecmp()` as macros or inline
-functions optimized for aligned memory access in a way that some compilers
-complain about array out-of-bounds access when comparing fixed short strings.
-For this reason, we compare strings with length 3 chars and less ("", "x",
-"on", "VAL") with fixed-length methods `strncmp()` and `strncasecmp()`,
-e.g. `strncmp(buf, "VAL", 3)`.
-
 Error reporting
 ~~~~~~~~~~~~~~~
 

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 2864 utf-8
+personal_ws-1.1 en 2861 utf-8
 AAS
 ACFAIL
 ACFREQ
@@ -2555,14 +2555,11 @@ strarr
 strcasecmp
 strcat
 strchr
-strcmp
 strcpy
 strdup
 strerror
 strftime
 strlen
-strncasecmp
-strncmp
 struct
 structs
 sts

--- a/drivers/apcsmart-old.c
+++ b/drivers/apcsmart-old.c
@@ -238,7 +238,7 @@ static ssize_t poll_data(apc_vartab_t *vt)
 	}
 
 	/* no longer supported by the hardware somehow */
-	if (!strncmp(tmp, "NA", 2)) {
+	if (!strcmp(tmp, "NA")) {
 		dstate_delinfo(vt->name);
 		return 1;
 	}
@@ -292,7 +292,7 @@ static int query_ups(const char *var, int first)
 
 	ser_comm_good();
 
-	if ((ret < 1) || (!strncmp(temp, "NA", 2)))		/* not supported */
+	if ((ret < 1) || (!strcmp(temp, "NA")))		/* not supported */
 		return 0;
 
 	vt->flags |= APC_PRESENT;
@@ -333,7 +333,7 @@ static void do_capabilities(void)
 	ret = ser_get_line(upsfd, temp, sizeof(temp), ENDCHAR,
 		MINIGNCHARS, SER_WAIT_SEC, SER_WAIT_USEC);
 
-	if ((ret < 1) || (!strncmp(temp, "NA", 2))) {
+	if ((ret < 1) || (!strcmp(temp, "NA"))) {
 
 		/* Early Smart-UPS, not as smart as later ones */
 		/* This should never happen since we only call
@@ -446,7 +446,7 @@ static int update_status(void)
 
 	ret = read_buf(buf, sizeof(buf));
 
-	if ((ret < 1) || (!strncmp(buf, "NA", 2))) {
+	if ((ret < 1) || (!strcmp(buf, "NA"))) {
 		dstate_datastale();
 		return 0;
 	}
@@ -566,7 +566,7 @@ static int firmware_table_lookup(void)
 	 * Some UPSes support both 'V' and 'b'. As 'b' doesn't always return
 	 * firmware version, we attempt that only if 'V' doesn't work.
 	 */
-	if ((ret < 1) || (!strncmp(buf, "NA", 2))) {
+	if ((ret < 1) || (!strcmp(buf, "NA"))) {
 		upsdebugx(1, "Attempting firmware lookup using command 'b'");
 		ret = ser_send_char(upsfd, 'b');
 
@@ -646,7 +646,7 @@ static void getbaseinfo(void)
 	ret = ser_get_line(upsfd, temp, sizeof(temp), ENDCHAR, IGNCHARS,
 		SER_WAIT_SEC, SER_WAIT_USEC);
 
-	if ((ret < 1) || (!strncmp(temp, "NA", 2))) {
+	if ((ret < 1) || (!strcmp(temp, "NA"))) {
 		/* We have an old dumb UPS - go to specific code for old stuff */
 		oldapcsetup();
 		return;
@@ -698,7 +698,7 @@ static int do_cal(int start)
 	ret = read_buf(temp, sizeof(temp));
 
 	/* if we can't check the current calibration status, bail out */
-	if ((ret < 1) || (!strncmp(temp, "NA", 2)))
+	if ((ret < 1) || (!strcmp(temp, "NA")))
 		return STAT_INSTCMD_HANDLED;		/* FUTURE: failure */
 
 	tval = strtol(temp, 0, 16);
@@ -723,7 +723,7 @@ static int do_cal(int start)
 
 		ret = read_buf(temp, sizeof(temp));
 
-		if ((ret < 1) || (!strncmp(temp, "NA", 2)) || (!strncmp(temp, "NO", 2))) {
+		if ((ret < 1) || (!strcmp(temp, "NA")) || (!strcmp(temp, "NO"))) {
 			upslogx(LOG_WARNING, "Stop calibration failed: %s",
 				temp);
 			return STAT_INSTCMD_HANDLED;	/* FUTURE: failure */
@@ -750,7 +750,7 @@ static int do_cal(int start)
 
 	ret = read_buf(temp, sizeof(temp));
 
-	if ((ret < 1) || (!strncmp(temp, "NA", 2)) || (!strncmp(temp, "NO", 2))) {
+	if ((ret < 1) || (!strcmp(temp, "NA")) || (!strcmp(temp, "NO"))) {
 		upslogx(LOG_WARNING, "Start calibration failed: %s", temp);
 		return STAT_INSTCMD_HANDLED;	/* FUTURE: failure */
 	}
@@ -778,7 +778,7 @@ static int smartmode(void)
 			IGNCHARS, SER_WAIT_SEC, SER_WAIT_USEC);
 
 		if (ret > 0)
-			if (!strncmp(temp, "SM", 2))
+			if (!strcmp(temp, "SM"))
 				return 1;	/* success */
 
 		sleep(1);	/* wait before trying again */
@@ -810,7 +810,7 @@ static long sdok(void)
 	ser_get_line(upsfd, temp, sizeof(temp), ENDCHAR, IGNCHARS, SER_WAIT_SEC, SER_WAIT_USEC);
 	upsdebugx(4, "sdok: got \"%s\"", temp);
 
-	if (!strncmp(temp, "*", 1) || !strncmp(temp, "OK", 2)) {
+	if (!strcmp(temp, "*") || !strcmp(temp, "OK")) {
 		upsdebugx(4, "Last issued shutdown command succeeded");
 		return 1;
 	}
@@ -1077,7 +1077,7 @@ void upsdrv_shutdown(void)
 		status = APC_STAT_LB | APC_STAT_OB;
 	}
 
-	if (testvar("advorder") && strncasecmp(getval("advorder"), "no", 2))
+	if (testvar("advorder") && strcasecmp(getval("advorder"), "no"))
 		upsdrv_shutdown_advanced(status);
 	else
 		upsdrv_shutdown_simple(status);
@@ -1144,7 +1144,7 @@ static int setvar_enum(apc_vartab_t *vt, const char *val)
 
 	ret = read_buf(orig, sizeof(orig));
 
-	if ((ret < 1) || (!strncmp(orig, "NA", 2)))
+	if ((ret < 1) || (!strcmp(orig, "NA")))
 		return STAT_SET_HANDLED;	/* FUTURE: failed */
 
 	ptr = convert_data(vt, orig);
@@ -1168,13 +1168,13 @@ static int setvar_enum(apc_vartab_t *vt, const char *val)
 		/* this should return either OK (if rotated) or NO (if not) */
 		ret = read_buf(temp, sizeof(temp));
 
-		if ((ret < 1) || (!strncmp(temp, "NA", 2)))
+		if ((ret < 1) || (!strcmp(temp, "NA")))
 			return STAT_SET_HANDLED;	/* FUTURE: failed */
 
 		/* sanity checks */
-		if (!strncmp(temp, "NO", 2))
+		if (!strcmp(temp, "NO"))
 			return STAT_SET_HANDLED;	/* FUTURE: failed */
-		if (strncmp(temp, "OK", 2) != 0)
+		if (strcmp(temp, "OK") != 0)
 			return STAT_SET_HANDLED;	/* FUTURE: failed */
 
 		/* see what it rotated onto */
@@ -1187,7 +1187,7 @@ static int setvar_enum(apc_vartab_t *vt, const char *val)
 
 		ret = read_buf(temp, sizeof(temp));
 
-		if ((ret < 1) || (!strncmp(temp, "NA", 2)))
+		if ((ret < 1) || (!strcmp(temp, "NA")))
 			return STAT_SET_HANDLED;	/* FUTURE: failed */
 
 		ptr = convert_data(vt, temp);
@@ -1238,7 +1238,7 @@ static int setvar_string(apc_vartab_t *vt, const char *val)
 
 	ret = read_buf(temp, sizeof(temp));
 
-	if ((ret < 1) || (!strncmp(temp, "NA", 2)))
+	if ((ret < 1) || (!strcmp(temp, "NA")))
 		return STAT_SET_HANDLED;	/* FUTURE: failed */
 
 	/* suppress redundant changes - easier on the eeprom */
@@ -1288,7 +1288,7 @@ static int setvar_string(apc_vartab_t *vt, const char *val)
 		return STAT_SET_HANDLED;	/* FUTURE: failed */
 	}
 
-	if (!strncmp(temp, "NO", 2)) {
+	if (!strcmp(temp, "NO")) {
 		upslogx(LOG_ERR, "setvar_string: got NO at final read");
 		return STAT_SET_HANDLED;	/* FUTURE: failed */
 	}
@@ -1356,7 +1356,7 @@ static int do_cmd(apc_cmdtab_t *ct)
 	if (ret < 1)
 		return STAT_INSTCMD_HANDLED;		/* FUTURE: failed */
 
-	if (strncmp(buf, "OK", 2) != 0) {
+	if (strcmp(buf, "OK") != 0) {
 		upslogx(LOG_WARNING, "Got [%s] after command [%s]",
 			buf, ct->name);
 

--- a/drivers/apcsmart.c
+++ b/drivers/apcsmart.c
@@ -308,7 +308,7 @@ static void apc_ser_set(void)
 	 * compatibility measure for windows systems and perhaps some
 	 * problematic serial cards/converters
 	 */
-	if ((val = getval("ttymode")) && !strncmp(val, "raw", 3))
+	if ((val = getval("ttymode")) && !strcmp(val, "raw"))
 		return;
 
 	memset(&tio, 0, sizeof(tio));
@@ -779,7 +779,7 @@ static const char *preread_data(apc_vartab_t *vt)
 
 	ret = apc_read(temp, sizeof(temp), SER_TO);
 
-	if (ret < 1 || !strncmp(temp, "NA", 2)) {
+	if (ret < 1 || !strcmp(temp, "NA")) {
 		if (ret >= 0)
 			upslogx(LOG_ERR, "%s: %s [%s] timed out or not supported", __func__, vt->name, prtchr(vt->cmd));
 		return 0;
@@ -804,7 +804,7 @@ static int poll_data(apc_vartab_t *vt)
 		return 0;
 
 	/* automagically no longer supported by the hardware somehow */
-	if (!strncmp(temp, "NA", 2)) {
+	if (!strcmp(temp, "NA")) {
 		upslogx(LOG_WARNING, "%s: verified variable %s [%s] returned NA, removing", __func__, vt->name, prtchr(vt->cmd));
 		vt->flags &= ~(unsigned int)APC_PRESENT;
 		apc_dstate_delinfo(vt, 0);
@@ -826,7 +826,7 @@ static int update_status(void)
 		return 0;
 	ret = apc_read(buf, sizeof(buf), SER_AA);
 
-	if ((ret < 1) || (!strncmp(buf, "NA", 2))) {
+	if ((ret < 1) || (!strcmp(buf, "NA"))) {
 		if (ret >= 0)
 			upslogx(LOG_WARNING, "%s: %s", __func__, "failed");
 		return 0;
@@ -973,7 +973,7 @@ static void apc_getcaps(int qco)
 	 */
 	ret = apc_read(temp, sizeof(temp), SER_CC|SER_TO);
 
-	if ((ret < 1) || (!strncmp(temp, "NA", 2))) {
+	if ((ret < 1) || (!strcmp(temp, "NA"))) {
 
 		/*
 		 * Early Smart-UPS not as smart as the later ones ...
@@ -1193,7 +1193,7 @@ static int firmware_table_lookup(void)
 	 * Some UPSes support both 'V' and 'b'. As 'b' doesn't always return
 	 * firmware version, we attempt that only if 'V' doesn't work.
 	 */
-	if (!ret || !strncmp(buf, "NA", 2)) {
+	if (!ret || !strcmp(buf, "NA")) {
 		upsdebugx(1, "attempting firmware lookup using [%s]", prtchr(APC_FW_NEW));
 
 		if (apc_write(APC_FW_NEW) != 1)
@@ -1274,7 +1274,7 @@ static int getbaseinfo(void)
 	if ((ret = apc_read(temp, sizeof(temp), SER_CS|SER_TO)) < 0)
 		return 0;
 
-	if (!ret || !strncmp(temp, "NA", 2) || !rexhlp(APC_CMDSET_FMT, temp)) {
+	if (!ret || !strcmp(temp, "NA") || !rexhlp(APC_CMDSET_FMT, temp)) {
 		/* We have an old dumb UPS - go to specific code for old stuff */
 		upslogx(LOG_NOTICE, "very old or unknown APC model, support will be limited");
 		oldapcsetup();
@@ -1323,7 +1323,7 @@ static int do_cal(int start)
 	ret = apc_read(temp, sizeof(temp), SER_AA);
 
 	/* if we can't check the current calibration status, bail out */
-	if ((ret < 1) || (!strncmp(temp, "NA", 2))) {
+	if ((ret < 1) || (!strcmp(temp, "NA"))) {
 		upslogx(LOG_WARNING, "%s", "runtime calibration state undeterminable");
 		return STAT_INSTCMD_HANDLED;		/* FUTURE: failure */
 	}
@@ -1349,7 +1349,7 @@ static int do_cal(int start)
 
 		ret = apc_read(temp, sizeof(temp), SER_AA);
 
-		if ((ret < 1) || (!strncmp(temp, "NA", 2)) || (!strncmp(temp, "NO", 2))) {
+		if ((ret < 1) || (!strcmp(temp, "NA")) || (!strcmp(temp, "NO"))) {
 			upslogx(LOG_WARNING, "stop calibration failed, cmd returned: %s", temp);
 			return STAT_INSTCMD_HANDLED;	/* FUTURE: failure */
 		}
@@ -1374,7 +1374,7 @@ static int do_cal(int start)
 
 	ret = apc_read(temp, sizeof(temp), SER_AA);
 
-	if ((ret < 1) || (!strncmp(temp, "NA", 2)) || (!strncmp(temp, "NO", 2))) {
+	if ((ret < 1) || (!strcmp(temp, "NA")) || (!strcmp(temp, "NO"))) {
 		upslogx(LOG_WARNING, "start calibration failed, cmd returned: %s", temp);
 		return STAT_INSTCMD_HANDLED;	/* FUTURE: failure */
 	}
@@ -1396,7 +1396,7 @@ static int smartmode(void)
 	}
 	ret = apc_read(temp, sizeof(temp), 0);
 
-	if ((ret < 1) || (!strncmp(temp, "NA", 2)) || (!strncmp(temp, "NO", 2))) {
+	if ((ret < 1) || (!strcmp(temp, "NA")) || (!strcmp(temp, "NO"))) {
 		upslogx(LOG_CRIT, "%s", "enabling smartmode failed !");
 		return 0;
 	}
@@ -1425,7 +1425,7 @@ static int smartmode(int cnt)
 
 		/* timeout here is intented */
 		ret = apc_read(temp, sizeof(temp), SER_TO|SER_D1);
-		if (ret > 0 && !strncmp(temp, "SM", 2))
+		if (ret > 0 && !strcmp(temp, "SM"))
 			return 1;	/* success */
 		if (ret < 0)
 			/* error, so we didn't timeout - wait a bit before retry */
@@ -1462,7 +1462,7 @@ static int sdok(int ign)
 
 	upsdebugx(1, "%s: got \"%s\"", __func__, temp);
 
-	if ((!ret && ign) || !strncmp(temp, "OK", 2)) {
+	if ((!ret && ign) || !strcmp(temp, "OK")) {
 		upsdebugx(1, "%s: %s", __func__, "last shutdown cmd succeeded");
 		return STAT_INSTCMD_HANDLED;
 	}
@@ -1751,7 +1751,7 @@ static int setvar_enum(apc_vartab_t *vt, const char *val)
 
 	ret = apc_read(orig, sizeof(orig), SER_AA);
 
-	if ((ret < 1) || (!strncmp(orig, "NA", 2)))
+	if ((ret < 1) || (!strcmp(orig, "NA")))
 		return STAT_SET_FAILED;
 
 	ptr = convert_data(vt, orig);
@@ -1771,13 +1771,13 @@ static int setvar_enum(apc_vartab_t *vt, const char *val)
 		/* this should return either OK (if rotated) or NO (if not) */
 		ret = apc_read(temp, sizeof(temp), SER_AA);
 
-		if ((ret < 1) || (!strncmp(temp, "NA", 2)))
+		if ((ret < 1) || (!strcmp(temp, "NA")))
 			return STAT_SET_FAILED;
 
 		/* sanity checks */
-		if (!strncmp(temp, "NO", 2))
+		if (!strcmp(temp, "NO"))
 			return STAT_SET_FAILED;
-		if (strncmp(temp, "OK", 2))
+		if (strcmp(temp, "OK"))
 			return STAT_SET_FAILED;
 
 		/* see what it rotated onto */
@@ -1786,7 +1786,7 @@ static int setvar_enum(apc_vartab_t *vt, const char *val)
 
 		ret = apc_read(temp, sizeof(temp), SER_AA);
 
-		if ((ret < 1) || (!strncmp(temp, "NA", 2)))
+		if ((ret < 1) || (!strcmp(temp, "NA")))
 			return STAT_SET_FAILED;
 
 		ptr = convert_data(vt, temp);
@@ -1836,7 +1836,7 @@ static int setvar_string(apc_vartab_t *vt, const char *val)
 
 	ret = apc_read(temp, sizeof(temp), SER_AA);
 
-	if ((ret < 1) || (!strncmp(temp, "NA", 2)))
+	if ((ret < 1) || (!strcmp(temp, "NA")))
 		return STAT_SET_FAILED;
 
 	/* suppress redundant changes - easier on the eeprom */
@@ -1865,7 +1865,7 @@ static int setvar_string(apc_vartab_t *vt, const char *val)
 		return STAT_SET_FAILED;
 	}
 
-	if (!strncmp(temp, "NO", 2)) {
+	if (!strcmp(temp, "NO")) {
 		upslogx(LOG_ERR, "%s: %s", __func__, "got NO at final read");
 		return STAT_SET_FAILED;
 	}
@@ -1947,7 +1947,7 @@ static int do_cmd(const apc_cmdtab_t *ct)
 	if (ret < 1)
 		return STAT_INSTCMD_FAILED;
 
-	if (strncmp(temp, "OK", 2)) {
+	if (strcmp(temp, "OK")) {
 		upslogx(LOG_WARNING, "%s: got [%s] after command [%s]",
 			__func__, temp, ct->name);
 

--- a/drivers/apcupsd-ups.c
+++ b/drivers/apcupsd-ups.c
@@ -64,7 +64,7 @@ static void process(char *item,char *data)
 		else if(!strcmp(data,"SELFTEST"))status_set("OB");
 		else for(;(data=strtok(data," "));data=NULL)
 		{
-			if(!strncmp(data, "CAL", 3))status_set("CAL");
+			if(!strcmp(data,"CAL"))status_set("CAL");
 			else if(!strcmp(data,"TRIM"))status_set("TRIM");
 			else if(!strcmp(data,"BOOST"))status_set("BOOST");
 			else if(!strcmp(data,"ONLINE"))status_set("OL");

--- a/drivers/belkin.c
+++ b/drivers/belkin.c
@@ -513,7 +513,7 @@ void upsdrv_initinfo(void)
 	/* deal with stupid firmware that breaks RAT */
 	send_belkin_command(STATUS, RATING, "");
 
-	if (!strncmp(temp, "001", 3)) {
+	if (!strcmp(temp, "001")) {
 		res = do_broken_rat(temp);
 	} else {
 		res = get_belkin_reply(temp);

--- a/drivers/belkinunv.c
+++ b/drivers/belkinunv.c
@@ -1270,10 +1270,10 @@ static int setvar(const char *varname, const char *val)
 	} else if (!strcasecmp(varname, "ups.beeper.status")) {
 		if (!strcasecmp(val, "disabled")) {
 			i=1;
-		} else if (!strncasecmp(val, "on", 2) ||
+		} else if (!strcasecmp(val, "on") ||
 			   !strcasecmp(val, "enabled")) {
 			i=2;
-		} else if (!strncasecmp(val, "off", 3) ||
+		} else if (!strcasecmp(val, "off") ||
 			   !strcasecmp(val, "muted")) {
 			i=3;
 		} else {

--- a/drivers/bestups.c
+++ b/drivers/bestups.c
@@ -53,57 +53,57 @@ static	int	inverted_bypass_bit = 0;
 
 static void model_set(const char *abbr, const char *rating)
 {
-	if (!strncmp(abbr, "FOR", 3)) {
+	if (!strcmp(abbr, "FOR")) {
 		dstate_setinfo("ups.mfr", "%s", "Best Power");
 		dstate_setinfo("ups.model", "Fortress %s", rating);
 		return;
 	}
 
-	if (!strncmp(abbr, "FTC", 3)) {
+	if (!strcmp(abbr, "FTC")) {
 		dstate_setinfo("ups.mfr", "%s", "Best Power");
 		dstate_setinfo("ups.model", "Fortress Telecom %s", rating);
 		return;
 	}
 
-	if (!strncmp(abbr, "PRO", 3)) {
+	if (!strcmp(abbr, "PRO")) {
 		dstate_setinfo("ups.mfr", "%s", "Best Power");
 		dstate_setinfo("ups.model", "Patriot Pro %s", rating);
 		inverted_bypass_bit = 1;
 		return;
 	}
 
-	if (!strncmp(abbr, "PR2", 3)) {
+	if (!strcmp(abbr, "PR2")) {
 		dstate_setinfo("ups.mfr", "%s", "Best Power");
 		dstate_setinfo("ups.model", "Patriot Pro II %s", rating);
 		inverted_bypass_bit = 1;
 		return;
 	}
 
-	if (!strncmp(abbr, "325", 3)) {
+	if (!strcmp(abbr, "325")) {
 		dstate_setinfo("ups.mfr", "%s", "Sola Australia");
 		dstate_setinfo("ups.model", "Sola 325 %s", rating);
 		return;
 	}
 
-	if (!strncmp(abbr, "520", 3)) {
+	if (!strcmp(abbr, "520")) {
 		dstate_setinfo("ups.mfr", "%s", "Sola Australia");
 		dstate_setinfo("ups.model", "Sola 520 %s", rating);
 		return;
 	}
 
-	if (!strncmp(abbr, "610", 3)) {
+	if (!strcmp(abbr, "610")) {
 		dstate_setinfo("ups.mfr", "%s", "Best Power");
 		dstate_setinfo("ups.model", "610 %s", rating);
 		return;
 	}
 
-	if (!strncmp(abbr, "620", 3)) {
+	if (!strcmp(abbr, "620")) {
 		dstate_setinfo("ups.mfr", "%s", "Sola Australia");
 		dstate_setinfo("ups.model", "Sola 620 %s", rating);
 		return;
 	}
 
-	if (!strncmp(abbr, "AX1", 3)) {
+	if (!strcmp(abbr, "AX1")) {
 		dstate_setinfo("ups.mfr", "%s", "Best Power");
 		dstate_setinfo("ups.model", "Axxium Rackmount %s", rating);
 		return;

--- a/drivers/clone-outlet.c
+++ b/drivers/clone-outlet.c
@@ -124,7 +124,7 @@ static int parse_args(size_t numargs, char **arg)
 		}
 
 		if (!strcasecmp(arg[1], prefix.status)) {
-			outlet.status = strncasecmp(arg[2], "off", 3);
+			outlet.status = strcasecmp(arg[2], "off");
 		}
 
 		if (!strcasecmp(arg[1], "ups.status")) {

--- a/drivers/clone.c
+++ b/drivers/clone.c
@@ -358,11 +358,11 @@ static int instcmd(const char *cmdname, const char *extra)
 
 	val = dstate_getinfo(getval("load.status"));
 	if (val) {
-		if (!strncasecmp(val, "off", 3) || !strncasecmp(val, "no", 2)) {
+		if (!strcasecmp(val, "off") || !strcasecmp(val, "no")) {
 			outlet = 0;
 		}
 
-		if (!strncasecmp(val, "on", 2) || !strncasecmp(val, "yes", 3)) {
+		if (!strcasecmp(val, "on") || !strcasecmp(val, "yes")) {
 			outlet = 1;
 		}
 	}

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -493,7 +493,7 @@ static int sock_arg(conn_t *conn, size_t numarg, char **arg)
 	}
 
 	/* SET <var> <value> [TRACKING <id>] */
-	if (!strncasecmp(arg[0], "SET", 3)) {
+	if (!strcasecmp(arg[0], "SET")) {
 		int ret;
 		char *setid = NULL;
 
@@ -1022,7 +1022,7 @@ void status_init(void)
 /* add a status element */
 void status_set(const char *buf)
 {
-	if (ignorelb && !strncasecmp(buf, "LB", 2)) {
+	if (ignorelb && !strcasecmp(buf, "LB")) {
 		upsdebugx(2, "%s: ignoring LB flag from device", __func__);
 		return;
 	}

--- a/drivers/gamatronic.c
+++ b/drivers/gamatronic.c
@@ -167,31 +167,31 @@ static void update_pseudovars( void )
 {
 	status_init();
 
-	if(strncmp(sec_varlist[9].value, "1", 1)== 0) {
+	if(strcmp(sec_varlist[9].value,"1")== 0) {
 		status_set("OFF");
 	}
-	if(strncmp(sec_varlist[76].value, "0", 1)== 0) {
+	if(strcmp(sec_varlist[76].value,"0")== 0) {
 		status_set("OL");
 	}
-	if(strncmp(sec_varlist[76].value, "1", 1)== 0) {
+	if(strcmp(sec_varlist[76].value,"1")== 0) {
 		status_set("OB");
 	}
-	if(strncmp(sec_varlist[76].value, "2", 1)== 0) {
+	if(strcmp(sec_varlist[76].value,"2")== 0) {
 		status_set("BYPASS");
 	}
-	if(strncmp(sec_varlist[76].value, "3", 1)== 0) {
+	if(strcmp(sec_varlist[76].value,"3")== 0) {
 		status_set("TRIM");
 	}
-	if(strncmp(sec_varlist[76].value, "4", 1)== 0) {
+	if(strcmp(sec_varlist[76].value,"4")== 0) {
 		status_set("BOOST");
 	}
-	if(strncmp(sec_varlist[10].value, "1", 1)== 0) {
+	if(strcmp(sec_varlist[10].value,"1")== 0) {
 		status_set("OVER");
 	}
-	if(strncmp(sec_varlist[22].value, "1", 1)== 0) {
+	if(strcmp(sec_varlist[22].value,"1")== 0) {
 		status_set("LB");
 	}
-	if(strncmp(sec_varlist[19].value, "2", 1)== 0) {
+	if(strcmp(sec_varlist[19].value,"2")== 0) {
 		status_set("RB");
 	}
 
@@ -246,7 +246,7 @@ static void sec_poll ( int pollflag ) {
 				}
 
 				/* If SEC VAR is alarm and it's on, add it to the alarm property */
-				if (sec_varlist[sqv(q,f)].flags & FLAG_ALARM && strncmp(r, "1", 1)== 0) {
+				if (sec_varlist[sqv(q,f)].flags & FLAG_ALARM && strcmp(r,"1")== 0) {
 					alarm_set(sec_varlist[sqv(q,f)].name);
 				}
 			}

--- a/drivers/huawei-ups2000.c
+++ b/drivers/huawei-ups2000.c
@@ -1267,9 +1267,9 @@ static int ups2000_autostart_set(const uint16_t reg, const char *string)
 	uint16_t val;
 	int r;
 
-	if (!strncasecmp(string, "yes", 3))
+	if (!strcasecmp(string, "yes"))
 		val = 1;
-	else if (!strncasecmp(string, "no", 2))
+	else if (!strcasecmp(string, "no"))
 		val = 0;
 	else
 		return STAT_SET_INVALID;

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -305,10 +305,10 @@ static int main_arg(char *var, char *val)
 
 	/* allow per-driver overrides of the global setting */
 	if (!strcmp(var, "synchronous")) {
-		if (!strncmp(val, "yes", 3))
-			do_synchronous = 1;
+		if (!strcmp(val, "yes"))
+			do_synchronous=1;
 		else
-			do_synchronous = 0;
+			do_synchronous=0;
 
 		return 1;	/* handled */
 	}
@@ -347,10 +347,10 @@ static void do_global_args(const char *var, const char *val)
 	}
 
 	if (!strcmp(var, "synchronous")) {
-		if (!strncmp(val, "yes", 3))
-			do_synchronous = 1;
+		if (!strcmp(val, "yes"))
+			do_synchronous=1;
 		else
-			do_synchronous = 0;
+			do_synchronous=0;
 	}
 
 

--- a/drivers/masterguard.c
+++ b/drivers/masterguard.c
@@ -412,7 +412,7 @@ static ssize_t ups_ident( void )
 			printf( "Old (broken) WH found\n" );
 		parseOldWH( buf );
 	}
-	else if( ret == 3 && strncmp(buf, "NAK", 3) == 0 )
+	else if( ret == 3 && strcmp(buf, "NAK") == 0 )
 	{
 		if( DEBUG )
 			printf( "WH was NAKed\n" );

--- a/drivers/mge-utalk.c
+++ b/drivers/mge-utalk.c
@@ -183,7 +183,7 @@ void upsdrv_initups(void)
 		mge_ups.LowBatt = atoi (getval ("lowbatt"));
 		/* Set the value in the UPS */
 		mge_command(buf, sizeof(buf), "Bl %d",  mge_ups.LowBatt);
-		if(!strncmp(buf, "OK", 2))
+		if(!strcmp(buf, "OK"))
 			upsdebugx(1, "Low Battery Level set to %d%%", mge_ups.LowBatt);
 		else
 			upsdebugx(1, "initups: Low Battery Level cannot be set");
@@ -195,7 +195,7 @@ void upsdrv_initups(void)
 		mge_ups.OnDelay = atoi (getval ("ondelay"));
 		/* Set the value in the UPS */
 		mge_command(buf, sizeof(buf), "Sm %d",  mge_ups.OnDelay);
-		if(!strncmp(buf, "OK", 2))
+		if(!strcmp(buf, "OK"))
 			upsdebugx(1, "ON delay set to %d min", mge_ups.OnDelay);
 		else
 			upsdebugx(1, "initups: OnDelay unavailable");
@@ -207,7 +207,7 @@ void upsdrv_initups(void)
 		mge_ups.OffDelay = atoi (getval ("offdelay"));
 		/* Set the value in the UPS */
 		mge_command(buf, sizeof(buf), "Sn %d",  mge_ups.OffDelay);
-		if(!strncmp(buf, "OK", 2))
+		if(!strcmp(buf, "OK"))
 			upsdebugx(1, "OFF delay set to %d sec", mge_ups.OffDelay);
 		else
 			upsdebugx(1, "initups: OffDelay unavailable");
@@ -476,13 +476,13 @@ void upsdrv_shutdown(void)
 
 	/* Only call the effective shutoff if restart is ok */
 	/* or if we need only a stayoff... */
-	if (!strncmp(buf, "OK", 2) || (sdtype == SD_STAYOFF)) {
+	if (!strcmp(buf, "OK") || (sdtype == SD_STAYOFF)) {
 		/* shutdown UPS */
 		mge_command(buf, sizeof(buf), "Sx 0");
 
 		upslogx(LOG_INFO, "UPS response to Shutdown was %s", buf);
 	}
-/*	if(strncmp(buf, "OK", 2)) */
+/*	if(strcmp(buf, "OK")) */
 
 	/* call the cleanup to disable/close the comm link */
 	upsdrv_cleanup();
@@ -509,7 +509,7 @@ int instcmd(const char *cmdname, const char *extra)
 		mge_command(temp, sizeof(temp), "Bx 1");
 		upsdebugx(2, "UPS response to %s was %s", cmdname, temp);
 
-		if(strncmp(temp, "OK", 2))
+		if(strcmp(temp, "OK"))
 			return STAT_INSTCMD_UNKNOWN;
 		else
 			return STAT_INSTCMD_HANDLED;
@@ -521,7 +521,7 @@ int instcmd(const char *cmdname, const char *extra)
 		mge_command(temp, sizeof(temp), "Sx 129");
 		upsdebugx(2, "UPS response to %s was %s", cmdname, temp);
 
-		if(strncmp(temp, "OK", 2))
+		if(strcmp(temp, "OK"))
 			return STAT_INSTCMD_UNKNOWN;
 		else
 			return STAT_INSTCMD_HANDLED;
@@ -547,13 +547,13 @@ int instcmd(const char *cmdname, const char *extra)
 		mge_command(temp, sizeof(temp), "Wy 65535");
 		upsdebugx(2, "UPS response to Select All Plugs was %s", temp);
 
-		if(strncmp(temp, "OK", 2))
+		if(strcmp(temp, "OK"))
 			return STAT_INSTCMD_UNKNOWN;
 		else
 		{
 			mge_command(temp, sizeof(temp), "Wx 0");
 			upsdebugx(2, "UPS response to %s was %s", cmdname, temp);
-			if(strncmp(temp, "OK", 2))
+			if(strcmp(temp, "OK"))
 				return STAT_INSTCMD_UNKNOWN;
 			else
 				return STAT_INSTCMD_HANDLED;
@@ -567,13 +567,13 @@ int instcmd(const char *cmdname, const char *extra)
 		mge_command(temp, sizeof(temp), "Wy 65535");
 		upsdebugx(2, "UPS response to Select All Plugs was %s", temp);
 
-		if(strncmp(temp, "OK", 2))
+		if(strcmp(temp, "OK"))
 			return STAT_INSTCMD_UNKNOWN;
 		else
 		{
 			mge_command(temp, sizeof(temp), "Wx 1");
 			upsdebugx(2, "UPS response to %s was %s", cmdname, temp);
-			if(strncmp(temp, "OK", 2))
+			if(strcmp(temp, "OK"))
 				return STAT_INSTCMD_UNKNOWN;
 			else
 				return STAT_INSTCMD_HANDLED;
@@ -601,7 +601,7 @@ int instcmd(const char *cmdname, const char *extra)
 
 			upsdebugx(2, "UPS response to %s was %s", cmdname, temp);
 
-			if(strncmp(temp, "OK", 2))
+			if(strcmp(temp, "OK"))
 				return STAT_INSTCMD_UNKNOWN;
 			else
 				return STAT_INSTCMD_HANDLED;

--- a/drivers/mge-xml.c
+++ b/drivers/mge-xml.c
@@ -1231,7 +1231,7 @@ static int mge_xml_startelm_cb(void *userdata, int parent, const char *nspace, c
 			/* url="upsprop.xml" or url="ws/summary.xml" */
 			int	i;
 			for (i = 0; atts[i] && atts[i+1]; i += 2) {
-				if (!strncasecmp(atts[i], "url", 3)) {
+				if (!strcasecmp(atts[i], "url")) {
 					free(mge_xml_subdriver.summary);
 					mge_xml_subdriver.summary = strdup(url_convert(atts[i+1]));
 				}
@@ -1243,7 +1243,7 @@ static int mge_xml_startelm_cb(void *userdata, int parent, const char *nspace, c
 			/* url="config.xml" */
 			int	i;
 			for (i = 0; atts[i] && atts[i+1]; i += 2) {
-				if (!strncasecmp(atts[i], "url", 3)) {
+				if (!strcasecmp(atts[i], "url")) {
 					free(mge_xml_subdriver.configure);
 					mge_xml_subdriver.configure = strdup(url_convert(atts[i+1]));
 				}
@@ -1263,7 +1263,7 @@ static int mge_xml_startelm_cb(void *userdata, int parent, const char *nspace, c
 			/* url="subscribe.cgi" security="basic" */
 			int	i;
 			for (i = 0; atts[i] && atts[i+1]; i += 2) {
-				if (!strncasecmp(atts[i], "url", 3)) {
+				if (!strcasecmp(atts[i], "url")) {
 					free(mge_xml_subdriver.subscribe);
 					mge_xml_subdriver.subscribe = strdup(url_convert(atts[i+1]));
 				}
@@ -1301,7 +1301,7 @@ static int mge_xml_startelm_cb(void *userdata, int parent, const char *nspace, c
 			/* url="getvalue.cgi" security="none" */
 			int	i;
 			for (i = 0; atts[i] && atts[i+1]; i += 2) {
-				if (!strncasecmp(atts[i], "url", 3)) {
+				if (!strcasecmp(atts[i], "url")) {
 					free(mge_xml_subdriver.getobject);
 					mge_xml_subdriver.getobject = strdup(url_convert(atts[i+1]));
 				}
@@ -1313,7 +1313,7 @@ static int mge_xml_startelm_cb(void *userdata, int parent, const char *nspace, c
 			/* url="setvalue.cgi" security="ssl" */
 			int	i;
 			for (i = 0; atts[i] && atts[i+1]; i += 2) {
-				if (!strncasecmp(atts[i], "url", 3)) {
+				if (!strcasecmp(atts[i], "url")) {
 					free(mge_xml_subdriver.setobject);
 					mge_xml_subdriver.setobject = strdup(url_convert(atts[i+1]));
 				}

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -4001,7 +4001,7 @@ int	ups_infoval_set(item_t *item)
 		if (item->qxflags & QX_FLAG_TRIM)
 			str_trim_m(value, "# ");
 
-		if (strncasecmp(item->dfl, "%s", 2)) {
+		if (strcasecmp(item->dfl, "%s")) {
 
 			if (strspn(value, "0123456789 .") != strlen(value)) {
 				upsdebugx(2, "%s: non numerical value [%s: %s]",

--- a/drivers/nutdrv_qx_bestups.c
+++ b/drivers/nutdrv_qx_bestups.c
@@ -432,11 +432,11 @@ static int	bestups_manufacturer(item_t *item, char *value, const size_t valuelen
 
 	/* Best Power devices */
 	if (
-		!strncmp(item->value, "AX1", 3) ||
-		!strncmp(item->value, "FOR", 3) ||
-		!strncmp(item->value, "FTC", 3) ||
-		!strncmp(item->value, "PR2", 3) ||
-		!strncmp(item->value, "PRO", 3)
+		!strcmp(item->value, "AX1") ||
+		!strcmp(item->value, "FOR") ||
+		!strcmp(item->value, "FTC") ||
+		!strcmp(item->value, "PR2") ||
+		!strcmp(item->value, "PRO")
 	) {
 		snprintf(value, valuelen, item->dfl, "Best Power");
 		return 0;
@@ -444,9 +444,9 @@ static int	bestups_manufacturer(item_t *item, char *value, const size_t valuelen
 
 	/* Sola Australia devices */
 	if (
-		!strncmp(item->value, "325", 3) ||
-		!strncmp(item->value, "520", 3) ||
-		!strncmp(item->value, "620", 3)
+		!strcmp(item->value, "325") ||
+		!strcmp(item->value, "520") ||
+		!strcmp(item->value, "620")
 	) {
 		snprintf(value, valuelen, item->dfl, "Sola Australia");
 		return 0;
@@ -479,35 +479,35 @@ static int	bestups_model(item_t *item, char *value, const size_t valuelen)
 
 	/* Best Power devices */
 
-	if (!strncmp(item->value, "AX1", 3)) {
+	if (!strcmp(item->value, "AX1")) {
 
 		snprintf(value, valuelen, item->dfl, "Axxium Rackmount");
 
-	} else if (!strncmp(item->value, "FOR", 3)) {
+	} else if (!strcmp(item->value, "FOR")) {
 
 		snprintf(value, valuelen, item->dfl, "Fortress");
 
-	} else if (!strncmp(item->value, "FTC", 3)) {
+	} else if (!strcmp(item->value, "FTC")) {
 
 		snprintf(value, valuelen, item->dfl, "Fortress Telecom");
 
-	} else if (!strncmp(item->value, "PR2", 3)) {
+	} else if (!strcmp(item->value, "PR2")) {
 
 		snprintf(value, valuelen, item->dfl, "Patriot Pro II");
 		inverted_bbb_bit = 1;
 
-	} else if (!strncmp(item->value, "PRO", 3)) {
+	} else if (!strcmp(item->value, "PRO")) {
 
 		snprintf(value, valuelen, item->dfl, "Patriot Pro");
 		inverted_bbb_bit = 1;
 
 	/* Sola Australia devices */
 	} else if (
-		!strncmp(item->value, "320", 3) ||
-		!strncmp(item->value, "325", 3) ||
-		!strncmp(item->value, "520", 3) ||
-		!strncmp(item->value, "525", 3) ||
-		!strncmp(item->value, "620", 3)
+		!strcmp(item->value, "320") ||
+		!strcmp(item->value, "325") ||
+		!strcmp(item->value, "520") ||
+		!strcmp(item->value, "525") ||
+		!strcmp(item->value, "620")
 	) {
 
 		snprintf(value, valuelen, "Sola %s", item->value);
@@ -523,7 +523,7 @@ static int	bestups_model(item_t *item, char *value, const size_t valuelen)
 	/* Unskip qx2nut table's items according to the UPS model */
 
 	/* battery.runtime var is not available on the Patriot Pro/Sola 320 model series: leave it skipped in these cases, otherwise unskip it */
-	if (strncmp(item->value, "PRO", 3) && strncmp(item->value, "320", 3)) {
+	if (strcmp(item->value, "PRO") && strcmp(item->value, "320")) {
 
 		unskip = find_nut_info("battery.runtime", 0, 0);
 
@@ -536,7 +536,7 @@ static int	bestups_model(item_t *item, char *value, const size_t valuelen)
 	}
 
 	/* battery.packs var is available only on the Axxium/Sola 620 model series: unskip it in these cases */
-	if (!strncmp(item->value, "AX1", 3) || !strncmp(item->value, "620", 3)) {
+	if (!strcmp(item->value, "AX1") || !strcmp(item->value, "620")) {
 
 		unskip = find_nut_info("battery.packs", 0, QX_FLAG_SETVAR);
 

--- a/drivers/nutdrv_qx_blazer-common.c
+++ b/drivers/nutdrv_qx_blazer-common.c
@@ -145,15 +145,13 @@ void	blazer_initups(item_t *qx2nut)
 			continue;
 
 		/* norating */
-		if (nr && !strncasecmp(item->command, "F\r", strlen("F\r"))) {
+		if (nr && !strcasecmp(item->command, "F\r")) {
 			upsdebugx(2, "%s: skipping %s", __func__, item->info_type);
 			item->qxflags |= QX_FLAG_SKIP;
 		}
 
 		/* novendor */
-		if (nv && (!strncasecmp(item->command, "I\r", strlen("I\r"))
-		|| !strncasecmp(item->command, "FW?\r", strlen("FW?\r")))
-		) {
+		if (nv && (!strcasecmp(item->command, "I\r") || !strcasecmp(item->command, "FW?\r"))) {
 			upsdebugx(2, "%s: skipping %s", __func__, item->info_type);
 			item->qxflags |= QX_FLAG_SKIP;
 		}

--- a/drivers/nutdrv_qx_voltronic-qs-hex.c
+++ b/drivers/nutdrv_qx_voltronic-qs-hex.c
@@ -318,7 +318,7 @@ static int	voltronic_qs_hex_protocol(item_t *item, char *value, const size_t val
 		{ NULL,				0,		0 }
 	};
 
-	if (strncasecmp(item->value, "P", 1) && strncasecmp(item->value, "T", 1)) {
+	if (strcasecmp(item->value, "P") && strcasecmp(item->value, "T")) {
 		upsdebugx(2, "%s: invalid protocol [%s]", __func__, item->value);
 		return -1;
 	}
@@ -339,7 +339,7 @@ static int	voltronic_qs_hex_protocol(item_t *item, char *value, const size_t val
 
 	/* Unskip items supported only by devices that implement 'T' protocol */
 
-	if (!strncasecmp(item->value, "P", 1))
+	if (!strcasecmp(item->value, "P"))
 		return 0;
 
 	for (i = 0; items_to_be_unskipped[i].info_type; i++) {

--- a/drivers/nutdrv_qx_voltronic-qs.c
+++ b/drivers/nutdrv_qx_voltronic-qs.c
@@ -191,7 +191,7 @@ static void	voltronic_qs_initups(void)
 /* Protocol used by the UPS */
 static int	voltronic_qs_protocol(item_t *item, char *value, const size_t valuelen)
 {
-	if (strncasecmp(item->value, "V", 1)) {
+	if (strcasecmp(item->value, "V")) {
 		upsdebugx(2, "%s: invalid protocol [%s]", __func__, item->value);
 		return -1;
 	}

--- a/drivers/nutdrv_qx_voltronic.c
+++ b/drivers/nutdrv_qx_voltronic.c
@@ -2438,12 +2438,12 @@ static int	voltronic_capability_set(item_t *item, char *value, const size_t valu
 #ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_FORMAT_SECURITY
 #pragma GCC diagnostic ignored "-Wformat-security"
 #endif
-	if (!strncasecmp(value, "yes", 3)) {
+	if (!strcasecmp(value, "yes")) {
 		snprintf(value, valuelen, item->command, "E");
 		return 0;
 	}
 
-	if (!strncasecmp(value, "no", 2)) {
+	if (!strcasecmp(value, "no")) {
 		snprintf(value, valuelen, item->command, "D");
 		return 0;
 	}
@@ -2980,7 +2980,7 @@ static int	voltronic_fault(item_t *item, char *value, const size_t valuelen)
 
 	upslogx(LOG_INFO, "Checking for faults..");
 
-	if (!strncasecmp(item->value, "OK", 2)) {
+	if (!strcasecmp(item->value, "OK")) {
 #ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_NONLITERAL
 #pragma GCC diagnostic push
 #endif

--- a/drivers/oneac.c
+++ b/drivers/oneac.c
@@ -1030,13 +1030,13 @@ int setcmd(const char* varname, const char* setvalue)
 
 	if (!strcasecmp(varname, "ups.start.auto"))
 	{
-		if (!strncasecmp(setvalue, "yes", 3))
+		if (!strcasecmp(setvalue, "yes"))
 		{
 			ser_send(upsfd,"%c0%s",SETX_AUTO_START, COMMAND_END);
 			dstate_setinfo("ups.start.auto", "yes");
 			return STAT_SET_HANDLED;
 		}
-		else if (!strncasecmp(setvalue, "no", 2))
+		else if (!strcasecmp(setvalue, "no"))
 		{
 			ser_send(upsfd,"%c1%s",SETX_AUTO_START, COMMAND_END);
 			dstate_setinfo("ups.start.auto", "no");

--- a/drivers/powercom.c
+++ b/drivers/powercom.c
@@ -437,9 +437,9 @@ static float input_voltage(void)
 	unsigned int model;
 	float tmp=0.0;
 
-	if ( !strncmp(types[type].name, "BNT", 3) && raw_data[MODELNUMBER]%16 > 7 ) {
+	if ( !strcmp(types[type].name, "BNT") && raw_data[MODELNUMBER]%16 > 7 ) {
 		tmp=2.2*raw_data[INPUT_VOLTAGE]-24;
-	} else if ( !strncmp(types[type].name, "KIN", 3)) {
+	} else if ( !strcmp(types[type].name, "KIN")) {
 		model=KINmodels[raw_data[MODELNUMBER]/16];
 		/* Process input voltage, according to line voltage and model rating */
 		if (linevoltage < 200) {
@@ -460,7 +460,7 @@ static float input_voltage(void)
 				tmp = 1.625 * raw_data[INPUT_VOLTAGE];
 			}
 		}
-	} else if ( !strncmp(types[type].name, "IMP", 3) || !strcmp(types[type].name, "OPTI")) {
+	} else if ( !strcmp(types[type].name, "IMP") || !strcmp(types[type].name, "OPTI")) {
 		tmp=raw_data[INPUT_VOLTAGE]*2.0;
 	} else {
 		tmp=linevoltage >= 220 ?
@@ -482,12 +482,12 @@ static float output_voltage(void)
 	static float datay2[]={0,1.73,1.74,1.74,1.77,0.9,0.9,0.9,13.204,13.204,0.88,0.88,0.88,6.645};
 	static float dataz2[]={0,1.15,0.9,0.9,0.75,1.1,1.1,1.1,0.8,0.8,0.86,0.86,0.86,0.7};
 
-	if ( !strncmp(types[type].name, "BNT", 3) || !strncmp(types[type].name, "KIN", 3)) {
+	if ( !strcmp(types[type].name, "BNT") || !strcmp(types[type].name, "KIN")) {
 		statINV=raw_data[STATUS_A] & ONLINE;
 		statAVR=raw_data[STATUS_A] & AVR_ON;
 		statAVRMode=raw_data[STATUS_A] & AVR_MODE;
 	}
-	if ( !strncmp(types[type].name, "BNT", 3) && raw_data[MODELNUMBER]%16 > 7 ) {
+	if ( !strcmp(types[type].name, "BNT") && raw_data[MODELNUMBER]%16 > 7 ) {
 		if (statINV==0) {
 			if (statAVR==0){
 				tmp=2.2*raw_data[OUTPUT_VOLTAGE]-24;
@@ -505,7 +505,7 @@ static float output_voltage(void)
 			else
 				tmp=0.0;
 		}
-	} else if ( !strncmp(types[type].name, "KIN", 3)) {
+	} else if ( !strcmp(types[type].name, "KIN")) {
 		model=KINmodels[raw_data[MODELNUMBER]/16];
 		if (statINV == 0) {
 			if (statAVR == 0) {
@@ -594,7 +594,7 @@ static float output_voltage(void)
 			}
 			/* FIXME: may miss a last processing with ErrorVal = 5 | 10 */
 		}
-	} else if ( !strncmp(types[type].name, "IMP", 3) || !strcmp(types[type].name, "OPTI")) {
+	} else if ( !strcmp(types[type].name, "IMP") || !strcmp(types[type].name, "OPTI")) {
 		tmp=raw_data[OUTPUT_VOLTAGE]*2.0;
 	} else {
 		tmp= linevoltage >= 220 ?
@@ -609,9 +609,9 @@ static float output_voltage(void)
 
 static float input_freq(void)
 {
-	if ( !strncmp(types[type].name, "BNT", 3) || !strncmp(types[type].name, "KIN", 3))
+	if ( !strcmp(types[type].name, "BNT") || !strcmp(types[type].name, "KIN"))
 		return 4807.0/raw_data[INPUT_FREQUENCY];
-	else if ( !strncmp(types[type].name, "IMP", 3) || !strcmp(types[type].name, "OPTI"))
+	else if ( !strcmp(types[type].name, "IMP") || !strcmp(types[type].name, "OPTI"))
 		return raw_data[INPUT_FREQUENCY];
 	return raw_data[INPUT_FREQUENCY] ?
 		1.0 / (types[type].freq[0] *
@@ -621,9 +621,9 @@ static float input_freq(void)
 
 static float output_freq(void)
 {
-	if ( !strncmp(types[type].name, "BNT", 3) || !strncmp(types[type].name, "KIN", 3))
+	if ( !strcmp(types[type].name, "BNT") || !strcmp(types[type].name, "KIN"))
 		return 4807.0/raw_data[OUTPUT_FREQUENCY];
-	else if ( !strncmp(types[type].name, "IMP", 3) || !strcmp(types[type].name, "OPTI"))
+	else if ( !strcmp(types[type].name, "IMP") || !strcmp(types[type].name, "OPTI"))
 		return raw_data[OUTPUT_FREQUENCY];
 	return raw_data[OUTPUT_FREQUENCY] ?
 		1.0 / (types[type].freq[0] *
@@ -652,7 +652,7 @@ static float load_level(void)
 	int load1000i[]={1,1,1,1,1,1,1,1,56,54,52};
 	int load1200i[]={1,1,1,1,1,1,1,1,76,74,72};
 
-	if ( !strncmp(types[type].name, "BNT", 3) && raw_data[MODELNUMBER]%16 > 7 ) {
+	if ( !strcmp(types[type].name, "BNT") && raw_data[MODELNUMBER]%16 > 7 ) {
 		statINV=raw_data[STATUS_A] & ONLINE;
 		voltage=raw_data[MODELNUMBER]%16;
 		model=BNTmodels[raw_data[MODELNUMBER]/16];
@@ -676,7 +676,7 @@ static float load_level(void)
 				case 2000: return raw_data[UPS_LOAD]*110.0/load1000i[voltage];
 			}
 		}
-	} else if (!strncmp(types[type].name, "KIN", 3)) {
+	} else if (!strcmp(types[type].name, "KIN")) {
 		statINV=raw_data[STATUS_A] & ONLINE;
 		voltage=raw_data[MODELNUMBER]%16;
 		model=KINmodels[raw_data[MODELNUMBER]/16];
@@ -693,7 +693,7 @@ static float load_level(void)
 			if (model<2000) return raw_data[UPS_LOAD]*1.66;
 			return raw_data[UPS_LOAD]*110.0/load2ki[voltage];
 		}
-	} else if ( !strncmp(types[type].name, "IMP", 3) || !strcmp(types[type].name, "OPTI")) {
+	} else if ( !strcmp(types[type].name, "IMP") || !strcmp(types[type].name, "OPTI")) {
 		return raw_data[UPS_LOAD];
 	}
 	return (raw_data[STATUS_A] & MAINS_FAILURE) ?
@@ -709,7 +709,7 @@ static float batt_level(void)
 	unsigned int model;
 	float battval;
 
-	if ( !strncmp(types[type].name, "BNT", 3) ) {
+	if ( !strcmp(types[type].name, "BNT") ) {
 		bat0=157;
 		bat29=165;
 		bat100=193;
@@ -722,7 +722,7 @@ static float batt_level(void)
 			return 30.0+(battval-bat29)*70.0/(bat100-bat29);
 		return 100.0;
 	}
-	if ( !strncmp(types[type].name, "KIN", 3)) {
+	if ( !strcmp(types[type].name, "KIN")) {
 		model=KINmodels[raw_data[MODELNUMBER]/16];
 		if (model>=800 && model<=2000){
 			battval=(raw_data[BATTERY_CHARGE]-165.0)*2.6;
@@ -750,7 +750,7 @@ static float batt_level(void)
 			return 30.0+(battval-bat29)*70.0/(bat100-bat29);
 		return 100;
 	}
-	if ( !strncmp(types[type].name, "IMP", 3) || !strcmp(types[type].name, "OPTI"))
+	if ( !strcmp(types[type].name, "IMP") || !strcmp(types[type].name, "OPTI"))
 		return raw_data[BATTERY_CHARGE];
 	return (raw_data[STATUS_A] & ONLINE) ? /* Are we on battery power? */
 		/* Yes */
@@ -997,7 +997,7 @@ void upsdrv_initups(void)
 	types[type].flowControl.setup_flow_control();
 
 	/* Setup Model and LineVoltage */
-	if (!strncmp(types[type].name, "BNT",3) || !strncmp(types[type].name, "KIN", 3) || !strncmp(types[type].name, "IMP", 3) || !strcmp(types[type].name, "OPTI")) {
+	if (!strncmp(types[type].name, "BNT",3) || !strcmp(types[type].name, "KIN") || !strcmp(types[type].name, "IMP") || !strcmp(types[type].name, "OPTI")) {
 		if (!ups_getinfo()) return;
 		/* Give "BNT-other" a chance! */
 		if (raw_data[MODELNAME]==0x42 || raw_data[MODELNAME]==0x4B || raw_data[MODELNAME]==0x4F){
@@ -1068,7 +1068,7 @@ void upsdrv_initups(void)
 	            types[type].shutdown_arguments.delay[0],
 	            types[type].shutdown_arguments.delay[1],
 	            types[type].shutdown_arguments.minutesShouldBeUsed);
-	if ( strncmp(types[type].name, "KIN", 3) && strncmp(types[type].name, "BNT", 3) && strncmp(types[type].name, "IMP", 3)) {
+	if ( strcmp(types[type].name, "KIN") && strcmp(types[type].name, "BNT") && strcmp(types[type].name, "IMP")) {
 		upsdebugx(1, " frequency calculation coefficients: '{%f,%f}'",
 		        types[type].freq[0], types[type].freq[1]);
 		upsdebugx(1, " load percentage calculation coefficients: "
@@ -1194,7 +1194,7 @@ void upsdrv_makevartable(void)
 		"Flow control method for UPS: 'dtr0rts1' or 'no_flow_control'");
 	addvar(VAR_VALUE, "validationSequence",
 		"Validation values: ByteIndex, ByteValue x 3");
-	if ( strncmp(types[type].name, "KIN", 3) && strncmp(types[type].name, "BNT", 3) && strncmp(types[type].name, "IMP", 3)) {
+	if ( strcmp(types[type].name, "KIN") && strcmp(types[type].name, "BNT") && strcmp(types[type].name, "IMP")) {
 		addvar(VAR_VALUE, "frequency",
 			"Frequency conversion values: FreqFactor, FreqConst");
 		addvar(VAR_VALUE, "loadPercentage",

--- a/drivers/powerman-pdu.c
+++ b/drivers/powerman-pdu.c
@@ -73,13 +73,13 @@ static int instcmd(const char *cmdname, const char *extra)
 	}
 
 	/* Power on the outlet */
-	if (!strncasecmp(cmdsuffix, "on", 2)) {
+	if (!strcasecmp(cmdsuffix, "on")) {
 		rv = pm_node_on(pm, outletname);
 		return (rv==PM_ESUCCESS)?STAT_INSTCMD_HANDLED:STAT_SET_INVALID;
 	}
 
 	/* Power off the outlet */
-	if (!strncasecmp(cmdsuffix, "off", 3)) {
+	if (!strcasecmp(cmdsuffix, "off")) {
 		rv = pm_node_off(pm, outletname);
 		return (rv==PM_ESUCCESS)?STAT_INSTCMD_HANDLED:STAT_SET_INVALID;
 	}

--- a/drivers/powerp-txt.c
+++ b/drivers/powerp-txt.c
@@ -150,7 +150,7 @@ static int powpan_instcmd(const char *cmdname, const char *extra)
 			continue;
 		}
 
-		if ((powpan_command(cmdtab[i].command) == 2) && (!strncasecmp(powpan_answer, "#0", 2))) {
+		if ((powpan_command(cmdtab[i].command) == 2) && (!strcasecmp(powpan_answer, "#0"))) {
 			return STAT_INSTCMD_HANDLED;
 		}
 
@@ -181,7 +181,7 @@ static int powpan_instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_UNKNOWN;
 	}
 
-	if ((powpan_command(command) == 2) && (!strncasecmp(powpan_answer, "#0", 2))) {
+	if ((powpan_command(command) == 2) && (!strcasecmp(powpan_answer, "#0"))) {
 		return STAT_INSTCMD_HANDLED;
 	}
 
@@ -219,7 +219,7 @@ static int powpan_setvar(const char *varname, const char *val)
 #pragma GCC diagnostic pop
 #endif
 
-		if ((powpan_command(command) == 2) && (!strncasecmp(powpan_answer, "#0", 2))) {
+		if ((powpan_command(command) == 2) && (!strcasecmp(powpan_answer, "#0"))) {
 			dstate_setinfo(varname, "%s", val);
 			return STAT_SET_HANDLED;
 		}

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -747,13 +747,13 @@ void nut_snmp_init(const char *type, const char *hostname)
 # pragma clang diagnostic push
 # pragma clang diagnostic ignored "-Warray-bounds"
 #endif
-	if ((strncmp(version, "v1", 3) == 0) || (strncmp(version, "v2c", 3) == 0)) {
-		g_snmp_sess.version = (strncmp(version, "v1", 3) == 0) ? SNMP_VERSION_1 : SNMP_VERSION_2c;
+	if ((strcmp(version, "v1") == 0) || (strcmp(version, "v2c") == 0)) {
+		g_snmp_sess.version = (strcmp(version, "v1") == 0) ? SNMP_VERSION_1 : SNMP_VERSION_2c;
 		community = testvar(SU_VAR_COMMUNITY) ? getval(SU_VAR_COMMUNITY) : "public";
 		g_snmp_sess.community = (unsigned char *)xstrdup(community);
 		g_snmp_sess.community_len = strlen(community);
 	}
-	else if (strncmp(version, "v3", 3) == 0) {
+	else if (strcmp(version, "v3") == 0) {
 #ifdef __clang__
 # pragma clang diagnostic pop
 #endif

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -810,21 +810,15 @@ void nut_snmp_init(const char *type, const char *hostname)
 		g_snmp_sess.securityAuthKeyLen = USM_AUTH_KU_LEN;
 		authProtocol = testvar(SU_VAR_AUTHPROT) ? getval(SU_VAR_AUTHPROT) : "MD5";
 
-		/* Note: start with strcmp of the longer strings,
-		 * or explicitly check the length (end of string),
-		 * to avoid matching everything as e.g. "SHA" by
-		 * strncmp() below - that was needed for platforms
-		 * where strcmp() is a built-in/macro which offends
-		 * alignment checks with short strings... */
 #if NUT_HAVE_LIBNETSNMP_usmHMACMD5AuthProtocol
-		if (strncmp(authProtocol, "MD5", 3) == 0 && authProtocol[3] == '\0') {
+		if (strncmp(authProtocol, "MD5", 3) == 0) {
 			g_snmp_sess.securityAuthProto = usmHMACMD5AuthProtocol;
 			g_snmp_sess.securityAuthProtoLen = sizeof(usmHMACMD5AuthProtocol)/sizeof(oid);
 		}
 		else
 #endif
 #if NUT_HAVE_LIBNETSNMP_usmHMACSHA1AuthProtocol
-		if (strncmp(authProtocol, "SHA", 3) == 0 && authProtocol[3] == '\0') {
+		if (strncmp(authProtocol, "SHA", 3) == 0) {
 			g_snmp_sess.securityAuthProto = usmHMACSHA1AuthProtocol;
 			g_snmp_sess.securityAuthProtoLen = sizeof(usmHMACSHA1AuthProtocol)/sizeof(oid);
 		}
@@ -893,17 +887,15 @@ net-snmp/library/keytools.h:   int    generate_Ku(const oid * hashtype, u_int ha
 
 		privProtocol = testvar(SU_VAR_PRIVPROT) ? getval(SU_VAR_PRIVPROT) : "DES";
 
-		/* Note: start with strcmp of the longer strings, or check string
-		 * lengths explicitly, to avoid matching everything as e.g. "AES"! */
 #if NUT_HAVE_LIBNETSNMP_usmDESPrivProtocol
-		if (strncmp(privProtocol, "DES", 3) == 0 && privProtocol[3] == '\0') {
+		if (strncmp(privProtocol, "DES", 3) == 0) {
 			g_snmp_sess.securityPrivProto = usmDESPrivProtocol;
 			g_snmp_sess.securityPrivProtoLen =  sizeof(usmDESPrivProtocol)/sizeof(oid);
 		}
 		else
 #endif
 #if NUT_HAVE_LIBNETSNMP_usmAESPrivProtocol || NUT_HAVE_LIBNETSNMP_usmAES128PrivProtocol
-		if (strncmp(privProtocol, "AES", 3) == 0 && privProtocol[3] == '\0') {
+		if (strncmp(privProtocol, "AES", 3) == 0) {
 			g_snmp_sess.securityPrivProto = usmAESPrivProtocol;
 			g_snmp_sess.securityPrivProtoLen = NUT_securityPrivProtoLen;
 		}

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -811,14 +811,14 @@ void nut_snmp_init(const char *type, const char *hostname)
 		authProtocol = testvar(SU_VAR_AUTHPROT) ? getval(SU_VAR_AUTHPROT) : "MD5";
 
 #if NUT_HAVE_LIBNETSNMP_usmHMACMD5AuthProtocol
-		if (strncmp(authProtocol, "MD5", 3) == 0) {
+		if (strcmp(authProtocol, "MD5") == 0) {
 			g_snmp_sess.securityAuthProto = usmHMACMD5AuthProtocol;
 			g_snmp_sess.securityAuthProtoLen = sizeof(usmHMACMD5AuthProtocol)/sizeof(oid);
 		}
 		else
 #endif
 #if NUT_HAVE_LIBNETSNMP_usmHMACSHA1AuthProtocol
-		if (strncmp(authProtocol, "SHA", 3) == 0) {
+		if (strcmp(authProtocol, "SHA") == 0) {
 			g_snmp_sess.securityAuthProto = usmHMACSHA1AuthProtocol;
 			g_snmp_sess.securityAuthProtoLen = sizeof(usmHMACSHA1AuthProtocol)/sizeof(oid);
 		}
@@ -888,14 +888,14 @@ net-snmp/library/keytools.h:   int    generate_Ku(const oid * hashtype, u_int ha
 		privProtocol = testvar(SU_VAR_PRIVPROT) ? getval(SU_VAR_PRIVPROT) : "DES";
 
 #if NUT_HAVE_LIBNETSNMP_usmDESPrivProtocol
-		if (strncmp(privProtocol, "DES", 3) == 0) {
+		if (strcmp(privProtocol, "DES") == 0) {
 			g_snmp_sess.securityPrivProto = usmDESPrivProtocol;
 			g_snmp_sess.securityPrivProtoLen =  sizeof(usmDESPrivProtocol)/sizeof(oid);
 		}
 		else
 #endif
 #if NUT_HAVE_LIBNETSNMP_usmAESPrivProtocol || NUT_HAVE_LIBNETSNMP_usmAES128PrivProtocol
-		if (strncmp(privProtocol, "AES", 3) == 0) {
+		if (strcmp(privProtocol, "AES") == 0) {
 			g_snmp_sess.securityPrivProto = usmAESPrivProtocol;
 			g_snmp_sess.securityPrivProtoLen = NUT_securityPrivProtoLen;
 		}
@@ -3620,7 +3620,7 @@ static int parse_mibconf_args(size_t numargs, char **arg)
 	/* special case for setting some OIDs value at driver startup */
 	if (!strcmp(arg[0], "init")) {
 		/* set value. */
-		if (!strncmp(arg[1], "str", 3)) {
+		if (!strcmp(arg[1], "str")) {
 			ret = nut_snmp_set_str(arg[3], arg[4]);
 		} else {
 			ret = nut_snmp_set_int(arg[3], strtol(arg[4], NULL, 0));

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -747,13 +747,13 @@ void nut_snmp_init(const char *type, const char *hostname)
 # pragma clang diagnostic push
 # pragma clang diagnostic ignored "-Warray-bounds"
 #endif
-	if ((strncmp(version, "v1", 2) == 0) || (strncmp(version, "v2c", 3) == 0)) {
-		g_snmp_sess.version = (strncmp(version, "v1", 2) == 0) ? SNMP_VERSION_1 : SNMP_VERSION_2c;
+	if ((strncmp(version, "v1", 3) == 0) || (strncmp(version, "v2c", 3) == 0)) {
+		g_snmp_sess.version = (strncmp(version, "v1", 3) == 0) ? SNMP_VERSION_1 : SNMP_VERSION_2c;
 		community = testvar(SU_VAR_COMMUNITY) ? getval(SU_VAR_COMMUNITY) : "public";
 		g_snmp_sess.community = (unsigned char *)xstrdup(community);
 		g_snmp_sess.community_len = strlen(community);
 	}
-	else if (strncmp(version, "v3", 2) == 0) {
+	else if (strncmp(version, "v3", 3) == 0) {
 #ifdef __clang__
 # pragma clang diagnostic pop
 #endif

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -945,7 +945,7 @@ static int setvar(const char *varname, const char *val)
 		index = atoi(index_str);
 		upslogx(LOG_DEBUG, "outlet.%d.switch = %s", index, val);
 
-		if(!strncasecmp(val, "on", 2) || !strncmp(val, "1", 1)) {
+		if(!strcasecmp(val, "on") || !strcmp(val, "1")) {
 			state = 1;
 		} else {
 			state = 0;

--- a/drivers/upscode2.c
+++ b/drivers/upscode2.c
@@ -1334,17 +1334,17 @@ static int upsc_simple(const simple_t *sp, const char *var, const char *val)
 				dstate_setinfo(sp->desc, "%s", val);
 				break;
 			case t_status:
-				if (strncmp(val, "00", 2) == 0)
+				if (strcmp(val, "00") == 0)
 					;
-				else if (strncmp(val, "11", 2) == 0)
+				else if (strcmp(val, "11") == 0)
 					status |= sp->status;
 				else
 					upslogx(LOG_ERR, "Unknown status value: '%s' '%s'", var, val);
 				break;
 			case t_alarm:
-				if (strncmp(val, "00", 2) == 0)
+				if (strcmp(val, "00") == 0)
 					;
-				else if (strncmp(val, "11", 2) == 0)
+				else if (strcmp(val, "11") == 0)
 					status |= sp->status;
 				else
 					upslogx(LOG_ERR, "Unknown alarm value: '%s' '%s'", var, val);

--- a/drivers/victronups.c
+++ b/drivers/victronups.c
@@ -244,31 +244,31 @@ void upsdrv_updateinfo(void)
 	if (start_is_datastale)
 	{
 		if (get_data("vDS?",temp)) return;
-		if (strncmp(temp+3, "NA", 2))
+		if (strcmp(temp+3,"NA"))
 			exist_ups_serial=1;
 
 		if (get_data("vBT?",temp)) return;
-		if (strncmp(temp+3, "NA", 2))
+		if (strcmp(temp+3,"NA"))
 			exist_ups_temperature =1;
 
 		if (get_data("vO0I?",temp)) return;
-		if (strncmp(temp+4, "NA", 2))
+		if (strcmp(temp+4,"NA"))
 			exist_output_current =1;
 
 		if (get_data("vBC?",temp)) return;
-		if (strncmp(temp+3, "NA", 2))
+		if (strcmp(temp+3,"NA"))
 			exist_battery_charge = 1;
 
 		if (get_data("vBI?",temp)) return;
-		if (strncmp(temp+3, "NA", 2))
+		if (strcmp(temp+3,"NA"))
 			exist_battery_charge = 1;
 
 		if (get_data("vBT?",temp)) return;
-		if (strncmp(temp+3, "NA", 2))
+		if (strcmp(temp+3,"NA"))
 			exist_battery_temperature = 1;
 
 		if (get_data("vBt?",temp)) return;
-		if (strncmp(temp+3, "NA", 2))
+		if (strcmp(temp+3,"NA"))
 			exist_battery_runtime = 1;
 
 		start_is_datastale = 0;

--- a/server/conf.c
+++ b/server/conf.c
@@ -118,11 +118,11 @@ static void ups_update(const char *fn, const char *name, const char *desc)
  */
 static int parse_boolean(char *arg, int *result)
 {
-	if ( (!strcasecmp(arg, "true")) || (!strncasecmp(arg, "on", 2)) || (!strncasecmp(arg, "yes", 3)) || (!strncasecmp(arg, "1", 1))) {
+	if ( (!strcasecmp(arg, "true")) || (!strcasecmp(arg, "on")) || (!strcasecmp(arg, "yes")) || (!strcasecmp(arg, "1"))) {
 		*result = 1;
 		return 1;
 	}
-	if ( (!strcasecmp(arg, "false")) || (!strncasecmp(arg, "off", 3)) || (!strncasecmp(arg, "no", 2)) || (!strncasecmp(arg, "0", 1))) {
+	if ( (!strcasecmp(arg, "false")) || (!strcasecmp(arg, "off")) || (!strcasecmp(arg, "no")) || (!strcasecmp(arg, "0"))) {
 		*result = 0;
 		return 1;
 	}
@@ -266,7 +266,7 @@ static int parse_upsd_conf_args(size_t numargs, char **arg)
 		return 0;
 
 	/* ACL <aclname> <ip block> */
-	if (!strncmp(arg[0], "ACL", 3)) {
+	if (!strcmp(arg[0], "ACL")) {
 		upslogx(LOG_WARNING, "ACL in upsd.conf is no longer supported - switch to LISTEN");
 		return 1;
 	}

--- a/server/netget.c
+++ b/server/netget.c
@@ -258,7 +258,7 @@ void net_get(nut_ctype_t *client, size_t numarg, const char **arg)
 	}
 
 	/* GET VAR UPS VARNAME */
-	if (!strncasecmp(arg[0], "VAR", 3)) {
+	if (!strcasecmp(arg[0], "VAR")) {
 		get_var(client, arg[1], arg[2]);
 		return;
 	}

--- a/server/netlist.c
+++ b/server/netlist.c
@@ -293,7 +293,7 @@ void net_list(nut_ctype_t *client, size_t numarg, const char **arg)
 	}
 
 	/* LIST UPS */
-	if (!strncasecmp(arg[0], "UPS", 3)) {
+	if (!strcasecmp(arg[0], "UPS")) {
 		list_ups(client);
 		return;
 	}
@@ -304,19 +304,19 @@ void net_list(nut_ctype_t *client, size_t numarg, const char **arg)
 	}
 
 	/* LIST VAR UPS */
-	if (!strncasecmp(arg[0], "VAR", 3)) {
+	if (!strcasecmp(arg[0], "VAR")) {
 		list_var(client, arg[1]);
 		return;
 	}
 
 	/* LIST RW UPS */
-	if (!strncasecmp(arg[0], "RW", 2)) {
+	if (!strcasecmp(arg[0], "RW")) {
 		list_rw(client, arg[1]);
 		return;
 	}
 
 	/* LIST CMD UPS */
-	if (!strncasecmp(arg[0], "CMD", 3)) {
+	if (!strcasecmp(arg[0], "CMD")) {
 		list_cmd(client, arg[1]);
 		return;
 	}

--- a/server/netset.c
+++ b/server/netset.c
@@ -181,7 +181,7 @@ void net_set(nut_ctype_t *client, size_t numarg, const char **arg)
 	}
 
 	/* SET VAR UPS VARNAME VALUE */
-	if (!strncasecmp(arg[0], "VAR", 3)) {
+	if (!strcasecmp(arg[0], "VAR")) {
 		if (numarg < 4) {
 			send_err(client, NUT_ERR_INVALID_ARGUMENT);
 			return;
@@ -199,11 +199,11 @@ void net_set(nut_ctype_t *client, size_t numarg, const char **arg)
 
 	/* SET TRACKING VALUE */
 	if (!strcasecmp(arg[0], "TRACKING")) {
-		if (!strncasecmp(arg[1], "ON", 2)) {
+		if (!strcasecmp(arg[1], "ON")) {
 			/* general enablement along with for this client */
 			client->tracking = tracking_enable();
 		}
-		else if (!strncasecmp(arg[1], "OFF", 3)) {
+		else if (!strcasecmp(arg[1], "OFF")) {
 			/* disable status tracking for this client first */
 			client->tracking = 0;
 			/* then only disable the general one if no other clients use it!

--- a/server/user.c
+++ b/server/user.c
@@ -222,7 +222,7 @@ static int user_matchinstcmd(ulist_t *user, const char * cmd)
 			return 1;	/* good */
 		}
 
-		if (!strncasecmp(tmp->cmd, "all", 3)) {
+		if (!strcasecmp(tmp->cmd, "all")) {
 			return 1;	/* good */
 		}
 	}
@@ -444,7 +444,7 @@ static void user_parse_arg(size_t numargs, char **arg)
 	}
 
 	/* handle 'foo = bar' (split form) */
-	if (!strncmp(arg[1], "=", 1)) {
+	if (!strcmp(arg[1], "=")) {
 
 		/*   0 1   2      3       4  ... */
 		/* foo = bar <rest1> <rest2> ... */

--- a/tests/cpputest.cpp
+++ b/tests/cpputest.cpp
@@ -46,7 +46,7 @@ int main(int argc, char* argv[])
 {
   bool verbose = false;
   if (argc > 1) {
-    if (strncmp("-v", argv[1], 2) == 0 || strcmp("--verbose", argv[1]) == 0 ) {
+    if (strcmp("-v", argv[1]) == 0 || strcmp("--verbose", argv[1]) == 0 ) {
       verbose = true;
     }
   }

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -525,10 +525,10 @@ int main(int argc, char *argv[])
 				else if (!strcmp(optarg, "STRAIGHT_PASSWORD_KEY")) {
 					ipmi_sec.authentication_type = IPMI_AUTHENTICATION_TYPE_STRAIGHT_PASSWORD_KEY;
 				}
-				else if (!strncmp(optarg, "MD2", 3)) {
+				else if (!strcmp(optarg, "MD2")) {
 					ipmi_sec.authentication_type = IPMI_AUTHENTICATION_TYPE_MD2;
 				}
-				else if (!strncmp(optarg, "MD5", 3)) {
+				else if (!strcmp(optarg, "MD5")) {
 					ipmi_sec.authentication_type = IPMI_AUTHENTICATION_TYPE_MD5;
 				}
 				else {

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -595,14 +595,8 @@ static int init_session(struct snmp_session * snmp_sess, nutscan_snmp_t * sec)
 #endif
 
 		if (sec->authProtocol) {
-			/* Note: start with strcmp of the longer strings,
-			 * or explicitly check string lengths (null char),
-			 * to avoid matching everything as e.g. "SHA" by
-			 * strncmp() below - that was needed for platforms
-			 * where strcmp() is a built-in/macro which offends
-			 * alignment checks with short strings... */
 #if NUT_HAVE_LIBNETSNMP_usmHMACSHA1AuthProtocol
-			if (strncmp(sec->authProtocol, "SHA", 3) == 0 && sec->authProtocol[3] == '\0') {
+			if (strncmp(sec->authProtocol, "SHA", 3) == 0) {
 				snmp_sess->securityAuthProto = nut_usmHMACSHA1AuthProtocol;
 				snmp_sess->securityAuthProtoLen =
 					sizeof(usmHMACSHA1AuthProtocol)/
@@ -695,10 +689,8 @@ static int init_session(struct snmp_session * snmp_sess, nutscan_snmp_t * sec)
 #endif
 
 		if (sec->privProtocol) {
-			/* Note: start with strcmp of the longer strings, or check
-			 * lengths, to avoid matching everything as e.g. "AES"! */
 #if NUT_HAVE_LIBNETSNMP_usmAESPrivProtocol || NUT_HAVE_LIBNETSNMP_usmAES128PrivProtocol
-			if (strncmp(sec->privProtocol, "AES", 3) == 0 && sec->privProtocol[3] == '\0') {
+			if (strncmp(sec->privProtocol, "AES", 3) == 0) {
 				snmp_sess->securityPrivProto = nut_usmAESPrivProtocol;
 				snmp_sess->securityPrivProtoLen =
 					sizeof(usmAESPrivProtocol)/

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -596,7 +596,7 @@ static int init_session(struct snmp_session * snmp_sess, nutscan_snmp_t * sec)
 
 		if (sec->authProtocol) {
 #if NUT_HAVE_LIBNETSNMP_usmHMACSHA1AuthProtocol
-			if (strncmp(sec->authProtocol, "SHA", 3) == 0) {
+			if (strcmp(sec->authProtocol, "SHA") == 0) {
 				snmp_sess->securityAuthProto = nut_usmHMACSHA1AuthProtocol;
 				snmp_sess->securityAuthProtoLen =
 					sizeof(usmHMACSHA1AuthProtocol)/
@@ -632,7 +632,7 @@ static int init_session(struct snmp_session * snmp_sess, nutscan_snmp_t * sec)
 			else
 #endif
 #if NUT_HAVE_LIBNETSNMP_usmHMACMD5AuthProtocol
-			if (strncmp(sec->authProtocol, "MD5", 3) != 0) {
+			if (strcmp(sec->authProtocol, "MD5") != 0) {
 #else
 			{
 #endif
@@ -690,7 +690,7 @@ static int init_session(struct snmp_session * snmp_sess, nutscan_snmp_t * sec)
 
 		if (sec->privProtocol) {
 #if NUT_HAVE_LIBNETSNMP_usmAESPrivProtocol || NUT_HAVE_LIBNETSNMP_usmAES128PrivProtocol
-			if (strncmp(sec->privProtocol, "AES", 3) == 0) {
+			if (strcmp(sec->privProtocol, "AES") == 0) {
 				snmp_sess->securityPrivProto = nut_usmAESPrivProtocol;
 				snmp_sess->securityPrivProtoLen =
 					sizeof(usmAESPrivProtocol)/
@@ -719,7 +719,7 @@ static int init_session(struct snmp_session * snmp_sess, nutscan_snmp_t * sec)
 # endif
 #endif /* NUT_HAVE_LIBNETSNMP_DRAFT_BLUMENTHAL_AES_04 */
 #if NUT_HAVE_LIBNETSNMP_usmDESPrivProtocol
-			if (strncmp(sec->privProtocol, "DES", 3) != 0) {
+			if (strcmp(sec->privProtocol, "DES") != 0) {
 #else
 			{
 #endif


### PR DESCRIPTION
Currently the configure script should properly avoid the built-in `strcmp()` versions which might upset a current build's chosen compiler when strings were short (under 4 bytes). Using the range-limited `strncmp()` has a downside of matching start-of-string which led to at least one caught bug, and made the code less consistent (strcmp still usable for longer strings) and maintainable.