### PR TITLE
Enhance ways that upsd/upsmon can send signals to their running siblings

### DIFF
--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -1393,6 +1393,13 @@ static void loadconfig(void)
 		fatalx(EXIT_FAILURE, "%s", ctx.errmsg);
 	}
 
+	if (reload_flag == 1) {
+		/* if upsmon.conf added or changed
+		 * (or commented away) the debug_min
+		 * setting, detect that */
+		nut_debug_level_global = -1;
+	}
+
 	while (pconf_file_next(&ctx)) {
 		if (pconf_parse_error(&ctx)) {
 			upslogx(LOG_ERR, "Parse error: %s:%d: %s",
@@ -1416,6 +1423,15 @@ static void loadconfig(void)
 					ctx.arglist[i]);
 
 			upslogx(LOG_WARNING, "%s", errmsg);
+		}
+	}
+
+	if (reload_flag == 1) {
+		if (nut_debug_level_global > -1) {
+			upslogx(LOG_INFO,
+				"Applying debug_min=%d from upsmon.conf",
+				nut_debug_level_global);
+			nut_debug_level = nut_debug_level_global;
 		}
 	}
 
@@ -1977,20 +1993,8 @@ static void reload_conf(void)
 	/* reset paranoia checker */
 	totalpv = 0;
 
-	/* if upsmon.conf added or changed
-	 * (or commented away) the debug_min
-	 * setting, detect that */
-	nut_debug_level_global = -1;
-
 	/* reread upsmon.conf */
 	loadconfig();
-
-	if (nut_debug_level_global > -1) {
-		upslogx(LOG_INFO,
-			"Applying debug_min=%d from upsmon.conf",
-			nut_debug_level_global);
-		nut_debug_level = nut_debug_level_global;
-	}
 
 	/* go through the utype_t struct again */
 	tmp = firstups;

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -1809,6 +1809,7 @@ static void help(const char *arg_progname)
 	printf("		 - fsd: shutdown all primary-mode UPSes (use with caution)\n");
 	printf("		 - reload: reread configuration\n");
 	printf("		 - stop: stop monitoring and exit\n");
+	printf("  -P <pid>	send the signal above to specified PID (bypassing PID file)\n");
 	printf("  -D		raise debugging level (and stay foreground by default)\n");
 	printf("  -F		stay foregrounded even if no debugging is enabled\n");
 	printf("  -B		stay backgrounded even if debugging is bumped\n");
@@ -2042,7 +2043,8 @@ static void check_parent(void)
 int main(int argc, char *argv[])
 {
 	const char	*prog = xbasename(argv[0]);
-	int	i, cmd = 0, checking_flag = 0, foreground = -1;
+	int	i, cmd = 0, cmdret = -1, checking_flag = 0, foreground = -1;
+	pid_t	oldpid = -1;
 
 	printf("Network UPS Tools %s %s\n", prog, UPS_VERSION);
 
@@ -2053,7 +2055,7 @@ int main(int argc, char *argv[])
 
 	run_as_user = xstrdup(RUN_AS_USER);
 
-	while ((i = getopt(argc, argv, "+DFBhic:f:pu:VK46")) != -1) {
+	while ((i = getopt(argc, argv, "+DFBhic:P:f:pu:VK46")) != -1) {
 		switch (i) {
 			case 'c':
 				if (!strncmp(optarg, "fsd", strlen(optarg)))
@@ -2067,6 +2069,12 @@ int main(int argc, char *argv[])
 				if (cmd == 0)
 					help(argv[0]);
 				break;
+
+			case 'P':
+				if ((oldpid = parsepid(optarg)) < 0)
+					help(argv[0]);
+				break;
+
 			case 'D':
 				nut_debug_level++;
 				break;
@@ -2121,17 +2129,41 @@ int main(int argc, char *argv[])
 	}
 
 	if (cmd) {
-		sendsignal(prog, cmd);
-		exit(EXIT_SUCCESS);
+		if (oldpid < 0) {
+			cmdret = sendsignal(prog, cmd);
+		} else {
+			cmdret = sendsignalpid(oldpid, cmd);
+		}
+		/* exit(EXIT_SUCCESS); */
+		exit((cmdret == 0)?EXIT_SUCCESS:EXIT_FAILURE);
 	}
 
 	/* otherwise, we are being asked to start.
 	 * so check if a previous instance is running by sending signal '0'
 	 * (Ie 'kill <pid> 0') */
-	if (sendsignal(prog, 0) == 0) {
+	if (oldpid < 0) {
+		cmdret = sendsignal(prog, 0);
+	} else {
+		cmdret = sendsignalpid(oldpid, 0);
+	}
+	switch (cmdret) {
+	case 0:
 		printf("Fatal error: A previous upsmon instance is already running!\n");
 		printf("Either stop the previous instance first, or use the 'reload' command.\n");
 		exit(EXIT_FAILURE);
+
+	case -3:
+	case -2:
+		upslogx(LOG_WARNING, "Could not %s PID file "
+			"to see if previous upsmon instance is "
+			"already running!\n",
+			(cmdret == -3 ? "find" : "parse"));
+		break;
+
+	case -1:
+	default:
+		/* Just failed to send signal, no competitor running */
+		break;
 	}
 
 	argc -= optind;

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -1279,7 +1279,7 @@ static int parse_conf_arg(size_t numargs, char **arg)
 	}
 
 	/* RUN_AS_USER <userid> */
- 	if (!strcmp(arg[0], "RUN_AS_USER")) {
+	if (!strcmp(arg[0], "RUN_AS_USER")) {
 		free(run_as_user);
 		run_as_user = xstrdup(arg[1]);
 		return 1;

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -1977,8 +1977,20 @@ static void reload_conf(void)
 	/* reset paranoia checker */
 	totalpv = 0;
 
+	/* if upsmon.conf added or changed
+	 * (or commented away) the debug_min
+	 * setting, detect that */
+	nut_debug_level_global = -1;
+
 	/* reread upsmon.conf */
 	loadconfig();
+
+	if (nut_debug_level_global > -1) {
+		upslogx(LOG_INFO,
+			"Applying debug_min=%d from upsmon.conf",
+			nut_debug_level_global);
+		nut_debug_level = nut_debug_level_global;
+	}
 
 	/* go through the utype_t struct again */
 	tmp = firstups;

--- a/common/common.c
+++ b/common/common.c
@@ -349,13 +349,15 @@ int sendsignalfn(const char *pidfn, int sig)
 		return -1;
 	}
 
-	/* now actually send it */
-	ret = kill(pid, sig);
+	if (sig != 0) {
+		/* now actually send it */
+		ret = kill(pid, sig);
 
-	if (ret < 0) {
-		perror("kill");
-		fclose(pidf);
-		return -1;
+		if (ret < 0) {
+			perror("kill");
+			fclose(pidf);
+			return -1;
+		}
 	}
 
 	fclose(pidf);

--- a/common/common.c
+++ b/common/common.c
@@ -293,7 +293,9 @@ void writepid(const char *name)
 	pidf = fopen(fn, "w");
 
 	if (pidf) {
-		fprintf(pidf, "%d\n", (int) getpid());
+		intmax_t pid = (intmax_t)getpid();
+		upsdebugx(1, "Saving PID %jd into %s", pid, fn);
+		fprintf(pidf, "%jd\n", pid);
 		fclose(pidf);
 	} else {
 		upslog_with_errno(LOG_NOTICE, "writepid: fopen %s", fn);

--- a/common/common.c
+++ b/common/common.c
@@ -302,7 +302,10 @@ void writepid(const char *name)
 	umask(mask);
 }
 
-/* open pidfn, get the pid, then send it sig */
+/* open pidfn, get the pid, then send it sig
+ * returns negative codes for errors, or
+ * zero for a successfully sent signal
+ */
 int sendsignalfn(const char *pidfn, int sig)
 {
 	char	buf[SMALLBUF];
@@ -313,13 +316,13 @@ int sendsignalfn(const char *pidfn, int sig)
 	pidf = fopen(pidfn, "r");
 	if (!pidf) {
 		upslog_with_errno(LOG_NOTICE, "fopen %s", pidfn);
-		return -1;
+		return -3;
 	}
 
 	if (fgets(buf, sizeof(buf), pidf) == NULL) {
 		upslogx(LOG_NOTICE, "Failed to read pid from %s", pidfn);
 		fclose(pidf);
-		return -1;
+		return -2;
 	}
 
 	{ /* scoping */

--- a/conf/upsd.conf.sample
+++ b/conf/upsd.conf.sample
@@ -155,3 +155,14 @@
 # running mode directly, and without need to edit init-scripts or service
 # unit definitions. Note that command-line option `-D` can only increase
 # this verbosity level.
+#
+# NOTE: if the running daemon receives a `reload` command, presence of the
+# `DEBUG_MIN NUMBER` value in the configuration file can be used to tune
+# debugging verbosity in the running service daemon (it is recommended to
+# comment it away or set the minimum to explicit zero when done, to avoid
+# huge journals and I/O system abuse). Keep in mind that for this run-time
+# tuning, the `DEBUG_MIN` value *present* in *reloaded* configuration files
+# is applied instantly and overrides any previously set value, from file
+# or CLI options, regardless of older logging level being higher or lower
+# than the newly found number; a missing (or commented away) value however
+# does not change the previously active logging verbosity.

--- a/conf/upsmon.conf.sample.in
+++ b/conf/upsmon.conf.sample.in
@@ -440,3 +440,14 @@ FINALDELAY 5
 # running mode directly, and without need to edit init-scripts or service
 # unit definitions. Note that command-line option `-D` can only increase
 # this verbosity level.
+#
+# NOTE: if the running daemon receives a `reload` command, presence of the
+# `DEBUG_MIN NUMBER` value in the configuration file can be used to tune
+# debugging verbosity in the running service daemon (it is recommended to
+# comment it away or set the minimum to explicit zero when done, to avoid
+# huge journals and I/O system abuse). Keep in mind that for this run-time
+# tuning, the `DEBUG_MIN` value *present* in *reloaded* configuration files
+# is applied instantly and overrides any previously set value, from file
+# or CLI options, regardless of older logging level being higher or lower
+# than the newly found number; a missing (or commented away) value however
+# does not change the previously active logging verbosity.

--- a/docs/man/upsd.conf.txt
+++ b/docs/man/upsd.conf.txt
@@ -135,6 +135,17 @@ Optionally specify a minimum debug level for `upsd` data daemon, e.g. for
 troubleshooting a deployment, without impacting foreground or background
 running mode directly. Command-line option `-D` can only increase this
 verbosity level.
++
+NOTE: if the running daemon receives a `reload` command, presence of the
+`DEBUG_MIN NUMBER` value in the configuration file can be used to tune
+debugging verbosity in the running service daemon (it is recommended to
+comment it away or set the minimum to explicit zero when done, to avoid
+huge journals and I/O system abuse). Keep in mind that for this run-time
+tuning, the `DEBUG_MIN` value *present* in *reloaded* configuration files
+is applied instantly and overrides any previously set value, from file
+or CLI options, regardless of older logging level being higher or lower
+than the newly found number; a missing (or commented away) value however
+does not change the previously active logging verbosity.
 
 SEE ALSO
 --------

--- a/docs/man/upsd.txt
+++ b/docs/man/upsd.txt
@@ -43,6 +43,11 @@ are:
 	*reload*;; reread configuration files
 	*stop*;; stop process and exit
 
+*-P* 'pid'::
+Send the command signal above using specified PID number, rather than
+consulting the PID file.  This can help define service units which
+start `upsd` as a foreground process so it does not create a PID file.
+
 *-D*::
 Raise the debugging level.  upsd will run in the foreground by default,
 and will print information on stdout about the monitoring process.

--- a/docs/man/upsd.txt
+++ b/docs/man/upsd.txt
@@ -47,6 +47,7 @@ are:
 Send the command signal above using specified PID number, rather than
 consulting the PID file.  This can help define service units which
 start `upsd` as a foreground process so it does not create a PID file.
+See also `-FF` option as an alternative.
 
 *-D*::
 Raise the debugging level.  upsd will run in the foreground by default,
@@ -55,6 +56,7 @@ Use this option multiple times for more details.
 
 *-F*::
 upsd will run in the foreground, regardless of debugging settings.
+Specify twice (`-FF` or `-F -F`) to save the PID file even in this mode.
 
 *-B*::
 upsd will run in the background, regardless of debugging settings.

--- a/docs/man/upsmon.conf.txt
+++ b/docs/man/upsmon.conf.txt
@@ -399,6 +399,17 @@ Optionally specify a minimum debug level for `upsmon` daemon, e.g. for
 troubleshooting a deployment, without impacting foreground or background
 running mode directly. Command-line option `-D` can only increase this
 verbosity level.
++
+NOTE: if the running daemon receives a `reload` command, presence of the
+`DEBUG_MIN NUMBER` value in the configuration file can be used to tune
+debugging verbosity in the running service daemon (it is recommended to
+comment it away or set the minimum to explicit zero when done, to avoid
+huge journals and I/O system abuse). Keep in mind that for this run-time
+tuning, the `DEBUG_MIN` value *present* in *reloaded* configuration files
+is applied instantly and overrides any previously set value, from file
+or CLI options, regardless of older logging level being higher or lower
+than the newly found number; a missing (or commented away) value however
+does not change the previously active logging verbosity.
 
 SEE ALSO
 --------

--- a/docs/man/upsmon.txt
+++ b/docs/man/upsmon.txt
@@ -11,7 +11,7 @@ SYNOPSIS
 
 *upsmon* -h
 
-*upsmon* -c 'command'
+*upsmon* -c 'command' [-P 'pid']
 
 *upsmon* [-D] [-F | -B] [-K] [-p] [-u 'user']
 
@@ -43,6 +43,12 @@ commands are:
 
 *reload*;; reread linkman:upsmon.conf[5] configuration file.  See
 "reloading nuances" below if this doesn't work.
+
+*-P* 'pid'::
+Send the command signal above using specified PID number, rather than
+consulting the PID file.  This can help define service units which
+start main `upsmon` as a foreground process so it does not have to
+rely on a PID file.
 
 *-D*::
 Raise the debugging level.  upsmon will run in the foreground by default,

--- a/include/common.h
+++ b/include/common.h
@@ -112,7 +112,13 @@ int snprintfcat(char *dst, size_t size, const char *fmt, ...)
 /* Report maximum platform value for the pid_t */
 pid_t get_max_pid_t(void);
 
-/* open <pidfn>, get the pid, then send it <sig> */
+/* open <pidfn>, get the pid, then send it <sig>
+ * returns zero for successfully sent signal,
+ * negative for errors:
+ * -3   PID file not found
+ * -2   PID file not parsable
+ * -1   Error sending signal
+ */
 int sendsignalfn(const char *pidfn, int sig);
 
 const char *xbasename(const char *file);

--- a/include/common.h
+++ b/include/common.h
@@ -103,6 +103,10 @@ void chroot_start(const char *path);
 /* write a pid file - <name> is a full pathname *or* just the program name */
 void writepid(const char *name);
 
+/* parses string buffer into a pid_t if it passes
+ * a few sanity checks; returns -1 on error */
+pid_t parsepid(const char *buf);
+
 /* send a signal to another running process */
 int sendsignal(const char *progname, int sig);
 
@@ -111,6 +115,10 @@ int snprintfcat(char *dst, size_t size, const char *fmt, ...)
 
 /* Report maximum platform value for the pid_t */
 pid_t get_max_pid_t(void);
+
+/* send sig to pid after some sanity checks, returns
+ * -1 for error, or zero for a successfully sent signal */
+int sendsignalpid(pid_t pid, int sig);
 
 /* open <pidfn>, get the pid, then send it <sig>
  * returns zero for successfully sent signal,

--- a/scripts/systemd/nut-server.service.in
+++ b/scripts/systemd/nut-server.service.in
@@ -20,7 +20,7 @@ PartOf=nut.target
 [Service]
 EnvironmentFile=-@CONFPATH@/nut.conf
 SyslogIdentifier=%N
-ExecStart=@SBINDIR@/upsd -F
+ExecStart=@SBINDIR@/upsd -FF
 ExecReload=@SBINDIR@/upsd -c reload
 
 [Install]

--- a/scripts/systemd/nut-server.service.in
+++ b/scripts/systemd/nut-server.service.in
@@ -20,8 +20,10 @@ PartOf=nut.target
 [Service]
 EnvironmentFile=-@CONFPATH@/nut.conf
 SyslogIdentifier=%N
-ExecStart=@SBINDIR@/upsd -FF
-ExecReload=@SBINDIR@/upsd -c reload
+# Note: foreground mode by default skips writing a PID file (and
+# needs Type=simple); can use "-FF" here to create one anyway:
+ExecStart=@SBINDIR@/upsd -F
+ExecReload=@SBINDIR@/upsd -c reload -P $MAINPID
 
 [Install]
 WantedBy=nut.target

--- a/server/conf.c
+++ b/server/conf.c
@@ -333,6 +333,13 @@ void load_upsdconf(int reloading)
 		return;
 	}
 
+	if (reloading) {
+		/* if upsd.conf added or changed
+		 * (or commented away) the debug_min
+		 * setting, detect that */
+		nut_debug_level_global = -1;
+	}
+
 	while (pconf_file_next(&ctx)) {
 		if (pconf_parse_error(&ctx)) {
 			upslogx(LOG_ERR, "Parse error: %s:%d: %s",
@@ -357,6 +364,15 @@ void load_upsdconf(int reloading)
 			upslogx(LOG_WARNING, "%s", errmsg);
 		}
 
+	}
+
+	if (reloading) {
+		if (nut_debug_level_global > -1) {
+			upslogx(LOG_INFO,
+				"Applying debug_min=%d from upsd.conf",
+				nut_debug_level_global);
+			nut_debug_level = nut_debug_level_global;
+		}
 	}
 
 	pconf_finish(&ctx);

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -1173,6 +1173,7 @@ static void help(const char *arg_progname)
 	printf("		commands:\n");
 	printf("		 - reload: reread configuration files\n");
 	printf("		 - stop: stop process and exit\n");
+	printf("  -P <pid>	send the signal above to specified PID (bypassing PID file)\n");
 	printf("  -D		raise debugging level (and stay foreground by default)\n");
 	printf("  -F		stay foregrounded even if no debugging is enabled\n");
 	printf("  -B		stay backgrounded even if debugging is bumped\n");
@@ -1251,6 +1252,7 @@ int main(int argc, char **argv)
 	char	*chroot_path = NULL;
 	const char	*user = RUN_AS_USER;
 	struct passwd	*new_uid = NULL;
+	pid_t	oldpid = -1;
 
 	progname = xbasename(argv[0]);
 
@@ -1263,7 +1265,7 @@ int main(int argc, char **argv)
 
 	printf("Network UPS Tools %s %s\n", progname, UPS_VERSION);
 
-	while ((i = getopt(argc, argv, "+h46p:qr:i:fu:Vc:DFB")) != -1) {
+	while ((i = getopt(argc, argv, "+h46p:qr:i:fu:Vc:P:DFB")) != -1) {
 		switch (i) {
 			case 'p':
 			case 'i':
@@ -1301,6 +1303,11 @@ int main(int argc, char **argv)
 					help(progname);
 				break;
 
+			case 'P':
+				if ((oldpid = parsepid(optarg)) < 0)
+					help(progname);
+				break;
+
 			case 'D':
 				nut_debug_level++;
 				break;
@@ -1334,14 +1341,22 @@ int main(int argc, char **argv)
 	}
 
 	if (cmd) {
-		cmdret = sendsignalfn(pidfn, cmd);
+		if (oldpid < 0) {
+			cmdret = sendsignalfn(pidfn, cmd);
+		} else {
+			cmdret = sendsignalpid(oldpid, cmd);
+		}
 		exit((cmdret == 0)?EXIT_SUCCESS:EXIT_FAILURE);
 	}
 
 	/* otherwise, we are being asked to start.
 	 * so check if a previous instance is running by sending signal '0'
 	 * (Ie 'kill <pid> 0') */
-	cmdret = sendsignalfn(pidfn, 0);
+	if (oldpid < 0) {
+		cmdret = sendsignalfn(pidfn, 0);
+	} else {
+		cmdret = sendsignalpid(oldpid, 0);
+	}
 	switch (cmdret) {
 	case 0:
 		printf("Fatal error: A previous upsd instance is already running!\n");

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -1458,6 +1458,7 @@ int main(int argc, char **argv)
 		background();
 		writepid(pidfn);
 	} else {
+		upslogx(LOG_WARNING, "Running as foreground process, not saving a PID file");
 		memset(pidfn, 0, sizeof(pidfn));
 	}
 

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -1341,10 +1341,26 @@ int main(int argc, char **argv)
 	/* otherwise, we are being asked to start.
 	 * so check if a previous instance is running by sending signal '0'
 	 * (Ie 'kill <pid> 0') */
-	if (sendsignalfn(pidfn, 0) == 0) {
+	cmdret = sendsignalfn(pidfn, 0);
+	switch (cmdret) {
+	case 0:
 		printf("Fatal error: A previous upsd instance is already running!\n");
 		printf("Either stop the previous instance first, or use the 'reload' command.\n");
 		exit(EXIT_FAILURE);
+
+	case -3:
+	case -2:
+		upslogx(LOG_WARNING, "Could not %s PID file '%s' "
+			"to see if previous upsd instance is "
+			"already running!\n",
+			(cmdret == -3 ? "find" : "parse"),
+			pidfn);
+		break;
+
+	case -1:
+	default:
+		/* Just failed to send signal, no competitor running */
+		break;
 	}
 
 	argc -= optind;


### PR DESCRIPTION
This PR aims to address concerns from issues like #123 and #1299 and optionally allow service daemon lifecycle without a PID file, including sending of signals for `reload` and other operations. 

It adds two ways of addressing the original problems:
* Allow foreground-running mode to create PID file for upsd, by specifying `-F` argument twice (e.g. `upsd -FF`), so that service integrations, init-scripts, etc. that would switch to using a non-forking daemon can still manage it with a PID file
* Allow to specify `-P pidnum` argument on command line of `upsd` and `upsmon` to directly tell it the PID number of the process to signal, instead of reading the value from a PID file. This should play well with systemd units that can pass a `$MAINPID` variable and that is not ambiguous (`upsd`).

As part of the solution, it refactors `sendsignalfn()` into reusable pieces, adding `sendsignalpid()` and `parsepid()` methods.

It also addresses a cosmetic problem (reports of missing PID file during daemon start) where such file is probed to see if a previous instance of the daemon is running and so might conflict, and a missing file may be a problem or just means there is no competition. Logging should now be clearer about that, e.g.:
````
Feb 16 14:10:17 mirabox nut-server[24909]: fopen /var/state/ups/upsd.pid: No such file or directory
Feb 16 14:10:17 mirabox nut-server[24909]: Could not find PID file '/var/state/ups/upsd.pid' to see if previous upsd instance is already running!
````

Building on `debug_min` support from #683 this PR allows to change (comment/uncomment) the `debug_min NUMBER` setting in `upsd.conf` or `upsmon.conf` and `systemctl reload nut-server` or `systemctl reload nut-monitor` respectively, to tune debugging verbosity in the running service daemon (it is recommended to comment it away or set the minimum to explicit zero when done, to avoid huge journals and I/O system abuse). Note that for this run-time tuning, the `debug_min` value *present* in *reloaded* configuration files is applied instantly and overrides any previously set value, from file or CLI options, regardless of older logging level being higher or lower than the newly found number.

Note that this PR does not fully address questions from #123 about PID file (and "main PID" seen by systemd, for that matter) of `upsmon` which by default forks anyway into a privileged part that can shut down the system, and unprivileged child that is networked for monitoring etc. (the PID file remains that of the latter). It also does not address the location of this PID file (by default /var/run/upsmon.pid) questioned in #1297 since for the root-half of the daemon the concern is a moot point.