### PR TITLE
Fix inclusion of `linkman*.txt` files from a builddir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .libs/
 .inst/
 /tmp/
+/obj/
 /_install_pkgprotodir/
 Makefile
 Makefile.in

--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -983,6 +983,9 @@ set | sort -n """
                     ['LANG=C','LC_ALL=C','TZ=UTC',
                      'BUILD_TYPE=default-all-errors',
                      'BUILD_WARNFATAL=yes',
+                     // Build in a subdirectory to check that out-of-dir
+                     // builds are healthy too
+                     'CI_BUILDDIR=obj',
                      // NOTE: "gcc-hard" warnings are still not as picky
                      // as "clang-hard" and do not differ much from the
                      // "gcc-medium" definition currently:

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -18,10 +18,12 @@ SCRIPTDIR="`cd "$SCRIPTDIR" && pwd`"
 # or to quickly hit the first-found errors in a larger matrix
 # (and then easily `make` to iterate fixes), like this:
 #   CI_REQUIRE_GOOD_GITIGNORE="false" CI_FAILFAST=true DO_CLEAN_CHECK=no BUILD_TYPE=fightwarn ./ci_build.sh
+#
 # For out-of-tree builds you can specify a CI_BUILDDIR (absolute or relative
 # to SCRIPTDIR - not current path), or just call .../ci_build.sh while being
 # in a different directory and then it would be used with a warning. This may
-# require that you `make distclean` the original source checkout first.
+# require that you `make distclean` the original source checkout first:
+#   CI_BUILDDIR=obj BUILD_TYPE=default-all-errors ./ci_build.sh
 case "$BUILD_TYPE" in
     fightwarn) ;; # for default compiler
     fightwarn-all)
@@ -123,7 +125,8 @@ esac
 # but is built in various directories with different configurations.
 # This is something to test via CI, that recipes are not broken for
 # such use-case. Note the path should be in .gitignore, e.g. equal to
-# or under ./tmp/ for CI_REQUIRE_GOOD_GITIGNORE sanity checks to pass.
+# or under ./tmp/ or ./obj/ for the CI_REQUIRE_GOOD_GITIGNORE sanity
+# checks to pass.
 case "${CI_BUILDDIR-}" in
     "") # Not set, likeliest case
         CI_BUILDDIR="`pwd`"

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -899,7 +899,8 @@ DOCBUILD_BEGIN = { \
         if ! test -s "$(builddir)/$<" && test -s "$(srcdir)/`basename $<`" ; then \
             ln -fs "$(srcdir)/`basename $<`" "$(builddir)/" ; \
         fi ; \
-     fi ; \
+    fi ; \
+    A2X_VERBOSE="$(ASCIIDOC_VERBOSE)"; if [ "$(V)" = 1 ]; then A2X_VERBOSE="--verbose"; fi; \
 }
 
 # Note that documents with sub-pages (see LIBNUTCLIENT_*_DEPS above)
@@ -922,16 +923,16 @@ DOCBUILD_END = { \
 	@A2X_OUTDIR="tmp/man-html.$(@F).$$$$" ; \
 	 echo "  DOC-MAN-HTML Generating $@"; \
 	 $(DOCBUILD_BEGIN) ; RES=0; \
-	 $(ASCIIDOC) --backend=xhtml11 \
-		--attribute localdate=`TZ=UTC date +%Y-%m-%d` \
-		--attribute localtime=`TZ=UTC date +%H:%M:%S` \
+	 $(ASCIIDOC) --backend=xhtml11 $${A2X_VERBOSE} \
+		--attribute localdate="`TZ=UTC date +%Y-%m-%d`" \
+		--attribute localtime="`TZ=UTC date +%H:%M:%S`" \
 		--attribute nutversion="@PACKAGE_VERSION@" \
 		-o "$${A2X_OUTDIR}/$(@F)" $< || RES=$$? ; \
 	 $(DOCBUILD_END) ; exit $$RES
 
 ### Prior to Asciidoc ~8.6.8, the --destination-dir flag didn't seem to affect the location of the intermediate .xml file.
 ### This parameter is currently required; see docs/Makefile.am for more detail.
-A2X_MANPAGE_OPTS = --doctype manpage --format manpage \
+A2X_MANPAGE_OPTS = --doctype manpage --format manpage $${A2X_VERBOSE} \
 	--xsltproc-opts="--nonet" \
 	--attribute mansource="Network UPS Tools" \
 	--attribute manversion="@PACKAGE_VERSION@" \

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -749,6 +749,7 @@ HTML_MANS = \
 # list of drivers with `- linkman:nutupsdrv[8]` entry
 # To regenerate these files, do `make distclean` first
 LINKMAN_INCLUDE_GENERATED = linkman-driver-names.txt linkman-drivertool-names.txt
+LINKMAN_INCLUDE_CONSUMERS = index.txt upsd.txt nutupsdrv.txt
 
 linkman-driver-names.txt:
 	@if test x"$(srcdir)" != x"$(builddir)" ; then \
@@ -779,9 +780,7 @@ linkman-drivertool-names.txt:
 
 # Dependencies are about particular filenames, since over time
 # we might have several use-cases for LINKMAN_INCLUDE_GENERATED:
-index.txt index.html \
-upsd.txt upsd.html upsd.8 upsd.pdf \
-nutupsdrv.txt nutupsdrv.html nutupsdrv.8 nutupsdrv.pdf : linkman-driver-names.txt linkman-drivertool-names.txt
+$(LINKMAN_INCLUDE_CONSUMERS): linkman-driver-names.txt linkman-drivertool-names.txt
 
 # These files are generated when we build from git source so not tracked in
 # git, but we want it as part of tarball just in case the end-user's build

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -783,10 +783,7 @@ linkman-drivertool-names.txt:
 $(LINKMAN_INCLUDE_CONSUMERS): linkman-driver-names.txt linkman-drivertool-names.txt
 
 # These files are generated when we build from git source so not tracked in
-# git, but we want it as part of tarball just in case the end-user's build
-# does not enable something related to docs:
-EXTRA_DIST += $(LINKMAN_INCLUDE_GENERATED)
-
+# git, and not part of tarball (to be in builddir) - so not in EXTRA_DIST.
 DISTCLEANFILES = $(LINKMAN_INCLUDE_GENERATED)
 
 all:
@@ -918,6 +915,10 @@ DOCBUILD_END = { \
     fi ; \
 }
 
+### Regarding absolute paths in attributes below: by default asciidoc
+### resolves include paths relative to the main document, so while we
+### see the relative builddir as "." in the makefile, for included
+### data it would mean the source directory where the .txt resides.
 .txt.html:
 	@A2X_OUTDIR="tmp/man-html.$(@F).$$$$" ; \
 	 echo "  DOC-MAN-HTML Generating $@"; \
@@ -926,6 +927,8 @@ DOCBUILD_END = { \
 		--attribute localdate="`TZ=UTC date +%Y-%m-%d`" \
 		--attribute localtime="`TZ=UTC date +%H:%M:%S`" \
 		--attribute nutversion="@PACKAGE_VERSION@" \
+		--attribute srcdir="$(abs_srcdir)" \
+		--attribute builddir="$(abs_builddir)" \
 		-o "$${A2X_OUTDIR}/$(@F)" $< || RES=$$? ; \
 	 $(DOCBUILD_END) ; exit $$RES
 
@@ -936,6 +939,8 @@ A2X_MANPAGE_OPTS = --doctype manpage --format manpage $${A2X_VERBOSE} \
 	--attribute mansource="Network UPS Tools" \
 	--attribute manversion="@PACKAGE_VERSION@" \
 	--attribute manmanual="NUT Manual" \
+	--attribute srcdir="$(abs_srcdir)" \
+	--attribute builddir="$(abs_builddir)" \
 	--destination-dir="$${A2X_OUTDIR}"
 
 .txt.1:

--- a/docs/man/index.txt
+++ b/docs/man/index.txt
@@ -50,13 +50,13 @@ CGI programs
 Driver control:
 ~~~~~~~~~~~~~~~
 
-include::linkman-drivertool-names.txt[]
+include::{builddir}/linkman-drivertool-names.txt[]
 
 Drivers:
 ~~~~~~~~
 
 - linkman:nutupsdrv[8]
-include::linkman-driver-names.txt[]
+include::{builddir}/linkman-driver-names.txt[]
 
 [[Developer_man]]
 Developer manual pages

--- a/docs/man/nutupsdrv.txt
+++ b/docs/man/nutupsdrv.txt
@@ -227,12 +227,12 @@ CGI programs:
 Driver control:
 ~~~~~~~~~~~~~~~
 
-include::linkman-drivertool-names.txt[]
+include::{builddir}/linkman-drivertool-names.txt[]
 
 Drivers:
 ~~~~~~~~
 
-include::linkman-driver-names.txt[]
+include::{builddir}/linkman-driver-names.txt[]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/man/upsd.txt
+++ b/docs/man/upsd.txt
@@ -174,13 +174,13 @@ CGI programs:
 Driver control:
 ~~~~~~~~~~~~~~~
 
-include::linkman-drivertool-names.txt[]
+include::{builddir}/linkman-drivertool-names.txt[]
 
 Drivers:
 ~~~~~~~~
 
 - linkman:nutupsdrv[8]
-include::linkman-driver-names.txt[]
+include::{builddir}/linkman-driver-names.txt[]
 
 Internet resources:
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 2951 utf-8
+personal_ws-1.1 en 2952 utf-8
 AAS
 ABI
 ACFAIL
@@ -1527,6 +1527,7 @@ buflen
 bugfix
 bugfixes
 buildbots
+builddir
 bullseye
 busybox
 bv


### PR DESCRIPTION
Also add handling of out-of-tree builds (not distcheck) with `ci_build.sh` by running it from a remote directory or specifying a `CI_BUILDDIR` envvar.

Thanks to @GregTroxel for locating the issue. Fallout from #1372