### PR TITLE
NEWS: Docs bump to summarize recent PRs and declare NUT 2.8.0 (instead of 2.7.5) as next release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -100,6 +100,10 @@ Release notes for NUT 2.7.5 - what's new since 2.7.4:
    RS-232 Modbus device support of Huawei UPS2000/2000A (1kVA-3kVA) series,
    and possibly some related FSP UPS models. [PR #954]
 
+ - socomec_jbus: added new driver for modbus-based JBUS protocol over serial
+   RS-232 for Socomec UPS (tested with a DIGYS 3/3 15kVA model, working
+   on Linux x86-64 and Raspberry Pi 3 ARM). [PR #1313]
+
  - generic_modbus: added new driver for TCP and Serial Modbus device support.
    The driver has been tested against PULS UPS (model UB40.241) via
    MOXA ioLogikR1212 (RS485) and ioLogikE1212 (TCP/IP), and configuration

--- a/NEWS
+++ b/NEWS
@@ -5,7 +5,12 @@ ChangeLog file (generated for release archives), or to the Git version
 control history for "live" codebase.
 
 ---------------------------------------------------------------------------
-Release notes for NUT 2.7.5 - what's new since 2.7.4:
+Release notes for NUT 2.8.0 - what's new since 2.7.4:
+
+ - New (optional) keywords for configuration files were added,
+   so existing NUT 2.7.x builds would not accept them if some
+   deployments switch versions back and forth -- due to this,
+   semantically the version was bumped to NUT 2.8.x.
 
  - Add support for openssl-1.1.0 (Arjen de Korte)
 

--- a/NEWS
+++ b/NEWS
@@ -177,6 +177,7 @@ Release notes for NUT 2.7.5 - what's new since 2.7.4:
      [PR #1199, issue #732]
    * add new ever-hid subdriver to support EVER UPS devices (Sinline RT Series,
      Sinline RT XL Series, ECO PRO AVR CDS Series) [PR #431]
+   * add ability to set `battery.mfr.date` for APC HID UPS [PR #1318]
 
  - usbhid-ups / mge-shut: compute a realpower output load approximation for
    Eaton UPS when the needed data is not present

--- a/UPGRADING
+++ b/UPGRADING
@@ -7,7 +7,7 @@ This file lists changes that affect users who installed older versions
 of this software.  When upgrading from an older version, be sure to
 check this file to see if you need to make changes to your system.
 
-Changes from 2.7.4 to 2.7.5
+Changes from 2.7.4 to 2.8.0
 ---------------------------
 
 - Note to distribution packagers: this version hopefully learns from many

--- a/docs/config-prereqs.txt
+++ b/docs/config-prereqs.txt
@@ -100,8 +100,18 @@ source versions on both Debian 8 Jessie and Debian 11 Buster).
     valgrind \
     cppcheck \
     pkg-config \
-    gcc g++ clang \
-    asciidoc source-highlight python3-pygments dblatex aspell \
+    gcc g++ clang
+
+# For spell-checking:
+:; apt-get install \
+    aspell aspell-en
+
+# For other doc types (man-page, PDF, HTML) generation - massive packages (TEX, X11):
+:; apt-get install \
+    asciidoc source-highlight python3-pygments dblatex
+
+# For CGI graph generation - massive packages (X11):
+:; apt-get install \
     libgd-dev
 
 # NOTE: Some older Debian-like distributions, could ship "libcrypto-dev"
@@ -216,8 +226,18 @@ https://unix.stackexchange.com/questions/475584/cannot-install-busybox-on-centos
     valgrind \
     cppcheck \
     pkgconfig \
-    gcc gcc-c++ clang \
-    asciidoc source-highlight python-pygments dblatex aspell \
+    gcc gcc-c++ clang
+
+# For spell-checking:
+:; yum install \
+    aspell aspell-en
+
+# For other doc types (man-page, PDF, HTML) generation - massive packages (TEX, X11):
+:; yum install \
+    asciidoc source-highlight python-pygments dblatex
+
+# For CGI graph generation - massive packages (X11):
+:; yum install \
     gd-devel
 
 # NOTE: "libusbx" is the CentOS way of naming "libusb-1.0"
@@ -277,8 +297,18 @@ below.
     valgrind \
     cppcheck \
     pkgconf \
-    gcc clang \
-    asciidoc source-highlight textproc/py-pygments dblatex en-aspell aspell \
+    gcc clang
+
+# For spell-checking:
+:; pkg install \
+    aspell en-aspell
+
+# For other doc types (man-page, PDF, HTML) generation - massive packages (TEX, X11):
+:; pkg install \
+    asciidoc source-highlight textproc/py-pygments dblatex
+
+# For CGI graph generation - massive packages (X11):
+:; pkg install \
     libgd
 
 :; pkg install \
@@ -367,8 +397,18 @@ networked repository (4.2.x vs 4.9.x)
     valgrind \
     cppcheck \
     pkgconf \
-    gcc clang \
-    asciidoc source-highlight py-pygments dblatex aspell \
+    gcc clang
+
+# For spell-checking:
+:; pkg_add \
+    aspell
+
+# For other doc types (man-page, PDF, HTML) generation - massive packages (TEX, X11):
+:; pkg_add \
+    asciidoc source-highlight py-pygments dblatex
+
+# For CGI graph generation - massive packages (X11):
+:; pkg_add \
     gd
 
 # Need to find proper package name and/or mirror for this:
@@ -447,10 +487,21 @@ Typical tooling would include:
     gnu-make autoconf automake libltdl libtool \
     valgrind \
     pkg-config \
-    gnu-binutils developer/linker \
-    asciidoc libxslt aspell text/aspell/en \
+    gnu-binutils developer/linker
+
+# For spell-checking:
+:; pkg install \
+    aspell text/aspell/en
+
+# For other doc types (man-page, PDF, HTML) generation - massive packages (TEX, X11):
+:; pkg install \
+    asciidoc libxslt \
     docbook/dtds docbook/dsssl docbook/xsl docbook docbook/sgml-common pygments-39 \
-    graphviz expect gd graphviz-tcl
+    graphviz expect graphviz-tcl
+
+# For CGI graph generation - massive packages (X11):
+:; pkg install \
+    gd
 
 :; pkg install \
     openssl library/mozilla-nss \

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 2864 utf-8
+personal_ws-1.1 en 2868 utf-8
 AAS
 ACFAIL
 ACFREQ
@@ -242,6 +242,7 @@ DES
 DESTDIR
 DF
 DHEA
+DIGYS
 DISCHRG
 DMF
 DN
@@ -486,6 +487,7 @@ Invter
 IoT
 Ioannou
 JAWAN
+JBUS
 JBus
 JKL
 JRE
@@ -1941,6 +1943,7 @@ ivtscd
 jNUT
 jNut
 jNutWebAPI
+jbus
 jdk
 jenkins
 jessie
@@ -2524,6 +2527,7 @@ snprintf
 snprintfcat
 snr
 sockdebug
+socomec
 solaris
 solis
 somepass


### PR DESCRIPTION
Just a bit of text

Bump suggested by semver question in #1263