### PR TITLE
Hcl updates

### DIFF
--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -68,17 +68,17 @@
 "APC"	"ups"	"1"	"Matrix-UPS"	""	"apcsmart"
 "APC"	"ups"	"1"	"Smart-UPS"	""	"apcsmart"
 "APC"	"ups"	"1"	"Smart-UPS SMT/SMX/SURTD"	"Microlink models with RJ45 socket - they *require* AP9620 SmartSlot expansion card and smart cable"	"apcsmart"
-"APC"	"ups"	"2"	"Back-UPS Pro USB"	"USB"	"usbhid-ups"
-"APC"	"ups"	"2"	"Back-UPS (USB)"	"USB"	"usbhid-ups"
-"APC"	"ups"	"2"	"Back-UPS CS USB"	"USB"	"usbhid-ups"
-"APC"	"ups"	"2"	"Back-UPS RS USB"	"USB"	"usbhid-ups"
-"APC"	"ups"	"2"	"Back-UPS LS USB"	"USB"	"usbhid-ups"
-"APC"	"ups"	"2"	"Back-UPS ES/CyberFort 350"	"USB"	"usbhid-ups"
-"APC"	"ups"	"2"	"Back-UPS BF500"	"USB"	"usbhid-ups"
-"APC"	"ups"	"2"	"BACK-UPS XS LCD"	"USB"	"usbhid-ups"
-"APC"	"ups"	"2"	"Back-UPS XS 1000M (Back-UPS Pro 1000, Model BX1000M)"	"USB"	"usbhid-ups"	# https://github.com/networkupstools/nut/issues/139
-"APC"	"ups"	"2"	"SMC2200BI-BR"	"USB"	"usbhid-ups"	# https://github.com/networkupstools/nut/issues/557
-"APC"	"ups"	"2"	"Smart-UPS (USB)"	"USB"	"usbhid-ups"
+"APC"	"ups"	"3"	"Back-UPS Pro USB"	"USB"	"usbhid-ups"
+"APC"	"ups"	"3"	"Back-UPS (USB)"	"USB"	"usbhid-ups"
+"APC"	"ups"	"3"	"Back-UPS CS USB"	"USB"	"usbhid-ups"
+"APC"	"ups"	"3"	"Back-UPS RS USB"	"USB"	"usbhid-ups"
+"APC"	"ups"	"3"	"Back-UPS LS USB"	"USB"	"usbhid-ups"
+"APC"	"ups"	"3"	"Back-UPS ES/CyberFort 350"	"USB"	"usbhid-ups"
+"APC"	"ups"	"3"	"Back-UPS BF500"	"USB"	"usbhid-ups"
+"APC"	"ups"	"3"	"BACK-UPS XS LCD"	"USB"	"usbhid-ups"
+"APC"	"ups"	"3"	"Back-UPS XS 1000M (Back-UPS Pro 1000, Model BX1000M)"	"USB"	"usbhid-ups"	# https://github.com/networkupstools/nut/issues/139
+"APC"	"ups"	"3"	"SMC2200BI-BR"	"USB"	"usbhid-ups"	# https://github.com/networkupstools/nut/issues/557
+"APC"	"ups"	"3"	"Smart-UPS (USB)"	"USB"	"usbhid-ups"
 "APC"	"ups"	"1"	"Back-UPS"	"940-0095A/C cables"	"genericups upstype=1"
 "APC"	"ups"	"1"	"Back-UPS"	"940-0020B/C cables"	"genericups upstype=2"
 "APC"	"ups"	"1"	"Back-UPS"	"940-0023A cable"	"genericups upstype=9"
@@ -147,23 +147,23 @@
 "Belkin"	"ups"	"1"	"Home Office F6H350-SER"	""	"genericups upstype=7"
 "Belkin"	"ups"	"1"	"Home Office F6H500-SER"	""	"genericups upstype=7"
 "Belkin"	"ups"	"1"	"Home Office F6H650-SER"	""	"genericups upstype=7"
-"Belkin"	"ups"	"2"	"F6H375-USB"	"USB (<= 2005 models, vendor id: 050d)"	"usbhid-ups"
+"Belkin"	"ups"	"3"	"F6H375-USB"	"USB (<= 2005 models, vendor id: 050d)"	"usbhid-ups"
 "Belkin"	"ups"	"2"	"F6H375-USB"	"USB (2007 models, vendor id: 0665)"	"blazer_usb"
-"Belkin"	"ups"	"2"	"Office Series F6C550-AVR"	"USB"	"usbhid-ups"
+"Belkin"	"ups"	"3"	"Office Series F6C550-AVR"	"USB"	"usbhid-ups"
 "Belkin"	"ups"	"3"	"Regulator PRO-USB"	"USB (~2000, product id: 0f51)"	"usbhid-ups"
 "Belkin"	"ups"	"2"	"Regulator Pro"	"F6C525-SER, F6C625-SER"	"belkin"
 "Belkin"	"ups"	"1"	"Resource"	""	"genericups upstype=4"
 "Belkin"	"ups"	"2"	"Small Enterprise F6C1500-TW-RK"	"serial port"	"belkin"
-"Belkin"	"ups"	"2"	"Small Enterprise F6C1500-TW-RK"	"USB"	"usbhid-ups"
-"Belkin"	"ups"	"2"	"Universal UPS F6C100-UNV"	"USB"	"usbhid-ups"
+"Belkin"	"ups"	"3"	"Small Enterprise F6C1500-TW-RK"	"USB"	"usbhid-ups"
+"Belkin"	"ups"	"3"	"Universal UPS F6C100-UNV"	"USB"	"usbhid-ups"
 "Belkin"	"ups"	"1"	"Universal UPS F6C120-UNV"	"serial port"	"belkinunv"
-"Belkin"	"ups"	"2"	"Universal UPS F6C120-UNV"	"USB"	"usbhid-ups"
+"Belkin"	"ups"	"3"	"Universal UPS F6C120-UNV"	"USB"	"usbhid-ups"
 "Belkin"	"ups"	"1"	"Universal UPS F6C800-UNV"	"serial port"	"belkinunv"
-"Belkin"	"ups"	"2"	"Universal UPS F6C800-UNV"	"USB"	"usbhid-ups"
+"Belkin"	"ups"	"3"	"Universal UPS F6C800-UNV"	"USB"	"usbhid-ups"
 "Belkin"	"ups"	"1"	"Universal UPS F6C1100-UNV"	"serial port (<= 2005 models)"	"belkinunv"
-"Belkin"	"ups"	"2"	"Universal UPS F6C1100-UNV"	"USB (<= 2005 models, vendor id: 050d)"	"usbhid-ups"
+"Belkin"	"ups"	"3"	"Universal UPS F6C1100-UNV"	"USB (<= 2005 models, vendor id: 050d)"	"usbhid-ups"
 "Belkin"	"ups"	"2"	"Universal UPS F6C1100-UNV"	"USB (2007 models, vendor id: 0665)"	"blazer_usb"
-"Belkin"	"ups"	"2"	"Universal UPS F6C1200-UNV"	"USB (<= 2005 models, vendor id: 050d)"	"usbhid-ups"
+"Belkin"	"ups"	"3"	"Universal UPS F6C1200-UNV"	"USB (<= 2005 models, vendor id: 050d)"	"usbhid-ups"
 "Belkin"	"ups"	"2"	"Universal UPS F6C1200-UNV"	"USB (2007 models, vendor id: 0665)"	"blazer_usb"
 "Belkin"	"ups"	"2"	"Universal UPS F6H350deUNV"	"serial port"	"blazer_ser"
 "Belkin"	"ups"	"2"	"Universal UPS F6H350ukUNV"	"serial port"	"blazer_ser"
@@ -225,22 +225,22 @@
 "Cyber Power Systems"	"ups"	"1"	"CPS900AVR"	""	"powerpanel"	# http://www.cyberpowersystems.com/products/ups-systems/other-ups/CPS900AVR.html
 "Cyber Power Systems"	"ups"	"1"	"PR2200"	""	"powerpanel"
 "Cyber Power Systems"	"ups"	"1"	"Power99"	""	"genericups upstype=7"
-"Cyber Power Systems"	"ups"	"2"	"AE550"	"USB"	"usbhid-ups"
+"Cyber Power Systems"	"ups"	"3"	"AE550"	"USB"	"usbhid-ups"
 "Cyber Power Systems"	"ups"	"3"	"BL1250U"	"USB"	"usbhid-ups"	# https://www.cyberpowersystems.com/product/ups/battery-backup/bl1250u/ https://github.com/networkupstools/nut/issues/1012
 "Cyber Power Systems"	"ups"	"3"	"BR1000ELCD"	"USB"	"usbhid-ups"	# https://www.cyberpower.com/eu/en/product/sku/BR1000ELCD https://github.com/networkupstools/nut/issues/552
-"Cyber Power Systems"	"ups"	"2"	"CP1350AVRLCD"	"USB"	"usbhid-ups"
-"Cyber Power Systems"	"ups"	"2"	"CP1500AVRLCD"	"USB"	"usbhid-ups"
-"Cyber Power Systems"	"ups"	"2"	"CP850PFCLCD"	"USB"	"usbhid-ups"	# https://github.com/networkupstools/nut/issues/605
-"Cyber Power Systems"	"ups"	"2"	"CP1500PFCLCD"	"USB"	"usbhid-ups"	# https://www.cyberpowersystems.com/product/ups/cp1500pfclcd/ https://github.com/networkupstools/nut/issues/520
-"Cyber Power Systems"	"ups"	"2"	"CP900AVR"	"USB"	"usbhid-ups"
-"Cyber Power Systems"	"ups"	"2"	"CPS685AVR"	"USB"	"usbhid-ups"
-"Cyber Power Systems"	"ups"	"2"	"CPS800AVR"	"USB"	"usbhid-ups"
+"Cyber Power Systems"	"ups"	"3"	"CP1350AVRLCD"	"USB"	"usbhid-ups"
+"Cyber Power Systems"	"ups"	"3"	"CP1500AVRLCD"	"USB"	"usbhid-ups"
+"Cyber Power Systems"	"ups"	"3"	"CP850PFCLCD"	"USB"	"usbhid-ups"	# https://github.com/networkupstools/nut/issues/605
+"Cyber Power Systems"	"ups"	"3"	"CP1500PFCLCD"	"USB"	"usbhid-ups"	# https://www.cyberpowersystems.com/product/ups/cp1500pfclcd/ https://github.com/networkupstools/nut/issues/520
+"Cyber Power Systems"	"ups"	"3"	"CP900AVR"	"USB"	"usbhid-ups"
+"Cyber Power Systems"	"ups"	"3"	"CPS685AVR"	"USB"	"usbhid-ups"
+"Cyber Power Systems"	"ups"	"3"	"CPS800AVR"	"USB"	"usbhid-ups"
 "Cyber Power Systems"	"ups"	"2"	"OL3000RMXL2U"	""	"powerpanel"
 "Cyber Power Systems"	"ups"	"2"	"PR3000E"	""	"powerpanel"
-"Cyber Power Systems"	"ups"	"2"	"Value 1500ELCD-RU"	"USB"	"usbhid-ups"
-"Cyber Power Systems"	"ups"	"2"	"Value 400E"	"USB"	"usbhid-ups"
-"Cyber Power Systems"	"ups"	"2"	"Value 600E"	"USB"	"usbhid-ups"
-"Cyber Power Systems"	"ups"	"2"	"Value 800E"	"USB"	"usbhid-ups"
+"Cyber Power Systems"	"ups"	"3"	"Value 1500ELCD-RU"	"USB"	"usbhid-ups"
+"Cyber Power Systems"	"ups"	"3"	"Value 400E"	"USB"	"usbhid-ups"
+"Cyber Power Systems"	"ups"	"3"	"Value 600E"	"USB"	"usbhid-ups"
+"Cyber Power Systems"	"ups"	"3"	"Value 800E"	"USB"	"usbhid-ups"
 "Cyber Power Systems"	"ups"	"3"	"VP1200ELCD (ValueII_1200E)"	"USB"	"usbhid-ups"
 "Cyber Power Systems"	"ups"	"3"	"CP 1500C"	"USB"	"usbhid-ups"
 "Cyber Power Systems"	"ups"	"3"	"CP1000PFCLCD"	"USB"	"usbhid-ups"
@@ -315,7 +315,7 @@
 "Dynamix"	"ups"	"2"	"650VA/1000VA"	"USB"	"blazer_usb langid_fix=0x0409"
 
 "Dynex"	"ups"	"1"	"975AVR"	""	"genericups upstype=7"
-"Dynex"	"ups"	"2"	"DX-800U"	"USB"	"usbhid-ups"
+"Dynex"	"ups"	"3"	"DX-800U"	"USB"	"usbhid-ups"
 
 "Eaton"	"ups"	"5"	"3S"	""	"usbhid-ups"
 "Eaton"	"ups"	"5"	"Protection Station 500/650/800 VA"	"USB"	"usbhid-ups"
@@ -461,7 +461,7 @@
 "GE Digital Energy"	"ups"	"2"	"EP Series"	""	"blazer_usb"
 "GE Digital Energy"	"ups"	"2"	"GT Series 1000/1500/2000/3000 VA Rack/Tower"	"UL-version"	"blazer_ser"
 
-"Geek Squad"	"ups"	"2"	"GS1285U"	"USB"	"usbhid-ups"
+"Geek Squad"	"ups"	"3"	"GS1285U"	"USB"	"usbhid-ups"
 
 "Gemini"	"ups"	"1"	"UPS625/UPS1000"	""	"safenet"
 
@@ -515,7 +515,7 @@
 
 "ICS"	"pdu"	"1"	"8064 Ethernet Relay Interface"	"16 outlets"	"powerman-pdu (experimental)"
 
-"iDowell"	"ups"	"2"	"iBox UPS"	""	"usbhid-ups"
+"iDowell"	"ups"	"3"	"iBox UPS"	""	"usbhid-ups"
 
 "INELT"	"ups"	"2"	"Monolith 1000LT"	""	"blazer_ser"
 "INELT"	"ups"	"2"	"Monolith 3000RT"	""	"blazer_ser"
@@ -586,8 +586,8 @@
 "Legrand"	"ups"	"2"	"Keor Multiplug"	"USB"	"nutdrv_qx"
 "Legrand"	"ups"	"2"	"Keor S"	"Serial"	"nutdrv_qx"
 "Legrand"	"ups"	"2"	"Keor S"	"USB"	"nutdrv_qx"
-"Legrand"	"ups"	"2"	"Keor PDU"	"USB"	"usbhid-ups"
-"Legrand"	"ups"	"2"	"Keor SP"	"USB"	"usbhid-ups"
+"Legrand"	"ups"	"3"	"Keor PDU"	"USB"	"usbhid-ups"
+"Legrand"	"ups"	"3"	"Keor SP"	"USB"	"usbhid-ups"
 "Legrand"	"ups"	"2"	"Keor SPX"	"USB"	"nutdrv_qx"
 "Legrand"	"ups"	"4"	"Megaline 1250"	"Serial"	"metasys"
 "Legrand"	"ups"	"4"	"Megaline 2500"	"Serial"	"metasys"
@@ -621,11 +621,11 @@
 "Liebert"	"ups"	"2"	"ITON 600VA"	""	"blazer_ser"
 "Liebert"	"ups"	"5"	"UPStation GXT2"	"contact-closure cable"	"liebert"
 "Liebert"	"ups"	"1"	"GXT2-3000RT230"	""	"liebert-esp2 (experimental)"
-"Liebert"	"ups"	"2"	"PowerSure Personal XT"	"USB"	"usbhid-ups"
-"Liebert"	"ups"	"2"	"PowerSure PSA"	"USB"	"usbhid-ups"
-"Liebert"	"ups"	"2"	"PowerSure PSA 500"	"USB"	"usbhid-ups"
-"Liebert"	"ups"	"2"	"PowerSure PSA500MT3-230U"	"USB"	"usbhid-ups"	# https://github.com/networkupstools/nut/issues/601
-"Liebert"	"ups"	"2"	"PowerSure PSI 1440"	"USB"	"usbhid-ups"	# http://www.emersonnetworkpower.com/en-US/Products/ACPower/Pages/LiebertPowerSurePSILineInteractiveUPS10003000VA.aspx
+"Liebert"	"ups"	"3"	"PowerSure Personal XT"	"USB"	"usbhid-ups"
+"Liebert"	"ups"	"3"	"PowerSure PSA"	"USB"	"usbhid-ups"
+"Liebert"	"ups"	"3"	"PowerSure PSA 500"	"USB"	"usbhid-ups"
+"Liebert"	"ups"	"3"	"PowerSure PSA500MT3-230U"	"USB"	"usbhid-ups"	# https://github.com/networkupstools/nut/issues/601
+"Liebert"	"ups"	"3"	"PowerSure PSI 1440"	"USB"	"usbhid-ups"	# http://www.emersonnetworkpower.com/en-US/Products/ACPower/Pages/LiebertPowerSurePSILineInteractiveUPS10003000VA.aspx
 
 "LNXI"	"pdu"	"1"	"Icebox"	"10 outlets"	"powerman-pdu (experimental)"
 
@@ -944,7 +944,7 @@
 "Powercom"	"ups"	"4"	"(various)"	"USB (<= 2009 models, product id: 0002)"	"powercom (requires 'usbserial' kernel module)"
 "Powercom"	"ups"	"5"	"(various)"	"USB (2009 models, product id: 00a?)"	"usbhid-ups (experimental)"
 "Powercom"	"ups"	"5"	"BNT-xxxAP"	"USB (product id: 0004)"	"usbhid-ups (experimental)"
-"Powercom"	"ups"	"1"	"BNT-xxxAP"	"USB (product id: 0001)"	"usbhid-ups (experimental)"
+"Powercom"	"ups"	"3"	"BNT-xxxAP"	"USB (product id: 0001)"	"usbhid-ups (experimental)"
 "Powercom"	"ups"	"3"	"RPT-600AP"	"USB"	"usbhid-ups"	# http://pcmups.com.tw/eA/html/product/show.php?num=226&root=13&kind=105&page=1&keyword= https://github.com/networkupstools/nut/issues/633
 "Powercom"	"ups"	"3"	"Raptor 2000"	"USB"	"usbhid-ups"	# https://github.com/networkupstools/nut/issues/633
 
@@ -981,17 +981,17 @@
 "PowerWalker"	"ups"	"2"	"Online VFI 1000RT/1500RT/2000RT/3000RT/6000RT/10000RT LCD"	""	"blazer_usb"
 "PowerWalker"	"ups"	"2"	"Line-Interactive VI 1000RT/1500RT/2000RT/3000RT LCD"	""	"blazer_usb"
 "PowerWalker"	"ups"	"2"	"VFI 1000 CG PF1"	""	"nutdrv_qx" # https://powerwalker.com/?page=product&item=10122108&lang=en
-"PowerWalker"	"ups"	"2"	"VFI 2000 TGS"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/560 and https://github.com/networkupstools/nut/pull/564
-"PowerWalker"	"ups"	"2"	"VI 650 SH"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/483
-"PowerWalker"	"ups"	"2"	"VI 650/850 SHL"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/646
-"PowerWalker"	"ups"	"2"	"VI 1200 SHL"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/1270
-"PowerWalker"	"ups"	"2"	"VI 2200 SHL"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/756
-"PowerWalker"	"ups"	"2"	"VI 1200 SH"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/646
-"PowerWalker"	"ups"	"2"	"VI 2200 SH"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/646
-"PowerWalker"	"ups"	"2"	"Basic VI 1000 SB"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/818
-"PowerWalker"	"ups"	"2"	"PR1500LCDRT2U"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/818
+"PowerWalker"	"ups"	"3"	"VFI 2000 TGS"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/560 and https://github.com/networkupstools/nut/pull/564
+"PowerWalker"	"ups"	"3"	"VI 650 SH"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/483
+"PowerWalker"	"ups"	"3"	"VI 650/850 SHL"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/646
+"PowerWalker"	"ups"	"3"	"VI 1200 SHL"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/1270
+"PowerWalker"	"ups"	"3"	"VI 2200 SHL"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/756
+"PowerWalker"	"ups"	"3"	"VI 1200 SH"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/646
+"PowerWalker"	"ups"	"3"	"VI 2200 SH"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/646
+"PowerWalker"	"ups"	"3"	"Basic VI 1000 SB"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/818
+"PowerWalker"	"ups"	"3"	"PR1500LCDRT2U"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/818
 "PowerWalker"	"ups"	"2"	"VI 3000 SCL"	"USB"	"blazer_usb" # https://github.com/networkupstools/nut/issues/971
-"PowerWalker"	"ups"	"2"	"VI 750T/HID"	"USB"	"usbhid-ups" # https://powerwalker.com/?page=select&cat=VI_THID&lang=en https://github.com/networkupstools/nut/issues/774
+"PowerWalker"	"ups"	"3"	"VI 750T/HID"	"USB"	"usbhid-ups" # https://powerwalker.com/?page=select&cat=VI_THID&lang=en https://github.com/networkupstools/nut/issues/774
 
 "Powerware"	"ups"	"4"	"3110"	""	"genericups upstype=7"
 "Powerware"	"ups"	"4"	"3115"	""	"genericups upstype=11"
@@ -1068,17 +1068,17 @@
 "Riello"	"ups"	"3"	"(various)"	"Netman Plus 102 SNMP Card"	"snmp-ups"
 "Riello"	"ups"	"3"	"(various)"	"Netman Plus 202 SNMP Card"	"snmp-ups"
 
-"Rocketfish"	"ups"	"2"	"RF-1000VA / RF-1025VA"	""	"usbhid-ups"
+"Rocketfish"	"ups"	"3"	"RF-1000VA / RF-1025VA"	""	"usbhid-ups"
 
 "Rucelf"	"ups"	"2"	"Rucelf UPOII-3000-96-EL"	""	"blazer_ser" # http://www.rucelf.ua/en/catalog/upoii-3000-96-el/
 
 "Salicru"	"ups"	"2"	"SPS ONE 700VA"	"USB"	"blazer_usb"
 "Salicru"	"ups"	"2"	"SPS ONE 2000VA"	"USB"	"nutdrv_qx"	# https://www.salicru.com/en/ups/sps-one.html https://github.com/networkupstools/nut/issues/554
-"Salicru"	"ups"	"2"	"SPS 650/850 HOME"	"usb"	"usbhid-ups (experimental)"
-"Salicru"	"ups"	"2"	"SLC TWIN PRO2"	"usb"	"usbhid-ups (experimental)" # https://github.com/networkupstools/nut/issues/450
-"Salicru"	"ups"	"2"	"SLC-1500-TWIN PRO3"	"usb"	"usbhid-ups (experimental)" # https://github.com/networkupstools/nut/issues/1142
-"Salicru"	"ups"	"2"	"SLC TWINPRO3"	"usb"	"usbhid-ups (experimental)"
-"Salicru"	"ups"	"2"	"SLC TWIN RT3"	"usb"	"usbhid-ups (experimental)"
+"Salicru"	"ups"	"3"	"SPS 650/850 HOME"	"usb"	"usbhid-ups (experimental)"
+"Salicru"	"ups"	"3"	"SLC TWIN PRO2"	"usb"	"usbhid-ups (experimental)" # https://github.com/networkupstools/nut/issues/450
+"Salicru"	"ups"	"3"	"SLC-1500-TWIN PRO3"	"usb"	"usbhid-ups (experimental)" # https://github.com/networkupstools/nut/issues/1142
+"Salicru"	"ups"	"3"	"SLC TWINPRO3"	"usb"	"usbhid-ups (experimental)"
+"Salicru"	"ups"	"3"	"SLC TWIN RT3"	"usb"	"usbhid-ups (experimental)"
 
 "Santak"	"ups"	"2"	"Castle C*K"	"Serial"	"blazer_ser"	# https://github.com/networkupstools/nut/issues/1039
 "Santak"	"ups"	"2"	"MT*-PRO"	"Serial"	"blazer_ser"	# https://github.com/networkupstools/nut/issues/1039
@@ -1143,7 +1143,7 @@
 "Sweex"	"ups"	"2"	"INTELLIGENT UPS 1500VA P220"	"USB"	"blazer_usb (USB ID 0665:5161)"	# http://www.sweex.com/en/notebook-pc-accessoires/ups/PP220/
 
 "Syndome"	"ups"	"2"	"Era 500VA"	"USB"	"blazer_usb"
-"Syndome"	"ups"	"2"	"Atom LCD-1000"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/483
+"Syndome"	"ups"	"3"	"Atom LCD-1000"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/483
 
 "Sysgration"	"ups"	"2"	"UPGUARDS Pro650"	""	"blazer_ser"
 
@@ -1152,7 +1152,7 @@
 "Tecnoware"	"ups"	"2"	"UPS ERA PLUS 1100"	"USB"	"blazer_usb"	# https://www.tecnoware.com/Prodotti/FGCERAPL1100/ups-era-plus-1100.aspx https://github.com/networkupstools/nut/issues/747
 
 "Tripp Lite"	"ups"	"1"	"(various)"	"Lan 2.2 interface - black 73-0844 cable"	"genericups upstype=5"
-"Tripp Lite"	"ups"	"2"	"1500 LCD"	"USB"	"usbhid-ups"
+"Tripp Lite"	"ups"	"3"	"1500 LCD"	"USB"	"usbhid-ups"
 "Tripp Lite"	"ups"	"3"	"AVR550U"	"USB (protocol 2010)"	"usbhid-ups"	# http://www.tripplite.com/en/products/model.cfm?txtSeriesID=930&txtModelID=3090
 "Tripp Lite"	"ups"	"3"	"AVR700U"	"USB (protocol 2010)"	"usbhid-ups"	# http://www.tripplite.com/en/products/model.cfm?txtSeriesID=930&txtModelID=4785
 "Tripp Lite"	"ups"	"3"	"AVR750U"	"USB (protocol 2010)"	"usbhid-ups"	# http://www.tripplite.com/en/products/model.cfm?txtSeriesID=930&txtModelID=3141
@@ -1184,7 +1184,7 @@
 "Tripp Lite"	"ups"	"3"	"INTERNETOFFICE700"	"USB (protocol 2012)"	"usbhid-ups"	# http://www.tripplite.com/en/products/model.cfm?txtSeriesID=930&txtModelID=14
 "Tripp Lite"	"ups"	"3"	"OMNI650LCD"	"USB (protocol 2010)"	"usbhid-ups"	# http://www.tripplite.com/en/products/model.cfm?txtModelID=3195
 "Tripp Lite"	"ups"	"3"	"OMNI900LCD"	"USB (protocol 2010)"	"usbhid-ups"	# http://www.tripplite.com/en/products/model.cfm?txtSeriesID=932&txtModelID=3082
-"Tripp Lite"	"ups"	"2"	"OMNI1000LCD"	"USB"	"usbhid-ups"
+"Tripp Lite"	"ups"	"3"	"OMNI1000LCD"	"USB"	"usbhid-ups"
 "Tripp Lite"	"ups"	"3"	"OMNISMART300PNP"	"USB (protocol 2010)"	"usbhid-ups"	# http://www.tripplite.com/en/products/model.cfm?txtSeriesID=932&txtModelID=19
 "Tripp Lite"	"ups"	"1"	"OMNISMART500"	"USB (older; product ID: 0001)"	"tripplite_usb"
 "Tripp Lite"	"ups"	"3"	"OMNISMART500"	"USB (protocol 2010)"	"usbhid-ups"	# http://www.tripplite.com/en/products/model.cfm?txtSeriesID=932&txtModelID=21

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -58,8 +58,8 @@
 "AEC"	"ups"	"1"	"MiniGuard UPS 700"	"Megatec M2501 cable"	"genericups upstype=21"
 
 "AEG Power Solutions"	"ups"	"2"	"PROTECT HOME"	""	"blazer_ser or blazer_usb"
-"AEG Power Solutions"	"ups"	"3"	"PROTECT NAS"	""	"usbhid-ups"
-"AEG Power Solutions"	"ups"	"3"	"PROTECT B"	""	"usbhid-ups"
+"AEG Power Solutions"	"ups"	"3"	"PROTECT NAS"	"USB"	"usbhid-ups"
+"AEG Power Solutions"	"ups"	"3"	"PROTECT B"	"USB"	"usbhid-ups"
 
 "APC"	"ups"	"3"	"APC AP9584 Serial-to-USB kit"	"USB"	"usbhid-ups"	# Allows USB connections to Serial-port APC devices, https://github.com/networkupstools/nut/pull/181
 "APC"	"ups"	"2"	"Back-UPS 1200BR (Microsol)"	""	"solis"
@@ -255,7 +255,7 @@
 "Cyber Power Systems"	"ups"	"3"	"OR500LCDRM1U"	"USB"	"usbhid-ups"	# https://www.cyberpowersystems.com/product/ups/or500lcdrm1u/ https://github.com/networkupstools/nut/issues/578
 "Cyber Power Systems"	"ups"	"3"	"RT650EI"	"USB"	"usbhid-ups"	# http://www.cyberpowersystems.de/produkte/backup-usv-serien/rt-serie.html https://github.com/networkupstools/nut/issues/453
 "Cyber Power Systems"	"ups"	"3"	"UT2200E"	"USB"	"usbhid-ups"	# https://www.cyberpower.com/ww/en/product/sku/UT2200E https://github.com/networkupstools/nut/issues/556
-"Cyber Power Systems"	"ups"	"3"	"PR1500RT2U"	""	"usbhid-ups"	# https://www.cyberpowersystems.com/product/ups/new-smart-app-sinewave/pr1500rt2u/ https://github.com/networkupstools/nut/issues/1191
+"Cyber Power Systems"	"ups"	"3"	"PR1500RT2U"	"USB"	"usbhid-ups"	# https://www.cyberpowersystems.com/product/ups/new-smart-app-sinewave/pr1500rt2u/ https://github.com/networkupstools/nut/issues/1191
 "Cyber Power Systems"	"ups"	"3"	"PR6000LCDRTXL5U"	"USB"	"usbhid-ups"
 "Cyber Power Systems"	"ups"	"3"	"PR2200LCDRT2U"	""	"snmp-ups"
 "Cyber Power Systems"	"ups"	"3"	"RMCARD100"	""	"snmp-ups"
@@ -317,7 +317,7 @@
 "Dynex"	"ups"	"1"	"975AVR"	""	"genericups upstype=7"
 "Dynex"	"ups"	"3"	"DX-800U"	"USB"	"usbhid-ups"
 
-"Eaton"	"ups"	"5"	"3S"	""	"usbhid-ups"
+"Eaton"	"ups"	"5"	"3S"	"USB"	"usbhid-ups"
 "Eaton"	"ups"	"5"	"Protection Station 500/650/800 VA"	"USB"	"usbhid-ups"
 "Eaton"	"ups"	"5"	"Ellipse ECO 650/800/1200/1600 VA"	"USB"	"usbhid-ups"
 "Eaton"	"ups"	"5"	"Ellipse ASR USBS 600/750/1000/1500 VA"	"USB cable"	"usbhid-ups"
@@ -378,7 +378,7 @@
 "Eaton"	"ups"	"5"	"Powerware 9125"	"USB card"	"bcmxcp_usb"
 "Eaton"	"ups"	"5"	"Powerware 9130"	""	"bcmxcp or usbhid-ups"
 "Eaton"	"ups"	"5"	"Powerware 9140"	""	"bcmxcp or usbhid-ups"
-"Eaton"	"ups"	"5"	"Powerware 5130"	""	"usbhid-ups"
+"Eaton"	"ups"	"5"	"Powerware 5130"	"USB"	"usbhid-ups"
 "Eaton"	"ups"	"5"	"9395"	"Serial port"	"bcmxcp"
 "Eaton"	"ups"	"5"	"Best Ferrups"	"older ConnectUPS"	"snmp-ups"
 "Eaton"	"ups"	"5"	"ConnectUPS X / BD / E Slot"	"Serial Pass-through mode"	"bcmxcp"
@@ -489,14 +489,14 @@
 "HP"	"ups"	"3"	"T500 / T750"	"older models, USB port"	"bcmxcp_usb"
 "HP"	"ups"	"3"	"R/T3000"	"Serial port"	"mge-shut"
 "HP"	"ups"	"3"	"R5000 / R7000"	"Serial port"	"mge-shut"
-"HP"	"ups"	"3"	"T750 INTL"	""	"usbhid-ups"
-"HP"	"ups"	"3"	"T1000 INTL"	""	"usbhid-ups"
-"HP"	"ups"	"3"	"T1500 INTL"	""	"usbhid-ups"
+"HP"	"ups"	"3"	"T750 INTL"	"USB"	"usbhid-ups"
+"HP"	"ups"	"3"	"T1000 INTL"	"USB"	"usbhid-ups"
+"HP"	"ups"	"3"	"T1500 INTL"	"USB"	"usbhid-ups"
 "HP"	"ups"	"3"	"T750 G2"	"USB port"	"usbhid-ups"
 "HP"	"ups"	"3"	"T1000 G3"	"USB port"	"usbhid-ups"
 "HP"	"ups"	"3"	"T1500 G3"	"USB port"	"usbhid-ups"
 "HP"	"ups"	"3"	"R1500 G2 INTL"	"USB port"	"usbhid-ups"
-"HP"	"ups"	"3"	"R/T 2200 G2"	""	"usbhid-ups"
+"HP"	"ups"	"3"	"R/T 2200 G2"	"USB"	"usbhid-ups"
 "HP"	"ups"	"3"	"R/T3000"	"USB port"	"usbhid-ups"
 "HP"	"ups"	"3"	"R5000 / R7000"	"USB port"	"usbhid-ups"
 "HP"	"ups"	"4"	"Various (SNMP mode)"	"HP UPS Management Module"	"snmp-ups"
@@ -515,7 +515,7 @@
 
 "ICS"	"pdu"	"1"	"8064 Ethernet Relay Interface"	"16 outlets"	"powerman-pdu (experimental)"
 
-"iDowell"	"ups"	"3"	"iBox UPS"	""	"usbhid-ups"
+"iDowell"	"ups"	"3"	"iBox UPS"	"USB"	"usbhid-ups"
 
 "INELT"	"ups"	"2"	"Monolith 1000LT"	""	"blazer_ser"
 "INELT"	"ups"	"2"	"Monolith 3000RT"	""	"blazer_ser"
@@ -1068,7 +1068,7 @@
 "Riello"	"ups"	"3"	"(various)"	"Netman Plus 102 SNMP Card"	"snmp-ups"
 "Riello"	"ups"	"3"	"(various)"	"Netman Plus 202 SNMP Card"	"snmp-ups"
 
-"Rocketfish"	"ups"	"3"	"RF-1000VA / RF-1025VA"	""	"usbhid-ups"
+"Rocketfish"	"ups"	"3"	"RF-1000VA / RF-1025VA"	"USB"	"usbhid-ups"
 
 "Rucelf"	"ups"	"2"	"Rucelf UPOII-3000-96-EL"	""	"blazer_ser" # http://www.rucelf.ua/en/catalog/upoii-3000-96-el/
 

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -98,7 +98,7 @@
 
 "Apollo"	"ups"	"1"	"1000A"	""	"genericups upstype=4"
 "Apollo"	"ups"	"1"	"1000F"	""	"genericups upstype=4"
-"Apollo"	"ups"	"2"	"850VA"	""	"blazer_usb"
+"Apollo"	"ups"	"2"	"850VA"	"USB"	"blazer_usb"
 
 "Appro"	"pdu"	"1"	"SWPDU"	"48 outlets"	"powerman-pdu (experimental)"
 
@@ -181,13 +181,13 @@
 "Best Power"	"ups"	"1"	"Micro-Ferrups"	""	"bestuferrups"
 "Best Power"	"ups"	"1"	"Fortress/Ferrups"	"f-command support"	"bestfcom"
 
-"Borri"	"ups"	"2"	"B400-010-B/B400-020-B/B400-030-B/B400-010-C/B400-020-C/B400-030-C"	""	"blazer_usb"
-"Borri"	"ups"	"2"	"B400-R010-B/B400-R020-B/B400-R030-B/B400-R010-C/B400-R020-C/B400-R030-C"	""	"blazer_usb"
-"Borri"	"ups"	"2"	"B500-060-B/B500-100-B/B500-060-C/B500-100-C"	""	"blazer_usb"
-"Borri"	"ups"	"2"	"B500-R060-B/B500-R100-B"	""	"blazer_usb"
-"Borri"	"ups"	"2"	"B500EVO-100-B/B500EVO-200-B"	""	"blazer_usb"
+"Borri"	"ups"	"2"	"B400-010-B/B400-020-B/B400-030-B/B400-010-C/B400-020-C/B400-030-C"	"USB"	"blazer_usb"
+"Borri"	"ups"	"2"	"B400-R010-B/B400-R020-B/B400-R030-B/B400-R010-C/B400-R020-C/B400-R030-C"	"USB"	"blazer_usb"
+"Borri"	"ups"	"2"	"B500-060-B/B500-100-B/B500-060-C/B500-100-C"	"USB"	"blazer_usb"
+"Borri"	"ups"	"2"	"B500-R060-B/B500-R100-B"	"USB"	"blazer_usb"
+"Borri"	"ups"	"2"	"B500EVO-100-B/B500EVO-200-B"	"USB"	"blazer_usb"
 
-"CABAC"	"ups"	"2"	"UPS-1700DV2"	""	"blazer_usb"
+"CABAC"	"ups"	"2"	"UPS-1700DV2"	"USB"	"blazer_usb"
 
 "Chloride"	"ups"	"2"	"Desk Power 650"	"serial port"	"blazer_ser"
 
@@ -200,9 +200,9 @@
 "Compaq"	"ups"	"4"	"R3000 XR"	""	"bcmxcp"
 "Compaq"	"ups"	"4"	"R5500 XR"	""	"bcmxcp"
 
-"COVER ENERGY SA"	"ups"	"2"	"COVER PRM 1K/2K/3K/6K/10K"	""	"blazer_usb"
-"COVER ENERGY SA"	"ups"	"2"	"COVER PRM 1K/2K/3K/6K/10K EC"	""	"blazer_usb"
-"COVER ENERGY SA"	"ups"	"2"	"COVER PRM 6K/10K PR"	""	"blazer_usb"
+"COVER ENERGY SA"	"ups"	"2"	"COVER PRM 1K/2K/3K/6K/10K"	"USB"	"blazer_usb"
+"COVER ENERGY SA"	"ups"	"2"	"COVER PRM 1K/2K/3K/6K/10K EC"	"USB"	"blazer_usb"
+"COVER ENERGY SA"	"ups"	"2"	"COVER PRM 6K/10K PR"	"USB"	"blazer_usb"
 
 "CPC"	"ups"	"2"	"RACK850VA"	"USB"	"nutdrv_qx port=auto vendorid=0001 productid=0000 product=MEC0003 protocol=hunnox langid_fix=0x0409 novendor noscanlangid"	# https://github.com/networkupstools/nut/pull/638 caveats at https://github.com/networkupstools/nut/issues/537
 
@@ -361,7 +361,7 @@
 "Eaton"	"ups"	"5"	"9PX Split Phase 6/8/10 kVA"	"SNMP/Web card"	"netxml-ups"
 "Eaton"	"ups"	"5"	"EX RT (XML/HTTP)"	"NMC Transverse card (ref 66074)"	"netxml-ups (experimental)"
 "Eaton"	"ups"	"5"	"EX RT (SNMP)"	"NMC Transverse card (ref 66074)"	"snmp-ups (experimental)"
-"Eaton"	"ups"	"5"	"E Series NV UPS 400-2000 VA"	""	"blazer_usb"
+"Eaton"	"ups"	"5"	"E Series NV UPS 400-2000 VA"	"USB"	"blazer_usb"
 "Eaton"	"ups"	"5"	"E Series DX UPS 1-20 kVA"	""	"blazer_ser"	# http://www.eaton.com/Eaton/ESeriesUPS/DXUPS/
 "Eaton"	"ups"	"4"	"NetUPS SE 450/700/1000/1500"	""	"upscode2"
 "Eaton"	"ups"	"5"	"BladeUPS (SNMP)"	"ConnectUPS Web/SNMP Card"	"snmp-ups (experimental)"
@@ -458,7 +458,7 @@
 "Gamatronic"	"ups"	"5"	"MS"	""	"gamatronic"
 "Gamatronic"	"ups"	"5"	"µPS3/1"	""	"gamatronic"
 
-"GE Digital Energy"	"ups"	"2"	"EP Series"	""	"blazer_usb"
+"GE Digital Energy"	"ups"	"2"	"EP Series"	"USB"	"blazer_usb"
 "GE Digital Energy"	"ups"	"2"	"GT Series 1000/1500/2000/3000 VA Rack/Tower"	"UL-version"	"blazer_ser"
 
 "Geek Squad"	"ups"	"3"	"GS1285U"	"USB"	"usbhid-ups"
@@ -470,8 +470,8 @@
 "Greencell"	"ups"	"2"	"Micropower 600"	"USB"	"nutdrv_qx"	# https://github.com/networkupstools/nut/issues/1080
 "Greencell"	"ups"	"2"	"Micropower 600"	"USB"	"blazer_usb"	# https://github.com/networkupstools/nut/issues/1080
 
-"Gtec"	"ups"	"2"	"ZP120N-1K / ZP120N-1KS / ZP120N-2K / ZP120N-2KS / ZP120N-3K / ZP120N-3KS"	""	"blazer_usb"
-"Gtec"	"ups"	"2"	"ZP120N-6K / ZP120N-6KS / ZP120N-10K-11 / ZP120N-10KS-11"	""	"blazer_usb"
+"Gtec"	"ups"	"2"	"ZP120N-1K / ZP120N-1KS / ZP120N-2K / ZP120N-2KS / ZP120N-3K / ZP120N-3KS"	"USB"	"blazer_usb"
+"Gtec"	"ups"	"2"	"ZP120N-6K / ZP120N-6KS / ZP120N-10K-11 / ZP120N-10KS-11"	"USB"	"blazer_usb"
 "Gtec"	"ups"	"2"	"ZP120N-10K-31-00 / ZP120N-10K-31-07 / ZP120N-10K-31-09 / ZP120N-10K-31-99 / ZP120N-20K"	"USB port"	"blazer_usb"
 "Gtec"	"ups"	"2"	"AP160N-1K / AP160LCD-1K-KS / AP160N-2K / AP160LCD-2K-KS / AP160N-3K / AP160LCD-3K-KS / AP160N-6K-PDU / AP160N-10K-PDU"	"USB port"	"blazer_usb"
 "Gtec"	"ups"	"2"	"ZP120N-10K-31-00 / ZP120N-10K-31-07 / ZP120N-10K-31-09 / ZP120N-10K-31-99 / ZP120N-20K"	"Serial port"	"blazer_ser"
@@ -534,7 +534,7 @@
 "Infosec"	"ups"	"2"	"XP 500"	"USB"	"blazer_usb"
 "Infosec"	"ups"	"2"	"XP 1000"	""	"blazer_ser"
 
-"IPAR"	"ups"	"2"	"Mini Energy ME 800"	""	"blazer_usb"
+"IPAR"	"ups"	"2"	"Mini Energy ME 800"	"USB"	"blazer_usb"
 
 "IPMI"	"pdu"	"1"	""	""	"powerman-pdu (experimental)"
 
@@ -550,7 +550,7 @@
 "Ippon"	"ups"	"2"	"Smart Winner 750/1000/1500/2000/3000"	"USB"	"blazer_usb (experimental)"
 "Ippon"	"ups"	"2"	"(various)"	""	"blazer_ser"
 "Ippon"	"ups"	"2"	"(various)"	"USB"	"blazer_usb"
-"Ippon"	"ups"	"2"	"INNOVA RT 1K/1.5K/2K/3K"	""	"blazer_usb"
+"Ippon"	"ups"	"2"	"INNOVA RT 1K/1.5K/2K/3K"	"USB"	"blazer_usb"
 
 "IVT"	"scd"	"1"	"SCD series"	""	"ivtscd"
 
@@ -564,17 +564,17 @@
 "Kebo"	"ups"	"2"	"UPS-1000D (UPS-1000VA)"	"USB"	"blazer_usb"	# https://github.com/networkupstools/nut/issues/981
 "Kebo"	"ups"	"2"	"UPS-650VA"	"USB"	"megatec_usb"
 
-"KOLFF"	"ups"	"2"	"BLACK NOVA 1K/2K/3K/6K/10K/20K TOWER"	""	"blazer_usb"
-"KOLFF"	"ups"	"2"	"BLACK NOVA 1K/2K/3K/6K/10K/20K XL TOWER"	""	"blazer_usb"
-"KOLFF"	"ups"	"2"	"BLACK NOVA 1K/1.5K/2K/3K/6K/10K RACK"	""	"blazer_usb"
-"KOLFF"	"ups"	"2"	"BLACK NOVA 1K/1.5K/2K/3K/6K/10K XL RACK"	""	"blazer_usb"
+"KOLFF"	"ups"	"2"	"BLACK NOVA 1K/2K/3K/6K/10K/20K TOWER"	"USB"	"blazer_usb"
+"KOLFF"	"ups"	"2"	"BLACK NOVA 1K/2K/3K/6K/10K/20K XL TOWER"	"USB"	"blazer_usb"
+"KOLFF"	"ups"	"2"	"BLACK NOVA 1K/1.5K/2K/3K/6K/10K RACK"	"USB"	"blazer_usb"
+"KOLFF"	"ups"	"2"	"BLACK NOVA 1K/1.5K/2K/3K/6K/10K XL RACK"	"USB"	"blazer_usb"
 
 "Krauler"	"ups"	"2"	"UP-D1200VA"	"USB"	"blazer_usb"
 "Krauler"	"ups"	"2"	"UP-M500VA"	"USB"	"blazer_usb"
 
 "Lacerda"	"ups"	"2"	"New Orion 800VA"	"USB"	"blazer_usb"
 
-"LDLC"	"ups"	"2"	"UPS-1200D"	""	"blazer_usb langid_fix=0x4095"
+"LDLC"	"ups"	"2"	"UPS-1200D"	"USB"	"blazer_usb langid_fix=0x4095"
 
 "Legrand"	"ups"	"2"	"Daker DK"	"Serial"	"nutdrv_qx"
 "Legrand"	"ups"	"2"	"Daker DK"	"USB"	"nutdrv_qx"
@@ -630,7 +630,7 @@
 "LNXI"	"pdu"	"1"	"Icebox"	"10 outlets"	"powerman-pdu (experimental)"
 
 "Lyonn"	"ups"	"2"	"CTB-800V"	""	"nutdrv_qx"
-"Lyonn"	"ups"	"2"	"CTB-1200"	""	"blazer_usb"
+"Lyonn"	"ups"	"2"	"CTB-1200"	"USB"	"blazer_usb"
 
 "Masterguard"	"ups"	"1"	"(various)"	""	"masterguard"
 
@@ -827,10 +827,10 @@
 "MicroDowell"	"ups"	"5"	"Enterprise N60"	""	"microdowell"
 "MicroDowell"	"ups"	"5"	"Enterprise HiBox ST"	""	"microdowell"
 
-"Microline"	"ups"	"2"	"C-Lion Innova RT 2K/3K"	""	"blazer_usb"
-"Microline"	"ups"	"2"	"C-Lion Innova RT 6K/10K (Parallel)"	""	"blazer_usb"
-"Microline"	"ups"	"2"	"C-Lion Innova Tower 6K/10K"	""	"blazer_usb"
-"Microline"	"ups"	"2"	"C-Lion Innova Combo 10K/20K (3/1)"	""	"blazer_usb"
+"Microline"	"ups"	"2"	"C-Lion Innova RT 2K/3K"	"USB"	"blazer_usb"
+"Microline"	"ups"	"2"	"C-Lion Innova RT 6K/10K (Parallel)"	"USB"	"blazer_usb"
+"Microline"	"ups"	"2"	"C-Lion Innova Tower 6K/10K"	"USB"	"blazer_usb"
+"Microline"	"ups"	"2"	"C-Lion Innova Combo 10K/20K (3/1)"	"USB"	"blazer_usb"
 
 "Micropower"	"ups"	"2"	"LCD 1000"	"USB"	"blazer_usb"
 
@@ -900,9 +900,9 @@
 "Oneac"	"ups"	"1"	"ON2000XIU"	"advanced interface"	"oneac"
 
 "Online"	"ups"	"1"	"P-Series"	""	"genericups upstype=14"
-"Online"	"ups"	"2"	"Zinto A"	""	"blazer_usb"
+"Online"	"ups"	"2"	"Zinto A"	"USB"	"blazer_usb"
 "Online"	"ups"	"1"	"Zinto D"	""	"optiups"
-"Online"	"ups"	"2"	"Yunto YQ450"	""	"blazer_usb"
+"Online"	"ups"	"2"	"Yunto YQ450"	"USB"	"blazer_usb"
 "Online"	"ups"	"2"	"Xanto S700"	"/dev/ttyUSB0"	"nutdrv_qx"	# https://github.com/networkupstools/nut/issues/1279
 
 "OnLite"	"ups"	"2"	"AQUA"	"50"	"blazer_ser"
@@ -912,7 +912,7 @@
 "Opti-UPS"	"ups"	"1"	"Power Series"	"PS1500E"	"blazer_usb"
 
 "Orvaldi Power Protection"	"ups"	"2"	"various"	"not 400 or 600"	"blazer_ser"
-"Orvaldi Power Protection"	"ups"	"2"	"750 / 900SP"	""	"blazer_usb"
+"Orvaldi Power Protection"	"ups"	"2"	"750 / 900SP"	"USB"	"blazer_usb"
 
 "Phasak"	"ups"	"2"	"400VA / 600VA"	""	"blazer_ser"
 "Phasak"	"ups"	"2"	"9465 or P6N"	"USB"	"nutdrv_qx"	# https://github.com/networkupstools/nut/issues/1187 => Voltronic-QS-Hex protocol detected
@@ -954,7 +954,7 @@
 "Powercool"	"ups"	"2"	"1500VA"	"USB"	"nutdrv_qx port=auto vendorid=0001 productid=0000 product=MEC0003 protocol=hunnox langid_fix=0x0409 novendor noscanlangid"	# https://github.com/networkupstools/nut/pull/638 caveats at https://github.com/networkupstools/nut/issues/537 - e.g. battery percentage is not being returned
 "Powercool"	"ups"	"2"	"2000VA"	"USB"	"nutdrv_qx port=auto vendorid=0001 productid=0000 product=MEC0003 protocol=hunnox langid_fix=0x0409 novendor noscanlangid"	# https://github.com/networkupstools/nut/pull/638 caveats at https://github.com/networkupstools/nut/issues/537
 
-"POWEREX"	"ups"	"2"	"VI 1000 LED"	""	"blazer_usb"
+"POWEREX"	"ups"	"2"	"VI 1000 LED"	"USB"	"blazer_usb"
 
 "PowerGuard"	"ups"	"2"	"PG-600"	""	"blazer_ser"
 
@@ -965,7 +965,7 @@
 "PowerMan"	"ups"	"2"	"RealSmart 1000"	""	"blazer_ser"
 "PowerMan"	"ups"	"1"	"BackPro"	""	"genericups upstype=4"
 
-"PowerShield"	"ups"	"2"	"Defender 1200VA"	""	"blazer_usb"
+"PowerShield"	"ups"	"2"	"Defender 1200VA"	"USB"	"blazer_usb"
 
 "PowerTech"	"ups"	"1"	"Comp1000"	"DTR cable power"	"genericups upstype=3"
 "PowerTech"	"ups"	"2"	"SMK-800"	""	"blazer_ser"
@@ -973,13 +973,13 @@
 "PowerWalker"	"ups"	"2"	"Line-Interactive VI 1000"	""	"blazer_ser"
 "PowerWalker"	"ups"	"2"	"Line-Interactive VI 400/800"	""	"blazer_ser"
 "PowerWalker"	"ups"	"2"	"Line-Interactive VI 600"	""	"blazer_ser"
-"PowerWalker"	"ups"	"2"	"Line-Interactive VI 600 SE"	""	"blazer_usb"
-"PowerWalker"	"ups"	"2"	"Line-Interactive VI 800 SE"	""	"blazer_usb"
-"PowerWalker"	"ups"	"2"	"Line-Interactive VI 1400"	""	"blazer_usb"
-"PowerWalker"	"ups"	"2"	"Line-Interactive VI 2000"	""	"blazer_usb"
-"PowerWalker"	"ups"	"2"	"Line-Interactive VI 850 LCD"	""	"blazer_usb"
-"PowerWalker"	"ups"	"2"	"Online VFI 1000RT/1500RT/2000RT/3000RT/6000RT/10000RT LCD"	""	"blazer_usb"
-"PowerWalker"	"ups"	"2"	"Line-Interactive VI 1000RT/1500RT/2000RT/3000RT LCD"	""	"blazer_usb"
+"PowerWalker"	"ups"	"2"	"Line-Interactive VI 600 SE"	"USB"	"blazer_usb"
+"PowerWalker"	"ups"	"2"	"Line-Interactive VI 800 SE"	"USB"	"blazer_usb"
+"PowerWalker"	"ups"	"2"	"Line-Interactive VI 1400"	"USB"	"blazer_usb"
+"PowerWalker"	"ups"	"2"	"Line-Interactive VI 2000"	"USB"	"blazer_usb"
+"PowerWalker"	"ups"	"2"	"Line-Interactive VI 850 LCD"	"USB"	"blazer_usb"
+"PowerWalker"	"ups"	"2"	"Online VFI 1000RT/1500RT/2000RT/3000RT/6000RT/10000RT LCD"	"USB"	"blazer_usb"
+"PowerWalker"	"ups"	"2"	"Line-Interactive VI 1000RT/1500RT/2000RT/3000RT LCD"	"USB"	"blazer_usb"
 "PowerWalker"	"ups"	"2"	"VFI 1000 CG PF1"	""	"nutdrv_qx" # https://powerwalker.com/?page=product&item=10122108&lang=en
 "PowerWalker"	"ups"	"3"	"VFI 2000 TGS"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/560 and https://github.com/networkupstools/nut/pull/564
 "PowerWalker"	"ups"	"3"	"VI 650 SH"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/483
@@ -998,8 +998,8 @@
 "Powerware"	"ups"	"4"	"5119, 5125"	""	"genericups upstype=15"
 "Powerware"	"ups"	"4"	"5119 RM"	""	"genericups upstype=20"
 "Powerware"	"ups"	"5"	"5119 RM"	""	"upscode2"
-"Powerware"	"ups"	"5"	"PW3105"	""	"bcmxcp_usb"
-"Powerware"	"ups"	"5"	"PW5110"	""	"bcmxcp_usb"
+"Powerware"	"ups"	"5"	"PW3105"	"USB"	"bcmxcp_usb"
+"Powerware"	"ups"	"5"	"PW5110"	"USB"	"bcmxcp_usb"
 "Powerware"	"ups"	"5"	"PW5115"	"Serial port"	"bcmxcp"
 "Powerware"	"ups"	"5"	"PW5115"	"USB port"	"bcmxcp_usb"
 "Powerware"	"ups"	"5"	"PW5125"	""	"bcmxcp"
@@ -1031,21 +1031,21 @@
 
 "Riello"	"ups"	"3"	"Riello Sentinel SDL 6000-7"	"Netman Plus 102 SNMP Card"	"snmp-ups"
 "Riello"	"ups"	"3"	"Riello Sentinel Dual SDH 1000-7"	"Netman Plus 102 SNMP Card"	"snmp-ups"
-"Riello"	"ups"	"4"	"IDG 400/600/800/1200/1600"	""	"riello_usb"
-"Riello"	"ups"	"4"	"IPG 600/800"	""	"riello_usb"
-"Riello"	"ups"	"5"	"WPG 400/600/800"	""	"riello_usb"
-"Riello"	"ups"	"5"	"NPW 600/800/1000/1500/2000"	""	"riello_usb"
-"Riello"	"ups"	"5"	"NDG 800/1000/1500/2000"	""	"riello_usb"
-"Riello"	"ups"	"5"	"DVT 500/800/1100/1500/2000"	""	"riello_usb"
-"Riello"	"ups"	"5"	"DVR 500/800/1100"	""	"riello_usb"
-"Riello"	"ups"	"5"	"DVD 1500/2200/3000"	""	"riello_usb"
-"Riello"	"ups"	"5"	"VST 800/1100/1500/2000"	""	"riello_usb"
-"Riello"	"ups"	"5"	"VSD 1100/1500/2200/3000"	""	"riello_usb"
-"Riello"	"ups"	"5"	"SEP 700/1000/1500/2200/3000"	""	"riello_usb"
-"Riello"	"ups"	"5"	"SDH 1000/1500/2200/3000"	""	"riello_usb"
-"Riello"	"ups"	"5"	"SDL 3300/4000/5000/6000/6500/8000/10000"	""	"riello_usb"
-"Riello"	"ups"	"5"	"SPW"	""	"riello_usb"
-"Riello"	"ups"	"5"	"SPT"	""	"riello_usb"
+"Riello"	"ups"	"4"	"IDG 400/600/800/1200/1600"	"USB"	"riello_usb"
+"Riello"	"ups"	"4"	"IPG 600/800"	"USB"	"riello_usb"
+"Riello"	"ups"	"5"	"WPG 400/600/800"	"USB"	"riello_usb"
+"Riello"	"ups"	"5"	"NPW 600/800/1000/1500/2000"	"USB"	"riello_usb"
+"Riello"	"ups"	"5"	"NDG 800/1000/1500/2000"	"USB"	"riello_usb"
+"Riello"	"ups"	"5"	"DVT 500/800/1100/1500/2000"	"USB"	"riello_usb"
+"Riello"	"ups"	"5"	"DVR 500/800/1100"	"USB"	"riello_usb"
+"Riello"	"ups"	"5"	"DVD 1500/2200/3000"	"USB"	"riello_usb"
+"Riello"	"ups"	"5"	"VST 800/1100/1500/2000"	"USB"	"riello_usb"
+"Riello"	"ups"	"5"	"VSD 1100/1500/2200/3000"	"USB"	"riello_usb"
+"Riello"	"ups"	"5"	"SEP 700/1000/1500/2200/3000"	"USB"	"riello_usb"
+"Riello"	"ups"	"5"	"SDH 1000/1500/2200/3000"	"USB"	"riello_usb"
+"Riello"	"ups"	"5"	"SDL 3300/4000/5000/6000/6500/8000/10000"	"USB"	"riello_usb"
+"Riello"	"ups"	"5"	"SPW"	"USB"	"riello_usb"
+"Riello"	"ups"	"5"	"SPT"	"USB"	"riello_usb"
 "Riello"	"ups"	"5"	"NDG 800/1000/1500/2000"	""	"riello_ser"
 "Riello"	"ups"	"5"	"DVT 500/800/1100/1500/2000"	""	"riello_ser"
 "Riello"	"ups"	"5"	"DVR 500/800/1100"	""	"riello_ser"

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -210,7 +210,6 @@
 
 "Cyber Power Systems"	"ups"	"1"	"550SL"	""	"genericups upstype=7"
 "Cyber Power Systems"	"ups"	"1"	"725SL"	""	"genericups upstype=7"
-"Cyber Power Systems"	"ups"	"3"	"BR1000ELCD"	"USB"	"usbhid-ups" # https://www.cyberpower.com/eu/en/product/sku/BR1000ELCD
 "Cyber Power Systems"	"ups"	"1"	"CPS1100AVR"	""	"powerpanel"
 "Cyber Power Systems"	"ups"	"1"	"CPS1200AVR"	""	"powerpanel"
 "Cyber Power Systems"	"ups"	"1"	"CPS1250AVR"	""	"powerpanel"
@@ -228,7 +227,7 @@
 "Cyber Power Systems"	"ups"	"1"	"Power99"	""	"genericups upstype=7"
 "Cyber Power Systems"	"ups"	"2"	"AE550"	"USB"	"usbhid-ups"
 "Cyber Power Systems"	"ups"	"3"	"BL1250U"	"USB"	"usbhid-ups"	# https://www.cyberpowersystems.com/product/ups/battery-backup/bl1250u/ https://github.com/networkupstools/nut/issues/1012
-"Cyber Power Systems"	"ups"	"2"	"BR1000ELCD"	"USB"	"usbhid-ups"	# https://www.cyberpower.com/eu/en/product/sku/BR1000ELCD https://github.com/networkupstools/nut/issues/552
+"Cyber Power Systems"	"ups"	"3"	"BR1000ELCD"	"USB"	"usbhid-ups"	# https://www.cyberpower.com/eu/en/product/sku/BR1000ELCD https://github.com/networkupstools/nut/issues/552
 "Cyber Power Systems"	"ups"	"2"	"CP1350AVRLCD"	"USB"	"usbhid-ups"
 "Cyber Power Systems"	"ups"	"2"	"CP1500AVRLCD"	"USB"	"usbhid-ups"
 "Cyber Power Systems"	"ups"	"2"	"CP850PFCLCD"	"USB"	"usbhid-ups"	# https://github.com/networkupstools/nut/issues/605

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -210,6 +210,7 @@
 
 "Cyber Power Systems"	"ups"	"1"	"550SL"	""	"genericups upstype=7"
 "Cyber Power Systems"	"ups"	"1"	"725SL"	""	"genericups upstype=7"
+"Cyber Power Systems"	"ups"	"3"	"BR1000ELCD"	"USB"	"usbhid-ups" # https://www.cyberpower.com/eu/en/product/sku/BR1000ELCD
 "Cyber Power Systems"	"ups"	"1"	"CPS1100AVR"	""	"powerpanel"
 "Cyber Power Systems"	"ups"	"1"	"CPS1200AVR"	""	"powerpanel"
 "Cyber Power Systems"	"ups"	"1"	"CPS1250AVR"	""	"powerpanel"

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -1241,6 +1241,7 @@
 "Tripp Lite"	"ups"	"3"	"SMART3000SLT"	"USB (protocol 3013)"	"usbhid-ups"	# http://www.tripplite.com/en/products/model.cfm?txtSeriesID=933&txtModelID=3490
 "Tripp Lite"	"ups"	"2"	"SMART500RT1U"	"USB (older; product ID 0001, protocol 3005)"	"tripplite_usb"
 "Tripp Lite"	"ups"	"3"	"SMART500RT1U"	"USB (newer; protocol/product ID 3005)"	"usbhid-ups"	# http://www.tripplite.com/en/products/model.cfm?txtModelID=2853
+"Tripp Lite"	"ups"	"3"	"SMC15002URM"	"USB (protocol 3015)"	"usbhid-ups"	# https://www.tripplite.com/smartpro-120v-1-5kva-1kw-line-interactive-sine-wave-ups-2u-rack-tower-lcd-usb-db9-8-outlets~SMC15002URM
 "Tripp Lite"	"ups"	"3"	"SMX1000LCD"	"USB (protocol 2005)"	"usbhid-ups"	# http://www.tripplite.com/en/products/model.cfm?txtModelID=3200
 "Tripp Lite"	"ups"	"3"	"SMX1000RT2U"	"USB (protocol 3015)"	"usbhid-ups"	# http://www.tripplite.com/en/products/model.cfm?txtModelID=2798
 "Tripp Lite"	"ups"	"3"	"SMX1050SLT"	"USB (protocol 3012)"	"usbhid-ups"	# http://www.tripplite.com/en/products/model.cfm?txtModelID=3249

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -242,6 +242,7 @@
 "Cyber Power Systems"	"ups"	"2"	"Value 400E"	"USB"	"usbhid-ups"
 "Cyber Power Systems"	"ups"	"2"	"Value 600E"	"USB"	"usbhid-ups"
 "Cyber Power Systems"	"ups"	"2"	"Value 800E"	"USB"	"usbhid-ups"
+"Cyber Power Systems"	"ups"	"3"	"VP1200ELCD (ValueII_1200E)"	"USB"	"usbhid-ups"
 "Cyber Power Systems"	"ups"	"3"	"CP 1500C"	"USB"	"usbhid-ups"
 "Cyber Power Systems"	"ups"	"3"	"CP1000PFCLCD"	"USB"	"usbhid-ups"
 "Cyber Power Systems"	"ups"	"3"	"CP1500EPFCLCD"	"USB"	"usbhid-ups"	# http://www.cyberpower-eu.com/products/ups_systems/pfc-sinewave/cp1500epfclcd.htm

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -232,6 +232,7 @@
 "Cyber Power Systems"	"ups"	"3"	"CP1500AVRLCD"	"USB"	"usbhid-ups"
 "Cyber Power Systems"	"ups"	"3"	"CP850PFCLCD"	"USB"	"usbhid-ups"	# https://github.com/networkupstools/nut/issues/605
 "Cyber Power Systems"	"ups"	"3"	"CP1500PFCLCD"	"USB"	"usbhid-ups"	# https://www.cyberpowersystems.com/product/ups/cp1500pfclcd/ https://github.com/networkupstools/nut/issues/520
+"Cyber Power Systems"	"ups"	"3"	"CPJ500"	"USB"	"usbhid-ups"	# https://www.cyberpower.com/jp/ja/product/sku/cpj500#downloads https://github.com/networkupstools/nut/issues/1403
 "Cyber Power Systems"	"ups"	"3"	"CP900AVR"	"USB"	"usbhid-ups"
 "Cyber Power Systems"	"ups"	"3"	"CPS685AVR"	"USB"	"usbhid-ups"
 "Cyber Power Systems"	"ups"	"3"	"CPS800AVR"	"USB"	"usbhid-ups"

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -465,7 +465,7 @@
 
 "Gemini"	"ups"	"1"	"UPS625/UPS1000"	""	"safenet"
 
-"Grafenthal"	"ups"	"2"	"PR-3000-HS"	"SNMP/Web Minislot card (ref 149G0006)"	"snmp-ups"	# http://grafenthal.de/produkte/usv/online/pr-hs-serie/pr-3000-hs/?L=3et8
+"Grafenthal"	"ups"	"3"	"PR-3000-HS"	"SNMP/Web Minislot card (ref 149G0006)"	"snmp-ups"	# http://grafenthal.de/produkte/usv/online/pr-hs-serie/pr-3000-hs/?L=3et8
 
 "Greencell"	"ups"	"2"	"Micropower 600"	"USB"	"nutdrv_qx"	# https://github.com/networkupstools/nut/issues/1080
 "Greencell"	"ups"	"2"	"Micropower 600"	"USB"	"blazer_usb"	# https://github.com/networkupstools/nut/issues/1080


### PR DESCRIPTION
<!-- Comment:
* Please revise the docs/developers.txt for coding style suggestions and
  other considerations applicable to NUT codebase contributions, as well
  as for which text documents to update. See also docs/developer-guide.txt
  for general points on NUT architecture and design.

* The checklist below is more of a reminder of steps to take and "dangers"
  to look out for. PRs to update this template are also welcome :)

* Local build iterations can be augmented with the ci_build.sh script.
-->

## General points

- [ ] Described the changes in the PR submission or a separate issue, e.g.
  known published or discovered protocols, applicable hardware (expected
  compatible and actually tested/developed against), limitations, etc.

- [ ] There may be multiple commits in the PR, aligned and commented with
  a functional change. Notably, coding style changes better belong in a
  separate PR, but certainly in a dedicated commit to simplify reviews
  of "real" changes in the other commits. Similarly for typo fixes in
  comments or text documents.

## Frequent "underwater rocks" for driver addition/update PRs

- [ ] Revised existing driver families and added a sub-driver if applicable
  (`nutdrv_qx`, `usbhid-ups`...) or added a brand new driver in the other
  case.

- [ ] Did not extend obsoleted drivers with new hardware support features
  (notably `blazer` and other single-device family drivers for Qx protocols,
  except the new `nutdrv_qx` which should cover them all).

- [ ] For updated existing device drivers, bumped the `DRIVER_VERSION` macro
  or its equivalent.

<!-- Comment:
  Some sub-drivers have `SUBDRIVER_VERSION` or customized names like
  e.g. `MEGATEC_VERSION` in `drivers/nutdrv_qx_megatec.c`
-->

- [ ] For USB devices (HID or not), revised that the driver uses unique
  VID/PID combinations, or raised discussions when this is not the case
  (several vendors do use same interface chips for unrelated protocols).

- [ ] For new USB devices, built and committed the changes for the
  `scripts/upower/95-upower-hid.hwdb` file

- [ ] Proposed NUT data mapping is aligned with existing `docs/nut-names.txt`
  file. If the device exposes useful data points not listed in the file, the
  `experimental.*` namespace can be used as documented there, and discussion
  should be raised on the NUT Developers mailing list to standardize the new
  concept.

- [ ] Updated `data/driver.list.in` if applicable (new tested device info)
<!-- Comment:
Also note below, a point about PR posting for NUT DDL
-->

## Frequent "underwater rocks" for general C code PRs

- [ ] Did not "blindly assume" default integer type sizes and value ranges,
  structure layout and alignment in memory, endianness (layout of bytes and
  bits in memory for multi-byte numeric types), or use of generic `int` where
  language or libraries dictate the use of `size_t` (or `ssize_t` sometimes).

<!-- Comment:
* NOTE: Casting and/or pragmas (support detected at compile time,
  see `m4/ax_c_pragmas.m4`) to silence warnings may be acceptable,
  but only if coupled with range checks or similar actions.
-->

- [ ] Progress and errors are handled with `upsdebugx()`, `upslogx()`,
  `fatalx()` and related methods, not with direct `printf()` or `exit()`.
  Similarly, NUT helpers are used for error-checked memory allocation and
  string operations (except where customized error handling is needed,
  such as unlocking device ports, etc.)

- [ ] Coding style (including whitespace for indentations) follows precedent
  in the code of the file, and examples/guide in `docs/developers.txt` file.

- [ ] For newly added files, the `Makefile.am` recipes were updated and the
  `make distcheck` target passes.

## General documentation updates

- [ ] Updated `docs/acknowledgements.txt` (for vendor-backed device support)

- [ ] Added or updated manual page information in `docs/man/*.txt` files
  and corresponding recipe lists in `docs/man/Makefile.am` for new pages

- [ ] Passed `make spellcheck`, updated spell-checking dictionary in the
  `docs/nut.dict` file if needed (did not remove any words -- the `make`
  rule printout in case of changes suggests how to maintain it).

## Additional work may be needed after posting this PR

- [ ] Propose a PR for NUT DDL with detailed device data dumps from tests
  against real hardware (the more models, the better).

- [ ] Address NUT CI farm build failures for the PR: testing on numerous
  platforms and toolkits can expose issues not seen on just one system.

<!-- Comment:
* One frequent "offence" is the appearance of unexpected (not git-ignored)
  or modification during build of files tracked in Git.

* Another frequent issue is not tracking newly introduced file names in
  `EXTRA_DIST` of the `Makefile.am` (and for `*.in` templates -- of rules
  in the `configure.ac` script) so the `make distcheck` fails.

* Avoid using GNU-specific constructs in the `Makefile.am`, even if that
  means cumbersome ways to build a target. This should not happen in mere
  driver updates, however.

* Also some third-party libraries or OS headers and method argument types
  and counts can differ -- necessitating m4 code for `configure` script
  probing, and `ifdef`, `typedef`, etc. in C code to adapt to the build
  environment (precedents available in NUT codebase). In extreme cases,
  you may need to spin up a VM or container to reproduce those issues
  and iterate on a fix locally; see `docs/config-prereqs.txt` and
  `docs/ci-farm-lxc-setup.txt` for notes taken during preparation of
  the multi-platform NUT CI farm.
-->

- [ ] Revise suggestions from LGTM.COM analysis about "new issues" with
  the changed codebase.

<!-- Comment:
  Take them with a grain of salt, especially with regard to things like
  architecture-dependent range checks, but many of the complaints from
  the tool are indeed useful.
-->
