### PR TITLE
docs/man: be sure to keep a blank line after SYNOPSIS and other titles [#1362]

### DIFF
--- a/docs/daisychain.txt
+++ b/docs/daisychain.txt
@@ -82,6 +82,7 @@ device(s) that have alarms vs. nothing?)
 
 Example
 ^^^^^^^
+
 Here is an example excerpt of three PDUs, connected in daisychain mode, with
 one master and two slaves:
 

--- a/docs/man/adelsystem_cbi.txt
+++ b/docs/man/adelsystem_cbi.txt
@@ -95,16 +95,19 @@ account to access it.
 
 AUTHOR
 ------
+
 Dimitris Economou <dimitris.s.economou@gmail.com>
 
 SEE ALSO
 --------
+
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8], linkman:ups.conf[5]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
-The NUT (Network UPS Tools) home page: http://www.networkupstools.org/
 
-libmodbus home page: http://libmodbus.org
+* The NUT (Network UPS Tools) home page: http://www.networkupstools.org/
+* libmodbus home page: http://libmodbus.org

--- a/docs/man/al175.txt
+++ b/docs/man/al175.txt
@@ -3,16 +3,19 @@ AL175(8)
 
 NAME
 ----
+
 al175 - Driver for Eltek UPS models with AL175 alarm module
 
 NOTE
 ----
+
 This man page only documents the hardware-specific features of the
 *al175* driver. For information about the core driver, see
 linkman:nutupsdrv[8].
 
 SUPPORTED HARDWARE
 ------------------
+
 The *al175* driver is known to work with the following UPSes:
 
     Eltek MPSU4000 with AL175 alarm module
@@ -26,11 +29,13 @@ See documentation supplied with your hardware on how to do it.
 
 EXTRA ARGUMENTS
 ---------------
+
 This driver does not support any extra settings in the
 linkman:ups.conf[5].
 
 INSTANT COMMANDS
 ----------------
+
 This driver supports some extra commands (see linkman:upscmd[8]):
 
 *test.battery.start*::
@@ -41,6 +46,7 @@ Stop a battery test.
 
 VARIABLES
 ---------
+
 Besides status, this driver reads UPS state into following variables:
 
 - *ups.test.result*
@@ -53,12 +59,14 @@ Besides status, this driver reads UPS state into following variables:
 
 KNOWN ISSUES AND BUGS
 ---------------------
+
 * Shutdown is not supported.  FIXME
 * The driver was reworked to meet the project code quality criteria, without
   testing on real hardware. Some bugs may have crept in.
 
 AUTHOR
 ------
+
 Kirill Smelkov <kirr@mns.spb.ru>
 
 SEE ALSO
@@ -66,8 +74,10 @@ SEE ALSO
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/apcsmart-old.txt
+++ b/docs/man/apcsmart-old.txt
@@ -96,8 +96,10 @@ SEE ALSO
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/apcsmart.txt
+++ b/docs/man/apcsmart.txt
@@ -384,6 +384,7 @@ linkman:solis[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/
 
 // vim: tw=80 ai si ts=8 sts=4 sw=4 et :

--- a/docs/man/apcupsd-ups.txt
+++ b/docs/man/apcupsd-ups.txt
@@ -3,17 +3,20 @@ APCUPSD-UPS(8)
 
 NAME
 ----
+
 apcupsd-ups - Driver for apcupsd client access
 
 NOTE
 ----
+
 This man page only documents the specific features of the
 *apcupsd-ups* driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
 
 DESCRIPTION
 -----------
-This driver is a client to *apcupsd*.
+
+This driver is a client to *apcupsd* (another UPS monitoring project).
 
 *apcupsd-ups* acts as an *apcupsd* client, simply forwarding data.
 This can be useful in cases where both protocols are required in a network,
@@ -37,13 +40,15 @@ For instance:
 BACKGROUND
 ----------
 
-This driver was originally written in one evening to allow interoperating with *apcupsd*.
+This driver was originally written in one evening to allow interoperating
+with *apcupsd*.
 
 SUPPORTED VARIABLES
 -------------------
 
-The following variables are translated from *apcupsd* to NUT. All times should be
-converted to seconds (please file a bug if you notice a mismatch in units).
+The following variables are translated from *apcupsd* to NUT.
+All times should be converted to seconds (please file a bug
+if you notice a mismatch in units).
 
 [width="50%",cols="m,m",options="header"]
 |===============================
@@ -85,6 +90,7 @@ converted to seconds (please file a bug if you notice a mismatch in units).
 
 LIMITATIONS
 -----------
+
 Access to *apcupsd* is strictly read only: no commands can be issued. This
 stems from the design of *apcupsd*, where the settings are changed in
 *apctest*. In order to run *apctest*, *apcupsd* must be stopped (and *apcupsd*
@@ -92,6 +98,7 @@ exposes the UPS to the network).
 
 AUTHOR
 ------
+
 Andreas Steinmetz
 
 SEE ALSO
@@ -102,6 +109,6 @@ linkman:nutupsdrv[8]
 
 Internet Resources:
 ~~~~~~~~~~~~~~~~~~~
-The NUT (Network UPS Tools) home page: http://www.networkupstools.org/
 
-The apcupsd home page: http://www.apcupsd.org/
+* The NUT (Network UPS Tools) home page: http://www.networkupstools.org/
+* The apcupsd home page: http://www.apcupsd.org/

--- a/docs/man/asem.txt
+++ b/docs/man/asem.txt
@@ -3,16 +3,19 @@ ASEM(8)
 
 NAME
 ----
+
 asem - driver for UPS in ASEM PB1300
 
 NOTE
 ----
+
 This man page only documents the hardware-specific features of the
 *asem* driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
 
 SUPPORTED HARDWARE
 ------------------
+
 The *asem* driver supports the UPS in ASEM PB1300 embedded PCs. Likely other
 I2C devices from the same manufacturer will work too, since this is a "custom"
 charger.
@@ -41,6 +44,7 @@ Set the high battery threshold to 'num' volts.
 
 INSTALLATION
 ------------
+
 This driver is specific to the Linux I2C API, and requires the lm_sensors
 libi2c-dev or its equivalent to compile.
 
@@ -60,11 +64,13 @@ DIAGNOSTICS
 
 KNOWN ISSUES AND BUGS
 ---------------------
+
 The driver shutdown function is not implemented, so other arrangements must be
 made to turn off the UPS.
 
 AUTHORS
 -------
+
 Giuseppe Corbelli <giuseppe.corbelli@copanitalia.com>
 
 SEE ALSO
@@ -72,12 +78,12 @@ SEE ALSO
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
-PB1300 specifications: http://www.asem.it/en/products/industrial-automation/box-pcs/performance/pb1300/
 
-BQ2060 datasheet: http://www.ti.com/lit/ds/symlink/bq2060.pdf
-
-The NUT (Network UPS Tools) home page: http://www.networkupstools.org/
+* PB1300 specifications: http://www.asem.it/en/products/industrial-automation/box-pcs/performance/pb1300/
+* BQ2060 datasheet: http://www.ti.com/lit/ds/symlink/bq2060.pdf
+* The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/bcmxcp.txt
+++ b/docs/man/bcmxcp.txt
@@ -8,12 +8,14 @@ bcmxcp - Driver for UPSes supporting the serial BCM/XCP protocol
 
 NOTE
 ----
+
 This man page only documents the hardware-specific features of the
 bcmxcp driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
 
 SUPPORTED HARDWARE
 ------------------
+
 This driver should recognize all serial BCM/XCP-compatible UPSes.  It has
 been developed and tested on Powerware PW5115 and PW9120 hardware. If your UPS
 has a USB connection, you may also consult the linkman:bcmxcp_usb[8] driver
@@ -21,6 +23,7 @@ documentation.
 
 EXTRA ARGUMENTS
 ---------------
+
 This driver supports the following optional settings in the
 linkman:ups.conf[5].
 
@@ -36,11 +39,13 @@ connected with. If not included in the config, it defaults to baud-hunting.
 
 DEFAULT VALUES FOR THE EXTRA ARGUMENTS
 --------------------------------------
+
  - *shutdown_delay =* '120'
  - *baud_rate =* 'none'
 
 INSTANT COMMANDS
 ----------------
+
 This driver supports the following Instant Commands:
 
 *shutdown.return*::
@@ -67,22 +72,28 @@ Access the config register to change settings.
 
 BUGS
 ----
+
 None known.
 
 AUTHOR
 ------
+
 Tore Ørpetveit <tore@orpetveit.net>
 
 SEE ALSO
 --------
+
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 The USB BCM/XCP driver:
 ~~~~~~~~~~~~~~~~~~~~~~~
+
 linkman:bcmxcp_usb[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/bcmxcp_usb.txt
+++ b/docs/man/bcmxcp_usb.txt
@@ -3,10 +3,12 @@ BCMXCP_USB(8)
 
 NAME
 ----
+
 bcmxcp_usb - Experimental driver for UPSes supporting the BCM/XCP protocol over USB
 
 NOTE
 ----
+
 This man page only documents the hardware-specific features of the
 bcmxcp_usb driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
@@ -14,6 +16,7 @@ This driver is a variant of the serial driver bcmxcp and uses the same core code
 
 SUPPORTED HARDWARE
 ------------------
+
 This driver should recognize all BCM/XCP-compatible UPSes that are connected
 via USB.  It has been developed and tested on Powerware PW3501 hardware. It also has
 been tested on PW5110 hardware.
@@ -30,10 +33,12 @@ shutdown command and actually shutting off.
 
 DEFAULT VALUES FOR THE EXTRA ARGUMENTS
 --------------------------------------
+
 *shutdown_delay =*'120'
 
 INSTANT COMMANDS
 ----------------
+
 This driver supports the following Instant Commands:
 
 *shutdown.return*::
@@ -56,6 +61,7 @@ BCM/XCP supports reporting of UPS statistics data.
 
 EXPERIMENTAL DRIVER
 -------------------
+
 This driver has been tagged experimental, even if it has been reported
 to be stable. Thus it is not suitable for production systems and it is
 not built by default. This is mainly due to the fact that it is a
@@ -63,6 +69,7 @@ new driver.
 
 INSTALLATION
 ------------
+
 This driver is not built by default.  You can build it by using
 "configure --with-usb=yes". Note that it will also install other USB
 drivers.
@@ -74,6 +81,7 @@ must have execution flag set (ie using chmod +x ...).
 
 IMPLEMENTATION
 --------------
+
 bcmxcp_usb only supports 1 UPS at this time. You can put the
 "auto" value for port in `ups.conf`, i.e.:
 
@@ -83,6 +91,7 @@ bcmxcp_usb only supports 1 UPS at this time. You can put the
 
 KNOWN ISSUES AND BUGS
 ---------------------
+
 "Got EPERM: Operation not permitted upon driver startup"
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -92,6 +101,7 @@ hotplug so that it applies these changes.
 
 AUTHOR
 ------
+
 Tore Ørpetveit <tore@orpetveit.net>,
 Wolfgang Ocker <weo@weo1.de>
 
@@ -100,8 +110,10 @@ SEE ALSO
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/belkin.txt
+++ b/docs/man/belkin.txt
@@ -15,6 +15,7 @@ linkman:nutupsdrv[8].
 
 SUPPORTED HARDWARE
 ------------------
+
 The *belkin* driver is known to support the Regulator Pro 525 (F6C525-SER).
 Other similar models such as the 425 and 625 should also work.
 
@@ -46,10 +47,12 @@ SEE ALSO
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Other Belkin drivers:
 ~~~~~~~~~~~~~~~~~~~~~
+
 linkman:belkinunv[8],
 linkman:blazer_ser[8],
 linkman:blazer_usb[8],
@@ -57,4 +60,5 @@ linkman:usbhid-ups[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/belkinunv.txt
+++ b/docs/man/belkinunv.txt
@@ -8,6 +8,7 @@ belkinunv - Driver for Belkin "Universal UPS" and compatible
 
 NOTE
 ----
+
 This man page only documents the hardware-specific features of the
 belkin driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
@@ -18,6 +19,7 @@ drivers you should use.
 
 SUPPORTED HARDWARE
 ------------------
+
 The belkinunv driver is known to work with the Belkin Universal UPS
 models F6C800-UNV and F6C120-UNV, and is expected to work with other
 Belkin Universal UPS models. The driver only supports serial
@@ -32,6 +34,7 @@ are supported using the linkman:genericups[8] driver with
 
 SOFT SHUTDOWN WORKAROUND
 ------------------------
+
 One problem with the Belkin Universal UPS is that it cannot enter a
 soft shutdown (shut down the load until AC power returns) unless the
 batteries are completely depleted. Thus, one cannot just shut off the
@@ -73,6 +76,7 @@ startup scripts.
 
 OPTIONS
 -------
+
 See also linkman:nutupsdrv[8] for generic options. Never use the
 *-k* option with this driver; it does not work properly.
 
@@ -126,6 +130,7 @@ line.
 
 VARIABLES
 ---------
+
 *battery.charge*::
 
 *battery.runtime*::
@@ -327,15 +332,22 @@ EXTRA ARGUMENTS
 
 This driver does not support any extra settings in linkman:ups.conf[5].
 
+AUTHOR
+------
+
+Peter Selinger <selinger@users.sourceforge.net>
+
 SEE ALSO
 --------
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Other Belkin drivers:
 ~~~~~~~~~~~~~~~~~~~~~
+
 linkman:belkinunv[8],
 linkman:blazer_ser[8],
 linkman:blazer_usb[8],
@@ -343,11 +355,7 @@ linkman:usbhid-ups[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
- - The NUT (Network UPS Tools) home page: http://www.networkupstools.org/
- - The documentation for the protocol used by this UPS:
-link:http://www.mscs.dal.ca/~selinger/ups/belkin-universal-ups.html[belkin-universal-ups.html]
 
-AUTHOR
-------
-
-Peter Selinger <selinger@users.sourceforge.net>
+* The NUT (Network UPS Tools) home page: http://www.networkupstools.org/
+* The documentation for the protocol used by this UPS:
+  link:http://www.mscs.dal.ca/~selinger/ups/belkin-universal-ups.html[belkin-universal-ups.html]

--- a/docs/man/bestfcom.txt
+++ b/docs/man/bestfcom.txt
@@ -8,12 +8,14 @@ bestfcom - Driver for Best Power Fortress/Ferrups
 
 NOTE
 ----
+
 This man page only documents the hardware-specific features of the
 bestfcom driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
 
 SUPPORTED HARDWARE
 ------------------
+
 Best Power Fortress/Ferrups implementing the Fortress UPS Protocol
 (f-command set).
 
@@ -25,21 +27,21 @@ linkman:ups.conf[5].
 
 AUTHORS
 -------
-Kent Polk (bestfcom)
 
-Andreas Wrede, John Stone (bestuferrups)
-
-Grant Taylor (bestfort)
-
-Russell Kroll (bestups)
+* Kent Polk (bestfcom)
+* Andreas Wrede, John Stone (bestuferrups)
+* Grant Taylor (bestfort)
+* Russell Kroll (bestups)
 
 SEE ALSO
 --------
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/bestfortress.txt
+++ b/docs/man/bestfortress.txt
@@ -15,10 +15,12 @@ linkman:nutupsdrv[8].
 
 SUPPORTED HARDWARE
 ------------------
+
 This driver supports old Best Fortress UPS equipment using a serial connection.
 
 EXTRA ARGUMENTS
 ---------------
+
 This driver supports the following optional settings in the
 linkman:ups.conf[5]:
 
@@ -28,22 +30,26 @@ Set the speed of the serial connection - 1200, 2400, 4800 or 9600.
 *max_load*='VA'::
 Set the full-scale value of the *ups.load* variable.
 
-AUTHOR
-------
-Holger Dietze <holger.dietze@advis.de>,
-Stuart D. Gathman <stuart@bmsi.com>
+AUTHORS
+-------
+
+* Holger Dietze <holger.dietze@advis.de>
+* Stuart D. Gathman <stuart@bmsi.com>
 
 SEE ALSO
 --------
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 The newer Best Power drivers:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 linkman:bestups[8], linkman:bestuferrups[8], linkman:bestfcom[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/bestuferrups.txt
+++ b/docs/man/bestuferrups.txt
@@ -8,12 +8,14 @@ bestuferrups - Driver for Best Power Micro-Ferrups
 
 NOTE
 ----
+
 This man page only documents the hardware-specific features of the
 bestuferrups driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
 
 SUPPORTED HARDWARE
 ------------------
+
 Best Power Micro-Ferrups ME3100, probably other similar models too.
 
 EXTRA ARGUMENTS
@@ -24,19 +26,20 @@ linkman:ups.conf[5].
 
 AUTHORS
 -------
-Andreas Wrede, John Stone (bestuferrups)
 
-Grant Taylor (bestfort)
-
-Russell Kroll (bestups)
+* Andreas Wrede, John Stone (bestuferrups)
+* Grant Taylor (bestfort)
+* Russell Kroll (bestups)
 
 SEE ALSO
 --------
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/bestups.txt
+++ b/docs/man/bestups.txt
@@ -15,6 +15,7 @@ linkman:nutupsdrv[8].
 
 SUPPORTED HARDWARE
 ------------------
+
 *bestups* was designed to monitor Best Power UPS hardware like the Fortress,
 Fortress Telecom, Axxium Rackmount and Patriot Pro.  It also recognizes
 and supports SOLA units such as the 325, 520 and 620.  In addition, the
@@ -101,17 +102,21 @@ things such as the perpetual 98.7% charge on the author's Fortress 750,
 even when it's been charging for weeks.  You can use `nombattvolt=` in
 linkman:ups.conf[8] to fix this.
 
-AUTHOR
-------
-Russell Kroll, Jason White
+AUTHORS
+-------
+
+* Russell Kroll
+* Jason White
 
 SEE ALSO
 --------
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/blazer-common.txt
+++ b/docs/man/blazer-common.txt
@@ -1,5 +1,6 @@
 NOTE
 ----
+
 This man page only documents the hardware-specific features of the
 blazer driver. For information about the core driver, see
 linkman:nutupsdrv[8].
@@ -304,8 +305,8 @@ The temperature and load value is known to be bogus in some models.
 AUTHORS
 -------
 
-Arjen de Korte <adkorte-guest at alioth.debian.org>,
-Alexander Gordeev <lasaine at lvk.cs.msu.su>
+* Arjen de Korte <adkorte-guest at alioth.debian.org>
+* Alexander Gordeev <lasaine at lvk.cs.msu.su>
 
 
 SEE ALSO
@@ -323,7 +324,6 @@ linkman:nutupsdrv[8], linkman:upsc[8], linkman:upscmd[8], linkman:upsrw[8]
 Internet Resources:
 ~~~~~~~~~~~~~~~~~~~
 
-The NUT (Network UPS Tools) home page: http://www.networkupstools.org/
-
-The NUT HCL: http://www.networkupstools.org/stable-hcl.html
+* The NUT (Network UPS Tools) home page: http://www.networkupstools.org/
+* The NUT HCL: http://www.networkupstools.org/stable-hcl.html
 

--- a/docs/man/clone.txt
+++ b/docs/man/clone.txt
@@ -3,22 +3,26 @@ CLONE(8)
 
 NAME
 ----
+
 clone - UPS driver clone
 
 NOTE
 ----
+
 This man page only documents the specific features of the
 clone driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
 
 DESCRIPTION
 -----------
+
 This driver, which sits on top of another driver socket, allows users to group
 clients to a particular outlet of a device and deal with this output as if it
 was a normal UPS.
 
 EXTRA ARGUMENTS
 ---------------
+
 This driver supports the following settings:
 
 *load.off*='command'::
@@ -58,6 +62,7 @@ Set the remaining battery runtime when the clone UPS switches to LB
 
 IMPLEMENTATION
 --------------
+
 The port specification in the linkman:ups.conf[5] reference the driver
 socket that the "real" UPS driver is using. For example:
 
@@ -75,6 +80,7 @@ socket that the "real" UPS driver is using. For example:
 
 IMPORTANT
 ---------
+
 Unlike a real UPS, you should *not* configure a upsmon primary mode for this
 driver.  When a upsmon primary sees the OB LB flags and tells the upsd server
 it is OK to initiate the shutdown sequence, the server will latch the FSD
@@ -88,6 +94,7 @@ FSD flag if needed without the help of a upsmon primary.
 
 CAVEATS
 -------
+
 The clone UPS will follow the status on the real UPS driver.  You can only
 make the clone UPS shutdown earlier than the real UPS driver, not later.
 If the real UPS driver initiates a shutdown, the clone UPS driver will
@@ -100,6 +107,7 @@ warning.
 
 AUTHOR
 ------
+
 Arjen de Korte <adkorte-guest@alioth.debian.org>
 
 SEE ALSO
@@ -112,4 +120,5 @@ linkman:nutupsdrv[8]
 
 Internet Resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/dummy-ups.txt
+++ b/docs/man/dummy-ups.txt
@@ -3,16 +3,19 @@ DUMMY-UPS(8)
 
 NAME
 ----
+
 dummy-ups - Driver for multi-purpose UPS emulation
 
 NOTE
 ----
+
 This man page only documents the specific features of the
 *dummy-ups* driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
 
 DESCRIPTION
 -----------
+
 This program is a multi-purpose UPS emulation tool.
 Its behavior depends on the running mode: "dummy" or "repeater".
 
@@ -165,11 +168,13 @@ which allows one to build a virtual device, composed of several other devices
 
 BUGS
 ----
+
 Instant commands are not yet supported in Dummy Mode, and data need name/value
 checking enforcement, as well as boundaries or enumeration definition.
 
 AUTHOR
 ------
+
 Arnaud Quette
 
 SEE ALSO
@@ -182,4 +187,5 @@ linkman:nutupsdrv[8]
 
 Internet Resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/etapro.txt
+++ b/docs/man/etapro.txt
@@ -3,33 +3,41 @@ ETAPRO(8)
 
 NAME
 ----
+
 etapro - Driver for ETA UPS equipment
 
 NOTE
 ----
+
 This man page only documents the hardware-specific features of the
 etapro driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
 
 SUPPORTED HARDWARE
 ------------------
+
 This driver supports ETA UPS equipment with the "PRO" option for smart mode.
 
 EXTRA ARGUMENTS
 ---------------
+
 This driver does not support any extra settings in the
 linkman:ups.conf[5].
 
 AUTHOR
 ------
+
 Marek Michalkiewicz <marekm@amelek.gda.pl>
 
 SEE ALSO
 --------
+
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/everups.txt
+++ b/docs/man/everups.txt
@@ -3,16 +3,19 @@ EVERUPS(8)
 
 NAME
 ----
+
 everups - Driver for Ever UPS models
 
 NOTE
 ----
+
 This man page only documents the hardware-specific features of the
 everups driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
 
 SUPPORTED HARDWARE
 ------------------
+
 This driver should recognize the NET *-DPC and AP *-PRO models.
 
 EXTRA ARGUMENTS
@@ -30,6 +33,7 @@ don't sleep and force a reboot.
 
 AUTHOR
 ------
+
 Bartek Szady <bszx@bszxdomain.edu.eu.org>
 
 SEE ALSO
@@ -37,8 +41,10 @@ SEE ALSO
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/gamatronic.txt
+++ b/docs/man/gamatronic.txt
@@ -3,16 +3,19 @@ GAMATRONIC(8)
 
 NAME
 ----
+
 gamatronic - Driver for Gamatronic UPS equipment
 
 NOTE
 ----
+
 This man page only documents the hardware-specific features of the
 gamatronic driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
 
 SUPPORTED HARDWARE
 ------------------
+
 Various - Rebuilt to work with Gamatronic UPS Units, but should recognize any
 UPS that speaks the SEC protocol at 1200-19200 bps.
 
@@ -24,6 +27,7 @@ linkman:ups.conf[5].
 
 AUTHOR
 ------
+
 Nadav Moskovitch <blutz@walla.com>
 
 SEE ALSO
@@ -31,8 +35,10 @@ SEE ALSO
 
 The core driver
 ~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources
 ~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/generic_modbus.txt
+++ b/docs/man/generic_modbus.txt
@@ -229,16 +229,19 @@ HB etc) by writing over those registers.
 
 AUTHOR
 ------
+
 Dimitris Economou <dimitris.s.economou@gmail.com>
 
 SEE ALSO
 --------
+
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8], linkman:ups.conf[5]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
-The NUT (Network UPS Tools) home page: http://www.networkupstools.org/
 
-libmodbus home page: http://libmodbus.org
+* The NUT (Network UPS Tools) home page: http://www.networkupstools.org/
+* libmodbus home page: http://libmodbus.org

--- a/docs/man/genericups.txt
+++ b/docs/man/genericups.txt
@@ -3,15 +3,18 @@ GENERICUPS(8)
 
 NAME
 ----
+
 genericups - Driver for contact-closure UPS equipment
 
 NOTE
 ----
+
 This man page only documents the specific features of the genericups
 driver.  For information about the core driver, see linkman:nutupsdrv[8].
 
 SUPPORTED HARDWARE
 ------------------
+
 This driver supports hardware from many different manufacturers as it only
 uses the very simplest of signaling schemes.  Contact closure refers to a
 kind of interface where basic high/low signals are provided to indicate
@@ -23,11 +26,13 @@ a smarter UPS.
 
 CABLING
 -------
+
 Cabling is different for every kind of UPS.  See the table below for
 information on what is known to work with a given UPS type.
 
 EXTRA ARGUMENTS
 ---------------
+
 This driver supports the following settings in the linkman:ups.conf[5]:
 
 upstype='type'::
@@ -89,6 +94,7 @@ recognizes a low battery condition when DCD is not held high.
 
 TYPE INFORMATION
 ----------------
+
 The essence of a UPS definition in this driver is how it uses the serial
 lines that are available.  These are the abbreviations you will see below:
 
@@ -392,8 +398,10 @@ SEE ALSO
 
 The core driver
 ~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
-Internet resources
-~~~~~~~~~~~~~~~~~~
+Internet resources:
+~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/hosts.conf.txt
+++ b/docs/man/hosts.conf.txt
@@ -36,4 +36,5 @@ linkman:upsset.cgi[8], linkman:upsstats.cgi[8], linkman:upsimage.cgi[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/huawei-ups2000.txt
+++ b/docs/man/huawei-ups2000.txt
@@ -342,20 +342,23 @@ Guide.
 
 AUTHOR
 ------
+
 Yifeng Li <tomli@tomli.me>
 
 SEE ALSO
 --------
+
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
-The NUT (Network UPS Tools) home page: http://www.networkupstools.org/
 
-Huawei UPS2000-A (1 kVA-3 kVA) User Manual: https://support.huawei.com/enterprise/en/doc/EDOC1000084260
-
-Huawei UPS2000 (1 kVA-3 kVA) Modbus Protocol Development Guide: https://support.huawei.com/enterprise/en/doc/EDOC1000110696
-
-libmodbus home page: http://libmodbus.org
+* The NUT (Network UPS Tools) home page: http://www.networkupstools.org/
+* Huawei UPS2000-A (1 kVA-3 kVA) User Manual:
+  https://support.huawei.com/enterprise/en/doc/EDOC1000084260
+* Huawei UPS2000 (1 kVA-3 kVA) Modbus Protocol Development Guide:
+  https://support.huawei.com/enterprise/en/doc/EDOC1000110696
+* libmodbus home page: http://libmodbus.org

--- a/docs/man/isbmex.txt
+++ b/docs/man/isbmex.txt
@@ -15,6 +15,7 @@ linkman:nutupsdrv[8].
 
 SUPPORTED HARDWARE
 ------------------
+
 This driver supports SOLA/BASIC Mexico ISBMEX protocol UPS equipment.
 
 EXTRA ARGUMENTS
@@ -25,6 +26,7 @@ linkman:ups.conf[5].
 
 AUTHOR
 ------
+
 Edscott Wilson Garcia <edscott@imp.mx>
 
 SEE ALSO
@@ -32,8 +34,10 @@ SEE ALSO
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/ivtscd.txt
+++ b/docs/man/ivtscd.txt
@@ -3,32 +3,40 @@ IVTSCD(8)
 
 NAME
 ----
+
 ivtscd - driver for the IVT Solar Controller Device
 
 NOTE
 ----
+
 This man page only documents the hardware-specific features of the
 *ivtscd* driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
 
 DESCRIPTION
 -----------
+
 This driver allows to access the IVT SCD-series devices.
 
 EXTRA ARGUMENTS
 ---------------
+
 This driver does not support any extra argument.
 
 AUTHOR
 ------
+
 Arjen de Korte <adkorte-guest@alioth.debian.org>
 
 SEE ALSO
 --------
+
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/libnutclient.txt
+++ b/docs/man/libnutclient.txt
@@ -39,10 +39,12 @@ See the `nutclient.h` header for more information.
 
 ERROR HANDLING
 --------------
+
 There is currently no specific mechanism around error handling.
 
 SEE ALSO
 --------
+
 linkman:libnutclient_devices[3]
 linkman:libnutclient_commands[3]
 linkman:libnutclient_general[3]

--- a/docs/man/libnutclient_commands.txt
+++ b/docs/man/libnutclient_commands.txt
@@ -42,6 +42,7 @@ The *nutclient_execute_device_command* intend to execute the instant command.
 
 SEE ALSO
 --------
+
 linkman:libnutclient[3]
 linkman:libnutclient_devices[3]
 linkman:libnutclient_general[3]

--- a/docs/man/libnutclient_devices.txt
+++ b/docs/man/libnutclient_devices.txt
@@ -35,6 +35,7 @@ The returned description string must be freed.
 
 SEE ALSO
 --------
+
 linkman:libnutclient[3]
 linkman:libnutclient_commands[3]
 linkman:libnutclient_devices[3]

--- a/docs/man/libnutclient_general.txt
+++ b/docs/man/libnutclient_general.txt
@@ -42,4 +42,5 @@ It also frees all pointed strings.
 
 SEE ALSO
 --------
+
 linkman:libnutclient[3]

--- a/docs/man/libnutclient_misc.txt
+++ b/docs/man/libnutclient_misc.txt
@@ -51,4 +51,5 @@ flag on the device.
 
 SEE ALSO
 --------
+
 linkman:libnutclient[3]

--- a/docs/man/libnutclient_tcp.txt
+++ b/docs/man/libnutclient_tcp.txt
@@ -50,5 +50,6 @@ The *nutclient_tcp_get_timeout()* function retrieve the timeout duration for I/O
 
 SEE ALSO
 --------
+
 linkman:libnutclient[3]
 linkman:libnutclient_general[3]

--- a/docs/man/libnutclient_variables.txt
+++ b/docs/man/libnutclient_variables.txt
@@ -59,6 +59,7 @@ The *nutclient_set_device_variable_values* intend to set multiple values of the 
 
 SEE ALSO
 --------
+
 linkman:libnutclient[3]
 linkman:libnutclient_devices[3]
 linkman:libnutclient_general[3]

--- a/docs/man/libupsclient-config.txt
+++ b/docs/man/libupsclient-config.txt
@@ -8,6 +8,7 @@ libupsclient-config - script to get information about the installed version of l
 
 SYNOPSIS
 --------
+
 *libupsclient-config* [--version] [--libs] [--cflags]
 
 DESCRIPTION
@@ -33,6 +34,7 @@ Print the compiler flags that are necessary to compile a *libupsclient* program.
 
 AUTHORS
 -------
+
 This manual page was written by Arnaud Quette <aquette.dev@gmail.com>.
 
 SEE ALSO
@@ -42,5 +44,6 @@ linkman:upsclient[3]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/
 

--- a/docs/man/liebert-esp2.txt
+++ b/docs/man/liebert-esp2.txt
@@ -8,12 +8,14 @@ liebert-esp2 - Driver for Liebert UPS, using the ESP-II serial protocol
 
 NOTE
 ----
+
 This man page only documents the hardware-specific features of the
 liebert-esp2 driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
 
 SPECIAL CABLING NOTE
 --------------------
+
 Be aware that an RS-232 cable with ONLY the RX, TX and ground pin
 must be used when interfacing with GXT2 series UPS units (and possibly others),
 since the handshaking lines are used for purposes other than RS-232 flow control.
@@ -23,8 +25,9 @@ the proper cable/wiring with the diagram provided in the manual with your UPS.
 
 SUPPORTED HARDWARE
 ------------------
+
 Tested to work on the following units:
-Liebert GXT2-6000RT208
+* Liebert GXT2-6000RT208
 
 This is an experimental driver.  You have been warned.
 
@@ -41,15 +44,20 @@ Set the speed of the serial connection - 1200, 2400 (default), 4800, 9600 or 192
 
 AUTHOR
 ------
-Richard Gregory <R.Gregory at liverpool.ac.uk>, Arjen de Korte <adkorte-guest at alioth.debian.org>, Nash Kaminski <nashkaminski at kaminski.io>
+
+* Richard Gregory <R.Gregory at liverpool.ac.uk>
+* Arjen de Korte <adkorte-guest at alioth.debian.org>
+* Nash Kaminski <nashkaminski at kaminski.io>
 
 SEE ALSO
 --------
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/liebert.txt
+++ b/docs/man/liebert.txt
@@ -8,12 +8,14 @@ liebert - Driver for Liebert contact-closure UPS equipment
 
 NOTE
 ----
+
 This man page only documents the hardware-specific features of the
 liebert driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
 
 SUPPORTED HARDWARE
 ------------------
+
 This driver supports some Liebert UPS equipment with a contact-closure
 interface.  This includes the UPStation GXT2 with their contact-closure
 cable.  The smart mode ("Multilink") cable is not supported by this
@@ -42,8 +44,10 @@ SEE ALSO
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/macosx-ups.txt
+++ b/docs/man/macosx-ups.txt
@@ -3,16 +3,19 @@ MACOSX-UPS(8)
 
 NAME
 ----
+
 macosx-ups - monitor for Mac OS X built-in UPS and battery driver
 
 NOTE
 ----
+
 This man page only documents the hardware-specific features of the
 *macosx-ups* driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
 
 SUPPORTED HARDWARE
 ------------------
+
 *macosx-ups* supports any USB HID Power Device Class (PDC) UPS which is
 matched by the Mac OS X built-in drivers. It also can monitor a laptop
 internal battery as though it were an UPS.
@@ -23,6 +26,7 @@ Preferences, this driver should be able to monitor it.
 
 EXTRA ARGUMENTS
 ----------------
+
 *port*=auto::
 Due to changes in the way that Mac OS X lists power sources, the *port*
 parameter no longer has any effect. The rest of NUT still requires a value here,
@@ -62,6 +66,7 @@ hardware only) or linkman:usbhid-ups[8].
 
 AUTHORS
 -------
+
 Charles Lepple <clepple+nut at gmail.com>
 
 SEE ALSO
@@ -71,10 +76,11 @@ linkman:usbhid-ups[8], *pmset*(8), *regex*(3)
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
-The NUT (Network UPS Tools) home page: http://www.networkupstools.org/
 
-The apcupsd home page: http://www.apcupsd.org/
+* The NUT (Network UPS Tools) home page: http://www.networkupstools.org/
+* The apcupsd home page: http://www.apcupsd.org/

--- a/docs/man/masterguard.txt
+++ b/docs/man/masterguard.txt
@@ -3,10 +3,12 @@ MASTERGUARD(8)
 
 NAME
 ----
+
 masterguard - Driver for Masterguard UPS equipment
 
 NOTES
 -----
+
 This man page only documents the hardware-specific features of the
 masterguard driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
@@ -16,6 +18,7 @@ framework that also supports USB, see linkman:nutdrv_qx[8].
 
 SUPPORTED HARDWARE
 ------------------
+
 This driver supports Masterguard UPS equipment (serial connection only).
 
 EXTRA ARGUMENTS
@@ -26,6 +29,7 @@ Cancel the shutdown procedure.
 
 AUTHOR
 ------
+
 Michael Spanier <mail@michael-spanier.de>
 
 SEE ALSO
@@ -33,12 +37,15 @@ SEE ALSO
 
 Newer driver:
 ~~~~~~~~~~~~~
+
 linkman:nutdrv_qx[8]
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/metasys.txt
+++ b/docs/man/metasys.txt
@@ -32,15 +32,18 @@ The driver should support all the common features of the ups models:
 
 CABLING
 -------
+
 The needed cable is a standard pin-to-pin serial cable with at least
 pins 2, 3, and 5 (on DB9 connector) connected.
 
 EXTRA ARGUMENTS
 ---------------
+
 This driver supports no extra arguments from linkman:ups.conf[5].
 
 BUGS
 ----
+
 This driver has been tested on Meta System HF Millennium 820 and
 ally HF 1000 only.
 
@@ -49,6 +52,7 @@ UPS are really welcome.
 
 AUTHOR
 ------
+
 Fabio Di Niro <blaxwan@users.sourceforge.net>
 
 SEE ALSO
@@ -56,8 +60,10 @@ SEE ALSO
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/mge-shut.txt
+++ b/docs/man/mge-shut.txt
@@ -90,8 +90,10 @@ SEE ALSO
 
 The core driver
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources
 ~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/mge-utalk.txt
+++ b/docs/man/mge-utalk.txt
@@ -75,24 +75,26 @@ This is due to the fact that these models don't support too much polling.
 To solve this problem, add "pollinterval=20" in ups.conf, and change the value
 of MAXAGE to 25 in upsd.conf, and DEADTIME to 25 in upsmon.conf.
 
-AUTHOR
-------
+AUTHORS
+-------
 
-Hans Ekkehard Plesser,
-Arnaud Quette,
-Martin Loyer,
-Patrick Agrain,
-Nicholas Reilly,
-Dave Abbott,
-Marek Kralewski
+* Hans Ekkehard Plesser
+* Arnaud Quette
+* Martin Loyer
+* Patrick Agrain
+* Nicholas Reilly
+* Dave Abbott
+* Marek Kralewski
 
 SEE ALSO
 --------
 
 The core driver
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources
 ~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/microdowell.txt
+++ b/docs/man/microdowell.txt
@@ -15,8 +15,9 @@ linkman:nutupsdrv[8].
 
 SUPPORTED HARDWARE
 ------------------
-This driver was developed for the Enterprise Nxx and Bxx models. Other
-Microdowell models may work, too.
+
+This driver was developed for the Enterprise Nxx and Bxx models.
+Other Microdowell models may work, too.
 
 EXTRA ARGUMENTS
 ---------------
@@ -26,6 +27,7 @@ linkman:ups.conf[5].
 
 AUTHOR
 ------
+
 Elio Corbolante <eliocor@microdowell.com>
 
 SEE ALSO
@@ -33,8 +35,10 @@ SEE ALSO
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/microsol-apc.txt
+++ b/docs/man/microsol-apc.txt
@@ -15,6 +15,7 @@ linkman:nutupsdrv[8].
 
 SUPPORTED HARDWARE
 ------------------
+
 This driver supports the following UPS models:
 
  * APC Back-UPS BZ1500-BR
@@ -53,17 +54,20 @@ models, but is untested.
 
 AUTHOR
 ------
-Ygor A. S. Regados <ygorre@tutanota.com>,
-Roberto P. Velloso <rvelloso@gmail.com>,
-Silvino B. Magalhães <sbm2yk@gmail.com>
+
+* Ygor A. S. Regados <ygorre@tutanota.com>
+* Roberto P. Velloso <rvelloso@gmail.com>
+* Silvino B. Magalhães <sbm2yk@gmail.com>
 
 SEE ALSO
 --------
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/netxml-ups.txt
+++ b/docs/man/netxml-ups.txt
@@ -3,18 +3,21 @@ netxml-ups(8)
 
 NAME
 ----
+
 netxml-ups - Driver for Eaton / MGE Network Management Card / Proxy
 (XML/HTTP Protocol) equipment
 
 NOTE
 ----
+
 This man page only documents the hardware-specific features of the
 netxml-ups driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
 
 SUPPORTED HARDWARE
 ------------------
-netxml-ups support all recent Eaton / MGE models which use a Network
+
+netxml-ups supports all recent Eaton / MGE models which use a Network
 Management Card or Proxy (MGE XML/HTTP protocol based). This applies to both
 Eaton (previously MGE Office Protection Systems) and to MGE UPS SYSTEMS.
 Supported card and proxy models are:
@@ -32,6 +35,7 @@ parameter.
 
 EXTRA ARGUMENTS
 ---------------
+
 This driver supports the following optional settings in the
 linkman:ups.conf[5]:
 
@@ -77,6 +81,7 @@ particular driver instance restores the old behavior for those measurements.
 
 IMPLEMENTATION
 --------------
+
 The hostname of the UPS is specified with the "port" value in
 *ups.conf*, i.e.:
 
@@ -94,6 +99,7 @@ linkman:ups.conf[5]) to at least 5 seconds.
 
 KNOWN ISSUES
 ------------
+
 Don't connect to the UPS through a proxy. Although it would be trivial to add
 support for proxies, this is not recommended and don't ask for it. Not only
 because it will prevent the driver to make a persistent connection to the UPS,
@@ -102,6 +108,7 @@ whatever reason), the driver will no longer be able to reach the UPS.
 
 AUTHORS
 -------
+
 Arjen de Korte <adkorte-guest@alioth.debian.org>
 
 SEE ALSO
@@ -109,8 +116,10 @@ SEE ALSO
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/nut-driver-enumerator.txt
+++ b/docs/man/nut-driver-enumerator.txt
@@ -8,6 +8,7 @@ nut-driver-enumerator - tool to map NUT device entries to service instances
 
 SYNOPSIS
 --------
+
 *nut-driver-enumerator.sh* -h
 
 *nut-driver-enumerator.sh*  (no args)
@@ -135,8 +136,10 @@ Absent or unreadable `ups.conf` file
 
 SEE ALSO
 --------
+
 linkman:upsdrvsvcctl[8], linkman:ups.conf[5]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/nut-ipmipsu.txt
+++ b/docs/man/nut-ipmipsu.txt
@@ -100,16 +100,19 @@ Here is an example output for a Dell r610 server:
 
 AUTHOR
 ------
+
 Arnaud Quette <arnaud.quette@free.fr>
 
 SEE ALSO
 --------
+
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
-The NUT (Network UPS Tools) home page: http://www.networkupstools.org/
 
-GNU FreeIPMI home page: http://www.gnu.org/software/freeipmi/
+* The NUT (Network UPS Tools) home page: http://www.networkupstools.org/
+* GNU FreeIPMI home page: http://www.gnu.org/software/freeipmi/

--- a/docs/man/nut-recorder.txt
+++ b/docs/man/nut-recorder.txt
@@ -1,17 +1,19 @@
 NUT-RECORDER(8)
 ===============
 
-
 NAME
 ----
+
 nut-recorder - utility to record device status and values changes
 
 SYNOPSIS
 --------
+
 *nut-recorder* 'device-name' [output-file] [interval]
 
 DESCRIPTION
 -----------
+
 *nut-recorder* is an utility to record sequences from running devices (such as
 power failures, or any other value changes) from upsd, and dump it in a .seq
 format.
@@ -21,6 +23,7 @@ to replay the sequence.
 
 OPTIONS
 -------
+
 'device-name'::
 
 Record the changes of this device.  The format for this option is
@@ -60,14 +63,18 @@ You can then define a dummy device in linkman:ups.conf[5]:
 
 AUTHOR
 ------
+
 Arnaud Quette
 
 SEE ALSO
 --------
 
+The dummy-ups driver:
+~~~~~~~~~~~~~~~~~~~~~
+
 linkman:dummy-ups[8]
 
-INTERNET RESOURCES
-------------------
+Internet resources:
+~~~~~~~~~~~~~~~~~~~
 
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/nut-scanner.txt
+++ b/docs/man/nut-scanner.txt
@@ -1,13 +1,14 @@
 NUT-SCANNER(8)
 ==============
 
-
 NAME
 ----
+
 nut-scanner - scan communication buses for NUT devices
 
 SYNOPSIS
 --------
+
 *nut-scanner* -h
 
 *nut-scanner* ['OPTIONS']
@@ -29,6 +30,7 @@ both during compilation and runtime, then SNMP discovery will be available.
 
 OPTIONS
 -------
+
 *-h*::
 Display the help text.
 
@@ -213,7 +215,7 @@ SEE ALSO
 
 linkman:ups.conf[5]
 
-INTERNET RESOURCES
-------------------
+Internet resources:
+~~~~~~~~~~~~~~~~~~~
 
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/nut.conf.txt
+++ b/docs/man/nut.conf.txt
@@ -3,6 +3,7 @@ NUT.CONF(5)
 
 NAME
 ----
+
 nut.conf - UPS definitions for Network UPS Tools
 
 DESCRIPTION
@@ -104,6 +105,7 @@ SEE ALSO
 linkman:ups.conf[5], linkman:upsd.conf[5], linkman:upsd.users[5],
 linkman:upsmon.conf[5]
 
-INTERNET RESOURCES
-------------------
+Internet resources:
+~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/nutdrv_atcl_usb.txt
+++ b/docs/man/nutdrv_atcl_usb.txt
@@ -3,15 +3,18 @@ NUTDRV_ATCL_USB(8)
 
 NAME
 ----
+
 nutdrv_atcl_usb - Driver for 'ATCL FOR UPS' equipment
 
 NOTE
 ----
+
 This man page only documents the specific features of the nutdrv_atcl_usb
 driver.  For information about the core driver, see linkman:nutupsdrv[8].
 
 SUPPORTED HARDWARE
 ------------------
+
 This driver is for UPS hardware which identifies itself as USB idVendor 0001
 and idProduct 0000, and iManufacturer +ATCL FOR UPS+.  Known manufacturers
 include Kanji and Plexus. The UPS interface seems to be a generic USB-to-serial
@@ -35,6 +38,7 @@ devices, such as linkman:nutdrv_qx[8].
 
 BUGS
 ----
+
 The UPS returns the same code for "load power is off" as for "on line power".
 This condition will not be observed if the NUT `upsmon` in primary mode runs
 on the box powered by the UPS, but may be an issue if the UPS is monitored
@@ -53,6 +57,7 @@ kind that allows detection and proper load cycling on command.
 
 AUTHORS
 -------
+
 Charles Lepple
 
 SEE ALSO
@@ -60,16 +65,20 @@ SEE ALSO
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 The generic serial driver:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 linkman:genericups[8]
 
 The Qx driver:
 ~~~~~~~~~~~~~~
+
 linkman:nutdrv_qx[8] (`fuji` subdriver)
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/nutdrv_siemens_sitop.txt
+++ b/docs/man/nutdrv_siemens_sitop.txt
@@ -3,16 +3,19 @@ NUTDRV_SIEMENS_SITOP(8)
 
 NAME
 ----
+
 nutdrv_siemens_sitop - driver for the Siemens SITOP UPS500 series UPS
 
 NOTE
 ----
+
 This man page only documents the hardware-specific features of the
 *nutdrv_siemens_sitop* driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
 
 SUPPORTED HARDWARE
 ------------------
+
 *nutdrv_siemens_sitop* supports Siemens UPS models from the SITOP UPS500 series.
 Some models have a serial port, others have a USB port.
 The models with USB port actually contain a serial-over-USB chip,
@@ -26,6 +29,7 @@ with USB port (Siemens product number 6EP1933-2EC41).
 
 DEVICE SETTINGS
 ---------------
+
 The UPS is configured via DIP-switches.
 For correct functioning in combination with NUT, set the DIP-switches
 to the following:
@@ -54,6 +58,7 @@ supply power from its batteries.
 
 USB driver
 ----------
+
 The USB-versions of the UPS contain an FTDI USB-to-serial converter chip.
 It is programmed with a non-standard product ID (for example _0403:e0e3_),
 but can still be used with the normal ftdi_sio driver.
@@ -85,6 +90,7 @@ SUBSYSTEM=="tty" ATTRS{idVendor}=="0403", ATTRS{idProduct}=="e0e3" SYMLINK+="tty
 
 POLLING
 -------
+
 The UPS does not have a special 'get status' command. Instead, it continuously
 sends out status update messages (tens of messages per second).
 Every *pollinterval*, these messages are read from the serial port buffer.
@@ -94,6 +100,7 @@ value is 1 (second).
 
 EXTRA ARGUMENTS
 ---------------
+
 This driver supports the following optional settings:
 
 *max_polls_without_data*='num'::
@@ -126,6 +133,7 @@ has been removed for at least 1 second, and has been re-applied.
 
 INSTALLATION
 ------------
+
 Make sure that your operating system has created a serial device for the UPS.
 See the section *USB driver* for more information.
 
@@ -136,6 +144,7 @@ or by adding the NUT user to a user group that can access serial devices
 
 DIAGNOSTICS
 -----------
+
 You can verify the correct functioning of the hardware, by monitoring the
 serial port with a terminal program, for example picocom:
 
@@ -156,6 +165,7 @@ To exit picocom, use Ctrl-A Ctrl-X.
 
 KNOWN ISSUES AND BUGS
 ---------------------
+
 *Untested models*::
 As mentioned under *Supported hardware*, this driver has not been tested
 with all models in the SITOP UPS500 series.
@@ -174,6 +184,7 @@ It is not sure if the serial models are affected by this issue as well.
 
 AUTHORS
 -------
+
 Matthijs H. ten Berge
 
 SEE ALSO
@@ -181,8 +192,10 @@ SEE ALSO
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/nutscan.txt
+++ b/docs/man/nutscan.txt
@@ -44,11 +44,13 @@ Helper functions are also provided to output data using standard formats:
 
 ERROR HANDLING
 --------------
+
 There is currently no specific mechanism for error handling.
 
 
 SEE ALSO
 --------
+
 linkman:nut-scanner[8],
 linkman:nutscan_scan_usb[3], linkman:nutscan_scan_snmp[3],
 linkman:nutscan_scan_xml_http[3], linkman:nutscan_scan_nut[3],
@@ -56,5 +58,9 @@ linkman:nutscan_scan_avahi[3], linkman:nutscan_scan_ipmi[3],
 linkman:nutscan_display_parsable[3], linkman:nutscan_display_ups_conf[3],
 linkman:nutscan_new_device[3], linkman:nutscan_free_device[3],
 linkman:nutscan_add_device_to_device[3], linkman:nutscan_add_option_to_device[3],
-linkman:nutscan_cidr_to_ip[3],
+linkman:nutscan_cidr_to_ip[3]
+
+Internet resources:
+~~~~~~~~~~~~~~~~~~~
+
 http://avahi.org/

--- a/docs/man/nutscan_add_device_to_device.txt
+++ b/docs/man/nutscan_add_device_to_device.txt
@@ -20,11 +20,11 @@ DESCRIPTION
 The `nutscan_device_t` contains the following variables:
 
 	nutscan_device_type_t   type;
-        char *          driver;
-        char *          port;
-        nutscan_options_t       opt;
-        struct nutscan_device * prev;
-        struct nutscan_device * next;
+	char *          driver;
+	char *          port;
+	nutscan_options_t       opt;
+	struct nutscan_device * prev;
+	struct nutscan_device * next;
 
 This is a double linked list of device. Each device is described by its `type`, its `driver` name, its `port` and any number of optional data.
 
@@ -37,6 +37,7 @@ The *nutscan_add_device_to_device()* functions returns a pointer to a device con
 
 SEE ALSO
 --------
+
 linkman:nutscan_scan_usb[3], linkman:nutscan_scan_xml_http[3],
 linkman:nutscan_scan_nut[3], linkman:nutscan_scan_avahi[3],
 linkman:nutscan_scan_ipmi[3], linkman:nutscan_scan_snmp[3],

--- a/docs/man/nutscan_add_option_to_device.txt
+++ b/docs/man/nutscan_add_option_to_device.txt
@@ -20,11 +20,11 @@ DESCRIPTION
 The `nutscan_device_t` contains the following variables:
 
 	nutscan_device_type_t   type;
-        char *          driver;
-        char *          port;
-        nutscan_options_t       opt;
-        struct nutscan_device * prev;
-        struct nutscan_device * next;
+	char *          driver;
+	char *          port;
+	nutscan_options_t       opt;
+	struct nutscan_device * prev;
+	struct nutscan_device * next;
 
 This is a double linked list of device. Each device is described by its `type`, its `driver` name, its `port` and any number of optional data.
 
@@ -32,6 +32,7 @@ The *nutscan_add_option_to_device()* adds an optional data in the given device. 
 
 SEE ALSO
 --------
+
 linkman:nutscan_scan_usb[3], linkman:nutscan_scan_xml_http[3],
 linkman:nutscan_scan_nut[3], linkman:nutscan_scan_avahi[3],
 linkman:nutscan_scan_ipmi[3], linkman:nutscan_scan_snmp[3],

--- a/docs/man/nutscan_cidr_to_ip.txt
+++ b/docs/man/nutscan_cidr_to_ip.txt
@@ -25,6 +25,7 @@ The *nutscan_cidr_to_ip()* function returns 0 if an error occurred (invalid 'cid
 
 SEE ALSO
 --------
+
 linkman:nutscan_scan_usb[3], linkman:nutscan_scan_xml_http[3],
 linkman:nutscan_scan_nut[3], linkman:nutscan_scan_avahi[3],
 linkman:nutscan_scan_ipmi[3], linkman:nutscan_scan_snmp[3],

--- a/docs/man/nutscan_display_parsable.txt
+++ b/docs/man/nutscan_display_parsable.txt
@@ -26,6 +26,7 @@ The *nutscan_display_parsable()* function displays all NUT devices in 'device' t
 
 SEE ALSO
 --------
+
 linkman:nutscan_scan_usb[3], linkman:nutscan_scan_xml_http[3],
 linkman:nutscan_scan_nut[3], linkman:nutscan_scan_avahi[3],
 linkman:nutscan_scan_ipmi[3], linkman:nutscan_scan_snmp[3],

--- a/docs/man/nutscan_display_ups_conf.txt
+++ b/docs/man/nutscan_display_ups_conf.txt
@@ -20,6 +20,7 @@ The *nutscan_display_ups_conf()* function displays all NUT devices in 'device' t
 
 SEE ALSO
 --------
+
 linkman:nutscan_scan_usb[3], linkman:nutscan_scan_xml_http[3],
 linkman:nutscan_scan_nut[3], linkman:nutscan_scan_avahi[3],
 linkman:nutscan_scan_ipmi[3], linkman:nutscan_scan_snmp[3],

--- a/docs/man/nutscan_free_device.txt
+++ b/docs/man/nutscan_free_device.txt
@@ -20,6 +20,7 @@ The *nutscan_free_device()* function free a `nutscan_device_type_t` structure. D
 
 SEE ALSO
 --------
+
 linkman:nutscan_scan_usb[3], linkman:nutscan_scan_xml_http[3],
 linkman:nutscan_scan_nut[3], linkman:nutscan_scan_avahi[3],
 linkman:nutscan_scan_ipmi[3], linkman:nutscan_scan_snmp[3],

--- a/docs/man/nutscan_get_serial_ports_list.txt
+++ b/docs/man/nutscan_get_serial_ports_list.txt
@@ -33,6 +33,7 @@ The *nutscan_get_serial_ports_list()* function returns NULL if an error occurred
 
 SEE ALSO
 --------
+
 linkman:nutscan_scan_usb[3], linkman:nutscan_scan_xml_http[3],
 linkman:nutscan_scan_nut[3], linkman:nutscan_scan_avahi[3],
 linkman:nutscan_scan_ipmi[3], linkman:nutscan_scan_snmp[3],

--- a/docs/man/nutscan_init.txt
+++ b/docs/man/nutscan_init.txt
@@ -31,6 +31,7 @@ Note that if a method is reported as unavailable by those variables, the call to
 
 SEE ALSO
 --------
+
 linkman:nutscan_init[3], linkman:nutscan_scan_usb[3],
 linkman:nutscan_scan_snmp[3], linkman:nutscan_scan_xml_http[3],
 linkman:nutscan_scan_nut[3], linkman:nutscan_scan_avahi[3],

--- a/docs/man/nutscan_new_device.txt
+++ b/docs/man/nutscan_new_device.txt
@@ -25,6 +25,7 @@ The *nutscan_new_device()* function returns the newly allocated `nutscan_device_
 
 SEE ALSO
 --------
+
 linkman:nutscan_scan_usb[3], linkman:nutscan_scan_xml_http[3],
 linkman:nutscan_scan_nut[3], linkman:nutscan_scan_avahi[3],
 linkman:nutscan_scan_ipmi[3], linkman:nutscan_scan_snmp[3]

--- a/docs/man/nutscan_scan_avahi.txt
+++ b/docs/man/nutscan_scan_avahi.txt
@@ -33,6 +33,7 @@ if no device is found.
 
 SEE ALSO
 --------
+
 linkman:nutscan_init[3],
 linkman:nutscan_scan_usb[3], linkman:nutscan_scan_xml_http[3],
 linkman:nutscan_scan_nut[3], linkman:nutscan_scan_snmp[3],
@@ -40,5 +41,9 @@ linkman:nutscan_scan_ipmi[3], linkman:nutscan_display_ups_conf[3],
 linkman:nutscan_display_parsable[3], linkman:nutscan_new_device[3],
 linkman:nutscan_free_device[3], linkman:nutscan_add_option_to_device[3],
 linkman:nutscan_add_device_to_device[3], linkman:nutscan_cidr_to_ip[3],
-linkman:nutscan_scan_eaton_serial[3],
+linkman:nutscan_scan_eaton_serial[3]
+
+Internet resources:
+~~~~~~~~~~~~~~~~~~~
+
 http://avahi.org/

--- a/docs/man/nutscan_scan_eaton_serial.txt
+++ b/docs/man/nutscan_scan_eaton_serial.txt
@@ -30,6 +30,7 @@ The *nutscan_scan_eaton_serial()* function returns a pointer to a `nutscan_devic
 
 SEE ALSO
 --------
+
 linkman:nutscan_init[3],
 linkman:nutscan_scan_usb[3], linkman:nutscan_scan_xml_http[3],
 linkman:nutscan_scan_snmp[3], linkman:nutscan_scan_avahi[3],

--- a/docs/man/nutscan_scan_ipmi.txt
+++ b/docs/man/nutscan_scan_ipmi.txt
@@ -27,6 +27,7 @@ The *nutscan_scan_ipmi()* function is not implemented yet.
 
 SEE ALSO
 --------
+
 linkman:nutscan_init[3],
 linkman:nutscan_scan_usb[3], linkman:nutscan_scan_xml_http[3],
 linkman:nutscan_scan_nut[3], linkman:nutscan_scan_avahi[3],

--- a/docs/man/nutscan_scan_nut.txt
+++ b/docs/man/nutscan_scan_nut.txt
@@ -31,6 +31,7 @@ The *nutscan_scan_nut()* function returns a pointer to a `nutscan_device_t` stru
 
 SEE ALSO
 --------
+
 linkman:nutscan_init[3],
 linkman:nutscan_scan_usb[3], linkman:nutscan_scan_xml_http[3],
 linkman:nutscan_scan_snmp[3], linkman:nutscan_scan_avahi[3],

--- a/docs/man/nutscan_scan_snmp.txt
+++ b/docs/man/nutscan_scan_snmp.txt
@@ -57,6 +57,7 @@ The *nutscan_scan_snmp()* function returns a pointer to a `nutscan_device_t` str
 
 SEE ALSO
 --------
+
 linkman:nutscan_init[3],
 linkman:nutscan_scan_usb[3], linkman:nutscan_scan_xml_http[3],
 linkman:nutscan_scan_nut[3], linkman:nutscan_scan_avahi[3],

--- a/docs/man/nutscan_scan_usb.txt
+++ b/docs/man/nutscan_scan_usb.txt
@@ -27,6 +27,7 @@ The *nutscan_scan_usb()* function returns a pointer to a `nutscan_device_t` stru
 
 SEE ALSO
 --------
+
 linkman:nutscan_init[3],
 linkman:nutscan_scan_snmp[3], linkman:nutscan_scan_xml_http[3],
 linkman:nutscan_scan_nut[3], linkman:nutscan_scan_avahi[3],

--- a/docs/man/nutscan_scan_xml_http.txt
+++ b/docs/man/nutscan_scan_xml_http.txt
@@ -27,6 +27,7 @@ The *nutscan_scan_xml_http()* function returns a pointer to a `nutscan_device_t`
 
 SEE ALSO
 --------
+
 linkman:nutscan_init[3],
 linkman:nutscan_scan_usb[3], linkman:nutscan_scan_snmp[3],
 linkman:nutscan_scan_nut[3], linkman:nutscan_scan_avahi[3],

--- a/docs/man/nutupsdrv.txt
+++ b/docs/man/nutupsdrv.txt
@@ -50,6 +50,7 @@ options and parameters that generally are not needed by normal users.
 
 OPTIONS
 -------
+
 *-h*::
 Display a help message without doing anything else.  This will also list
 possible values for '-x' in that driver, and other help text that the
@@ -171,6 +172,7 @@ production use.
 
 FILES
 -----
+
 ups.conf::
 Required configuration file.  This contains all details on which drivers
 to start and where the hardware is attached.
@@ -202,19 +204,29 @@ SEE ALSO
 --------
 
 Server:
+~~~~~~~
+
 linkman:upsd[8]
 
 Clients:
+~~~~~~~~
+
 linkman:upsc[8], linkman:upscmd[8],
 linkman:upsrw[8], linkman:upslog[8], linkman:upsmon[8]
 
 CGI programs:
+~~~~~~~~~~~~~
+
 linkman:upsset.cgi[8], linkman:upsstats.cgi[8], linkman:upsimage.cgi[8]
 
 Driver control:
-linkman:upsdrvctl[8]
+~~~~~~~~~~~~~~~
+
+linkman:upsdrvctl[8], linkman:upsdrvsvcctl[8]
 
 Drivers:
+~~~~~~~~
+
 linkman:al175[8]
 linkman:apcsmart[8],
 linkman:bcmxcp[8],
@@ -259,4 +271,6 @@ linkman:upscode2[8],
 linkman:victronups[8]
 
 Internet resources:
+~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/oneac.txt
+++ b/docs/man/oneac.txt
@@ -28,6 +28,7 @@ linkman:genericups[8] driver.
 
 EXTRA ARGUMENTS
 ---------------
+
 This driver supports the following optional settings in the
 linkman:ups.conf[5] file:
 
@@ -39,6 +40,7 @@ Change shutdown delay time from 0 second default.
 
 INSTANT COMMANDS
 ----------------
+
 This driver supports the following Instant Commands.
 (See linkman:upscmd[8])
 
@@ -97,6 +99,7 @@ Mutes the UPS beeper/buzzer for the current alarm condition(s).
 
 Writable Variables
 ------------------
+
 See linkman:upsrw[8] to see what variables are writable for the UPS.
 
 NOTE: If your UPS supports writing battery.runtime.low, the new set value
@@ -110,6 +113,7 @@ defined range (for example: tap change or switch to inverter).
 
 AUTHOR
 ------
+
 Bill Elliot <bill@wreassoc.com>,
 Eric Lawson <elawson@inficad.com>
 
@@ -118,8 +122,10 @@ SEE ALSO
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/optiups.txt
+++ b/docs/man/optiups.txt
@@ -76,8 +76,9 @@ BUGS
 On the 420E, `ups.serial` and `ups.temperature` are unsupported features.  This
 is not a bug in NUT or the NUT driver, just the way things are with this UPS.
 
-AUTHOR
-------
+AUTHORS
+-------
+
 Russell Kroll, Scott Heavner, Matthias Goebl
 
 SEE ALSO
@@ -85,8 +86,10 @@ SEE ALSO
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/phoenixcontact_modbus.txt
+++ b/docs/man/phoenixcontact_modbus.txt
@@ -75,16 +75,19 @@ This driver doesn't support any instant commands.
 
 AUTHOR
 ------
+
 Spiros Ioannou <sivann@gmail.com>
 
 SEE ALSO
 --------
+
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
-The NUT (Network UPS Tools) home page: http://www.networkupstools.org/
 
-libmodbus home page: http://libmodbus.org
+* The NUT (Network UPS Tools) home page: http://www.networkupstools.org/
+* libmodbus home page: http://libmodbus.org

--- a/docs/man/pijuice.txt
+++ b/docs/man/pijuice.txt
@@ -3,10 +3,12 @@ PIJUICE(8)
 
 NAME
 ----
+
 pijuice - driver for UPS in PiJuice HAT
 
 NOTE
 ----
+
 This man page only documents the hardware-specific features of the
 *pijuice* driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
@@ -17,6 +19,7 @@ may not fully apply to PiJuice HAT, patches from experts are welcome.
 
 SUPPORTED HARDWARE
 ------------------
+
 The *pijuice* driver supports the portable PiJuice HAT UPS for Raspberry Pi
 embedded PCs.
 
@@ -30,6 +33,7 @@ On the PiJuice HAT, this should be `/dev/i2c-1`.
 
 INSTALLATION
 ------------
+
 NOTE: This section was copied from `asem` driver manpage and may not fully
 apply to PiJuice HAT, patches are welcome.
 
@@ -52,6 +56,7 @@ DIAGNOSTICS
 
 KNOWN ISSUES AND BUGS
 ---------------------
+
 NOTE: This section was copied from `asem` driver manpage and may not fully
 apply to PiJuice HAT, patches are welcome.
 
@@ -60,6 +65,7 @@ made to turn off the UPS.
 
 AUTHORS
 -------
+
 Andrew Anderson <aander07@gmail.com>
 
 SEE ALSO
@@ -67,10 +73,12 @@ SEE ALSO
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 Initial pull requests adding this driver:
 
 * https://github.com/networkupstools/nut/pull/730

--- a/docs/man/powercom.txt
+++ b/docs/man/powercom.txt
@@ -8,12 +8,14 @@ powercom - UPS driver for serial Powercom/Trust/Advice UPS equipment
 
 NOTE
 ----
+
 This man page only documents the hardware-specific features of the
 powercom driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
 
 SUPPORTED HARDWARE
 ------------------
+
 This driver supports many similar kinds of serial UPS hardware (as well as a
 few USB UPS models with USB-to-serial adapters).  The most common ones are the
 Trust 425/625, Powercom, and Advice Partner/King PR750.  Others using the same
@@ -24,6 +26,7 @@ see the NUT Hardware Compatibility List (HCL).
 
 EXTRA ARGUMENTS
 ---------------
+
 This driver supports the following optional settings in the
 linkman:ups.conf[5] file:
 
@@ -116,6 +119,7 @@ system startup -- just when the power consumption tends to be high.
 
 DEFAULT VALUES FOR THE EXTRA ARGUMENTS
 --------------------------------------
+
  linevoltage = 230
  manufacturer = PowerCom
  modelname = Unknown
@@ -128,6 +132,7 @@ values for ALL models.
 
 Trust
 ~~~~~
+
  numOfBytesFromUPS = 11
  methodOfFlowControl = dtr0rts1
  validationSequence = {{5,0},{7,0},{8,0}}
@@ -139,6 +144,7 @@ Trust
 
 KP625AP
 ~~~~~~~
+
  numOfBytesFromUPS = 16
  methodOfFlowControl = dtr0rts1
  validationSequence = {{5,0x80},{7,0},{8,0}}
@@ -150,6 +156,7 @@ KP625AP
 
 Egys
 ~~~~
+
  numOfBytesFromUPS = 16
  methodOfFlowControl = no_flow_control
  validationSequence = {{5,0x80},{7,0},{8,0}}
@@ -161,6 +168,7 @@ Egys
 
 IMP
 ~~~
+
  numOfBytesFromUPS = 16
  methodOfFlowControl = no_flow_control
  validationSequence = {{5,0xFF},{7,0},{8,0}}
@@ -168,6 +176,7 @@ IMP
 
 KIN
 ~~~
+
  numOfBytesFromUPS = 16
  methodOfFlowControl = no_flow_control
  validationSequence = {{11,0x4b},{8,0},{8,0}}
@@ -175,6 +184,7 @@ KIN
 
 BNT
 ~~~
+
  numOfBytesFromUPS = 16
  methodOfFlowControl = no_flow_control
  validationSequence = {{11,0x42},{8,0},{8,0}}
@@ -182,6 +192,7 @@ BNT
 
 BNT-other
 ~~~~~~~~~
+
  numOfBytesFromUPS = 16
  methodOfFlowControl = no_flow_control
  validationSequence = {{8,0},{8,0},{8,0}}
@@ -193,25 +204,29 @@ BNT-other
 
 OPTI
 ~~~~
+
  numOfBytesFromUPS = 16
  methodOfFlowControl = no_flow_control
  validationSequence = {{5,0xFF},{7,0},{8,0}}
  shutdownArguments = {{1,30},y}
 
-AUTHOR
-------
-Peter Bieringer <pb@bieringer.de>,
-Alexey Sidorov <alexsid@altlinux.org>,
-Keven L. Ates <atescomp@gmail.com>,
-Rouben Tchakhmakhtchian <rouben@rouben.net>
+AUTHORS
+-------
+
+* Peter Bieringer <pb@bieringer.de>
+* Alexey Sidorov <alexsid@altlinux.org>
+* Keven L. Ates <atescomp@gmail.com>
+* Rouben Tchakhmakhtchian <rouben@rouben.net>
 
 SEE ALSO
 --------
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/powerman-pdu.txt
+++ b/docs/man/powerman-pdu.txt
@@ -38,6 +38,7 @@ This driver is not built by default.  You can build it by using
 
 UPS COMMANDS
 ------------
+
 The following instant commands (see linkman:upscmd[8]) are available for each
 outlet of the PDU, with *X* standing for the outlet number:
 
@@ -55,6 +56,7 @@ Cycle the outlet (power off then power on, possibly with a delay).
 
 IMPLEMENTATION
 --------------
+
 The hostname of the Powerman server is specified using the "port" value in
 *ups.conf*, i.e.:
 
@@ -66,22 +68,26 @@ The port used to reach 'powermand' is optional if the default port is used.
 
 KNOWN ISSUES
 ------------
+
 In the current NUT version (2.4.1), ups.status is still exposed, with the value
 "WAIT". Some other values from the
 ups collection are also exposed.
 
 AUTHOR
 ------
+
 Arnaud Quette <arnaud.quette@gmail.com>
 
 SEE ALSO
 --------
+
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
-The NUT (Network UPS Tools) home page: http://www.networkupstools.org/
 
-The PowerMan home page: http://powerman.sourceforge.net/
+* The NUT (Network UPS Tools) home page: http://www.networkupstools.org/
+* The PowerMan home page: https://github.com/chaos/powerman

--- a/docs/man/powerpanel.txt
+++ b/docs/man/powerpanel.txt
@@ -8,12 +8,14 @@ powerpanel - Driver for serial PowerPanel Plus compatible UPS equipment
 
 NOTE
 ----
+
 This man page only documents the hardware-specific features of the
 powerpanel driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
 
 SUPPORTED HARDWARE
 ------------------
+
 This driver supports CyberPower BC1200, PR2200 and many other similar
 devices, both for the text and binary protocols. The driver will
 autodetect which protocol is used.
@@ -24,6 +26,7 @@ network cards via SNMP.
 
 EXTRA ARGUMENTS
 ---------------
+
 This driver supports the following optional settings in linkman:ups.conf[5]:
 
 *protocol=*['text,binary']::
@@ -51,6 +54,7 @@ seconds will be truncated to 6 seconds intervals, values above 60 seconds to
 
 VARIABLES
 ---------
+
 Depending on the type of your UPS unit, some of the following variables may
 be changed with linkman:upsrw[8]. If the driver can't read a variable from the
 UPS, it will not be made available.
@@ -72,6 +76,7 @@ writable: allow cold start from battery
 
 COMMANDS
 --------
+
 Depending on the type of your UPS unit, some of the following commands may
 be available.
 
@@ -88,6 +93,7 @@ must verify that these work as expected (see <<_shutdown_issues,Shutdown Issues>
 
 SUPPORT STATUS
 --------------
+
 Vendor support is absent for this driver, so if you need some features that
 are currently not available, provide ample documentation on what the driver
 should sent to the UPS in order to make this work. If more information
@@ -98,6 +104,7 @@ isn't willing to share this with us.
 
 SHUTDOWN ISSUES
 ---------------
+
 If the *shutdown.return* command on your UPS doesn't seem to work,
 chances are that your UPS is an older model. Try a couple of different
 settings for 'offdelay'. If no value in the range 6..600 works, your
@@ -114,6 +121,7 @@ supported through the text protocol are affected by this.
 
 KNOWN PROBLEMS
 --------------
+
 The CyberPower OP series don't offer direct voltage, charge, frequency
 and temperature readings. Instead, they will return a binary value
 that needs conversion to the actual value.
@@ -128,6 +136,7 @@ instrument.
 
 AUTHORS
 -------
+
 Arjen de Korte <arjen@de-korte.org>, Doug Reynolds <mav@wastegate.net>
 
 SEE ALSO
@@ -135,13 +144,16 @@ SEE ALSO
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Other drivers:
 ~~~~~~~~~~~~~~
+
 linkman:usbhid-ups[8],
 linkman:snmp-ups[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/rhino.txt
+++ b/docs/man/rhino.txt
@@ -3,17 +3,20 @@ RHINO(8)
 
 NAME
 ----
+
 rhino - Driver for Brazilian Microsol RHINO UPS equipment
 
 NOTE
 ----
+
 This man page only documents the hardware-specific features of the
 rhino driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
 
 SUPPORTED HARDWARE
 ------------------
-This driver has been tested with :
+
+This driver has been tested with:
 
  * Rhino   6000 VA
  * Rhino   7500 VA
@@ -45,6 +48,7 @@ COMMANDS
 
 AUTHOR
 ------
+
 Silvino B. Magalhães <sbm2yk@gmail.com>
 
 SEE ALSO
@@ -52,8 +56,10 @@ SEE ALSO
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/richcomm_usb.txt
+++ b/docs/man/richcomm_usb.txt
@@ -3,16 +3,19 @@ RICHCOMM_USB(8)
 
 NAME
 ----
+
 richcomm_usb - Driver UPS equipment using Richcomm dry-contact to USB
 solution
 
 NOTE
 ----
+
 This man page only documents the specific features of the richcomm_usb
 driver.  For information about the core driver, see linkman:nutupsdrv[8].
 
 SUPPORTED HARDWARE
 ------------------
+
 The Richcomm dry-contact to USB solution is a generic interface that is
 used to upgrade an existing (RS-232) contact closure UPS interface to USB.
 As such, all the limitations of the underlying contact closure interface
@@ -21,6 +24,7 @@ OB, and LB.  See also linkman:genericups[8].
 
 BUGS
 ----
+
 Most contact-closure UPSes will not power down the load if the line power
 is present.  This can create a race when using secondary linkman:upsmon[8]
 systems.  See the linkman:upsmon[8] man page for more information.
@@ -31,20 +35,23 @@ UPS of some kind that allows detection and proper load cycling on command.
 AUTHORS
 -------
 
-Peter van Valderen <p.v.valderen at probu.nl>,
-Dirk Teurlings <dirk at upexia.nl>
+* Peter van Valderen <p.v.valderen at probu.nl>
+* Dirk Teurlings <dirk at upexia.nl>
 
 SEE ALSO
 --------
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 The generic serial driver:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 linkman:genericups[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/riello_ser.txt
+++ b/docs/man/riello_ser.txt
@@ -36,8 +36,10 @@ SEE ALSO
 
 The core driver
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources
 ~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/riello_usb.txt
+++ b/docs/man/riello_usb.txt
@@ -35,8 +35,10 @@ SEE ALSO
 
 The core driver
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources
 ~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/safenet.txt
+++ b/docs/man/safenet.txt
@@ -3,21 +3,25 @@ SAFENET(8)
 
 NAME
 ----
+
 safenet - Driver for SafeNet compatible UPS equipment
 
 NOTE
 ----
+
 This man page only documents the hardware-specific features of the
 safenet driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
 
 SUPPORTED HARDWARE
 ------------------
+
 This driver supports UPS equipment which can be controlled via
 SafeNet v1.0 for Windows (serial interface only).
 
 EXTRA ARGUMENTS
 ---------------
+
 This driver supports the following optional settings in the
 linkman:ups.conf[5] file:
 
@@ -38,8 +42,9 @@ Time to wait before switching on the UPS (minutes). Defaults to 1 minute.
 *offdelay=*'value'::
 Time to wait before shutting down the UPS (seconds). Defaults to 30 seconds.
 
-UPSCMD
-------
+INSTANT COMMANDS
+----------------
+
 This driver supports some instant commands (see linkman:upscmd[8]):
 
 *test.battery.start*::
@@ -73,6 +78,7 @@ and *ondelay*.
 
 KNOWN PROBLEMS
 --------------
+
 If you run the *shutdown.return* command with mains present, the output
 may stay on or switch off and not back on again. The *shutdown.reboot*
 command will unconditionally switch on the load again (with or without mains
@@ -87,6 +93,7 @@ return when the power comes back.
 
 AUTHOR
 ------
+
 Arjen de Korte <adkorte-guest at alioth.debian.org>
 
 SEE ALSO
@@ -94,8 +101,10 @@ SEE ALSO
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/skel.txt
+++ b/docs/man/skel.txt
@@ -3,10 +3,12 @@ SKEL(8)
 
 NAME
 ----
+
 skel - skeleton driver man page
 
 NOTE
 ----
+
 This man page only documents the hardware-specific features of the
 *skel* driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
@@ -31,6 +33,7 @@ apropos(8) database is properly rebuilt.
 
 SUPPORTED HARDWARE
 ------------------
+
 *skel* supports ...
 
 //////////////////////////////////////////
@@ -44,6 +47,7 @@ CABLING
 
 EXTRA ARGUMENTS
 ---------------
+
 This driver also supports the following optional settings:
 
 *option1*='num'::
@@ -86,6 +90,7 @@ encountered when implementing the protocol for your UPS.
 
 KNOWN ISSUES AND BUGS
 ---------------------
+
 *Got "EPERM: Operation not permitted" upon driver startup*::
 
 You have forgotten to install the udev files, as explained
@@ -100,6 +105,7 @@ some form of contact information so that users can report bugs.
 
 AUTHORS
 -------
+
 J Random User <user@example.org>
 
 //////////////////////////////////////////
@@ -114,8 +120,10 @@ SEE ALSO
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/snmp-ups.txt
+++ b/docs/man/snmp-ups.txt
@@ -8,6 +8,7 @@ snmp-ups - Multi-MIB Driver for SNMP UPS equipment
 
 NOTE
 ----
+
 This man page only documents the hardware-specific features of the
 snmp-ups driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
@@ -149,6 +150,7 @@ run-time supported list.
 
 REQUIREMENTS
 ------------
+
 You will need to install the Net-SNMP package from
 http://www.net-snmp.org/ before building this driver.
 
@@ -156,6 +158,7 @@ SNMP v3 also requires OpenSSL support from http://www.openssl.org.
 
 LIMITATIONS
 -----------
+
 Shutdown
 ~~~~~~~~
 
@@ -168,12 +171,14 @@ supported command.
 
 INSTALLATION
 ------------
+
 This driver is only built if the Net-SNMP development files are present at
 configuration time.  You can also force it to be built by using
 +configure --with-snmp=yes+ before calling make.
 
 EXAMPLES
 --------
+
 The hostname of the UPS is specified with the "port" value in
 `ups.conf`, and may include a non-standard (161) remote peer port:
 
@@ -197,6 +202,7 @@ The hostname of the UPS is specified with the "port" value in
 
 AUTHORS
 -------
+
 Arnaud Quette, Dmitry Frolov
 
 
@@ -205,12 +211,15 @@ SEE ALSO
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 NUT SNMP Protocols Library
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Available at: http://www.networkupstools.org/ups-protocols.html#_snmp
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/socomec_jbus.txt
+++ b/docs/man/socomec_jbus.txt
@@ -144,18 +144,21 @@ powered USB hub, try a full-speed USB isolator, etc.
 
 AUTHOR
 ------
+
 Thanos Chatziathanassiou <tchatzi@arx.net>
 
 SEE ALSO
 --------
+
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
-The NUT (Network UPS Tools) home page: http://www.networkupstools.org/
 
-Socomec JBUS/Modbus Reference Guide: https://www.socomec.com/files/live/sites/systemsite/files/GB-JBUS-MODBUS-for-Delphys-MP-and-Delphys-MX-operating-manual.pdf
-
-libmodbus home page: http://libmodbus.org
+* The NUT (Network UPS Tools) home page: http://www.networkupstools.org/
+* Socomec JBUS/Modbus Reference Guide:
+  https://www.socomec.com/files/live/sites/systemsite/files/GB-JBUS-MODBUS-for-Delphys-MP-and-Delphys-MX-operating-manual.pdf
+* libmodbus home page: http://libmodbus.org

--- a/docs/man/solis.txt
+++ b/docs/man/solis.txt
@@ -15,7 +15,8 @@ linkman:nutupsdrv[8].
 
 SUPPORTED HARDWARE
 ------------------
-This driver has been tested with :
+
+This driver has been tested with:
 
  * Solis   1000 VA
  * Solis   1500 VA
@@ -55,6 +56,7 @@ connect to the UPS, but some values are read incorrectly.
 
 AUTHOR
 ------
+
 Silvino B. Magalhães <sbm2yk@gmail.com>
 
 SEE ALSO
@@ -62,8 +64,10 @@ SEE ALSO
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/tripplite.txt
+++ b/docs/man/tripplite.txt
@@ -3,22 +3,26 @@ TRIPPLITE(8)
 
 NAME
 ----
+
 tripplite - Driver for Tripp-Lite SmartPro UPS equipment
 
 NOTE
 ----
+
 This man page only documents the hardware-specific features of the
 tripplite driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
 
 SUPPORTED HARDWARE
 ------------------
+
 This driver should work on the SmartPro line, including the SMART700
 and SMART700SER.  It only supports SmartPro models that communicate
 using the serial port.
 
 EXTRA ARGUMENTS
 ---------------
+
 This driver supports the following optional settings in the
 linkman:ups.conf[5]:
 
@@ -36,25 +40,31 @@ reboot command.  The default value is 60 (in seconds).
 
 KNOWN ISSUES AND BUGS
 ---------------------
+
 Battery charge information may not be correct for all UPSes.  It is tuned
 to be correct for a SMART700SER.  Other models may not provide correct
 information.  Information from the manufacturer would be helpful.
 
 AUTHORS
 -------
-Rickard E. (Rik) Faith, Nicholas Kain
+
+* Rickard E. (Rik) Faith
+* Nicholas Kain
 
 SEE ALSO
 --------
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Other drivers for Tripp-Lite hardware:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 linkman:tripplitesu[8], linkman:tripplite_usb[8], linkman:usbhid-ups[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/tripplite_usb.txt
+++ b/docs/man/tripplite_usb.txt
@@ -1,19 +1,21 @@
 TRIPPLITE_USB(8)
 ================
 
-
 NAME
 ----
+
 tripplite_usb - Driver for older Tripp Lite USB UPSes (not PDC HID)
 
 SYNOPSIS
 --------
+
 *tripplite_usb* -h
 
 *tripplite_usb* -a 'UPS_NAME' ['OPTIONS']
 
 SUPPORTED HARDWARE
 ------------------
+
 This driver should work with older Tripp Lite UPSes which are detected as USB
 HID-class devices, but are not true HID Power-Device Class devices.  So far,
 the devices supported by tripplite_usb have product ID 0001, and the newer
@@ -152,11 +154,13 @@ exposed as a USB string descriptor, there is no easy way to use this ID to
 distinguish between multiple UPS units on a single machine. The UPS would need
 to be claimed by the driver in order to read this ID.
 
-AUTHOR
-------
-Written by Charles Lepple, based on the linkman:tripplite[8] driver by Rickard E. (Rik)
-Faith and Nicholas Kain. Please do not email the authors directly - use the
-nut-upsdev mailing list.
+AUTHORS
+-------
+
+Written by Charles Lepple, based on the linkman:tripplite[8] driver
+by Rickard E. (Rik) Faith and Nicholas Kain.
+
+Please do not email the authors directly - use the nut-upsdev mailing list.
 
 A Tripp Lite OMNIVS1000 was graciously donated to the NUT project by Bradley
 Feldman (http://www.bradleyloritheo.com)
@@ -166,19 +170,21 @@ SEE ALSO
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Other drivers for Tripp-Lite hardware:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 linkman:tripplite[8], linkman:tripplitesu[8], linkman:usbhid-ups[8]
 
 Other tools:
 ~~~~~~~~~~~~
+
 regex(7), lsusb(8)
 
-
-INTERNET RESOURCES
-------------------
+Internet resources:
+~~~~~~~~~~~~~~~~~~~
 
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/
 

--- a/docs/man/tripplitesu.txt
+++ b/docs/man/tripplitesu.txt
@@ -3,20 +3,24 @@ TRIPPLITESU(8)
 
 NAME
 ----
+
 tripplitesu - Driver for Tripp-Lite SmartOnline (SU) UPS equipment
 
 NOTE
 ----
+
 This man page only documents the hardware-specific features of the
 tripplitesu driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
 
 SUPPORTED HARDWARE
 ------------------
+
 This driver supports the Tripp Lite SmartOnline family (via the serial port).
 
 EXTRA ARGUMENTS
 ---------------
+
 This driver supports the following optional settings in the
 linkman:ups.conf[5]:
 
@@ -27,6 +31,7 @@ until there are only a few seconds left.  Common values are around 25--30.
 
 AUTHOR
 ------
+
 Allan N. Hessenflow <allanh@kallisti.com>
 
 SEE ALSO
@@ -34,12 +39,15 @@ SEE ALSO
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Other drivers for Tripp-Lite hardware:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 linkman:tripplite[8], linkman:tripplite_usb[8], linkman:usbhid-ups[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/ups.conf.txt
+++ b/docs/man/ups.conf.txt
@@ -3,6 +3,7 @@ UPS.CONF(5)
 
 NAME
 ----
+
 ups.conf - UPS definitions for Network UPS Tools
 
 DESCRIPTION
@@ -140,6 +141,7 @@ verbosity level.
 
 UPS FIELDS
 ----------
+
 *driver*::
 
 Required.  This specifies which program will be monitoring this UPS.  You
@@ -289,8 +291,11 @@ from linkman:upsc[8] or similar as "snoopy@doghouse".
 
 SEE ALSO
 --------
-linkman:upsd[8], linkman:nutupsdrv[8], linkman:upsdrvctl[8]
+
+linkman:upsd[8], linkman:nutupsdrv[8], linkman:upsdrvctl[8],
+linkman:upsdrvsvcctl[8]
 
 Internet resources
 ~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/upsc.txt
+++ b/docs/man/upsc.txt
@@ -1,13 +1,14 @@
 UPSC(8)
 =======
 
-
 NAME
 ----
+
 upsc - example lightweight UPS client
 
 SYNOPSIS
 --------
+
 *upsc* -l | -L ['host']
 
 *upsc* 'ups' ['variable']
@@ -23,6 +24,7 @@ want to include the full interface.
 
 OPTIONS
 -------
+
 *-l* 'host'::
 
   List all UPS names configured at 'host', one name per line. The hostname
@@ -113,7 +115,7 @@ SEE ALSO
 
 linkman:upsd[8]
 
-INTERNET RESOURCES
-------------------
+Internet resources:
+~~~~~~~~~~~~~~~~~~~
 
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/upscli_add_host_cert.txt
+++ b/docs/man/upscli_add_host_cert.txt
@@ -16,6 +16,7 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
+
 The *upscli_add_host_cert()* function register a security rule associated
 to the 'hostname'. All connections to this host use this rule.
 
@@ -34,5 +35,6 @@ RETURN VALUE
 
 SEE ALSO
 --------
+
 linkman:upscli_init[3], linkman:upscli_connect[3], linkman:upscli_ssl[3],
 linkman:upscli_strerror[3], linkman:upscli_upserror[3]

--- a/docs/man/upscli_cleanup.txt
+++ b/docs/man/upscli_cleanup.txt
@@ -15,6 +15,7 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
+
 The *upscli_cleanup()* function flushes SSL caches and frees memory
 used internally in upsclient module.
 
@@ -25,5 +26,6 @@ The *upscli_cleanup()* function returns 1 on success, or -1 if an error occurs.
 
 SEE ALSO
 --------
+
 linkman:upscli_init[3],
 linkman:upscli_strerror[3], linkman:upscli_upserror[3]

--- a/docs/man/upscli_connect.txt
+++ b/docs/man/upscli_connect.txt
@@ -15,6 +15,7 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
+
 The *upscli_connect()* function takes the pointer 'ups' to a
 `UPSCONN_t` state structure and opens a TCP connection to the 'host' on
 the given 'port'.
@@ -45,6 +46,7 @@ returns 0 on success, or -1 if an error occurs.
 
 SEE ALSO
 --------
+
 linkman:upscli_disconnect[3], linkman:upscli_fd[3],
 linkman:upscli_splitaddr[3], linkman:upscli_splitname[3],
 linkman:upscli_ssl[3], linkman:upscli_strerror[3],

--- a/docs/man/upscli_disconnect.txt
+++ b/docs/man/upscli_disconnect.txt
@@ -15,6 +15,7 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
+
 The *upscli_disconnect()* function takes the pointer 'ups' to a
 `UPSCONN_t` state structure, shuts down the connection to the server, and
 frees dynamic memory used by the state structure.  The `UPSCONN_t` structure
@@ -31,5 +32,6 @@ error occurs.
 
 SEE ALSO
 --------
+
 linkman:upscli_connect[3], linkman:upscli_fd[3],
 linkman:upscli_strerror[3], linkman:upscli_upserror[3]

--- a/docs/man/upscli_get.txt
+++ b/docs/man/upscli_get.txt
@@ -3,7 +3,8 @@ UPSCLI_GET(3)
 
 NAME
 ----
-upscli_get - retrieve data from a UPS
+
+upscli_get - retrieve data from an UPS
 
 SYNOPSIS
 --------
@@ -15,6 +16,7 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
+
 The *upscli_get()* function takes the pointer 'ups' to a
 `UPSCONN_t` state structure, and the pointer 'query' to an array of
 'numq' query elements.  It builds a properly-formatted request from
@@ -40,6 +42,7 @@ Some examples are:
 
 QUERY FORMATTING
 ----------------
+
 To generate a request for `GET NUMLOGINS su700`, you would populate
 query and numq as follows:
 
@@ -55,6 +58,7 @@ is handled for you inside this function.
 
 ANSWER FORMATTING
 -----------------
+
 The raw response from upsd to the above query would be `NUMLOGINS su700 1`.
 Since this is split up for you, the values work out like this:
 
@@ -69,6 +73,7 @@ Notice that the value which you seek typically starts at answer[numq].
 
 ERROR CHECKING
 --------------
+
 This function will check your query against the response from
 linkman:upsd[8].  For example, if you send "VAR" "su700" "ups.status", it
 will expect to see those at the beginning of the response.
@@ -79,6 +84,7 @@ happens, linkman:upscli_upserror[3] will return 'UPSCLI_ERR_PROTOCOL'.
 
 ANSWER ARRAY LIFETIME
 ---------------------
+
 The pointers contained within the 'answer' array are only valid
 until the next call to a 'upsclient' function which references them.
 If you need to use data from multiple calls, you must copy it somewhere
@@ -95,6 +101,7 @@ access after that point is also undefined.
 
 RETURN VALUE
 ------------
+
 The *upscli_get()* function returns 0 on success, or -1 if an
 error occurs.
 
@@ -110,5 +117,6 @@ will allow the *upscli_get()* call to return an error in that case:
 
 SEE ALSO
 --------
+
 linkman:upscli_list_start[3], linkman:upscli_list_next[3],
 linkman:upscli_strerror[3], linkman:upscli_upserror[3]

--- a/docs/man/upscli_init.txt
+++ b/docs/man/upscli_init.txt
@@ -16,6 +16,7 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
+
 The *upscli_init()* function initialize upsclient module and set many
 SSL-related properties: 'certverify' to 1 makes certificate verification
 required for all SSL connections and 'certpath' is the location of
@@ -53,6 +54,7 @@ The *upscli_init()* function returns 1 on success, or -1 if an error occurs.
 
 SEE ALSO
 --------
+
 linkman:upscli_add_host_cert[3], linkman:upscli_cleanup[3],
 linkman:upscli_disconnect[3], linkman:upscli_fd[3],
 linkman:upscli_splitaddr[3], linkman:upscli_splitname[3],

--- a/docs/man/upscli_list_next.txt
+++ b/docs/man/upscli_list_next.txt
@@ -66,5 +66,6 @@ its first call in that case.
 
 SEE ALSO
 --------
+
 linkman:upscli_list_start[3],
 linkman:upscli_strerror[3], linkman:upscli_upserror[3]

--- a/docs/man/upscli_list_start.txt
+++ b/docs/man/upscli_list_start.txt
@@ -69,6 +69,7 @@ When this happens, linkman:upscli_upserror[3] will return
 
 RETURN VALUE
 ------------
+
 The *upscli_list_start()* function returns 0 on success, or -1 if an
 error occurs.
 

--- a/docs/man/upscli_readline.txt
+++ b/docs/man/upscli_readline.txt
@@ -18,6 +18,7 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
+
 The *upscli_readline()* and *upscli_readline_timeout()* functions take the
 pointer 'ups' to a `UPSCONN_t` state structure, receive a single line from the
 server, and copy up to 'buflen' bytes of the response into the buffer 'buf'.

--- a/docs/man/upscli_sendline.txt
+++ b/docs/man/upscli_sendline.txt
@@ -9,7 +9,6 @@ upscli_sendline, upscli_sendline_timeout - send a single command to a UPS
 SYNOPSIS
 --------
 
-
  #include <upsclient.h>
 
  int upscli_sendline(UPSCONN_t *ups, const char *buf, size_t buflen);

--- a/docs/man/upscli_splitname.txt
+++ b/docs/man/upscli_splitname.txt
@@ -37,6 +37,7 @@ Definitions without an explicit port value receive the default value of
 
 MEMORY USAGE
 ------------
+
 You must *free*(3) the pointers to 'upsname' and 'hostname'
 when you are done with them to avoid memory leaks.
 

--- a/docs/man/upsclient.txt
+++ b/docs/man/upsclient.txt
@@ -60,6 +60,7 @@ in memory and file descriptor leaks in your program.
 
 ERROR HANDLING
 --------------
+
 In the event of an error, linkman:upscli_strerror[3] will provide
 human-readable details on what happened.  linkman:upscli_upserror[3] may
 also be used to retrieve the error number.  These numbers are defined in
@@ -67,6 +68,7 @@ also be used to retrieve the error number.  These numbers are defined in
 
 SEE ALSO
 --------
+
 linkman:libupsclient-config[1],
 linkman:upscli_init[3], linkman:upscli_cleanup[3], linkman:upscli_add_host_cert[3],
 linkman:upscli_connect[3], linkman:upscli_disconnect[3], linkman:upscli_fd[3],

--- a/docs/man/upscmd.txt
+++ b/docs/man/upscmd.txt
@@ -3,10 +3,12 @@ UPSCMD(8)
 
 NAME
 ----
+
 upscmd - UPS administration program for instant commands
 
 SYNOPSIS
 --------
+
 *upscmd* -h
 
 *upscmd* -l 'ups'
@@ -102,8 +104,10 @@ It involves magic cookies.
 
 SEE ALSO
 --------
+
 linkman:upsd[8], linkman:upsrw[8]
 
-INTERNET RESOURCES
-------------------
+Internet resources:
+~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/upscode2.txt
+++ b/docs/man/upscode2.txt
@@ -3,22 +3,26 @@ UPSCODE2(8)
 
 NAME
 ----
+
 upscode2 - Driver for UPScode II compatible UPS equipment
 
 NOTE
 ----
+
 This man page only documents the hardware-specific features of the
 upscode2 driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
 
 SUPPORTED HARDWARE
 ------------------
+
 This driver supports UPS equipment which can be controlled via the UPScode II
 protocol.  This is mainly Fiskars, Powerware equipment, but also
 some (probably OEM'ed) products from Compaq.
 
 EXTRA ARGUMENTS
 ---------------
+
 This driver supports the following optional settings in the
 linkman:ups.conf[5]:
 
@@ -82,18 +86,21 @@ have not returned a value for 'battery.charge'. Therefore, the driver will
 guestimate a value based on the nominal battery min/max and the current
 battery voltage.
 
-AUTHOR
-------
-Håvard Lygre <hklygre@online.no>,
-Niels Baggesen <niels@baggesen.net>
+AUTHORS
+-------
+
+* Håvard Lygre <hklygre@online.no
+* Niels Baggesen <niels@baggesen.net>
 
 SEE ALSO
 --------
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/upsd.conf.txt
+++ b/docs/man/upsd.conf.txt
@@ -152,6 +152,7 @@ SEE ALSO
 
 linkman:upsd[8], linkman:nutupsdrv[8], linkman:upsd.users[5]
 
-INTERNET RESOURCES
-------------------
+Internet resources:
+~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/upsd.txt
+++ b/docs/man/upsd.txt
@@ -8,6 +8,7 @@ upsd - UPS information server
 
 SYNOPSIS
 --------
+
 *upsd* -h
 
 *upsd* ['OPTIONS']
@@ -156,15 +157,18 @@ SEE ALSO
 
 Clients:
 ~~~~~~~~
+
 linkman:upsc[8], linkman:upscmd[8],
 linkman:upsrw[8], linkman:upslog[8], linkman:upsmon[8]
 
 CGI programs:
 ~~~~~~~~~~~~~
+
 linkman:upsset.cgi[8], linkman:upsstats.cgi[8], linkman:upsimage.cgi[8]
 
 Drivers:
 ~~~~~~~~
+
 linkman:nutupsdrv[8],
 linkman:apcsmart[8], linkman:belkin[8], linkman:belkinunv[8],
 linkman:bestuferrups[8], linkman:bestups[8],
@@ -177,4 +181,5 @@ linkman:tripplite[8], linkman:tripplitesu[8], linkman:victronups[8],
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/upsd.users.txt
+++ b/docs/man/upsd.users.txt
@@ -3,6 +3,7 @@ UPSD.USERS(5)
 
 NAME
 ----
+
 upsd.users - Administrative user definitions for NUT upsd
 
 DESCRIPTION
@@ -84,7 +85,8 @@ SEE ALSO
 
 linkman:upsd[8], linkman:upsd.conf[5]
 
-INTERNET RESOURCES
-------------------
+Internet resources:
+~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/
 

--- a/docs/man/upsdrvctl.txt
+++ b/docs/man/upsdrvctl.txt
@@ -8,6 +8,7 @@ upsdrvctl - UPS driver controller
 
 SYNOPSIS
 --------
+
 *upsdrvctl* -h
 
 *upsdrvctl* ['OPTIONS'] {start | stop | shutdown} ['ups']
@@ -103,8 +104,10 @@ background.
 
 SEE ALSO
 --------
+
 linkman:upsdrvsvcctl[8], linkman:nutupsdrv[8], linkman:upsd[8], linkman:ups.conf[5]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/upsdrvsvcctl.txt
+++ b/docs/man/upsdrvsvcctl.txt
@@ -8,6 +8,7 @@ upsdrvsvcctl - UPS driver service instance controller
 
 SYNOPSIS
 --------
+
 *upsdrvsvcctl* -h
 
 *upsdrvsvcctl* ['OPTIONS'] {start | stop } ['ups']
@@ -189,9 +190,11 @@ Look for `/var/svc/log/system-power-nut-driver:instance-name.log` file.
 
 SEE ALSO
 --------
+
 linkman:upsdrvctl[8], linkman:nutupsdrv[8], linkman:upsd[8],
 linkman:nut-driver-enumerator[8], linkman:ups.conf[5]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/upsimage.cgi.txt
+++ b/docs/man/upsimage.cgi.txt
@@ -45,6 +45,5 @@ linkman:upsd[8], linkman:upsstats.cgi[8]
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
 
-The gd home page: http://libgd.bitbucket.org
-
-The NUT (Network UPS Tools) home page: http://www.networkupstools.org/
+* The NUT (Network UPS Tools) home page: http://www.networkupstools.org/
+* The gd home page: http://libgd.bitbucket.org

--- a/docs/man/upslog.txt
+++ b/docs/man/upslog.txt
@@ -115,13 +115,16 @@ SEE ALSO
 
 Server:
 ~~~~~~~
+
 linkman:upsd[8]
 
 Clients:
 ~~~~~~~~
+
 linkman:upsc[8], linkman:upscmd[8],
 linkman:upsrw[8], linkman:upsmon[8], linkman:upssched[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/upsmon.conf.txt
+++ b/docs/man/upsmon.conf.txt
@@ -413,8 +413,10 @@ does not change the previously active logging verbosity.
 
 SEE ALSO
 --------
+
 linkman:upsmon[8], linkman:upsd[8], linkman:nutupsdrv[8].
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/upsmon.txt
+++ b/docs/man/upsmon.txt
@@ -450,17 +450,21 @@ SEE ALSO
 
 Server:
 ~~~~~~~
+
 linkman:upsd[8]
 
 Clients:
 ~~~~~~~~
+
 linkman:upsc[8], linkman:upscmd[8],
 linkman:upsrw[8], linkman:upsmon[8]
 
 CGI programs:
 ~~~~~~~~~~~~~
+
 linkman:upsset.cgi[8], linkman:upsstats.cgi[8], linkman:upsimage.cgi[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/upsrw.txt
+++ b/docs/man/upsrw.txt
@@ -112,8 +112,10 @@ confusing.
 
 SEE ALSO
 --------
+
 linkman:upsd[8], linkman:upscmd[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/upssched.conf.txt
+++ b/docs/man/upssched.conf.txt
@@ -107,4 +107,5 @@ linkman:upssched[8], linkman:upsmon[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/upssched.txt
+++ b/docs/man/upssched.txt
@@ -8,6 +8,7 @@ upssched - Timer helper for scheduling events from upsmon
 
 SYNOPSIS
 --------
+
 *upssched*
 
 NOTE: *upssched* should be run from linkman:upsmon[8] via the NOTIFYCMD.
@@ -112,4 +113,5 @@ linkman:upsmon[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/upsset.cgi.txt
+++ b/docs/man/upsset.cgi.txt
@@ -94,4 +94,5 @@ SEE ALSO
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/upsset.conf.txt
+++ b/docs/man/upsset.conf.txt
@@ -55,8 +55,10 @@ web server, don't blame me.
 
 SEE ALSO
 --------
+
 linkman:upsset.cgi[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/upsstats.cgi.txt
+++ b/docs/man/upsstats.cgi.txt
@@ -59,4 +59,5 @@ linkman:upsimage.cgi[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/upsstats.html.txt
+++ b/docs/man/upsstats.html.txt
@@ -232,4 +232,5 @@ linkman:upsstats.cgi[8], linkman:upsimage.cgi[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/usbhid-ups.txt
+++ b/docs/man/usbhid-ups.txt
@@ -261,8 +261,10 @@ SEE ALSO
 
 The core driver
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources
 ~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/man/victronups.txt
+++ b/docs/man/victronups.txt
@@ -3,16 +3,19 @@ VICTRONUPS(8)
 
 NAME
 ----
+
 victronups - Driver for IMV/Victron UPS unit Match, Match Lite, NetUps
 
 NOTE
 ----
+
 This man page only documents the hardware-specific features of the the
 victronups driver.  For information about the core driver, see
 linkman:nutupsdrv[8].
 
 SUPPORTED HARDWARE
 ------------------
+
 The victronups driver should recognize all Victron models that use a serial
 protocol at 1200 bps.  These include Match Lite, Match and the NetUps line.
 
@@ -29,6 +32,7 @@ docs/cables/victron.txt
 
 EXTRA ARGUMENTS
 ---------------
+
 This driver supports the following optional setting in the
 linkman:ups.conf[5]:
 
@@ -41,20 +45,24 @@ Set delay before shutdown on UPS
 
 BUGS
 ----
+
 The protocol for this UPS is not officially documented.
 
-AUTHOR
-------
-Radek Benedikt <benedikt@lphard.cz>,
-Daniel Prynych <Daniel.Prynych@hornet.cz>
+AUTHORS
+-------
+
+* Radek Benedikt <benedikt@lphard.cz>
+* Daniel Prynych <Daniel.Prynych@hornet.cz>
 
 SEE ALSO
 --------
 
 The core driver:
 ~~~~~~~~~~~~~~~~
+
 linkman:nutupsdrv[8]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~
+
 The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/nut-names.txt
+++ b/docs/nut-names.txt
@@ -274,11 +274,13 @@ broken down to their base components.
 
 Phase Count Determination
 ^^^^^^^^^^^^^^^^^^^^^^^^^
+
 input.phases (3 for three-phase, absent or 1 for 1phase)
 output.phases (as for input.phases)
 
 DOMAINs
 ^^^^^^^
+
 Any input or output is considered a valid DOMAIN.
 
 input (should really be called input.mains, but keep this for compat)

--- a/docs/packager-guide.txt
+++ b/docs/packager-guide.txt
@@ -130,6 +130,7 @@ The following packagers should be interested in working on this subject:
 
 Possible use cases
 ------------------
+
 - standalone (1 system + 1-n UPS)
 - network server (same as standalone, but serving data to network clients)
 - network monitoring client
@@ -162,6 +163,7 @@ This standard was created by:
 
 Overview of the package tree
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 FIXME: make a dependency graph
 
 - <<pkg-nut,nut>>
@@ -383,6 +385,7 @@ TO BE CONTINUED
 
 Configuration option
 ^^^^^^^^^^^^^^^^^^^^
+
 name= "ups" or "nut"
 ./configure \
             --prefix=/ \


### PR DESCRIPTION
Part of release preparations - embedding of the notice into historic release sub-sites misfires with texts which do not follow a single standard.