### PR TITLE
Update riello (ser, usb) for shutdown/reboot delays (Fixes #530)

### DIFF
--- a/drivers/riello_usb.c
+++ b/drivers/riello_usb.c
@@ -979,10 +979,10 @@ void upsdrv_initinfo(void)
 	dstate_addcmd("test.battery.start");
 	dstate_addcmd("test.panel.start");
 
-	dstate_setinfo("ups.delay.shutdown", "%d", offdelay);
+	dstate_setinfo("ups.delay.shutdown", "%u", offdelay);
 	dstate_setflags("ups.delay.shutdown", ST_FLAG_RW | ST_FLAG_STRING);
 	dstate_setaux("ups.delay.shutdown", 3);
-	dstate_setinfo("ups.delay.reboot", "%d", bootdelay);
+	dstate_setinfo("ups.delay.reboot", "%u", bootdelay);
 	dstate_setflags("ups.delay.reboot", ST_FLAG_RW | ST_FLAG_STRING);
 	dstate_setaux("ups.delay.reboot", 3);
 
@@ -1076,6 +1076,7 @@ void upsdrv_updateinfo(void)
 		dstate_setinfo("battery.charge", "%u", DevData.BatCap);
 		dstate_setinfo("battery.runtime", "%u", DevData.BatTime*60);
 	}
+
 	if (DevData.Tsystem < 0xFF)
 		dstate_setinfo("ups.temperature", "%u", DevData.Tsystem);
 

--- a/drivers/riello_usb.c
+++ b/drivers/riello_usb.c
@@ -36,7 +36,10 @@
 #include "riello.h"
 
 #define DRIVER_NAME	"Riello USB driver"
-#define DRIVER_VERSION	"0.06"
+#define DRIVER_VERSION	"0.07"
+
+#define DEFAULT_OFFDELAY   5  /*!< seconds (max 0xFF) */
+#define DEFAULT_BOOTDELAY  5  /*!< seconds (max 0xFF) */
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -54,6 +57,10 @@ static uint8_t gpser_error_control;
 
 static uint8_t input_monophase;
 static uint8_t output_monophase;
+
+/*! Time in seconds to delay before shutting down. */
+static unsigned int offdelay = DEFAULT_OFFDELAY;
+static unsigned int bootdelay = DEFAULT_BOOTDELAY;
 
 static TRielloData DevData;
 
@@ -972,6 +979,13 @@ void upsdrv_initinfo(void)
 	dstate_addcmd("test.battery.start");
 	dstate_addcmd("test.panel.start");
 
+	dstate_setinfo("ups.delay.shutdown", "%d", offdelay);
+	dstate_setflags("ups.delay.shutdown", ST_FLAG_RW | ST_FLAG_STRING);
+	dstate_setaux("ups.delay.shutdown", 3);
+	dstate_setinfo("ups.delay.reboot", "%d", bootdelay);
+	dstate_setflags("ups.delay.reboot", ST_FLAG_RW | ST_FLAG_STRING);
+	dstate_setaux("ups.delay.reboot", 3);
+
 	/* install handlers */
 /*	upsh.setvar = hid_set_value; setvar; */
 
@@ -1058,9 +1072,13 @@ void upsdrv_updateinfo(void)
 	dstate_setinfo("input.bypass.frequency", "%.2f", DevData.Fbypass/10.0);
 	dstate_setinfo("output.frequency", "%.2f", DevData.Fout/10.0);
 	dstate_setinfo("battery.voltage", "%.1f", DevData.Ubat/10.0);
-	dstate_setinfo("battery.charge", "%u", DevData.BatCap);
-	dstate_setinfo("battery.runtime", "%u", DevData.BatTime*60);
-	dstate_setinfo("ups.temperature", "%u", DevData.Tsystem);
+	if ((DevData.BatCap < 0xFFFF) &&  (DevData.BatTime < 0xFFFF)) {
+		dstate_setinfo("battery.charge", "%u", DevData.BatCap);
+		dstate_setinfo("battery.runtime", "%u", DevData.BatTime*60);
+	}
+	if (DevData.Tsystem < 0xFF)
+		dstate_setinfo("ups.temperature", "%u", DevData.Tsystem);
+
 
 	if (input_monophase) {
 		dstate_setinfo("input.voltage", "%u", DevData.Uinp1);


### PR DESCRIPTION
This should address the issues in #530. Tested with an IDG1600

Output from `upsc` below

```
battery.capacity: 9
battery.voltage: 27.0
battery.voltage.nominal: 24
device.mfr: RPS S.p.a.
device.model: UNV1
device.serial:
device.type: ups
driver.name: riello_usb
driver.parameter.pollinterval: 2
driver.parameter.port: /dev/ttyUSB0
driver.parameter.synchronous: no
driver.version: 2.7.4-4547-gc911e825
driver.version.internal: 0.07
input.bypass.frequency: 409.50
input.bypass.voltage: 4095
input.frequency: 50.10
input.voltage: 240
output.frequency: 50.10
output.frequency.nominal: 50.0
output.L1.current: 0
output.L1.power: 0
output.L1.realpower: 0
output.L2.current: 0
output.L2.power: 0
output.L2.realpower: 0
output.L3.current: 0
output.L3.power: 0
output.L3.realpower: 0
output.power.percent: 0
output.voltage: 237
output.voltage.nominal: 230
ups.delay.reboot: 5
ups.delay.shutdown: 5
ups.firmware: SWM038-02-04
ups.load: 0
ups.mfr: RPS S.p.a.
ups.model: UNV1
ups.power.nominal: 1600
ups.productid: 5500
ups.realpower.nominal: 960
ups.serial:
ups.status: OL
ups.vendorid: 04b4
```