### PR TITLE
Some more troubleshooting for `make check-NIT`

### DIFF
--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -179,6 +179,7 @@ stop_daemons() {
     if [ -n "$PID_UPSD$PID_DUMMYUPS$PID_DUMMYUPS1$PID_DUMMYUPS2" ] ; then
         log_info "Stopping test daemons"
         kill -15 $PID_UPSD $PID_DUMMYUPS $PID_DUMMYUPS1 $PID_DUMMYUPS2 2>/dev/null
+        wait $PID_UPSD $PID_DUMMYUPS $PID_DUMMYUPS1 $PID_DUMMYUPS2
     fi
 }
 

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -444,6 +444,7 @@ testcase_upsd_allow_no_device() {
     generatecfg_ups_trivial
     upsd -F &
     PID_UPSD="$!"
+    log_debug "Tried to start UPSD as PID $PID_UPSD"
     sleep 2
 
     COUNTDOWN=60
@@ -536,6 +537,7 @@ sandbox_start_upsd() {
     log_info "Starting UPSD for sandbox"
     upsd -F &
     PID_UPSD="$!"
+    log_debug "Tried to start UPSD as PID $PID_UPSD"
     sleep 5
 }
 
@@ -612,8 +614,10 @@ testcase_sandbox_start_upsd_after_drivers() {
     # Historically this is a fallback from testcase_sandbox_start_drivers_after_upsd
     kill -15 $PID_UPSD 2>/dev/null
     wait $PID_UPSD
+
     upsd -F &
     PID_UPSD="$!"
+    log_debug "Tried to start UPSD as PID $PID_UPSD"
 
     sandbox_start_drivers
     sandbox_start_upsd


### PR DESCRIPTION
On some runs there is still a situation where we try to start `upsd` and it logs some messages; however later the expected PID is not seen running (and can't be killed). These commits aim to help in troubleshooting, as well as improve around a possibly related issue.

One wild guess is that if/when `libtool` wrappers are used, the actually launched PID_UPSD is that of a wrapper script, and maybe that one exits/crashes unexpectedly while the daemon works?

Given how the problem happens on random platforms, there may be something else in play (including an OOM killer where relevant? nothing logged in the build consoles about that...)