### PR TITLE
[Issue #840] Protocol update for "PRIMARY" command (alias to deprecated "MASTER")

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -290,11 +290,25 @@ Release notes for NUT 2.8.0 - what's new since 2.7.4:
       ISO 8601 Calendar date "YYYY-MM-DD" was added to snmp-ups.c [PR #1078]
 
  - Master/Slave terminology was deprecated in favor of Primary/Secondary
-   modes of upsmon client. Respective keywords in the configuration are
-   supported as backwards-compatible settings, but obsoleted values are
-   no longer documented. [For details see issue #840 and several pull
-   requests referenced from it, and discussions on NUT mailing lists]
-   * Note: protocol keyword support currently was not updated
+   modes of `upsmon` client:
+   * Respective keywords in the configuration files (`upsd.users` and
+     `upsmon.conf`) are supported as backwards-compatible settings,
+     but the obsoleted values are no longer documented.
+   * Protocol keyword support was similarly updated, with `upsmon` now
+     first trying to elevate privileges with `PRIMARY <ups>` request,
+     and falling back to `MASTER <ups>` just in case it talks to an
+     older build of an `upsd` server.
+   * For the principle of least surprise, NUT codebase still exposes the
+     `net_master()` (as handler for `MASTER` net command) in header and
+     C code for the sake of existing linked binaries, and returns the
+     `OK MASTER-GRANTED` line to the older client that invoked it.
+   * Newly introduced `net_primary()` (as handler for `PRIMARY` net command)
+     calls the exact same application logic, but returns `OK PRIMARY-GRANTED`
+     line to the client.
+   * Python binding updated to handle both cases, as the only found in-tree
+     protocol consumer of the full-line text.
+   * For more details see issue #840 and several pull requests referenced
+     from it, and discussions on NUT mailing lists.
 
  - Build fixes:
    * In general, numerous fixes were applied to ensure portability and avoid

--- a/NEWS
+++ b/NEWS
@@ -5,7 +5,12 @@ ChangeLog file (generated for release archives), or to the Git version
 control history for "live" codebase.
 
 ---------------------------------------------------------------------------
-Release notes for NUT 2.7.5 - what's new since 2.7.4:
+Release notes for NUT 2.8.0 - what's new since 2.7.4:
+
+ - New (optional) keywords for configuration files were added,
+   so existing NUT 2.7.x builds would not accept them if some
+   deployments switch versions back and forth -- due to this,
+   semantically the version was bumped to NUT 2.8.x.
 
  - Add support for openssl-1.1.0 (Arjen de Korte)
 

--- a/UPGRADING
+++ b/UPGRADING
@@ -7,7 +7,7 @@ This file lists changes that affect users who installed older versions
 of this software.  When upgrading from an older version, be sure to
 check this file to see if you need to make changes to your system.
 
-Changes from 2.7.4 to 2.7.5
+Changes from 2.7.4 to 2.8.0
 ---------------------------
 
 - Note to distribution packagers: this version hopefully learns from many

--- a/docs/net-protocol.txt
+++ b/docs/net-protocol.txt
@@ -489,8 +489,11 @@ NOTE: You probably shouldn't send this command unless you are upsmon,
 or a upsmon replacement.
 
 
-MASTER
-------
+PRIMARY (since NUT 2.8.0) or MASTER (deprecated)
+------------------------------------------------
+
+NOTE: This command was renamed in NUT 2.8.0 to "PRIMARY" with the older
+name "MASTER" kept as deprecated alias for compatibility.
 
 Form:
 
@@ -498,18 +501,25 @@ Form:
 
 Response:
 
-	OK	(upon success)
+	OK MASTER-GRANTED	(upon success)
+
+Form:
+
+	PRIMARY <upsname>
+
+Response:
+
+	OK PRIMARY-GRANTED	(upon success)
 
 or <<np-errors,various errors>>
 
 NOTE: This requires "upsmon primary" in upsd.users
 
+NOTE: Previously documented response was just `OK` -- clients checking
+that server reply *starts with* that keyword would handle all cases.
+
 This function doesn't do much by itself.  It is used by upsmon to make
 sure that primary-mode functions like FSD are available if necessary.
-
-NOTE: This command will be eventually renamed to "PRIMARY" with the older
-name "MASTER" kept as deprecated alias for compatibility; a protocol bump
-or special backwards-compatibility handling may be needed for that however.
 
 
 FSD

--- a/scripts/python/module/PyNUT.py.in
+++ b/scripts/python/module/PyNUT.py.in
@@ -272,17 +272,22 @@ Returns OK on success or raises an error
 
 Returns OK on success or raises an error
 
-TODO: API change pending to replace MASTER with PRIMARY
+NOTE: API changed since NUT 2.8.0 to replace MASTER with PRIMARY
 (and backwards-compatible alias handling)
         """
 
         if self.__debug :
-            print( "[DEBUG] MASTER called..." )
+            print( "[DEBUG] "PRIMARY called..." )
 
-        self.__srv_handler.write( ("MASTER %s\n" % ups).encode('ascii') )
+        self.__srv_handler.write( ("PRIMARY %s\n" % ups).encode('ascii') )
         result = self.__srv_handler.read_until( b"\n" )
-        if ( result != b"OK MASTER-GRANTED\n" ) :
-            raise PyNUTError( ( "Master level function are not available", "" ) )
+        if ( result != b"OK PRIMARY-GRANTED\n" ) :
+            if self.__debug :
+                print( "[DEBUG] Retrying: "MASTER called..." )
+            self.__srv_handler.write( ("MASTER %s\n" % ups).encode('ascii') )
+            result = self.__srv_handler.read_until( b"\n" )
+            if ( result != b"OK MASTER-GRANTED\n" ) :
+                raise PyNUTError( ( "Primary level functions are not available", "" ) )
 
         if self.__debug :
             print( "[DEBUG] FSD called..." )

--- a/server/netcmds.h
+++ b/server/netcmds.h
@@ -61,9 +61,10 @@ static struct {
 
 	{ "LOGIN",	net_login,	FLAG_USER	},
 	{ "LOGOUT", 	net_logout,	0		},
-	/* FIXME: Protocol update needed to handle master/primary alias
-	 * and probably an API bump also, to rename/alias the routine.
+	/* NOTE: Protocol in NUT 2.8.0 allows to handle
+	 * master/primary to rename/alias the routine.
 	 */
+	{ "PRIMARY",	net_primary,	FLAG_USER	},
 	{ "MASTER",	net_master,	FLAG_USER	},
 
 	{ "FSD",	net_fsd,	FLAG_USER	},

--- a/server/netuser.c
+++ b/server/netuser.c
@@ -115,7 +115,6 @@ static int do_net_primary(nut_ctype_t *client, size_t numarg, const char **arg)
 	/* this is just an access level check */
 	/* sendback() will be worded by caller below */
 	return 0;
-	sendback(client, "OK PRIMARY-GRANTED\n");
 }
 
 /* MASTER <upsname> (deprecated) */
@@ -128,6 +127,7 @@ void net_master(nut_ctype_t *client, size_t numarg, const char **arg) {
 		"since NUT 2.8.0",
 		client->username, client->addr,
 		(numarg > 0) ? arg[0] : "<null>");
+
 	if (0 == do_net_primary(client, numarg, arg)) {
 		sendback(client, "OK MASTER-GRANTED\n");
 	}

--- a/server/netuser.c
+++ b/server/netuser.c
@@ -53,6 +53,8 @@ void net_login(nut_ctype_t *client, size_t numarg, const char **arg)
 
 	/* make sure this is a valid user */
 	if (!user_checkaction(client->username, client->password, "LOGIN")) {
+		upsdebugx(3, "%s: not a valid user: %s",
+			__func__, client->username);
 		send_err(client, NUT_ERR_ACCESS_DENIED);
 		return;
 	}

--- a/server/netuser.c
+++ b/server/netuser.c
@@ -85,34 +85,54 @@ void net_logout(nut_ctype_t *client, size_t numarg, const char **arg)
 	client->last_heard = 0;
 }
 
-/* MASTER <upsname> */
-/* FIXME: Protocol update needed to handle master/primary alias
- * and probably an API bump also, to rename/alias the routine.
+/* NOTE: Protocol updated since NUT 2.8.0 to handle master/primary
+ * and API bumped, to rename/alias the routine.
  */
-void net_master(nut_ctype_t *client, size_t numarg, const char **arg)
+static int do_net_primary(nut_ctype_t *client, size_t numarg, const char **arg)
 {
 	upstype_t	*ups;
 
 	if (numarg != 1) {
 		send_err(client, NUT_ERR_INVALID_ARGUMENT);
-		return;
+		return -1;
 	}
 
 	ups = get_ups_ptr(arg[0]);
 
 	if (!ups) {
 		send_err(client, NUT_ERR_UNKNOWN_UPS);
-		return;
+		return -1;
 	}
 
-	/* make sure this user is allowed to do MASTER */
-	if (!user_checkaction(client->username, client->password, "MASTER")) {
+	/* make sure this user is allowed to do PRIMARY or MASTER */
+	if (!user_checkaction(client->username, client->password, "PRIMARY")
+	&&  !user_checkaction(client->username, client->password, "MASTER")
+	) {
 		send_err(client, NUT_ERR_ACCESS_DENIED);
-		return;
+		return -1;
 	}
 
 	/* this is just an access level check */
-	sendback(client, "OK MASTER-GRANTED\n");
+	/* sendback() will be worded by caller below */
+	return 0;
+	sendback(client, "OK PRIMARY-GRANTED\n");
+}
+
+/* MASTER <upsname> (deprecated) */
+void net_master(nut_ctype_t *client, size_t numarg, const char **arg) {
+	/* Allow existing binaries linked against this file to still work */
+	upsdebugx(1, "WARNING: net_master() is deprecated in favor of net_primary() since NUT 2.8.0");
+	if (0 == do_net_primary(client, numarg, arg)) {
+		sendback(client, "OK MASTER-GRANTED\n");
+	}
+}
+
+/* PRIMARY <upsname> (since NUT 2.8.0) */
+void net_primary(nut_ctype_t *client, size_t numarg, const char **arg)
+{
+	if (0 == do_net_primary(client, numarg, arg)) {
+		sendback(client, "OK PRIMARY-GRANTED\n");
+	}
 }
 
 /* USERNAME <username> */

--- a/server/netuser.c
+++ b/server/netuser.c
@@ -121,7 +121,13 @@ static int do_net_primary(nut_ctype_t *client, size_t numarg, const char **arg)
 /* MASTER <upsname> (deprecated) */
 void net_master(nut_ctype_t *client, size_t numarg, const char **arg) {
 	/* Allow existing binaries linked against this file to still work */
-	upsdebugx(1, "WARNING: net_master() is deprecated in favor of net_primary() since NUT 2.8.0");
+	upsdebugx(1,
+		"WARNING: Client %s@%s "
+		"requested MASTER level for device %s - "
+		"which is deprecated in favor of PRIMARY "
+		"since NUT 2.8.0",
+		client->username, client->addr,
+		(numarg > 0) ? arg[0] : "<null>");
 	if (0 == do_net_primary(client, numarg, arg)) {
 		sendback(client, "OK MASTER-GRANTED\n");
 	}

--- a/server/netuser.h
+++ b/server/netuser.h
@@ -33,10 +33,14 @@ extern "C" {
 
 void net_login(nut_ctype_t *client, size_t numarg, const char **arg);
 void net_logout(nut_ctype_t *client, size_t numarg, const char **arg);
-/* FIXME: Protocol update needed to handle master/primary alias
- * and probably an API bump also, to rename/alias the routine.
+
+/* NOTE: Since NUT 2.8.0 we handle master as alias for primary
+ * Header keyword kept for building older consumers, but
+ * the implementation will warn that it is deprecated.
  */
 void net_master(nut_ctype_t *client, size_t numarg, const char **arg);
+void net_primary(nut_ctype_t *client, size_t numarg, const char **arg);
+
 void net_username(nut_ctype_t *client, size_t numarg, const char **arg);
 void net_password(nut_ctype_t *client, size_t numarg, const char **arg);
 


### PR DESCRIPTION
CC @NUT-RogerPrice

This PR completes the effort for issue #840 to move away from master/slave terminolgy, now covering also the protocol.

The implementation allows `upsmon` client to request `PRIMARY <ups>` elevation from a server and fall back to requesting a `MASTER <ups>` in case it talks to an older server.

The server (or rather `netcmds` table) in turn handles both keywords, mapping respectively to `net_primary()` and `net_master()` as implementations, which both call a static `do_net_primary()` to weed out error cases like before, and then return `OK PRIMARY-GRANTED` or `OK MASTER-GRANTED` respectively. The server would log callers of the deprecated command, e.g.:
````
   3.397427     User upsmon@127.0.0.1 logged into UPS [dummy]
   3.397464     [D1] WARNING: Client upsmon@127.0.0.1 requested MASTER level for device dummy - which is deprecated in favor of PRIMARY since NUT 2.8.0
   3.397481     [D2] write: [destfd=7] [len=18] [OK MASTER-GRANTED]
````

I assume the chosen approach allows older NUT clients to talk to the newer server and vice versa, and for any third-party binaries (if any) dynamically linked against older API (with `net_master()` token) to remain resolvable.