### PR TITLE
Huawei UPS2000: support newer UPS2000G/CH341 variants.

### DIFF
--- a/docs/man/huawei-ups2000.txt
+++ b/docs/man/huawei-ups2000.txt
@@ -26,33 +26,42 @@ UPS with the following characteristics.
 
 1. Output power: 1 kVA to 3 kVA (higher power models are unsupported).
 
-2. Connection: USB or RS-232 (USB is only supported on Linux 5.12 and
-newer kernels, read the section *Cabling* carefully).
+2. Connection: USB or RS-232 (for most UPS models, USB is only supported
+on Linux 5.12 and newer kernels, but there are exceptions, read the section
+*Cabling* carefully).
 
 The UPS2000 series has two variants: UPS2000-A with a tower chassis,
 and UPS2000-G with a rack-mount chassis. Both should be equally supported,
 but more testers are needed.
-
 Currently, it has been tested on the following models.
 
-* UPS2000-A-1KTTS (firmware: V2R1C1SPC40, P1.0-D1.0)
-* UPS2000-A-2KTTS (firmware: V2R1C1SPC50, P1.0-D1.0)
-* UPS2000-G-3KRTS (firmware: V2R1C1SPC40, P1.0-D1.0)
+* UPS2000-A-1KTTS (firmware: UPS2000A, V2R1C1SPC40, P1.0-D1.0)
+* UPS2000-A-2KTTS (firmware: UPS2000A, V2R1C1SPC50, P1.0-D1.0)
+* UPS2000-G-3KRTS (firmware: UPS2000A, V2R1C1SPC40, P1.0-D1.0)
+* UPS2000-G-3KRTS (firmware: UPS2000G, V2R1C1SPC50, P1.0-D1.0)
 
 If your model is not in the list, we encourage you to report successful
 or unsuccessful results to the bug tracker or the mailing list.
 Make sure to include the full model number of your UPS manually
-in your report, because the firmware only reports "UPS2000-A"
-for all models, including the G series.
+in your report, because many units only report themselves as "UPS2000-A"
+regardless of their models, including the G series.
+
+As of 2022, there is also a new hardware variant with a WCH CH341
+USB-to-serial chip instead of a MaxLinear/Exar RX21V1410 chip and
+reports itself as "UPS2000G". Driver support has been added since
+v0.03.
 
 huawei-ups2000 uses the libmodbus project, for Modbus implementation.
 
 CABLING
 -------
 
-The UPS has a USB port and a RS-232 port. Both are supported, but USB is
-only usable on Linux 5.12 and later, via the *xr_serial* kernel module (see
-subsection *USB* for details). RS-232 is supported on all operating systems.
+The UPS has a USB port and a RS-232 port. Both are supported, but on
+most UPS models, USB is only usable on Linux 5.12 and later, via the
+*xr_serial* kernel module. But for the newer hardware variant with a
+WCH CH341 chip, it should have better compatibility via the *ch341*
+kernel module. See subsection *USB* for details. On the other hand,
+RS-232 is always supported on all operating systems.
 
 Only one port can be used at a time. When USB is used, RS-232 should be
 unplugged from the UPS, and vice versa. Further, optional adapter cards,
@@ -68,12 +77,32 @@ screen to go black. Finally reconnect line power and restart your UPS.
 USB
 ~~~~
 
-The USB port on the UPS2000 is powered by a MaxLinear/Exar RX21V1410
-USB-to-serial converter chip, it's only supported by Linux 5.12 or
-newer, via the *xr_serial* kernel module.
+The USB port on the UPS2000 is originally powered by a MaxLinear/Exar
+RX21V1410 USB-to-serial converter chip, it's only supported by Linux
+5.12 or newer, via the *xr_serial* kernel module. Its *lsusb* report
+is:
 
-When the UPS2000 is connected via USB to a supported Linux system,
-you should see the following logs in *dmesg*.
+    04e2:1410 Exar Corp. XR21V1410 USB-UART IC
+
+However, a recent hardware variant switched to the WCH CH341 serial
+chip:
+
+    1a86:5523 QinHeng Electronics CH341 in serial mode, usb to serial port converter
+
+If your unit has a WCH CH341 chip (likely only found in units made
+after 2022), when the UPS2000 is connected via USB, you should see
+the following logs in *dmesg*.
+
+    ch341 2-1.2:1.0: ch341-uart converter detected
+    usb 2-1.2: ch341-uart converter now attached to ttyUSB0
+
+If so, you should be able to proceed without worrying about kernel
+compatibility. This CH341 chip has been around for a decade and should be
+compatible with your system.
+
+On the other hand, if your unit has a MaxLinear/Exar XR21V1410 chip, like
+most users do, when the UPS2000 is connected via USB to a supported Linux
+system, you should see the following logs in *dmesg*.
 
     xr_serial 1-1.2:1.1: xr_serial converter detected
     usb 1-1.2: xr_serial converter now attached to ttyUSB0
@@ -86,8 +115,8 @@ necessary device driver, you will get this message instead:
 The generic driver *cdc_acm* is incompatible and cannot be used.
 You should upgrade your Linux kernel to Linux 5.12 or newer.
 
-WARNING: On an unsupported system, the USB device can still be
-recognized as a USB ACM device, but communication is impossible,
+WARNING: On an unsupported system, the XR21V1410 USB device can still
+be recognized as a USB ACM device, but communication is impossible,
 please don't waste your time on *cdc_acm*.
 
 If you're already running on Linux 5.12 or newer kernels, but still
@@ -97,7 +126,8 @@ report to your Linux distro maintainers and ask them to enable
 *xr_serial* (kernel option `CONFIG_USB_SERIAL_XR`).
 
 When upgrading the Linux kernel isn't an option, or when you are using
-another operating system (e.g. FreeBSD), RS-232 must be used.
+another operating system (e.g. FreeBSD), RS-232 must be used. Even for
+CH341 users, one can try this option if USB somehow refuses to work.
 
 RS-232
 ~~~~~~
@@ -323,17 +353,23 @@ UPS selects the correct communication interface. Also, if you have
 discovered a reproducible serial port lockup problem, it can be an
 previously unknown bug, make sure to file a bug report.
 
-USB is unsupported
-~~~~~~~~~~~~~~~~~~~
+USB chip (MaxLinear/Exar RX21V1410) is unsupported
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-As previously stated, only RS-232 is supported on all systems. USB
-requires a device-specific driver, which is only available on Linux
+As previously stated, only RS-232 is supported on all systems. On
+most UPS units, the USB chip RX21V1410 is used, and it requires a
+device-specific driver *xr_serial*, which is only available on Linux
 5.12 and newer kernels.
 
 On an unsupported system, the USB device can still be recognized as a
 USB ACM device, but in reality, communication is impossible. It can
 only be fixed by implementing a driver for your system, nothing can
-be done within NUT.
+be done within NUT. Please use the RS-232 port instead.
+
+Alternatively, if your unit has a WCH CH341 chip (likely only found in
+units made after 2022), it should have better compatibility.
+
+See the previous section *Cabling* for more information.
 
 Finally, in the unlike scenario that you are using NUT on Microsoft
 Windows, you should be able to install the USB device driver following

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -456,6 +456,7 @@ Hunnox
 Hurd
 Håvard
 IANA
+IC
 ID's
 IDEN
 IDentifiers
@@ -922,6 +923,7 @@ PwrOut
 PyGTK
 PyNUT
 PyNUTClient
+QinHeng
 QBDR
 QBT
 QBV
@@ -1295,6 +1297,7 @@ Václav
 WALKMODE
 WARNFATAL
 WARNOPT
+WCH
 WELI
 WHAD
 WIPO
@@ -2766,6 +2769,7 @@ tx
 txg
 txt
 typedef
+uart
 uA
 uD
 uM

--- a/drivers/huawei-ups2000.c
+++ b/drivers/huawei-ups2000.c
@@ -1,33 +1,21 @@
 /*
  * huawei-ups2000.c - Driver for Huawei UPS2000 (1kVA-3kVA)
  *
- * Note: Huawei UPS2000 (1kVA-3kVA) can be accessed via RS-232,
- * USB, or an optional RMS-MODBUS01B (RS-485) adapter. Only
- * RS-232 and USB are supported, RS-485 is not.
+ * Note: If you're trying to debug the driver because it doesn't work,
+ * please BE SURE to read the manual in "docs/man/huawei-ups2000.txt"
+ * first! Otherwise you are guaranteed to waste your time!
  *
- * The USB port on the UPS is implemented via a MaxLinear RX21V1410
- * USB-to-serial converter, and can be recongized as a standard
- * USB-CDC serial device. Unfortunately, the generic USB-CDC driver
- * is incompatible with the specific chip configuration and cannot
- * be used. A device-specific driver, "xr_serial", must be used.
- *
- * The driver has only been merged to Linux 5.12 or later, via the
- * "xr_serial" kernel module. When the UPS2000 is connected via USB
- * to a supported Linux system, you should see the following logs in
- * "dmesg".
- *
- *     xr_serial 1-1.2:1.1: xr_serial converter detected
- *     usb 1-1.2: xr_serial converter now attached to ttyUSB0
- *
- * The driver must be "xr_serial". If your system doesn't have the
- * necessary device driver, you will get this message instead:
- *
- *     cdc_acm 1-1.2:1.0: ttyACM0: USB ACM device
- *
- * On other operating systems, USB cannot be used due to the absence
- * of the driver. You must use connect UPS2000 to your computer via
- * RS-232, either directly or using an USB-to-RS-232 converter supported
- * by your Linux or BSD kernel.
+ * Long story short, Huawei UPS2000 (1kVA-3kVA) can be accessed via
+ * RS-232, USB, or an optional RMS-MODBUS01B (RS-485) adapter. Only
+ * RS-232 and USB are supported, RS-485 is not. Also, for most UPS
+ * units, their USB ports are implemented via the MaxLinear RX21V1410
+ * USB-to-serial converter, and they DO NOT WORK without a special
+ * "xr_serial" driver, only available on Linux 5.12+ (not BSD or Solaris).
+ * Without this driver, the USB can still be recognized as a generic
+ * USB ACM device, but it DOES NOT WORK. Alternatively, some newer UPS
+ * units use the WCH CH341 chip, which should have better compatibility.
+ * Detailed information will not be repeated here, please read
+ * "docs/man/huawei-ups2000.txt".
  *
  * A document describing the protocol implemented by this driver can
  * be found online at:
@@ -36,7 +24,7 @@
  *
  * Huawei UPS2000 driver implemented by
  *   Copyright (C) 2020, 2021 Yifeng Li <tomli@tomli.me>
- *   The author is not affiliated to Huawei or other manufacturers.
+ *   The author is not affiliated with Huawei or other manufacturers.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/drivers/huawei-ups2000.c
+++ b/drivers/huawei-ups2000.c
@@ -61,7 +61,7 @@
 #include "serial.h"
 
 #define DRIVER_NAME	"NUT Huawei UPS2000 (1kVA-3kVA) RS-232 Modbus driver"
-#define DRIVER_VERSION	"0.02"
+#define DRIVER_VERSION	"0.03"
 
 #define CHECK_BIT(var,pos) ((var) & (1<<(pos)))
 #define MODBUS_SLAVE_ID 1
@@ -72,7 +72,7 @@
  * model of the UPS2000 series.
  */
 static const char *supported_model[] = {
-	"UPS2000", "UPS2000A",
+	"UPS2000", "UPS2000A", "UPS2000G",
 	NULL
 };
 


### PR DESCRIPTION
We received a report of the existence of a new hardware variant from the bug tracker [1].

This UPS unit has the model number UPS2000-G-3KRTS just like a model we've previously tested, and it has the same V2R1C1SPC50 firmware, which was tested by us as well (although not on UPS2000-G-3KRTS but on UPS2000-A-2KTTS).

However, there are two obvious hardware differences. First, this unit reports itself as "UPS2000G" via the protocol instead, which is a new value not found in the datasheet or previously encountered by us. Previously, even a "UPS2000G" model reports itself as the "UPS2000A". Another difference is the use of WCH CH341 serial-to-USB converter chip instead of the MaxLinear/Exar RX21V1410 chip.

    Bus 002 Device 005: ID 1a86:5523 QinHeng Electronics CH341 in serial mode, usb to serial port converter

The production label on the UPS says 2021-12-04. So it's likely a newer hardware revision or variant. Was it redesigned to improve USB serial compatibility? Or my personal guess, due to chip shortage? Who knows.

Nevertheless, once the "UPS2000G" model string is added to the supported list, it was reported that the driver correctly functions without doing anything else. Thus, from a software perspective there's no difference.

The driver version has been bumped to v0.03. Its man page has also been updated with additional instructions for CH341 users.

Thanks GitHub user @Qinka for reporting it.

[1] https://github.com/networkupstools/nut/issues/1066#issuecomment-1158417669