### PR TITLE
Cast to unsigned type when interpreting HID descriptor length bytes (libusb 0.1)

### DIFF
--- a/drivers/libusb0.c
+++ b/drivers/libusb0.c
@@ -377,7 +377,7 @@ static int libusb_open(usb_dev_handle **udevp,
 
 				upsdebug_hex(3, "HID descriptor, method 1", buf, 9);
 
-				rdlen1 = buf[7] | (buf[8] << 8);
+				rdlen1 = (uint8_t)buf[7] | ((uint8_t)buf[8] << 8);
 			}
 
 			if (rdlen1 < -1) {
@@ -407,7 +407,7 @@ static int libusb_open(usb_dev_handle **udevp,
 				) {
 					p = (usb_ctrl_char *)&iface->extra[i];
 					upsdebug_hex(3, "HID descriptor, method 2", p, 9);
-					rdlen2 = p[7] | (p[8] << 8);
+					rdlen2 = (uint8_t)p[7] | ((uint8_t)p[8] << 8);
 					break;
 				}
 			}


### PR DESCRIPTION


The libusb 0.1 interface definition declares a (signed) char type for
control messages.  The HID descriptor length contained within a control
message is intended to be interpreted as a pair of unsigned bytes so
we must cast to uint8_t when doing the arithmetic rather than trip over
the sign bit.

Closes #1261, closes #1312.
