### PR TITLE
Announce NUT_NETVERSION=1.3

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -373,7 +373,7 @@ Release notes for NUT 2.8.0 - what's new since 2.7.4:
    few changes also happened in header files installed for builds configured
    `--with-dev` and so may impact `upsclient` and `nutclient` (C++) consumers.
    At the very least, binaries for those consumers should be rebuilt to remain
-   stable with NUT 2.7.5 and not mismatch int-type sizes and other arguments.
+   stable with NUT 2.8.0 and not mismatch int-type sizes and other arguments.
 
  - As usual, more bugfixes, cleanup and improvements, on both source code
    and documentation.

--- a/UPGRADING
+++ b/UPGRADING
@@ -25,7 +25,7 @@ Changes from 2.7.4 to 2.8.0
   few changes also happened in header files installed for builds configured
   `--with-dev` and so may impact `upsclient` and `nutclient` (C++) consumers.
   At the very least, binaries for those consumers should be rebuilt to remain
-  stable with NUT 2.7.5 and not mismatch int-type sizes and other arguments.
+  stable with NUT 2.8.0 and not mismatch int-type sizes and other arguments.
 
 - libusb-1.0: NUT now defaults to building against libusb-1.0 API version
   if the configure script finds the development headers, falling back to

--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,7 @@ AC_PREFIX_DEFAULT(/usr/local/ups)
 AM_INIT_AUTOMAKE([subdir-objects])
 
 dnl we need Autoconf 2.61 or better to enable features of Posix that are extensions to C
+dnl (and actually 2.64 or better for m4/ax_check_compile_flag.m4 when it is sourced)
 AC_MSG_CHECKING(for autoconf macro to enable system extensions)
 m4_version_prereq(2.61, [
 	AC_MSG_RESULT(yes)

--- a/configure.ac
+++ b/configure.ac
@@ -50,7 +50,7 @@ AC_DEFINE_UNQUOTED(TREE_VERSION, "${TREE_VERSION}", [NUT tree version])
 
 dnl Should not be necessary, since old servers have well-defined errors for
 dnl unsupported commands:
-NUT_NETVERSION="1.2"
+NUT_NETVERSION="1.3"
 AC_DEFINE_UNQUOTED(NUT_NETVERSION, "${NUT_NETVERSION}", [NUT network protocol version])
 
 

--- a/docs/config-notes.txt
+++ b/docs/config-notes.txt
@@ -209,7 +209,7 @@ This can be a big issue on systems which monitor multiple devices, such as
 big servers with multiple power sources, or administrative workstations
 which monitor a datacenter full of UPSes.
 
-For this reason, NUT starting with version 2.7.5 supports startup of its
+For this reason, NUT starting with version 2.8.0 supports startup of its
 drivers as independent instances of a `nut-driver` service under the Linux
 systemd and Solaris/illumos SMF service-management frameworks (corresponding
 files and scripts may be not pre-installed in packaging for other systems).

--- a/docs/man/upscmd.txt
+++ b/docs/man/upscmd.txt
@@ -45,7 +45,7 @@ like -u, and you will be prompted for it if necessary.
 *-w*::
 Wait for the completion of command execution by the driver and return its
 actual result from the device. Note that this feature requires that both upsd
-and the driver support TRACKING (NUT version 2.7.5 or higher) or it will
+and the driver support TRACKING (NUT version 2.8.0 or higher) or it will
 otherwise fail.
 The command will also block until an actual result is provided from the driver,
 or the timeout is reached (see *-t*).

--- a/docs/man/upsrw.txt
+++ b/docs/man/upsrw.txt
@@ -61,7 +61,7 @@ like -u, and you will be prompted for it if necessary.
 *-w*::
 Wait for the completion of setting execution by the driver and return its
 actual result from the device. Note that this feature requires that both upsd
-and the driver support TRACKING (NUT version 2.7.5 or higher) or it will
+and the driver support TRACKING (NUT version 2.8.0 or higher) or it will
 otherwise fail.
 The command will also block until an actual result is provided from the driver,
 or the timeout is reached (see *-t*).

--- a/docs/net-protocol.txt
+++ b/docs/net-protocol.txt
@@ -44,7 +44,7 @@ NUT network protocol, over the time:
 |1.1              |>= 1.5.0    |Original protocol (without old commands)
 .2+|1.2        .2+|>= 2.6.4    |Add "LIST CLIENTS" and "NETVER" commands
                                |Add ranges of values for writable variables
-.2+|1.3        .2+|>= 2.7.5    |Add "cmdparam" to "INSTCMD"
+.2+|1.3        .2+|>= 2.8.0    |Add "cmdparam" to "INSTCMD"
                                |Add "TRACKING" commands (GET, SET)
 |===============================================================================
 

--- a/docs/net-protocol.txt
+++ b/docs/net-protocol.txt
@@ -46,6 +46,9 @@ NUT network protocol, over the time:
                                |Add ranges of values for writable variables
 .2+|1.3        .2+|>= 2.8.0    |Add "cmdparam" to "INSTCMD"
                                |Add "TRACKING" commands (GET, SET)
+                               |Add "PRIMARY" as alias to older "MASTER"
+                               |    (implementation tested to be backwards
+                               |    compatible in `upsd` and `upsmon`)
 |===============================================================================
 
 NOTE: any new version of the protocol implies an update of NUT_NETVERSION


### PR DESCRIPTION
Update the `configure.ac` to report the new version in `netmisc.c`, and update docs that referred to "2.7.5" as the new release to speak about "2.8.0" which sings to similar tune as #1263.

Also documents `PRIMARY` command as alias to `MASTER` (per #840) in protocol 1.3, although the practical implementation is expected to be compatible with protocol 1.2 client/server (see #1328).

CC @NUT-RogerPrice