### PR TITLE
Fix spellcheck regression & document UPS2000-G-1KRTS.

### DIFF
--- a/docs/man/huawei-ups2000.txt
+++ b/docs/man/huawei-ups2000.txt
@@ -37,6 +37,7 @@ Currently, it has been tested on the following models.
 
 * UPS2000-A-1KTTS (firmware: UPS2000A, V2R1C1SPC40, P1.0-D1.0)
 * UPS2000-A-2KTTS (firmware: UPS2000A, V2R1C1SPC50, P1.0-D1.0)
+* UPS2000-G-1KRTS (firmware: UPS2000A, V2R1C1SPC40, P1.0-D1.0)
 * UPS2000-G-3KRTS (firmware: UPS2000A, V2R1C1SPC40, P1.0-D1.0)
 * UPS2000-G-3KRTS (firmware: UPS2000G, V2R1C1SPC50, P1.0-D1.0)
 

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -444,6 +444,7 @@ Harnhammar
 Havard
 Heavner
 Hessenflow
+Hirschler
 HiBox
 HiFreq
 HighBatt


### PR DESCRIPTION
This commit adds UPS2000-G-1KRTS to the list of tested UPS models. Thanks GitHub user @sumsethan for reporting it [1]. Coincidentally, it also fixes a spellcheck regression in 7bfc617c1f6de1d57fe2c06d1a94a9cd97838497 by adding the developer's name to the dict.

[1] https://github.com/networkupstools/nut/issues/1066#issuecomment-1180005297