### PR TITLE
drivers/mge-hid.c: mge_claim(): test that VendorID==PHOENIXTEC 0x06da…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -180,6 +180,10 @@ refer to this change set (too long in the making) as NUT 2.7.5.
      of firmware for) CyberPower CPS*EPFCLCD [issue #439, PR #1245]
    * added `onlinedischarge` option for UPSes that report `OL+DISCHRG`
      when wall power is lost [PR #811]
+   * changed detection of VendorID 0x06da handling of which is claimed
+     by Liebert/Phoenixtec HID historically, and MGE HID (for AEG PROTECT
+     NAS UPSes) since NUT 2.7.4, so that the higher-priority MGE subdriver
+     would not grab each and all of the devices exposing that ID [PR #1357]
    * CPS HID: add input.frequency and output.frequency
    * OpenUPS2: only check OEM Information string once (fewer log messages)
    * Liebert GXT4 USB VID:PID [10AF:0000]

--- a/drivers/mge-hid.c
+++ b/drivers/mge-hid.c
@@ -1566,6 +1566,21 @@ static int mge_claim(HIDDevice_t *hd) {
 				 * not a UPS, so don't use possibly_supported here
 				 */
 				return 0;
+
+			case PHOENIXTEC:
+				/* The vendorid 0x06da is primarily handled by
+				 * liebert-hid, except for (maybe) AEG PROTECT NAS
+				 * branded devices */
+				if (hd->Vendor && strstr(hd->Vendor, "AEG")) {
+					return 1;
+				}
+				if (hd->Product && strstr(hd->Product, "AEG")) {
+					return 1;
+				}
+
+				/* Let liebert-hid grab this */
+				return 0;
+
 			default: /* Valid for Eaton */
 				/* by default, reject, unless the productid option is given */
 				if (getval("productid")) {
@@ -1576,6 +1591,21 @@ static int mge_claim(HIDDevice_t *hd) {
 		}
 
 	case SUPPORTED:
+
+		switch (hd->VendorID)
+		{
+			case PHOENIXTEC: /* see comments above */
+				if (hd->Vendor && strstr(hd->Vendor, "AEG")) {
+					return 1;
+				}
+				if (hd->Product && strstr(hd->Product, "AEG")) {
+					return 1;
+				}
+
+				/* Let liebert-hid grab this */
+				return 0;
+		}
+
 		return 1;
 
 	case NOT_SUPPORTED:


### PR DESCRIPTION
… has also Vendor or Product containing "AEG"

Follows up from investigation for #564 and #560 that we have a conflict for USB Vendor ID 0x06da in the upshid-ups subdrivers. This PR aims to separate the detection in a way that the mge-hid.c would only claim devices whose Vendor or Product strings contain "AEG", and so allow liebert-hid.c to still support the rest of devices with this chip.

This is an opportunistically proposed "logically meaningful" change as I have no such devices to really test against. Looking at existing code, I think that liebert-hid.c got shadowed after commit a08a2292afc559d6dfb9eede014a941d8f6b511d (in 2016) and all devices with this VID were grabbed by mge-hid.c after NUT 2.7.4.