### PR TITLE
Fix man-page building when just a few drivers are built by name

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -34,7 +34,8 @@ PLANNED: Release notes for NUT 2.8.1 - what's new since 2.8.0:
 
 https://github.com/networkupstools/nut/milestone/8
 
- - Bug fixes for fallout possible due to "fightwarn" effort in 2.8.0:
+ - Bug fixes for fallout possible due to "fightwarn" effort and other
+   evolution in NUT v2.8.0 release:
    * The `upsdebugx()` and similar methods were converted to macros in #685
      to avoid useless data manipulations and requests for logged information,
      whose results would be ignored instantly because the debug level is
@@ -50,6 +51,8 @@ https://github.com/networkupstools/nut/milestone/8
    * A change for file-change detection in `dummy-ups` driver for NUT
      v2.8.0 release misfired on some platforms. Regression fixed for NUT
      v2.8.1 [#1420]
+   * Fixed building of NUT man pages when just a few drivers are selected
+     by `configure` script for custom builds [#1467]
 
  - huawei-ups2000 is now known to support more devices, noted in docs and
    for auto-detection [#1448]
@@ -67,9 +70,6 @@ https://github.com/networkupstools/nut/milestone/8
  - Regular CI coverage for NUT codebase enhanced with CircleCI running some
    scenarios on MacOS, might add Windows in the future. Fixed some build
    issues for MacOS that had crept into NUT v2.8.0 release [#1415, #1421]
-
- - Fixed building of NUT man pages when just a few drivers are selected by
-   `configure` script for custom builds [#1467]
 
  - NUT software-only drivers (dummy-ups, clone, clone-outlet) separated from
    serial drivers in respective Makefile and configure script options [#1446]

--- a/NEWS
+++ b/NEWS
@@ -33,6 +33,9 @@ https://github.com/networkupstools/nut/milestone/8
    scenarios on MacOS, might add Windows in the future. Fixed some build
    issues for MacOS that had crept into NUT v2.8.0 release [#1415, #1421]
 
+ - Fixed building of NUT man pages when just a few drivers are selected by
+   `configure` script for custom builds [#1467]
+
  - NUT software-only drivers (dummy-ups, clone, clone-outlet) separated from
    serial drivers in respective Makefile and configure script options [#1446]
 

--- a/configure.ac
+++ b/configure.ac
@@ -1745,6 +1745,7 @@ AC_DEFINE_UNQUOTED(LOG_FACILITY, ${LOGFACILITY}, [Desired syslog facility - see 
 AC_MSG_RESULT(${LOGFACILITY})
 
 AC_MSG_CHECKING(which driver man pages to install)
+DRIVER_MAN_LIST_PAGES=""
 if test "${WITH_MANS}" = "yes"; then
 	if test "${DRIVER_BUILD_LIST}" = "all"; then
 		DRIVER_MAN_LIST=all
@@ -1752,8 +1753,10 @@ if test "${WITH_MANS}" = "yes"; then
 	else
 		DRIVER_MAN_LIST=""
 		for i in ${DRIVER_BUILD_LIST}; do
-			if test -f ${srcdir}/docs/man/$i.8; then
+		    dnl See if source or pre-generated (tarball) doc file exists:
+			if test -f ${srcdir}/docs/man/$i.txt -o -f ${srcdir}/docs/man/$i.8; then
 				DRIVER_MAN_LIST="${DRIVER_MAN_LIST} $i.8"
+				DRIVER_MAN_LIST_PAGES="${DRIVER_MAN_LIST_PAGES} $i.txt"
 			fi
 		done
 		AC_MSG_RESULT(${DRIVER_MAN_LIST})
@@ -2526,6 +2529,7 @@ AC_SUBST(LIBLTDL_CFLAGS)
 AC_SUBST(LIBLTDL_LIBS)
 AC_SUBST(DRIVER_BUILD_LIST)
 AC_SUBST(DRIVER_MAN_LIST)
+AC_SUBST(DRIVER_MAN_LIST_PAGES)
 AC_SUBST(DRIVER_INSTALL_TARGET)
 AC_SUBST(NETLIBS)
 AC_SUBST(SERLIBS)

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -695,6 +695,14 @@ SRC_DRIVERS_PAGES = \
 	$(SRC_MODBUS_PAGES) \
 	$(SRC_LINUX_I2C_PAGES)
 
+if SOME_DRIVERS
+# The list above probably came up empty in this case, so make sure that
+# the drivers requested by configure script are documented in the build;
+# notably in the linkman-driver-names.txt file.
+SRC_DRIVERS_PAGES += \
+	$(DRIVER_MAN_LIST_PAGES)
+endif
+
 # distribute everything, even those not installed by default
 # Note that 'dist' target requires AsciiDoc!
 SRC_ALL_PAGES = \
@@ -764,6 +772,7 @@ linkman-driver-names.txt:
 	    | sort -n | uniq \
 	    | sed 's,^\(.*\)\.txt$$,- linkman:\1[8],' ; \
 	 ) > "$@"
+	@if test ! -s "$@" ; then echo "- No NUT drivers were built" > "$@" ; fi
 
 linkman-drivertool-names.txt:
 	@if test x"$(srcdir)" != x"$(builddir)" ; then \
@@ -777,6 +786,7 @@ linkman-drivertool-names.txt:
 	    | sort -n | uniq \
 	    | sed 's,^\(.*\)\.txt$$,- linkman:\1[8],' ; \
 	 ) > "$@"
+	@if test ! -s "$@" ; then echo "- No NUT driver tools were built" > "$@" ; fi
 
 # Dependencies are about particular filenames, since over time
 # we might have several use-cases for LINKMAN_INCLUDE_GENERATED:

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 2971 utf-8
+personal_ws-1.1 en 2974 utf-8
 AAS
 ABI
 ACFAIL
@@ -340,6 +340,7 @@ FHS
 FINALDELAY
 FIPS
 FIXME
+FMRI
 FO
 FOREACHUPS
 FPT
@@ -1039,6 +1040,7 @@ SHUTDOWNCMD
 SIG
 SIGHUP
 SIGINT
+SIGKILL
 SIGPIPE
 SIGPWR
 SIGTERM
@@ -2317,6 +2319,7 @@ ol
 oldmac
 oldmge
 oldnut
+omnios
 onbatt
 onbattwarn
 onclick


### PR DESCRIPTION
Regression for custom-builders in NUT 2.8.0 release

Closes: #1467

Thanks: @Kaapeli64 for the finding and suggesting a mostly-correct fix