### PR TITLE
Fix/troubleshoot NIT on slow systems

### DIFF
--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -345,6 +345,7 @@ isPidAlive() {
 }
 
 FAILED=0
+FAILED_FUNCS=""
 PASSED=0
 
 testcase_upsd_no_configs_at_all() {
@@ -354,6 +355,7 @@ testcase_upsd_no_configs_at_all() {
     if [ "$?" = 0 ]; then
         log_error "upsd should fail without configs"
         FAILED="`expr $FAILED + 1`"
+        FAILED_FUNCS="$FAILED_FUNCS testcase_upsd_no_configs_at_all"
     else
         log_info "OK, upsd failed to start in wrong conditions"
         PASSED="`expr $PASSED + 1`"
@@ -368,6 +370,7 @@ testcase_upsd_no_configs_driver_file() {
     if [ "$?" = 0 ]; then
         log_error "upsd should fail without driver config file"
         FAILED="`expr $FAILED + 1`"
+        FAILED_FUNCS="$FAILED_FUNCS testcase_upsd_no_configs_driver_file"
     else
         log_info "OK, upsd failed to start in wrong conditions"
         PASSED="`expr $PASSED + 1`"
@@ -383,6 +386,7 @@ testcase_upsd_no_configs_in_driver_file() {
     if [ "$?" = 0 ]; then
         log_error "upsd should fail without drivers defined in config file"
         FAILED="`expr $FAILED + 1`"
+        FAILED_FUNCS="$FAILED_FUNCS testcase_upsd_no_configs_in_driver_file"
     else
         log_info "OK, upsd failed to start in wrong conditions"
         PASSED="`expr $PASSED + 1`"
@@ -408,6 +412,7 @@ testcase_upsd_allow_no_device() {
         if [ -n "$OUT" ] ; then
             log_error "got reply for upsc listing when none was expected: $OUT"
             FAILED="`expr $FAILED + 1`"
+            FAILED_FUNCS="$FAILED_FUNCS testcase_upsd_allow_no_device"
         else
             log_info "OK, empty response as expected"
             PASSED="`expr $PASSED + 1`"
@@ -415,6 +420,7 @@ testcase_upsd_allow_no_device() {
     else
         log_error "upsd was expected to be running although no devices are defined"
         FAILED="`expr $FAILED + 1`"
+        FAILED_FUNCS="$FAILED_FUNCS testcase_upsd_allow_no_device"
     fi
     kill -15 $PID_UPSD
     wait $PID_UPSD
@@ -513,6 +519,7 @@ UPS2"
     if [ x"$OUT" != x"$EXPECTED_UPSLIST" ] ; then
         log_error "got this reply for upsc listing when '$EXPECTED_UPSLIST' was expected: $OUT"
         FAILED="`expr $FAILED + 1`"
+        FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_start_upsd_alone"
     else
         PASSED="`expr $PASSED + 1`"
     fi
@@ -521,10 +528,12 @@ UPS2"
     OUT="`upsc dummy@localhost:$NUT_PORT 2>&1`" && {
         log_error "upsc was supposed to answer with error exit code: $OUT"
         FAILED="`expr $FAILED + 1`"
+        FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_start_upsd_alone"
     }
     if ! echo "$OUT" | grep 'Error: Driver not connected' ; then
         log_error "got reply for upsc query when 'Error: Driver not connected' was expected: '$OUT'"
         FAILED="`expr $FAILED + 1`"
+        FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_start_upsd_alone"
     else
         PASSED="`expr $PASSED + 1`"
     fi
@@ -593,6 +602,7 @@ testcase_sandbox_upsc_query_model() {
     if [ x"$OUT" != x"Dummy UPS" ] ; then
         log_error "got this reply for upsc query when 'Dummy UPS' was expected: $OUT"
         FAILED="`expr $FAILED + 1`"
+        FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_upsc_query_model"
     else
         PASSED="`expr $PASSED + 1`"
     fi
@@ -603,10 +613,12 @@ testcase_sandbox_upsc_query_bogus() {
     OUT="`upsc dummy@localhost:$NUT_PORT ups.bogus.value 2>&1`" && {
         log_error "upsc was supposed to answer with error exit code: $OUT"
         FAILED="`expr $FAILED + 1`"
+        FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_upsc_query_bogus"
     }
     if ! echo "$OUT" | grep 'Error: Variable not supported by UPS' ; then
         log_error "got reply for upsc query when 'Error: Variable not supported by UPS' was expected: $OUT"
         FAILED="`expr $FAILED + 1`"
+        FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_upsc_query_bogus"
     else
         PASSED="`expr $PASSED + 1`"
     fi
@@ -634,6 +646,7 @@ testcase_sandbox_upsc_query_timer() {
     else
         log_error "ups.status did not flip over time"
         FAILED="`expr $FAILED + 1`"
+        FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_upsc_query_timer"
     fi
 }
 
@@ -660,6 +673,7 @@ testcase_sandbox_python_without_credentials() {
     else
         log_error "PyNUT complained, check above"
         FAILED="`expr $FAILED + 1`"
+        FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_python_without_credentials"
     fi
 }
 
@@ -682,6 +696,7 @@ testcase_sandbox_python_with_credentials() {
     else
         log_error "PyNUT complained, check above"
         FAILED="`expr $FAILED + 1`"
+        FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_python_with_credentials"
     fi
 }
 
@@ -717,6 +732,7 @@ testcase_sandbox_cppnit_without_creds() {
     else
         log_error "cppnit complained, check above"
         FAILED="`expr $FAILED + 1`"
+        FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_cppnit_without_creds"
     fi
 }
 
@@ -744,6 +760,7 @@ testcase_sandbox_cppnit_simple_admin() {
     else
         log_error "cppnit complained, check above"
         FAILED="`expr $FAILED + 1`"
+        FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_cppnit_simple_admin"
     fi
 }
 
@@ -765,6 +782,7 @@ testcase_sandbox_cppnit_upsmon_primary() {
     else
         log_error "cppnit complained, check above"
         FAILED="`expr $FAILED + 1`"
+        FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_cppnit_upsmon_primary"
     fi
 }
 
@@ -786,6 +804,7 @@ testcase_sandbox_cppnit_upsmon_master() {
     else
         log_error "cppnit complained, check above"
         FAILED="`expr $FAILED + 1`"
+        FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_cppnit_upsmon_master"
     fi
 }
 
@@ -848,6 +867,9 @@ esac
 
 log_separator
 log_info "OVERALL: PASSED=$PASSED FAILED=$FAILED"
+if [ -n "$FAILED_FUNCS" ]; then
+    for F in $FAILED_FUNCS ; do echo "$F" ; done | sort | uniq -c
+fi
 
 # Allow to leave the sandbox daemons running for a while,
 # to experiment with them interactively:

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -158,6 +158,8 @@ export NUT_STATEPATH NUT_ALTPIDPATH NUT_CONFPATH
     || NUT_PORT=34931
 }
 export NUT_PORT
+# Help track collisions in log, if someone else starts a test in same directory
+log_info "Using NUT_PORT=${NUT_PORT} for this test run"
 
 ### upsd.conf: ##################################################
 

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -602,7 +602,7 @@ testcase_sandbox_start_drivers_after_upsd() {
         OUT="`upsc dummy@localhost:$NUT_PORT`" \
         && case "$OUT" in
             "ups.status: WAIT") ;;
-            *) echo "$OUT" ; break ;;
+            *) log_info "Got output:" ; echo "$OUT" ; break ;;
         esac
         sleep 1
         COUNTDOWN="`expr $COUNTDOWN - 1`"
@@ -626,7 +626,7 @@ testcase_sandbox_start_drivers_after_upsd() {
             while [ x"$OUT" = x"ups.status: WAIT" ] \
             || ! OUT="`upsc $U@localhost:$NUT_PORT ups.status`" \
             ; do
-                [ x"$OUT" = x"ups.status: WAIT" ] || echo "$OUT"
+                [ x"$OUT" = x"ups.status: WAIT" ] || { log_info "Got output:"; echo "$OUT"; break; }
                 sleep 1
                 COUNTDOWN="`expr $COUNTDOWN - 1`"
                 # Systemic error, e.g. could not create socket file?

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -63,6 +63,9 @@ die() {
     exit 1
 }
 
+# By default, keep stdout hidden but report the errors:
+[ -n "$RUNCMD_QUIET_OUT" ] || RUNCMD_QUIET_OUT=true
+[ -n "$RUNCMD_QUIET_ERR" ] || RUNCMD_QUIET_ERR=false
 runcmd() {
     # Re-uses a couple of files in test scratch area NUT_STATEPATH
     # to store the stderr and stdout of the launched program.
@@ -80,8 +83,8 @@ runcmd() {
     CMDOUT="`cat "${NUT_STATEPATH}/runcmd.out"`"
     CMDERR="`cat "${NUT_STATEPATH}/runcmd.err"`"
 
-    [ "$RUNCMD_QUIET_OUT" = true ] || echo "$CMDOUT"
-    [ "$RUNCMD_QUIET_ERR" = true ] || echo "$CMDERR" >&2
+    [ "$RUNCMD_QUIET_OUT" = true ] || { [ -z "$CMDOUT" ] || echo "$CMDOUT" ; }
+    [ "$RUNCMD_QUIET_ERR" = true ] || { [ -z "$CMDERR" ] || echo "$CMDERR" >&2 ; }
 
     return $CMDRES
 }

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -63,6 +63,29 @@ die() {
     exit 1
 }
 
+runcmd() {
+    # Re-uses a couple of files in test scratch area NUT_STATEPATH
+    # to store the stderr and stdout of the launched program.
+    # Prints the captured output back and returns the exit code.
+
+    [ -n "${NUT_STATEPATH}" -a -d "${NUT_STATEPATH}" -a -w "${NUT_STATEPATH}" ] \
+    || die "runcmd() called when NUT_STATEPATH was not yet set up"
+
+    # Values from variables below may be used until next runcmd():
+    CMDRES=0
+    CMDOUT=""
+    CMDERR=""
+
+    "$@" > "${NUT_STATEPATH}/runcmd.out" 2>"${NUT_STATEPATH}/runcmd.err" || CMDRES=$?
+    CMDOUT="`cat "${NUT_STATEPATH}/runcmd.out"`"
+    CMDERR="`cat "${NUT_STATEPATH}/runcmd.err"`"
+
+    [ "$RUNCMD_QUIET_OUT" = true ] || echo "$CMDOUT"
+    [ "$RUNCMD_QUIET_ERR" = true ] || echo "$CMDERR" >&2
+
+    return $CMDRES
+}
+
 # Note: current directory is assumed to be writeable for temporary
 # data, e.g. the $(builddir) from the Makefile. Static resources
 # from the source codebase are where the script resides, e.g.

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -50,6 +50,10 @@ log_info() {
     echo "[INFO] $@" >&2
 }
 
+log_warn() {
+    echo "[WARNING] $@" >&2
+}
+
 log_error() {
     echo "[ERROR] $@" >&2
 }
@@ -571,6 +575,10 @@ testcase_sandbox_start_drivers_after_upsd() {
         COUNTDOWN="`expr $COUNTDOWN - 1`"
     done
 
+    if [ "$COUNTDOWN" -le 58 ] ; then
+        log_warn "Had to wait a few retries for the dummy driver to connect"
+    fi
+
     if [ "$COUNTDOWN" -le 1 ] ; then
         # Should not get to this, except on very laggy systems maybe
         log_error "Query failed, retrying with UPSD started after drivers"
@@ -591,6 +599,9 @@ testcase_sandbox_start_drivers_after_upsd() {
                 # Systemic error, e.g. could not create socket file?
                 [ "$COUNTDOWN" -lt 1 ] && die "Dummy driver did not start or respond in time"
             done
+            if [ "$COUNTDOWN" -le 58 ] ; then
+                log_warn "Had to wait a few retries for the $U driver to connect"
+            fi
         done
     fi
 

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -408,7 +408,7 @@ testcase_upsd_allow_no_device() {
 
         log_separator
         log_info "Test that UPSD responds to UPSC"
-        OUT="`upsc -l localhost:$NUT_PORT`" || die "upsd does not respond ($?): $OUT"
+        OUT="`upsc -l localhost:$NUT_PORT`" || die "upsd does not respond on port ${NUT_PORT} ($?): $OUT"
         if [ -n "$OUT" ] ; then
             log_error "got reply for upsc listing when none was expected: $OUT"
             FAILED="`expr $FAILED + 1`"
@@ -515,7 +515,7 @@ UPS2"
     fi
 
     log_info "Query listing from UPSD by UPSC (driver not running yet)"
-    OUT="`upsc -l localhost:$NUT_PORT`" || die "upsd does not respond ($?): $OUT"
+    OUT="`upsc -l localhost:$NUT_PORT`" || die "upsd does not respond on port ${NUT_PORT} ($?): $OUT"
     if [ x"$OUT" != x"$EXPECTED_UPSLIST" ] ; then
         log_error "got this reply for upsc listing when '$EXPECTED_UPSLIST' was expected: $OUT"
         FAILED="`expr $FAILED + 1`"
@@ -550,7 +550,7 @@ testcase_sandbox_start_upsd_after_drivers() {
     sandbox_start_upsd
 
     sleep 5
-    upsc dummy@localhost:$NUT_PORT || die "upsd does not respond ($?)"
+    upsc dummy@localhost:$NUT_PORT || die "upsd does not respond on port ${NUT_PORT} ($?)"
 }
 
 testcase_sandbox_start_drivers_after_upsd() {
@@ -598,7 +598,7 @@ testcase_sandbox_start_drivers_after_upsd() {
 }
 
 testcase_sandbox_upsc_query_model() {
-    OUT="`upsc dummy@localhost:$NUT_PORT device.model`" || die "upsd does not respond ($?): $OUT"
+    OUT="`upsc dummy@localhost:$NUT_PORT device.model`" || die "upsd does not respond on port ${NUT_PORT} ($?): $OUT"
     if [ x"$OUT" != x"Dummy UPS" ] ; then
         log_error "got this reply for upsc query when 'Dummy UPS' was expected: $OUT"
         FAILED="`expr $FAILED + 1`"
@@ -628,16 +628,16 @@ testcase_sandbox_upsc_query_timer() {
     log_separator
     log_info "Test that dummy-ups TIMER action changes the reported state"
     # Driver is set up to flip ups.status every 5 sec, so check every 3
-    OUT1="`upsc dummy@localhost:$NUT_PORT ups.status`" || die "upsd does not respond ($?): $OUT1" ; sleep 3
-    OUT2="`upsc dummy@localhost:$NUT_PORT ups.status`" || die "upsd does not respond ($?): $OUT2"
+    OUT1="`upsc dummy@localhost:$NUT_PORT ups.status`" || die "upsd does not respond on port ${NUT_PORT} ($?): $OUT1" ; sleep 3
+    OUT2="`upsc dummy@localhost:$NUT_PORT ups.status`" || die "upsd does not respond on port ${NUT_PORT} ($?): $OUT2"
     OUT3=""
     OUT4=""
     if [ x"$OUT1" = x"$OUT2" ]; then
         sleep 3
-        OUT3="`upsc dummy@localhost:$NUT_PORT ups.status`" || die "upsd does not respond ($?): $OUT3"
+        OUT3="`upsc dummy@localhost:$NUT_PORT ups.status`" || die "upsd does not respond on port ${NUT_PORT} ($?): $OUT3"
         if [ x"$OUT2" = x"$OUT3" ]; then
             sleep 3
-            OUT4="`upsc dummy@localhost:$NUT_PORT ups.status`" || die "upsd does not respond ($?): $OUT4"
+            OUT4="`upsc dummy@localhost:$NUT_PORT ups.status`" || die "upsd does not respond on port ${NUT_PORT} ($?): $OUT4"
         fi
     fi
     if echo "$OUT1$OUT2$OUT3$OUT4" | grep "OB" && echo "$OUT1$OUT2$OUT3$OUT4" | grep "OL" ; then

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -404,7 +404,7 @@ testcase_upsd_allow_no_device() {
 
         log_separator
         log_info "Test that UPSD responds to UPSC"
-        OUT="`upsc -l localhost:$NUT_PORT`" || die "upsd does not respond: $OUT"
+        OUT="`upsc -l localhost:$NUT_PORT`" || die "upsd does not respond ($?): $OUT"
         if [ -n "$OUT" ] ; then
             log_error "got reply for upsc listing when none was expected: $OUT"
             FAILED="`expr $FAILED + 1`"
@@ -509,7 +509,7 @@ UPS2"
     fi
 
     log_info "Query listing from UPSD by UPSC (driver not running yet)"
-    OUT="`upsc -l localhost:$NUT_PORT`" || die "upsd does not respond: $OUT"
+    OUT="`upsc -l localhost:$NUT_PORT`" || die "upsd does not respond ($?): $OUT"
     if [ x"$OUT" != x"$EXPECTED_UPSLIST" ] ; then
         log_error "got this reply for upsc listing when '$EXPECTED_UPSLIST' was expected: $OUT"
         FAILED="`expr $FAILED + 1`"
@@ -541,7 +541,7 @@ testcase_sandbox_start_upsd_after_drivers() {
     sandbox_start_upsd
 
     sleep 5
-    upsc dummy@localhost:$NUT_PORT || die "upsd does not respond"
+    upsc dummy@localhost:$NUT_PORT || die "upsd does not respond ($?)"
 }
 
 testcase_sandbox_start_drivers_after_upsd() {
@@ -573,7 +573,7 @@ testcase_sandbox_start_drivers_after_upsd() {
 }
 
 testcase_sandbox_upsc_query_model() {
-    OUT="`upsc dummy@localhost:$NUT_PORT device.model`" || die "upsd does not respond: $OUT"
+    OUT="`upsc dummy@localhost:$NUT_PORT device.model`" || die "upsd does not respond ($?): $OUT"
     if [ x"$OUT" != x"Dummy UPS" ] ; then
         log_error "got this reply for upsc query when 'Dummy UPS' was expected: $OUT"
         FAILED="`expr $FAILED + 1`"
@@ -600,16 +600,16 @@ testcase_sandbox_upsc_query_timer() {
     log_separator
     log_info "Test that dummy-ups TIMER action changes the reported state"
     # Driver is set up to flip ups.status every 5 sec, so check every 3
-    OUT1="`upsc dummy@localhost:$NUT_PORT ups.status`" || die "upsd does not respond: $OUT1" ; sleep 3
-    OUT2="`upsc dummy@localhost:$NUT_PORT ups.status`" || die "upsd does not respond: $OUT2"
+    OUT1="`upsc dummy@localhost:$NUT_PORT ups.status`" || die "upsd does not respond ($?): $OUT1" ; sleep 3
+    OUT2="`upsc dummy@localhost:$NUT_PORT ups.status`" || die "upsd does not respond ($?): $OUT2"
     OUT3=""
     OUT4=""
     if [ x"$OUT1" = x"$OUT2" ]; then
         sleep 3
-        OUT3="`upsc dummy@localhost:$NUT_PORT ups.status`" || die "upsd does not respond: $OUT3"
+        OUT3="`upsc dummy@localhost:$NUT_PORT ups.status`" || die "upsd does not respond ($?): $OUT3"
         if [ x"$OUT2" = x"$OUT3" ]; then
             sleep 3
-            OUT4="`upsc dummy@localhost:$NUT_PORT ups.status`" || die "upsd does not respond: $OUT4"
+            OUT4="`upsc dummy@localhost:$NUT_PORT ups.status`" || die "upsd does not respond ($?): $OUT4"
         fi
     fi
     if echo "$OUT1$OUT2$OUT3$OUT4" | grep "OB" && echo "$OUT1$OUT2$OUT3$OUT4" | grep "OL" ; then

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -434,10 +434,17 @@ testcase_upsd_allow_no_device() {
         PASSED="`expr $PASSED + 1`"
 
         log_separator
-        log_info "Test that UPSD responds to UPSC"
-        OUT="`upsc -l localhost:$NUT_PORT`" || die "upsd does not respond on port ${NUT_PORT} ($?): $OUT"
-        if [ -n "$OUT" ] ; then
-            log_error "got reply for upsc listing when none was expected: $OUT"
+        log_info "Query listing from UPSD by UPSC (no devices configured yet) to test that UPSD responds to UPSC"
+        if ! runcmd upsc -l localhost:$NUT_PORT ; then
+            if [ "$CMDERR" = "Error: Server disconnected" ]; then
+                log_warn "Retry once to rule out laggy systems"
+                sleep 3
+                runcmd upsc -l localhost:$NUT_PORT
+            fi
+            [ "$CMDRES" = 0 ] || die "upsd does not respond on port ${NUT_PORT} ($?): $CMDOUT"
+        fi
+        if [ -n "$CMDOUT" ] ; then
+            log_error "got reply for upsc listing when none was expected: $CMDOUT"
             FAILED="`expr $FAILED + 1`"
             FAILED_FUNCS="$FAILED_FUNCS testcase_upsd_allow_no_device"
         else


### PR DESCRIPTION
This PR addresses part of issue #1405 to help troubleshoot (and in one situation try to fix) flakiness of the new NUT integration tests.

Empirically, when the NUT CI farm has build storms (e.g. a PR or few have landed, and some got merged, etc.) or the VMs involved are otherwise slow (Fosshost hypervisors overloaded by other projects?), the `make check-NIT` part of the builds tends to randomly fail one or a few times across the build matrix, requiring log investigation by NUT team to make sure the problem was not with contributed codebase.

This is something hard to reproduce otherwise, so the assumption is that the root cause gotta be about timeouts, with ordinarily sub-second operations such as driver start-up, connection to upsd, and responding to queries suddenly taking order(s) of magnitude more wall-clock time.