### PR TITLE
LibUSB related code - revise for bit-maths with signed char

### DIFF
--- a/drivers/blazer_usb.c
+++ b/drivers/blazer_usb.c
@@ -684,7 +684,7 @@ void upsdrv_initups(void)
 		 * This should allow automatic application of the workaround */
 		ret = usb_get_string(udev, 0, 0, (usb_ctrl_charbuf)tbuf, sizeof(tbuf));
 		if (ret >= 4) {
-			langid = tbuf[2] | (tbuf[3] << 8);
+			langid = (unsigned char)tbuf[2] | ((unsigned char)tbuf[3] << 8);
 			upsdebugx(1, "First supported language ID: 0x%x (please report to the NUT maintainer!)", langid);
 		}
 	}

--- a/drivers/libshut.c
+++ b/drivers/libshut.c
@@ -334,7 +334,7 @@ static int shut_control_msg(
 
 /* Data portability */
 /* realign packet data according to Endianess */
-#define BYTESWAP(in) (((in & 0xFF) << 8) + ((in & 0xFF00) >> 8))
+#define BYTESWAP(in) ((((uint16_t)in & 0x00FF) << 8) + (((uint16_t)in & 0xFF00) >> 8))
 static void align_request(struct shut_ctrltransfer_s *ctrl)
 {
 #if (defined (WORDS_BIGENDIAN)) && (WORDS_BIGENDIAN)

--- a/drivers/libshut.c
+++ b/drivers/libshut.c
@@ -893,7 +893,7 @@ static unsigned char shut_checksum(
 	unsigned char chk=0;
 
 	for(i=0; i<bufsize; i++)
-		chk^=buf[i];
+		chk ^= (unsigned char)buf[i];
 
 	upsdebugx (4, "shut_checksum: %02x", chk);
 	return chk;

--- a/drivers/libusb0.c
+++ b/drivers/libusb0.c
@@ -377,7 +377,7 @@ static int libusb_open(usb_dev_handle **udevp,
 
 				upsdebug_hex(3, "HID descriptor, method 1", buf, 9);
 
-				rdlen1 = (uint8_t)buf[7] | ((uint8_t)buf[8] << 8);
+				rdlen1 = ((uint16_t)buf[7] & 0x00FF) | (((uint16_t)buf[8] & 0x00FF) << 8);
 			}
 
 			if (rdlen1 < -1) {
@@ -407,7 +407,7 @@ static int libusb_open(usb_dev_handle **udevp,
 				) {
 					p = (usb_ctrl_char *)&iface->extra[i];
 					upsdebug_hex(3, "HID descriptor, method 2", p, 9);
-					rdlen2 = (uint8_t)p[7] | ((uint8_t)p[8] << 8);
+					rdlen2 = ((uint16_t)p[7] & 0x00FF) | (((uint16_t)p[8] & 0x00FF) << 8);
 					break;
 				}
 			}

--- a/drivers/libusb0.c
+++ b/drivers/libusb0.c
@@ -377,7 +377,7 @@ static int libusb_open(usb_dev_handle **udevp,
 
 				upsdebug_hex(3, "HID descriptor, method 1", buf, 9);
 
-				rdlen1 = ((uint16_t)buf[7] & 0x00FF) | (((uint16_t)buf[8] & 0x00FF) << 8);
+				rdlen1 = ((uint8_t)buf[7]) | (((uint8_t)buf[8]) << 8);
 			}
 
 			if (rdlen1 < -1) {
@@ -407,7 +407,7 @@ static int libusb_open(usb_dev_handle **udevp,
 				) {
 					p = (usb_ctrl_char *)&iface->extra[i];
 					upsdebug_hex(3, "HID descriptor, method 2", p, 9);
-					rdlen2 = ((uint16_t)p[7] & 0x00FF) | (((uint16_t)p[8] & 0x00FF) << 8);
+					rdlen2 = ((uint8_t)p[7]) | (((uint8_t)p[8]) << 8);
 					break;
 				}
 			}

--- a/drivers/libusb1.c
+++ b/drivers/libusb1.c
@@ -141,7 +141,9 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 #if (defined HAVE_LIBUSB_DETACH_KERNEL_DRIVER) || (defined HAVE_LIBUSB_DETACH_KERNEL_DRIVER_NP)
 	int retries;
 #endif
-	int rdlen1, rdlen2; /* report descriptor length, method 1+2 */
+	/* libusb-1.0 usb_ctrl_charbufsize is uint16_t and we
+	 * want the rdlen vars signed - so taking a wider type */
+	int32_t rdlen1, rdlen2; /* report descriptor length, method 1+2 */
 	USBDeviceMatcher_t *m;
 	libusb_device **devlist;
 	ssize_t	devcount = 0;
@@ -159,7 +161,7 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 
 	/* report descriptor */
 	unsigned char	rdbuf[MAX_REPORT_SIZE];
-	int		rdlen;
+	int32_t		rdlen;
 
 	/* libusb base init */
 	if (libusb_init(NULL) < 0) {
@@ -425,7 +427,7 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 
 			upsdebug_hex(3, "HID descriptor, method 1", buf, 9);
 
-			rdlen1 = buf[7] | (buf[8] << 8);
+			rdlen1 = ((uint16_t)buf[7] & 0x00FF) | (((uint16_t)buf[8] & 0x00FF) << 8);
 		}
 
 		if (rdlen1 < -1) {
@@ -450,7 +452,7 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 			if (i+9 <= if_desc->extra_length && if_desc->extra[i] >= 9 && if_desc->extra[i+1] == 0x21) {
 				p = &if_desc->extra[i];
 				upsdebug_hex(3, "HID descriptor, method 2", p, 9);
-				rdlen2 = p[7] | (p[8] << 8);
+				rdlen2 = ((uint16_t)p[7] & 0x00FF) | (((uint16_t)p[8] & 0x00FF) << 8);
 				break;
 			}
 		}

--- a/drivers/libusb1.c
+++ b/drivers/libusb1.c
@@ -427,7 +427,7 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 
 			upsdebug_hex(3, "HID descriptor, method 1", buf, 9);
 
-			rdlen1 = ((uint16_t)buf[7] & 0x00FF) | (((uint16_t)buf[8] & 0x00FF) << 8);
+			rdlen1 = ((uint8_t)buf[7]) | (((uint8_t)buf[8]) << 8);
 		}
 
 		if (rdlen1 < -1) {
@@ -452,7 +452,7 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 			if (i+9 <= if_desc->extra_length && if_desc->extra[i] >= 9 && if_desc->extra[i+1] == 0x21) {
 				p = &if_desc->extra[i];
 				upsdebug_hex(3, "HID descriptor, method 2", p, 9);
-				rdlen2 = ((uint16_t)p[7] & 0x00FF) | (((uint16_t)p[8] & 0x00FF) << 8);
+				rdlen2 = ((uint8_t)p[7]) | (((uint8_t)p[8]) << 8);
 				break;
 			}
 		}

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -3058,7 +3058,7 @@ void	upsdrv_initups(void)
 			ret = usb_get_string(udev, 0, 0,
 				(usb_ctrl_charbuf)tbuf, sizeof(tbuf));
 			if (ret >= 4) {
-				langid = tbuf[2] | (tbuf[3] << 8);
+				langid = ((uint16_t)tbuf[2] & 0x00FF) | (((uint16_t)tbuf[3] & 0x00FF) << 8);
 				upsdebugx(1,
 					"First supported language ID: 0x%x "
 					"(please report to the NUT maintainer!)",

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -3058,7 +3058,7 @@ void	upsdrv_initups(void)
 			ret = usb_get_string(udev, 0, 0,
 				(usb_ctrl_charbuf)tbuf, sizeof(tbuf));
 			if (ret >= 4) {
-				langid = ((uint16_t)tbuf[2] & 0x00FF) | (((uint16_t)tbuf[3] & 0x00FF) << 8);
+				langid = ((uint8_t)tbuf[2]) | (((uint8_t)tbuf[3]) << 8);
 				upsdebugx(1,
 					"First supported language ID: 0x%x "
 					"(please report to the NUT maintainer!)",

--- a/drivers/riello_usb.c
+++ b/drivers/riello_usb.c
@@ -95,9 +95,9 @@ static int cypress_setfeatures()
 
 	/* Write features report */
 	ret = usb_control_msg(udev, USB_ENDPOINT_OUT + USB_TYPE_CLASS + USB_RECIP_INTERFACE,
-								0x09,						/* HID_REPORT_SET = 0x09 */
-								0 + (0x03 << 8),		/* HID_REPORT_TYPE_FEATURE */
-								0, (usb_ctrl_charbuf) bufOut, 0x5, 1000);
+		0x09,				/* HID_REPORT_SET = 0x09 */
+		0 + (0x03 << 8),		/* HID_REPORT_TYPE_FEATURE */
+		0, (usb_ctrl_charbuf) bufOut, 0x5, 1000);
 
 	if (ret <= 0) {
 		upsdebugx(3, "send: %s", ret ? nut_usb_strerror(ret) : "error");

--- a/drivers/riello_usb.c
+++ b/drivers/riello_usb.c
@@ -197,7 +197,7 @@ static int Get_USB_Packet(uint8_t *buffer)
 	}
 
 	/* copy to buffer */
-	size = inBuf[0] & 0x07;
+	size = (unsigned char)(inBuf[0]) & 0x07;
 	if (size)
 		memcpy(buffer, &inBuf[1], size);
 

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -743,10 +743,11 @@ static int soft_shutdown(void)
 static int hard_shutdown(void)
 {
 	int ret;
-	char buf[256], cmd_N[]="N\0x", cmd_K[] = "K\0";
+	unsigned char buf[256], cmd_N[]="N\0x", cmd_K[] = "K\0";
 
-	cmd_N[2] = offdelay;
-	cmd_N[1] = offdelay >> 8;
+	/* FIXME: Assumes memory layout / endianness? */
+	cmd_N[2] = (unsigned char)(offdelay & 0x00FF);
+	cmd_N[1] = (unsigned char)(offdelay >> 8);
 	upsdebugx(3, "hard_shutdown(offdelay=%d): N", offdelay);
 
 	ret = send_cmd(cmd_N, sizeof(cmd_N), buf, sizeof(buf));


### PR DESCRIPTION
As recently found, the chosen approach with conversion to "typedef'ed" support of libusb/libhid/libshut/... codebases and respective APIs, including the buffer-passing that ultimately evaluated to arrays of signed or unsigned chars, had backfired a bit in cases where code did some maths (and bit maths) with individual bytes of those buffers.

As @nbriggs suggested, I went over the codebase looking for files that contain `usb_ctrl_char` string and further for operations in them that matched regex `(>>|<<|[^&~|^][&^|~][= (0-9A-Za-z])` and in fact there were not many places that looked doubtful, PR #1320 caught almost all of them which seemed significant :)

Building and testing in practice with various architectures (32/64-bit, x86, SPARC, ARM...) would be very useful I guess, to be more sure about quality of pending NUT release.