### PR TITLE
Clang 13 ready

### DIFF
--- a/drivers/belkinunv.c
+++ b/drivers/belkinunv.c
@@ -1196,35 +1196,43 @@ int instcmd(const char *cmdname, const char *extra)
 
 	if (!strcasecmp(cmdname, "test.failure.start")) {
 		r = belkin_nut_write_int(REG_TESTSTATUS, 2);
+		if (r == -1) upslogx(LOG_WARNING, "Command '%s' failed", cmdname);
 		return STAT_INSTCMD_HANDLED;  /* Future: failure if r==-1 */
 	}
 	if (!strcasecmp(cmdname, "test.failure.stop")) {
 		r = belkin_nut_write_int(REG_TESTSTATUS, 3);
+		if (r == -1) upslogx(LOG_WARNING, "Command '%s' failed", cmdname);
 		return STAT_INSTCMD_HANDLED;  /* Future: failure if r==-1 */
 	}
 	if (!strcasecmp(cmdname, "test.battery.start")) {
 		r = belkin_nut_write_int(REG_TESTSTATUS, 1);
+		if (r == -1) upslogx(LOG_WARNING, "Command '%s' failed", cmdname);
 		return STAT_INSTCMD_HANDLED;  /* Future: failure if r==-1 */
 	}
 	if (!strcasecmp(cmdname, "test.battery.stop")) {
 		r = belkin_nut_write_int(REG_TESTSTATUS, 3);
+		if (r == -1) upslogx(LOG_WARNING, "Command '%s' failed", cmdname);
 		return STAT_INSTCMD_HANDLED;  /* Future: failure if r==-1 */
 	}
 	if (!strcasecmp(cmdname, "beeper.disable")) {
 		r = belkin_nut_write_int(REG_ALARMSTATUS, 1);
+		if (r == -1) upslogx(LOG_WARNING, "Command '%s' failed", cmdname);
 		return STAT_INSTCMD_HANDLED;  /* Future: failure if r==-1 */
 	}
 	if (!strcasecmp(cmdname, "beeper.enable")) {
 		r = belkin_nut_write_int(REG_ALARMSTATUS, 2);
+		if (r == -1) upslogx(LOG_WARNING, "Command '%s' failed", cmdname);
 		return STAT_INSTCMD_HANDLED;  /* Future: failure if r==-1 */
 	}
 	if (!strcasecmp(cmdname, "beeper.mute")) {
 		r = belkin_nut_write_int(REG_ALARMSTATUS, 3);
+		if (r == -1) upslogx(LOG_WARNING, "Command '%s' failed", cmdname);
 		return STAT_INSTCMD_HANDLED;  /* Future: failure if r==-1 */
 	}
 	if (!strcasecmp(cmdname, "shutdown.stayoff")) {
 		r = belkin_nut_write_int(REG_RESTARTTIMER, 0);
 		r |= belkin_nut_write_int(REG_SHUTDOWNTIMER, 1); /* 1 second */
+		if (r == -1) upslogx(LOG_WARNING, "Command '%s' failed", cmdname);
 		return STAT_INSTCMD_HANDLED;  /* Future: failure if r==-1 */
 	}
 	if (!strcasecmp(cmdname, "shutdown.reboot")) {
@@ -1236,11 +1244,13 @@ int instcmd(const char *cmdname, const char *extra)
 		   the UPS will stay off between 60 and 120 seconds */
 		r = belkin_nut_write_int(REG_RESTARTTIMER, 2); /* 2 minutes */
 		r |= belkin_nut_write_int(REG_SHUTDOWNTIMER, 1); /* 1 second */
+		if (r == -1) upslogx(LOG_WARNING, "Command '%s' failed", cmdname);
 		return STAT_INSTCMD_HANDLED;  /* Future: failure if r==-1 */
 	}
 	if (!strcasecmp(cmdname, "shutdown.reboot.graceful")) {
 		r = belkin_nut_write_int(REG_RESTARTTIMER, 2); /* 2 minutes */
 		r |= belkin_nut_write_int(REG_SHUTDOWNTIMER, 40); /* 40 seconds */
+		if (r == -1) upslogx(LOG_WARNING, "Command '%s' failed", cmdname);
 		return STAT_INSTCMD_HANDLED;  /* Future: failure if r==-1 */
 	}
 	if (!strcasecmp(cmdname, "reset.input.minmax")) {

--- a/drivers/riello.c
+++ b/drivers/riello.c
@@ -645,42 +645,42 @@ void riello_parse_re(uint8_t* buffer, TRielloData* data)
 	pom_long += (buffer[j++]-0x30)*256;
 	pom_long += (buffer[j++]-0x30)*16;
 	pom_long += (buffer[j++]-0x30);
-	data->Pout1W = pom_word;
+	data->Pout1W = pom_long;
 
 	pom_long = (buffer[j++]-0x30)*65536;
 	pom_long += (buffer[j++]-0x30)*4096;
 	pom_long += (buffer[j++]-0x30)*256;
 	pom_long += (buffer[j++]-0x30)*16;
 	pom_long += (buffer[j++]-0x30);
-	data->Pout2W = pom_word;
+	data->Pout2W = pom_long;
 
 	pom_long = (buffer[j++]-0x30)*65536;
 	pom_long += (buffer[j++]-0x30)*4096;
 	pom_long += (buffer[j++]-0x30)*256;
 	pom_long += (buffer[j++]-0x30)*16;
 	pom_long += (buffer[j++]-0x30);
-	data->Pout3W = pom_word;
+	data->Pout3W = pom_long;
 
 	pom_long = (buffer[j++]-0x30)*65536;
 	pom_long += (buffer[j++]-0x30)*4096;
 	pom_long += (buffer[j++]-0x30)*256;
 	pom_long += (buffer[j++]-0x30)*16;
 	pom_long += (buffer[j++]-0x30);
-	data->Pout1VA = pom_word;
+	data->Pout1VA = pom_long;
 
 	pom_long = (buffer[j++]-0x30)*65536;
 	pom_long += (buffer[j++]-0x30)*4096;
 	pom_long += (buffer[j++]-0x30)*256;
 	pom_long += (buffer[j++]-0x30)*16;
 	pom_long += (buffer[j++]-0x30);
-	data->Pout2VA = pom_word;
+	data->Pout2VA = pom_long;
 
 	pom_long = (buffer[j++]-0x30)*65536;
 	pom_long += (buffer[j++]-0x30)*4096;
 	pom_long += (buffer[j++]-0x30)*256;
 	pom_long += (buffer[j++]-0x30)*16;
 	pom_long += (buffer[j++]-0x30);
-	data->Pout3VA = pom_word;
+	data->Pout3VA = pom_long;
 }
 
 void riello_parse_rc(uint8_t* buffer, TRielloData* data)

--- a/m4/nut_compiler_family.m4
+++ b/m4/nut_compiler_family.m4
@@ -102,13 +102,11 @@ dnl -fdiagnostics-color=ARG: help find where bugs are in the wall of text (gcc)
     dnl First check for this to avoid failing on unused include paths etc:
     NUT_CHECK_COMPILE_FLAG([-Qunused-arguments])
 
-dnl # Future: test for something else?
-dnl    m4_foreach_w([TESTCOMPILERFLAG], [
-dnl        -Qunused-arguments
-dnl        -Wno-unknown-warning-option
-dnl    ], [
-dnl        NUT_CHECK_COMPILE_FLAG([TESTCOMPILERFLAG])
-dnl    ])
+    m4_foreach_w([TESTCOMPILERFLAG], [
+        -Wno-reserved-identifier
+    ], [
+        NUT_CHECK_COMPILE_FLAG([TESTCOMPILERFLAG])
+    ])
 
     dnl Note: each m4_foreach_w arg must be named uniquely
     dnl Note: Seems -fcolor-diagnostics is clang-only and sometimes


### PR DESCRIPTION
As tested on Ubuntu impish 21.10, `clang-13` complains about underscores in identifiers, mostly stemming from system headers:
````
libtool: compile:  /usr/lib/ccache/clang -DHAVE_CONFIG_H -I. -I../include -I/home/abuild/nut/tmp/include -I../include -I/home/abuild/nut/tmp/include -Qunused-arguments -fdiagnostics-color=always -Wno-unknown-warning-option -std=gnu99 -ferror-limit=0 -Wno-system-headers -Wall -Wextra -Weverything -Wno-disabled-macro-expansion -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -Wno-documentation -Wno-cast-qual -pedantic -Wno-float-conversion -Wno-double-promotion -Wno-implicit-float-conversion -Wno-conversion -Wno-incompatible-pointer-types-discards-qualifiers -Werror -MT common.lo -MD -MP -MF .deps/common.Tpo -c common.c  -fPIC -DPIC -o .libs/common.o
common.c:917:2: error: identifier '__i' is reserved because it starts with '__' [-Werror,-Wreserved-identifier]
        FD_ZERO(&fds);
        ^
/usr/include/x86_64-linux-gnu/sys/select.h:88:26: note: expanded from macro 'FD_ZERO'
#define FD_ZERO(fdsetp)         __FD_ZERO (fdsetp)
                                ^
/usr/include/x86_64-linux-gnu/bits/select.h:27:18: note: expanded from macro '__FD_ZERO'
    unsigned int __i;                                                         \
                 ^
common.c:917:2: error: identifier '__arr' is reserved because it starts with '__' [-Werror,-Wreserved-identifier]
/usr/include/x86_64-linux-gnu/sys/select.h:88:26: note: expanded from macro 'FD_ZERO'
#define FD_ZERO(fdsetp)         __FD_ZERO (fdsetp)
                                ^
/usr/include/x86_64-linux-gnu/bits/select.h:28:13: note: expanded from macro '__FD_ZERO'
    fd_set *__arr = (s);                                                      \
            ^
common.c:941:2: error: identifier '__i' is reserved because it starts with '__' [-Werror,-Wreserved-identifier]
        FD_ZERO(&fds);
        ^
/usr/include/x86_64-linux-gnu/sys/select.h:88:26: note: expanded from macro 'FD_ZERO'
#define FD_ZERO(fdsetp)         __FD_ZERO (fdsetp)
                                ^
/usr/include/x86_64-linux-gnu/bits/select.h:27:18: note: expanded from macro '__FD_ZERO'
    unsigned int __i;                                                         \
                 ^
common.c:941:2: error: identifier '__arr' is reserved because it starts with '__' [-Werror,-Wreserved-identifier]
/usr/include/x86_64-linux-gnu/sys/select.h:88:26: note: expanded from macro 'FD_ZERO'
#define FD_ZERO(fdsetp)         __FD_ZERO (fdsetp)
                                ^
/usr/include/x86_64-linux-gnu/bits/select.h:28:13: note: expanded from macro '__FD_ZERO'
    fd_set *__arr = (s);                                                      \
            ^
4 errors generated.
````

Also quite a bit in cppunit related sources:
````
example.cpp:39:3: error: identifier 'getTestNamer__' is reserved because it contains '__' [-Werror,-Wreserved-identifier]
  CPPUNIT_TEST_SUITE( ExampleTest );
  ^
/usr/include/cppunit/extensions/HelperMacros.h:105:41: note: expanded from macro 'CPPUNIT_TEST_SUITE'
    static const CPPUNIT_NS::TestNamer &getTestNamer__()                    \
                                        ^
example.cpp:41:3: error: identifier 'CppUnitDummyTypedefForSemiColonEnding__' is reserved because it contains '__' [-Werror,-Wreserved-identifier]
  CPPUNIT_TEST_SUITE_END();
  ^
/usr/include/cppunit/extensions/HelperMacros.h:183:17: note: expanded from macro 'CPPUNIT_TEST_SUITE_END'
    typedef int CppUnitDummyTypedefForSemiColonEnding__
                ^
example.cpp:51:1: error: identifier 'autoRegisterRegistry__51' is reserved because it contains '__' [-Werror,-Wreserved-identifier]
CPPUNIT_TEST_SUITE_REGISTRATION( ExampleTest );
^
/usr/include/cppunit/extensions/HelperMacros.h:474:14: note: expanded from macro 'CPPUNIT_TEST_SUITE_REGISTRATION'
             CPPUNIT_MAKE_UNIQUE_NAME(autoRegisterRegistry__ )
             ^
/usr/include/cppunit/Portability.h:161:44: note: expanded from macro 'CPPUNIT_MAKE_UNIQUE_NAME'
#define CPPUNIT_MAKE_UNIQUE_NAME( prefix ) CPPUNIT_JOIN( prefix, CPPUNIT_UNIQUE_COUNTER )
                                           ^
/usr/include/cppunit/Portability.h:143:42: note: expanded from macro 'CPPUNIT_JOIN'
#define CPPUNIT_JOIN( symbol1, symbol2 ) _CPPUNIT_DO_JOIN( symbol1, symbol2 )
                                         ^
/usr/include/cppunit/Portability.h:146:46: note: expanded from macro '_CPPUNIT_DO_JOIN'
#define _CPPUNIT_DO_JOIN( symbol1, symbol2 ) _CPPUNIT_DO_JOIN2( symbol1, symbol2 )
                                             ^
/usr/include/cppunit/Portability.h:149:47: note: expanded from macro '_CPPUNIT_DO_JOIN2'
#define _CPPUNIT_DO_JOIN2( symbol1, symbol2 ) symbol1##symbol2
                                              ^
<scratch space>:319:1: note: expanded from here
autoRegisterRegistry__51
^
3 errors generated.
make[1]: *** [Makefile:871: cppunittest-example.o] Error 1
nutclienttest.cpp:40:2: error: identifier 'getTestNamer__' is reserved because it contains '__' [-Werror,-Wreserved-identifier]
        CPPUNIT_TEST_SUITE( NutClientTest );
        ^
/usr/include/cppunit/extensions/HelperMacros.h:105:41: note: expanded from macro 'CPPUNIT_TEST_SUITE'
    static const CPPUNIT_NS::TestNamer &getTestNamer__()                    \
                                        ^
nutclienttest.cpp:55:2: error: identifier 'CppUnitDummyTypedefForSemiColonEnding__' is reserved because it contains '__' [-Werror,-Wreserved-identifier]
        CPPUNIT_TEST_SUITE_END();
        ^
/usr/include/cppunit/extensions/HelperMacros.h:183:17: note: expanded from macro 'CPPUNIT_TEST_SUITE_END'
    typedef int CppUnitDummyTypedefForSemiColonEnding__
                ^
nutclienttest.cpp:78:1: error: identifier 'autoRegisterRegistry__78' is reserved because it contains '__' [-Werror,-Wreserved-identifier]
CPPUNIT_TEST_SUITE_REGISTRATION( NutClientTest );
^
/usr/include/cppunit/extensions/HelperMacros.h:474:14: note: expanded from macro 'CPPUNIT_TEST_SUITE_REGISTRATION'
             CPPUNIT_MAKE_UNIQUE_NAME(autoRegisterRegistry__ )
             ^
/usr/include/cppunit/Portability.h:161:44: note: expanded from macro 'CPPUNIT_MAKE_UNIQUE_NAME'
#define CPPUNIT_MAKE_UNIQUE_NAME( prefix ) CPPUNIT_JOIN( prefix, CPPUNIT_UNIQUE_COUNTER )
                                           ^
/usr/include/cppunit/Portability.h:143:42: note: expanded from macro 'CPPUNIT_JOIN'
#define CPPUNIT_JOIN( symbol1, symbol2 ) _CPPUNIT_DO_JOIN( symbol1, symbol2 )
                                         ^
/usr/include/cppunit/Portability.h:146:46: note: expanded from macro '_CPPUNIT_DO_JOIN'
#define _CPPUNIT_DO_JOIN( symbol1, symbol2 ) _CPPUNIT_DO_JOIN2( symbol1, symbol2 )
                                             ^
/usr/include/cppunit/Portability.h:149:47: note: expanded from macro '_CPPUNIT_DO_JOIN2'
#define _CPPUNIT_DO_JOIN2( symbol1, symbol2 ) symbol1##symbol2
                                              ^
<scratch space>:328:1: note: expanded from here
autoRegisterRegistry__78
^
3 errors generated.
````

and I saw one from NUT sources:
````
optiups.c:79:13: error: identifier '_buf' is reserved because it starts with '_' at global scope [-Werror,-Wreserved-identifier]
static char _buf[256];
            ^
optiups.c:109:17: error: identifier '_pollv' is reserved because it starts with '_' at global scope [-Werror,-Wreserved-identifier]
static ezfill_t _pollv[] = {
                ^
optiups.c:116:17: error: identifier '_pollv_zinto' is reserved because it starts with '_' at global scope [-Werror,-Wreserved-identifier]
static ezfill_t _pollv_zinto[] = {
                ^
optiups.c:126:17: error: identifier '_initv' is reserved because it starts with '_' at global scope [-Werror,-Wreserved-identifier]
static ezfill_t _initv[] = {
                ^
4 errors generated.
````
although per https://gcc.gnu.org/bugzilla/show_bug.cgi?id=51437 discussion, this should be valid:
> "All identifiers that begin with an underscore are always reserved for use as
> identifiers with file scope in both the ordinary and tag name spaces."

Enabling `-isystem /usr/include` did not help, so this PR disables the warning if found supported.

On the upside, clang-13 found a couple more variables set but not used, including probably a bug in `riello.c` that would previously set bogus output W and VA values, if I read that right.