### PR TITLE
SIGKILL an earlier driver instance if SIGTERM does not cut it [part of #1423 fix]

### DIFF
--- a/drivers/main.c
+++ b/drivers/main.c
@@ -879,12 +879,12 @@ int main(int argc, char **argv)
 				break;
 			}
 
+			upslogx(LOG_WARNING, "Duplicate driver instance detected (PID file %s exists)! Terminating other driver!", buffer);
+
 			if (sendsignalfn(buffer, SIGTERM) != 0) {
 				/* Can't send signal to PID, assume invalid file */
 				break;
 			}
-
-			upslogx(LOG_WARNING, "Duplicate driver instance detected (PID file %s exists)! Terminating other driver!", buffer);
 
 			/* Allow driver some time to quit */
 			sleep(5);

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -199,6 +199,9 @@ static void stop_driver(const ups_t *ups)
 		for (i = 0; i < 5 ; i++) {
 			if (sendsignalfn(pidfn, 0) != 0) {
 				upsdebugx(2, "Sending signal to %s failed, driver is finally down or wrongly owned", pidfn);
+				// While a TERMinated driver cleans up,
+				// a stuck and KILLed one does not, so:
+				unlink(pidfn);
 				return;
 			}
 			sleep(1);


### PR DESCRIPTION
See #1423 for context and "screenshots"

The short of it is along these lines:
````
  10.017450     Duplicate driver instance detected (PID file /var/run/nut/nutdrv_qx-innotech.pid exists)! Terminating other driver!
  15.026749     Duplicate driver instance is still alive (PID file /var/run/nut/nutdrv_qx-innotech.pid exists) after several termination attempts! Killing other driver!
kill: No such process
  20.038688     Could not signal the other driver after kill, either its process is finally dead or owned by another user!
````