### PR TITLE
drivers/libhid.c: fix misfire of fightwarn commit 58e5b49…

### DIFF
--- a/drivers/libhid.c
+++ b/drivers/libhid.c
@@ -915,7 +915,8 @@ static int string_to_path(const char *string, HIDPath_t *path, usage_tables_t *u
 			continue;
 		} else {
 			/* hid_lookup_usage() logs for itself: ... -> not found in lookup table */
-			/*upsdebugx(5, "string_to_path: badvalue (usage): %ld negative", usage);*/
+			upsdebugx(5, "string_to_path: hid_lookup_usage failed, "
+				"checking if token %s is a raw value", token);
 		}
 
 		/* translate unnamed path components such as "ff860024" */


### PR DESCRIPTION
... (string_to_path(): range-check)

Closes: #1286

> The first block for usage table lookups with a `HIDNode_t` (`uint32_t` currently) processed as a `long` ended up as negative with `0xFnnnnnnn` numbers. Previously (2.7.4) the check was for `-1` specifically as an error for entry not found in the tables; my "fix" for `>=0` apparently misfired and chopped off half of the range for valid values. Fit this fix-back in place, after a few minutes of driver uptime, there is no alarm appearing anymore.

Big thanks to @nbriggs for a fresh look at the logs me and @toxic0berliner collected.