### PR TITLE
drivers/libusb{0,1}.c: report why we could not open any HID devices

### DIFF
--- a/drivers/libusb0.c
+++ b/drivers/libusb0.c
@@ -180,6 +180,9 @@ static int libusb_open(usb_dev_handle **udevp,
 	usb_ctrl_char *p;
 	char string[256];
 	int i;
+	int count_open_EACCESS = 0;
+	int count_open_errors = 0;
+	int count_open_attempts = 0;
 
 	/* report descriptor */
 	usb_ctrl_char	rdbuf[MAX_REPORT_SIZE];
@@ -201,6 +204,8 @@ static int libusb_open(usb_dev_handle **udevp,
 		for (dev = bus->devices; dev; dev = dev->next) {
 			/* int	if_claimed = 0; */
 
+			count_open_attempts++;
+
 			upsdebugx(2, "Checking device (%04X/%04X) (%s/%s)",
 				dev->descriptor.idVendor, dev->descriptor.idProduct,
 				bus->dirname, dev->filename);
@@ -211,10 +216,30 @@ static int libusb_open(usb_dev_handle **udevp,
 			/* open the device */
 			*udevp = udev = usb_open(dev);
 			if (!udev) {
+				/* It seems that with libusb-0.1 API we
+				 * can only evaluate the string value of
+				 * usb_strerror() return values - in the
+				 * library source there is magic about
+				 * tracking errors in their string buffer
+				 * or as a printable errno, and no reliably
+				 * usable way to learn of an EACCESS or
+				 * other situation diagnostics otherwise.
+				 * So we have to search for sub-strings
+				 * and hope for locale to be right...
+				 */
+				char *libusb_error = usb_strerror();
 				upsdebugx(1, "Failed to open device (%04X/%04X), skipping: %s",
 					dev->descriptor.idVendor,
 					dev->descriptor.idProduct,
-					usb_strerror());
+					libusb_error);
+
+				count_open_errors++;
+				if (strcasestr(libusb_error, "Access denied")
+				||  strcasestr(libusb_error, "insufficient permissions")
+				) {
+					count_open_EACCESS++;
+				}
+
 				continue;
 			}
 
@@ -522,6 +547,20 @@ static int libusb_open(usb_dev_handle **udevp,
 	*udevp = NULL;
 	upsdebugx(2, "libusb0: No appropriate HID device found");
 	fflush(stdout);
+
+	if (count_open_attempts == 0) {
+		upslogx(LOG_WARNING,
+			"libusb0: Could not open any HID devices: "
+			"no USB buses found");
+	}
+	else
+	if (count_open_errors > 0
+	&&  count_open_errors == count_open_EACCESS
+	) {
+		upslogx(LOG_WARNING,
+			"libusb0: Could not open any HID devices: "
+			"insufficient permissions on everything");
+	}
 
 	return -1;
 }


### PR DESCRIPTION
e.g. no USB devices present (found), or no access permissions to each one device tried (e.g. driver started not as a user specified in udev rules).

Closes: #477