### PR TITLE
Modbus drivers: fix to use `uint16_t` and `unsigned int`

### DIFF
--- a/drivers/adelsystem_cbi.c
+++ b/drivers/adelsystem_cbi.c
@@ -657,25 +657,25 @@ int register_read(modbus_t *mb, int addr, regtype_t type, void *data)
 	int rval = -1;
 
 	/* register bit masks */
-	uint mask8 = 0x00FF;
-	uint mask16 = 0xFFFF;
+	uint16_t mask8 = 0x00FF;
+	uint16_t mask16 = 0xFFFF;
 
 	switch (type) {
 		case COIL:
 			rval = modbus_read_bits(mb, addr, 1, (uint8_t *)data);
-			*(uint *)data = *(uint *)data & mask8;
+			*(uint16_t *)data = *(uint16_t *)data & mask8;
 			break;
 		case INPUT_B:
 			rval = modbus_read_input_bits(mb, addr, 1, (uint8_t *)data);
-			*(uint *)data = *(uint *)data & mask8;
+			*(uint16_t *)data = *(uint16_t *)data & mask8;
 			break;
 		case INPUT_R:
 			rval = modbus_read_input_registers(mb, addr, 1, (uint16_t *)data);
-			*(uint *)data = *(uint *)data & mask16;
+			*(uint16_t *)data = *(uint16_t *)data & mask16;
 			break;
 		case HOLDING:
 			rval = modbus_read_registers(mb, addr, 1, (uint16_t *)data);
-			*(uint *)data = *(uint *)data & mask16;
+			*(uint16_t *)data = *(uint16_t *)data & mask16;
 			break;
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
 # pragma GCC diagnostic push
@@ -723,7 +723,7 @@ int register_read(modbus_t *mb, int addr, regtype_t type, void *data)
 			modbus_reconnect();
 		}
 	}
-	upsdebugx(3, "register addr: 0x%x, register type: %d read: %d",addr, type, *(uint *)data);
+	upsdebugx(3, "register addr: 0x%x, register type: %d read: %u",addr, type, *(unsigned int *)data);
 	return rval;
 }
 
@@ -733,16 +733,16 @@ int register_write(modbus_t *mb, int addr, regtype_t type, void *data)
 	int rval = -1;
 
 	/* register bit masks */
-	uint mask8 = 0x00FF;
-	uint mask16 = 0xFFFF;
+	uint16_t mask8 = 0x00FF;
+	uint16_t mask16 = 0xFFFF;
 
 	switch (type) {
 		case COIL:
-			*(uint *)data = *(uint *)data & mask8;
+			*(uint16_t *)data = *(uint16_t *)data & mask8;
 			rval = modbus_write_bit(mb, addr, *(uint8_t *)data);
 			break;
 		case HOLDING:
-			*(uint *)data = *(uint *)data & mask16;
+			*(uint16_t *)data = *(uint16_t *)data & mask16;
 			rval = modbus_write_register(mb, addr, *(uint16_t *)data);
 			break;
 
@@ -780,7 +780,7 @@ int register_write(modbus_t *mb, int addr, regtype_t type, void *data)
 			modbus_reconnect();
 		}
 	}
-	upsdebugx(3, "register addr: 0x%x, register type: %d read: %d",addr, type, *(uint *)data);
+	upsdebugx(3, "register addr: 0x%x, register type: %d read: %u",addr, type, *(unsigned int *)data);
 	return rval;
 }
 
@@ -847,9 +847,9 @@ int get_dev_state(devreg_t regindx, devstate_t **dvstat)
 	int n;
 	int rval;						/* return value */
 	static char *ptr = NULL;		/* temporary pointer */
-	uint reg_val;					/* register value */
+	unsigned int reg_val;					/* register value */
 #if READALL_REGS == 0
-	uint num;						/* register number */
+	unsigned int num;						/* register number */
 	regtype_t rtype;				/* register type */
 	int addr;						/* register address */
 #endif

--- a/drivers/generic_modbus.c
+++ b/drivers/generic_modbus.c
@@ -23,7 +23,8 @@
 #include "main.h"
 #include "generic_modbus.h"
 #include <modbus.h>
-#include <timehead.h>
+#include "timehead.h"
+#include "nut_stdint.h"
 
 #define DRIVER_NAME "NUT Generic Modbus driver"
 #define DRIVER_VERSION  "0.03"
@@ -409,25 +410,25 @@ int register_read(modbus_t *mb, int addr, regtype_t type, void *data)
 	int rval = -1;
 
 	/* register bit masks */
-	uint mask8 = 0x000F;
-	uint mask16 = 0x00FF;
+	uint16_t mask8 = 0x000F;
+	uint16_t mask16 = 0x00FF;
 
 	switch (type) {
 		case COIL:
 			rval = modbus_read_bits(mb, addr, 1, (uint8_t *)data);
-			*(uint *)data = *(uint *)data & mask8;
+			*(uint16_t *)data = *(uint16_t *)data & mask8;
 			break;
 		case INPUT_B:
 			rval = modbus_read_input_bits(mb, addr, 1, (uint8_t *)data);
-			*(uint *)data = *(uint *)data & mask8;
+			*(uint16_t *)data = *(uint16_t *)data & mask8;
 			break;
 		case INPUT_R:
 			rval = modbus_read_input_registers(mb, addr, 1, (uint16_t *)data);
-			*(uint *)data = *(uint *)data & mask16;
+			*(uint16_t *)data = *(uint16_t *)data & mask16;
 			break;
 		case HOLDING:
 			rval = modbus_read_registers(mb, addr, 1, (uint16_t *)data);
-			*(uint *)data = *(uint *)data & mask16;
+			*(uint16_t *)data = *(uint16_t *)data & mask16;
 			break;
 
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
@@ -475,7 +476,7 @@ int register_read(modbus_t *mb, int addr, regtype_t type, void *data)
 			modbus_reconnect();
 		}
 	}
-	upsdebugx(3, "register addr: 0x%x, register type: %d read: %d",addr, type, *(uint *)data);
+	upsdebugx(3, "register addr: 0x%x, register type: %d read: %u",addr, type, *(unsigned int *)data);
 	return rval;
 }
 
@@ -485,16 +486,16 @@ int register_write(modbus_t *mb, int addr, regtype_t type, void *data)
 	int rval = -1;
 
 	/* register bit masks */
-	uint mask8 = 0x000F;
-	uint mask16 = 0x00FF;
+	uint16_t mask8 = 0x000F;
+	uint16_t mask16 = 0x00FF;
 
 	switch (type) {
 		case COIL:
-			*(uint *)data = *(uint *)data & mask8;
+			*(uint16_t *)data = *(uint16_t *)data & mask8;
 			rval = modbus_write_bit(mb, addr, *(uint8_t *)data);
 			break;
 		case HOLDING:
-			*(uint *)data = *(uint *)data & mask16;
+			*(uint16_t *)data = *(uint16_t *)data & mask16;
 			rval = modbus_write_register(mb, addr, *(uint16_t *)data);
 			break;
 
@@ -531,7 +532,7 @@ int register_write(modbus_t *mb, int addr, regtype_t type, void *data)
 			modbus_reconnect();
 		}
 	}
-	upsdebugx(3, "register addr: 0x%x, register type: %d read: %d",addr, type, *(uint *)data);
+	upsdebugx(3, "register addr: 0x%x, register type: %d read: %u",addr, type, *(unsigned int *)data);
 	return rval;
 }
 


### PR DESCRIPTION
Fix code using less-than-standard type names.

CC @dtsecon - FYI