### PR TITLE
Adding waitbeforereconnect parameter to usbhid-ups (default 0 second)

### DIFF
--- a/docs/man/usbhid-ups.txt
+++ b/docs/man/usbhid-ups.txt
@@ -149,6 +149,17 @@ INPUT flagged objects. Some Powercom units need this option.
 Limit the number of bytes to read from interrupt pipe. For some Powercom units
 this option should be equal to 8.
 
+*waitbeforereconnect*::
+The driver automatically tries to reconnect to the ups on unexpected error.
+This parameter allow to wait before attempting the reconnection.
+The default value is 0 (in seconds)
++
+Note : for instance, it was found that Eaton MGE Ellipse Max 1500 FR ups firmware
+stops responding every few hours, which causes usbhid-ups driver to detect an
+insufficient memory error (ERROR_NO_MEM); in this case, trying to reconnect too
+early, sometimes lead the ups firmware to crash and turn load off immediatly !!!
+Setting this parameter to 30 seconds solve this problem. (20 seconds not enough)
+
 INSTALLATION
 ------------
 

--- a/docs/man/usbhid-ups.txt
+++ b/docs/man/usbhid-ups.txt
@@ -157,7 +157,7 @@ The default value is 0 (in seconds)
 Note : for instance, it was found that Eaton MGE Ellipse Max 1500 FR ups firmware
 stops responding every few hours, which causes usbhid-ups driver to detect an
 insufficient memory error (ERROR_NO_MEM); in this case, trying to reconnect too
-early, sometimes lead the ups firmware to crash and turn load off immediatly !!!
+early, sometimes lead the ups firmware to crash and turn load off immediately !!!
 Setting this parameter to 30 seconds solve this problem. (20 seconds not enough)
 
 INSTALLATION

--- a/docs/man/usbhid-ups.txt
+++ b/docs/man/usbhid-ups.txt
@@ -149,16 +149,17 @@ INPUT flagged objects. Some Powercom units need this option.
 Limit the number of bytes to read from interrupt pipe. For some Powercom units
 this option should be equal to 8.
 
-*waitbeforereconnect*::
-The driver automatically tries to reconnect to the ups on unexpected error.
-This parameter allow to wait before attempting the reconnection.
-The default value is 0 (in seconds)
+*waitbeforereconnect*='num'::
+The driver automatically tries to reconnect to the UPS on unexpected error.
+This parameter (in seconds) allows it to wait before attempting the reconnection.
+The default value is 0.
 +
-Note : for instance, it was found that Eaton MGE Ellipse Max 1500 FR ups firmware
+NOTE: for instance, it was found that Eaton MGE Ellipse Max 1500 FR UPS firmware
 stops responding every few hours, which causes usbhid-ups driver to detect an
-libusb insufficient memory error; in this case, trying to reconnect too
-early, sometimes lead the ups firmware to crash and turn load off immediately !!!
-Setting this parameter to 30 seconds solve this problem. (20 seconds not enough)
+libusb insufficient memory error; in this case, when the usbhid-ups driver tries
+to reconnect too early, the activity sometimes led the UPS firmware to crash and
+turn off the load immediately! Setting this parameter to 30 seconds solved this
+problem (while 20 seconds were not enough).
 
 INSTALLATION
 ------------

--- a/docs/man/usbhid-ups.txt
+++ b/docs/man/usbhid-ups.txt
@@ -156,7 +156,7 @@ The default value is 0 (in seconds)
 +
 Note : for instance, it was found that Eaton MGE Ellipse Max 1500 FR ups firmware
 stops responding every few hours, which causes usbhid-ups driver to detect an
-insufficient memory error (ERROR_NO_MEM); in this case, trying to reconnect too
+libusb insufficient memory error; in this case, trying to reconnect too
 early, sometimes lead the ups firmware to crash and turn load off immediately !!!
 Setting this parameter to 30 seconds solve this problem. (20 seconds not enough)
 

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -2892,6 +2892,7 @@ vod
 voltronic
 von
 wDescriptorLength
+waitbeforereconnect
 wakeup
 wc
 wchar

--- a/drivers/usb-common.h
+++ b/drivers/usb-common.h
@@ -170,6 +170,11 @@
  #define ERROR_OVERFLOW		LIBUSB_ERROR_OVERFLOW
  #define ERROR_PIPE			LIBUSB_ERROR_PIPE
  #define ERROR_TIMEOUT		LIBUSB_ERROR_TIMEOUT
+ #define ERROR_NO_MEM   LIBUSB_ERROR_NO_MEM
+ #define ERROR_INVALID_PARAM  LIBUSB_ERROR_INVALID_PARAM
+ #define ERROR_INTERRUPTED    LIBUSB_ERROR_INTERRUPTED
+ #define ERROR_NOT_SUPPORTED  LIBUSB_ERROR_NOT_SUPPORTED
+ #define ERROR_OTHER          LIBUSB_ERROR_OTHER
 
  /* Functions, including range-checks to convert data types of the two APIs.
   * Follows an example from libusb-1.0 headers that liberally cast int args

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -1595,22 +1595,19 @@ static int reconnect_ups(void)
 	if (udev)
 		comm_driver->close(udev);
 
+	upsdebugx(4, "===================================================================");
 	if (wait_before_reconnect > 0 ) {
-		upsdebugx(4, "===================================================================");
 		upsdebugx(4, " device has been disconnected, trying to reconnect in %i seconds", wait_before_reconnect);
-		upsdebugx(4, "===================================================================");
 		sleep(wait_before_reconnect);
 		upsdebugx(4, " trying to reconnect");
-		upsdebugx(4, "===================================================================");
 	}else{
-		upsdebugx(4, "==================================================");
-		upsdebugx(4, "= device has been disconnected, try to reconnect =");
-		upsdebugx(4, "==================================================");
+		upsdebugx(4, " device has been disconnected, try to reconnect");
 	}
+	upsdebugx(4, "===================================================================");
 
-   upsdebugx(4, "Opening comm_driver ...");
+	upsdebugx(4, "Opening comm_driver ...");
 	ret = comm_driver->open(&udev, &curDevice, subdriver_matcher, NULL);
-   upsdebugx(4, "Opening comm_driver returns ret=%i", ret);
+	upsdebugx(4, "Opening comm_driver returns ret=%i", ret);
 	if (ret > 0) {
 		return 1;
 	}


### PR DESCRIPTION
### Goal
The purpose of this evolution is to allow the introduction of a relaxation time, before a reconnection attempt following an error, to allow time for the ups firmware to recover from a possible fail state and avoid it to crash.

### Proposed solution
A parameter "waitbeforereconnect" is added for this purpose, default value 0, unit seconds.

### Reason and investigation
I spent quite a bit of time, trying first many parameters configuration sets (enlarging pollinterval, pollfreq, MAXAGE) without convincing result, then debugging, to figure out why an **Eaton MGE Ellipse 1500 Max UPS** is able to abruptly cut off the load and go Online Off (OL OFF) for no reason. 

The results of my investigations, carried out on the configuration described below with the ups being always powered by the mains, shows that the observed sequence is the following :

1. Starting from UPS :

- Online (**ups.status OL**), 
- Battery fully charged (**battery.charge: 100**),
- Battery runtime maximum (**battery.runtime: 2006** 00:33:26)

2. Without any reason, ups firmware does not respond, usbhid-ups detects an insufficient memory error (libusb ERROR_NO_MEM), then try to reconnect according to issue [#1422](https://github.com/networkupstools/nut/pull/1422)

3. Continuing to communicate with this ups firmware via usb, may result to see that the load cuts off !!!

4. After reconnection which may occur in few seconds and up to 2 minutes, ups status is following one :

- Online Off (**ups.status OL OFF**)
- Battery not fully charged (**battery.charge: 85**),
- Battery runtime reduced (**battery.runtime: 111** 00:1:51)

My conclusion is that **the ups firmware crashes** and overwrites these values !

This behavior motivated the present evolution, to stop any communication with the firmware for a few moment, aiming to avoid prohibitive "load.off" !


### Tests carried out

#### Test setup and results

/etc/nut/ups.conf
```
maxretry = 3
retrydelay = 1
[MGE_ELLIPSE_MAX_1500_1]
  desc = EATON MGE Ellipse Max 1500
  driver = usbhid-ups
  port = auto
  productid = "ffff"
  vendorid = "0463"
  pollonly = true
  pollinterval = 1
  pollfreq = 5
  waitbeforereconnect = 30
```
Please note : pollinterval and pollfreq are voluntary set to small values for test purpose in order to maximize failure occurence.

- First test with waitbeforereconnect = 60 : 7 reconnections on ~7h30min without any load off. (OK)
- Second test with waitbeforereconnect = 20 : load off occurs after 52min. (NOK)
- Third test with waitbeforereconnect = 30 : 33 reconnections on ~19h30min without any load off.(OK)

#### Choosen configuration
/etc/nut/ups.conf
```
maxretry = 3
retrydelay = 1
[MGE_ELLIPSE_MAX_1500_1]
  desc = EATON MGE Ellipse Max 1500
  driver = usbhid-ups
  port = auto
  productid = "ffff"
  vendorid = "0463"
  pollonly = true
  waitbeforereconnect = 30
```
With : pollinterval = 2 (default) and pollfreq = 30 (default)


### Software and hardware configuration used
**System**
Proxmox Virtual Environment (PVE) 7.2-3
Operating system : Debian 11 (bullseye)
uname -a : Linux hostname 5.15.35-1-pve # 1 SMP PVE 5.15.35-3 (Wed, 11 May 2022 07:57:51 +0200) x86_64 GNU/Linux
Network UPS Tools : 2.7.4 (except for usbhid-ups driver)

**UPS model from nameplate**
Eaton MGE Ellipse Max 1500 USBS FR
Art: FUE-511521

**UPS check (upsc) command result**
```
battery.charge: 100
battery.charge.low: 20
battery.runtime: 2006
battery.type: PbAc
device.mfr: MGE UPS SYSTEMS
device.model: Ellipse MAX 1500
device.serial: PbAc
device.type: ups
driver.name: usbhid-ups
driver.parameter.pollfreq: 5
driver.parameter.pollinterval: 1
driver.parameter.pollonly: true
driver.parameter.port: auto
driver.parameter.productid: ffff
driver.parameter.synchronous: auto
driver.parameter.vendorid: 0463
driver.parameter.waitbeforereconnect: 30
driver.version: 2.8.0-22-gdfed36eb9
driver.version.data: MGE HID 1.46
driver.version.internal: 0.47
driver.version.usb: libusb-1.0.24 (API: 0x1000109)
input.sensitivity: normal
input.transfer.boost.low: 185
input.transfer.high: 285
input.transfer.low: 165
input.transfer.trim.high: 265
input.voltage.extended: no
outlet.1.desc: PowerShare Outlet 1
outlet.1.id: 2
outlet.1.status: on
outlet.1.switchable: no
outlet.desc: Main Outlet
outlet.id: 1
outlet.switchable: no
output.frequency.nominal: 50
output.voltage: 230.0
output.voltage.nominal: 230
ups.beeper.status: enabled
ups.delay.shutdown: 20
ups.delay.start: 30
ups.firmware: 1.01
ups.load: 0
ups.mfr: MGE UPS SYSTEMS
ups.model: Ellipse MAX 1500
ups.power.nominal: 1500
ups.productid: ffff
ups.realpower: 0
ups.serial: PbAc
ups.status: OL
ups.timer.shutdown: -1
ups.timer.start: -1
ups.vendorid: 0463
``` 

