### PR TITLE
Standardize use of `PRI[xuid](MAX|SIZE)` macros instead of `%j*` and `%z*`

### DIFF
--- a/clients/nutclient.cpp
+++ b/clients/nutclient.cpp
@@ -60,6 +60,8 @@ static inline void *xrealloc(void *ptr, size_t size){return realloc(ptr, size);}
 static inline char *xstrdup(const char *string){return strdup(string);}
 #endif /* HAVE_NUTCOMMON */
 
+#include "nut_stdint.h" /* PRIuMAX etc. */
+
 /* To stay in line with modern C++, we use nullptr (not numeric NULL
  * or shim __null on some systems) which was defined after C++98.
  * The NUT C++ interface is intended for C++11 and newer, so we
@@ -186,7 +188,7 @@ void Socket::connect(const std::string& host, uint16_t port)
 		throw nut::UnknownHostException();
 	}
 
-	snprintf(sport, sizeof(sport), "%ju", static_cast<uintmax_t>(port));
+	snprintf(sport, sizeof(sport), "%" PRIuMAX, static_cast<uintmax_t>(port));
 
 	memset(&hints, 0, sizeof(hints));
 	hints.ai_family = AF_UNSPEC;

--- a/clients/upsc.c
+++ b/clients/upsc.c
@@ -87,7 +87,7 @@ static void printvar(const char *var)
 	}
 
 	if (numa < numq) {
-		fatalx(EXIT_FAILURE, "Error: insufficient data (got %zu args, need at least %zu)", numa, numq);
+		fatalx(EXIT_FAILURE, "Error: insufficient data (got %" PRIuSIZE " args, need at least %" PRIuSIZE ")", numa, numq);
 	}
 
 	printf("%s\n", answer[3]);
@@ -120,7 +120,7 @@ static void list_vars(void)
 
 		/* VAR <upsname> <varname> <val> */
 		if (numa < 4) {
-			fatalx(EXIT_FAILURE, "Error: insufficient data (got %zu args, need at least 4)", numa);
+			fatalx(EXIT_FAILURE, "Error: insufficient data (got %" PRIuSIZE " args, need at least 4)", numa);
 		}
 
 		printf("%s: %s\n", answer[2], answer[3]);
@@ -152,7 +152,7 @@ static void list_upses(int verbose)
 
 		/* UPS <upsname> <description> */
 		if (numa < 3) {
-			fatalx(EXIT_FAILURE, "Error: insufficient data (got %zu args, need at least 3)", numa);
+			fatalx(EXIT_FAILURE, "Error: insufficient data (got %" PRIuSIZE " args, need at least 3)", numa);
 		}
 
 		if(verbose) {
@@ -189,7 +189,7 @@ static void list_clients(const char *devname)
 
 		/* CLIENT <upsname> <address> */
 		if (numa < 3) {
-			fatalx(EXIT_FAILURE, "Error: insufficient data (got %zu args, need at least 3)", numa);
+			fatalx(EXIT_FAILURE, "Error: insufficient data (got %" PRIuSIZE " args, need at least 3)", numa);
 		}
 
 		printf("%s\n", answer[2]);

--- a/clients/upsclient.c
+++ b/clients/upsclient.c
@@ -168,7 +168,7 @@ static int ssl_error(SSL *ssl, ssize_t ret)
 	int	e;
 
 	if (ret >= INT_MAX) {
-		upslogx(LOG_ERR, "ssl_error() ret=%zd would not fit in an int", ret);
+		upslogx(LOG_ERR, "ssl_error() ret=%" PRIiSIZE " would not fit in an int", ret);
 		return -1;
 	}
 	e = SSL_get_error(ssl, (int)ret);
@@ -176,23 +176,23 @@ static int ssl_error(SSL *ssl, ssize_t ret)
 	switch (e)
 	{
 	case SSL_ERROR_WANT_READ:
-		upslogx(LOG_ERR, "ssl_error() ret=%zd SSL_ERROR_WANT_READ", ret);
+		upslogx(LOG_ERR, "ssl_error() ret=%" PRIiSIZE " SSL_ERROR_WANT_READ", ret);
 		break;
 
 	case SSL_ERROR_WANT_WRITE:
-		upslogx(LOG_ERR, "ssl_error() ret=%zd SSL_ERROR_WANT_WRITE", ret);
+		upslogx(LOG_ERR, "ssl_error() ret=%" PRIiSIZE " SSL_ERROR_WANT_WRITE", ret);
 		break;
 
 	case SSL_ERROR_SYSCALL:
 		if (ret == 0 && ERR_peek_error() == 0) {
 			upslogx(LOG_ERR, "ssl_error() EOF from client");
 		} else {
-			upslogx(LOG_ERR, "ssl_error() ret=%zd SSL_ERROR_SYSCALL", ret);
+			upslogx(LOG_ERR, "ssl_error() ret=%" PRIiSIZE " SSL_ERROR_SYSCALL", ret);
 		}
 		break;
 
 	default:
-		upslogx(LOG_ERR, "ssl_error() ret=%zd SSL_ERROR %d", ret, e);
+		upslogx(LOG_ERR, "ssl_error() ret=%" PRIiSIZE " SSL_ERROR %d", ret, e);
 		ssl_debug();
 	}
 

--- a/clients/upsclient.c
+++ b/clients/upsclient.c
@@ -974,7 +974,7 @@ int upscli_tryconnect(UPSCONN_t *ups, const char *host, uint16_t port, int flags
 		return -1;
 	}
 
-	snprintf(sport, sizeof(sport), "%ju", (uintmax_t)port);
+	snprintf(sport, sizeof(sport), "%" PRIuMAX, (uintmax_t)port);
 
 	memset(&hints, 0, sizeof(hints));
 

--- a/clients/upscmd.c
+++ b/clients/upscmd.c
@@ -113,7 +113,7 @@ static void listcmds(void)
 
 		/* CMD <upsname> <cmdname> */
 		if (numa < 3) {
-			fatalx(EXIT_FAILURE, "Error: insufficient data (got %zu args, need at least 3)", numa);
+			fatalx(EXIT_FAILURE, "Error: insufficient data (got %" PRIuSIZE " args, need at least 3)", numa);
 		}
 
 		/* we must first read the entire list of commands,

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -638,7 +638,7 @@ static int get_var(utype_t *ups, const char *var, char *buf, size_t bufsize)
 
 	if (numa < numq) {
 		upslogx(LOG_ERR, "%s: Error: insufficient data "
-			"(got %zu args, need at least %zu)",
+			"(got %" PRIuSIZE " args, need at least %" PRIuSIZE ")",
 			var, numa, numq);
 		return -1;
 	}

--- a/clients/upsrw.c
+++ b/clients/upsrw.c
@@ -397,7 +397,7 @@ static void do_enum(const char *varname, const int vartype, const long len)
 		/* ENUM <upsname> <varname> <value> */
 
 		if (numa < 4) {
-			fatalx(EXIT_FAILURE, "Error: insufficient data (got %zu args, need at least 4)", numa);
+			fatalx(EXIT_FAILURE, "Error: insufficient data (got %" PRIuSIZE " args, need at least 4)", numa);
 		}
 
 		printf("Option: \"%s\"", answer[3]);
@@ -450,7 +450,7 @@ static void do_range(const char *varname)
 		/* RANGE <upsname> <varname> <min> <max> */
 
 		if (numa < 5) {
-			fatalx(EXIT_FAILURE, "Error: insufficient data (got %zu args, need at least 4)", numa);
+			fatalx(EXIT_FAILURE, "Error: insufficient data (got %" PRIuSIZE " args, need at least 4)", numa);
 		}
 
 		min = atoi(answer[3]);
@@ -593,7 +593,7 @@ static void print_rwlist(void)
 
 		/* RW <upsname> <varname> <value> */
 		if (numa < 4) {
-			fatalx(EXIT_FAILURE, "Error: insufficient data (got %zu args, need at least 4)", numa);
+			fatalx(EXIT_FAILURE, "Error: insufficient data (got %" PRIuSIZE " args, need at least 4)", numa);
 		}
 
 		/* sock this entry away for later */

--- a/clients/upssched.c
+++ b/clients/upssched.c
@@ -479,7 +479,7 @@ static void log_unknown(size_t numarg, char **arg)
 	upslogx(LOG_INFO, "Unknown command on socket: ");
 
 	for (i = 0; i < numarg; i++)
-		upslogx(LOG_INFO, "arg %zu: %s", i, arg[i]);
+		upslogx(LOG_INFO, "arg %" PRIuSIZE ": %s", i, arg[i]);
 }
 
 static int sock_read(conn_t *conn)

--- a/clients/upsset.c
+++ b/clients/upsset.c
@@ -411,7 +411,7 @@ static void showcmds(void)
 		/* CMD upsname cmdname */
 		if (numa < 3) {
 			fprintf(stderr, "Error: insufficient data "
-				"(got %zu args, need at least 3)\n", numa);
+				"(got %" PRIuSIZE " args, need at least 3)\n", numa);
 
 			return;
 		}
@@ -698,7 +698,7 @@ static void do_enum(const char *varname)
 
 		if (numa < 4) {
 			fprintf(stderr, "Error: insufficient data "
-				"(got %zu args, need at least 4)\n", numa);
+				"(got %" PRIuSIZE " args, need at least 4)\n", numa);
 
 			free(val);
 			return;

--- a/common/common.c
+++ b/common/common.c
@@ -295,8 +295,8 @@ void writepid(const char *name)
 
 	if (pidf) {
 		intmax_t pid = (intmax_t)getpid();
-		upsdebugx(1, "Saving PID %jd into %s", pid, fn);
-		fprintf(pidf, "%jd\n", pid);
+		upsdebugx(1, "Saving PID %" PRIdMAX " into %s", pid, fn);
+		fprintf(pidf, "%" PRIdMAX "\n", pid);
 		fclose(pidf);
 	} else {
 		upslog_with_errno(LOG_NOTICE, "writepid: fopen %s", fn);

--- a/common/common.c
+++ b/common/common.c
@@ -588,8 +588,8 @@ void check_unix_socket_filename(const char *fn) {
 	 */
 	fatalx(EXIT_FAILURE,
 		"Can't create a unix domain socket: pathname '%s' "
-		"is too long (%zu) for 'struct sockaddr_un->sun_path' "
-		"on this system (%zu)",
+		"is too long (%" PRIuSIZE ") for 'struct sockaddr_un->sun_path' "
+		"on this system (%" PRIuSIZE ")",
 		fn, strlen(fn), sizeof(ssaddr.sun_path));
 }
 
@@ -728,7 +728,7 @@ void s_upsdebug_hex(int level, const char *msg, const void *buf, size_t len)
 	int n;	/* number of characters currently in line */
 	size_t i;	/* number of bytes output from buffer */
 
-	n = snprintf(line, sizeof(line), "%s: (%zu bytes) =>", msg, len);
+	n = snprintf(line, sizeof(line), "%s: (%" PRIuSIZE " bytes) =>", msg, len);
 	if (n < 0) goto failed;
 
 	for (i = 0; i < len; i++) {

--- a/drivers/al175.c
+++ b/drivers/al175.c
@@ -891,7 +891,7 @@ static int recv_register_data(io_head_t *io, raw_data_t *io_buf)
 
 	reply_head.begin -= 1;  /* restore STX */
 
-	upsdebugx(4, "\t\t--> addr: 0x%" PRIxSIZE "  len: 0x%" PRIxSIZE "", io->addr, io->len);
+	upsdebugx(4, "\t\t--> addr: 0x%" PRIxSIZE "  len: 0x%" PRIxSIZE, io->addr, io->len);
 
 	/* 4:  allocate space for full reply and copy header there */
 	reply = raw_xmalloc(11/*head*/ + io->len/*data*/ + 2/*ETX BCC*/);

--- a/drivers/al175.c
+++ b/drivers/al175.c
@@ -518,7 +518,7 @@ static int al_parse_reply_head(io_head_t *io, const raw_data_t raw_reply_head)
 	}
 
 	if (io_len > IO_LEN_MAX) {
-		upsdebugx(3, "nob too big\t(%zu > %i)", io_len, IO_LEN_MAX);
+		upsdebugx(3, "nob too big\t(%" PRIuSIZE " > %i)", io_len, IO_LEN_MAX);
 		return -1;		/* too much data claimed */
 	}
 
@@ -572,7 +572,7 @@ static int al_parse_reply(io_head_t *io_head, raw_data_t *io_buf, /*const*/ raw_
 	reply = raw_reply.begin - 1;
 
 	if ( (raw_reply.end - raw_reply.begin) != (ptrdiff_t)(10 + io_head->len))  {
-		upsdebugx(3, "%s: corrupt sentence\t(%i != %zi)",
+		upsdebugx(3, "%s: corrupt sentence\t(%i != %" PRIiSIZE ")",
 				__func__, (int)(raw_reply.end - raw_reply.begin), 10 + io_head->len);
 		return -1;		/* corrupt sentence	*/
 	}
@@ -580,7 +580,7 @@ static int al_parse_reply(io_head_t *io_head, raw_data_t *io_buf, /*const*/ raw_
 
 	/* extract the data */
 	if (io_buf->buf_size < io_head->len)	{
-		upsdebugx(3, "%s: too much data to fit in io_buf\t(%zu > %zu)",
+		upsdebugx(3, "%s: too much data to fit in io_buf\t(%" PRIuSIZE " > %" PRIuSIZE ")",
 				__func__, io_head->len, io_buf->buf_size);
 		return -1;		/* too much data to fit in io_buf	*/
 	}
@@ -891,7 +891,7 @@ static int recv_register_data(io_head_t *io, raw_data_t *io_buf)
 
 	reply_head.begin -= 1;  /* restore STX */
 
-	upsdebugx(4, "\t\t--> addr: 0x%zx  len: 0x%zx", io->addr, io->len);
+	upsdebugx(4, "\t\t--> addr: 0x%" PRIxSIZE "  len: 0x%" PRIxSIZE "", io->addr, io->len);
 
 	/* 4:  allocate space for full reply and copy header there */
 	reply = raw_xmalloc(11/*head*/ + io->len/*data*/ + 2/*ETX BCC*/);
@@ -905,7 +905,7 @@ static int recv_register_data(io_head_t *io, raw_data_t *io_buf)
 	/* 5:  receive tail of the frame */
 	err = get_buf(reply.end, io->len + 2);
 	if (err!=(int)(io->len+2)) {
-		upsdebugx(4, "rx_tail failed, err=%zi (!= %zi)", err, io->len+2);
+		upsdebugx(4, "rx_tail failed, err=%" PRIiSIZE " (!= %" PRIiSIZE ")", err, io->len+2);
 		ret = -1; goto out;
 	}
 
@@ -1005,7 +1005,7 @@ static int al175_read(byte_t *dst, size_t addr, size_t count)
 		return -1;
 
 	if ( (io.addr != addr) || (io.len != count) ) {
-		upsdebugx(3, "%s: io_head mismatch\t(%zx,%zx != %zx,%zx)",
+		upsdebugx(3, "%s: io_head mismatch\t(%" PRIxSIZE ",%" PRIxSIZE " != %" PRIxSIZE ",%" PRIxSIZE ")",
 				__func__, io.addr, io.len, addr, count);
 		return -1;
 	}

--- a/drivers/apcsmart.c
+++ b/drivers/apcsmart.c
@@ -1550,7 +1550,7 @@ static int sdcmd_AT(const void *str)
 	/* Range-check: padto is 2 or 3 per above */
 	if (ret != (ssize_t)padto + 1) {
 		upslogx(LOG_ERR,
-			"issuing [%s] with %zu digits failed",
+			"issuing [%s] with %" PRIuSIZE " digits failed",
 			prtchr(APC_CMD_GRACEDOWN), padto);
 		return STAT_INSTCMD_FAILED;
 	}

--- a/drivers/bcmxcp.c
+++ b/drivers/bcmxcp.c
@@ -794,11 +794,11 @@ bool_t init_command(int size)
 
 		res = answer[iIndex];
 		NumComms = (int)res; /* Number of commands implemented in this UPS */
-		upsdebugx(3, "Number of commands implemented in ups %" PRIiSIZE "", res);
+		upsdebugx(3, "Number of commands implemented in ups %" PRIiSIZE, res);
 		iIndex++;
 		res = answer[iIndex]; /* Entry length - bytes reported for each command */
 		iIndex++;
-		upsdebugx(5, "bytes per command %" PRIiSIZE "", res);
+		upsdebugx(5, "bytes per command %" PRIiSIZE, res);
 
 		/* In case of debug - make explanation of values */
 		upsdebugx(2, "Index\tCmd byte\tDescription");
@@ -1043,7 +1043,7 @@ unsigned char init_outlet(unsigned char len)
 	if (res <= 0)
 		fatal_with_errno(EXIT_FAILURE, "Could not communicate with the ups");
 	else
-		upsdebugx(1, "init_outlet(%i), res=%" PRIiSIZE "", len, res);
+		upsdebugx(1, "init_outlet(%i), res=%" PRIiSIZE, len, res);
 
 	num_outlet = answer[iIndex++];
 	upsdebugx(2, "Number of outlets: %u", num_outlet);

--- a/drivers/bcmxcp.c
+++ b/drivers/bcmxcp.c
@@ -794,11 +794,11 @@ bool_t init_command(int size)
 
 		res = answer[iIndex];
 		NumComms = (int)res; /* Number of commands implemented in this UPS */
-		upsdebugx(3, "Number of commands implemented in ups %zd", res);
+		upsdebugx(3, "Number of commands implemented in ups %" PRIiSIZE "", res);
 		iIndex++;
 		res = answer[iIndex]; /* Entry length - bytes reported for each command */
 		iIndex++;
-		upsdebugx(5, "bytes per command %zd", res);
+		upsdebugx(5, "bytes per command %" PRIiSIZE "", res);
 
 		/* In case of debug - make explanation of values */
 		upsdebugx(2, "Index\tCmd byte\tDescription");
@@ -1043,7 +1043,7 @@ unsigned char init_outlet(unsigned char len)
 	if (res <= 0)
 		fatal_with_errno(EXIT_FAILURE, "Could not communicate with the ups");
 	else
-		upsdebugx(1, "init_outlet(%i), res=%zi", len, res);
+		upsdebugx(1, "init_outlet(%i), res=%" PRIiSIZE "", len, res);
 
 	num_outlet = answer[iIndex++];
 	upsdebugx(2, "Number of outlets: %u", num_outlet);
@@ -1564,11 +1564,11 @@ void upsdrv_initinfo(void)
 		len = init_outlet((unsigned char)outlet_block_len /* arg ignored */);
 
 		for (res = 1 ; (unsigned int)res <= (unsigned int)len ; res++) {
-			snprintf(outlet_name, sizeof(outlet_name) - 1, "outlet.%zd.shutdown.return", res);
+			snprintf(outlet_name, sizeof(outlet_name) - 1, "outlet.%" PRIiSIZE ".shutdown.return", res);
 			dstate_addcmd(outlet_name);
-			snprintf(outlet_name, sizeof(outlet_name) - 1, "outlet.%zd.load.on", res);
+			snprintf(outlet_name, sizeof(outlet_name) - 1, "outlet.%" PRIiSIZE ".load.on", res);
 			dstate_addcmd(outlet_name);
-			snprintf(outlet_name, sizeof(outlet_name) - 1, "outlet.%zd.load.off", res);
+			snprintf(outlet_name, sizeof(outlet_name) - 1, "outlet.%" PRIiSIZE ".load.off", res);
 			dstate_addcmd(outlet_name);
 		}
 	}

--- a/drivers/bcmxcp_ser.c
+++ b/drivers/bcmxcp_ser.c
@@ -184,7 +184,7 @@ ssize_t get_answer(unsigned char *data, unsigned char command)
 		/* Try to read all the remaining bytes */
 		res = ser_get_buf_len(upsfd, my_buf + 4, length, 1, 0);
 		if (res < 0) {
-			ser_comm_fail("%s(): ser_get_buf_len() returned error code %" PRIiSIZE "", __func__, res);
+			ser_comm_fail("%s(): ser_get_buf_len() returned error code %" PRIiSIZE, __func__, res);
 			return res;
 		}
 
@@ -397,11 +397,11 @@ static void pw_comm_setup(const char *port)
 		}
 
 		if (ret > 0) {
-			upslogx(LOG_INFO, "Connected to UPS on %s with baudrate %" PRIuSIZE "", port, pw_baud_rates[i].name);
+			upslogx(LOG_INFO, "Connected to UPS on %s with baudrate %" PRIuSIZE, port, pw_baud_rates[i].name);
 			return;
 		}
 
-		upsdebugx(2, "No response from UPS on %s with baudrate %" PRIuSIZE "", port, pw_baud_rates[i].name);
+		upsdebugx(2, "No response from UPS on %s with baudrate %" PRIuSIZE, port, pw_baud_rates[i].name);
 	}
 
 	fatalx(EXIT_FAILURE, "Can't connect to the UPS on port %s!\n", port);

--- a/drivers/bcmxcp_ser.c
+++ b/drivers/bcmxcp_ser.c
@@ -102,7 +102,7 @@ ssize_t get_answer(unsigned char *data, unsigned char command)
 
 			if (res != 1) {
 				upsdebugx(1,
-					"Receive error (PW_COMMAND_START_BYTE): %zd, cmd=%x!!!\n",
+					"Receive error (PW_COMMAND_START_BYTE): %" PRIiSIZE ", cmd=%x!!!\n",
 					res, command);
 				return -1;
 			}
@@ -120,7 +120,7 @@ ssize_t get_answer(unsigned char *data, unsigned char command)
 		res = ser_get_char(upsfd, my_buf + 1, 1, 0);
 
 		if (res != 1) {
-			ser_comm_fail("Receive error (Block number): %zd!!!\n", res);
+			ser_comm_fail("Receive error (Block number): %" PRIiSIZE "!!!\n", res);
 			return -1;
 		}
 
@@ -149,14 +149,14 @@ ssize_t get_answer(unsigned char *data, unsigned char command)
 		res = ser_get_char(upsfd, my_buf + 2, 1, 0);
 
 		if (res != 1) {
-			ser_comm_fail("Receive error (length): %zd!!!\n", res);
+			ser_comm_fail("Receive error (length): %" PRIiSIZE "!!!\n", res);
 			return -1;
 		}
 
 		length = (unsigned char)my_buf[2];
 
 		if (length < 1) {
-			ser_comm_fail("Receive error (length): packet length %zx!!!\n", length);
+			ser_comm_fail("Receive error (length): packet length %" PRIxSIZE "!!!\n", length);
 			return -1;
 		}
 
@@ -164,7 +164,7 @@ ssize_t get_answer(unsigned char *data, unsigned char command)
 		res = ser_get_char(upsfd, my_buf + 3, 1, 0);
 
 		if (res != 1) {
-			ser_comm_fail("Receive error (sequence): %zd!!!\n", res);
+			ser_comm_fail("Receive error (sequence): %" PRIiSIZE "!!!\n", res);
 			return -1;
 		}
 
@@ -184,12 +184,12 @@ ssize_t get_answer(unsigned char *data, unsigned char command)
 		/* Try to read all the remaining bytes */
 		res = ser_get_buf_len(upsfd, my_buf + 4, length, 1, 0);
 		if (res < 0) {
-			ser_comm_fail("%s(): ser_get_buf_len() returned error code %zd", __func__, res);
+			ser_comm_fail("%s(): ser_get_buf_len() returned error code %" PRIiSIZE "", __func__, res);
 			return res;
 		}
 
 		if ((size_t)res != length) {
-			ser_comm_fail("Receive error (data): got %zd bytes instead of %zu!!!\n", res, length);
+			ser_comm_fail("Receive error (data): got %" PRIiSIZE " bytes instead of %" PRIuSIZE "!!!\n", res, length);
 			return -1;
 		}
 
@@ -197,7 +197,7 @@ ssize_t get_answer(unsigned char *data, unsigned char command)
 		res = ser_get_char(upsfd, my_buf + (4 + length), 1, 0);
 
 		if (res != 1) {
-			ser_comm_fail("Receive error (checksum): %zx!!!\n", res);
+			ser_comm_fail("Receive error (checksum): %" PRIxSIZE "!!!\n", res);
 			return -1;
 		}
 
@@ -397,11 +397,11 @@ static void pw_comm_setup(const char *port)
 		}
 
 		if (ret > 0) {
-			upslogx(LOG_INFO, "Connected to UPS on %s with baudrate %zu", port, pw_baud_rates[i].name);
+			upslogx(LOG_INFO, "Connected to UPS on %s with baudrate %" PRIuSIZE "", port, pw_baud_rates[i].name);
 			return;
 		}
 
-		upsdebugx(2, "No response from UPS on %s with baudrate %zu", port, pw_baud_rates[i].name);
+		upsdebugx(2, "No response from UPS on %s with baudrate %" PRIuSIZE "", port, pw_baud_rates[i].name);
 	}
 
 	fatalx(EXIT_FAILURE, "Can't connect to the UPS on port %s!\n", port);

--- a/drivers/bcmxcp_usb.c
+++ b/drivers/bcmxcp_usb.c
@@ -243,7 +243,7 @@ ssize_t get_answer(unsigned char *data, unsigned char command)
 
 		/* Check data length byte (remove the header length) */
 		length = my_buf[2];
-		upsdebugx(3, "get_answer: data length = %" PRIuSIZE "", length);
+		upsdebugx(3, "get_answer: data length = %" PRIuSIZE, length);
 		if (bytes_read < (length + PW_HEADER_SIZE)) {
 			if (need_data < 0) --need_data; /* count zerro byte too */
 			need_data += length + 1; /* packet lenght + checksum */
@@ -305,7 +305,7 @@ ssize_t get_answer(unsigned char *data, unsigned char command)
 		else if (tail == 0)
 			my_buf = &buf[0];
 		else { /* if (tail < 0) */
-			upsdebugx(1, "get_answer(): did not expect to get negative tail size: %" PRIiSIZE "", tail);
+			upsdebugx(1, "get_answer(): did not expect to get negative tail size: %" PRIiSIZE, tail);
 			return -1;
 		}
 

--- a/drivers/bcmxcp_usb.c
+++ b/drivers/bcmxcp_usb.c
@@ -243,7 +243,7 @@ ssize_t get_answer(unsigned char *data, unsigned char command)
 
 		/* Check data length byte (remove the header length) */
 		length = my_buf[2];
-		upsdebugx(3, "get_answer: data length = %zu", length);
+		upsdebugx(3, "get_answer: data length = %" PRIuSIZE "", length);
 		if (bytes_read < (length + PW_HEADER_SIZE)) {
 			if (need_data < 0) --need_data; /* count zerro byte too */
 			need_data += length + 1; /* packet lenght + checksum */
@@ -305,7 +305,7 @@ ssize_t get_answer(unsigned char *data, unsigned char command)
 		else if (tail == 0)
 			my_buf = &buf[0];
 		else { /* if (tail < 0) */
-			upsdebugx(1, "get_answer(): did not expect to get negative tail size: %zd", tail);
+			upsdebugx(1, "get_answer(): did not expect to get negative tail size: %" PRIiSIZE "", tail);
 			return -1;
 		}
 

--- a/drivers/belkin.c
+++ b/drivers/belkin.c
@@ -26,6 +26,7 @@
 #include "main.h"
 #include "serial.h"
 #include "belkin.h"
+#include "nut_stdint.h"
 
 #define DRIVER_NAME	"Belkin Smart protocol driver"
 #define DRIVER_VERSION	"0.25"

--- a/drivers/belkin.c
+++ b/drivers/belkin.c
@@ -120,7 +120,7 @@ static ssize_t get_belkin_reply(char *buf)
 	ret = ser_get_buf_len(upsfd, (unsigned char *)tmp, 7, 2, 0);
 
 	if (ret != 7) {
-		ser_comm_fail("Initial read returned %zd bytes", ret);
+		ser_comm_fail("Initial read returned %" PRIiSIZE " bytes", ret);
 		return -1;
 	}
 
@@ -147,7 +147,7 @@ static ssize_t get_belkin_reply(char *buf)
 	upsdebugx(3, "Received: %s", buf);
 
 	if (ret != cnt) {
-		ser_comm_fail("Second read returned %zd bytes, expected %ld", ret, cnt);
+		ser_comm_fail("Second read returned %" PRIiSIZE " bytes, expected %ld", ret, cnt);
 		return -1;
 	}
 
@@ -168,7 +168,7 @@ static ssize_t do_broken_rat(char *buf)
 	ret = ser_get_buf_len(upsfd, (unsigned char *)tmp, 7, 2, 0);
 
 	if (ret != 7) {
-		ser_comm_fail("Initial read returned %zd bytes", ret);
+		ser_comm_fail("Initial read returned %" PRIiSIZE " bytes", ret);
 		return -1;
 	}
 
@@ -200,7 +200,7 @@ static ssize_t do_broken_rat(char *buf)
 	upsdebugx(3, "Received: %s", buf);
 
 	if (ret != cnt) {
-		ser_comm_fail("Second read returned %zd bytes, expected %ld", ret, cnt);
+		ser_comm_fail("Second read returned %" PRIiSIZE " bytes, expected %ld", ret, cnt);
 		return -1;
 	}
 

--- a/drivers/bestfortress.c
+++ b/drivers/bestfortress.c
@@ -263,7 +263,7 @@ void upsdrv_updateinfo(void)
 			}
 		} while (temp[2] == 0);
 
-		upsdebugx(1, "upsdrv_updateinfo: received %zi bytes (try %i)", recv, retry);
+		upsdebugx(1, "upsdrv_updateinfo: received %" PRIiSIZE " bytes (try %i)", recv, retry);
 		upsdebug_hex(5, "buffer", temp, (size_t)recv);
 
 		/* syslog (LOG_DAEMON | LOG_NOTICE,"ups: got %d chars '%s'\n", recv, temp + 2); */

--- a/drivers/bestups.c
+++ b/drivers/bestups.c
@@ -353,13 +353,13 @@ void upsdrv_updateinfo(void)
 	}
 
 	if (ret < 46) {
-		ser_comm_fail("Poll failed: short read (got %zd bytes)", ret);
+		ser_comm_fail("Poll failed: short read (got %" PRIiSIZE " bytes)", ret);
 		dstate_datastale();
 		return;
 	}
 
 	if (ret > 46) {
-		ser_comm_fail("Poll failed: response too long (got %zd bytes)",
+		ser_comm_fail("Poll failed: response too long (got %" PRIiSIZE " bytes)",
 			ret);
 		dstate_datastale();
 		return;

--- a/drivers/bestups.c
+++ b/drivers/bestups.c
@@ -26,6 +26,7 @@
 
 #include "main.h"
 #include "serial.h"
+#include "nut_stdint.h"
 
 #define DRIVER_NAME	"Best UPS driver"
 #define DRIVER_VERSION	"1.07"

--- a/drivers/clone-outlet.c
+++ b/drivers/clone-outlet.c
@@ -159,8 +159,8 @@ static int sstate_connect(void)
 	if ((uintmax_t)len >= (uintmax_t)sizeof(sa.sun_path)) {
 		fatalx(EXIT_FAILURE,
 			"Can't create a unix domain socket: pathname '%s/%s' "
-			"is too long (%zu) for 'struct sockaddr_un->sun_path' "
-			"on this system (%zu)",
+			"is too long (%" PRIuSIZE ") for 'struct sockaddr_un->sun_path' "
+			"on this system (%" PRIuSIZE ")",
 			dflt_statepath(), device_path,
 			strlen(dflt_statepath()) + 1 + strlen(device_path),
 			sizeof(sa.sun_path));

--- a/drivers/clone.c
+++ b/drivers/clone.c
@@ -175,8 +175,8 @@ static int sstate_connect(void)
 	if ((uintmax_t)len >= (uintmax_t)sizeof(sa.sun_path)) {
 		fatalx(EXIT_FAILURE,
 			"Can't create a unix domain socket: pathname '%s/%s' "
-			"is too long (%zu) for 'struct sockaddr_un->sun_path' "
-			"on this system (%zu)",
+			"is too long (%" PRIuSIZE ") for 'struct sockaddr_un->sun_path' "
+			"on this system (%" PRIuSIZE ")",
 			dflt_statepath(), device_path,
 			strlen(dflt_statepath()) + 1 + strlen(device_path),
 			sizeof(sa.sun_path));

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -215,8 +215,8 @@ static void send_to_all(const char *fmt, ...)
 		ret = write(conn->fd, buf, buflen);
 
 		if ((ret < 1) || (ret != (ssize_t)buflen)) {
-			upsdebugx(0, "WARNING: %s: write %zd bytes to "
-				"socket %d failed (ret=%zd), disconnecting: %s",
+			upsdebugx(0, "WARNING: %s: write %" PRIiSIZE " bytes to "
+				"socket %d failed (ret=%" PRIiSIZE "), disconnecting: %s",
 				__func__, buflen, conn->fd, ret, strerror(errno));
 			upsdebugx(6, "failed write: %s", buf);
 			sock_disconnect(conn);
@@ -232,8 +232,8 @@ static void send_to_all(const char *fmt, ...)
 			dstate_setinfo("driver.parameter.synchronous", "%s",
 				(do_synchronous==1)?"yes":((do_synchronous==0)?"no":"auto"));
 		} else {
-			upsdebugx(6, "%s: write %zd bytes to socket %d succeeded "
-				"(ret=%zd): %s",
+			upsdebugx(6, "%s: write %" PRIiSIZE " bytes to socket %d succeeded "
+				"(ret=%" PRIiSIZE "): %s",
 				__func__, buflen, conn->fd, ret, buf);
 		}
 	}
@@ -279,7 +279,7 @@ static int send_to_one(conn_t *conn, const char *fmt, ...)
 		upsdebugx(5, "%s: %.*s", __func__, (int)(ret-1), buf);
 
 /*
-	upsdebugx(0, "%s: writing %zd bytes to socket %d: %s",
+	upsdebugx(0, "%s: writing %" PRIiSIZE " bytes to socket %d: %s",
 		__func__, buflen, conn->fd, buf);
 */
 
@@ -288,8 +288,8 @@ static int send_to_one(conn_t *conn, const char *fmt, ...)
 	if (ret < 0) {
 		/* Hacky bugfix: throttle down for upsd to read that */
 		upsdebugx(1, "%s: had to throttle down to retry "
-			"writing %zd bytes to socket %d "
-			"(ret=%zd, errno=%d, strerror=%s): %s",
+			"writing %" PRIiSIZE " bytes to socket %d "
+			"(ret=%" PRIiSIZE ", errno=%d, strerror=%s): %s",
 			__func__, buflen, conn->fd,
 			ret, errno, strerror(errno),
 			buf);
@@ -301,8 +301,8 @@ static int send_to_one(conn_t *conn, const char *fmt, ...)
 	}
 
 	if ((ret < 1) || (ret != (ssize_t)buflen)) {
-		upsdebugx(0, "WARNING: %s: write %zd bytes to "
-			"socket %d failed (ret=%zd), disconnecting: %s",
+		upsdebugx(0, "WARNING: %s: write %" PRIiSIZE " bytes to "
+			"socket %d failed (ret=%" PRIiSIZE "), disconnecting: %s",
 			__func__, buflen, conn->fd, ret, strerror(errno));
 		upsdebugx(6, "failed write: %s", buf);
 		sock_disconnect(conn);
@@ -320,8 +320,8 @@ static int send_to_one(conn_t *conn, const char *fmt, ...)
 
 		return 0;	/* failed */
 	} else {
-		upsdebugx(6, "%s: write %zd bytes to socket %d succeeded "
-			"(ret=%zd): %s",
+		upsdebugx(6, "%s: write %" PRIiSIZE " bytes to socket %d succeeded "
+			"(ret=%" PRIiSIZE "): %s",
 			__func__, buflen, conn->fd, ret, buf);
 	}
 
@@ -483,7 +483,7 @@ static void send_tracking(conn_t *conn, const char *id, int value)
 
 static int sock_arg(conn_t *conn, size_t numarg, char **arg)
 {
-	upsdebugx(6, "Driver on %s is now handling %s with %zu args",
+	upsdebugx(6, "Driver on %s is now handling %s with %" PRIuSIZE " args",
 		sockfn, numarg ? arg[0] : "<skipped: no command>", numarg);
 
 	if (numarg < 1) {
@@ -1246,7 +1246,7 @@ void alarm_set(const char *buf)
 			}
 		}
 		upslogx(LOG_WARNING, "%s: result was truncated while setting or appending "
-			"alarm_buf (limited to %zu bytes), with message: %s%s",
+			"alarm_buf (limited to %" PRIuSIZE " bytes), with message: %s%s",
 			__func__, sizeof(alarm_buf), alarm_tmp,
 			( (buflen < sizeof(alarm_tmp)) ? "" : "...<also truncated>" ));
 	}

--- a/drivers/dummy-ups.c
+++ b/drivers/dummy-ups.c
@@ -571,7 +571,7 @@ static int upsclient_update_vars(void)
 		/* VAR <upsname> <varname> <val> */
 		if (numa < 4)
 		{
-			upsdebugx(1, "Error: insufficient data (got %zu args, need at least 4)", numa);
+			upsdebugx(1, "Error: insufficient data (got %" PRIuSIZE " args, need at least 4)", numa);
 		}
 
 		upsdebugx(5, "Received: %s %s %s %s",

--- a/drivers/gamatronic.c
+++ b/drivers/gamatronic.c
@@ -101,7 +101,7 @@ static ssize_t sec_cmd(const char mode, const char *command, char *msgbuf, ssize
 	upsdebugx(1, "PC-->UPS: \"%s\"",msg);
 	ret = ser_send(upsfd, "%s", msg);
 
-	upsdebugx(1, " send returned: %" PRIiSIZE "",ret);
+	upsdebugx(1, " send returned: %" PRIiSIZE, ret);
 
 	if (ret == -1) return -1;
 

--- a/drivers/gamatronic.c
+++ b/drivers/gamatronic.c
@@ -101,7 +101,7 @@ static ssize_t sec_cmd(const char mode, const char *command, char *msgbuf, ssize
 	upsdebugx(1, "PC-->UPS: \"%s\"",msg);
 	ret = ser_send(upsfd, "%s", msg);
 
-	upsdebugx(1, " send returned: %zd",ret);
+	upsdebugx(1, " send returned: %" PRIiSIZE "",ret);
 
 	if (ret == -1) return -1;
 
@@ -368,7 +368,7 @@ static void setup_serial(const char *port)
 		exit (1);
 	}
 	else
-		printf("Connected to UPS on %s baudrate: %zu\n",
+		printf("Connected to UPS on %s baudrate: %" PRIuSIZE "\n",
 			port, baud_rates[i].name);
 }
 

--- a/drivers/huawei-ups2000.c
+++ b/drivers/huawei-ups2000.c
@@ -47,6 +47,7 @@
 #include <modbus.h>
 #include "main.h"
 #include "serial.h"
+#include "nut_stdint.h"
 
 #define DRIVER_NAME	"NUT Huawei UPS2000 (1kVA-3kVA) RS-232 Modbus driver"
 #define DRIVER_VERSION	"0.03"

--- a/drivers/huawei-ups2000.c
+++ b/drivers/huawei-ups2000.c
@@ -333,7 +333,7 @@ static void ups2000_device_identification(void)
 
 		if (ptr + IDENT_RESPONSE_HEADER_LEN > ident_response_end) {
 			fatalx(EXIT_FAILURE, "response header too short! "
-					     "expected %d, received %zu.",
+					     "expected %d, received %" PRIuSIZE ".",
 					     IDENT_RESPONSE_HEADER_LEN, ident_response_len);
 		}
 

--- a/drivers/isbmex.c
+++ b/drivers/isbmex.c
@@ -174,8 +174,9 @@ static const char *getpacket(int *we_know){
 		return NULL;
 	}
 
-	r=read(upsfd,buf,255);
-	D(printf("%zd bytes read: ",r);)
+	r = read(upsfd,buf,255);
+	D(printf("%" PRIiSIZE " bytes read: ",r);)
+
 	buf[r]=0;
 	if (bytes_per_packet && r < bytes_per_packet){
 		ssize_t rr;

--- a/drivers/ivtscd.c
+++ b/drivers/ivtscd.c
@@ -21,6 +21,7 @@
 #include "config.h"
 #include "main.h"
 #include "serial.h"
+#include "nut_stdint.h"
 #include "attribute.h"
 
 #define DRIVER_NAME	"IVT Solar Controller driver"

--- a/drivers/ivtscd.c
+++ b/drivers/ivtscd.c
@@ -115,7 +115,7 @@ static ssize_t ivt_status(void)
 	ret = sscanf(reply, "R:%f;%f;%f;%f;%f;%f;%f;", &battery.voltage.act, &battery.current.act, &battery.temperature,
 					&battery.voltage.min, &battery.voltage.max, &battery.current.min, &battery.current.max);
 
-	upsdebugx(3, "Parsed %zd parameters from reply", ret);
+	upsdebugx(3, "Parsed %" PRIiSIZE " parameters from reply", ret);
 	return ret;
 }
 

--- a/drivers/libhid.c
+++ b/drivers/libhid.c
@@ -198,7 +198,7 @@ static int refresh_report_buffer(reportbuf_t *rbuf, hid_dev_handle_t udev, HIDDa
 #endif
 	if ((uintmax_t)r > (uintmax_t)USB_CTRL_CHARBUFSIZE_MAX) {
 		upsdebugx(2,
-			"%s: suggested buffer size %zu exceeds "
+			"%s: suggested buffer size %" PRIuSIZE " exceeds "
 			"USB_CTRL_CHARBUFSIZE_MAX %ju; "
 			"report will be constrained",
 			__func__, r, (uintmax_t)USB_CTRL_CHARBUFSIZE_MAX);
@@ -239,7 +239,7 @@ static int refresh_report_buffer(reportbuf_t *rbuf, hid_dev_handle_t udev, HIDDa
 	if (rbuf->len[id] != r) {
 		/* e.g. if maxreportsize flag was set */
 		upsdebugx(2,
-			"%s: expected %zu bytes, but got %zu instead",
+			"%s: expected %" PRIuSIZE " bytes, but got %" PRIuSIZE " instead",
 			__func__, rbuf->len[id], r);
 		upsdebug_hex(3, "Report[err]",
 			(usb_ctrl_charbuf)rbuf->data[id], r);
@@ -311,7 +311,7 @@ static int set_item_buffered(reportbuf_t *rbuf, hid_dev_handle_t udev, HIDData_t
 #endif
 	if ((uintmax_t)r > (uintmax_t)USB_CTRL_CHARBUFSIZE_MAX) {
 		upsdebugx(2,
-			"%s: suggested buffer size %zu exceeds "
+			"%s: suggested buffer size %" PRIuSIZE " exceeds "
 			"USB_CTRL_CHARBUFSIZE_MAX %ju; "
 			"item setting will be constrained",
 			__func__, r, (uintmax_t)USB_CTRL_CHARBUFSIZE_MAX);
@@ -362,7 +362,7 @@ static int file_report_buffer(reportbuf_t *rbuf, unsigned char *buf, size_t bufl
 
 	if (rbuf->len[id] != buflen) {
 		upsdebugx(2,
-			"%s: expected %zu bytes, but got %zu instead",
+			"%s: expected %" PRIuSIZE " bytes, but got %" PRIuSIZE " instead",
 			__func__, rbuf->len[id], buflen);
 		upsdebug_hex(3, "Report[err]", buf, buflen);
 	} else {
@@ -421,7 +421,7 @@ void HIDDumpTree(hid_dev_handle_t udev, HIDDevice_t *hd, usage_tables_t *utab)
 		return;
 	}
 
-	upsdebugx(1, "%zu HID objects found", pDesc->nitems);
+	upsdebugx(1, "%" PRIuSIZE " HID objects found", pDesc->nitems);
 
 	for (i = 0; i < pDesc->nitems; i++)
 	{
@@ -590,7 +590,7 @@ char *HIDGetIndexString(hid_dev_handle_t udev, const int Index, char *buf, size_
 
 	if ((uintmax_t)buflen > (uintmax_t)USB_CTRL_CHARBUFSIZE_MAX) {
 		upsdebugx(2,
-			"%s: suggested buffer size %zu exceeds "
+			"%s: suggested buffer size %" PRIuSIZE " exceeds "
 			"USB_CTRL_CHARBUFSIZE_MAX %ju; "
 			"index string will be constrained",
 			__func__, buflen,
@@ -722,7 +722,7 @@ int HIDGetEvents(hid_dev_handle_t udev, HIDData_t **event, int eventsize)
 	if ((uintmax_t)r > (uintmax_t)USB_CTRL_CHARBUFSIZE_MAX) {
 		/* FIXME: Should we try here, or plain abort? */
 		upsdebugx(2,
-			"%s: suggested buffer size %zu exceeds "
+			"%s: suggested buffer size %" PRIuSIZE " exceeds "
 			"USB_CTRL_CHARBUFSIZE_MAX %ju; "
 			"report will be constrained",
 			__func__, r, (uintmax_t)USB_CTRL_CHARBUFSIZE_MAX);

--- a/drivers/libhid.c
+++ b/drivers/libhid.c
@@ -43,6 +43,7 @@
 #include "libhid.h"
 #include "hidparser.h"
 #include "common.h" /* for xmalloc, upsdebugx prototypes */
+#include "nut_stdint.h"
 
 /* Communication layers and drivers (USB and MGE SHUT) */
 #ifdef SHUT_MODE
@@ -199,7 +200,7 @@ static int refresh_report_buffer(reportbuf_t *rbuf, hid_dev_handle_t udev, HIDDa
 	if ((uintmax_t)r > (uintmax_t)USB_CTRL_CHARBUFSIZE_MAX) {
 		upsdebugx(2,
 			"%s: suggested buffer size %" PRIuSIZE " exceeds "
-			"USB_CTRL_CHARBUFSIZE_MAX %ju; "
+			"USB_CTRL_CHARBUFSIZE_MAX %" PRIuMAX "; "
 			"report will be constrained",
 			__func__, r, (uintmax_t)USB_CTRL_CHARBUFSIZE_MAX);
 		if ((uintmax_t)USB_CTRL_CHARBUFSIZE_MAX <= (uintmax_t)SIZE_MAX
@@ -312,7 +313,7 @@ static int set_item_buffered(reportbuf_t *rbuf, hid_dev_handle_t udev, HIDData_t
 	if ((uintmax_t)r > (uintmax_t)USB_CTRL_CHARBUFSIZE_MAX) {
 		upsdebugx(2,
 			"%s: suggested buffer size %" PRIuSIZE " exceeds "
-			"USB_CTRL_CHARBUFSIZE_MAX %ju; "
+			"USB_CTRL_CHARBUFSIZE_MAX %" PRIuMAX "; "
 			"item setting will be constrained",
 			__func__, r, (uintmax_t)USB_CTRL_CHARBUFSIZE_MAX);
 		if ((uintmax_t)USB_CTRL_CHARBUFSIZE_MAX <= (uintmax_t)SIZE_MAX
@@ -579,7 +580,7 @@ char *HIDGetIndexString(hid_dev_handle_t udev, const int Index, char *buf, size_
 	) {
 		upsdebugx(2,
 			"%s: requested index number is out of range, "
-			"expected %jd < %i < %ju",
+			"expected %" PRIdMAX " < %i < %" PRIuMAX,
 			__func__,
 			(intmax_t)USB_CTRL_STRINDEX_MIN,
 			Index,
@@ -591,7 +592,7 @@ char *HIDGetIndexString(hid_dev_handle_t udev, const int Index, char *buf, size_
 	if ((uintmax_t)buflen > (uintmax_t)USB_CTRL_CHARBUFSIZE_MAX) {
 		upsdebugx(2,
 			"%s: suggested buffer size %" PRIuSIZE " exceeds "
-			"USB_CTRL_CHARBUFSIZE_MAX %ju; "
+			"USB_CTRL_CHARBUFSIZE_MAX %" PRIuMAX "; "
 			"index string will be constrained",
 			__func__, buflen,
 			(uintmax_t)USB_CTRL_CHARBUFSIZE_MAX);
@@ -723,7 +724,7 @@ int HIDGetEvents(hid_dev_handle_t udev, HIDData_t **event, int eventsize)
 		/* FIXME: Should we try here, or plain abort? */
 		upsdebugx(2,
 			"%s: suggested buffer size %" PRIuSIZE " exceeds "
-			"USB_CTRL_CHARBUFSIZE_MAX %ju; "
+			"USB_CTRL_CHARBUFSIZE_MAX %" PRIuMAX "; "
 			"report will be constrained",
 			__func__, r, (uintmax_t)USB_CTRL_CHARBUFSIZE_MAX);
 
@@ -938,7 +939,7 @@ static int string_to_path(const char *string, HIDPath_t *path, usage_tables_t *u
 			/* Note: currently per hidtypes.h, HIDNode_t == uint32_t */
 			if (l < 0 || (uintmax_t)l > (uintmax_t)UINT32_MAX) {
 				upsdebugx(5, "string_to_path: badvalue (pathcomp): "
-					"%ld negative or %ju too large",
+					"%ld negative or %" PRIuMAX " too large",
 					l, (uintmax_t)l);
 				goto badvalue;
 			}
@@ -952,7 +953,7 @@ static int string_to_path(const char *string, HIDPath_t *path, usage_tables_t *u
 			int l = atoi(token + 1); /* +1: skip the bracket */
 			if (l < 0 || (uintmax_t)l > (uintmax_t)UINT32_MAX) {
 				upsdebugx(5, "string_to_path: badvalue(indexed): "
-					"%d negative or %ju too large",
+					"%d negative or %" PRIuMAX " too large",
 					l, (uintmax_t)l);
 				goto badvalue;
 			}

--- a/drivers/libshut.c
+++ b/drivers/libshut.c
@@ -583,7 +583,7 @@ static int libshut_open(
 #endif
 		upsdebugx(2,
 			"HID descriptor too long %" PRI_NUT_USB_CTRL_CHARBUFSIZE
-			" (max %zu)",
+			" (max %" PRIuSIZE ")",
 			rdlen, sizeof(rdbuf));
 		return -1;
 	}

--- a/drivers/libshut.h
+++ b/drivers/libshut.h
@@ -28,7 +28,7 @@
 #define NUT_LIBSHUT_H_SEEN 1
 
 #include "main.h"	/* for subdrv_info_t */
-#include "nut_stdint.h"	/* for uint16_t, size_t, PRIsize etc. */
+#include "nut_stdint.h"	/* for uint16_t, size_t, PRIuSIZE etc. */
 
 extern upsdrv_info_t comm_upsdrv_info;
 
@@ -91,7 +91,7 @@ typedef unsigned char usb_ctrl_char;
 typedef size_t usb_ctrl_charbufsize;	/*typedef int usb_ctrl_charbufsize;*/
 #define USB_CTRL_CHARBUFSIZE_MIN	0
 #define USB_CTRL_CHARBUFSIZE_MAX	SIZE_MAX
-#define PRI_NUT_USB_CTRL_CHARBUFSIZE PRIsize
+#define PRI_NUT_USB_CTRL_CHARBUFSIZE PRIuSIZE
 
 typedef int usb_ctrl_timeout_msec;	/* in milliseconds */
 #define USB_CTRL_TIMEOUTMSEC_MIN	INT_MIN

--- a/drivers/libusb0.c
+++ b/drivers/libusb0.c
@@ -491,7 +491,7 @@ static int libusb_open(usb_dev_handle **udevp,
 			if ((uintmax_t)rdlen > sizeof(rdbuf)) {
 				upsdebugx(2,
 					"HID descriptor too long %" PRI_NUT_USB_CTRL_CHARBUFSIZE
-					" (max %zu)",
+					" (max %" PRIuSIZE ")",
 					rdlen, sizeof(rdbuf));
 				goto next_device;
 			}

--- a/drivers/libusb1.c
+++ b/drivers/libusb1.c
@@ -564,7 +564,7 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 		) {
 			upsdebugx(2,
 				"Report descriptor length is out of range on this device: "
-				"should be %ji < %d < %ju",
+				"should be %" PRIdMAX " < %d < %" PRIuMAX,
 					(intmax_t)USB_CTRL_CHARBUFSIZE_MIN, rdlen,
 					(uintmax_t)USB_CTRL_CHARBUFSIZE_MAX);
 			goto next_device;

--- a/drivers/libusb1.c
+++ b/drivers/libusb1.c
@@ -186,7 +186,7 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 		libusb_device	*device = devlist[devnum];
 
 		libusb_get_device_descriptor(device, &dev_desc);
-		upsdebugx(2, "Checking device %zu of %zu (%04X/%04X)",
+		upsdebugx(2, "Checking device %" PRIuSIZE " of %" PRIuSIZE " (%04X/%04X)",
 			devnum + 1, devcount,
 			dev_desc.idVendor, dev_desc.idProduct);
 

--- a/drivers/liebert-esp2.c
+++ b/drivers/liebert-esp2.c
@@ -201,7 +201,7 @@ void upsdrv_initinfo(void)
 		}
 
 		buf[i<<1] = 0;
-		upsdebugx(1, "return: %zd (8=success)", ret);
+		upsdebugx(1, "return: %" PRIiSIZE " (8=success)", ret);
 
 		if (ret == 8) { /* last command successful */
 			dstate_setinfo(vartab[vari].var,"%s",buf);

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -1055,7 +1055,7 @@ int main(int argc, char **argv)
 	}
 
 	/* The poll_interval may have been changed from the default */
-	dstate_setinfo("driver.parameter.pollinterval", "%jd", (intmax_t)poll_interval);
+	dstate_setinfo("driver.parameter.pollinterval", "%" PRIdMAX, (intmax_t)poll_interval);
 
 	/* The synchronous option may have been changed from the default */
 	dstate_setinfo("driver.parameter.synchronous", "%s",

--- a/drivers/masterguard.c
+++ b/drivers/masterguard.c
@@ -426,7 +426,7 @@ static ssize_t ups_ident( void )
 	else if( ret > 0 )
 	{
 		if( DEBUG )
-			printf( "WH says <%s> with length %zi\n", buf, ret );
+			printf( "WH says <%s> with length %" PRIiSIZE "\n", buf, ret );
 		upslog_with_errno( LOG_INFO,
 			"New WH String found. Please report to maintainer\n" );
 	}
@@ -507,7 +507,7 @@ void upsdrv_updateinfo(void)
 	if( ret != lenRSP )
 	{
 		if( DEBUG )
-			printf( "buf = %s len = %zi\n", buf, ret );
+			printf( "buf = %s len = %" PRIiSIZE "\n", buf, ret );
 		upslog_with_errno( LOG_ERR, "Error in UPS response " );
 		dstate_datastale();
 		return;

--- a/drivers/masterguard.c
+++ b/drivers/masterguard.c
@@ -26,6 +26,7 @@
 
 #include "main.h"
 #include "serial.h"
+#include "nut_stdint.h"
 
 #define DRIVER_NAME	"MASTERGUARD UPS driver"
 #define DRIVER_VERSION	"0.25"

--- a/drivers/metasys.c
+++ b/drivers/metasys.c
@@ -189,7 +189,7 @@ static int get_answer(unsigned char *data) {
 	/* Read STX byte */
 	res = ser_get_char(upsfd, my_buf, 1, 0);
 	if (res < 1) {
-		ser_comm_fail("Receive error (STX): %zd!!!\n", res);
+		ser_comm_fail("Receive error (STX): %" PRIiSIZE "!!!\n", res);
 		return -1;
 	}
 	if (my_buf[0] != 0x02) {
@@ -199,7 +199,7 @@ static int get_answer(unsigned char *data) {
 	/* Read data length byte */
 	res = ser_get_char(upsfd, my_buf, 1, 0);
 	if (res < 1) {
-		ser_comm_fail("Receive error (length): %zd!!!\n", res);
+		ser_comm_fail("Receive error (length): %" PRIiSIZE "!!!\n", res);
 		return -1;
 	}
 	packet_length = my_buf[0];
@@ -210,7 +210,7 @@ static int get_answer(unsigned char *data) {
 	/* Try to read all the remainig bytes (packet_length) */
 	res = ser_get_buf_len(upsfd, my_buf, packet_length, 1, 0);
 	if (res != packet_length) {
-		ser_comm_fail("Receive error (data): got %zd bytes instead of %d!!!\n", res, packet_length);
+		ser_comm_fail("Receive error (data): got %" PRIiSIZE " bytes instead of %d!!!\n", res, packet_length);
 		return -1;
 	}
 

--- a/drivers/mge-utalk.c
+++ b/drivers/mge-utalk.c
@@ -943,7 +943,7 @@ static ssize_t mge_command(char *reply, size_t replylen, const char *fmt, ...)
 	bytes_rcvd = ser_get_line(upsfd, reply, replylen,
 		MGE_REPLY_ENDCHAR, MGE_REPLY_IGNCHAR, 3, 0);
 
-	upsdebugx(4, "mge_command: received %zd byte(s)", bytes_rcvd);
+	upsdebugx(4, "mge_command: received %" PRIiSIZE " byte(s)", bytes_rcvd);
 
 	return bytes_rcvd;
 }

--- a/drivers/microsol-common.c
+++ b/drivers/microsol-common.c
@@ -575,7 +575,7 @@ static void get_base_info(void)
 
 	upsdebugx(4, "%s: requesting %d bytes from ser_get_buf_len()", __func__, PACKET_SIZE);
 	tam = ser_get_buf_len(upsfd, packet, PACKET_SIZE, 3, 0);
-	upsdebugx(2, "%s: received %zd bytes from ser_get_buf_len()", __func__, tam);
+	upsdebugx(2, "%s: received %" PRIiSIZE " bytes from ser_get_buf_len()", __func__, tam);
 	if (tam > 0 && nut_debug_level >= 4) {
 		upsdebug_hex(4, "received from ser_get_buf_len()", packet, (size_t)tam);
 	}
@@ -639,7 +639,7 @@ static void get_updated_info(void)
 	upsdebugx(3, "%s: requesting %d bytes from ser_get_buf_len()", __func__, PACKET_SIZE);
 	tam = ser_get_buf_len(upsfd, temp, PACKET_SIZE, 3, 0);
 
-	upsdebugx(2, "%s: received %zd bytes from ser_get_buf_len()", __func__, tam);
+	upsdebugx(2, "%s: received %" PRIiSIZE " bytes from ser_get_buf_len()", __func__, tam);
 	if (tam > 0 && nut_debug_level >= 4)
 		upsdebug_hex(4, "received from ser_get_buf_len()", temp, (size_t)tam);
 

--- a/drivers/netxml-ups.c
+++ b/drivers/netxml-ups.c
@@ -314,7 +314,7 @@ void upsdrv_updateinfo(void)
 			/* alarm message received */
 
 			ne_xml_parser	*parser = ne_xml_create();
-			upsdebugx(2, "%s: ne_sock_read(%zd bytes) => %s", __func__, ret, buf);
+			upsdebugx(2, "%s: ne_sock_read(%" PRIiSIZE " bytes) => %s", __func__, ret, buf);
 			ne_xml_push_handler(parser, subdriver->startelm_cb, subdriver->cdata_cb, subdriver->endelm_cb, NULL);
 			ne_xml_parse(parser, buf, strlen(buf));
 			ne_xml_destroy(parser);
@@ -330,7 +330,7 @@ void upsdrv_updateinfo(void)
 
 			upslogx(LOG_ERR, "NSM connection with '%s' lost", uri.host);
 
-			upsdebugx(2, "%s: ne_sock_read(%zd) => %s", __func__, ret, ne_sock_error(sock));
+			upsdebugx(2, "%s: ne_sock_read(%" PRIiSIZE ") => %s", __func__, ret, ne_sock_error(sock));
 			ne_sock_close(sock);
 
 			if (netxml_alarm_subscribe(subdriver->subscribe) == NE_OK) {

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -471,7 +471,7 @@ static int	cypress_command(const char *cmd, char *buf, size_t buflen)
 	size_t	i;
 
 	if (buflen > INT_MAX) {
-		upsdebugx(3, "%s: requested to read too much (%zu), "
+		upsdebugx(3, "%s: requested to read too much (%" PRIuSIZE "), "
 			"reducing buflen to (INT_MAX-1)",
 			__func__, buflen);
 		buflen = (INT_MAX - 1);
@@ -530,7 +530,7 @@ static int	cypress_command(const char *cmd, char *buf, size_t buflen)
 	upsdebugx(3, "read: %.*s", (int)strcspn(buf, "\r"), buf);
 
 	if (i > INT_MAX) {
-		upsdebugx(3, "%s: read too much (%zu)", __func__, i);
+		upsdebugx(3, "%s: read too much (%" PRIuSIZE ")", __func__, i);
 		return -1;
 	}
 	return (int)i;
@@ -544,7 +544,7 @@ static int	sgs_command(const char *cmd, char *buf, size_t buflen)
 	size_t  cmdlen, i;
 
 	if (buflen > INT_MAX) {
-		upsdebugx(3, "%s: requested to read too much (%zu), "
+		upsdebugx(3, "%s: requested to read too much (%" PRIuSIZE "), "
 			"reducing buflen to (INT_MAX-1)",
 			__func__, buflen);
 		buflen = (INT_MAX - 1);
@@ -635,7 +635,7 @@ static int	sgs_command(const char *cmd, char *buf, size_t buflen)
 	upsdebugx(3, "read: %.*s", (int)strcspn(buf, "\r"), buf);
 
 	if (i > INT_MAX) {
-		upsdebugx(3, "%s: read too much (%zu)", __func__, i);
+		upsdebugx(3, "%s: read too much (%" PRIuSIZE ")", __func__, i);
 		return -1;
 	}
 	return (int)i;
@@ -649,7 +649,7 @@ static int	phoenix_command(const char *cmd, char *buf, size_t buflen)
 	size_t	i;
 
 	if (buflen > INT_MAX) {
-		upsdebugx(3, "%s: requested to read too much (%zu), "
+		upsdebugx(3, "%s: requested to read too much (%" PRIuSIZE "), "
 			"reducing buflen to (INT_MAX-1)",
 			__func__, buflen);
 		buflen = (INT_MAX - 1);
@@ -737,7 +737,7 @@ static int	phoenix_command(const char *cmd, char *buf, size_t buflen)
 	upsdebugx(3, "read: %.*s", (int)strcspn(buf, "\r"), buf);
 
 	if (i > INT_MAX) {
-		upsdebugx(3, "%s: read too much (%zu)", __func__, i);
+		upsdebugx(3, "%s: read too much (%" PRIuSIZE ")", __func__, i);
 		return -1;
 	}
 	return (int)i;
@@ -751,7 +751,7 @@ static int	ippon_command(const char *cmd, char *buf, size_t buflen)
 	size_t	i, len;
 
 	if (buflen > INT_MAX) {
-		upsdebugx(3, "%s: requested to read too much (%zu), "
+		upsdebugx(3, "%s: requested to read too much (%" PRIuSIZE "), "
 			"reducing buflen to (INT_MAX-1)",
 			__func__, buflen);
 		buflen = (INT_MAX - 1);
@@ -832,7 +832,7 @@ static int	ippon_command(const char *cmd, char *buf, size_t buflen)
 	}
 
 	if (len > INT_MAX) {
-		upsdebugx(3, "%s: read too much (%zu)", __func__, len);
+		upsdebugx(3, "%s: read too much (%" PRIuSIZE ")", __func__, len);
 		return -1;
 	}
 	return (int)len;
@@ -918,7 +918,7 @@ static int	krauler_command(const char *cmd, char *buf, size_t buflen)
 	upsdebugx(3, "send: %.*s", (int)strcspn(cmd, "\r"), cmd);
 
 	if (buflen > INT_MAX) {
-		upsdebugx(3, "%s: requested to read too much (%zu), "
+		upsdebugx(3, "%s: requested to read too much (%" PRIuSIZE "), "
 			"reducing buflen to (INT_MAX-1)",
 			__func__, buflen);
 		buflen = (INT_MAX - 1);
@@ -1042,7 +1042,7 @@ static int	fabula_command(const char *cmd, char *buf, size_t buflen)
 	upsdebugx(3, "send: %.*s", (int)strcspn(cmd, "\r"), cmd);
 
 	if (buflen > INT_MAX) {
-		upsdebugx(3, "%s: requested to read too much (%zu), "
+		upsdebugx(3, "%s: requested to read too much (%" PRIuSIZE "), "
 			"reducing buflen to (INT_MAX-1)",
 			__func__, buflen);
 		buflen = (INT_MAX - 1);
@@ -1167,7 +1167,7 @@ static int	hunnox_command(const char *cmd, char *buf, size_t buflen)
 	upsdebugx(3, "send: %.*s", (int)strcspn(cmd, "\r"), cmd);
 
 	if (buflen > INT_MAX) {
-		upsdebugx(3, "%s: requested to read too much (%zu), "
+		upsdebugx(3, "%s: requested to read too much (%" PRIuSIZE "), "
 			"reducing buflen to (INT_MAX-1)",
 			__func__, buflen);
 		buflen = (INT_MAX - 1);
@@ -1330,7 +1330,7 @@ static int	fuji_command(const char *cmd, char *buf, size_t buflen)
 	};
 
 	if (buflen > INT_MAX) {
-		upsdebugx(3, "%s: requested to read too much (%zu), "
+		upsdebugx(3, "%s: requested to read too much (%" PRIuSIZE "), "
 			"reducing buflen to (INT_MAX-1)",
 			__func__, buflen);
 		buflen = (INT_MAX - 1);
@@ -1469,13 +1469,13 @@ static int	phoenixtec_command(const char *cmd, char *buf, size_t buflen)
 	size_t cmdlen = strlen(cmd);
 
 	if (cmdlen > INT_MAX) {
-		upsdebugx(3, "%s: requested command is too long (%zu)",
+		upsdebugx(3, "%s: requested command is too long (%" PRIuSIZE ")",
 			__func__, cmdlen);
 		return 0;
 	}
 
 	if (buflen > INT_MAX) {
-		upsdebugx(3, "%s: requested to read too much (%zu), "
+		upsdebugx(3, "%s: requested to read too much (%" PRIuSIZE "), "
 			"reducing buflen to (INT_MAX-1)",
 			__func__, buflen);
 		buflen = (INT_MAX - 1);
@@ -1530,7 +1530,7 @@ static int	phoenixtec_command(const char *cmd, char *buf, size_t buflen)
 		/* buflen constrained to INT_MAX above, so we can cast: */
 		return (int)(e - buf);
 	} else {
-		upsdebugx(3, "read: buflen %zu too small", buflen);
+		upsdebugx(3, "read: buflen %" PRIuSIZE " too small", buflen);
 		*buf = '\0';
 		return 0;
 	}
@@ -1556,7 +1556,7 @@ static int	snr_command(const char *cmd, char *buf, size_t buflen)
 	upsdebugx(3, "send: %.*s", (int)strcspn(cmd, "\r"), cmd);
 
 	if (buflen > INT_MAX) {
-		upsdebugx(3, "%s: requested to read too much (%zu), "
+		upsdebugx(3, "%s: requested to read too much (%" PRIuSIZE "), "
 			"reducing buflen to (INT_MAX-1)",
 			__func__, buflen);
 		buflen = (INT_MAX - 1);
@@ -1666,7 +1666,7 @@ static int ablerex_command(const char *cmd, char *buf, size_t buflen)
 	upsdebugx(3, "send: %.*s", (int)strcspn(cmd, "\r"), cmd);
 
 	if (buflen > INT_MAX) {
-		upsdebugx(3, "%s: requested to read too much (%zu), reducing buflen to (INT_MAX-1)",
+		upsdebugx(3, "%s: requested to read too much (%" PRIuSIZE "), reducing buflen to (INT_MAX-1)",
 			__func__, buflen);
 		buflen = (INT_MAX - 1);
 	}
@@ -3255,7 +3255,7 @@ static ssize_t	qx_command(const char *cmd, char *buf, size_t buflen)
 		ret = ser_send(upsfd, "%s", cmd);
 
 		if (ret <= 0) {
-			upsdebugx(3, "send: %s (%zd)",
+			upsdebugx(3, "send: %s (%" PRIiSIZE ")",
 				ret ? strerror(errno) : "timeout", ret);
 			return ret;
 		}
@@ -3266,7 +3266,7 @@ static ssize_t	qx_command(const char *cmd, char *buf, size_t buflen)
 		ret = ser_get_buf(upsfd, buf, buflen, SER_WAIT_SEC, 0);
 
 		if (ret <= 0) {
-			upsdebugx(3, "read: %s (%zd)",
+			upsdebugx(3, "read: %s (%" PRIiSIZE ")",
 				ret ? strerror(errno) : "timeout", ret);
 			return ret;
 		}

--- a/drivers/nutdrv_qx_masterguard.c
+++ b/drivers/nutdrv_qx_masterguard.c
@@ -24,6 +24,7 @@
 
 #include "nutdrv_qx_masterguard.h"
 #include <stddef.h>
+#include "nut_stdint.h"
 
 #define MASTERGUARD_VERSION "Masterguard 0.02"
 

--- a/drivers/nutdrv_qx_masterguard.c
+++ b/drivers/nutdrv_qx_masterguard.c
@@ -353,9 +353,9 @@ static int masterguard_output_voltages(item_t *item, char *value, const size_t v
 	strncpy(value, item->value, valuelen); /* save before strtok mangles it */
 	for (w = strtok(item->value, sep); w; w = strtok(NULL, sep)) {
 		n++;
-		upsdebugx(4, "output voltage #%zu: %s", n, w);
+		upsdebugx(4, "output voltage #%" PRIuSIZE ": %s", n, w);
 		if ((masterguard_e_outvolts = realloc(masterguard_e_outvolts, n * sizeof(info_rw_t))) == NULL) {
-			upsdebugx(1, "output voltages: allocating #%zu failed", n);
+			upsdebugx(1, "output voltages: allocating #%" PRIuSIZE " failed", n);
 			return -1;
 		}
 		strncpy(masterguard_e_outvolts[n - 1].value, w, SMALLBUF - 1);
@@ -363,7 +363,7 @@ static int masterguard_output_voltages(item_t *item, char *value, const size_t v
 	}
 	/* need to do this seperately in case the loop is run zero times */
 	if ((masterguard_e_outvolts = realloc(masterguard_e_outvolts, (n + 1) * sizeof(info_rw_t))) == NULL) {
-		upsdebugx(1, "output voltages: allocating terminator after #%zu failed", n);
+		upsdebugx(1, "output voltages: allocating terminator after #%" PRIuSIZE " failed", n);
 		return -1;
 	}
 	masterguard_e_outvolts[n].value[0] = '\0';

--- a/drivers/nutdrv_siemens_sitop.c
+++ b/drivers/nutdrv_siemens_sitop.c
@@ -110,7 +110,7 @@ static int check_for_new_data() {
 		num_received = ser_get_buf(upsfd, rx_buffer + rx_count, RX_BUFFER_SIZE - rx_count, 0, 0);
 		if (num_received < 0) {
 			/* comm error */
-			ser_comm_fail("error %zd while reading", num_received);
+			ser_comm_fail("error %" PRIiSIZE " while reading", num_received);
 			/* discard any remaining old data from the receive buffer: */
 			rx_count = 0;
 			/* try to re-open the serial port: */

--- a/drivers/nutdrv_siemens_sitop.c
+++ b/drivers/nutdrv_siemens_sitop.c
@@ -277,7 +277,7 @@ void upsdrv_initups(void) {
 	 */
 	if (poll_interval > 5) {
 		upslogx(LOG_NOTICE,
-			"Option poll_interval is recommended to be lower than 5 (found: %jd)",
+			"Option poll_interval is recommended to be lower than 5 (found: %" PRIdMAX ")",
 			(intmax_t)poll_interval);
 	}
 

--- a/drivers/oneac.c
+++ b/drivers/oneac.c
@@ -89,7 +89,7 @@ static ssize_t OneacGetResponse (char* chBuff, const size_t BuffSize, int Expect
 			break;
 
 		upsdebugx (3,
-			"!OneacGetResponse retry (%zd, %d)...",
+			"!OneacGetResponse retry (%" PRIiSIZE ", %d)...",
 			return_val, Retries);
 
 	} while (--Retries > 0);

--- a/drivers/oneac.c
+++ b/drivers/oneac.c
@@ -41,6 +41,7 @@
 #include "main.h"
 #include "serial.h"
 #include "oneac.h"
+#include "nut_stdint.h"
 
 /* Prototypes to allow setting pointer before function is defined */
 int setcmd(const char* varname, const char* setvalue);

--- a/drivers/optiups.c
+++ b/drivers/optiups.c
@@ -158,7 +158,7 @@ static inline ssize_t optireadline(void)
 		}
 	}
 	else
-		upsdebugx(1, "READ ERROR: %" PRIiSIZE "", r );
+		upsdebugx(1, "READ ERROR: %" PRIiSIZE, r);
 	return r;
 }
 

--- a/drivers/optiups.c
+++ b/drivers/optiups.c
@@ -25,6 +25,7 @@
 
 #include "main.h"
 #include "serial.h"
+#include "nut_stdint.h"
 
 #define DRIVER_NAME	"Opti-UPS driver"
 #define DRIVER_VERSION "1.02"

--- a/drivers/optiups.c
+++ b/drivers/optiups.c
@@ -157,7 +157,7 @@ static inline ssize_t optireadline(void)
 		}
 	}
 	else
-		upsdebugx(1, "READ ERROR: %zd", r );
+		upsdebugx(1, "READ ERROR: %" PRIiSIZE "", r );
 	return r;
 }
 

--- a/drivers/powercom.c
+++ b/drivers/powercom.c
@@ -411,7 +411,7 @@ static int ups_getinfo(void)
 			dstate_datastale();
 			return 0;
 		} else
-			upsdebugx(5, "Num of bytes received from UPS: %" PRIiSIZE "", c);
+			upsdebugx(5, "Num of bytes received from UPS: %" PRIiSIZE, c);
 	}
 
 	/* optional dump of raw data */

--- a/drivers/powercom.c
+++ b/drivers/powercom.c
@@ -407,11 +407,11 @@ static int ups_getinfo(void)
 			types[type].num_of_bytes_from_ups, 3, 0);
 
 		if (c != (ssize_t)types[type].num_of_bytes_from_ups) {
-			upslogx(LOG_NOTICE, "data receiving error (%zd instead of %d bytes)", c, types[type].num_of_bytes_from_ups);
+			upslogx(LOG_NOTICE, "data receiving error (%" PRIiSIZE " instead of %d bytes)", c, types[type].num_of_bytes_from_ups);
 			dstate_datastale();
 			return 0;
 		} else
-			upsdebugx(5, "Num of bytes received from UPS: %zd", c);
+			upsdebugx(5, "Num of bytes received from UPS: %" PRIiSIZE "", c);
 	}
 
 	/* optional dump of raw data */

--- a/drivers/powerp-bin.c
+++ b/drivers/powerp-bin.c
@@ -628,7 +628,7 @@ static ssize_t powpan_initups(void)
 		upsdebug_hex(3, "read", powpan_answer, (size_t)ret);
 
 		if (ret < 20) {
-			upsdebugx(2, "Expected 20 bytes but only got %" PRIiSIZE "", ret);
+			upsdebugx(2, "Expected 20 bytes but only got %" PRIiSIZE, ret);
 			continue;
 		}
 

--- a/drivers/powerp-bin.c
+++ b/drivers/powerp-bin.c
@@ -628,7 +628,7 @@ static ssize_t powpan_initups(void)
 		upsdebug_hex(3, "read", powpan_answer, (size_t)ret);
 
 		if (ret < 20) {
-			upsdebugx(2, "Expected 20 bytes but only got %zd", ret);
+			upsdebugx(2, "Expected 20 bytes but only got %" PRIiSIZE "", ret);
 			continue;
 		}
 

--- a/drivers/powerp-txt.c
+++ b/drivers/powerp-txt.c
@@ -577,7 +577,7 @@ static ssize_t powpan_initups(void)
 		}
 
 		if (ret < 46) {
-			upsdebugx(2, "Expected 46 bytes, but only got %" PRIiSIZE "", ret);
+			upsdebugx(2, "Expected 46 bytes, but only got %" PRIiSIZE, ret);
 			continue;
 		}
 

--- a/drivers/powerp-txt.c
+++ b/drivers/powerp-txt.c
@@ -30,6 +30,7 @@
 
 #include "main.h"
 #include "serial.h"
+#include "nut_stdint.h"
 
 #include "powerp-txt.h"
 

--- a/drivers/powerp-txt.c
+++ b/drivers/powerp-txt.c
@@ -576,7 +576,7 @@ static ssize_t powpan_initups(void)
 		}
 
 		if (ret < 46) {
-			upsdebugx(2, "Expected 46 bytes, but only got %zd", ret);
+			upsdebugx(2, "Expected 46 bytes, but only got %" PRIiSIZE "", ret);
 			continue;
 		}
 

--- a/drivers/rhino.c
+++ b/drivers/rhino.c
@@ -34,6 +34,7 @@
 #include "main.h"
 #include "serial.h"
 #include "nut_float.h"
+#include "nut_stdint.h"
 #include "timehead.h"
 
 #define DRIVER_NAME		"Microsol Rhino UPS driver"

--- a/drivers/rhino.c
+++ b/drivers/rhino.c
@@ -394,7 +394,7 @@ CommReceive(const unsigned char *bufptr, ssize_t size)
 	if( size == 37 )
 		Waiting = 0;
 
-	printf("CommReceive size = %zd waiting = %d\n", size, Waiting );
+	printf("CommReceive size = %" PRIiSIZE " waiting = %d\n", size, Waiting );
 
 	switch( Waiting )
 	{

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -957,7 +957,7 @@ net-snmp/library/keytools.h:   int    generate_Ku(const oid * hashtype, u_int ha
 # pragma GCC diagnostic pop
 #endif
 				fatalx(EXIT_FAILURE,
-					"Bad SNMPv3 securityAuthProtoLen: %" PRIuSIZE "",
+					"Bad SNMPv3 securityAuthProtoLen: %" PRIuSIZE,
 					g_snmp_sess.securityAuthProtoLen);
 			}
 
@@ -1025,7 +1025,7 @@ net-snmp/library/keytools.h:   int    generate_Ku(const oid * hashtype, u_int ha
 # pragma GCC diagnostic pop
 #endif
 				fatalx(EXIT_FAILURE,
-					"Bad SNMPv3 securityAuthProtoLen: %" PRIuSIZE "",
+					"Bad SNMPv3 securityAuthProtoLen: %" PRIuSIZE,
 					g_snmp_sess.securityAuthProtoLen);
 			}
 

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -957,7 +957,7 @@ net-snmp/library/keytools.h:   int    generate_Ku(const oid * hashtype, u_int ha
 # pragma GCC diagnostic pop
 #endif
 				fatalx(EXIT_FAILURE,
-					"Bad SNMPv3 securityAuthProtoLen: %zu",
+					"Bad SNMPv3 securityAuthProtoLen: %" PRIuSIZE "",
 					g_snmp_sess.securityAuthProtoLen);
 			}
 
@@ -1025,7 +1025,7 @@ net-snmp/library/keytools.h:   int    generate_Ku(const oid * hashtype, u_int ha
 # pragma GCC diagnostic pop
 #endif
 				fatalx(EXIT_FAILURE,
-					"Bad SNMPv3 securityAuthProtoLen: %zu",
+					"Bad SNMPv3 securityAuthProtoLen: %" PRIuSIZE "",
 					g_snmp_sess.securityAuthProtoLen);
 			}
 

--- a/drivers/solis.c
+++ b/drivers/solis.c
@@ -765,13 +765,13 @@ static void get_base_info(void) {
 		/* synchronization failed */
 		fatalx(EXIT_FAILURE, NO_SOLIS);
 	} else {
-		upsdebugx(4, "%s: requesting %zu bytes from ser_get_buf_len()", __func__, packet_size);
+		upsdebugx(4, "%s: requesting %" PRIuSIZE " bytes from ser_get_buf_len()", __func__, packet_size);
 		tam = ser_get_buf_len(upsfd, packet, packet_size, 3, 0);
 		if (tam < 0) {
-			upsdebugx(0, "%s: Error (%zd) reading from ser_get_buf_len()", __func__, tam);
+			upsdebugx(0, "%s: Error (%" PRIiSIZE ") reading from ser_get_buf_len()", __func__, tam);
 			fatalx(EXIT_FAILURE, NO_SOLIS);
 		}
-		upsdebugx(2, "%s: received %zd bytes from ser_get_buf_len()", __func__, tam);
+		upsdebugx(2, "%s: received %" PRIiSIZE " bytes from ser_get_buf_len()", __func__, tam);
 		if (tam > 0 && nut_debug_level >= 4) {
 			upsdebug_hex(4, "received from ser_get_buf_len()", packet, (size_t)tam);
 		}
@@ -875,15 +875,15 @@ static void get_update_info(void) {
 	/* get update package */
 	temp[0] = 0; /* flush temp buffer */
 
-	upsdebugx(3, "%s: requesting %zu bytes from ser_get_buf_len()", __func__, packet_size);
+	upsdebugx(3, "%s: requesting %" PRIuSIZE " bytes from ser_get_buf_len()", __func__, packet_size);
 	tam = ser_get_buf_len(upsfd, temp, packet_size, 3, 0);
 
 	if (tam < 0) {
-		upsdebugx(0, "%s: Error (%zd) reading from ser_get_buf_len()", __func__, tam);
+		upsdebugx(0, "%s: Error (%" PRIiSIZE ") reading from ser_get_buf_len()", __func__, tam);
 		fatalx(EXIT_FAILURE, NO_SOLIS);
 	}
 
-	upsdebugx(2, "%s: received %zd bytes from ser_get_buf_len()", __func__, tam);
+	upsdebugx(2, "%s: received %" PRIiSIZE " bytes from ser_get_buf_len()", __func__, tam);
 	if(tam > 0 && nut_debug_level >= 4)
 		upsdebug_hex(4, "received from ser_get_buf_len()", temp, (size_t)tam);
 

--- a/drivers/tripplite.c
+++ b/drivers/tripplite.c
@@ -395,7 +395,7 @@ void upsdrv_updateinfo(void)
 	if (len != 21) {
 		++numfails;
 		if (numfails > MAXTRIES) {
-			ser_comm_fail("Data command failed: [%zd] bytes != 21 bytes.", len);
+			ser_comm_fail("Data command failed: [%" PRIiSIZE "] bytes != 21 bytes.", len);
 			dstate_datastale();
 		}
 		return;

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -622,7 +622,7 @@ static int send_cmd(const unsigned char *msg, size_t msg_len, unsigned char *rep
 			(usb_ctrl_charbufsize)sizeof(buffer_out));
 
 		if(ret != sizeof(buffer_out)) {
-			upslogx(1, "libusb_set_report() returned %d instead of %" PRIuSIZE "",
+			upslogx(1, "libusb_set_report() returned %d instead of %" PRIuSIZE,
 				ret, sizeof(buffer_out));
 			return ret;
 		}

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -622,7 +622,7 @@ static int send_cmd(const unsigned char *msg, size_t msg_len, unsigned char *rep
 			(usb_ctrl_charbufsize)sizeof(buffer_out));
 
 		if(ret != sizeof(buffer_out)) {
-			upslogx(1, "libusb_set_report() returned %d instead of %zu",
+			upslogx(1, "libusb_set_report() returned %d instead of %" PRIuSIZE "",
 				ret, sizeof(buffer_out));
 			return ret;
 		}

--- a/drivers/tripplitesu.c
+++ b/drivers/tripplitesu.c
@@ -235,7 +235,7 @@ static ssize_t do_command(char type, const char *command, const char *parameters
 		return -1;
 	}
 
-	upsdebugx(3, "do_command: %zd bytes sent [%s] -> OK", ret, buffer);
+	upsdebugx(3, "do_command: %" PRIiSIZE " bytes sent [%s] -> OK", ret, buffer);
 
 	ret = ser_get_buf_len(upsfd, (unsigned char *)buffer, 4, 3, 0);
 	if (ret < 0) {
@@ -248,7 +248,7 @@ static ssize_t do_command(char type, const char *command, const char *parameters
 	}
 
 	buffer[ret] = '\0';
-	upsdebugx(3, "do_command: %zd byted read [%s]", ret, buffer);
+	upsdebugx(3, "do_command: %" PRIiSIZE " byted read [%s]", ret, buffer);
 
 	if (!strcmp(buffer, "~00D")) {
 
@@ -263,7 +263,7 @@ static ssize_t do_command(char type, const char *command, const char *parameters
 		}
 
 		buffer[ret] = '\0';
-		upsdebugx(3, "do_command: %zd bytes read [%s]", ret, buffer);
+		upsdebugx(3, "do_command: %" PRIiSIZE " bytes read [%s]", ret, buffer);
 
 		int c = atoi(buffer);
 		if (c < 0) {
@@ -297,7 +297,7 @@ static ssize_t do_command(char type, const char *command, const char *parameters
 		}
 
 		response[ret] = '\0';
-		upsdebugx(3, "do_command: %zd bytes read [%s]", ret, response);
+		upsdebugx(3, "do_command: %" PRIiSIZE " bytes read [%s]", ret, response);
 
 		/* Tripp Lite pads their string responses with spaces.
 		   I don't like that, so I remove them.  This is safe to

--- a/drivers/tripplitesu.c
+++ b/drivers/tripplitesu.c
@@ -123,6 +123,7 @@
 
 #include "main.h"
 #include "serial.h"
+#include "nut_stdint.h"
 
 #define DRIVER_NAME		"Tripp Lite SmartOnline driver"
 #define DRIVER_VERSION	"0.06"

--- a/drivers/upscode2.c
+++ b/drivers/upscode2.c
@@ -517,7 +517,7 @@ void upsdrv_initups(void)
 			fatalx(EXIT_FAILURE, "Bad output_pace parameter: %s", str);
 		output_pace_usec = (useconds_t)temp;
 	}
-	upsdebugx(1, "output_pace = %ju uSec", (uintmax_t)output_pace_usec);
+	upsdebugx(1, "output_pace = %" PRIuMAX " uSec", (uintmax_t)output_pace_usec);
 
 	if ((str = getval("full_update_timer")) != NULL) {
 		int temp = atoi(str);

--- a/drivers/upscode2.c
+++ b/drivers/upscode2.c
@@ -1052,7 +1052,7 @@ static ssize_t upscrecv(char *buf)
 	} else {
 		/* Note: s should end up same as buf */
 		char *s = str_rtrim(buf, ENDCHAR);
-		upsdebugx(3, "upscrecv: %zd bytes:\t'%s'", res-1, s);
+		upsdebugx(3, "upscrecv: %" PRIiSIZE " bytes:\t'%s'", res-1, s);
 	}
 
 	return res;

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -370,7 +370,7 @@ static void start_driver(const ups_t *ups)
 			m = (size_t)nut_debug_level + 1;
 		} else {
 			upsdebugx(1, "Requested debugging level %d is too "
-				"high for pass-through args, truncated to %zu",
+				"high for pass-through args, truncated to %" PRIuSIZE "",
 				nut_debug_level,
 				(m - 1)	/* count off '-' (and '\0' already) chars */
 				);

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -370,7 +370,7 @@ static void start_driver(const ups_t *ups)
 			m = (size_t)nut_debug_level + 1;
 		} else {
 			upsdebugx(1, "Requested debugging level %d is too "
-				"high for pass-through args, truncated to %" PRIuSIZE "",
+				"high for pass-through args, truncated to %" PRIuSIZE,
 				nut_debug_level,
 				(m - 1)	/* count off '-' (and '\0' already) chars */
 				);

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -32,6 +32,7 @@
 #define HU_VAR_WAITBEFORERECONNECT "waitbeforereconnect"
 
 #include "main.h"
+#include "nut_stdint.h"
 #include "libhid.h"
 #include "usbhid-ups.h"
 #include "hidparser.h"

--- a/include/nut_stdint.h
+++ b/include/nut_stdint.h
@@ -72,15 +72,26 @@
 #  endif
 #endif
 
+/* Note: Windows headers are known to define at least "d" values,
+ * so macros below revolve around that and not "i" directly */
 #ifndef PRIiSIZE
 # ifdef PRIssize
 #  define PRIiSIZE PRIssize
 # else
-#  if defined(__MINGW32__) || defined (WIN32)
-#   define PRIiSIZE "lld"
+#  ifdef PRIdSIZE
+#   define PRIiSIZE PRIdSIZE
 #  else
-#   define PRIiSIZE "zd"
+#   if defined(__MINGW32__) || defined (WIN32)
+#    define PRIiSIZE "lld"
+#   else
+#    define PRIiSIZE "zd"
+#   endif
+#   define PRIdSIZE PRIiSIZE
 #  endif
+# endif
+#else
+# ifndef PRIdSIZE
+#  define PRIdSIZE PRIiSIZE
 # endif
 #endif /* format for size_t and ssize_t */
 
@@ -110,26 +121,35 @@
 #endif /* format for uintmax_t and intmax_t */
 
 #ifndef PRIdMAX
-# if defined(__MINGW32__) || defined (WIN32)
-#  if (SIZEOF_VOID_P == 8)
-#   ifdef PRId64
-#    define PRIdMAX PRId64
-#   else
-/* assume new enough compiler and standard, and no Windows %I64 etc... check "%ll" support via configure? */
-#    define PRIdMAX "lld"
-#   endif
-#  endif
-#  if (SIZEOF_VOID_P == 4)
-#   ifdef PRId32
-#    define PRIdMAX PRId32
-#   else
-/* assume new enough compiler and standard, and no Windows %I64 etc... check "%ll" support via configure? */
-#    define PRIdMAX "ld"
-#   endif
-#  endif
+# ifdef PRIiMAX
+#  define PRIdMAX PRIiMAX
 # else
+#  if defined(__MINGW32__) || defined (WIN32)
+#   if (SIZEOF_VOID_P == 8)
+#    ifdef PRId64
+#     define PRIdMAX PRId64
+#    else
+/* assume new enough compiler and standard, and no Windows %I64 etc... check "%ll" support via configure? */
+#     define PRIdMAX "lld"
+#    endif
+#   endif
+#   if (SIZEOF_VOID_P == 4)
+#    ifdef PRId32
+#     define PRIdMAX PRId32
+#    else
+/* assume new enough compiler and standard, and no Windows %I64 etc... check "%ll" support via configure? */
+#     define PRIdMAX "ld"
+#    endif
+#   endif
+#  else
 /* assume new enough compiler and standard... check "%j" support via configure? */
-#  define PRIdMAX "jd"
+#   define PRIdMAX "jd"
+#  endif
+#  define PRIiMAX PRIdMAX
+# endif
+#else
+# ifndef PRIiMAX
+#  define PRIiMAX PRIdMAX
 # endif
 #endif /* format for uintmax_t and intmax_t */
 

--- a/include/nut_stdint.h
+++ b/include/nut_stdint.h
@@ -52,19 +52,35 @@
 #endif
 
 /* Printing format for size_t and ssize_t */
-#ifndef PRIsize
-# if defined(__MINGW32__)
-#  define PRIsize "u"
+#ifndef PRIuSIZE
+# ifdef PRIsize
+#  define PRIuSIZE PRIsize
 # else
-#  define PRIsize "zu"
+#  if defined(__MINGW32__) || defined (WIN32)
+#   define PRIuSIZE "llu"
+#  else
+#   define PRIuSIZE "zu"
+#  endif
 # endif
 #endif
 
-#ifndef PRIssize
-# if defined(__MINGW32__)
-#  define PRIssize "d"
+#ifndef PRIxSIZE
+#  if defined(__MINGW32__) || defined (WIN32)
+#   define PRIxSIZE "llx"
+#  else
+#   define PRIxSIZE "zx"
+#  endif
+#endif
+
+#ifndef PRIiSIZE
+# ifdef PRIssize
+#  define PRIiSIZE PRIssize
 # else
-#  define PRIssize "zd"
+#  if defined(__MINGW32__) || defined (WIN32)
+#   define PRIiSIZE "lld"
+#  else
+#   define PRIiSIZE "zd"
+#  endif
 # endif
 #endif /* format for size_t and ssize_t */
 

--- a/include/nut_stdint.h
+++ b/include/nut_stdint.h
@@ -84,4 +84,77 @@
 # endif
 #endif /* format for size_t and ssize_t */
 
+/* Printing format for uintmax_t and intmax_t */
+#ifndef PRIuMAX
+# if defined(__MINGW32__) || defined (WIN32)
+#  if (SIZEOF_VOID_P == 8)
+#   ifdef PRIu64
+#    define PRIuMAX PRIu64
+#   else
+/* assume new enough compiler and standard, and no Windows %I64 etc... check "%ll" support via configure? */
+#    define PRIuMAX "llu"
+#   endif
+#  endif
+#  if (SIZEOF_VOID_P == 4)
+#   ifdef PRIu32
+#    define PRIuMAX PRIu32
+#   else
+/* assume new enough compiler and standard, and no Windows %I64 etc... check "%ll" support via configure? */
+#    define PRIuMAX "lu"
+#   endif
+#  endif
+# else
+/* assume new enough compiler and standard... check "%j" support via configure? */
+#  define PRIuMAX "ju"
+# endif
+#endif /* format for uintmax_t and intmax_t */
+
+#ifndef PRIdMAX
+# if defined(__MINGW32__) || defined (WIN32)
+#  if (SIZEOF_VOID_P == 8)
+#   ifdef PRId64
+#    define PRIdMAX PRId64
+#   else
+/* assume new enough compiler and standard, and no Windows %I64 etc... check "%ll" support via configure? */
+#    define PRIdMAX "lld"
+#   endif
+#  endif
+#  if (SIZEOF_VOID_P == 4)
+#   ifdef PRId32
+#    define PRIdMAX PRId32
+#   else
+/* assume new enough compiler and standard, and no Windows %I64 etc... check "%ll" support via configure? */
+#    define PRIdMAX "ld"
+#   endif
+#  endif
+# else
+/* assume new enough compiler and standard... check "%j" support via configure? */
+#  define PRIdMAX "jd"
+# endif
+#endif /* format for uintmax_t and intmax_t */
+
+#ifndef PRIxMAX
+# if defined(__MINGW32__) || defined (WIN32)
+#  if (SIZEOF_VOID_P == 8)
+#   ifdef PRIx64
+#    define PRIxMAX PRIx64
+#   else
+/* assume new enough compiler and standard, and no Windows %I64 etc... check "%ll" support via configure? */
+#    define PRIxMAX "llx"
+#   endif
+#  endif
+#  if (SIZEOF_VOID_P == 4)
+#   ifdef PRIx32
+#    define PRIxMAX PRIx32
+#   else
+/* assume new enough compiler and standard, and no Windows %I64 etc... check "%ll" support via configure? */
+#    define PRIxMAX "lx"
+#   endif
+#  endif
+# else
+/* assume new enough compiler and standard... check "%j" support via configure? */
+#  define PRIxMAX "jx"
+# endif
+#endif /* format for uintmax_t and intmax_t */
+
 #endif	/* NUT_STDINT_H_SEEN */

--- a/server/netssl.c
+++ b/server/netssl.c
@@ -689,7 +689,7 @@ ssize_t ssl_write(nut_ctype_t *client, const char *buf, size_t buflen)
 	ret = PR_Write(client->ssl, buf, (PRInt32)buflen);
 #endif /* WITH_OPENSSL | WITH_NSS */
 
-	upsdebugx(5, "ssl_write ret=%" PRIiSIZE "", ret);
+	upsdebugx(5, "ssl_write ret=%" PRIiSIZE, ret);
 
 	return ret;
 }

--- a/server/netssl.c
+++ b/server/netssl.c
@@ -136,7 +136,7 @@ static int ssl_error(SSL *ssl, ssize_t ret)
 	int	e;
 
 	if (ret >= INT_MAX) {
-		upslogx(LOG_ERR, "ssl_error() ret=%zd would not fit in an int", ret);
+		upslogx(LOG_ERR, "ssl_error() ret=%" PRIiSIZE " would not fit in an int", ret);
 		return -1;
 	}
 	e = SSL_get_error(ssl, (int)ret);
@@ -144,23 +144,23 @@ static int ssl_error(SSL *ssl, ssize_t ret)
 	switch (e)
 	{
 	case SSL_ERROR_WANT_READ:
-		upsdebugx(1, "ssl_error() ret=%zd SSL_ERROR_WANT_READ", ret);
+		upsdebugx(1, "ssl_error() ret=%" PRIiSIZE " SSL_ERROR_WANT_READ", ret);
 		break;
 
 	case SSL_ERROR_WANT_WRITE:
-		upsdebugx(1, "ssl_error() ret=%zd SSL_ERROR_WANT_WRITE", ret);
+		upsdebugx(1, "ssl_error() ret=%" PRIiSIZE " SSL_ERROR_WANT_WRITE", ret);
 		break;
 
 	case SSL_ERROR_SYSCALL:
 		if (ret == 0 && ERR_peek_error() == 0) {
 			upsdebugx(1, "ssl_error() EOF from client");
 		} else {
-			upsdebugx(1, "ssl_error() ret=%zd SSL_ERROR_SYSCALL", ret);
+			upsdebugx(1, "ssl_error() ret=%" PRIiSIZE " SSL_ERROR_SYSCALL", ret);
 		}
 		break;
 
 	default:
-		upsdebugx(1, "ssl_error() ret=%zd SSL_ERROR %d", ret, e);
+		upsdebugx(1, "ssl_error() ret=%" PRIiSIZE " SSL_ERROR %d", ret, e);
 		ssl_debug();
 	}
 
@@ -689,7 +689,7 @@ ssize_t ssl_write(nut_ctype_t *client, const char *buf, size_t buflen)
 	ret = PR_Write(client->ssl, buf, (PRInt32)buflen);
 #endif /* WITH_OPENSSL | WITH_NSS */
 
-	upsdebugx(5, "ssl_write ret=%zd", ret);
+	upsdebugx(5, "ssl_write ret=%" PRIiSIZE "", ret);
 
 	return ret;
 }

--- a/server/sockdebug.c
+++ b/server/sockdebug.c
@@ -35,7 +35,7 @@ static void sock_arg(size_t numarg, char **arg)
 {
 	size_t	i;
 
-	printf("numarg=%zu : ", numarg);
+	printf("numarg=%" PRIuSIZE " : ", numarg);
 
 	for (i = 0; i < numarg; i++)
 		printf("[%s] ", arg[i]);

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -390,7 +390,7 @@ int sendback(nut_ctype_t *client, const char *fmt, ...)
 
 	{ /* scoping */
 		char * s = str_rtrim(ans, '\n');
-		upsdebugx(2, "write: [destfd=%d] [len=%zu] [%s]", client->sock_fd, len, s);
+		upsdebugx(2, "write: [destfd=%d] [len=%" PRIuSIZE "] [%s]", client->sock_fd, len, s);
 	}
 
 	if (res < 0 || len != (size_t)res) {
@@ -752,7 +752,7 @@ static void poll_reload(void)
 	size_t maxalloc = SIZE_MAX / sizeof(void *);
 	if ((uintmax_t)maxalloc < (uintmax_t)maxconn) {
 		fatalx(EXIT_FAILURE,
-			"You requested %jd as maximum number of connections, but we can only allocate %zu.\n"
+			"You requested %jd as maximum number of connections, but we can only allocate %" PRIuSIZE ".\n"
 			"The server won't start until this problem is resolved.\n", (intmax_t)maxconn, maxalloc);
 	}
 

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -738,13 +738,13 @@ static void poll_reload(void)
 	if ((intmax_t)ret < (intmax_t)maxconn) {
 		fatalx(EXIT_FAILURE,
 			"Your system limits the maximum number of connections to %ld\n"
-			"but you requested %jd. The server won't start until this\n"
+			"but you requested %" PRIdMAX ". The server won't start until this\n"
 			"problem is resolved.\n", ret, (intmax_t)maxconn);
 	}
 
 	if (1 > maxconn) {
 		fatalx(EXIT_FAILURE,
-			"You requested %jd as maximum number of connections.\n"
+			"You requested %" PRIdMAX " as maximum number of connections.\n"
 			"The server won't start until this problem is resolved.\n", (intmax_t)maxconn);
 	}
 
@@ -752,7 +752,7 @@ static void poll_reload(void)
 	size_t maxalloc = SIZE_MAX / sizeof(void *);
 	if ((uintmax_t)maxalloc < (uintmax_t)maxconn) {
 		fatalx(EXIT_FAILURE,
-			"You requested %jd as maximum number of connections, but we can only allocate %" PRIuSIZE ".\n"
+			"You requested %" PRIdMAX " as maximum number of connections, but we can only allocate %" PRIuSIZE ".\n"
 			"The server won't start until this problem is resolved.\n", (intmax_t)maxconn, maxalloc);
 	}
 
@@ -1067,7 +1067,7 @@ static void mainloop(void)
 		nfds++;
 	}
 
-	upsdebugx(2, "%s: polling %jd filedescriptors", __func__, (intmax_t)nfds);
+	upsdebugx(2, "%s: polling %" PRIdMAX " filedescriptors", __func__, (intmax_t)nfds);
 
 	ret = poll(fds, nfds, 2000);
 

--- a/tests/getvaluetest.c
+++ b/tests/getvaluetest.c
@@ -118,7 +118,7 @@ static int RunBuiltInTests(char *argv[]) {
 
 		GetValue(reportBuf, &data, &value);
 
-		printf("Test #%zd ", i + 1);
+		printf("Test #%" PRIiSIZE " ", i + 1);
 		PrintBufAndData(reportBuf, bufSize,  &data);
 		if (value == testData[i].expectedValue) {
 			printf(" value %ld PASS\n", value);

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -208,7 +208,7 @@ static void show_usage()
 	printf("  -E, --eaton_serial <serial ports list>: Scan serial Eaton devices (XCP, SHUT and Q1).\n");
 
 #if (defined HAVE_PTHREAD) && (defined HAVE_PTHREAD_TRYJOIN)
-	printf("  -T, --thread <max number of threads>: Limit the amount of scanning threads running simultaneously (default: %zu).\n", max_threads);
+	printf("  -T, --thread <max number of threads>: Limit the amount of scanning threads running simultaneously (default: %" PRIuSIZE ").\n", max_threads);
 #else
 	printf("  -T, --thread <max number of threads>: Limit the amount of scanning threads running simultaneously (not implemented in this build: no pthread support)");
 #endif
@@ -582,7 +582,7 @@ int main(int argc, char *argv[])
 							"thread count %s (%ld) exceeds the "
 							"current file descriptor count limit "
 							"(minus reservation), constraining "
-							"to %zu\n",
+							"to %" PRIuSIZE "\n",
 							optarg, val, max_threads);
 					} else
 # endif /* HAVE_SYS_RESOURCE_H */
@@ -591,7 +591,7 @@ int main(int argc, char *argv[])
 					fprintf(stderr,
 						"WARNING: Requested max scanning "
 						"thread count %s (%ld) is out of range, "
-						"using default %zu\n",
+						"using default %" PRIuSIZE "\n",
 						optarg, val, max_threads);
 				}
 #else

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -566,10 +566,10 @@ int main(int argc, char *argv[])
 					&& (uintmax_t)val > (uintmax_t)(nofile_limit.rlim_cur - RESERVE_FD_COUNT)
 					) {
 						upsdebugx(1, "Detected soft limit for "
-							"file descriptor count is %ju",
+							"file descriptor count is %" PRIuMAX,
 							(uintmax_t)nofile_limit.rlim_cur);
 						upsdebugx(1, "Detected hard limit for "
-							"file descriptor count is %ju",
+							"file descriptor count is %" PRIuMAX,
 							(uintmax_t)nofile_limit.rlim_max);
 
 						max_threads = (size_t)nofile_limit.rlim_cur;

--- a/tools/nut-scanner/scan_eaton_serial.c
+++ b/tools/nut-scanner/scan_eaton_serial.c
@@ -474,8 +474,8 @@ nutscan_device_t * nutscan_scan_eaton_serial(const char* ports_range)
 		 * other protocol scanners...
 		 */
 		if (curr_threads >= max_threads) {
-			upsdebugx(2, "%s: already running %zu scanning threads "
-				"(launched overall: %zu), "
+			upsdebugx(2, "%s: already running %" PRIuSIZE " scanning threads "
+				"(launched overall: %" PRIuSIZE "), "
 				"waiting until some would finish",
 				__func__, curr_threads, thread_count);
 			while (curr_threads >= max_threads) {
@@ -489,12 +489,12 @@ nutscan_device_t * nutscan_scan_eaton_serial(const char* ports_range)
 					ret = pthread_tryjoin_np(thread_array[i].thread, NULL);
 					switch (ret) {
 						case ESRCH:     /* No thread with the ID thread could be found - already "joined"? */
-							upsdebugx(5, "%s: Was thread #%zu joined earlier?", __func__, i);
+							upsdebugx(5, "%s: Was thread #%" PRIuSIZE " joined earlier?", __func__, i);
 							break;
 						case 0:         /* thread exited */
 							if (curr_threads > 0) {
 								curr_threads --;
-								upsdebugx(4, "%s: Joined a finished thread #%zu", __func__, i);
+								upsdebugx(4, "%s: Joined a finished thread #%" PRIuSIZE "", __func__, i);
 							} else {
 								/* threadcount_mutex fault? */
 								upsdebugx(0, "WARNING: %s: Accounting of thread count "
@@ -503,13 +503,13 @@ nutscan_device_t * nutscan_scan_eaton_serial(const char* ports_range)
 							thread_array[i].active = FALSE;
 							break;
 						case EBUSY:     /* actively running */
-							upsdebugx(6, "%s: thread #%zu still busy (%i)",
+							upsdebugx(6, "%s: thread #%" PRIuSIZE " still busy (%i)",
 								__func__, i, ret);
 							break;
 						case EDEADLK:   /* Errors with thread interactions... bail out? */
 						case EINVAL:    /* Errors with thread interactions... bail out? */
 						default:        /* new pthreads abilities? */
-							upsdebugx(5, "%s: thread #%zu reported code %i",
+							upsdebugx(5, "%s: thread #%" PRIuSIZE " reported code %i",
 								__func__, i, ret);
 							break;
 					}
@@ -572,7 +572,7 @@ nutscan_device_t * nutscan_scan_eaton_serial(const char* ports_range)
 					if (!thread_array[i].active) {
 						/* Probably should not get here,
 						 * but handle it just in case */
-						upsdebugx(0, "WARNING: %s: Midway clean-up: did not expect thread %zu to be not active",
+						upsdebugx(0, "WARNING: %s: Midway clean-up: did not expect thread %" PRIuSIZE " to be not active",
 							__func__, i);
 						sem_post(semaphore);
 						continue;
@@ -619,7 +619,7 @@ nutscan_device_t * nutscan_scan_eaton_serial(const char* ports_range)
 			pthread_mutex_lock(&threadcount_mutex);
 			if (curr_threads > 0) {
 				curr_threads --;
-				upsdebugx(5, "%s: Clean-up: Joined a finished thread #%zu",
+				upsdebugx(5, "%s: Clean-up: Joined a finished thread #%" PRIuSIZE "",
 					__func__, i);
 			} else {
 				upsdebugx(0, "WARNING: %s: Clean-up: Accounting of thread count "

--- a/tools/nut-scanner/scan_eaton_serial.c
+++ b/tools/nut-scanner/scan_eaton_serial.c
@@ -494,7 +494,7 @@ nutscan_device_t * nutscan_scan_eaton_serial(const char* ports_range)
 						case 0:         /* thread exited */
 							if (curr_threads > 0) {
 								curr_threads --;
-								upsdebugx(4, "%s: Joined a finished thread #%" PRIuSIZE "", __func__, i);
+								upsdebugx(4, "%s: Joined a finished thread #%" PRIuSIZE, __func__, i);
 							} else {
 								/* threadcount_mutex fault? */
 								upsdebugx(0, "WARNING: %s: Accounting of thread count "
@@ -619,7 +619,7 @@ nutscan_device_t * nutscan_scan_eaton_serial(const char* ports_range)
 			pthread_mutex_lock(&threadcount_mutex);
 			if (curr_threads > 0) {
 				curr_threads --;
-				upsdebugx(5, "%s: Clean-up: Joined a finished thread #%" PRIuSIZE "",
+				upsdebugx(5, "%s: Clean-up: Joined a finished thread #%" PRIuSIZE,
 					__func__, i);
 			} else {
 				upsdebugx(0, "WARNING: %s: Clean-up: Accounting of thread count "

--- a/tools/nut-scanner/scan_nut.c
+++ b/tools/nut-scanner/scan_nut.c
@@ -330,8 +330,8 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 		if (curr_threads >= max_threads
 		|| (curr_threads >= max_threads_scantype && max_threads_scantype > 0)
 		) {
-			upsdebugx(2, "%s: already running %zu scanning threads "
-				"(launched overall: %zu), "
+			upsdebugx(2, "%s: already running %" PRIuSIZE " scanning threads "
+				"(launched overall: %" PRIuSIZE "), "
 				"waiting until some would finish",
 				__func__, curr_threads, thread_count);
 			while (curr_threads >= max_threads
@@ -347,12 +347,12 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 					ret = pthread_tryjoin_np(thread_array[i].thread, NULL);
 					switch (ret) {
 						case ESRCH:     /* No thread with the ID thread could be found - already "joined"? */
-							upsdebugx(5, "%s: Was thread #%zu joined earlier?", __func__, i);
+							upsdebugx(5, "%s: Was thread #%" PRIuSIZE " joined earlier?", __func__, i);
 							break;
 						case 0:         /* thread exited */
 							if (curr_threads > 0) {
 								curr_threads --;
-								upsdebugx(4, "%s: Joined a finished thread #%zu", __func__, i);
+								upsdebugx(4, "%s: Joined a finished thread #%" PRIuSIZE "", __func__, i);
 							} else {
 								/* threadcount_mutex fault? */
 								upsdebugx(0, "WARNING: %s: Accounting of thread count "
@@ -361,13 +361,13 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 							thread_array[i].active = FALSE;
 							break;
 						case EBUSY:     /* actively running */
-							upsdebugx(6, "%s: thread #%zu still busy (%i)",
+							upsdebugx(6, "%s: thread #%" PRIuSIZE " still busy (%i)",
 								__func__, i, ret);
 							break;
 						case EDEADLK:   /* Errors with thread interactions... bail out? */
 						case EINVAL:    /* Errors with thread interactions... bail out? */
 						default:        /* new pthreads abilities? */
-							upsdebugx(5, "%s: thread #%zu reported code %i",
+							upsdebugx(5, "%s: thread #%" PRIuSIZE " reported code %i",
 								__func__, i, ret);
 							break;
 					}
@@ -453,7 +453,7 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 					if (!thread_array[i].active) {
 						/* Probably should not get here,
 						 * but handle it just in case */
-						upsdebugx(0, "WARNING: %s: Midway clean-up: did not expect thread %zu to be not active",
+						upsdebugx(0, "WARNING: %s: Midway clean-up: did not expect thread %" PRIuSIZE " to be not active",
 							__func__, i);
 						sem_post(semaphore);
 						if (max_threads_scantype > 0)
@@ -506,7 +506,7 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 			pthread_mutex_lock(&threadcount_mutex);
 			if (curr_threads > 0) {
 				curr_threads --;
-				upsdebugx(5, "%s: Clean-up: Joined a finished thread #%zu",
+				upsdebugx(5, "%s: Clean-up: Joined a finished thread #%" PRIuSIZE "",
 					__func__, i);
 			} else {
 				upsdebugx(0, "WARNING: %s: Clean-up: Accounting of thread count "

--- a/tools/nut-scanner/scan_nut.c
+++ b/tools/nut-scanner/scan_nut.c
@@ -352,7 +352,7 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 						case 0:         /* thread exited */
 							if (curr_threads > 0) {
 								curr_threads --;
-								upsdebugx(4, "%s: Joined a finished thread #%" PRIuSIZE "", __func__, i);
+								upsdebugx(4, "%s: Joined a finished thread #%" PRIuSIZE, __func__, i);
 							} else {
 								/* threadcount_mutex fault? */
 								upsdebugx(0, "WARNING: %s: Accounting of thread count "
@@ -506,7 +506,7 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 			pthread_mutex_lock(&threadcount_mutex);
 			if (curr_threads > 0) {
 				curr_threads --;
-				upsdebugx(5, "%s: Clean-up: Joined a finished thread #%" PRIuSIZE "",
+				upsdebugx(5, "%s: Clean-up: Joined a finished thread #%" PRIuSIZE,
 					__func__, i);
 			} else {
 				upsdebugx(0, "WARNING: %s: Clean-up: Accounting of thread count "

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -658,7 +658,7 @@ static int init_session(struct snmp_session * snmp_sess, nutscan_snmp_t * sec)
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) )
 # pragma GCC diagnostic pop
 #endif
-			fprintf(stderr, "Bad SNMPv3 securityAuthProtoLen: %" PRIuSIZE "",
+			fprintf(stderr, "Bad SNMPv3 securityAuthProtoLen: %" PRIuSIZE,
 				snmp_sess->securityAuthProtoLen);
 			return 0;
 		}
@@ -746,7 +746,7 @@ static int init_session(struct snmp_session * snmp_sess, nutscan_snmp_t * sec)
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) )
 # pragma GCC diagnostic pop
 #endif
-			fprintf(stderr, "Bad SNMPv3 securityAuthProtoLen: %" PRIuSIZE "",
+			fprintf(stderr, "Bad SNMPv3 securityAuthProtoLen: %" PRIuSIZE,
 				snmp_sess->securityAuthProtoLen);
 			return 0;
 		}
@@ -1016,7 +1016,7 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 						case 0:         /* thread exited */
 							if (curr_threads > 0) {
 								curr_threads --;
-								upsdebugx(4, "%s: Joined a finished thread #%" PRIuSIZE "", __func__, i);
+								upsdebugx(4, "%s: Joined a finished thread #%" PRIuSIZE, __func__, i);
 							} else {
 								/* threadcount_mutex fault? */
 								upsdebugx(0, "WARNING: %s: Accounting of thread count "
@@ -1153,7 +1153,7 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 			pthread_mutex_lock(&threadcount_mutex);
 			if (curr_threads > 0) {
 				curr_threads --;
-				upsdebugx(5, "%s: Clean-up: Joined a finished thread #%" PRIuSIZE "",
+				upsdebugx(5, "%s: Clean-up: Joined a finished thread #%" PRIuSIZE,
 					__func__, i);
 			} else {
 				upsdebugx(0, "WARNING: %s: Clean-up: Accounting of thread count "

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -658,7 +658,7 @@ static int init_session(struct snmp_session * snmp_sess, nutscan_snmp_t * sec)
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) )
 # pragma GCC diagnostic pop
 #endif
-			fprintf(stderr, "Bad SNMPv3 securityAuthProtoLen: %zu",
+			fprintf(stderr, "Bad SNMPv3 securityAuthProtoLen: %" PRIuSIZE "",
 				snmp_sess->securityAuthProtoLen);
 			return 0;
 		}
@@ -746,7 +746,7 @@ static int init_session(struct snmp_session * snmp_sess, nutscan_snmp_t * sec)
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) )
 # pragma GCC diagnostic pop
 #endif
-			fprintf(stderr, "Bad SNMPv3 securityAuthProtoLen: %zu",
+			fprintf(stderr, "Bad SNMPv3 securityAuthProtoLen: %" PRIuSIZE "",
 				snmp_sess->securityAuthProtoLen);
 			return 0;
 		}
@@ -994,8 +994,8 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 		if (curr_threads >= max_threads
 		|| (curr_threads >= max_threads_scantype && max_threads_scantype > 0)
 		) {
-			upsdebugx(2, "%s: already running %zu scanning threads "
-				"(launched overall: %zu), "
+			upsdebugx(2, "%s: already running %" PRIuSIZE " scanning threads "
+				"(launched overall: %" PRIuSIZE "), "
 				"waiting until some would finish",
 				__func__, curr_threads, thread_count);
 			while (curr_threads >= max_threads
@@ -1011,12 +1011,12 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 					ret = pthread_tryjoin_np(thread_array[i].thread, NULL);
 					switch (ret) {
 						case ESRCH:     /* No thread with the ID thread could be found - already "joined"? */
-							upsdebugx(5, "%s: Was thread #%zu joined earlier?", __func__, i);
+							upsdebugx(5, "%s: Was thread #%" PRIuSIZE " joined earlier?", __func__, i);
 							break;
 						case 0:         /* thread exited */
 							if (curr_threads > 0) {
 								curr_threads --;
-								upsdebugx(4, "%s: Joined a finished thread #%zu", __func__, i);
+								upsdebugx(4, "%s: Joined a finished thread #%" PRIuSIZE "", __func__, i);
 							} else {
 								/* threadcount_mutex fault? */
 								upsdebugx(0, "WARNING: %s: Accounting of thread count "
@@ -1025,13 +1025,13 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 							thread_array[i].active = FALSE;
 							break;
 						case EBUSY:     /* actively running */
-							upsdebugx(6, "%s: thread #%zu still busy (%i)",
+							upsdebugx(6, "%s: thread #%" PRIuSIZE " still busy (%i)",
 								__func__, i, ret);
 							break;
 						case EDEADLK:   /* Errors with thread interactions... bail out? */
 						case EINVAL:    /* Errors with thread interactions... bail out? */
 						default:        /* new pthreads abilities? */
-							upsdebugx(5, "%s: thread #%zu reported code %i",
+							upsdebugx(5, "%s: thread #%" PRIuSIZE " reported code %i",
 								__func__, i, ret);
 							break;
 					}
@@ -1100,7 +1100,7 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 					if (!thread_array[i].active) {
 						/* Probably should not get here,
 						 * but handle it just in case */
-						upsdebugx(0, "WARNING: %s: Midway clean-up: did not expect thread %zu to be not active",
+						upsdebugx(0, "WARNING: %s: Midway clean-up: did not expect thread %" PRIuSIZE " to be not active",
 							__func__, i);
 						sem_post(semaphore);
 						if (max_threads_scantype > 0)
@@ -1153,7 +1153,7 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 			pthread_mutex_lock(&threadcount_mutex);
 			if (curr_threads > 0) {
 				curr_threads --;
-				upsdebugx(5, "%s: Clean-up: Joined a finished thread #%zu",
+				upsdebugx(5, "%s: Clean-up: Joined a finished thread #%" PRIuSIZE "",
 					__func__, i);
 			} else {
 				upsdebugx(0, "WARNING: %s: Clean-up: Accounting of thread count "

--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -482,8 +482,8 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 		if (curr_threads >= max_threads
 		|| (curr_threads >= max_threads_scantype && max_threads_scantype > 0)
 		) {
-					upsdebugx(2, "%s: already running %zu scanning threads "
-						"(launched overall: %zu), "
+					upsdebugx(2, "%s: already running %" PRIuSIZE " scanning threads "
+						"(launched overall: %" PRIuSIZE "), "
 						"waiting until some would finish",
 						__func__, curr_threads, thread_count);
 			while (curr_threads >= max_threads
@@ -499,12 +499,12 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 							ret = pthread_tryjoin_np(thread_array[i].thread, NULL);
 							switch (ret) {
 								case ESRCH:     /* No thread with the ID thread could be found - already "joined"? */
-									upsdebugx(5, "%s: Was thread #%zu joined earlier?", __func__, i);
+									upsdebugx(5, "%s: Was thread #%" PRIuSIZE " joined earlier?", __func__, i);
 									break;
 								case 0:         /* thread exited */
 									if (curr_threads > 0) {
 										curr_threads --;
-										upsdebugx(4, "%s: Joined a finished thread #%zu", __func__, i);
+										upsdebugx(4, "%s: Joined a finished thread #%" PRIuSIZE "", __func__, i);
 									} else {
 										/* threadcount_mutex fault? */
 										upsdebugx(0, "WARNING: %s: Accounting of thread count "
@@ -513,13 +513,13 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 									thread_array[i].active = FALSE;
 									break;
 								case EBUSY:     /* actively running */
-									upsdebugx(6, "%s: thread #%zu still busy (%i)",
+									upsdebugx(6, "%s: thread #%" PRIuSIZE " still busy (%i)",
 										__func__, i, ret);
 									break;
 								case EDEADLK:   /* Errors with thread interactions... bail out? */
 								case EINVAL:    /* Errors with thread interactions... bail out? */
 								default:        /* new pthreads abilities? */
-									upsdebugx(5, "%s: thread #%zu reported code %i",
+									upsdebugx(5, "%s: thread #%" PRIuSIZE " reported code %i",
 										__func__, i, ret);
 									break;
 							}
@@ -597,7 +597,7 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 							if (!thread_array[i].active) {
 								/* Probably should not get here,
 								 * but handle it just in case */
-								upsdebugx(0, "WARNING: %s: Midway clean-up: did not expect thread %zu to be not active",
+								upsdebugx(0, "WARNING: %s: Midway clean-up: did not expect thread %" PRIuSIZE " to be not active",
 									__func__, i);
 								sem_post(semaphore);
 								if (max_threads_scantype > 0)
@@ -650,7 +650,7 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 					pthread_mutex_lock(&threadcount_mutex);
 					if (curr_threads > 0) {
 						curr_threads --;
-						upsdebugx(5, "%s: Clean-up: Joined a finished thread #%zu",
+						upsdebugx(5, "%s: Clean-up: Joined a finished thread #%" PRIuSIZE "",
 							__func__, i);
 					} else {
 						upsdebugx(0, "WARNING: %s: Clean-up: Accounting of thread count "

--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -505,7 +505,7 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 								case 0:         /* thread exited */
 									if (curr_threads > 0) {
 										curr_threads --;
-										upsdebugx(4, "%s: Joined a finished thread #%" PRIuSIZE "", __func__, i);
+										upsdebugx(4, "%s: Joined a finished thread #%" PRIuSIZE, __func__, i);
 									} else {
 										/* threadcount_mutex fault? */
 										upsdebugx(0, "WARNING: %s: Accounting of thread count "
@@ -651,7 +651,7 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 					pthread_mutex_lock(&threadcount_mutex);
 					if (curr_threads > 0) {
 						curr_threads --;
-						upsdebugx(5, "%s: Clean-up: Joined a finished thread #%" PRIuSIZE "",
+						upsdebugx(5, "%s: Clean-up: Joined a finished thread #%" PRIuSIZE,
 							__func__, i);
 					} else {
 						upsdebugx(0, "WARNING: %s: Clean-up: Accounting of thread count "

--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -27,6 +27,7 @@
 
 #include "common.h"
 #include "nut-scan.h"
+#include "nut_stdint.h"
 
 #ifdef WITH_NEON
 #include <sys/types.h>
@@ -218,7 +219,7 @@ static void * nutscan_scan_xml_http_generic(void * arg)
 		if (ip == NULL) {
 			upsdebugx(2,
 				"nutscan_scan_xml_http_generic() : scanning connected network segment(s) "
-				"with a broadcast, attempt %d of %d with a timeout of %jd usec",
+				"with a broadcast, attempt %d of %d with a timeout of %" PRIdMAX " usec",
 				(i + 1), MAX_RETRIES, (uintmax_t)usec_timeout);
 			sockAddress_udp.sin_addr.s_addr = INADDR_BROADCAST;
 			setsockopt(peerSocket, SOL_SOCKET, SO_BROADCAST, &sockopt_on,
@@ -226,7 +227,7 @@ static void * nutscan_scan_xml_http_generic(void * arg)
 		} else {
 			upsdebugx(2,
 				"nutscan_scan_xml_http_generic() : scanning IP '%s' with a unicast, "
-				"attempt %d of %d with a timeout of %jd usec",
+				"attempt %d of %d with a timeout of %" PRIdMAX " usec",
 				ip, (i + 1), MAX_RETRIES, (uintmax_t)usec_timeout);
 			inet_pton(AF_INET, ip, &(sockAddress_udp.sin_addr));
 		}


### PR DESCRIPTION
"Noisy" part of changes from PR #1524