### PR TITLE
News update for NUT v2.8.1

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,7 +5,7 @@ ChangeLog file (generated for release archives), or to the Git version
 control history for "live" codebase.
 
 ---------------------------------------------------------------------------
-PLANNED: Release notes for NUT 2.8.2 - what's new since 2.8.1:
+PLANNED: Release notes for NUT 2.8.3 - what's new since 2.8.2:
 
 https://github.com/networkupstools/nut/milestone/9
 
@@ -13,12 +13,10 @@ https://github.com/networkupstools/nut/milestone/9
    the driver binaries to be built once and data mappings to be loaded
    and modernized on the fly [Ported from 42ITy project]
 
- - (expected) Bug fixes for fallout possible due to "fightwarn" effort in 2.8.0
-
 ---------------------------------------------------------------------------
-PLANNED: Release notes for NUT 2.8.1 - what's new since 2.8.0:
+PLANNED: Release notes for NUT 2.8.2 - what's new since 2.8.1:
 
-https://github.com/networkupstools/nut/milestone/8
+https://github.com/networkupstools/nut/milestone/10
 
  - (expected) clean-up of libusb API variants support [#300 and follow-ups]
 
@@ -28,6 +26,13 @@ https://github.com/networkupstools/nut/milestone/8
    to patterns defined in docs/nut-names.txt
 
  - (expected) Porting of performance and bug fixes from 42ITy project
+
+ - (expected) Bug fixes for fallout possible due to "fightwarn" effort in 2.8.0
+
+---------------------------------------------------------------------------
+PLANNED: Release notes for NUT 2.8.1 - what's new since 2.8.0:
+
+https://github.com/networkupstools/nut/milestone/8
 
  - Bug fixes for fallout possible due to "fightwarn" effort in 2.8.0:
    * The `upsdebugx()` and similar methods were converted to macros in #685

--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,8 @@ https://github.com/networkupstools/nut/milestone/9
    the driver binaries to be built once and data mappings to be loaded
    and modernized on the fly [Ported from 42ITy project]
 
+ - (expected) Bug fixes for fallout possible due to "fightwarn" effort in 2.8.0
+
 ---------------------------------------------------------------------------
 PLANNED: Release notes for NUT 2.8.1 - what's new since 2.8.0:
 
@@ -27,7 +29,15 @@ https://github.com/networkupstools/nut/milestone/8
 
  - (expected) Porting of performance and bug fixes from 42ITy project
 
- - (expected) Bug fixes for fallout possible due to "fightwarn" effort in 2.7.5
+ - Bug fixes for fallout possible due to "fightwarn" effort in 2.8.0:
+   * The `upsdebugx()` and similar methods were converted to macros in #685
+     to avoid useless data manipulations and requests for logged information,
+     whose results would be ignored instantly because the debug level is
+     too low. As issue #1455 and PR #1495 found, in two cases the called
+     commands did "meaningfully" modify data -- so without debug logs the
+     program misbehaved. A known regression for `upscode2` driver; might
+     be or not be a problem with `upsd` driver in NUT v2.8.0 release,
+     fixed for NUT v2.8.1.
 
  - Regular CI coverage for NUT codebase enhanced with CircleCI running some
    scenarios on MacOS, might add Windows in the future. Fixed some build

--- a/NEWS
+++ b/NEWS
@@ -38,6 +38,10 @@ https://github.com/networkupstools/nut/milestone/8
      program misbehaved. A known regression for `upscode2` driver; might
      be or not be a problem with `upsd` driver in NUT v2.8.0 release,
      fixed for NUT v2.8.1.
+   * A table in `cyberpower-mib` (for `snmp-ups` driver) sources was
+     arranged in NUT v2.8.0 release in a way that precluded the driver
+     logic from looking at all of its entries. Regression fixed for NUT
+     v2.8.1 [#1432]
 
  - usbhid-ups updates:
    * cps-hid subdriver now applies same report descriptor fixing logic to

--- a/NEWS
+++ b/NEWS
@@ -58,6 +58,9 @@ https://github.com/networkupstools/nut/milestone/8
  - NUT software-only drivers (dummy-ups, clone, clone-outlet) separated from
    serial drivers in respective Makefile and configure script options [#1446]
 
+ - Stuck drivers that do not react to `SIGTERM` quickly are now retried with
+   `SIGKILL` [#1424]
+
 ---------------------------------------------------------------------------
 Release notes for NUT 2.8.0 - what's new since 2.7.4:
 

--- a/NEWS
+++ b/NEWS
@@ -43,6 +43,9 @@ https://github.com/networkupstools/nut/milestone/8
      logic from looking at all of its entries. Regression fixed for NUT
      v2.8.1 [#1432]
 
+ - huawei-ups2000 is now known to support more devices, noted in docs and
+   for auto-detection [#1448]
+
  - usbhid-ups updates:
    * cps-hid subdriver now applies same report descriptor fixing logic to
      devices with ProductID 0x0601 as done earlier for 0x0501, to get the

--- a/NEWS
+++ b/NEWS
@@ -39,6 +39,11 @@ https://github.com/networkupstools/nut/milestone/8
      be or not be a problem with `upsd` driver in NUT v2.8.0 release,
      fixed for NUT v2.8.1.
 
+ - usbhid-ups updates:
+   * cps-hid subdriver now applies same report descriptor fixing logic to
+     devices with ProductID 0x0601 as done earlier for 0x0501, to get the
+     correct output voltage data [#1497]
+
  - Regular CI coverage for NUT codebase enhanced with CircleCI running some
    scenarios on MacOS, might add Windows in the future. Fixed some build
    issues for MacOS that had crept into NUT v2.8.0 release [#1415, #1421]

--- a/NEWS
+++ b/NEWS
@@ -53,6 +53,11 @@ https://github.com/networkupstools/nut/milestone/8
    * cps-hid subdriver now applies same report descriptor fixing logic to
      devices with ProductID 0x0601 as done earlier for 0x0501, to get the
      correct output voltage data [#1497]
+   * the `usbhid-ups` driver should now reconnect if `libusb` returned a
+     memory allocation error [#1422] (seen as "Can't retrieve Report 0a:
+     Resource temporarily unavailable"), which can cause practical problems
+     in the field -- the driver otherwise interpreted the situation as
+     `ups.status` being `OL OFF` and cut the power supply.
 
  - Regular CI coverage for NUT codebase enhanced with CircleCI running some
    scenarios on MacOS, might add Windows in the future. Fixed some build

--- a/NEWS
+++ b/NEWS
@@ -42,6 +42,9 @@ https://github.com/networkupstools/nut/milestone/8
      arranged in NUT v2.8.0 release in a way that precluded the driver
      logic from looking at all of its entries. Regression fixed for NUT
      v2.8.1 [#1432]
+   * A change for file-change detection in `dummy-ups` driver for NUT
+     v2.8.0 release misfired on some platforms. Regression fixed for NUT
+     v2.8.1 [#1420]
 
  - huawei-ups2000 is now known to support more devices, noted in docs and
    for auto-detection [#1448]

--- a/docs/config-prereqs.txt
+++ b/docs/config-prereqs.txt
@@ -823,9 +823,14 @@ Note you may need not just the "Core" IPS package publisher, but also the
 #   :; pkg info -r | grep -Ei 'perl|python'
 ------
 
-OmniOS lacks a pre-packaged libusb, however the binary build from contemporary
-OpenIndiana can be used (copy the header files and the library+symlinks for
-all architectures you would need).
+Your OmniOS version may lack a pre-packaged libusb, however the binary
+build from contemporary OpenIndiana can be used (copy the header files
+and the library+symlinks for all architectures you would need).
+
+NOTE: As of July 2022, a `libusb-1` package recipe was proposed for the
+`omnios-extra` repository (NUT itself and further dependencies may also
+appear there, per
+link:https://github.com/networkupstools/nut/issues/1498[issue #1498]).
 
 You may need to set up `ccache` with the same `/usr/lib/ccache` dir used
 in other OS recipes. Assuming your Build Essentials pulled GCC 9 version,


### PR DESCRIPTION
Initially the committed state of the `NEWS` file contained a lot of planned work for 2.8.1 as catching up with ideas not finished (not urgent) before cutting the NUT v2.8.0 release a few months ago.

As we accumulated (and fixed in master branch) some reports of regressions in that release, it becomes more urgent to cut a bug-fix release soon so the better-functioning code can get into distributions etc. Many of those are still catching up with updating the recipes to provide something after 2.7.4 anyway.

Milestone definitions in Github were updated, although work not completed in practice by whenever we decide that 2.8.1 is ready to roll would move in planning to 2.8.2 just at that point in time (moving of lines in `NEWS` in this PR now may be not final).