### PR TITLE
Noted that SKE devices work with the nutdrv_qx driver.

### DIFF
--- a/docs/man/nutdrv_qx.txt
+++ b/docs/man/nutdrv_qx.txt
@@ -19,7 +19,7 @@ SUPPORTED HARDWARE
 
 The *nutdrv_qx* driver is known to work with various UPSes from
 'Armac', 'Blazer', 'Energy Sistem', 'Fenton Technologies', 'General Electric',
-'Hunnox', 'Masterguard', 'Mustek', 'Powercool', 'Voltronic Power'
+'Hunnox', 'Masterguard', 'Mustek', 'Powercool', 'Voltronic Power', 'SKE'
 (rebranded by many, many - have I said many? - others...
 
 Long story short: if your UPS came with a software called 'Viewpower',


### PR DESCRIPTION
I've created this pull for a change in documentation to reflect that SKE (specifically the SK600, maybe others) devices will work with the nutdrv_qx driver.

Note:
Seems to work with this configuration in `/etc/nut/ups.conf`:
```
[SK600]
        driver = "nutdrv_qx"
        port = "auto"
        vendorid = "0001"
        productid = "0000"
        bus = "003"
```