### PR TITLE
drivers/riello*.{c,h}: update links to PDF protocol documentation

### DIFF
--- a/drivers/riello.c
+++ b/drivers/riello.c
@@ -4,8 +4,8 @@
  * Documents describing the protocol implemented by this driver can be
  * found online at:
  *
- *   http://www.networkupstools.org/ups-protocols/riello/PSGPSER-0104.pdf
- *   http://www.networkupstools.org/ups-protocols/riello/PSSENTR-0100.pdf
+ *   https://networkupstools.org/protocols/riello/PSGPSER-0104.pdf
+ *   https://networkupstools.org/protocols/riello/PSSENTR-0100.pdf
  *
  * Copyright (C) 2012 - Elio Parisi <e.parisi@riello-ups.com>
  *

--- a/drivers/riello.h
+++ b/drivers/riello.h
@@ -4,8 +4,8 @@
  * Documents describing the protocol implemented by this driver can be
  * found online at:
  *
- *   http://www.networkupstools.org/ups-protocols/riello/PSGPSER-0104.pdf
- *   http://www.networkupstools.org/ups-protocols/riello/PSSENTR-0100.pdf
+ *   https://networkupstools.org/protocols/riello/PSGPSER-0104.pdf
+ *   https://networkupstools.org/protocols/riello/PSSENTR-0100.pdf
  *
  * Copyright (C) 2012 - Elio Parisi <e.parisi@riello-ups.com>
  *

--- a/drivers/riello_ser.c
+++ b/drivers/riello_ser.c
@@ -2,8 +2,8 @@
  * riello_ser.c: support for Riello serial protocol based UPSes
  *
  * A document describing the protocol implemented by this driver can be
- * found online at "http://www.networkupstools.org/ups-protocols/riello/PSGPSER-0104.pdf"
- * and "http://www.networkupstools.org/ups-protocols/riello/PSSENTR-0100.pdf".
+ * found online at "https://networkupstools.org/protocols/riello/PSGPSER-0104.pdf"
+ * and "https://networkupstools.org/protocols/riello/PSSENTR-0100.pdf".
  *
  * Copyright (C) 2012 - Elio Parisi <e.parisi@riello-ups.com>
  *

--- a/drivers/riello_usb.c
+++ b/drivers/riello_usb.c
@@ -4,7 +4,7 @@
  * A document describing the protocol implemented by this driver can be
  * found online at:
  *
- *   http://www.networkupstools.org/ups-protocols/riello/PSGPSER-0104.pdf
+ *   https://networkupstools.org/protocols/riello/PSGPSER-0104.pdf
  *
  * Copyright (C) 2012 - Elio Parisi <e.parisi@riello-ups.com>
  * Copyright (C) 2016   Eaton


### PR DESCRIPTION
Help driver maintainers and hackers find the relevant docs more easily.

Closes: #1481