### PR TITLE
drivers/upsdrvctl: add "-d" option to pass current debug level from upsdrvctl to drivers

### DIFF
--- a/docs/man/upsdrvctl.txt
+++ b/docs/man/upsdrvctl.txt
@@ -57,6 +57,9 @@ This may be set in ups.conf with "user" in the global section.
 *-D*::
 Raise the debug level.  Use this multiple times for additional details.
 
+*-d*::
+Pass the selected debug level from `upsdrvctl` to launched drivers.
+
 COMMANDS
 --------
 

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -590,7 +590,9 @@ int main(int argc, char **argv)
 			"Below you'll find one or more lines starting with 'exec:' followed by an absolute\n"
 			"path to the driver binary and some command line option. This is what the driver\n"
 			"starts and you need to copy and paste that line and append the debug flags to that\n"
-			"line (less the 'exec:' prefix).\n");
+			"line (less the 'exec:' prefix).\n\n"
+			"Alternately, provide an additional '-d' (lower-case) parameter to 'upsdrvctl' to\n"
+			"pass its current debug level to the launched driver.\n");
 	}
 
 	if (!strcmp(argv[0], "start"))

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -582,14 +582,16 @@ int main(int argc, char **argv)
 			nut_debug_level = 2;
 	}
 
-	upsdebugx(2, "\n"
-		   "If you're not a NUT core developer, chances are that you're told to enable debugging\n"
-		   "to see why a driver isn't working for you. We're sorry for the confusion, but this is\n"
-		   "the 'upsdrvctl' wrapper, not the driver you're interested in.\n\n"
-		   "Below you'll find one or more lines starting with 'exec:' followed by an absolute\n"
-		   "path to the driver binary and some command line option. This is what the driver\n"
-		   "starts and you need to copy and paste that line and append the debug flags to that\n"
-		   "line (less the 'exec:' prefix).\n");
+	if (nut_debug_level_passthrough == 0) {
+		upsdebugx(2, "\n"
+			"If you're not a NUT core developer, chances are that you're told to enable debugging\n"
+			"to see why a driver isn't working for you. We're sorry for the confusion, but this is\n"
+			"the 'upsdrvctl' wrapper, not the driver you're interested in.\n\n"
+			"Below you'll find one or more lines starting with 'exec:' followed by an absolute\n"
+			"path to the driver binary and some command line option. This is what the driver\n"
+			"starts and you need to copy and paste that line and append the debug flags to that\n"
+			"line (less the 'exec:' prefix).\n");
+	}
 
 	if (!strcmp(argv[0], "start"))
 		command = &start_driver;


### PR DESCRIPTION
Closes: #1036

(Note: that issue discusses other possible improvements around this subject, which are synergetic with this one and posted as separate issues and PRs)