### PR TITLE
Hook NIT into (dist)check targets

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -118,7 +118,7 @@ all-docs check-docs \
 man all-man man-man check-man man-html all-html:
 	cd $(builddir)/docs && $(MAKE) $@
 
-check-NIT:
+check-NIT check-NIT-devel:
 	cd $(builddir)/tests/NIT && $(MAKE) $@
 
 # This target adds syntax-checking for committed shell script files,

--- a/NEWS
+++ b/NEWS
@@ -303,8 +303,8 @@ refer to this change set (too long in the making) as NUT 2.7.5.
    in upscmd
 
  - dummy-ups can now specify `mode` as a driver argument, and separates the
-   notion of `dummy-once` (new default for `*.dev` files) vs. `dummy-loop`
-   (legacy default for `*.seq` and others) [issue #1385]
+   notion of `dummy-once` (new default for `*.dev` files that do not change)
+   vs. `dummy-loop` (legacy default for `*.seq` and others) [issue #1385]
 
  - new protocol variables:
    * `input.phase.shift`

--- a/NEWS
+++ b/NEWS
@@ -302,6 +302,10 @@ refer to this change set (too long in the making) as NUT 2.7.5.
  - Add support for extra parameter for instant commands, both in library and
    in upscmd
 
+ - dummy-ups can now specify `mode` as a driver argument, and separates the
+   notion of `dummy-once` (new default for `*.dev` files) vs. `dummy-loop`
+   (legacy default for `*.seq` and others) [issue #1385]
+
  - new protocol variables:
    * `input.phase.shift`
    * `outlet.N.name`

--- a/UPGRADING
+++ b/UPGRADING
@@ -89,14 +89,16 @@ Changes from 2.7.4 to 2.8.0
   with your platform.
 
 - dummy-ups can now specify `mode` as a driver argument, and separates the
-  notion of `dummy-once` (new default for `*.dev` files) vs. `dummy-loop`
-  (legacy default for `*.seq` and others) [issue #1385]
+  notion of `dummy-once` (new default for `*.dev` files that do not change)
+  vs. `dummy-loop` (legacy default for `*.seq` and others) [issue #1385]
 
   * Note this can break third-party test scripts which expected `*.dev`
     files to work as a looping sequence with a `TIMER` keywords to change
     values slowly; now such files should get processed to the end once.
     Specify `mode=dummy-loop` driver option or rename the data file used
     in the `port` option for legacy behavior.
+    Use/Test-cases which modified such files content externally should
+    not be impacted.
 
 - Python: scripts have been updated to work with Python 3 as well as 2.
 

--- a/UPGRADING
+++ b/UPGRADING
@@ -88,6 +88,16 @@ Changes from 2.7.4 to 2.8.0
   search code in common/common.c. Please file an issue if this does not work
   with your platform.
 
+- dummy-ups can now specify `mode` as a driver argument, and separates the
+  notion of `dummy-once` (new default for `*.dev` files) vs. `dummy-loop`
+  (legacy default for `*.seq` and others) [issue #1385]
+
+  * Note this can break third-party test scripts which expected `*.dev`
+    files to work as a looping sequence with a `TIMER` keywords to change
+    values slowly; now such files should get processed to the end once.
+    Specify `mode=dummy-loop` driver option or rename the data file used
+    in the `port` option for legacy behavior.
+
 - Python: scripts have been updated to work with Python 3 as well as 2.
 
   * PyNUT module (protocol binding) supports both Python generations.

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -743,7 +743,9 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
 
     # TODO: Consider `--enable-maintainer-mode` to add recipes that
     # would quickly regenerate Makefile(.in) if you edit Makefile.am
-    CONFIG_OPTS+=("--enable-check-NIT")
+    # TODO: Resolve port-collision reliably (for multi-executor agents)
+    # and enable the test for CI runs. Bonus for making it quieter.
+    CONFIG_OPTS+=("--enable-check-NIT=no")
 
     if [ -n "${PYTHON-}" ]; then
         # WARNING: Watch out for whitespaces, not handled here!

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -1511,15 +1511,16 @@ bindings)
 
     ./autogen.sh
 
-    # TODO: Consider `--enable-maintainer-mode` to add recipes that
-    # would quickly regenerate Makefile(.in) if you edit Makefile.am
     # NOTE: Default NUT "configure" actually insists on some features,
     # like serial port support unless told otherwise, or docs if possible.
     # Below we aim for really fast iterations of C/C++ development so
     # enable whatever is auto-detectable (except docs), and highlight
     # any warnings if we can:
     #./configure
-    ./configure --enable-Wcolor --with-all=auto --with-cgi=auto --with-serial=auto --with-dev=auto --with-doc=skip
+    ./configure --enable-Wcolor \
+        --with-all=auto --with-cgi=auto --with-serial=auto \
+        --with-dev=auto --with-doc=skip \
+        --enable-check-NIT --enable-maintainer-mode
 
     # NOTE: Currently parallel builds are expected to succeed (as far
     # as recipes are concerned), and the builds without a BUILD_TYPE

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -743,6 +743,7 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
 
     # TODO: Consider `--enable-maintainer-mode` to add recipes that
     # would quickly regenerate Makefile(.in) if you edit Makefile.am
+    CONFIG_OPTS+=("--enable-check-NIT")
 
     if [ -n "${PYTHON-}" ]; then
         # WARNING: Watch out for whitespaces, not handled here!

--- a/clients/nutclient.h
+++ b/clients/nutclient.h
@@ -360,6 +360,11 @@ protected:
  */
 class TcpClient : public Client
 {
+	/* We have a number of direct-call methods we do not expose
+	 * generally, but still want covered with integration tests
+	 */
+	friend class NutActiveClientTest;
+
 public:
 	/**
 	 * Construct a nut TcpClient object.

--- a/clients/upssched.c
+++ b/clients/upssched.c
@@ -272,6 +272,7 @@ static int open_sock(void)
 	int	ret, fd;
 	struct	sockaddr_un	ssaddr;
 
+	check_unix_socket_filename(pipefn);
 	fd = socket(AF_UNIX, SOCK_STREAM, 0);
 
 	if (fd < 0)
@@ -631,6 +632,8 @@ static int try_connect(void)
 {
 	int	pipefd, ret;
 	struct	sockaddr_un saddr;
+
+	check_unix_socket_filename(pipefn);
 
 	memset(&saddr, '\0', sizeof(saddr));
 	saddr.sun_family = AF_UNIX;

--- a/common/str.c
+++ b/common/str.c
@@ -614,3 +614,16 @@ int	str_to_double_strict(const char *string, double *number, const int base)
 
 	return 1;
 }
+
+int str_ends_with(const char *s, const char *suff) {
+	size_t slen;
+	size_t sufflen;
+
+	if (!s) return 0;	/* null string does not end with anything */
+	if (!suff) return 1;	/* null suffix tails anything */
+
+	slen = strlen(s);
+	sufflen = strlen(suff);
+
+	return (slen >= sufflen) && (!memcmp(s + slen - sufflen, suff, sufflen));
+}

--- a/configure.ac
+++ b/configure.ac
@@ -1225,7 +1225,7 @@ nut_enable_check_NIT="no"
 AC_ARG_ENABLE([check-NIT],
 	AS_HELP_STRING([--enable-check-NIT], [Run check-NIT among default checks (no)]),
 [
-	case "${withval}" in
+	case "${enableval}" in
 	no)
 		AC_MSG_RESULT(no)
 		;;
@@ -1760,7 +1760,7 @@ AC_MSG_CHECKING(whether to strip debug symbols)
 AC_ARG_ENABLE(strip,
 	AS_HELP_STRING([--enable-strip], [Strip debugging symbols from binaries (no)]),
 [
-	case "${withval}" in
+	case "${enableval}" in
 	no)
 		AC_MSG_RESULT(no)
 		;;

--- a/configure.ac
+++ b/configure.ac
@@ -1220,7 +1220,24 @@ AM_CONDITIONAL(WITH_CPPCHECK, test "${WITH_CPPCHECK}" = "yes")
 dnl ----------------------------------------------------------------------
 dnl checks related to --enable-check-NIT
 
-NUT_ARG_ENABLE([check-NIT], [Run check-NIT among default checks], [no])
+AC_MSG_CHECKING(whether to run NIT among default make check target)
+nut_enable_check_NIT="no"
+AC_ARG_ENABLE([check-NIT],
+	AS_HELP_STRING([--enable-check-NIT], [Run check-NIT among default checks (no)]),
+[
+	case "${withval}" in
+	no)
+		AC_MSG_RESULT(no)
+		;;
+	*)
+		AC_MSG_RESULT(yes)
+		nut_enable_check_NIT="yes"
+		;;
+	esac
+], [
+	AC_MSG_RESULT(no)
+])
+
 AM_CONDITIONAL(WITH_CHECK_NIT, test "${nut_enable_check_NIT}" = "yes")
 
 dnl ----------------------------------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -1218,6 +1218,12 @@ esac
 AM_CONDITIONAL(WITH_CPPCHECK, test "${WITH_CPPCHECK}" = "yes")
 
 dnl ----------------------------------------------------------------------
+dnl checks related to --enable-check-NIT
+
+NUT_ARG_ENABLE([check-NIT], [Run check-NIT among default checks], [no])
+AM_CONDITIONAL(WITH_CHECK_NIT, test "${nut_enable_check_NIT}" = "yes")
+
+dnl ----------------------------------------------------------------------
 dnl checks related to --with-doc
 
 dnl Always check for AsciiDoc prerequisites, since even if --with-doc

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -205,6 +205,25 @@ Development files
 Build and install the upsclient and nutclient library and header files, to
 build further projects against NUT (such as wmNUT client and many others).
 
+Options for developers
+~~~~~~~~~~~~~~~~~~~~~~
+
+	--enable-check-NIT (default: no)
+
+Add `make check-NIT` to default activity of `make check` to run the
+NUT Integration Testing suite. This is potentially dangerous (e.g. due
+to port conflicts when running many such tests in same environment),
+so not active by default.
+
+	--enable-maintainer-mode (default: no)
+
+Use maintainer mode to keep `Makefile.in` and `Makefile` in sync with
+ever-changing `Makefile.am` content after Git updates or editing.
+
+	--enable-cppcheck (default: no)
+
+Activate recipes for static analysis with `cppcheck` tools (if available).
+
 I want it all!
 ~~~~~~~~~~~~~~
 

--- a/docs/man/clone.txt
+++ b/docs/man/clone.txt
@@ -107,6 +107,22 @@ drivers are not affected, so if you tell the real UPS driver to shutdown
 the outlet of the clone UPS driver, your clients will lose power without
 warning.
 
+If you use service management frameworks like systemd or SMF to manage the
+dependencies between driver instances and the data server, and some of these
+drivers are `dummy-ups` in repeater mode (or `clone` drivers) representing
+data from another driver running on the same system, then you may have to
+set up special dependencies (e.g. with systemd "drop-in" snippet files)
+to allow your `nut-server` to start after the "real" device drivers and
+before such repeater drivers (without a responding server, they would fail
+to start anyway). This may also need special care in `upsd.conf` and/or
+`ups.conf` files to not block the system start-up for too long while the
+repeater driver has not started.
+
+//////////////////////////////////////
+TODO later: declare the driver as "optional", see
+https://github.com/networkupstools/nut/issues/1389
+//////////////////////////////////////
+
 AUTHOR
 ------
 
@@ -119,6 +135,15 @@ linkman:upscmd[1],
 linkman:upsrw[1],
 linkman:ups.conf[5],
 linkman:nutupsdrv[8]
+
+Dummy driver:
+~~~~~~~~~~~~~
+
+The "repeater" mode of 'dummy-ups' driver is in some ways similar to the
+'clone' driver, by relaying information from a locally or remotely running
+"real" device driver (and NUT data server).
+
+linkman:dummy-ups[8]
 
 Internet Resources:
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/man/clone.txt
+++ b/docs/man/clone.txt
@@ -108,15 +108,9 @@ the outlet of the clone UPS driver, your clients will lose power without
 warning.
 
 If you use service management frameworks like systemd or SMF to manage the
-dependencies between driver instances and the data server, and some of these
-drivers are `dummy-ups` in repeater mode (or `clone` drivers) representing
-data from another driver running on the same system, then you may have to
-set up special dependencies (e.g. with systemd "drop-in" snippet files)
-to allow your `nut-server` to start after the "real" device drivers and
-before such repeater drivers (without a responding server, they would fail
-to start anyway). This may also need special care in `upsd.conf` and/or
-`ups.conf` files to not block the system start-up for too long while the
-repeater driver has not started.
+dependencies between driver instances and other units, then you may have
+to set up special dependencies (e.g. with systemd "drop-in" snippet files)
+to queue your `clone` drivers to start after the "real" device drivers.
 
 //////////////////////////////////////
 TODO later: declare the driver as "optional", see

--- a/docs/man/dummy-ups.txt
+++ b/docs/man/dummy-ups.txt
@@ -74,9 +74,11 @@ path name. In the latter case the NUT sysconfig directory (i.e. `/etc/nut`,
 Since NUT v2.8.0 two aspects of this mode are differentiated:
 
 * `dummy-once` reads the specified file once to the end (interrupting for
-  `TIMER` lines, etc.) and does not re-process it;
-  this allows use/test cases to `upsrw` variables in the driver instance
-  and they remain in memory until the driver is restarted;
+  `TIMER` lines, etc.) and does not re-process it until the filesystem
+  timestamp of the data file is changed; this reduces run-time stress if
+  you test with a lot of dummy devices, and allows use/test cases to
+  `upsrw` variables into the driver instance -- and they remain in memory
+  until the driver is restarted (or the file is touched or modified);
 +
 Since NUT v2.8.0 `dummy-once` is assigned by default to files with a `*.dev`
   naming pattern.

--- a/docs/man/dummy-ups.txt
+++ b/docs/man/dummy-ups.txt
@@ -41,6 +41,12 @@ the UPS. This arrangement can also help with networked UPSes, whose network
 management cards can be overwhelmed with a farm of servers directly polling
 SNMP or other protocols every few seconds.
 
+////////////////////////////////////////
+Future intention: Meta mode to aggregate several drivers as one device
+e.g. to represent same UPS with Serial + USB + SNMP links, and/or cover
+an SNMP UPS that supports different data in different MIBs.
+////////////////////////////////////////
+
 IMPLEMENTATION
 --------------
 
@@ -68,7 +74,7 @@ only to modify values of these variables), and has the same format as an
 linkman:upsc[8] dump (`<varname>: <value>`). So you can easily create
 definition files from an existing UPS using `upsc > file.dev`.
 
-Note that the Network UPS project provides a
+Note that the Network UPS project provides an extensive
 link:https://networkupstools.org/ddl/index.html[DDL (Devices Dumps Library)]
 with files which can be used for modelling real devices.
 Entries for the DDL library are best prepared with the
@@ -81,8 +87,8 @@ available: `device.*`, `driver.*`, `ups.mfr`, `ups.model`, `ups.status`
 as filled by the driver itself.
 
 Some sample definition files are available in the `data` directory of the
-NUT source tree, and generally in the sysconfig directory of your system
-distribution.
+NUT source tree, and generally in the sysconfig or share directory of your
+system distribution.
 
 Since *dummy-ups* will loop on reading this file, you can dynamically modify
 it with some external process to "interact" with the driver. This will avoid

--- a/docs/man/dummy-ups.txt
+++ b/docs/man/dummy-ups.txt
@@ -240,10 +240,10 @@ checking enforcement, as well as boundaries or enumeration definition.
 CAVEATS
 -------
 
-If you use service management frameworks like systemd or SMF to manage the
-dependencies between driver instances and the data server, and some of these
-drivers are `dummy-ups` in repeater mode (or `clone` drivers) representing
-data from another driver running on the same system, then you may have to
+If you use service management frameworks like systemd or SMF to manage
+the dependencies between driver instances and the data server, and some
+of these drivers are `dummy-ups` in repeater mode representing data
+from another driver running on the same system, then you may have to
 set up special dependencies (e.g. with systemd "drop-in" snippet files)
 to allow your `nut-server` to start after the "real" device drivers and
 before such repeater drivers (without a responding server, they would fail

--- a/docs/man/dummy-ups.txt
+++ b/docs/man/dummy-ups.txt
@@ -95,6 +95,9 @@ Now such files should get processed to the end once.
 
 Specify `mode=dummy-loop` driver option or rename the data file
 used in the `port` option for legacy behavior.
+
+Use/Test-cases which modified such files content externally should
+not be impacted.
 ======
 
 For instance:
@@ -132,7 +135,7 @@ This will avoid message spam into your system log files, if you are
 using NUT default configuration.
 
 NOTE: By default since NUT v2.8.0, it will not loop on files in `dummy-once`
-mode, e.g. those with a `.dev` extension.
+mode, e.g. those with a `.dev` extension, unless their timestamp changes.
 
 You can also use the `TIMER <seconds>` instruction to create scheduled event
 sequences (such files are traditionally named with the `.seq` extension).

--- a/docs/man/dummy-ups.txt
+++ b/docs/man/dummy-ups.txt
@@ -205,7 +205,9 @@ linkman:upsrw[1] and linkman:upscmd[1] commands.
 
 Note that in simulation mode, new variables can be added on the fly, but only
 by adding these to the definition file (and waiting for it to be re-read).
-Conversely, if you need to remove variable (such as transient ones, like
+That is, the driver should not allow to define a new variable via `upsrw`.
+
+Conversely, if you need to remove a variable (such as transient ones, like
 `ups.alarm`), simply update these by setting an empty value. As a result,
 they will get removed from the data.
 

--- a/docs/man/dummy-ups.txt
+++ b/docs/man/dummy-ups.txt
@@ -17,7 +17,11 @@ DESCRIPTION
 -----------
 
 This program is a multi-purpose UPS emulation tool.
-Its behavior depends on the running mode: "dummy" or "repeater".
+Its general behavior depends on the running mode: "dummy" ("dummy-once"
+or "dummy-loop"), or "repeater".
+////////////////////////////////////////
+...or "meta" eventually.
+////////////////////////////////////////
 
 Dummy Mode
 ~~~~~~~~~~
@@ -29,6 +33,9 @@ linkman:upscmd[1] commands (or equivalent graphical tool), and batchable
 through script files. It can be configured, launched and used as any other
 "real" NUT driver. This mode is mostly useful for development and testing
 purposes.
+
+NOTE: See below about the differences of `dummy-once` vs. `dummy-loop`
+modes -- the former may be more suitable for "interactive" uses and tests.
 
 Repeater Mode
 ~~~~~~~~~~~~~
@@ -102,10 +109,15 @@ not be impacted.
 
 For instance:
 
-	[dummy]
+	[dummy1]
 		driver = dummy-ups
 		port = evolution500.seq
-		desc = "dummy-ups in dummy mode"
+		desc = "dummy-ups in dummy-loop mode"
+
+	[dummy2]
+		driver = dummy-ups
+		port = epdu-managed.dev
+		desc = "dummy-ups in dummy-once mode"
 
 This file is generally named `something.dev` or `something.seq`. It contains
 a list of all valid variables and associated values (you can later use `upsrw`

--- a/docs/man/dummy-ups.txt
+++ b/docs/man/dummy-ups.txt
@@ -218,17 +218,18 @@ BACKGROUND
 ----------
 
 Dummy Mode was originally written in one evening to replace the previous
-dummycons testing driver, which was too limited, and required a terminal for
-interaction.
+'dummycons' testing driver, which was too limited, and required a terminal
+for interaction.
 
 *dummy-ups* is useful for NUT client development, and other testing purposes.
 
-It also helps the NUT Quality Assurance effort, by automating some tests on the
-NUT framework.
+It also helps the NUT Quality Assurance effort, by automating some tests on
+the NUT framework.
 
 It now offers a repeater mode. This will help in building the Meta UPS approach,
 which allows one to build a virtual device, composed of several other devices
-(either UPS, PDUs).
+(either UPS, PDUs), or perhaps represent the same device which supports
+several communication protocols and different media (Serial, USB, SNMP...)
 
 BUGS
 ----

--- a/docs/man/dummy-ups.txt
+++ b/docs/man/dummy-ups.txt
@@ -220,6 +220,25 @@ BUGS
 Instant commands are not yet supported in Dummy Mode, and data need name/value
 checking enforcement, as well as boundaries or enumeration definition.
 
+CAVEATS
+-------
+
+If you use service management frameworks like systemd or SMF to manage the
+dependencies between driver instances and the data server, and some of these
+drivers are `dummy-ups` in repeater mode (or `clone` drivers) representing
+data from another driver running on the same system, then you may have to
+set up special dependencies (e.g. with systemd "drop-in" snippet files)
+to allow your `nut-server` to start after the "real" device drivers and
+before such repeater drivers (without a responding server, they would fail
+to start anyway). This may also need special care in `upsd.conf` and/or
+`ups.conf` files to not block the system start-up for too long while the
+repeater driver has not started.
+
+//////////////////////////////////////
+TODO later: declare the driver as "optional", see
+https://github.com/networkupstools/nut/issues/1389
+//////////////////////////////////////
+
 AUTHOR
 ------
 
@@ -232,6 +251,16 @@ linkman:upscmd[1],
 linkman:upsrw[1],
 linkman:ups.conf[5],
 linkman:nutupsdrv[8]
+
+Clone driver:
+~~~~~~~~~~~~~
+
+The "repeater" mode of 'dummy-ups' driver is in some ways similar to the
+'clone' driver, which sits on top of another driver socket, and allows
+users to group clients to a particular outlet of a device and deal with
+this output as if it were a normal UPS.
+
+linkman:clone[8]
 
 Internet Resources:
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/man/dummy-ups.txt
+++ b/docs/man/dummy-ups.txt
@@ -53,6 +53,9 @@ IMPLEMENTATION
 The `port` specification in `ups.conf` depends on the running mode, and allows
 the driver to select the right mode of operation.
 
+Since NUT v2.8.0, the `mode` specification in `ups.conf` allows users to
+override the mode of operation which would be otherwise guessed by the driver.
+
 Dummy Mode
 ~~~~~~~~~~
 
@@ -60,6 +63,39 @@ In this context, `port` in the `ups.conf` block defines a file name for the
 *dummy-ups* to read data from. This can either be an absolute or a relative
 path name. In the latter case the NUT sysconfig directory (i.e. `/etc/nut`,
 `/usr/local/ups/etc`, ...) is prepended.
+
+Since NUT v2.8.0 two aspects of this mode are differentiated:
+
+* `dummy-once` reads the specified file once to the end (interrupting for
+  `TIMER` lines, etc.) and does not re-process it;
+  this allows use/test cases to `upsrw` variables in the driver instance
+  and they remain in memory until the driver is restarted;
++
+Since NUT v2.8.0 `dummy-once` is assigned by default to files with a `*.dev`
+  naming pattern.
+
+* `dummy-loop` reads the specified file again and again, with a short sleep
+  between the processing cycles; for sequence files using a `TIMER` keyword
+  (see below), or for use/test cases which modify file contents with external
+  means, this allows an impression of a device whose state changes over time.
++
+Before NUT v2.8.0 this was the only aspect, so a simple `dummy` mode value
+  maps to this behavior for backwards compatibility.
++
+Since NUT v2.8.0 `dummy-loop` is assigned by default to files with a `*.seq`
+  naming pattern, and `dummy` is assigned by default to files with other
+  naming patterns that the driver could not classify.
+
+[NOTE]
+======
+Said defaulting based on filename pattern can break third-party
+test scripts which earlier expected `*.dev` files to work as a
+looping sequence with a `TIMER` keywords to change values slowly.
+Now such files should get processed to the end once.
+
+Specify `mode=dummy-loop` driver option or rename the data file
+used in the `port` option for legacy behavior.
+======
 
 For instance:
 
@@ -90,10 +126,13 @@ Some sample definition files are available in the `data` directory of the
 NUT source tree, and generally in the sysconfig or share directory of your
 system distribution.
 
-Since *dummy-ups* will loop on reading this file, you can dynamically modify
-it with some external process to "interact" with the driver. This will avoid
-message spam into your system log files, if you are using NUT default
-configuration.
+Since *dummy-ups* will usually loop on reading this file, you can dynamically
+modify it with some external process to "interact" with the driver.
+This will avoid message spam into your system log files, if you are
+using NUT default configuration.
+
+NOTE: By default since NUT v2.8.0, it will not loop on files in `dummy-once`
+mode, e.g. those with a `.dev` extension.
 
 You can also use the `TIMER <seconds>` instruction to create scheduled event
 sequences (such files are traditionally named with the `.seq` extension).
@@ -107,9 +146,9 @@ between "OL", "OB" and "OB LB" every minute:
 	ups.status: OB LB
 	TIMER 60
 
-It is wise to end the script with a `TIMER` keyword. Otherwise *dummy-ups*
-will directly go back to the beginning of the file and, in particular, forget
-any values you could have just set with `upsrw`.
+It is wise to end the script for `dummy-loop` mode with a `TIMER` keyword.
+Otherwise `dummy-ups` will directly go back to the beginning of the file
+and, in particular, forget any values you could have just set with `upsrw`.
 
 Note that to avoid CPU overload with an infinite loop, the driver "sleeps"
 a bit between file-reading cycles (currently this delay is hardcoded to one

--- a/docs/nut-qa.txt
+++ b/docs/nut-qa.txt
@@ -126,7 +126,9 @@ FIXME (POST):
   a few data points and checks that these are well propagated with upsc.
 
 - similar approach is explored in NIT (NUT Integration Testing) suite,
-  which is part of the codebase and `make check` activities
+  which is part of the codebase and automated with `make check-NIT`;
+  it can also be added to default `make check` activities by running
+  `configure --enable-check-NIT`
 
 - link:https://bugzilla.redhat.com/buglist.cgi?component=nut[Redhat / Fedora Bug tracker]
 

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 2946 utf-8
+personal_ws-1.1 en 2950 utf-8
 AAS
 ABI
 ACFAIL
@@ -1912,6 +1912,8 @@ httpd
 https
 huawei
 hunnox
+hypervisor
+hypervisors
 iBox
 iDowell
 iManufacturer
@@ -2318,6 +2320,7 @@ openmp
 opensolaris
 openssh
 openssl
+optimizations
 optiups
 oq
 os
@@ -2711,6 +2714,7 @@ th
 timehead
 timeline
 timername
+timestamp
 timeticks
 tiocm
 tios

--- a/drivers/clone.c
+++ b/drivers/clone.c
@@ -22,6 +22,7 @@
 #include "main.h"
 #include "parseconf.h"
 #include "attribute.h"
+#include "nut_stdint.h"
 
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -159,13 +160,27 @@ static int parse_args(size_t numargs, char **arg)
 static int sstate_connect(void)
 {
 	ssize_t	ret;
-	int	fd;
+	int	fd, len;
 	const char	*dumpcmd = "DUMPALL\n";
 	struct sockaddr_un	sa;
 
 	memset(&sa, '\0', sizeof(sa));
 	sa.sun_family = AF_UNIX;
-	snprintf(sa.sun_path, sizeof(sa.sun_path), "%s/%s", dflt_statepath(), device_path);
+	len = snprintf(sa.sun_path, sizeof(sa.sun_path), "%s/%s", dflt_statepath(), device_path);
+
+	if (len < 0) {
+		fatalx(EXIT_FAILURE, "Can't create a unix domain socket: "
+			"failed to prepare the pathname");
+	}
+	if ((uintmax_t)len >= (uintmax_t)sizeof(sa.sun_path)) {
+		fatalx(EXIT_FAILURE,
+			"Can't create a unix domain socket: pathname '%s/%s' "
+			"is too long (%zu) for 'struct sockaddr_un->sun_path' "
+			"on this system (%zu)",
+			dflt_statepath(), device_path,
+			strlen(dflt_statepath()) + 1 + strlen(device_path),
+			sizeof(sa.sun_path));
+	}
 
 	fd = socket(AF_UNIX, SOCK_STREAM, 0);
 

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -281,9 +281,9 @@ static int send_to_one(conn_t *conn, const char *fmt, ...)
 		__func__, buflen, conn->fd, buf);
 */
 
-  ret = write(conn->fd, buf, buflen);
+	ret = write(conn->fd, buf, buflen);
 
-  if (ret < 0) {
+	if (ret < 0) {
 		/* Hacky bugfix: throttle down for upsd to read that */
 		upsdebugx(1, "%s: had to throttle down to retry "
 			"writing %zd bytes to socket %d "

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -109,6 +109,8 @@ static int sock_open(const char *fn)
 	int	ret, fd;
 	struct sockaddr_un	ssaddr;
 
+	check_unix_socket_filename(fn);
+
 	fd = socket(AF_UNIX, SOCK_STREAM, 0);
 
 	if (fd < 0) {

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -481,6 +481,9 @@ static void send_tracking(conn_t *conn, const char *id, int value)
 
 static int sock_arg(conn_t *conn, size_t numarg, char **arg)
 {
+	upsdebugx(6, "Driver on %s is now handling %s with %zu args",
+		sockfn, numarg ? arg[0] : "<skipped: no command>", numarg);
+
 	if (numarg < 1) {
 		return 0;
 	}

--- a/drivers/dummy-ups.c
+++ b/drivers/dummy-ups.c
@@ -171,8 +171,33 @@ void upsdrv_initinfo(void)
 			break;
 
 		case MODE_NONE:
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT
+# pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+# pragma GCC diagnostic ignored "-Wunreachable-code"
+#endif
+/* Older CLANG (e.g. clang-3.4) seems to not support the GCC pragmas above */
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunreachable-code"
+# pragma clang diagnostic ignored "-Wcovered-switch-default"
+#endif
+		/* All enum cases defined as of the time of coding
+		 * have been covered above. Handle later definitions,
+		 * memory corruptions and buggy inputs below...
+		 */
 		default:
 			fatalx(EXIT_FAILURE, "no suitable definition found!");
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic pop
+#endif
 	}
 	upsh.instcmd = instcmd;
 
@@ -245,8 +270,33 @@ void upsdrv_updateinfo(void)
 			break;
 
 		case MODE_NONE:
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT
+# pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+# pragma GCC diagnostic ignored "-Wunreachable-code"
+#endif
+/* Older CLANG (e.g. clang-3.4) seems to not support the GCC pragmas above */
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunreachable-code"
+# pragma clang diagnostic ignored "-Wcovered-switch-default"
+#endif
+		/* All enum cases defined as of the time of coding
+		 * have been covered above. Handle later definitions,
+		 * memory corruptions and buggy inputs below...
+		 */
 		default:
 			break;
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic pop
+#endif
 	}
 }
 
@@ -352,6 +402,28 @@ void upsdrv_initups(void)
 				dstate_setinfo("driver.parameter.mode", "dummy-loop");
 				break;
 
+			case MODE_NONE:
+			case MODE_REPEATER:
+			case MODE_META:
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT
+# pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+# pragma GCC diagnostic ignored "-Wunreachable-code"
+#endif
+/* Older CLANG (e.g. clang-3.4) seems to not support the GCC pragmas above */
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunreachable-code"
+# pragma clang diagnostic ignored "-Wcovered-switch-default"
+#endif
+		/* All enum cases defined as of the time of coding
+		 * have been covered above. Handle later definitions,
+		 * memory corruptions and buggy inputs below...
+		 */
 			default:
 				/* This was the only mode until MODE_DUMMY_LOOP
 				 * got split from MODE_DUMMY_ONCE in NUT v2.8.0
@@ -362,6 +434,12 @@ void upsdrv_initups(void)
 				mode = MODE_DUMMY_LOOP;
 				dstate_setinfo("driver.parameter.mode", "dummy");
 				break;
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic pop
+#endif
 		}
 
 		if (0 != fstat (upsfd, &datafile_stat) && 0 != stat (device_path, &datafile_stat)) {

--- a/drivers/dummy-ups.c
+++ b/drivers/dummy-ups.c
@@ -222,9 +222,15 @@ void upsdrv_updateinfo(void)
 			/* less stress on the sys */
 			if (ctx == NULL && next_update == -1) {
 				struct stat	fs;
+				char fn[SMALLBUF];
 
-				if (0 != fstat (upsfd, &fs) && 0 != stat (device_path, &fs)) {
-					upsdebugx(2, "Can't open %s currently", device_path);
+				if (device_path[0] == '/')
+					snprintf(fn, sizeof(fn), "%s", device_path);
+				else
+					snprintf(fn, sizeof(fn), "%s/%s", confpath(), device_path);
+
+				if (0 != fstat (upsfd, &fs) && 0 != stat (fn, &fs)) {
+					upsdebugx(2, "Can't open %s currently", fn);
 					/* retry ASAP until we get a file */
 					memset(&datafile_stat, 0, sizeof(struct stat));
 					next_update = 1;
@@ -362,6 +368,7 @@ void upsdrv_initups(void)
 	}
 	else
 	{
+		char fn[SMALLBUF];
 		mode = MODE_NONE;
 
 		if (val) {
@@ -441,6 +448,11 @@ void upsdrv_initups(void)
 # pragma GCC diagnostic pop
 #endif
 		}
+
+		if (device_path[0] == '/')
+			snprintf(fn, sizeof(fn), "%s", device_path);
+		else
+			snprintf(fn, sizeof(fn), "%s/%s", confpath(), device_path);
 
 		if (0 != fstat (upsfd, &datafile_stat) && 0 != stat (device_path, &datafile_stat)) {
 			upsdebugx(2, "Can't open %s currently", device_path);

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -526,9 +526,17 @@ void do_upsconf_args(char *confupsname, char *var, char *val)
 		if (snprintfcat(buf, sizeof(buf), "lt-%s", val) < 0)
 			buf[0] = '\0';
 
-		if (strcmp(val, progname) != 0
-		&&  strcmp(buf, progname) != 0
-		) {
+		upsdebugx(6, "progname: check '%s' vs '%s' vs '%s'", progname, val, buf);
+		if (strcmp(buf, progname) == 0) {
+			upsdebugx(1, "Seems this driver binary %s is a libtool "
+				"wrapped build for driver %s", progname, val);
+			/* progname points to xbasename(argv[0]) in-place;
+			 * roll the pointer forward a bit, we know we can:
+			 */
+			progname = progname + strlen("lt-");
+		}
+
+		if (strcmp(val, progname) != 0) {
 			fatalx(EXIT_FAILURE, "Error: UPS [%s] is for driver %s, but I'm %s!\n",
 				confupsname, val, progname);
 		}

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -522,18 +522,17 @@ void do_upsconf_args(char *confupsname, char *var, char *val)
 		/* Accomodate for libtool wrapped developer iterations
 		 * running e.g. `drivers/.libs/lt-dummy-ups` filenames
 		 */
-		char buf[PATH_MAX];
-		if (snprintfcat(buf, sizeof(buf), "lt-%s", val) < 0)
-			buf[0] = '\0';
-
-		upsdebugx(6, "progname: check '%s' vs '%s' vs '%s'", progname, val, buf);
-		if (strcmp(buf, progname) == 0) {
-			upsdebugx(1, "Seems this driver binary %s is a libtool "
+		size_t tmplen = strlen("lt-");
+		if (strncmp("lt-", progname, tmplen) == 0
+		&&  strcmp(val, progname + tmplen) == 0) {
+			/* debug level may be not initialized yet, and situation
+			 * should not happen in end-user builds, so ok to yell: */
+			upsdebugx(0, "Seems this driver binary %s is a libtool "
 				"wrapped build for driver %s", progname, val);
 			/* progname points to xbasename(argv[0]) in-place;
 			 * roll the pointer forward a bit, we know we can:
 			 */
-			progname = progname + strlen("lt-");
+			progname = progname + tmplen;
 		}
 
 		if (strcmp(val, progname) != 0) {

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -519,13 +519,15 @@ void do_upsconf_args(char *confupsname, char *var, char *val)
 
 	/* don't let the user shoot themselves in the foot */
 	if (!strcmp(var, "driver")) {
-		/* Accomodate for libtool wrapped developer iterations */
+		/* Accomodate for libtool wrapped developer iterations
+		 * running e.g. `drivers/.libs/lt-dummy-ups` filenames
+		 */
 		char buf[PATH_MAX];
-		if (snprintfcat(buf, sizeof(buf), "lt-%s", progname) < 0)
+		if (snprintfcat(buf, sizeof(buf), "lt-%s", val) < 0)
 			buf[0] = '\0';
 
 		if (strcmp(val, progname) != 0
-		&&  strcmp(val, buf) != 0
+		&&  strcmp(buf, progname) != 0
 		) {
 			fatalx(EXIT_FAILURE, "Error: UPS [%s] is for driver %s, but I'm %s!\n",
 				confupsname, val, progname);

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -519,9 +519,17 @@ void do_upsconf_args(char *confupsname, char *var, char *val)
 
 	/* don't let the user shoot themselves in the foot */
 	if (!strcmp(var, "driver")) {
-		if (strcmp(val, progname) != 0)
+		/* Accomodate for libtool wrapped developer iterations */
+		char buf[PATH_MAX];
+		if (snprintfcat(buf, sizeof(buf), "lt-%s", progname) < 0)
+			buf[0] = '\0';
+
+		if (strcmp(val, progname) != 0
+		&&  strcmp(val, buf) != 0
+		) {
 			fatalx(EXIT_FAILURE, "Error: UPS [%s] is for driver %s, but I'm %s!\n",
 				confupsname, val, progname);
+		}
 		return;
 	}
 

--- a/include/common.h
+++ b/include/common.h
@@ -144,6 +144,9 @@ const char * dflt_statepath(void);
 /* Return the alternate path for pid files */
 const char * altpidpath(void);
 
+/* Die with a standard message if socket filename is too long */
+void check_unix_socket_filename(const char *fn);
+
 /* upslog*() messages are sent to syslog always;
  * their life after that is out of NUT's control */
 void upslog_with_errno(int priority, const char *fmt, ...)

--- a/include/str.h
+++ b/include/str.h
@@ -129,6 +129,10 @@ int	str_to_ulong_strict(const char *string, unsigned long *number, const int bas
 int	str_to_double(const char *string, double *number, const int base);
 int	str_to_double_strict(const char *string, double *number, const int base);
 
+/* Return non-zero if string s ends exactly with suff
+ * Note: s=NULL always fails the test; otherwise suff=NULL always matches
+ */
+int	str_ends_with(const char *s, const char *suff);
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 }

--- a/scripts/python/Makefile.am
+++ b/scripts/python/Makefile.am
@@ -35,3 +35,6 @@ EXTRA_DIST += $(EXTRA_DIST_PY2GTK2)
 EXTRA_DIST += $(EXTRA_DIST_PY3QT5)
 
 MAINTAINERCLEANFILES = Makefile.in .dirstamp
+
+clean-local:
+	rm -rf *.pyc __pycache__ */*.pyc */__pycache__ */*/*.pyc */*/__pycache__

--- a/server/sockdebug.c
+++ b/server/sockdebug.c
@@ -48,6 +48,8 @@ static int socket_connect(const char *sockfn)
 	int	ret, fd;
 	struct	sockaddr_un sa;
 
+	check_unix_socket_filename(sockfn);
+
 	memset(&sa, '\0', sizeof(sa));
 	sa.sun_family = AF_UNIX;
 	snprintf(sa.sun_path, sizeof(sa.sun_path), "%s", sockfn);

--- a/server/sstate.c
+++ b/server/sstate.c
@@ -181,6 +181,8 @@ int sstate_connect(upstype_t *ups)
 	ssize_t	ret;
 	struct sockaddr_un	sa;
 
+	check_unix_socket_filename(ups->fn);
+
 	memset(&sa, '\0', sizeof(sa));
 	sa.sun_family = AF_UNIX;
 	snprintf(sa.sun_path, sizeof(sa.sun_path), "%s", ups->fn);

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,6 +1,9 @@
 /cppunittest
 /cppunittest.log
 /cppunittest.trs
+/cppnit
+/cppnit.log
+/cppnit.trs
 /test-suite.log
 /selftest-rw/*
 /nutlogtest

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -51,7 +51,7 @@ CPPUNITTESTERSRC = cpputest.cpp
 
 CPPCLIENTTESTSRC = cpputest-client.cpp
 
-TESTS_CXX11 = cppunittest cppnit
+TESTS_CXX11 = cppunittest
 
 if HAVE_CXX11
 if HAVE_CPPUNIT
@@ -59,6 +59,9 @@ if HAVE_CPPUNIT
 # that we HAVE_CXX11 - but better have it explicit
 
 TESTS += $(TESTS_CXX11)
+
+# Note: we only build it, but do not run directly (NIT prepares the sandbox)
+check_PROGRAMS += cppnit
 
 if WITH_VALGRIND
 check-local: $(check_PROGRAMS)
@@ -86,12 +89,18 @@ else !HAVE_CPPUNIT
 
 EXTRA_DIST += $(CPPUNITTESTSRC) $(CPPCLIENTTESTSRC) $(CPPUNITTESTERSRC)
 
+cppnit:
+	@echo "SKIP: $@ not implemented without C++11 and CPPUNIT enabled" >&2 ; exit 1
+
 endif !HAVE_CPPUNIT
 
 else !HAVE_CXX11
 # Just redistribute test source into tarball if not building C++ at all
 
 EXTRA_DIST += $(CPPUNITTESTSRC) $(CPPCLIENTTESTSRC) $(CPPUNITTESTERSRC)
+
+cppnit:
+	@echo "SKIP: $@ not implemented without C++11 and CPPUNIT enabled" >&2 ; exit 1
 
 endif !HAVE_CXX11
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -15,7 +15,7 @@ AM_CXXFLAGS = -I$(top_srcdir)/include
 check_PROGRAMS = $(TESTS)
 
 # NUT Integration Testing suite
-check-NIT:
+check-NIT check-NIT-devel:
 	cd "$(builddir)/NIT" && $(MAKE) $@
 
 nutlogtest_SOURCES = nutlogtest.c

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -49,7 +49,9 @@ CPPUNITTESTSRC = example.cpp nutclienttest.cpp
 # The test driver which orchestrates running those tests above
 CPPUNITTESTERSRC = cpputest.cpp
 
-TESTS_CXX11 = cppunittest
+CPPCLIENTTESTSRC = cpputest-client.cpp
+
+TESTS_CXX11 = cppunittest cppnit
 
 if HAVE_CXX11
 if HAVE_CPPUNIT
@@ -68,6 +70,11 @@ cppunittest_LDFLAGS = $(CPPUNIT_LDFLAGS) $(CPPUNIT_LIBS)
 cppunittest_LDADD = $(top_builddir)/clients/libnutclient.la $(top_builddir)/clients/libnutclientstub.la
 cppunittest_SOURCES = $(CPPUNITTESTSRC) $(CPPUNITTESTERSRC)
 
+cppnit_CXXFLAGS = $(AM_CXXFLAGS) $(CPPUNIT_CFLAGS) $(CPPUNIT_CXXFLAGS) $(CPPUNIT_NUT_CXXFLAGS) $(CXXFLAGS)
+cppnit_LDFLAGS = $(CPPUNIT_LDFLAGS) $(CPPUNIT_LIBS)
+cppnit_LDADD = $(top_builddir)/clients/libnutclient.la $(top_builddir)/clients/libnutclientstub.la
+cppnit_SOURCES = $(CPPCLIENTTESTSRC) $(CPPUNITTESTERSRC)
+
 # Make sure out-of-dir C++ dependencies exist (especially when dev-building
 # only some parts of NUT):
 $(top_builddir)/clients/libnutclient.la \
@@ -75,16 +82,16 @@ $(top_builddir)/clients/libnutclientstub.la: dummy
 	@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
 else !HAVE_CPPUNIT
-# Just redistribute test source into tarball
+# Just redistribute test source into tarball if not building tests
 
-EXTRA_DIST += $(CPPUNITTESTSRC) $(CPPUNITTESTERSRC)
+EXTRA_DIST += $(CPPUNITTESTSRC) $(CPPCLIENTTESTSRC) $(CPPUNITTESTERSRC)
 
 endif !HAVE_CPPUNIT
 
 else !HAVE_CXX11
-# Just redistribute test source into tarball
+# Just redistribute test source into tarball if not building C++ at all
 
-EXTRA_DIST += example.cpp cpputest.cpp
+EXTRA_DIST += $(CPPUNITTESTSRC) $(CPPCLIENTTESTSRC) $(CPPUNITTESTERSRC)
 
 endif !HAVE_CXX11
 

--- a/tests/NIT/Makefile.am
+++ b/tests/NIT/Makefile.am
@@ -1,6 +1,11 @@
 EXTRA_DIST = nit.sh README
 
+if WITH_CHECK_NIT
 check: check-NIT
+else
+check:
+	@echo "NO-OP: $@ in `pwd` is inactive by default. Run 'configure --enable-check-NIT' or 'make check-NIT' explicitly" >&2
+endif
 
 # Run in builddir, use script from srcdir
 # Avoid running "$<" - not all make implementations handle that

--- a/tests/NIT/Makefile.am
+++ b/tests/NIT/Makefile.am
@@ -3,9 +3,10 @@ EXTRA_DIST = nit.sh README
 check: check-NIT
 
 # Run in builddir, use script from srcdir
+# Avoid running "$<" - not all make implementations handle that
 check-NIT: $(abs_srcdir)/nit.sh
 	@cd .. && ( $(MAKE) -s cppnit || echo "OPTIONAL C++ test client test will be skipped" )
-	"$<"
+	"$(abs_srcdir)/nit.sh"
 
 MAINTAINERCLEANFILES = Makefile.in .dirstamp
 

--- a/tests/NIT/Makefile.am
+++ b/tests/NIT/Makefile.am
@@ -5,8 +5,15 @@ check: check-NIT
 # Run in builddir, use script from srcdir
 # Avoid running "$<" - not all make implementations handle that
 check-NIT: $(abs_srcdir)/nit.sh
-	@cd .. && ( $(MAKE) -s cppnit || echo "OPTIONAL C++ test client test will be skipped" )
 	"$(abs_srcdir)/nit.sh"
+
+# Make sure pre-requisites for NIT are fresh as we iterate
+check-NIT-devel: $(abs_srcdir)/nit.sh
+	@cd .. && ( $(MAKE) -s cppnit || echo "OPTIONAL C++ test client test will be skipped" )
+	@cd "$(top_builddir)/clients" && $(MAKE) -s upsc upsrw upsmon
+	@cd "$(top_builddir)/server" && $(MAKE) -s upsd
+	@cd "$(top_builddir)/drivers" && $(MAKE) -s dummy-ups
+	@$(MAKE) check-NIT
 
 MAINTAINERCLEANFILES = Makefile.in .dirstamp
 

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -780,6 +780,13 @@ testgroup_sandbox_cppnit() {
     sandbox_forget_configs
 }
 
+testgroup_sandbox_cppnit_simple_admin() {
+    # Arrange for quick test iterations
+    testcase_sandbox_start_drivers_after_upsd
+    testcase_sandbox_cppnit_simple_admin
+    sandbox_forget_configs
+}
+
 ################################################################
 
 case "${NIT_CASE}" in

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -140,7 +140,7 @@ stop_daemons() {
     fi
 }
 
-trap 'RES=$?; stop_daemons; exit $RES;' 0 1 2 3 15
+trap 'RES=$?; stop_daemons; if [ "${TESTDIR}" != "${BUILDDIR}/tmp" ] ; then rm -rf "${TESTDIR}" ; fi; exit $RES;' 0 1 2 3 15
 
 NUT_STATEPATH="${TESTDIR}/run"
 NUT_ALTPIDPATH="${TESTDIR}/run"

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -482,9 +482,13 @@ fi
 
 # TODO: Some upsmon tests?
 
+log_separator
+log_info "OVERALL: PASSED=$PASSED FAILED=$FAILED"
+
 # Allow to leave the sandbox daemons running for a while,
 # to experiment with them interactively:
 if [ -n "${DEBUG_SLEEP-}" ] ; then
+    log_separator
     log_info "Sleeping now as asked, so you can play with the driver and server (port $NUT_PORT) running"
     if [ "${DEBUG_SLEEP-}" -gt 0 ] ; then
         sleep "${DEBUG_SLEEP}"
@@ -492,10 +496,9 @@ if [ -n "${DEBUG_SLEEP-}" ] ; then
         sleep 60
     fi
     log_info "Sleep finished"
+    log_separator
 fi
 
-log_separator
-log_info "OVERALL: PASSED=$PASSED FAILED=$FAILED"
 if [ "$PASSED" = 0 ] || [ "$FAILED" != 0 ] ; then
     die "Some test scenarios failed!"
 else

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -257,20 +257,20 @@ generatecfg_ups_trivial() {
 generatecfg_ups_dummy() {
     generatecfg_ups_trivial
 
-    cat > "$NUT_CONFPATH/dummy.dev" << EOF
+    cat > "$NUT_CONFPATH/dummy.seq" << EOF
 ups.status: OB
 TIMER 5
 ups.status: OL
 TIMER 5
 EOF
-    [ $? = 0 ] || die "Failed to populate temporary FS structure for the NIT: dummy.dev"
+    [ $? = 0 ] || die "Failed to populate temporary FS structure for the NIT: dummy.seq"
 
     cat >> "$NUT_CONFPATH/ups.conf" << EOF
 [dummy]
     driver = dummy-ups
     desc = "Crash Dummy"
-    port = dummy.dev
-    mode = dummy-loop
+    port = dummy.seq
+    #mode = dummy-loop
 EOF
     [ $? = 0 ] || die "Failed to populate temporary FS structure for the NIT: ups.conf"
 

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -270,6 +270,7 @@ EOF
     driver = dummy-ups
     desc = "Crash Dummy"
     port = dummy.dev
+    mode = dummy-loop
 EOF
     [ $? = 0 ] || die "Failed to populate temporary FS structure for the NIT: ups.conf"
 
@@ -286,11 +287,13 @@ EOF
     driver = dummy-ups
     desc = "Example ePDU data dump"
     port = epdu-managed.dev
+    mode = dummy-once
 EOF
         [ $? = 0 ] || die "Failed to populate temporary FS structure for the NIT: ups.conf"
 
         # HACK: Avoid empty ups.status that may be present in example docs
         # FIXME: Might we actually want that value (un-)set for tests?..
+        # TODO: Check if the problem was with dummy-ups looping? [#1385]
         for F in "$NUT_CONFPATH/"*.dev "$NUT_CONFPATH/"*.seq ; do
             sed -e 's,^ups.status: *$,ups.status: OL BOOST,' -i "$F"
             grep -E '^ups.status:' "$F" >/dev/null || { echo "ups.status: OL BOOST" >> "$F"; }

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -288,6 +288,13 @@ EOF
     port = epdu-managed.dev
 EOF
         [ $? = 0 ] || die "Failed to populate temporary FS structure for the NIT: ups.conf"
+
+        # HACK: Avoid empty ups.status that may be present in example docs
+        # FIXME: Might we actually want that value (un-)set for tests?..
+        for F in "$NUT_CONFPATH/"*.dev "$NUT_CONFPATH/"*.seq ; do
+            sed -e 's,^ups.status: *$,ups.status: OL BOOST,' -i "$F"
+            grep -E '^ups.status:' "$F" >/dev/null || { echo "ups.status: OL BOOST" >> "$F"; }
+        done
     fi
 
 }

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -540,6 +540,17 @@ testcase_sandbox_start_drivers_after_upsd() {
         log_error "Query failed, retrying with UPSD started after drivers"
         testcase_start_upsd_after_drivers
     }
+
+    if [ x"${TOP_SRCDIR}" != x ]; then
+        log_info "Wait for dummy UPSes with larger data sets to initialize"
+        for U in UPS1 UPS2 ; do
+            while ! upsc $U@localhost:$NUT_PORT ups.status ; do
+                sleep 1
+            done
+        done
+    fi
+
+    log_info "Expected drivers are now responding via UPSD"
 }
 
 testcase_sandbox_upsc_query_model() {

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -135,6 +135,7 @@ export NUT_STATEPATH NUT_ALTPIDPATH NUT_CONFPATH
     && [ "$NUT_PORT" -gt 0 ] && [ "$NUT_PORT" -lt 65536 ] \
     || NUT_PORT=34931
 }
+export NUT_PORT
 
 ### upsd.conf: ##################################################
 
@@ -478,7 +479,72 @@ if [ x"${TOP_BUILDDIR}" != x ] \
     fi
 fi
 
-# TODO: Make and run C++ client tests
+# We optionally make and here can run C++ client tests:
+if [ x"${TOP_BUILDDIR}" != x ] && [ -x "${TOP_BUILDDIR}/tests/cppnit" ] ; then
+    log_separator
+    log_info "Call libnutclient test suite: cppnit without login credentials"
+    if ( unset NUT_USER || true
+         unset NUT_PASS || true
+        "${TOP_BUILDDIR}/tests/cppnit"
+    ) ; then
+        log_info "OK, cppnit did not complain"
+        PASSED="`expr $PASSED + 1`"
+    else
+        log_error "cppnit complained, check above"
+        FAILED="`expr $FAILED + 1`"
+    fi
+
+    log_separator
+    log_info "Call libnutclient test suite: cppnit with login credentials: simple admin"
+    if (
+        NUT_USER='admin'
+        NUT_PASS="${TESTPASS_ADMIN}"
+        NUT_SETVAR_DEVICE='dummy'
+        unset NUT_PRIMARY_DEVICE
+        export NUT_USER NUT_PASS NUT_SETVAR_DEVICE
+        "${TOP_BUILDDIR}/tests/cppnit"
+    ) ; then
+        log_info "OK, cppnit did not complain"
+        PASSED="`expr $PASSED + 1`"
+    else
+        log_error "cppnit complained, check above"
+        FAILED="`expr $FAILED + 1`"
+    fi
+
+    log_separator
+    log_info "Call libnutclient test suite: cppnit with login credentials: upsmon-primary"
+    if (
+        NUT_USER='dummy-admin'
+        NUT_PASS="${TESTPASS_UPSMON_PRIMARY}"
+        NUT_PRIMARY_DEVICE='dummy'
+        unset NUT_SETVAR_DEVICE
+        export NUT_USER NUT_PASS NUT_PRIMARY_DEVICE
+        "${TOP_BUILDDIR}/tests/cppnit"
+    ) ; then
+        log_info "OK, cppnit did not complain"
+        PASSED="`expr $PASSED + 1`"
+    else
+        log_error "cppnit complained, check above"
+        FAILED="`expr $FAILED + 1`"
+    fi
+
+    log_separator
+    log_info "Call libnutclient test suite: cppnit with login credentials: upsmon-master"
+    if (
+        NUT_USER='dummy-admin-m'
+        NUT_PASS="${TESTPASS_UPSMON_PRIMARY}"
+        NUT_PRIMARY_DEVICE='dummy'
+        unset NUT_SETVAR_DEVICE
+        export NUT_USER NUT_PASS NUT_PRIMARY_DEVICE
+        "${TOP_BUILDDIR}/tests/cppnit"
+    ) ; then
+        log_info "OK, cppnit did not complain"
+        PASSED="`expr $PASSED + 1`"
+    else
+        log_error "cppnit complained, check above"
+        FAILED="`expr $FAILED + 1`"
+    fi
+fi
 
 # TODO: Some upsmon tests?
 

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -551,7 +551,7 @@ testcase_sandbox_start_drivers_after_upsd() {
     upsc dummy@localhost:$NUT_PORT || {
         # Should not get to this, except on very laggy systems maybe
         log_error "Query failed, retrying with UPSD started after drivers"
-        testcase_start_upsd_after_drivers
+        testcase_sandbox_start_upsd_after_drivers
     }
 
     if [ x"${TOP_SRCDIR}" != x ]; then

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -582,9 +582,17 @@ testcase_sandbox_upsc_query_timer() {
     log_info "Test that dummy-ups TIMER action changes the reported state"
     # Driver is set up to flip ups.status every 5 sec, so check every 3
     OUT1="`upsc dummy@localhost:$NUT_PORT ups.status`" || die "upsd does not respond: $OUT1" ; sleep 3
-    OUT2="`upsc dummy@localhost:$NUT_PORT ups.status`" || die "upsd does not respond: $OUT2" ; sleep 3
-    OUT3="`upsc dummy@localhost:$NUT_PORT ups.status`" || die "upsd does not respond: $OUT3" ; sleep 3
-    OUT4="`upsc dummy@localhost:$NUT_PORT ups.status`" || die "upsd does not respond: $OUT4" ; sleep 3
+    OUT2="`upsc dummy@localhost:$NUT_PORT ups.status`" || die "upsd does not respond: $OUT2"
+    OUT3=""
+    OUT4=""
+    if [ x"$OUT1" = x"$OUT2" ]; then
+        sleep 3
+        OUT3="`upsc dummy@localhost:$NUT_PORT ups.status`" || die "upsd does not respond: $OUT3"
+        if [ x"$OUT2" = x"$OUT3" ]; then
+            sleep 3
+            OUT4="`upsc dummy@localhost:$NUT_PORT ups.status`" || die "upsd does not respond: $OUT4"
+        fi
+    fi
     if echo "$OUT1$OUT2$OUT3$OUT4" | grep "OB" && echo "$OUT1$OUT2$OUT3$OUT4" | grep "OL" ; then
         log_info "OK, ups.status flips over time"
         PASSED="`expr $PASSED + 1`"

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -295,7 +295,7 @@ EOF
         # FIXME: Might we actually want that value (un-)set for tests?..
         # TODO: Check if the problem was with dummy-ups looping? [#1385]
         for F in "$NUT_CONFPATH/"*.dev "$NUT_CONFPATH/"*.seq ; do
-            sed -e 's,^ups.status: *$,ups.status: OL BOOST,' -i "$F"
+            sed -e 's,^ups.status: *$,ups.status: OL BOOST,' -i '' "$F"
             grep -E '^ups.status:' "$F" >/dev/null || { echo "ups.status: OL BOOST" >> "$F"; }
         done
     fi

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -120,7 +120,14 @@ rm -rf "$BUILDDIR/tmp" || true
 mkdir -p "$BUILDDIR/tmp/etc" "$BUILDDIR/tmp/run" && chmod 750 "$BUILDDIR/tmp/run" \
 || die "Failed to create temporary FS structure for the NIT"
 
-trap 'RES=$?; if [ -n "$PID_UPSD$PID_DUMMYUPS$PID_DUMMYUPS1$PID_DUMMYUPS2" ] ; then kill -15 $PID_UPSD $PID_DUMMYUPS $PID_DUMMYUPS1 $PID_DUMMYUPS2 ; fi; exit $RES;' 0 1 2 3 15
+stop_daemons() {
+    if [ -n "$PID_UPSD$PID_DUMMYUPS$PID_DUMMYUPS1$PID_DUMMYUPS2" ] ; then
+        log_info "Stopping test daemons"
+        kill -15 $PID_UPSD $PID_DUMMYUPS $PID_DUMMYUPS1 $PID_DUMMYUPS2 2>/dev/null
+    fi
+}
+
+trap 'RES=$?; stop_daemons; exit $RES;' 0 1 2 3 15
 
 NUT_STATEPATH="$BUILDDIR/tmp/run"
 NUT_ALTPIDPATH="$BUILDDIR/tmp/run"

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -156,32 +156,37 @@ generatecfg_upsd_nodev() {
 
 ### upsd.users: ##################################################
 
+TESTPASS_ADMIN='mypass'
+TESTPASS_TESTER='pass words'
+TESTPASS_UPSMON_PRIMARY='P@ssW0rdAdm'
+TESTPASS_UPSMON_SECONDARY='P@ssW0rd'
+
 generatecfg_upsdusers_trivial() {
     cat > "$NUT_CONFPATH/upsd.users" << EOF
 [admin]
-    password = mypass
+    password = $TESTPASS_ADMIN
     actions = SET
     instcmds = ALL
 
 [tester]
-    password = "pass words"
+    password = "${TESTPASS_TESTER}"
     instcmds = test.battery.start
     instcmds = test.battery.stop
 
 [dummy-admin-m]
-    password = 'P@ssW0rdAdm'
+    password = "${TESTPASS_UPSMON_PRIMARY}"
     upsmon master
 
 [dummy-admin]
-    password = 'P@ssW0rdAdm'
+    password = "${TESTPASS_UPSMON_PRIMARY}"
     upsmon primary
 
 [dummy-user-s]
-    password = 'P@ssW0rd'
+    password = "${TESTPASS_UPSMON_SECONDARY}"
     upsmon slave
 
 [dummy-user]
-    password = 'P@ssW0rd'
+    password = "${TESTPASS_UPSMON_SECONDARY}"
     upsmon secondary
 EOF
     [ $? = 0 ] || die "Failed to populate temporary FS structure for the NIT: upsd.users"
@@ -200,25 +205,25 @@ generatecfg_upsmon_trivial() {
 
 generatecfg_upsmon_master() {
     generatecfg_upsmon_trivial
-    echo "MONITOR 'dummy@localhost:$NUT_PORT' 0 'dummy-admin-m' 'P@ssW0rdAdm' master" >> "$NUT_CONFPATH/upsmon.conf" \
+    echo "MONITOR 'dummy@localhost:$NUT_PORT' 0 'dummy-admin-m' '${TESTPASS_UPSMON_PRIMARY}' master" >> "$NUT_CONFPATH/upsmon.conf" \
     || die "Failed to populate temporary FS structure for the NIT: upsmon.conf"
 }
 
 generatecfg_upsmon_primary() {
     generatecfg_upsmon_trivial
-    echo "MONITOR 'dummy@localhost:$NUT_PORT' 0 'dummy-admin' 'P@ssW0rdAdm' primary" >> "$NUT_CONFPATH/upsmon.conf" \
+    echo "MONITOR 'dummy@localhost:$NUT_PORT' 0 'dummy-admin' '${TESTPASS_UPSMON_PRIMARY}' primary" >> "$NUT_CONFPATH/upsmon.conf" \
     || die "Failed to populate temporary FS structure for the NIT: upsmon.conf"
 }
 
 generatecfg_upsmon_slave() {
     generatecfg_upsmon_trivial
-    echo "MONITOR 'dummy@localhost:$NUT_PORT' 0 'dummy-user-s' 'P@ssW0rd' slave" >> "$NUT_CONFPATH/upsmon.conf" \
+    echo "MONITOR 'dummy@localhost:$NUT_PORT' 0 'dummy-user-s' '${TESTPASS_UPSMON_SECONDARY}' slave" >> "$NUT_CONFPATH/upsmon.conf" \
     || die "Failed to populate temporary FS structure for the NIT: upsmon.conf"
 }
 
 generatecfg_upsmon_secondary() {
     generatecfg_upsmon_trivial
-    echo "MONITOR 'dummy@localhost:$NUT_PORT' 0 'dummy-user' 'P@ssW0rd' secondary" >> "$NUT_CONFPATH/upsmon.conf" \
+    echo "MONITOR 'dummy@localhost:$NUT_PORT' 0 'dummy-user' '${TESTPASS_UPSMON_SECONDARY}' secondary" >> "$NUT_CONFPATH/upsmon.conf" \
     || die "Failed to populate temporary FS structure for the NIT: upsmon.conf"
 }
 
@@ -461,7 +466,7 @@ if [ x"${TOP_BUILDDIR}" != x ] \
     log_info "Call Python module test suite: PyNUT (NUT Python bindings) with login credentials"
     if (
         NUT_USER='admin'
-        NUT_PASS='mypass'
+        NUT_PASS="${TESTPASS_ADMIN}"
         export NUT_USER NUT_PASS
         "${TOP_BUILDDIR}/scripts/python/module/test_nutclient.py"
     ) ; then

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -295,7 +295,7 @@ EOF
         # FIXME: Might we actually want that value (un-)set for tests?..
         # TODO: Check if the problem was with dummy-ups looping? [#1385]
         for F in "$NUT_CONFPATH/"*.dev "$NUT_CONFPATH/"*.seq ; do
-            sed -e 's,^ups.status: *$,ups.status: OL BOOST,' -i '' "$F"
+            sed -e 's,^ups.status: *$,ups.status: OL BOOST,' -i'.bak' "$F"
             grep -E '^ups.status:' "$F" >/dev/null || { echo "ups.status: OL BOOST" >> "$F"; }
         done
     fi

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -544,8 +544,12 @@ testcase_sandbox_start_drivers_after_upsd() {
     if [ x"${TOP_SRCDIR}" != x ]; then
         log_info "Wait for dummy UPSes with larger data sets to initialize"
         for U in UPS1 UPS2 ; do
+            COUNTDOWN=60
             while ! upsc $U@localhost:$NUT_PORT ups.status ; do
                 sleep 1
+                COUNTDOWN="`expr $COUNTDOWN - 1`"
+                # Systemic error, e.g. could not create socket file?
+                [ "$COUNTDOWN" -lt 1 ] && die "Dummy driver did not start or respond in time"
             done
         done
     fi

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -437,13 +437,17 @@ else
     FAILED="`expr $FAILED + 1`"
 fi
 
-if [ x"${TOP_BUILDDIR}" != x ]; then
+# We optionally make python module (if interpreter is found):
+if [ x"${TOP_BUILDDIR}" != x ] \
+&& [ -x "${TOP_BUILDDIR}/scripts/python/module/test_nutclient.py" ] \
+; then
     # That script says it expects data/evolution500.seq (as the UPS1 dummy)
     # but the dummy data does not currently let issue the commands and
     # setvars tested from python script.
     log_separator
     log_info "Call Python module test suite: PyNUT (NUT Python bindings) without login credentials"
-    if ( export NUT_PORT
+    if ( unset NUT_USER || true
+         unset NUT_PASS || true
         "${TOP_BUILDDIR}/scripts/python/module/test_nutclient.py"
     ) ; then
         log_info "OK, PyNUT did not complain"
@@ -458,7 +462,7 @@ if [ x"${TOP_BUILDDIR}" != x ]; then
     if (
         NUT_USER='admin'
         NUT_PASS='mypass'
-        export NUT_USER NUT_PASS NUT_PORT
+        export NUT_USER NUT_PASS
         "${TOP_BUILDDIR}/scripts/python/module/test_nutclient.py"
     ) ; then
         log_info "OK, PyNUT did not complain"

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -499,7 +499,13 @@ if [ x"${TOP_BUILDDIR}" != x ] && [ -x "${TOP_BUILDDIR}/tests/cppnit" ] ; then
     if (
         NUT_USER='admin'
         NUT_PASS="${TESTPASS_ADMIN}"
-        NUT_SETVAR_DEVICE='dummy'
+        if [ x"${TOP_SRCDIR}" != x ]; then
+            # Avoid dummies with TIMER flip-flops
+            NUT_SETVAR_DEVICE='UPS2'
+        else
+            # Risks failure when lauching sub-test at the wrong second
+            NUT_SETVAR_DEVICE='dummy'
+        fi
         unset NUT_PRIMARY_DEVICE
         export NUT_USER NUT_PASS NUT_SETVAR_DEVICE
         "${TOP_BUILDDIR}/tests/cppnit"

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -14,6 +14,7 @@
 # Caller can export envvars to impact the script behavior, e.g.:
 #	DEBUG=true	to print debug messages, running processes, etc.
 #	DEBUG_SLEEP=60	to sleep after tests, with driver+server running
+#	NUT_PORT=12345	custom port for upsd to listen and clients to query
 #
 # Design note: written with dumbed-down POSIX shell syntax, to
 # properly work in whatever different OSes have (bash, dash,
@@ -125,7 +126,8 @@ NUT_CONFPATH="$BUILDDIR/tmp/etc"
 export NUT_STATEPATH NUT_ALTPIDPATH NUT_CONFPATH
 
 # TODO: Find a portable way to grab a random unprivileged port?
-NUT_PORT="34931"
+[ -n "${NUT_PORT-}" ] && [ "$NUT_PORT" -gt 0 ] && [ "$NUT_PORT" -lt 65536 ] \
+|| NUT_PORT="34931"
 
 ### upsd.conf: ##################################################
 

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -148,6 +148,14 @@ LISTEN localhost $NUT_PORT
 EOF
     [ $? = 0 ] || die "Failed to populate temporary FS structure for the NIT: upsd.conf"
     chmod 640 "$NUT_CONFPATH/upsd.conf"
+
+    # Some systems listining on symbolic "localhost" actually
+    # only bind to IPv6, and Python telnetlib resolves IPv4
+    # and fails its connection tests. Others fare well with
+    # both addresses in one command.
+    for LH in 127.0.0.1 '::1' ; do
+        ping -c 1 "$LH" 2>/dev/null >/dev/null && { echo "LISTEN $LH $NUT_PORT" >> "$NUT_CONFPATH/upsd.conf"; }
+    done
 }
 
 generatecfg_upsd_nodev() {

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -125,9 +125,16 @@ NUT_ALTPIDPATH="$BUILDDIR/tmp/run"
 NUT_CONFPATH="$BUILDDIR/tmp/etc"
 export NUT_STATEPATH NUT_ALTPIDPATH NUT_CONFPATH
 
-# TODO: Find a portable way to grab a random unprivileged port?
+# TODO: Find a portable way to (check and) grab a random unprivileged port?
 [ -n "${NUT_PORT-}" ] && [ "$NUT_PORT" -gt 0 ] && [ "$NUT_PORT" -lt 65536 ] \
-|| NUT_PORT="34931"
+|| {
+    DELTA1="`date +%S`" || DELTA1=0
+    DELTA2="`expr $$ % 99`" || DELTA2=0
+
+    NUT_PORT="`expr 34931 + $DELTA1 + $DELTA2`" \
+    && [ "$NUT_PORT" -gt 0 ] && [ "$NUT_PORT" -lt 65536 ] \
+    || NUT_PORT=34931
+}
 
 ### upsd.conf: ##################################################
 

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -584,7 +584,8 @@ testcase_sandbox_upsc_query_timer() {
     OUT1="`upsc dummy@localhost:$NUT_PORT ups.status`" || die "upsd does not respond: $OUT1" ; sleep 3
     OUT2="`upsc dummy@localhost:$NUT_PORT ups.status`" || die "upsd does not respond: $OUT2" ; sleep 3
     OUT3="`upsc dummy@localhost:$NUT_PORT ups.status`" || die "upsd does not respond: $OUT3" ; sleep 3
-    if echo "$OUT1$OUT2$OUT3" | grep "OB" && echo "$OUT1$OUT2$OUT3" | grep "OL" ; then
+    OUT4="`upsc dummy@localhost:$NUT_PORT ups.status`" || die "upsd does not respond: $OUT4" ; sleep 3
+    if echo "$OUT1$OUT2$OUT3$OUT4" | grep "OB" && echo "$OUT1$OUT2$OUT3$OUT4" | grep "OL" ; then
         log_info "OK, ups.status flips over time"
         PASSED="`expr $PASSED + 1`"
     else

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -507,8 +507,8 @@ UPS2"
         log_error "upsc was supposed to answer with error exit code: $OUT"
         FAILED="`expr $FAILED + 1`"
     }
-    if [ x"$OUT" != x'Error: Driver not connected' ] ; then
-        log_error "got reply for upsc query when 'Error: Driver not connected' was expected: $OUT"
+    if ! echo "$OUT" | grep 'Error: Driver not connected' ; then
+        log_error "got reply for upsc query when 'Error: Driver not connected' was expected: '$OUT'"
         FAILED="`expr $FAILED + 1`"
     else
         PASSED="`expr $PASSED + 1`"
@@ -569,7 +569,7 @@ testcase_sandbox_upsc_query_bogus() {
         log_error "upsc was supposed to answer with error exit code: $OUT"
         FAILED="`expr $FAILED + 1`"
     }
-    if [ x"$OUT" != x'Error: Variable not supported by UPS' ] ; then
+    if ! echo "$OUT" | grep 'Error: Variable not supported by UPS' ; then
         log_error "got reply for upsc query when 'Error: Variable not supported by UPS' was expected: $OUT"
         FAILED="`expr $FAILED + 1`"
     else

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -575,7 +575,8 @@ log_info "OVERALL: PASSED=$PASSED FAILED=$FAILED"
 # to experiment with them interactively:
 if [ -n "${DEBUG_SLEEP-}" ] ; then
     log_separator
-    log_info "Sleeping now as asked, so you can play with the driver and server (port $NUT_PORT) running"
+    log_info "Sleeping now as asked, so you can play with the driver and server running; hint: export NUT_PORT=$NUT_PORT"
+    log_separator
     if [ "${DEBUG_SLEEP-}" -gt 0 ] ; then
         sleep "${DEBUG_SLEEP}"
     else

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -154,7 +154,12 @@ EOF
     # and fails its connection tests. Others fare well with
     # both addresses in one command.
     for LH in 127.0.0.1 '::1' ; do
-        ping -c 1 "$LH" 2>/dev/null >/dev/null && { echo "LISTEN $LH $NUT_PORT" >> "$NUT_CONFPATH/upsd.conf"; }
+        if (
+           ( cat /etc/hosts || getent hosts ) | grep "$LH" \
+             || ping -c 1 "$LH"
+        ) 2>/dev/null >/dev/null ; then
+            echo "LISTEN $LH $NUT_PORT" >> "$NUT_CONFPATH/upsd.conf"
+        fi
     done
 }
 

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -68,7 +68,7 @@ TOP_BUILDDIR=""
 case "${BUILDDIR}" in
     */tests/NIT)
         TOP_BUILDDIR="`cd "${BUILDDIR}"/../.. && pwd`" ;;
-    *) log_info "Current directory is not a .../tests/NIT" ;;
+    *) log_info "Current directory '${BUILDDIR}' is not a .../tests/NIT" ;;
 esac
 if ! test -w "${BUILDDIR}" ; then
     log_error "BUILDDIR='${BUILDDIR}' is not writeable, tests may fail below"
@@ -80,6 +80,7 @@ TOP_SRCDIR=""
 case "${SRCDIR}" in
     */tests/NIT)
         TOP_SRCDIR="`cd "${SRCDIR}"/../.. && pwd`" ;;
+    *) log_info "Script source directory '${SRCDIR}' is not a .../tests/NIT" ;;
 esac
 
 # No fuss about LD_LIBRARY_PATH: for binaries that need it,
@@ -105,7 +106,7 @@ unset PATH_ADD
 log_debug "Using PATH='$PATH'"
 
 for PROG in upsd upsc dummy-ups upsmon ; do
-    (command -v ${PROG}) || die "Useless setup: ${PROG} not found in PATH"
+    (command -v ${PROG}) || die "Useless setup: ${PROG} not found in PATH: ${PATH}"
 done
 
 PID_UPSD=""

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -14,6 +14,7 @@
 # Caller can export envvars to impact the script behavior, e.g.:
 #	DEBUG=true	to print debug messages, running processes, etc.
 #	DEBUG_SLEEP=60	to sleep after tests, with driver+server running
+#	NUT_DEBUG_MIN=3	to set (minimum) debug level for drivers, upsd...
 #	NUT_PORT=12345	custom port for upsd to listen and clients to query
 #
 # Design note: written with dumbed-down POSIX shell syntax, to
@@ -161,6 +162,10 @@ EOF
             echo "LISTEN $LH $NUT_PORT" >> "$NUT_CONFPATH/upsd.conf"
         fi
     done
+
+    if [ -n "${NUT_DEBUG_MIN-}" ] ; then
+        echo "DEBUG_MIN ${NUT_DEBUG_MIN}" >> "$NUT_CONFPATH/upsd.conf" || exit
+    fi
 }
 
 generatecfg_upsd_nodev() {
@@ -214,6 +219,10 @@ generatecfg_upsmon_trivial() {
     # Populate the configs for the run
     (  echo 'MINSUPPLIES 0' > "$NUT_CONFPATH/upsmon.conf" || exit
        echo 'SHUTDOWNCMD "echo TESTING_DUMMY_SHUTDOWN_NOW"' >> "$NUT_CONFPATH/upsmon.conf" || exit
+
+       if [ -n "${NUT_DEBUG_MIN-}" ] ; then
+           echo "DEBUG_MIN ${NUT_DEBUG_MIN}" >> "$NUT_CONFPATH/upsmon.conf" || exit
+       fi
     ) || die "Failed to populate temporary FS structure for the NIT: upsmon.conf"
     chmod 640 "$NUT_CONFPATH/upsmon.conf"
 }
@@ -250,8 +259,12 @@ generatecfg_ups_trivial() {
         if [ x"${TOP_BUILDDIR}" != x ]; then
             echo "driverpath = '${TOP_BUILDDIR}/drivers'" >> "$NUT_CONFPATH/ups.conf" || exit
         fi
+        if [ -n "${NUT_DEBUG_MIN-}" ] ; then
+            echo "debug_min = ${NUT_DEBUG_MIN}" >> "$NUT_CONFPATH/ups.conf" || exit
+        fi
     ) || die "Failed to populate temporary FS structure for the NIT: ups.conf"
     chmod 640 "$NUT_CONFPATH/ups.conf"
+
 }
 
 generatecfg_ups_dummy() {

--- a/tests/cpputest-client.cpp
+++ b/tests/cpputest-client.cpp
@@ -245,14 +245,14 @@ void NutActiveClientTest::test_auth_user() {
 			TrackingResult tres;
 			TrackingID tid;
 			std::string nutVar = "ups.status"; /* Has a risk of flip-flop with NIT dummy setup */
-			std::string s = c.getDeviceVariableValue(NUT_SETVAR_DEVICE, nutVar)[0];
-			std::string sTest = s + "-test";
+			std::string s1 = c.getDeviceVariableValue(NUT_SETVAR_DEVICE, nutVar)[0];
+			std::string sTest = s1 + "-test";
 
 			std::cerr << "[D] Got initial device '" << NUT_SETVAR_DEVICE
-				<< "' variable '" << nutVar << "' value: " << s << std::endl;
+				<< "' variable '" << nutVar << "' value: " << s1 << std::endl;
 			CPPUNIT_ASSERT_MESSAGE(
 				"Did not expect empty value here",
-				!s.empty());
+				!s1.empty());
 
 			tid = c.setDeviceVariable(NUT_SETVAR_DEVICE, nutVar, sTest);
 			while ( (tres = c.getTrackingResult(tid)) == PENDING) {
@@ -267,7 +267,7 @@ void NutActiveClientTest::test_auth_user() {
 			std::string s2 = c.getDeviceVariableValue(NUT_SETVAR_DEVICE, nutVar)[0];
 
 			/* Fix it back */
-			tid = c.setDeviceVariable(NUT_SETVAR_DEVICE, nutVar, s);
+			tid = c.setDeviceVariable(NUT_SETVAR_DEVICE, nutVar, s1);
 			while ( (tres = c.getTrackingResult(tid)) == PENDING) {
 				usleep(100);
 			}
@@ -278,16 +278,16 @@ void NutActiveClientTest::test_auth_user() {
 			}
 			std::string s3 = c.getDeviceVariableValue(NUT_SETVAR_DEVICE, nutVar)[0];
 
-			if (s3 != s) {
+			if (s3 != s1) {
 				std::cerr << "[D] Final device variable value '" << s3
-					<< "' differs from original '" << s
+					<< "' differs from original '" << s1
 					<< "'" << std::endl;
 				noException = false;
 			}
 
-			if (s2 == s) {
+			if (s2 == s1) {
 				std::cerr << "[D] Tweaked device variable value '" << s2
-					<< "' does not differ from original '" << s
+					<< "' does not differ from original '" << s1
 					<< "'" << std::endl;
 				noException = false;
 			}

--- a/tests/cpputest-client.cpp
+++ b/tests/cpputest-client.cpp
@@ -265,6 +265,7 @@ void NutActiveClientTest::test_auth_user() {
 			}
 			/* Check what we got after set */
 			std::string s2 = c.getDeviceVariableValue(NUT_SETVAR_DEVICE, nutVar)[0];
+			std::cerr << "[D] Read back: " << s2 << std::endl;
 
 			/* Fix it back */
 			tid = c.setDeviceVariable(NUT_SETVAR_DEVICE, nutVar, s1);
@@ -277,6 +278,7 @@ void NutActiveClientTest::test_auth_user() {
 				noException = false;
 			}
 			std::string s3 = c.getDeviceVariableValue(NUT_SETVAR_DEVICE, nutVar)[0];
+			std::cerr << "[D] Read back: " << s3 << std::endl;
 
 			if (s3 != s1) {
 				std::cerr << "[D] Final device variable value '" << s3

--- a/tests/cpputest-client.cpp
+++ b/tests/cpputest-client.cpp
@@ -1,0 +1,383 @@
+/* cpputest-client - CppUnit libnutclient active test
+
+   Module for NUT `cpputest` runner, to check client-server interactions
+   as part of NIT (NUT Integration Testing) suite and similar scenarios.
+   This is an "active" NUT client talking to an `upsd` on $NUT_PORT,
+   as opposed to nutclienttest.cpp which unit-tests the class API etc.
+   in isolated-binary fashion.
+
+   Copyright (C) 2022  Jim Klimov <jimklimov@gmail.com>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
+#include "common.h"
+
+/* Current CPPUnit offends the honor of C++98 */
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_EXIT_TIME_DESTRUCTORS || defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_GLOBAL_CONSTRUCTORS)
+#pragma GCC diagnostic push
+# ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_GLOBAL_CONSTRUCTORS
+#  pragma GCC diagnostic ignored "-Wglobal-constructors"
+# endif
+# ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_EXIT_TIME_DESTRUCTORS
+#  pragma GCC diagnostic ignored "-Wexit-time-destructors"
+# endif
+#endif
+
+#include <cppunit/extensions/HelperMacros.h>
+#include <stdexcept>
+#include <cstdint>
+#include <cstdlib>
+#include <stdlib.h>
+
+namespace nut {
+
+class NutActiveClientTest : public CppUnit::TestFixture
+{
+	/* Note: is "friend" of nut::TcpClient class
+	 * to test a few of its protected methods */
+
+	CPPUNIT_TEST_SUITE( NutActiveClientTest );
+		CPPUNIT_TEST( test_query_ver );
+		CPPUNIT_TEST( test_list_ups );
+		CPPUNIT_TEST( test_auth_user );
+		CPPUNIT_TEST( test_auth_primary );
+	CPPUNIT_TEST_SUITE_END();
+
+private:
+	/* Fed by caller via envvars: */
+	uint16_t NUT_PORT = 0;
+	std::string NUT_USER = "";
+	std::string NUT_PASS = "";
+	std::string NUT_PRIMARY_DEVICE = "";
+	std::string NUT_SETVAR_DEVICE = "";
+
+public:
+	void setUp() override;
+	void tearDown() override;
+
+	void test_query_ver();
+	void test_list_ups();
+	void test_auth_user();
+	void test_auth_primary();
+};
+
+// Registers the fixture into the 'registry'
+CPPUNIT_TEST_SUITE_REGISTRATION( NutActiveClientTest );
+
+} // namespace nut {}
+
+#ifndef _NUTCLIENTTEST_BUILD
+# define _NUTCLIENTTEST_BUILD 1
+#endif
+
+#include "../clients/nutclient.h"
+#include "../clients/nutclientmem.h"
+
+namespace nut {
+
+extern "C" {
+strarr stringset_to_strarr(const std::set<std::string>& strset);
+strarr stringvector_to_strarr(const std::vector<std::string>& strset);
+} // extern "C"
+
+void NutActiveClientTest::setUp()
+{
+	/* NUT_PORT etc. are provided by external test suite driver */
+	char * s;
+
+	s = std::getenv("NUT_PORT");
+	if (s) {
+		long l = atol(s);
+		if (l < 1 || l > 65535) {
+			throw std::runtime_error("NUT_PORT specified by caller is out of range");
+		}
+		NUT_PORT = static_cast<uint16_t>(l);
+	} else {
+		throw std::runtime_error("NUT_PORT not specified by caller, NIT should call this test");
+	}
+
+	s = std::getenv("NUT_USER");
+	if (s) {
+		NUT_USER = s;
+	} // else stays empty
+
+	s = std::getenv("NUT_PASS");
+	if (s) {
+		NUT_PASS = s;
+	} // else stays empty
+
+	s = std::getenv("NUT_PRIMARY_DEVICE");
+	if (s) {
+		NUT_PRIMARY_DEVICE = s;
+	} // else stays empty
+
+	s = std::getenv("NUT_SETVAR_DEVICE");
+	if (s) {
+		NUT_SETVAR_DEVICE = s;
+	} // else stays empty
+}
+
+void NutActiveClientTest::tearDown()
+{
+}
+
+void NutActiveClientTest::test_query_ver() {
+	nut::TcpClient c("localhost", NUT_PORT);
+	std::string s;
+
+	std::cerr << "[D] C++ NUT Client lib test running against Data Server at: "
+		<< c.getHost() << ':' << c.getPort() << std::endl;
+
+	CPPUNIT_ASSERT_MESSAGE(
+		"TcpClient is not connected after constructor",
+		c.isConnected());
+
+	/* Note: generic client code can not use protected methods
+	 * like low-level sendQuery(), list(), get() and some more,
+	 * but this NutActiveClientTest is a friend of TcpClient:
+	 */
+	s = c.sendQuery("VER");
+	std::cerr << "[D] Got Data Server VER: " << s << std::endl;
+
+	try {
+		s = c.sendQuery("PROTVER");
+		std::cerr << "[D] Got PROTVER: " << s << std::endl;
+	}
+	catch(nut::NutException& ex)
+	{
+		std::cerr << "[D] Did not get PROTVER: " << ex.what() << std::endl;
+	}
+
+	try {
+		s = c.sendQuery("NETVER");
+		std::cerr << "[D] Got NETVER (obsolete): " << s << std::endl;
+	}
+	catch(nut::NutException& ex)
+	{
+		std::cerr << "[D] Did not get NETVER (obsolete): " << ex.what() << std::endl;
+	}
+
+	try {
+		c.logout();
+	}
+	catch(nut::NutException& ex)
+	{
+		std::cerr << "[D] Could not get LOGOUT: " << ex.what() << std::endl;
+	}
+
+	try {
+		c.disconnect();
+	}
+	catch(nut::NutException& ex)
+	{
+		/* NUT_UNUSED_VARIABLE(ex); */
+		std::cerr << "[D] Could not get disconnect(): " << ex.what() << std::endl;
+	}
+}
+
+void NutActiveClientTest::test_list_ups() {
+	nut::TcpClient c("localhost", NUT_PORT);
+	std::set<std::string> devs;
+	bool noException = true;
+
+	try {
+		devs = c.getDeviceNames();
+		std::cerr << "[D] Got device list (" << devs.size() << "): [";
+		for (std::set<std::string>::iterator it = devs.begin();
+			it != devs.end(); it++
+		) {
+			if (it != devs.begin()) {
+				std::cerr << ", ";
+			}
+			std::cerr << '"' << *it << '"';
+		}
+		std::cerr << "]" << std::endl;
+	}
+	catch(nut::NutException& ex)
+	{
+		std::cerr << "[D] Could not device list: " << ex.what() << std::endl;
+		noException = false;
+	}
+
+	c.logout();
+	c.disconnect();
+
+	CPPUNIT_ASSERT_MESSAGE(
+		"Failed to list UPS with TcpClient: threw NutException",
+		noException);
+}
+
+void NutActiveClientTest::test_auth_user() {
+	if (NUT_USER.empty()) {
+		std::cerr << "[D] SKIPPING test_auth_user()" << std::endl;
+		return;
+	}
+
+	nut::TcpClient c("localhost", NUT_PORT);
+	bool noException = true;
+	try {
+		c.authenticate(NUT_USER, NUT_PASS);
+		std::cerr << "[D] Authenticated without exceptions" << std::endl;
+		/* Note: no high hopes here, credentials are checked by server
+		 * when running critical commands, not at auth request itself */
+	}
+	catch(nut::NutException& ex)
+	{
+		std::cerr << "[D] Could not authenticate as a simple user: " << ex.what() << std::endl;
+		noException = false;
+	}
+
+	if (!NUT_SETVAR_DEVICE.empty()) {
+		try {
+			TrackingResult tres;
+			TrackingID tid;
+			std::string nutVar = "ups.status"; /* Has a risk of flip-flop with NIT dummy setup */
+			std::string s = c.getDeviceVariableValue(NUT_SETVAR_DEVICE, nutVar)[0];
+			std::string sTest = s + "-test";
+
+			tid = c.setDeviceVariable(NUT_SETVAR_DEVICE, nutVar, sTest);
+			while ( (tres = c.getTrackingResult(tid)) == PENDING) {
+				usleep(100);
+			}
+			if (tres != SUCCESS) {
+				std::cerr << "[D] Failed to set device variable: "
+					<< "tracking result is " << tres << std::endl;
+				noException = false;
+			}
+			/* Check what we got after set */
+			std::string s2 = c.getDeviceVariableValue(NUT_SETVAR_DEVICE, nutVar)[0];
+
+			/* Fix it back */
+			tid = c.setDeviceVariable(NUT_SETVAR_DEVICE, nutVar, s);
+			while ( (tres = c.getTrackingResult(tid)) == PENDING) {
+				usleep(100);
+			}
+			if (tres != SUCCESS) {
+				std::cerr << "[D] Failed to set device variable: "
+					<< "tracking result is " << tres << std::endl;
+				noException = false;
+			}
+			std::string s3 = c.getDeviceVariableValue(NUT_SETVAR_DEVICE, nutVar)[0];
+
+			if (s3 != s) {
+				std::cerr << "[D] Final device variable value '" << s3
+					<< "' differs from original '" << s
+					<< "'" << std::endl;
+				noException = false;
+			}
+
+			if (s2 == s) {
+				std::cerr << "[D] Tweaked device variable value '" << s2
+					<< "' does not differ from original '" << s
+					<< "'" << std::endl;
+				noException = false;
+			}
+
+			if (noException) {
+				std::cerr << "[D] Tweaked device variable value OK" << std::endl;
+			}
+		}
+		catch(nut::NutException& ex)
+		{
+			std::cerr << "[D] Failed to set device variable: "
+				<< ex.what() << std::endl;
+			noException = false;
+		}
+	} else {
+		std::cerr << "[D] SKIPPING test_auth_user() active test "
+			<< "(got no NUT_SETVAR_DEVICE to poke)" << std::endl;
+	}
+
+	c.logout();
+	c.disconnect();
+
+	CPPUNIT_ASSERT_MESSAGE(
+		"Failed to auth as user with TcpClient or tweak device variable",
+		noException);
+}
+
+void NutActiveClientTest::test_auth_primary() {
+	if (NUT_USER.empty() || NUT_PRIMARY_DEVICE.empty()) {
+		std::cerr << "[D] SKIPPING test_auth_primary()" << std::endl;
+		return;
+	}
+
+	nut::TcpClient c("localhost", NUT_PORT);
+	bool noException = true;
+	try {
+		c.authenticate(NUT_USER, NUT_PASS);
+		std::cerr << "[D] Authenticated without exceptions" << std::endl;
+	}
+	catch(nut::NutException& ex)
+	{
+		std::cerr << "[D] Could not authenticate as an upsmon primary user: "
+			<< ex.what() << std::endl;
+		noException = false;
+	}
+
+	try {
+		Device d = c.getDevice(NUT_PRIMARY_DEVICE);
+		bool gotPrimary = false;
+		bool gotMaster = false;
+
+		try {
+			c.deviceMaster(NUT_PRIMARY_DEVICE);
+			gotMaster = true;
+			std::cerr << "[D] Elevated as MASTER without exceptions" << std::endl;
+		}
+		catch(nut::NutException& ex)
+		{
+			std::cerr << "[D] Could not elevate as MASTER for "
+				<< "NUT_PRIMARY_DEVICE " << NUT_PRIMARY_DEVICE << ": "
+				<< ex.what() << std::endl;
+		}
+
+		try {
+			c.devicePrimary(NUT_PRIMARY_DEVICE);
+			gotPrimary = true;
+			std::cerr << "[D] Elevated as PRIMARY without exceptions" << std::endl;
+		}
+		catch(nut::NutException& ex)
+		{
+			std::cerr << "[D] Could not elevate as PRIMARY for "
+				<< "NUT_PRIMARY_DEVICE " << NUT_PRIMARY_DEVICE << ": "
+				<< ex.what() << std::endl;
+		}
+
+		if (!gotMaster && !gotPrimary)
+			noException = false;
+	}
+	catch(nut::NutException& ex)
+	{
+		std::cerr << "[D] NUT_PRIMARY_DEVICE " << NUT_PRIMARY_DEVICE
+			<< " not found on Data Server: "
+			<< ex.what() << std::endl;
+		noException = false;
+	}
+
+	c.logout();
+	c.disconnect();
+
+	CPPUNIT_ASSERT_MESSAGE(
+		"Failed to auth as user with TcpClient: threw NutException",
+		noException);
+}
+
+} // namespace nut {}
+
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_EXIT_TIME_DESTRUCTORS || defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_GLOBAL_CONSTRUCTORS)
+#pragma GCC diagnostic pop
+#endif

--- a/tests/cpputest-client.cpp
+++ b/tests/cpputest-client.cpp
@@ -248,6 +248,12 @@ void NutActiveClientTest::test_auth_user() {
 			std::string s = c.getDeviceVariableValue(NUT_SETVAR_DEVICE, nutVar)[0];
 			std::string sTest = s + "-test";
 
+			std::cerr << "[D] Got initial device '" << NUT_SETVAR_DEVICE
+				<< "' variable '" << nutVar << "' value: " << s << std::endl;
+			CPPUNIT_ASSERT_MESSAGE(
+				"Did not expect empty value here",
+				!s.empty());
+
 			tid = c.setDeviceVariable(NUT_SETVAR_DEVICE, nutVar, sTest);
 			while ( (tres = c.getTrackingResult(tid)) == PENDING) {
 				usleep(100);


### PR DESCRIPTION
Recent PRs added the "usable PoC" of NIT (NUT Integration Testing suite), which is a portable-shell script to set up the sandbox with a running `upsd` and some dummy-ups instances, and tests them with a few `upsc` queries as well as PyNUT self-test suite (so that code gets regularly covered also).

In some ways it is similar to Ubuntu QART `test-nut.py` (see issue #3) which tests a packaged installation; however NIT should be able to test a recent build iteration right in the source/build tree, as well as a separate (packaged) recent version of NUT with compatible CLI, without impacting system configuration, processes and communication ports/sockets.

This PR refines the script a bit and integrates it with `make check` and `make distcheck` recipes for NUT.
It also adds and calls a simple C++ client `cppnit` (optional, where we can build it) to test `libnutclient`, and updated `dummy-ups` to address issue #1385 uncovered during this work.

Further plans include:
* devising a way to modularize this script, calling externally tracked test suites against prepared sandbox (and giving them tools to recycle configs and daemons as needed) instead of keeping a huge single script for everything;
* integrate with TAP protocol instead of arbitrary run-and-log approach: https://www.gnu.org/software/automake/manual/html_node/Using-the-TAP-test-protocol.html and https://www.gnu.org/software/automake/manual/html_node/Scripts_002dbased-Testsuites.html
* reduce noise by default (e.g. stderr from daemons, especially where we expect them to fail with invalid configs, etc.)