### PR TITLE
drivers/cyberpower-mib.c: update cyberpower_power_status[]…

### DIFF
--- a/drivers/cyberpower-mib.c
+++ b/drivers/cyberpower-mib.c
@@ -24,20 +24,26 @@
 
 #include "cyberpower-mib.h"
 
-#define CYBERPOWER_MIB_VERSION		"0.5"
+#define CYBERPOWER_MIB_VERSION		"0.51"
 #define CYBERPOWER_OID_MODEL_NAME	".1.3.6.1.4.1.3808.1.1.1.1.1.1.0"
 
 /* CPS-MIB::ups */
 #define CYBERPOWER_SYSOID			".1.3.6.1.4.1.3808.1.1.1"
 
+/* https://www.cyberpowersystems.com/products/software/mib-files/ */
+/* Per CPS MIB 2.9 upsBaseOutputStatus OBJECT-TYPE: */
 static info_lkp_t cyberpower_power_status[] = {
-	{ 2, "OL", NULL, NULL },
-	{ 3, "OB", NULL, NULL },
-	{ 4, "OL BOOST", NULL, NULL },
-	{ 5, "OFF", NULL, NULL },
-	{ 7, "OL", NULL, NULL },
-	{ 1, "NULL", NULL, NULL },
-	{ 6, "OFF", NULL, NULL },
+	{ 1, "NULL", NULL, NULL },	/* unknown */
+	{ 2, "OL", NULL, NULL },	/* onLine */
+	{ 3, "OB", NULL, NULL },	/* onBattery */
+	{ 4, "OL BOOST", NULL, NULL },	/* onBoost */
+	{ 5, "OFF", NULL, NULL },	/* onSleep */
+	{ 6, "OFF", NULL, NULL },	/* off */
+	{ 7, "OL", NULL, NULL },	/* rebooting */
+	{ 8, "OL", NULL, NULL },	/* onECO */
+	{ 9, "OL BYPASS", NULL, NULL },	/* onBypass */
+	{ 10, "OL TRIM", NULL, NULL },	/* onBuck */
+	{ 11, "OL OVER", NULL, NULL },	/* onOverload */
 	{ 0, NULL, NULL, NULL }
 } ;
 


### PR DESCRIPTION
… with new values [#1377] [#590]

To reviewers: is "OL TRIM" etc. correct to couple tokens, or should one be used like e.g. "BYPASS" in some drivers?