### PR TITLE
Introduce `synchronous=auto` as new default value for the driver setting

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -33,6 +33,16 @@ Release notes for NUT 2.7.5 - what's new since 2.7.4:
    for them to complete initializing. This matters on systems that monitor
    from dozens to hundreds of devices.
 
+ - Drivers support a new value for `synchronous` setting, which is the
+   new default now: `auto`.  Initially after driver start-up this mode
+   acts as the older default `off`, but would fall back to `on` in case
+   the driver fails to send reports to `upsd` by overflowing the socket
+   buffer in async mode -- so the next connections of this driver uptime
+   would be synchronized (potentially slower, but safer -- blocking on
+   writes to the data server).  This adaptation would primarily impact
+   and benefit devices with many (hundreds of) data points, such as
+   ePDUs and daisy chains. [issue #1309, PR #1315]
+
  - Daemons such as upsd, upsmon, upslog, and device drivers previously
    implied that enabled debugging (or upslog to stdout) means foreground
    running, otherwise the daemon was always sent to the background.

--- a/conf/ups.conf.sample
+++ b/conf/ups.conf.sample
@@ -110,7 +110,8 @@ maxretry = 3
 #                The default is 45 seconds.
 #
 # synchronous: optional.  The driver work by default in asynchronous
-#              mode (i.e *synchronous=no*).  This means that all data
+#              mode (like *no*) with fallback to synchronous if sending
+#              fails (i.e *synchronous=auto*).  This means that all data
 #              are pushed by the driver on the communication socket to
 #              upsd (Unix socket on Unix, Named pipe on Windows) without
 #              waiting for these data to be actually consumed.  With

--- a/docs/man/ups.conf.txt
+++ b/docs/man/ups.conf.txt
@@ -93,8 +93,9 @@ provided in the respective driver man pages.
 
 *synchronous*::
 
-Optional.  The driver work by default in asynchronous mode (i.e
-*synchronous=no*).  This means that all data are pushed by the driver
+Optional.  The drivers work by default in asynchronous mode initially
+but can fall back to synchronous mode if writes to server socket failed
+(i.e *synchronous=auto*).  This means that all data are pushed by the driver
 on the communication socket to upsd (Unix socket on Unix, Named pipe
 on Windows) without waiting for these data to be actually consumed.
 With some HW, such as ePDUs, that can produce a lot of data,
@@ -108,8 +109,11 @@ By enabling the 'synchronous' flag (value = 'yes'), the driver will wait
 for data to be consumed by upsd, prior to publishing more.  This can be
 enabled either globally or per driver.
 +
-The default is 'no' (i.e. asynchronous mode) for backward compatibility
-of the driver behavior.
+The default of 'auto' acts like 'no' (i.e. asynchronous mode) for backward
+compatibility of the driver behavior, until communications fail with a
+"Resource temporarily unavailable" condition, which happens when the
+driver has many data points to send in a burst, and the server can not
+handle that quickly enough so the buffer fills up.
 
 *user*::
 

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -214,7 +214,7 @@ static void send_to_all(const char *fmt, ...)
 
 		if ((ret < 1) || (ret != (ssize_t)buflen)) {
 			upsdebugx(1, "%s: write %zd bytes to socket %d failed "
-				"(ret=%zd): %s",
+				"(ret=%zd), disconnecting: %s",
 				__func__, buflen, conn->fd, ret, strerror(errno));
 			upsdebugx(6, "failed write: %s", buf);
 			sock_disconnect(conn);
@@ -265,7 +265,7 @@ static int send_to_one(conn_t *conn, const char *fmt, ...)
 
 	if ((ret < 1) || (ret != (ssize_t)buflen)) {
 		upsdebugx(1, "%s: write %zd bytes to socket %d failed "
-			"(ret=%zd): %s",
+			"(ret=%zd), disconnecting: %s",
 			__func__, buflen, conn->fd, ret, strerror(errno));
 		upsdebugx(6, "failed write: %s", buf);
 		sock_disconnect(conn);

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -261,7 +261,7 @@ static int send_to_one(conn_t *conn, const char *fmt, ...)
 	if (ret <= INT_MAX)
 		upsdebugx(5, "%s: %.*s", __func__, (int)(ret-1), buf);
 
-	ret = write(conn->fd, buf, strlen(buf));
+	ret = write(conn->fd, buf, buflen);
 
 	if ((ret < 1) || (ret != (ssize_t)buflen)) {
 		upsdebugx(1, "%s: write %zd bytes to socket %d failed "

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -213,8 +213,8 @@ static void send_to_all(const char *fmt, ...)
 		ret = write(conn->fd, buf, buflen);
 
 		if ((ret < 1) || (ret != (ssize_t)buflen)) {
-			upsdebugx(1, "%s: write %zd bytes to socket %d failed "
-				"(ret=%zd), disconnecting: %s",
+			upsdebugx(0, "WARNING: %s: write %zd bytes to "
+				"socket %d failed (ret=%zd), disconnecting: %s",
 				__func__, buflen, conn->fd, ret, strerror(errno));
 			upsdebugx(6, "failed write: %s", buf);
 			sock_disconnect(conn);
@@ -282,8 +282,8 @@ static int send_to_one(conn_t *conn, const char *fmt, ...)
 	}
 
 	if ((ret < 1) || (ret != (ssize_t)buflen)) {
-		upsdebugx(0, "%s: write %zd bytes to socket %d failed "
-			"(ret=%zd), disconnecting: %s",
+		upsdebugx(0, "WARNING: %s: write %zd bytes to "
+			"socket %d failed (ret=%zd), disconnecting: %s",
 			__func__, buflen, conn->fd, ret, strerror(errno));
 		upsdebugx(6, "failed write: %s", buf);
 		sock_disconnect(conn);

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -218,6 +218,17 @@ static void send_to_all(const char *fmt, ...)
 				__func__, buflen, conn->fd, ret, strerror(errno));
 			upsdebugx(6, "failed write: %s", buf);
 			sock_disconnect(conn);
+
+			/* TOTHINK: Maybe fallback elsewhere in other cases? */
+			if (ret < 0 && errno == EAGAIN && do_synchronous == -1) {
+				upsdebugx(0, "%s: synchronous mode was 'auto', "
+					"will try 'on' for next connections",
+					__func__);
+				do_synchronous = 1;
+			}
+
+			dstate_setinfo("driver.parameter.synchronous", "%s",
+				(do_synchronous==1)?"yes":((do_synchronous==0)?"no":"auto"));
 		} else {
 			upsdebugx(6, "%s: write %zd bytes to socket %d succeeded "
 				"(ret=%zd): %s",

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -218,6 +218,10 @@ static void send_to_all(const char *fmt, ...)
 				__func__, buflen, conn->fd, ret, strerror(errno));
 			upsdebugx(6, "failed write: %s", buf);
 			sock_disconnect(conn);
+		} else {
+			upsdebugx(6, "%s: write %zd bytes to socket %d succeeded "
+				"(ret=%zd): %s",
+				__func__, buflen, conn->fd, ret, buf);
 		}
 	}
 }
@@ -301,7 +305,7 @@ static int send_to_one(conn_t *conn, const char *fmt, ...)
 
 		return 0;	/* failed */
 	} else {
-		upsdebugx(1, "%s: write %zd bytes to socket %d succeeded "
+		upsdebugx(6, "%s: write %zd bytes to socket %d succeeded "
 			"(ret=%zd): %s",
 			__func__, buflen, conn->fd, ret, buf);
 	}

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -282,7 +282,7 @@ static int send_to_one(conn_t *conn, const char *fmt, ...)
 	}
 
 	if ((ret < 1) || (ret != (ssize_t)buflen)) {
-		upsdebugx(1, "%s: write %zd bytes to socket %d failed "
+		upsdebugx(0, "%s: write %zd bytes to socket %d failed "
 			"(ret=%zd), disconnecting: %s",
 			__func__, buflen, conn->fd, ret, strerror(errno));
 		upsdebugx(6, "failed write: %s", buf);

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -213,7 +213,10 @@ static void send_to_all(const char *fmt, ...)
 		ret = write(conn->fd, buf, buflen);
 
 		if ((ret < 1) || (ret != (ssize_t)buflen)) {
-			upsdebugx(1, "write %zd bytes to socket %d failed", buflen, conn->fd);
+			upsdebugx(1, "%s: write %zd bytes to socket %d failed "
+				"(ret=%zd): %s",
+				__func__, buflen, conn->fd, ret, strerror(errno));
+			upsdebugx(6, "failed write: %s", buf);
 			sock_disconnect(conn);
 		}
 	}
@@ -261,7 +264,10 @@ static int send_to_one(conn_t *conn, const char *fmt, ...)
 	ret = write(conn->fd, buf, strlen(buf));
 
 	if ((ret < 1) || (ret != (ssize_t)buflen)) {
-		upsdebugx(1, "write %zd bytes to socket %d failed", buflen, conn->fd);
+		upsdebugx(1, "%s: write %zd bytes to socket %d failed "
+			"(ret=%zd): %s",
+			__func__, buflen, conn->fd, ret, strerror(errno));
+		upsdebugx(6, "failed write: %s", buf);
 		sock_disconnect(conn);
 		return 0;	/* failed */
 	}

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -43,8 +43,9 @@ int	extrafd = -1;
 /* for ser_open */
 int	do_lock_port = 1;
 
-/* for dstate->sock_connect, default to asynchronous */
-int	do_synchronous = 0;
+/* for dstate->sock_connect, default to effectively
+ * asynchronous (0) with fallback to synchronous (1) */
+int	do_synchronous = -1;
 
 /* for detecting -a values that don't match anything */
 static	int	upsname_found = 0;
@@ -379,6 +380,9 @@ static int main_arg(char *var, char *val)
 		if (!strcmp(val, "yes"))
 			do_synchronous=1;
 		else
+		if (!strcmp(val, "auto"))
+			do_synchronous=-1;
+		else
 			do_synchronous=0;
 
 		return 1;	/* handled */
@@ -461,6 +465,9 @@ static void do_global_args(const char *var, const char *val)
 	if (!strcmp(var, "synchronous")) {
 		if (!strcmp(val, "yes"))
 			do_synchronous=1;
+		else
+		if (!strcmp(val, "auto"))
+			do_synchronous=-1;
 		else
 			do_synchronous=0;
 	}
@@ -1013,7 +1020,7 @@ int main(int argc, char **argv)
 
 	/* The synchronous option may have been changed from the default */
 	dstate_setinfo("driver.parameter.synchronous", "%s",
-		(do_synchronous==1)?"yes":"no");
+		(do_synchronous==1)?"yes":((do_synchronous==0)?"no":"auto"));
 
 	/* remap the device.* info from ups.* for the transition period */
 	if (dstate_getinfo("ups.mfr") != NULL)

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -2920,6 +2920,13 @@ bool_t snmp_ups_walk(int mode)
 			 * with a consideration for directly-addressable
 			 * slave devices (can be seen in chain via master,
 			 * but also queryable alone with an IP connection)
+			 * NOTE: until proven otherwise, "single" may mean
+			 * both (either) a daisy-chain enabled master device
+			 * without further connected "slave" devices, and
+			 * a directly addressable (IP-connected) "slave".
+			 * Possibly also an ePDU etc. that serves a MIB
+			 * which resolves "device.count" with the selected
+			 * subdriver.
 			 */
 			if (daisychain_enabled == TRUE) {
 				upsdebugx(1, "%s: processing daisy-chain device %i (%s)",

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -2924,6 +2924,9 @@ bool_t snmp_ups_walk(int mode)
 						? (devices_count > 1 ? "master" : "single")
 						: (current_device_number > 1 ? "slave" : "whole")
 					);
+			} else {
+				upsdebugx(1, "%s: processing unitary device (%i)",
+					__func__, current_device_number);
 			}
 
 			/* Check if we are asked to stop (reactivity++) */

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -273,9 +273,11 @@ void upsdrv_updateinfo(void)
 
 		/* update all dynamic info fields */
 		if (snmp_ups_walk(SU_WALKMODE_UPDATE)) {
+			upsdebugx(1, "%s: pollfreq: Data OK", __func__);
 			dstate_dataok();
 		}
 		else {
+			upsdebugx(1, "%s: pollfreq: Data STALE", __func__);
 			dstate_datastale();
 		}
 

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -2933,7 +2933,7 @@ bool_t snmp_ups_walk(int mode)
  * then we'd skip it still (unitary device is at current_device_number == 1)...
  */
 			/* skip the whole-daisychain for now */
-			if (current_device_number == 0) {
+			if (daisychain_enabled == TRUE && current_device_number == 0) {
 				upsdebugx(1, "Skipping daisychain device.0 for now...");
 				continue;
 			}

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -2893,7 +2893,8 @@ bool_t snmp_ups_walk(int mode)
 		current_device_number <= devices_count; current_device_number++)
 	{
 
-		upsdebugx(0, "%s: walking device.%d", __func__, current_device_number);
+		upsdebugx(1, "%s: walking device %d",
+			__func__, current_device_number);
 
 		/* reinit the alarm buffer, before */
 		if (devices_count > 1)

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -2889,8 +2889,12 @@ bool_t snmp_ups_walk(int mode)
 	 * for the whole (#0) virtual device, so it *seems* similar to unitary.
 	 */
 
-	for (current_device_number = 0 ; current_device_number <= devices_count ; current_device_number++)
+	for (current_device_number = (daisychain_enabled == FALSE && devices_count == 1 ? 1 : 0) ;
+		current_device_number <= devices_count; current_device_number++)
 	{
+
+		upsdebugx(0, "%s: walking device.%d", __func__, current_device_number);
+
 		/* reinit the alarm buffer, before */
 		if (devices_count > 1)
 			device_alarm_init();
@@ -2949,12 +2953,8 @@ bool_t snmp_ups_walk(int mode)
  * then we'd skip it still (unitary device is at current_device_number == 1)...
  */
 			/* skip the whole-daisychain for now */
-			if (current_device_number == 0) {
-				/* for a standalone device, we walk <= device_count
-				 * above, so hitting both .0 and .1 queries
-				 */
-				if (daisychain_enabled == TRUE)
-					upsdebugx(1, "Skipping daisychain device.0 for now...");
+			if (current_device_number == 0 && daisychain_enabled == TRUE) {
+				upsdebugx(1, "Skipping daisychain device.0 for now...");
 				continue;
 			}
 

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -5,7 +5,7 @@
  *  Copyright (C)
  *	2002 - 2014	Arnaud Quette <arnaud.quette@free.fr>
  *	2015 - 2021	Eaton (author: Arnaud Quette <ArnaudQuette@Eaton.com>)
- *	2016 - 2021	Eaton (author: Jim Klimov <EvgenyKlimov@Eaton.com>)
+ *	2016 - 2022	Eaton (author: Jim Klimov <EvgenyKlimov@Eaton.com>)
  *	2002 - 2006	Dmitry Frolov <frolov@riss-telecom.ru>
  *			J.W. Hoogervorst <jeroen@hoogervorst.net>
  *			Niels Baggesen <niels@baggesen.net>
@@ -2894,16 +2894,23 @@ bool_t snmp_ups_walk(int mode)
 		/* Loop through all mapping entries for the current_device_number */
 		for (su_info_p = &snmp_info[0]; (su_info_p != NULL && su_info_p->info_type != NULL) ; su_info_p++) {
 
-			/* FIXME:
+			/* NOTE: Effectively below we do this:
 			 * switch(current_device_number) {
-			 * case 0: devtype = "daisychain whole"
-			 * case 1: devtype = "daisychain master"
-			 * default: devtype = "daisychain slave"
+			 *  case 0: devtype = "daisychain whole"
+			 *  case 1: devtype = "daisychain master"
+			 *  default: devtype = "daisychain slave"
+			 * }
+			 * with a consideration for directly-addressable
+			 * slave devices (can be seen in chain via master,
+			 * but also queryable alone with an IP connection)
 			 */
 			if (daisychain_enabled == TRUE) {
-				upsdebugx(1, "%s: processing device %i (%s)", __func__,
-					current_device_number,
-					(current_device_number == 1)?"master":"slave"); /* FIXME: daisychain */
+				upsdebugx(1, "%s: processing daisy-chain device %i (%s)",
+					__func__, current_device_number,
+					(current_device_number == 1)
+						? (devices_count > 1 ? "master" : "single")
+						: (current_device_number > 1 ? "slave" : "whole")
+					);
 			}
 
 			/* Check if we are asked to stop (reactivity++) */

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -2946,8 +2946,12 @@ bool_t snmp_ups_walk(int mode)
  * then we'd skip it still (unitary device is at current_device_number == 1)...
  */
 			/* skip the whole-daisychain for now */
-			if (daisychain_enabled == TRUE && current_device_number == 0) {
-				upsdebugx(1, "Skipping daisychain device.0 for now...");
+			if (current_device_number == 0) {
+				/* for a standalone device, we walk <= device_count
+				 * above, so hitting both .0 and .1 queries
+				 */
+				if (daisychain_enabled == TRUE)
+					upsdebugx(1, "Skipping daisychain device.0 for now...");
 				continue;
 			}
 

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -135,10 +135,23 @@ int g_pwr_battery;
 int pollfreq; /* polling frequency */
 static int quirk_symmetra_threephase = 0;
 
-/* Number of device(s): standard is "1", but daisychain means more than 1 */
+/* Number of device(s): standard is "1", but talking
+ * to a daisychain (master device) means more than 1
+ * (a directly addressable member of a daisy chain
+ * would be seen as a single-device chain though)
+ */
 static long devices_count = 1;
-static int current_device_number = 0;      /* global var to handle daisychain iterations - changed by loops in snmp_ups_walk() and su_addcmd(); may be 0 for addressing certain values across all chain devices via master (1) */
-static bool_t daisychain_enabled = FALSE;  /* global var to handle daisychain iterations */
+/* global var to handle daisychain iterations -
+ * changed by loops in snmp_ups_walk() and su_addcmd();
+ * may be 0 for addressing certain values/commands
+ * across all chain devices via master (1);
+ * also may be 0 for non-daisychained devices
+ */
+static int current_device_number = 0;
+/* global var to handle daisychain iterations -
+ * made TRUE if we resolved a "device.count" value
+ */
+static bool_t daisychain_enabled = FALSE;
 static daisychain_info_t **daisychain_info = NULL;
 
 /* pointer to the Snmp2Nut lookup table */

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -137,7 +137,7 @@ static int quirk_symmetra_threephase = 0;
 
 /* Number of device(s): standard is "1", but daisychain means more than 1 */
 static long devices_count = 1;
-static int current_device_number = 0;      /* global var to handle daisychain iterations - changed by loops in snmp_ups_walk() and su_addcmd() */
+static int current_device_number = 0;      /* global var to handle daisychain iterations - changed by loops in snmp_ups_walk() and su_addcmd(); may be 0 for addressing certain values across all chain devices via master (1) */
 static bool_t daisychain_enabled = FALSE;  /* global var to handle daisychain iterations */
 static daisychain_info_t **daisychain_info = NULL;
 

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -2095,7 +2095,8 @@ static bool_t is_multiple_template(const char *OID_template)
  * Note: remember to adapt info_type, OID and optionaly dfl */
 static snmp_info_t *instantiate_info(snmp_info_t *info_template, snmp_info_t *new_instance)
 {
-	upsdebugx(1, "%s(%s)", __func__, info_template ? info_template->info_type : "n/a");
+	upsdebugx(1, "%s(%s)", __func__,
+		info_template ? info_template->info_type : "n/a");
 
 	/* sanity check */
 	if (info_template == NULL)
@@ -2103,6 +2104,8 @@ static snmp_info_t *instantiate_info(snmp_info_t *info_template, snmp_info_t *ne
 
 	if (new_instance == NULL)
 		new_instance = (snmp_info_t *)xmalloc(sizeof(snmp_info_t));
+	/* TOTHINK: Should there be an "else" to free()
+	 * the fields which we (re-)allocate below? */
 
 	new_instance->info_type = (char *)xmalloc(SU_INFOSIZE);
 	if (new_instance->info_type)
@@ -2112,8 +2115,10 @@ static snmp_info_t *instantiate_info(snmp_info_t *info_template, snmp_info_t *ne
 		if (new_instance->OID)
 			memset((char *)new_instance->OID, 0, SU_INFOSIZE);
 	}
-	else
+	else {
 		new_instance->OID = NULL;
+	}
+
 	new_instance->info_flags = info_template->info_flags;
 	new_instance->info_len = info_template->info_len;
 	/* FIXME: check if we need to adapt this one... */
@@ -2558,7 +2563,8 @@ bool_t get_and_process_data(int mode, snmp_info_t *su_info_p)
 {
 	bool_t status = FALSE;
 
-	upsdebugx(1, "%s: %s (%s)", __func__, su_info_p->info_type, su_info_p->OID);
+	upsdebugx(1, "%s: %s (%s)", __func__,
+		su_info_p->info_type, su_info_p->OID);
 
 	/* ok, update this element. */
 	status = su_ups_get(su_info_p);
@@ -3084,7 +3090,9 @@ bool_t su_ups_get(snmp_info_t *su_info_p)
 
 			/* adapt info_type */
 			if (su_info_p->info_type != NULL) {
-				snprintf((char *)tmp_info_p->info_type, SU_INFOSIZE, "%s", su_info_p->info_type);
+				snprintf((char *)tmp_info_p->info_type,
+					SU_INFOSIZE, "%s",
+					su_info_p->info_type);
 			}
 			else {
 				free_info(tmp_info_p);
@@ -3221,7 +3229,8 @@ bool_t su_ups_get(snmp_info_t *su_info_p)
 	}
 
 	if (su_info_p->info_flags & ST_FLAG_STRING) {
-		status = nut_snmp_get_str(su_info_p->OID, buf, sizeof(buf), su_info_p->oid2info);
+		status = nut_snmp_get_str(su_info_p->OID, buf,
+			sizeof(buf), su_info_p->oid2info);
 		if (status == TRUE) {
 			if (quirk_symmetra_threephase) {
 				if (!strcasecmp(su_info_p->info_type, "input.transfer.low")
@@ -3273,8 +3282,9 @@ bool_t su_ups_get(snmp_info_t *su_info_p)
 		su_setinfo(su_info_p, buf);
 		upsdebugx(2, "=> value: %s", buf);
 	}
-	else
+	else {
 		upsdebugx(2, "=> Failed");
+	}
 
 	free_info(tmp_info_p);
 	return status;

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -669,6 +669,9 @@ static void driver_free(void)
 	upstype_t	*ups, *unext;
 
 	for (ups = firstups; ups; ups = unext) {
+		upsdebugx(1, "%s: forgetting UPS [%s] (FD %d)",
+			__func__, ups->name, ups->sock_fd);
+
 		unext = ups->next;
 
 		if (ups->sock_fd != -1) {
@@ -985,7 +988,11 @@ static void mainloop(void)
 
 		/* see if we need to (re)connect to the socket */
 		if (ups->sock_fd < 0) {
+			upsdebugx(1, "%s: UPS [%s] is not currently connected",
+				__func__, ups->name);
 			ups->sock_fd = sstate_connect(ups);
+			upsdebugx(1, "%s: UPS [%s] is now connected as FD %d",
+				__func__, ups->name, ups->sock_fd);
 			continue;
 		}
 


### PR DESCRIPTION
Closes: #1309

Also
Closes: #1314 (to not snmpwalk an "unitary" device twice)

Some commits picked from #320

While the issue was discovered with snmp-ups driver, the problem after analysis seems to generally impact drivers with many data points, depending on performance and competing workload of the machines running the drivers and data server. I suspect this may be why reports with particularly Raspberry Pi, especially of older revisions, were prominent in the recent years of issue tracking.
