### PR TITLE
huawei-ups2000.c: rename NULL macros, close #1474.

### DIFF
--- a/drivers/huawei-ups2000.c
+++ b/drivers/huawei-ups2000.c
@@ -1422,7 +1422,8 @@ static int ups2000_delay_set(const char *var, const char *string)
  * used to handle commands that needs additional processing.
  * If "reg1" is not necessary or unsuitable, "-1" is used.
  */
-#define REG_NONE -1, -1
+#define REG_NULL  -1, -1
+#define FUNC_NULL NULL
 
 static struct ups2000_cmd_t {
 	const char *cmd;
@@ -1430,20 +1431,20 @@ static struct ups2000_cmd_t {
 	int (*const handler_func)(const uint16_t);
 } ups2000_cmd[] =
 {
-	{ "test.battery.start.quick", 2028,  1, REG_NONE, NULL },
-	{ "test.battery.start.deep",  2021,  1, REG_NONE, NULL },
-	{ "test.battery.stop",        2023,  1, REG_NONE, NULL },
-	{ "beeper.enable",            1046,  0, REG_NONE, NULL },
-	{ "beeper.disable",           1046,  1, REG_NONE, NULL },
-	{ "load.off",                 1045,  0, 1030, 1,  NULL },
-	{ "bypass.stop",              1029,  1, 1045, 0,  NULL },
-	{ "load.on",                  1029, -1, REG_NONE, ups2000_instcmd_load_on                  },
-	{ "bypass.start",             REG_NONE, REG_NONE, ups2000_instcmd_bypass_start             },
-	{ "beeper.toggle",            1046, -1, REG_NONE, ups2000_instcmd_beeper_toggle            },
-	{ "shutdown.stayoff",         1049, -1, REG_NONE, ups2000_instcmd_shutdown_stayoff         },
-	{ "shutdown.return",          REG_NONE, REG_NONE, ups2000_instcmd_shutdown_return          },
-	{ "shutdown.reboot",          REG_NONE, REG_NONE, ups2000_instcmd_shutdown_reboot          },
-	{ "shutdown.reboot.graceful", REG_NONE, REG_NONE, ups2000_instcmd_shutdown_reboot_graceful },
+	{ "test.battery.start.quick", 2028,  1, REG_NULL, FUNC_NULL },
+	{ "test.battery.start.deep",  2021,  1, REG_NULL, FUNC_NULL },
+	{ "test.battery.stop",        2023,  1, REG_NULL, FUNC_NULL },
+	{ "beeper.enable",            1046,  0, REG_NULL, FUNC_NULL },
+	{ "beeper.disable",           1046,  1, REG_NULL, FUNC_NULL },
+	{ "load.off",                 1045,  0, 1030, 1,  FUNC_NULL },
+	{ "bypass.stop",              1029,  1, 1045, 0,  FUNC_NULL },
+	{ "load.on",                  1029, -1, REG_NULL, ups2000_instcmd_load_on                  },
+	{ "bypass.start",             REG_NULL, REG_NULL, ups2000_instcmd_bypass_start             },
+	{ "beeper.toggle",            1046, -1, REG_NULL, ups2000_instcmd_beeper_toggle            },
+	{ "shutdown.stayoff",         1049, -1, REG_NULL, ups2000_instcmd_shutdown_stayoff         },
+	{ "shutdown.return",          REG_NULL, REG_NULL, ups2000_instcmd_shutdown_return          },
+	{ "shutdown.reboot",          REG_NULL, REG_NULL, ups2000_instcmd_shutdown_reboot          },
+	{ "shutdown.reboot.graceful", REG_NULL, REG_NULL, ups2000_instcmd_shutdown_reboot_graceful },
 	{ NULL, -1, -1, -1, -1, NULL },
 };
 


### PR DESCRIPTION
Originally, in the struct array `ups2000_cmd[]`, a `REG_NONE` macro was used as a short-hand for a nonexistent register value. Unfortunately it was in conflict with a Windows NT macro of the same name (previously not found because it was only tested on Unix systems). Thus, this commit renames it to `REG_NULL`. To avoid visual confusions with the function pointer field (which also uses C's NULL for its nonexistence), this commit also replaces it with a new macro `FUNC_NULL`, which is a simple alias to C's `NULL`.

It's not exactly the best practice, a `UPS2000_` prefix should've been used in principle. However, using it in this case creates exceedingly long lines and makes the struct array definition more difficult to read, which defeats the very purpose of defining these macros to begin with. Considering that it's only an one-off use, it's unlikely to cause further problems.

This PR closes #1474.