### PR TITLE
usb, shut headers and drivers: update from ERROR_* macros to LIBUSB_ERROR_*…

### DIFF
--- a/drivers/blazer_usb.c
+++ b/drivers/blazer_usb.c
@@ -129,11 +129,11 @@ static int phoenix_command(const char *cmd, char *buf, size_t buflen)
 		 */
 		switch (ret)
 		{
-		case ERROR_PIPE:    /** Pipe error or Broken pipe */
+		case LIBUSB_ERROR_PIPE:    /** Pipe error or Broken pipe */
 			usb_clear_halt(udev, 0x81);
 			break;
 
-		case ERROR_TIMEOUT: /** Operation or Connection timed out */
+		case LIBUSB_ERROR_TIMEOUT: /** Operation or Connection timed out */
 			break;
 		}
 
@@ -204,7 +204,7 @@ static int ippon_command(const char *cmd, char *buf, size_t buflen)
 			0x09, 0x2, 0, (usb_ctrl_charbuf)&tmp[i], 8, 1000);
 
 		if (ret <= 0) {
-			upsdebugx(3, "send: %s", (ret != ERROR_TIMEOUT) ? nut_usb_strerror(ret) : "Connection timed out");
+			upsdebugx(3, "send: %s", (ret != LIBUSB_ERROR_TIMEOUT) ? nut_usb_strerror(ret) : "Connection timed out");
 			return ret;
 		}
 	}
@@ -221,7 +221,7 @@ static int ippon_command(const char *cmd, char *buf, size_t buflen)
 	 * will happen after successfully writing a command to the UPS)
 	 */
 	if (ret <= 0) {
-		upsdebugx(3, "read: %s", (ret != ERROR_TIMEOUT) ? nut_usb_strerror(ret) : "Connection timed out");
+		upsdebugx(3, "read: %s", (ret != LIBUSB_ERROR_TIMEOUT) ? nut_usb_strerror(ret) : "Connection timed out");
 		return ret;
 	}
 
@@ -456,7 +456,7 @@ ssize_t blazer_command(const char *cmd, char *buf, size_t buflen)
 
 	switch (ret)
 	{
-	case ERROR_BUSY:		/* Device or resource busy */
+	case LIBUSB_ERROR_BUSY:		/* Device or resource busy */
 		fatal_with_errno(EXIT_FAILURE, "Got disconnected by another driver");
 #ifndef HAVE___ATTRIBUTE__NORETURN
 		exit(EXIT_FAILURE);	/* Should not get here in practice, but compiler is afraid we can fall through */
@@ -470,7 +470,7 @@ ssize_t blazer_command(const char *cmd, char *buf, size_t buflen)
 # endif
 #endif /* WITH_LIBUSB_0_1 */
 
-	case ERROR_PIPE:		/* Broken pipe */
+	case LIBUSB_ERROR_PIPE:		/* Broken pipe */
 		if (usb_clear_halt(udev, 0x81) == 0) {
 			upsdebugx(1, "Stall condition cleared");
 			break;
@@ -484,21 +484,21 @@ ssize_t blazer_command(const char *cmd, char *buf, size_t buflen)
 			upsdebugx(1, "Device reset handled");
 		}
 		goto fallthrough_case_reconnect;
-	case ERROR_NO_DEVICE: /* No such device */
-	case ERROR_ACCESS:    /* Permission denied */
-	case ERROR_IO:        /* I/O error */
+	case LIBUSB_ERROR_NO_DEVICE: /* No such device */
+	case LIBUSB_ERROR_ACCESS:    /* Permission denied */
+	case LIBUSB_ERROR_IO:        /* I/O error */
 #if WITH_LIBUSB_0_1 /* limit to libusb 0.1 implementation */
 	case -ENXIO:		/* No such device or address */
 #endif
-	case ERROR_NOT_FOUND:		/* No such file or directory */
+	case LIBUSB_ERROR_NOT_FOUND:		/* No such file or directory */
 	fallthrough_case_reconnect:
 		/* Uh oh, got to reconnect! */
 		usb->close(udev);
 		udev = NULL;
 		break;
 
-	case ERROR_TIMEOUT:  /* Connection timed out */
-	case ERROR_OVERFLOW: /* Value too large for defined data type */
+	case LIBUSB_ERROR_TIMEOUT:  /* Connection timed out */
+	case LIBUSB_ERROR_OVERFLOW: /* Value too large for defined data type */
 #if EPROTO && WITH_LIBUSB_0_1
 	case -EPROTO:		/* Protocol error */
 #endif

--- a/drivers/libshut.h
+++ b/drivers/libshut.h
@@ -98,14 +98,19 @@ typedef int usb_ctrl_timeout_msec;	/* in milliseconds */
 #define USB_CTRL_TIMEOUTMSEC_MAX	INT_MAX
 
 /* Same error-code definitions as in usb-common.h for libusb-0.1 API */
-#define ERROR_ACCESS		-EACCES
-#define ERROR_BUSY			-EBUSY
-#define ERROR_IO			-EIO
-#define ERROR_NO_DEVICE		-ENODEV
-#define ERROR_NOT_FOUND		-ENOENT
-#define ERROR_OVERFLOW		-EOVERFLOW
-#define ERROR_PIPE			-EPIPE
-#define ERROR_TIMEOUT		-ETIMEDOUT
+#define LIBUSB_ERROR_ACCESS		-EACCES
+#define LIBUSB_ERROR_BUSY			-EBUSY
+#define LIBUSB_ERROR_IO			-EIO
+#define LIBUSB_ERROR_NO_DEVICE		-ENODEV
+#define LIBUSB_ERROR_NOT_FOUND		-ENOENT
+#define LIBUSB_ERROR_OVERFLOW		-EOVERFLOW
+#define LIBUSB_ERROR_PIPE			-EPIPE
+#define LIBUSB_ERROR_TIMEOUT		-ETIMEDOUT
+#define LIBUSB_ERROR_NO_MEM		-ENOMEM
+#define LIBUSB_ERROR_INVALID_PARAM	-EINVAL
+#define LIBUSB_ERROR_INTERRUPTED	-EINTR
+#define LIBUSB_ERROR_NOT_SUPPORTED	-ENOSYS
+#define LIBUSB_ERROR_OTHER		-ERANGE
 
 /*!
  * SHUTDevice_t: Describe a SHUT device. This structure contains exactly

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -597,7 +597,7 @@ static int	sgs_command(const char *cmd, char *buf, size_t buflen)
 
 		/* No error!!! */
 		/* if (ret == -110) */
-		if (ret == ERROR_TIMEOUT)
+		if (ret == LIBUSB_ERROR_TIMEOUT)
 			break;
 
 		/* Any errors here mean that we are unable to read a reply
@@ -669,11 +669,11 @@ static int	phoenix_command(const char *cmd, char *buf, size_t buflen)
 		 * data (e.g. it times out). */
 		switch (ret)
 		{
-		case ERROR_PIPE:	/* Broken pipe */
+		case LIBUSB_ERROR_PIPE:	/* Broken pipe */
 			usb_clear_halt(udev, 0x81);
 			break;
 
-		case ERROR_TIMEOUT:	/* Connection timed out */
+		case LIBUSB_ERROR_TIMEOUT:	/* Connection timed out */
 			break;
 		}
 
@@ -769,7 +769,7 @@ static int	ippon_command(const char *cmd, char *buf, size_t buflen)
 
 		if (ret <= 0) {
 			upsdebugx(3, "send: %s (%d)",
-				(ret != ERROR_TIMEOUT) ? nut_usb_strerror(ret) : "Connection timed out",
+				(ret != LIBUSB_ERROR_TIMEOUT) ? nut_usb_strerror(ret) : "Connection timed out",
 				ret);
 			return ret;
 		}
@@ -788,7 +788,7 @@ static int	ippon_command(const char *cmd, char *buf, size_t buflen)
 	 * to the UPS) */
 	if (ret <= 0) {
 		upsdebugx(3, "read: %s (%d)",
-			(ret != ERROR_TIMEOUT) ? nut_usb_strerror(ret) : "Connection timed out",
+			(ret != LIBUSB_ERROR_TIMEOUT) ? nut_usb_strerror(ret) : "Connection timed out",
 			ret);
 		return ret;
 	}
@@ -3177,7 +3177,7 @@ static ssize_t	qx_command(const char *cmd, char *buf, size_t buflen)
 
 		switch (ret)
 		{
-		case ERROR_BUSY:	/* Device or resource busy */
+		case LIBUSB_ERROR_BUSY:	/* Device or resource busy */
 			fatal_with_errno(EXIT_FAILURE, "Got disconnected by another driver");
 #ifndef HAVE___ATTRIBUTE__NORETURN
 # if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE)
@@ -3205,7 +3205,7 @@ static ssize_t	qx_command(const char *cmd, char *buf, size_t buflen)
 #endif
 	#endif	/* WITH_LIBUSB_0_1 */
 
-		case ERROR_PIPE:	/* Broken pipe */
+		case LIBUSB_ERROR_PIPE:	/* Broken pipe */
 			if (usb_clear_halt(udev, 0x81) == 0) {
 				upsdebugx(1, "Stall condition cleared");
 				break;
@@ -3219,21 +3219,21 @@ static ssize_t	qx_command(const char *cmd, char *buf, size_t buflen)
 				upsdebugx(1, "Device reset handled");
 			}
 			goto fallthrough_case_reconnect;
-		case ERROR_NO_DEVICE:	/* No such device */
-		case ERROR_ACCESS:	/* Permission denied */
-		case ERROR_IO:		/* I/O error */
+		case LIBUSB_ERROR_NO_DEVICE:	/* No such device */
+		case LIBUSB_ERROR_ACCESS:	/* Permission denied */
+		case LIBUSB_ERROR_IO:		/* I/O error */
 #if WITH_LIBUSB_0_1			/* limit to libusb 0.1 implementation */
 		case -ENXIO:		/* No such device or address */
 #endif	/* WITH_LIBUSB_0_1 */
-		case ERROR_NOT_FOUND:	/* No such file or directory */
+		case LIBUSB_ERROR_NOT_FOUND:	/* No such file or directory */
 		fallthrough_case_reconnect:
 			/* Uh oh, got to reconnect! */
 			usb->close(udev);
 			udev = NULL;
 			break;
 
-		case ERROR_TIMEOUT:	/* Connection timed out */
-		case ERROR_OVERFLOW:	/* Value too large for defined data type */
+		case LIBUSB_ERROR_TIMEOUT:	/* Connection timed out */
+		case LIBUSB_ERROR_OVERFLOW:	/* Value too large for defined data type */
 #if EPROTO && WITH_LIBUSB_0_1		/* limit to libusb 0.1 implementation */
 		case -EPROTO:		/* Protocol error */
 #endif

--- a/drivers/riello_usb.c
+++ b/drivers/riello_usb.c
@@ -369,7 +369,7 @@ static int riello_command(uint8_t *cmd, uint8_t *buf, uint16_t length, uint16_t 
 
 	switch (ret)
 	{
-	case ERROR_BUSY:			/* Device or resource busy */
+	case LIBUSB_ERROR_BUSY:			/* Device or resource busy */
 		fatal_with_errno(EXIT_FAILURE, "Got disconnected by another driver");
 #ifndef HAVE___ATTRIBUTE__NORETURN
 		exit(EXIT_FAILURE);	/* Should not get here in practice, but compiler is afraid we can fall through */
@@ -383,7 +383,7 @@ static int riello_command(uint8_t *cmd, uint8_t *buf, uint16_t length, uint16_t 
 # endif
 #endif
 
-	case ERROR_PIPE:			/* Broken pipe */
+	case LIBUSB_ERROR_PIPE:			/* Broken pipe */
 		if (usb_clear_halt(udev, 0x81) == 0) {
 			upsdebugx(1, "Stall condition cleared");
 			break;
@@ -397,24 +397,24 @@ static int riello_command(uint8_t *cmd, uint8_t *buf, uint16_t length, uint16_t 
 			upsdebugx(1, "Device reset handled");
 		}
 		goto fallthrough_case_reconnect;
-	case ERROR_NO_DEVICE: /* No such device */
-	case ERROR_ACCESS:    /* Permission denied */
-	case ERROR_IO:        /* I/O error */
+	case LIBUSB_ERROR_NO_DEVICE: /* No such device */
+	case LIBUSB_ERROR_ACCESS:    /* Permission denied */
+	case LIBUSB_ERROR_IO:        /* I/O error */
 #if WITH_LIBUSB_0_1 /* limit to libusb 0.1 implementation */
 	case -ENXIO:				/* No such device or address */
 #endif
-	case ERROR_NOT_FOUND:		/* No such file or directory */
+	case LIBUSB_ERROR_NOT_FOUND:		/* No such file or directory */
 	fallthrough_case_reconnect:
 		/* Uh oh, got to reconnect! */
 		usb->close(udev);
 		udev = NULL;
 		break;
 
-	case ERROR_TIMEOUT:  /* Connection timed out */
+	case LIBUSB_ERROR_TIMEOUT:  /* Connection timed out */
 		upsdebugx (3, "riello_command err: Resource temporarily unavailable");
 		break;
 
-	case ERROR_OVERFLOW: /* Value too large for defined data type */
+	case LIBUSB_ERROR_OVERFLOW: /* Value too large for defined data type */
 #if EPROTO && WITH_LIBUSB_0_1
 	case -EPROTO:		/* Protocol error */
 #endif

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -543,7 +543,7 @@ static void usb_comm_fail(int res, const char *msg)
 	static int try = 0;
 
 	switch(res) {
-		case ERROR_BUSY:
+		case LIBUSB_ERROR_BUSY:
 			upslogx(LOG_WARNING,
 				"%s: Device claimed by another process", msg);
 			fatalx(EXIT_FAILURE, "Terminating: EBUSY");
@@ -1017,7 +1017,7 @@ void upsdrv_initinfo(void)
 	if(tl_model != TRIPP_LITE_SMARTPRO ) {
 		ret = send_cmd(w_msg, sizeof(w_msg), w_value, sizeof(w_value)-1);
 		if(ret <= 0) {
-			if(ret == ERROR_PIPE) {
+			if(ret == LIBUSB_ERROR_PIPE) {
 				fatalx(EXIT_FAILURE, "Could not reset watchdog. Please check and"
 						"see if usbhid-ups(8) works with this UPS.");
 			} else {

--- a/drivers/usb-common.h
+++ b/drivers/usb-common.h
@@ -162,6 +162,7 @@
  #define USB_TYPE_CLASS				LIBUSB_REQUEST_TYPE_CLASS
  #define USB_TYPE_VENDOR			LIBUSB_REQUEST_TYPE_VENDOR
 
+/* Codebase updated to use LIBUSB_* tokens:
  #define ERROR_ACCESS		LIBUSB_ERROR_ACCESS
  #define ERROR_BUSY			LIBUSB_ERROR_BUSY
  #define ERROR_IO			LIBUSB_ERROR_IO
@@ -175,6 +176,7 @@
  #define ERROR_INTERRUPTED    LIBUSB_ERROR_INTERRUPTED
  #define ERROR_NOT_SUPPORTED  LIBUSB_ERROR_NOT_SUPPORTED
  #define ERROR_OTHER          LIBUSB_ERROR_OTHER
+*/
 
  /* Functions, including range-checks to convert data types of the two APIs.
   * Follows an example from libusb-1.0 headers that liberally cast int args
@@ -430,14 +432,19 @@
  #define USB_CTRL_TIMEOUTMSEC_MAX	INT_MAX
 
  /* defines */
- #define ERROR_ACCESS		-EACCES
- #define ERROR_BUSY			-EBUSY
- #define ERROR_IO			-EIO
- #define ERROR_NO_DEVICE	-ENODEV
- #define ERROR_NOT_FOUND	-ENOENT
- #define ERROR_OVERFLOW		-EOVERFLOW
- #define ERROR_PIPE			-EPIPE
- #define ERROR_TIMEOUT		-ETIMEDOUT
+ #define LIBUSB_ERROR_ACCESS		-EACCES
+ #define LIBUSB_ERROR_BUSY			-EBUSY
+ #define LIBUSB_ERROR_IO			-EIO
+ #define LIBUSB_ERROR_NO_DEVICE	-ENODEV
+ #define LIBUSB_ERROR_NOT_FOUND	-ENOENT
+ #define LIBUSB_ERROR_OVERFLOW		-EOVERFLOW
+ #define LIBUSB_ERROR_PIPE			-EPIPE
+ #define LIBUSB_ERROR_TIMEOUT		-ETIMEDOUT
+ #define LIBUSB_ERROR_NO_MEM		-ENOMEM
+ #define LIBUSB_ERROR_INVALID_PARAM		-EINVAL
+ #define LIBUSB_ERROR_INTERRUPTED		-EINTR
+ #define LIBUSB_ERROR_NOT_SUPPORTED	-ENOSYS
+ #define LIBUSB_ERROR_OTHER		-ERANGE
 
  /* Functions for which simple mappings seem to suffice (no build warnings emitted): */
  #define nut_usb_strerror(a)	usb_strerror()

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -107,37 +107,6 @@ typedef enum {
 	HU_WALKMODE_FULL_UPDATE
 } walkmode_t;
 
-/* Compatibility layer between libusb 0.1 and 1.0, for errno/return codes */
-#if WITH_LIBUSB_0_1 || (defined SHUT_MODE)
- #define ERROR_BUSY	-EBUSY
- #define ERROR_NO_DEVICE -ENODEV
- #define ERROR_ACCESS -EACCES
- #define ERROR_IO -EIO
- #define ERROR_NOT_FOUND -ENOENT
- #define ERROR_TIMEOUT -ETIMEDOUT
- #define ERROR_OVERFLOW -EOVERFLOW
- #define ERROR_PIPE -EPIPE
- #define ERROR_NO_MEM -ENOMEM
- #define ERROR_INVALID_PARAM -EINVAL
- #define ERROR_INTERRUPTED -EINTR
- #define ERROR_NOT_SUPPORTED -ENOSYS
- #define ERROR_OTHER -ERANGE
-#else /* for libusb 1.0 */
- #define ERROR_BUSY	LIBUSB_ERROR_BUSY
- #define ERROR_NO_DEVICE LIBUSB_ERROR_NO_DEVICE
- #define ERROR_ACCESS LIBUSB_ERROR_ACCESS
- #define ERROR_IO LIBUSB_ERROR_IO
- #define ERROR_NOT_FOUND LIBUSB_ERROR_NOT_FOUND
- #define ERROR_TIMEOUT LIBUSB_ERROR_TIMEOUT
- #define ERROR_OVERFLOW LIBUSB_ERROR_OVERFLOW
- #define ERROR_PIPE LIBUSB_ERROR_PIPE
- #define ERROR_NO_MEM LIBUSB_ERROR_NO_MEM
- #define ERROR_INVALID_PARAM LIBUSB_ERROR_INVALID_PARAM
- #define ERROR_INTERRUPTED LIBUSB_ERROR_INTERRUPTED
- #define ERROR_NOT_SUPPORTED LIBUSB_ERROR_NOT_SUPPORTED
- #define ERROR_OTHER LIBUSB_ERROR_OTHER
-#endif
-
 /* pointer to the active subdriver object (changed in callback() function) */
 static subdriver_t *subdriver = NULL;
 
@@ -883,20 +852,20 @@ void upsdrv_updateinfo(void)
 		evtCount = HIDGetEvents(udev, event, MAX_EVENT_NUM);
 		switch (evtCount)
 		{
-		case ERROR_BUSY:      /* Device or resource busy */
+		case LIBUSB_ERROR_BUSY:      /* Device or resource busy */
 			upslog_with_errno(LOG_CRIT, "Got disconnected by another driver");
 			goto fallthrough_reconnect;
 #if WITH_LIBUSB_0_1 /* limit to libusb 0.1 implementation */
 		case -EPERM:		/* Operation not permitted */
 #endif
-		case ERROR_NO_DEVICE: /* No such device */
-		case ERROR_ACCESS:    /* Permission denied */
-		case ERROR_IO:        /* I/O error */
+		case LIBUSB_ERROR_NO_DEVICE: /* No such device */
+		case LIBUSB_ERROR_ACCESS:    /* Permission denied */
+		case LIBUSB_ERROR_IO:        /* I/O error */
 #if WITH_LIBUSB_0_1         /* limit to libusb 0.1 implementation */
 		case -ENXIO:		    /* No such device or address */
 #endif
-		case ERROR_NOT_FOUND: /* No such file or directory */
-		case ERROR_NO_MEM:    /* Insufficient memory */
+		case LIBUSB_ERROR_NOT_FOUND: /* No such file or directory */
+		case LIBUSB_ERROR_NO_MEM:    /* Insufficient memory */
 		fallthrough_reconnect:
 			/* Uh oh, got to reconnect! */
 			hd = NULL;
@@ -1493,20 +1462,20 @@ static bool_t hid_ups_walk(walkmode_t mode)
 
 		switch (retcode)
 		{
-		case ERROR_BUSY:      /* Device or resource busy */
+		case LIBUSB_ERROR_BUSY:      /* Device or resource busy */
 			upslog_with_errno(LOG_CRIT, "Got disconnected by another driver");
 			goto fallthrough_reconnect;
 #if WITH_LIBUSB_0_1 /* limit to libusb 0.1 implementation */
 		case -EPERM:		/* Operation not permitted */
 #endif
-		case ERROR_NO_DEVICE: /* No such device */
-		case ERROR_ACCESS:    /* Permission denied */
-		case ERROR_IO:        /* I/O error */
-#if WITH_LIBUSB_0_1         /* limit to libusb 0.1 implementation */
-		case -ENXIO:		    /* No such device or address */
+		case LIBUSB_ERROR_NO_DEVICE: /* No such device */
+		case LIBUSB_ERROR_ACCESS:    /* Permission denied */
+		case LIBUSB_ERROR_IO:        /* I/O error */
+#if WITH_LIBUSB_0_1           /* limit to libusb 0.1 implementation */
+		case -ENXIO:		  /* No such device or address */
 #endif
-		case ERROR_NOT_FOUND: /* No such file or directory */
-		case ERROR_NO_MEM:    /* Insufficient memory */
+		case LIBUSB_ERROR_NOT_FOUND: /* No such file or directory */
+		case LIBUSB_ERROR_NO_MEM:    /* Insufficient memory */
 		fallthrough_reconnect:
 			/* Uh oh, got to reconnect! */
 			hd = NULL;
@@ -1518,12 +1487,12 @@ static bool_t hid_ups_walk(walkmode_t mode)
 		case 0:
 			continue;
 
-		case ERROR_TIMEOUT:   /* Connection timed out */
-		case ERROR_OVERFLOW:  /* Value too large for defined data type */
+		case LIBUSB_ERROR_TIMEOUT:   /* Connection timed out */
+		case LIBUSB_ERROR_OVERFLOW:  /* Value too large for defined data type */
 #if EPROTO && WITH_LIBUSB_0_1
 		case -EPROTO:		/* Protocol error */
 #endif
-		case ERROR_PIPE:      /* Broken pipe */
+		case LIBUSB_ERROR_PIPE:      /* Broken pipe */
 		default:
 			/* Don't know what happened, try again later... */
 		   upsdebugx(1, "HIDGetDataValue unknown retcode '%i'", retcode);


### PR DESCRIPTION
…macros (avoid conflict on WIN32 - Some lessons learned from preparing the NUT for Windows branch, which should be useful in general codebase and reduce the discrepancies between the two efforts; follows up from issue #300 in a way)

Also define LIBUSB_ERROR_INTERRUPTED, LIBUSB_ERROR_NOT_SUPPORTED and LIBUSB_ERROR_OTHER tokens for libusb-0.1 and SHUT builds for completeness