### PR TITLE
docs/config-notes.txt: Fix link to the blazer_usb manual page

### DIFF
--- a/docs/config-notes.txt
+++ b/docs/config-notes.txt
@@ -168,7 +168,7 @@ information on matching a specific device.
 References: linkman:ups.conf[5],
 linkman:nutupsdrv[8],
 linkman:bcmxcp_usb[8],
-linkman:blazer[8],
+linkman:blazer_usb[8],
 linkman:nutdrv_qx[8],
 linkman:richcomm_usb[8],
 linkman:riello_usb[8],


### PR DESCRIPTION
There's no man page for blazer[8]; I think blazer_usb is the intended
one, since all the links in that set are to the USB drivers.

(I was reading https://networkupstools.org/docs/user-manual.chunked/ar01s06.html and that link was broken.)