### PR TITLE
configure.ac: improve "--with-drivers=name[,name...]" handling [issue #1271]

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -477,7 +477,21 @@ AC_ARG_WITH(drivers,
 		if test -z "${with_powerman}"; then with_powerman="yes"; fi
 		if test -z "${with_modbus}"; then with_modbus="yes"; fi
 		if test -z "${with_ipmi}"; then with_ipmi="yes"; fi
-		if test -z "${with_linux_i2c}"; then with_linux_i2c="yes"; fi
+
+		dnl Platform-dependent snowflakes that are required or auto:
+		if test -z "${with_linux_i2c}"; then
+			case ${target_os} in
+				linux*) with_linux_i2c="yes";;
+				*) with_linux_i2c="auto";;
+			esac
+		fi
+		if test -z "${with_macosx_ups}"; then
+			if test -d /System/Library/Frameworks/IOKit.framework/ ; then
+				with_macosx_ups="yes"
+			else
+				with_macosx_ups="auto"
+			fi
+		fi
 		AC_MSG_RESULT(${DRIVER_BUILD_LIST})
 		;;
 	auto)
@@ -491,6 +505,7 @@ AC_ARG_WITH(drivers,
 		if test -z "${with_modbus}"; then with_modbus="${withval}"; fi
 		if test -z "${with_ipmi}"; then with_ipmi="${withval}"; fi
 		if test -z "${with_linux_i2c}"; then with_linux_i2c="${withval}"; fi
+		if test -z "${with_macosx_ups}"; then with_macosx_ups="${withval}"; fi
 		AC_MSG_RESULT(${DRIVER_BUILD_LIST})
 		;;
 	*)
@@ -647,17 +662,36 @@ AC_ARG_WITH(all,
 	if test -n "${withval}"; then
 		dnl Note: we allow "no" as a positive value, because
 		dnl this is what the user expects from --without-all
+		dnl Note: these settings do not touch generation of
+		dnl "--with-docs=...", that is handled separately
 		if test -z "${with_serial}"; then with_serial="${withval}"; fi
 		if test -z "${with_usb}"; then with_usb="${withval}"; fi
 		if test -z "${with_snmp}"; then with_snmp="${withval}"; fi
 		if test -z "${with_neon}"; then with_neon="${withval}"; fi
 		if test -z "${with_powerman}"; then with_powerman="${withval}"; fi
 		if test -z "${with_modbus}"; then with_modbus="${withval}"; fi
+		if test -z "${with_ipmi}"; then with_ipmi="${withval}"; fi
+
+		dnl Platform-dependent snowflakes that are required or auto:
+		if test -z "${with_linux_i2c}"; then
+			with_linux_i2c="${withval}"
+			case ${target_os} in
+				linux*) ;;
+				*) test x"${withval}" = xno || with_linux_i2c="auto" ;;
+			esac
+		fi
+		if test -z "${with_macosx_ups}"; then
+			with_macosx_ups="${withval}"
+			if ! test -d /System/Library/Frameworks/IOKit.framework/ ; then
+				test x"${withval}" = xno || with_macosx_ups="auto"
+			fi
+		fi
+
+		dnl These are not driver families, but other features:
 		if test -z "${with_cgi}"; then with_cgi="${withval}"; fi
 		if test -z "${with_dev}"; then with_dev="${withval}"; fi
 		if test -z "${with_avahi}"; then with_avahi="${withval}"; fi
-		if test -z "${with_ipmi}"; then with_ipmi="${withval}"; fi
-		if test -z "${with_linux_i2c}"; then with_linux_i2c="${withval}"; fi
+
 		AC_MSG_RESULT("${withval}")
 	else
 		AC_MSG_RESULT(not given)
@@ -952,6 +986,9 @@ if test "${nut_with_macosx_ups}" != no; then
    if test -d /System/Library/Frameworks/IOKit.framework/ ; then
       nut_with_macosx_ups="yes"
    else
+      if test "${nut_with_macosx_ups}" = yes; then
+          AC_MSG_ERROR([macosx-ups was required but can not be fulfilled for this build: not MacOS])
+      fi
       nut_with_macosx_ups="no"
    fi
 fi
@@ -1005,6 +1042,9 @@ if test "${nut_with_linux_i2c}" != no; then
                 ])
             ;;
         * )
+            if test "${nut_with_linux_i2c}" = yes; then
+                AC_MSG_ERROR([i2c was required but can not be fulfilled for this build: not linux])
+            fi
             nut_with_linux_i2c="no"
             ;;
     esac

--- a/configure.ac
+++ b/configure.ac
@@ -487,7 +487,34 @@ dnl note that options with further investigation methods are listed
 dnl a bit below to be grouped with their additional with/enable help.
 
 NUT_ARG_WITH([dev], [build and install the development files], [no])
-NUT_ARG_WITH([serial], [build and install serial drivers], [yes])
+
+dnl Autoconf versions before 2.62 do not allow consecutive quadrigraphs,
+dnl so the help string depends on the version used
+AC_MSG_CHECKING(which drivers to build)
+AC_ARG_WITH(drivers,
+	AS_HELP_STRING([m4_version_prereq(2.62,
+		[@<:@--with-drivers=driver@<:@,driver@:>@@:>@],
+		[[[[--with-drivers=driver@<:@,driver@:>@]]]])],
+	[Only build specific drivers (all)]),
+[
+	case "${withval}" in
+	yes|no)
+		AC_MSG_ERROR(invalid option --with(out)-drivers - see docs/configure.txt)
+		;;
+	*)
+		DRIVER_BUILD_LIST="`echo ${withval} | sed "s/,/ /g"`"
+		AC_MSG_RESULT(${DRIVER_BUILD_LIST})
+		;;
+	esac
+], [
+	DRIVER_BUILD_LIST="all"
+	AC_MSG_RESULT(all available)
+])
+AM_CONDITIONAL(SOME_DRIVERS, test "${DRIVER_BUILD_LIST}" != "all")
+
+if test "${DRIVER_BUILD_LIST}" != "all"; then
+	NUT_REPORT([only build specific drivers], [${DRIVER_BUILD_LIST}])
+fi
 
 dnl The NUT legacy option was --with-doc; however to simplify configuration
 dnl in some common packaging frameworks, we also allow --with-docs as
@@ -509,6 +536,8 @@ dnl To help find warning/error details in a wall of text, see --enable-Wcolor ha
 
 dnl ----------------------------------------------------------------------
 dnl Check for presence and compiler flags of various libraries
+
+NUT_ARG_WITH([serial], [build and install serial drivers], [yes])
 
 dnl These checks are performed unconditionally, even if the corresponding
 dnl --with-* options are not given. This is because we cannot predict
@@ -1476,34 +1505,6 @@ AC_ARG_WITH(logfacility,
 ])
 AC_DEFINE_UNQUOTED(LOG_FACILITY, ${LOGFACILITY}, [Desired syslog facility - see syslog(3)])
 AC_MSG_RESULT(${LOGFACILITY})
-
-dnl Autoconf versions before 2.62 do not allow consecutive quadrigraphs,
-dnl so the help string depends on the version used
-AC_MSG_CHECKING(which drivers to build)
-AC_ARG_WITH(drivers,
-	AS_HELP_STRING([m4_version_prereq(2.62,
-		[@<:@--with-drivers=driver@<:@,driver@:>@@:>@],
-		[[[[--with-drivers=driver@<:@,driver@:>@]]]])],
-	[Only build specific drivers (all)]),
-[
-	case "${withval}" in
-	yes|no)
-		AC_MSG_ERROR(invalid option --with(out)-drivers - see docs/configure.txt)
-		;;
-	*)
-		DRIVER_BUILD_LIST=`echo ${withval} | sed "s/,/ /g"`
-		AC_MSG_RESULT(${DRIVER_BUILD_LIST})
-		;;
-	esac
-], [
-	DRIVER_BUILD_LIST="all"
-	AC_MSG_RESULT(all available)
-])
-AM_CONDITIONAL(SOME_DRIVERS, test "${DRIVER_BUILD_LIST}" != "all")
-
-if test "${DRIVER_BUILD_LIST}" != "all"; then
-	NUT_REPORT([only build specific drivers], [${DRIVER_BUILD_LIST}])
-fi
 
 AC_MSG_CHECKING(which driver man pages to install)
 if test "${WITH_MANS}" = "yes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -558,6 +558,7 @@ AC_ARG_WITH(drivers,
 			dnl Note: do not quote the expansion below to keep it multi-token:
 			for DRV in $DRIVER_BUILD_LIST ; do
 
+				DRV_HITS=""
 				dnl #DEVEL-DEBUG# AC_MSG_NOTICE([= Checking DRV="$DRV"])
 				for DRVLIST_NAME in $DRVLIST_NAMES; do
 					dnl #DEVEL-DEBUG# AC_MSG_NOTICE([== Checking DRVLIST_NAME="$DRVLIST_NAME"])
@@ -567,6 +568,7 @@ AC_ARG_WITH(drivers,
 					for DN in $DRVLIST ; do
 						dnl #DEVEL-DEBUG# AC_MSG_NOTICE([=== Checking DN="$DN"])
 						AS_IF([test x"$DN" = x"$DRV"], [
+							DRV_HITS="$DRV_HITS $DRVLIST_NAME"
 							AS_CASE(["$DRVLIST_NAME"],
 
 								[SERIAL_DRIVERLIST], [
@@ -633,6 +635,8 @@ AC_ARG_WITH(drivers,
 							dnl Break once, maybe a driver hits several categories
 						])
 					done
+					AS_IF([test -z "${DRV_HITS}"],
+						[AC_MSG_ERROR([Requested driver '$DRV' is not defined in drivers/Makefile.am (or configure.ac has a bug/lag detecting driver lists)])])
 				done
 
 			done

--- a/configure.ac
+++ b/configure.ac
@@ -452,6 +452,192 @@ NUT_CHECK_PYTHON2
 NUT_CHECK_PYTHON3
 
 dnl ----------------------------------------------------------------------
+dnl check for --with-drivers=all (or --with-drivers=name[,name...]) flag
+
+dnl Autoconf versions before 2.62 do not allow consecutive quadrigraphs
+dnl (square brackets), so the help string depends on the version used
+AC_MSG_CHECKING(which drivers to build)
+AC_ARG_WITH(drivers,
+	AS_HELP_STRING([m4_version_prereq(2.62,
+		[@<:@--with-drivers=driver@<:@,driver@:>@@:>@],
+		[[[[--with-drivers=driver@<:@,driver@:>@]]]])],
+	[Only build specific drivers (all)]),
+[
+	case "${withval}" in
+	yes|no|'')
+		AC_MSG_ERROR(invalid option --with(out)-drivers - see docs/configure.txt)
+		;;
+	all)
+		dnl Explicit request to build all drivers (unless specified), or fail
+		DRIVER_BUILD_LIST="all"
+		if test -z "${with_serial}"; then with_serial="yes"; fi
+		if test -z "${with_usb}"; then with_usb="yes"; fi
+		if test -z "${with_snmp}"; then with_snmp="yes"; fi
+		if test -z "${with_neon}"; then with_neon="yes"; fi
+		if test -z "${with_powerman}"; then with_powerman="yes"; fi
+		if test -z "${with_modbus}"; then with_modbus="yes"; fi
+		if test -z "${with_ipmi}"; then with_ipmi="yes"; fi
+		if test -z "${with_linux_i2c}"; then with_linux_i2c="yes"; fi
+		AC_MSG_RESULT(${DRIVER_BUILD_LIST})
+		;;
+	auto)
+		dnl Explicit request to build all drivers that we can
+		DRIVER_BUILD_LIST="all"
+		if test -z "${with_serial}"; then with_serial="${withval}"; fi
+		if test -z "${with_usb}"; then with_usb="${withval}"; fi
+		if test -z "${with_snmp}"; then with_snmp="${withval}"; fi
+		if test -z "${with_neon}"; then with_neon="${withval}"; fi
+		if test -z "${with_powerman}"; then with_powerman="${withval}"; fi
+		if test -z "${with_modbus}"; then with_modbus="${withval}"; fi
+		if test -z "${with_ipmi}"; then with_ipmi="${withval}"; fi
+		if test -z "${with_linux_i2c}"; then with_linux_i2c="${withval}"; fi
+		AC_MSG_RESULT(${DRIVER_BUILD_LIST})
+		;;
+	*)
+		DRIVER_BUILD_LIST="`echo ${withval} | sed 's/,/ /g'`"
+		AC_MSG_RESULT(${DRIVER_BUILD_LIST})
+
+		AS_IF([test -n "$DRIVER_BUILD_LIST"],
+			[dnl DRVLIST is occasionally synced with drivers/Makefile.am
+			 dnl NOTE: Currently "USB_DRIVERLIST" is not used standalone:
+			DRVLIST_NAMES="
+				SERIAL_DRIVERLIST USB_LIBUSB_DRIVERLIST SERIAL_USB_DRIVERLIST
+				SNMP_DRIVERLIST NEONXML_DRIVERLIST
+				MACOSX_DRIVERLIST MODBUS_DRIVERLIST LINUX_I2C_DRIVERLIST
+				POWERMAN_DRIVERLIST IPMI_DRIVERLIST"
+
+			get_drvlist() (
+				dnl Note escaped brackets - "against" m4 parser
+				m4_version_prereq(2.62,
+					[LB="@<:@"; RB="@:>@"],
+					[LB="[["; RB="]]"]
+				)
+				SPACE="`printf "$LB"' \t'"$RB"`"
+				SPACES="${SPACE}*"
+				sed -e "s/${SPACES}""$LB"'+'"$RB"'*='"${SPACES}/=/" \
+				    -e "s/^${SPACES}//" < drivers/Makefile.am \
+				| {
+					C=false; V=false
+					while read LINE ; do
+						case "$LINE" in
+							*'\') C=true; if $V ; then echo "$LINE" ; fi ;;
+							*) C=false; V=false ;;
+						esac
+						case "$LINE" in
+							"$1"=*)
+								echo "$LINE" | sed -e 's,^'"$LB"'^='"$RB"'*=,,' -e 's,\$,,'
+								V=$C
+								;;
+						esac
+					done
+				} | tr '\n' ' ' | sed -e "s,${SPACE}${SPACES}, ," -e "s,${SPACES}\$,,"
+			)
+
+			for DRVLIST_NAME in $DRVLIST_NAMES; do
+				OUT="`get_drvlist "$DRVLIST_NAME"`" \
+				&& test -n "$OUT" || OUT=""
+				eval $DRVLIST_NAME="\$OUT"
+				AC_MSG_NOTICE([Will check custom driver selection against $DRVLIST_NAME="$OUT"])
+			done
+
+			dnl Note: do not quote the expansion below to keep it multi-token:
+			for DRV in $DRIVER_BUILD_LIST ; do
+
+				dnl #DEVEL-DEBUG# AC_MSG_NOTICE([= Checking DRV="$DRV"])
+				for DRVLIST_NAME in $DRVLIST_NAMES; do
+					dnl #DEVEL-DEBUG# AC_MSG_NOTICE([== Checking DRVLIST_NAME="$DRVLIST_NAME"])
+					eval DRVLIST="\${$DRVLIST_NAME}"
+					dnl #DEVEL-DEBUG# AC_MSG_NOTICE([== Contents DRVLIST="$DRVLIST"])
+
+					for DN in $DRVLIST ; do
+						dnl #DEVEL-DEBUG# AC_MSG_NOTICE([=== Checking DN="$DN"])
+						AS_IF([test x"$DN" = x"$DRV"], [
+							AS_CASE(["$DRVLIST_NAME"],
+
+								[SERIAL_DRIVERLIST], [
+									AS_IF([test -z "${with_serial}"],
+										[AC_MSG_NOTICE([Requiring --with-serial=yes for driver "$DRV"])
+										with_serial=yes]
+									)],
+								[USB_LIBUSB_DRIVERLIST], [
+									AS_IF([test -z "${with_usb}"],
+										[AC_MSG_NOTICE([Requiring --with-usb=yes for driver "$DRV"])
+										with_usb=yes]
+									)],
+								[SERIAL_USB_DRIVERLIST], [
+									dnl e.g. nutdrv_qx that can do both
+									AS_IF([test -z "${with_usb}"],
+										[AC_MSG_NOTICE([Requiring --with-usb=yes for driver "$DRV"])
+										with_usb=yes]
+									)
+									AS_IF([test -z "${with_serial}"],
+										[AC_MSG_NOTICE([Requiring --with-serial=yes for driver "$DRV"])
+										with_serial=yes]
+									)],
+								[SNMP_DRIVERLIST], [
+									AS_IF([test -z "${with_snmp}"],
+										[AC_MSG_NOTICE([Requiring --with-snmp=yes for driver "$DRV"])
+										with_snmp=yes]
+									)],
+								[NEONXML_DRIVERLIST], [
+									AS_IF([test -z "${with_neon}"],
+										[AC_MSG_NOTICE([Requiring --with-neon=yes for driver "$DRV"])
+										with_neon=yes]
+									)],
+								[MACOSX_DRIVERLIST], [
+									dnl NOTE: This one is a bit special,
+									dnl just one certain driver so far
+									AS_IF([test -z "${with_macosx_ups}"],
+										[AC_MSG_NOTICE([Requiring --with-macosx-ups=yes for driver "$DRV"])
+										with_macosx_ups=yes]
+									)],
+								[MODBUS_DRIVERLIST], [
+									AS_IF([test -z "${with_modbus}"],
+										[AC_MSG_NOTICE([Requiring --with-modbus=yes for driver "$DRV"])
+										with_modbus=yes]
+									)],
+								[LINUX_I2C_DRIVERLIST], [
+									AS_IF([test -z "${with_linux_i2c}"],
+										[AC_MSG_NOTICE([Requiring --with-linux-i2c=yes for driver "$DRV"])
+										with_linux_i2c=yes]
+									)],
+								[POWERMAN_DRIVERLIST], [
+									AS_IF([test -z "${with_powerman}"],
+										[AC_MSG_NOTICE([Requiring --with-powerman=yes for driver "$DRV"])
+										with_powerman=yes]
+									)],
+								[IPMI_DRIVERLIST], [
+									AS_IF([test -z "${with_ipmi}"],
+										[AC_MSG_NOTICE([Requiring --with-ipmi=yes for driver "$DRV"])
+										with_ipmi=yes]
+									)],
+
+								[AC_MSG_WARN([Unhandled DRVLIST_NAME=$DRVLIST_NAME])]
+							)
+							break
+							dnl Break once, maybe a driver hits several categories
+						])
+					done
+				done
+
+			done
+			])
+
+		;;
+	esac
+], [
+	dnl Implicit request to build whatever is enabled;
+	dnl do not force --with-all here:
+	DRIVER_BUILD_LIST="all"
+	AC_MSG_RESULT(all available)
+])
+AM_CONDITIONAL(SOME_DRIVERS, test "${DRIVER_BUILD_LIST}" != "all")
+
+if test "${DRIVER_BUILD_LIST}" != "all"; then
+	NUT_REPORT([only build specific drivers], [${DRIVER_BUILD_LIST}])
+fi
+
+dnl ----------------------------------------------------------------------
 dnl check for --with-all (or --without-all, or --with-all=auto) flag
 
 AC_MSG_CHECKING(for --with-all)
@@ -487,34 +673,6 @@ dnl note that options with further investigation methods are listed
 dnl a bit below to be grouped with their additional with/enable help.
 
 NUT_ARG_WITH([dev], [build and install the development files], [no])
-
-dnl Autoconf versions before 2.62 do not allow consecutive quadrigraphs,
-dnl so the help string depends on the version used
-AC_MSG_CHECKING(which drivers to build)
-AC_ARG_WITH(drivers,
-	AS_HELP_STRING([m4_version_prereq(2.62,
-		[@<:@--with-drivers=driver@<:@,driver@:>@@:>@],
-		[[[[--with-drivers=driver@<:@,driver@:>@]]]])],
-	[Only build specific drivers (all)]),
-[
-	case "${withval}" in
-	yes|no)
-		AC_MSG_ERROR(invalid option --with(out)-drivers - see docs/configure.txt)
-		;;
-	*)
-		DRIVER_BUILD_LIST="`echo ${withval} | sed "s/,/ /g"`"
-		AC_MSG_RESULT(${DRIVER_BUILD_LIST})
-		;;
-	esac
-], [
-	DRIVER_BUILD_LIST="all"
-	AC_MSG_RESULT(all available)
-])
-AM_CONDITIONAL(SOME_DRIVERS, test "${DRIVER_BUILD_LIST}" != "all")
-
-if test "${DRIVER_BUILD_LIST}" != "all"; then
-	NUT_REPORT([only build specific drivers], [${DRIVER_BUILD_LIST}])
-fi
 
 dnl The NUT legacy option was --with-doc; however to simplify configuration
 dnl in some common packaging frameworks, we also allow --with-docs as

--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -52,6 +52,8 @@ NEONXML_DRIVERLIST = netxml-ups
 MACOSX_DRIVERLIST = macosx-ups
 MODBUS_DRIVERLIST = phoenixcontact_modbus generic_modbus huawei-ups2000
 LINUX_I2C_DRIVERLIST = asem pijuice
+POWERMAN_DRIVERLIST = powerman-pdu
+IPMI_DRIVERLIST = nut-ipmipsu
 
 # distribute all drivers, even ones that are not built by default
 EXTRA_PROGRAMS  = $(SERIAL_DRIVERLIST) $(USB_DRIVERLIST) $(SERIAL_USB_DRIVERLIST)
@@ -80,10 +82,10 @@ if WITH_NEON
    driverexec_PROGRAMS += $(NEONXML_DRIVERLIST)
 endif
 if WITH_LIBPOWERMAN
-   driverexec_PROGRAMS += powerman-pdu
+   driverexec_PROGRAMS += $(POWERMAN_DRIVERLIST)
 endif
 if WITH_IPMI
-   driverexec_PROGRAMS += nut-ipmipsu
+   driverexec_PROGRAMS += $(IPMI_DRIVERLIST)
 endif
 if WITH_MACOSX
    driverexec_PROGRAMS += $(MACOSX_DRIVERLIST)


### PR DESCRIPTION
As  raised in #1017 and detailed in #1271, until now we could request specific drivers to build, but that also required to still specify dependencies involved.

With this PR, requiring a driver would require the corresponding dependencies - same as if `--with-modbus` etc. was specified, unless some other flag for that dependency is requested explicitly.

Also this fixes handling of `--with-linux-i2c=yes` and `--with-macosx-ups=yes` to fail on unsuitable platforms (unable to fulfill explicit requirement), but to not default them to "yes" blindly everywhere (via `--with-all` or `--with-drivers=all`), just on those platforms ("auto" on others to try building anyway but not failing if can't configure such build).

Closes: #1271