### PR TITLE
nut-scanner does not detect UPS with unknown ProductID

### DIFF
--- a/tools/nut-scanner/scan_usb.c
+++ b/tools/nut-scanner/scan_usb.c
@@ -189,7 +189,7 @@ static char* is_usb_device_supported(usb_device_id_t *usb_device_id_list,
 
 	for (usbdev = usb_device_id_list; usbdev->driver_name != NULL; usbdev++) {
 		if ((usbdev->vendorID == dev_VendorID)
-		 && (usbdev->productID == dev_ProductID)
+		 && ((usbdev->productID == dev_ProductID) || ((usbdev->productID & dev_ProductID) == dev_ProductID))
 		) {
 			return usbdev->driver_name;
 		}


### PR DESCRIPTION
nut-scanner is not able to detect properly UPS if product id
is defined as 0xffff in usb_device_table. For instance entry:

{ 0x2e51, 0xffff, "usbhid-ups" }

Does not recognize properly my UPS, which appears as

Bus 003 Device 002: ID 2e51:0000 EVER ECO PRO AVR CDS

with lsusb command, but is fully supported.
I don't know if setting 0xffff in usb_device table was intentional,
for this purpose, but this commit treats ProductID from
usb_device_table, as bitmask while traversing over usb devices.

The following approach resulted in, the following output running
nut-scanner with my Ever UPS attached:

./nut-scanner -U
Scanning USB bus.
[nutdev1]
    driver = "usbhid-ups"
    port = "auto"
    vendorid = "2E51"
    productid = "0000"
    product = "ECO PRO AVR CDS"
    serial = "XXXXXXXXXXXXXXXXXXXXXXX"
    vendor = "EVER"
    bus = "003"
