### PR TITLE
[CI] Jenkinsfile-dynamatrix: make use of dsbcStageTimeoutSettings

### DIFF
--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -58,6 +58,14 @@ import org.nut.dynamatrix.*;
     dynacfgPipeline.failFast = //true //
         false
 
+    // How long can a single "slow-build stage" run before we
+    // consider that the build agent is stuck or network dropped?
+    // The dynamatrix should try to re-schedule this scenario then.
+    dynacfgPipeline.dsbcStageTimeoutSettings = [
+        time: 2,
+        unit: 'HOURS'
+        ]
+
     // Note: this setting causes a lot of noise in build summary page and
     // parent job definition (PR, branch...) overview page on Jenkins,
     // by reporting dozens of lines for each analyzer ID ever published.


### PR DESCRIPTION
Try to limit the time a single executor may be occupied by a dynamatrix build scenario. Sometimes Jenkins does not detect factual drops early enough and builds linger for hours without progress - better drop this attempted stage and try it on another agent (or another lifetime of a restarted agent).