### PR TITLE
Avoid meaningful work in upsdebug*() macro call [#1455]

### DIFF
--- a/drivers/upscode2.c
+++ b/drivers/upscode2.c
@@ -1050,7 +1050,9 @@ static ssize_t upscrecv(char *buf)
 	} else if (res == 0) {
 		upsdebugx(3, "upscrecv: Timeout");
 	} else {
-		upsdebugx(3, "upscrecv: %zd bytes:\t'%s'", res-1, str_rtrim(buf, ENDCHAR));
+		/* Note: s should end up same as buf */
+		char *s = str_rtrim(buf, ENDCHAR);
+		upsdebugx(3, "upscrecv: %zd bytes:\t'%s'", res-1, s);
 	}
 
 	return res;

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -388,7 +388,10 @@ int sendback(nut_ctype_t *client, const char *fmt, ...)
 		res = write(client->sock_fd, ans, len);
 	}
 
-	upsdebugx(2, "write: [destfd=%d] [len=%zu] [%s]", client->sock_fd, len, str_rtrim(ans, '\n'));
+	{ /* scoping */
+		char * s = str_rtrim(ans, '\n');
+		upsdebugx(2, "write: [destfd=%d] [len=%zu] [%s]", client->sock_fd, len, s);
+	}
 
 	if (res < 0 || len != (size_t)res) {
 		upslog_with_errno(LOG_NOTICE, "write() failed for %s", client->addr);


### PR DESCRIPTION
Thanks to @marekm72 for noticing in #1455 that `str_rtrim()` modifies the original string, but macroization of `upsdebugx()` et al in #685 caused this method to not get called unless debug level is high - so less-than-expected data goes down the datapath.

Not sure if it practically impacted `upsd`, but for the `upscode2` driver this did cause a regression in NUT v2.8.0 release compared to earlier releases.

I went over the codebase to look at other arguments to existing debug calls, with the following grep, and did not notice other similar "offenses":

````
:; git grep -A10 -E 'upsdebug(x|_hex|_ascii|_with_errno)' | (\
    H=false; while IFS= read LINE ; do
        case "$LINE" in *upsdebug*) H=true ;; esac;
        $H && echo "$LINE" ;
        case "$LINE" in *");") H=false; echo "---" ;; esac ;
    done )| uniq | less
````

It is not a 100% perfect selection, catches a bit more than expected, but is good enough for the code trawling.

Possibly, similar inspection makes sense for code added/modified with the Windows #5, DMF #182/#469, and other long-standing feature branches. 