### PR TITLE
reinstate handling for STATUS(ONLINE) in usbhid-ups

### DIFF
--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -1660,6 +1660,8 @@ static void ups_status_set(void)
 			/* if we're calibrating */
 			status_set("OL");	/* on line */
 		}
+	} else if ((ups_status & STATUS(ONLINE))) {
+		status_set("OL");
 	}
 	if ((ups_status & STATUS(DISCHRG)) &&
 		!(ups_status & STATUS(DEPLETED))) {


### PR DESCRIPTION
I have a CyberPower CP1300EPFCLCD which in normal conditions reports ACPresent 1 / Charging 0 / Discharging 0 (presumably the battery condition is OK so it has no need to actively charge). This isn't handled by the change recently brought in for onlinedischarge (a8e3687 in usbhid-ups.c, PR #811).

Here's an excerpt from -DDDDDD showing the problem.

```
   0.135100     [D2] Path: UPS.Output.DelayBeforeShutdown, Type: Feature, ReportID: 0x15, Offset: 0, Size: 16, Value: -60
   0.135103     [D3] Report[buf]: (2 bytes) => 0b 11
   0.135104     [D5] PhyMax = 0, PhyMin = 0, LogMax = 1, LogMin = 0
   0.135106     [D5] Unit = 00000000, UnitExp = 0
   0.135107     [D5] Exponent = 0
   0.135109     [D2] Path: UPS.PowerSummary.PresentStatus.ACPresent, Type: Feature, ReportID: 0x0b, Offset: 0, Size: 1, Value: 1
   0.135110     [D5] hu_find_infoval: found online (value: 1)
   0.135112     [D5] process_boolean_info: online
   0.135114     [D3] Report[buf]: (2 bytes) => 0b 11
   0.135115     [D5] PhyMax = 0, PhyMin = 0, LogMax = 1, LogMin = 0
   0.135120     [D5] Unit = 00000000, UnitExp = 0
   0.135121     [D5] Exponent = 0
   0.135123     [D2] Path: UPS.PowerSummary.PresentStatus.Charging, Type: Feature, ReportID: 0x0b, Offset: 1, Size: 1, Value: 0
   0.135124     [D5] hu_find_infoval: found !chrg (value: 0)
   0.135126     [D5] process_boolean_info: !chrg
   0.135128     [D3] Report[buf]: (2 bytes) => 0b 11
   0.135129     [D5] PhyMax = 0, PhyMin = 0, LogMax = 1, LogMin = 0
   0.135131     [D5] Unit = 00000000, UnitExp = 0
   0.135133     [D5] Exponent = 0
   0.135135     [D2] Path: UPS.PowerSummary.PresentStatus.Discharging, Type: Feature, ReportID: 0x0b, Offset: 2, Size: 1, Value: 0
   0.135136     [D5] hu_find_infoval: found !dischrg (value: 0)
   0.135138     [D5] process_boolean_info: !dischrg
   0.135139     [D3] Report[buf]: (2 bytes) => 0b 11
   0.135141     [D5] PhyMax = 0, PhyMin = 0, LogMax = 1, LogMin = 0
   0.135142     [D5] Unit = 00000000, UnitExp = 0
   0.135143     [D5] Exponent = 0
   0.135145     [D2] Path: UPS.PowerSummary.PresentStatus.BelowRemainingCapacityLimit, Type: Feature, ReportID: 0x0b, Offset: 3, Size: 1, Value: 0
   0.135147     [D5] hu_find_infoval: found !lowbatt (value: 0)
   0.135148     [D5] process_boolean_info: !lowbatt
   0.135152     [D5] send_to_all: SETINFO ups.status ""
   0.135169     [D5] send_to_all: DATAOK
   0.135363     [D2] dstate_init: sock /var/db/nut/usbhid-ups-office open on fd 5
   0.135371     [D5] send_to_all: SETINFO driver.parameter.pollinterval "2"
   0.135374     [D5] send_to_all: SETINFO driver.parameter.synchronous "auto"
   0.135376     [D5] send_to_all: SETINFO device.mfr "CPS"
   0.135379     [D5] send_to_all: SETINFO device.model "CP1300EPFCLCD"
   0.135382     [D5] send_to_all: SETINFO device.serial "CRWHY2000030"
   0.135383     [D1] upsdrv_updateinfo...
   0.135388     nut_libusb_get_interrupt: Operation not supported or unimplemented on this platform
   0.135392     [D1] Got 0 HID objects...
   0.135393     [D1] Quick update...
```

With usbhid-ups.c from before this commit, or with the patch in this PR, status is set as 'send_to_all: SETINFO ups.status "OL"'.

Hopefully this has everything you need, if not then please let me know what further information I can provide. Thanks!