### PR TITLE
Report deprecation messages when starting older Qx drivers

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -50,10 +50,11 @@ Changes from 2.7.4 to 2.8.0
 
 - oldmge-shut has been removed, and replaced by mge-shut.
 
-- New drivers for devices with "Qx" family of protocols should be developed
-  as sub-drivers in the `nutdrv_qx` framework for USB and Serial connected
-  devices, not as updates/clones of older e.g. `blazer` family and `bestups`.
-  Sources of such older drivers were marked with "OBSOLETION WARNING".
+- New drivers for devices with "Qx" (also known as "Megatec Q*") family of
+  protocols should be developed as sub-drivers in the `nutdrv_qx` framework
+  for USB and Serial connected devices, not as updates/clones of older e.g.
+  `blazer` family and `bestups`. Sources, man pages and start-up messages
+  of such older drivers were marked with "OBSOLETION WARNING".
 
 - liebert-esp2: some multi-phase variable names have been updated to match the
   rest of NUT.

--- a/docs/FAQ.txt
+++ b/docs/FAQ.txt
@@ -544,7 +544,11 @@ There are several driver to support USB models.
 - usbhid-ups supports various manufacturers complying to the HID Power Device Class (PDC) standard,
 - tripplite_usb supports various older Tripp-Lite units (with USB ProductID 0001)
 - bcmxcp_usb supports various Powerware units,
-- nutdrv_qx and blazer_usb support various manufacturers that use the Megatec / Q1 protocol.
+- blazer_usb supports various manufacturers that use the Megatec / Q1 protocol.
+- nutdrv_qx supports various manufacturers that use the Megatec / Q* protocol
+  family. This is the driver slated to receive all further development in this
+  area, it was specially designed to support many more sub-drivers and has
+  added a lot over time, so please do try it first nowadays.
 
 Refer to the 'driver-name' (8) man page for more information.
 
@@ -568,7 +572,7 @@ connection option that works for Windows users.
 Your best bet is to search for community discussions of issues on NUT GitHub
 at https://github.com/networkupstools/nut/issues?q=is%3Aissue and try options
 there. Devices with these chips were known to connect with drivers for such
-unrelated protocols as Megatec Qx (different sub-drivers, often `fabula` or
+unrelated protocols as Megatec Q* (different sub-drivers, often `fabula` or
 `hunnox`), ATCL, or USB-HID.
 
 == My USB UPS is supported but doesn't work!

--- a/docs/man/bestups.txt
+++ b/docs/man/bestups.txt
@@ -13,6 +13,19 @@ This man page only documents the hardware-specific features of the
 bestups driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
 
+NOTE
+----
+
+Please note that this driver is deprecated and will not receive
+new development. If it works for managing your devices -- fine,
+but if you are running it to try setting up a new device, please
+consider the newer linkman:nutdrv_qx[8] instead, which should
+handle all 'Q*' protocol variants for NUT.
++
+Please do also report if your device works with this driver,
+but linkman:nutdrv_qx[8] would not actually support it with any
+subdriver!
+
 SUPPORTED HARDWARE
 ------------------
 *bestups* was designed to monitor Best Power UPS hardware like the Fortress,

--- a/docs/man/blazer-common.txt
+++ b/docs/man/blazer-common.txt
@@ -4,6 +4,18 @@ This man page only documents the hardware-specific features of the
 blazer driver. For information about the core driver, see
 linkman:nutupsdrv[8].
 
+NOTE
+----
+
+Please note that this driver is deprecated and will not receive
+new development. If it works for managing your devices -- fine,
+but if you are running it to try setting up a new device, please
+consider the newer linkman:nutdrv_qx[8] instead, which should
+handle all 'Q*' protocol variants for NUT.
++
+Please do also report if your device works with this driver,
+but linkman:nutdrv_qx[8] would not actually support it with any
+subdriver!
 
 SUPPORTED HARDWARE
 ------------------

--- a/docs/man/masterguard.txt
+++ b/docs/man/masterguard.txt
@@ -5,14 +5,24 @@ NAME
 ----
 masterguard - Driver for Masterguard UPS equipment
 
-NOTES
------
+NOTE
+----
 This man page only documents the hardware-specific features of the
 masterguard driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
 
-There's a much newer and more comprehensive driver based on the Q*
-framework that also supports USB, see linkman:nutdrv_qx[8].
+NOTE
+----
+
+Please note that this driver is deprecated and will not receive
+new development. If it works for managing your devices -- fine,
+but if you are running it to try setting up a new device, please
+consider the newer linkman:nutdrv_qx[8] instead, which should
+handle all 'Q*' protocol variants for NUT.
++
+Please do also report if your device works with this driver,
+but linkman:nutdrv_qx[8] would not actually support it with any
+subdriver!
 
 SUPPORTED HARDWARE
 ------------------

--- a/drivers/bestups.c
+++ b/drivers/bestups.c
@@ -436,6 +436,15 @@ void upsdrv_makevartable(void)
 
 void upsdrv_initups(void)
 {
+	upsdebugx(0,
+		"Please note that this driver is deprecated and will not receive\n"
+		"new development. If it works for managing your devices - fine,\n"
+		"but if you are running it to try setting up a new device, please\n"
+		"consider the newer nutdrv_qx instead, which should handle all 'Qx'\n"
+		"protocol variants for NUT. (Please also report if your device works\n"
+		"with this driver, but nutdrv_qx would not actually support it with\n"
+		"any subdriver!)\n");
+
 	upsfd = ser_open(device_path);
 	ser_set_speed(upsfd, device_path, B2400);
 }

--- a/drivers/blazer.c
+++ b/drivers/blazer.c
@@ -696,6 +696,15 @@ void blazer_initinfo(void)
 	const char	*protocol = getval("protocol");
 	int	retry;
 
+	upsdebugx(0,
+		"Please note that this driver is deprecated and will not receive\n"
+		"new development. If it works for managing your devices - fine,\n"
+		"but if you are running it to try setting up a new device, please\n"
+		"consider the newer nutdrv_qx instead, which should handle all 'Qx'\n"
+		"protocol variants for NUT. (Please also report if your device works\n"
+		"with this driver, but nutdrv_qx would not actually support it with\n"
+		"any subdriver!)\n");
+
 	for (proto = 0; command[proto].status; proto++) {
 
 		int	ret = -1;

--- a/drivers/masterguard.c
+++ b/drivers/masterguard.c
@@ -4,6 +4,11 @@
 
    masterguard.c created on 15.8.2001
 
+   OBSOLETION WARNING: Please to not base new development on this
+   codebase, instead create a new subdriver for nutdrv_qx which
+   generally covers all Megatec/Qx protocol family and aggregates
+   device support from such legacy drivers over time.
+
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; either version 2 of the License, or
@@ -561,6 +566,15 @@ void upsdrv_initups(void)
 	int     count = 0;
 	int     fail  = 0;
 	int     good  = 0;
+
+	upsdebugx(0,
+		"Please note that this driver is deprecated and will not receive\n"
+		"new development. If it works for managing your devices - fine,\n"
+		"but if you are running it to try setting up a new device, please\n"
+		"consider the newer nutdrv_qx instead, which should handle all 'Qx'\n"
+		"protocol variants for NUT. (Please also report if your device works\n"
+		"with this driver, but nutdrv_qx would not actually support it with\n"
+		"any subdriver!)\n");
 
 	/* setup serial port */
 	upsfd = ser_open(device_path);


### PR DESCRIPTION
Seeing quite a few `blazer_ser` and `blazer_usb` mentions in the issue tracker (for varied NUT version TBH), I thought that it would be helpful to point users who copy-paste configurations from older tickets and blogs to try `nutdrv_qx` instead.

I looked for drivers whose source mentions `"Q1"` or `"Q3"` and came up with the ones in this PR:
* bestups
* blazer
* masterguard

There are also some whose protocol I am not sure about, but per "fightwarn" effort they needed similar fixes (at least among themselves) :)
* riello
* bcmxcp
* richcomm