### PR TITLE
drivers/libusb.h, libshut.h, nutdrv_qx et al: rename open/close fields

### DIFF
--- a/drivers/blazer_usb.c
+++ b/drivers/blazer_usb.c
@@ -442,7 +442,7 @@ ssize_t blazer_command(const char *cmd, char *buf, size_t buflen)
 	ssize_t	ret;
 
 	if (udev == NULL) {
-		ret = usb->open(&udev, &usbdevice, reopen_matcher, NULL);
+		ret = usb->open_dev(&udev, &usbdevice, reopen_matcher, NULL);
 
 		if (ret < 1) {
 			return ret;
@@ -493,7 +493,7 @@ ssize_t blazer_command(const char *cmd, char *buf, size_t buflen)
 	case LIBUSB_ERROR_NOT_FOUND:		/* No such file or directory */
 	fallthrough_case_reconnect:
 		/* Uh oh, got to reconnect! */
-		usb->close(udev);
+		usb->close_dev(udev);
 		udev = NULL;
 		break;
 
@@ -647,7 +647,7 @@ void upsdrv_initups(void)
 	/* link the matchers */
 	regex_matcher->next = &device_matcher;
 
-	ret = usb->open(&udev, &usbdevice, regex_matcher, NULL);
+	ret = usb->open_dev(&udev, &usbdevice, regex_matcher, NULL);
 	if (ret < 0) {
 		fatalx(EXIT_FAILURE,
 			"No supported devices found. Please check your device availability with 'lsusb'\n"
@@ -703,7 +703,7 @@ void upsdrv_initinfo(void)
 void upsdrv_cleanup(void)
 {
 #ifndef TESTING
-	usb->close(udev);
+	usb->close_dev(udev);
 	USBFreeExactMatcher(reopen_matcher);
 	USBFreeRegexMatcher(regex_matcher);
 	free(usbdevice.Vendor);

--- a/drivers/libshut.h
+++ b/drivers/libshut.h
@@ -139,13 +139,13 @@ typedef struct shut_communication_subdriver_s {
 	const char *name;				/* name of this subdriver		*/
 	const char *version;			/* version of this subdriver	*/
 
-	int (*open)(usb_dev_handle *upsfd,			/* try to open the next available	*/
+	int (*open_dev)(usb_dev_handle *upsfd,			/* try to open the next available	*/
 		SHUTDevice_t *curDevice,	/* device matching USBDeviceMatcher_t	*/
 		char *device_path,
 		int (*callback)(usb_dev_handle upsfd, SHUTDevice_t *hd,
 			usb_ctrl_charbuf rdbuf, usb_ctrl_charbufsize rdlen));
 
-	void (*close)(usb_dev_handle upsfd);
+	void (*close_dev)(usb_dev_handle upsfd);
 
 	int (*get_report)(usb_dev_handle upsfd, usb_ctrl_repindex ReportId,
 		usb_ctrl_charbuf raw_buf, usb_ctrl_charbufsize ReportSize);

--- a/drivers/nut_libusb.h
+++ b/drivers/nut_libusb.h
@@ -52,13 +52,13 @@ typedef struct usb_communication_subdriver_s {
 	const char *name;				/* name of this subdriver		*/
 	const char *version;			/* version of this subdriver	*/
 
-	int (*open)(usb_dev_handle **sdevp,	/* try to open the next available	*/
+	int (*open_dev)(usb_dev_handle **sdevp,	/* try to open the next available	*/
 		USBDevice_t *curDevice,		/* device matching USBDeviceMatcher_t	*/
 		USBDeviceMatcher_t *matcher,
 		int (*callback)(usb_dev_handle *udev, USBDevice_t *hd,
 			usb_ctrl_charbuf rdbuf, usb_ctrl_charbufsize rdlen));
 
-	void (*close)(usb_dev_handle *sdev);
+	void (*close_dev)(usb_dev_handle *sdev);
 
 	int (*get_report)(usb_dev_handle *sdev, usb_ctrl_repindex ReportId,
 		usb_ctrl_charbuf raw_buf, usb_ctrl_charbufsize ReportSize);

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -3023,7 +3023,7 @@ void	upsdrv_initups(void)
 		/* Link the matchers */
 		regex_matcher->next = &device_matcher;
 
-		ret = usb->open(&udev, &usbdevice, regex_matcher, NULL);
+		ret = usb->open_dev(&udev, &usbdevice, regex_matcher, NULL);
 		if (ret < 0) {
 			fatalx(EXIT_FAILURE,
 				"No supported devices found. "
@@ -3117,7 +3117,7 @@ void	upsdrv_cleanup(void)
 
 #ifdef QX_USB
 
-		usb->close(udev);
+		usb->close_dev(udev);
 		USBFreeExactMatcher(reopen_matcher);
 		USBFreeRegexMatcher(regex_matcher);
 		free(usbdevice.Vendor);
@@ -3162,7 +3162,7 @@ static ssize_t	qx_command(const char *cmd, char *buf, size_t buflen)
 #  endif	/* QX_SERIAL (&& QX_USB)*/
 
 		if (udev == NULL) {
-			ret = usb->open(&udev, &usbdevice, reopen_matcher, NULL);
+			ret = usb->open_dev(&udev, &usbdevice, reopen_matcher, NULL);
 
 			if (ret < 1) {
 				return ret;
@@ -3228,7 +3228,7 @@ static ssize_t	qx_command(const char *cmd, char *buf, size_t buflen)
 		case LIBUSB_ERROR_NOT_FOUND:	/* No such file or directory */
 		fallthrough_case_reconnect:
 			/* Uh oh, got to reconnect! */
-			usb->close(udev);
+			usb->close_dev(udev);
 			udev = NULL;
 			break;
 

--- a/drivers/riello_usb.c
+++ b/drivers/riello_usb.c
@@ -350,7 +350,7 @@ static int riello_command(uint8_t *cmd, uint8_t *buf, uint16_t length, uint16_t 
 	int ret;
 
 	if (udev == NULL) {
-		ret = usb->open(&udev, &usbdevice, reopen_matcher, &driver_callback);
+		ret = usb->open_dev(&udev, &usbdevice, reopen_matcher, &driver_callback);
 
 		upsdebugx (3, "riello_command err udev NULL : %d ", ret);
 		if (ret < 0)
@@ -406,7 +406,7 @@ static int riello_command(uint8_t *cmd, uint8_t *buf, uint16_t length, uint16_t 
 	case LIBUSB_ERROR_NOT_FOUND:		/* No such file or directory */
 	fallthrough_case_reconnect:
 		/* Uh oh, got to reconnect! */
-		usb->close(udev);
+		usb->close_dev(udev);
 		udev = NULL;
 		break;
 
@@ -894,7 +894,7 @@ void upsdrv_initups(void)
 	/* link the matchers */
 	regex_matcher->next = &device_matcher;
 
-	ret = usb->open(&udev, &usbdevice, regex_matcher, &driver_callback);
+	ret = usb->open_dev(&udev, &usbdevice, regex_matcher, &driver_callback);
 	if (ret < 0) {
 		fatalx(EXIT_FAILURE,
 			"No supported devices found. Please check your device availability with 'lsusb'\n"
@@ -1216,7 +1216,7 @@ void upsdrv_updateinfo(void)
 
 void upsdrv_cleanup(void)
 {
-	usb->close(udev);
+	usb->close_dev(udev);
 	USBFreeExactMatcher(reopen_matcher);
 	USBFreeRegexMatcher(regex_matcher);
 	free(usbdevice.Vendor);

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -329,7 +329,7 @@ static int reconnect_ups(void)
 	upsdebugx(2, "= device has been disconnected, try to reconnect =");
 	upsdebugx(2, "==================================================");
 
-	ret = comm_driver->open(&udev, &curDevice, reopen_matcher, NULL);
+	ret = comm_driver->open_dev(&udev, &curDevice, reopen_matcher, NULL);
 	if (ret < 1) {
 		upslogx(LOG_INFO, "Reconnecting to UPS failed; will retry later...");
 		dstate_datastale();
@@ -1589,7 +1589,7 @@ void upsdrv_initups(void)
 
 	/* Search for the first supported UPS matching the regular
 	 * expression */
-	r = comm_driver->open(&udev, &curDevice, regex_matcher, NULL);
+	r = comm_driver->open_dev(&udev, &curDevice, regex_matcher, NULL);
 	if (r < 1) {
 		fatalx(EXIT_FAILURE, "No matching USB/HID UPS found");
 	}
@@ -1642,7 +1642,7 @@ void upsdrv_initups(void)
 
 void upsdrv_cleanup(void)
 {
-	comm_driver->close(udev);
+	comm_driver->close_dev(udev);
 	USBFreeExactMatcher(reopen_matcher);
 	USBFreeRegexMatcher(regex_matcher);
 	free(curDevice.Vendor);

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -1051,7 +1051,7 @@ void upsdrv_initups(void)
 
 	/* Search for the first supported UPS matching the
 	   regular expression (USB) or device_path (SHUT) */
-	ret = comm_driver->open(&udev, &curDevice, subdriver_matcher, &callback);
+	ret = comm_driver->open_dev(&udev, &curDevice, subdriver_matcher, &callback);
 	if (ret < 1)
 		fatalx(EXIT_FAILURE, "No matching HID UPS found");
 
@@ -1130,7 +1130,7 @@ void upsdrv_cleanup(void)
 {
 	upsdebugx(1, "upsdrv_cleanup...");
 
-	comm_driver->close(udev);
+	comm_driver->close_dev(udev);
 	Free_ReportDesc(pDesc);
 	free_report_buffer(reportbuf);
 #ifndef SHUT_MODE
@@ -1562,20 +1562,20 @@ static int reconnect_ups(void)
 	upsdebugx(4, "Closing comm_driver previous handle");
 	/* Try to close the previous handle */
 	if (udev)
-		comm_driver->close(udev);
+		comm_driver->close_dev(udev);
 
 	upsdebugx(4, "===================================================================");
 	if (wait_before_reconnect > 0 ) {
 		upsdebugx(4, " device has been disconnected, trying to reconnect in %i seconds", wait_before_reconnect);
 		sleep(wait_before_reconnect);
 		upsdebugx(4, " trying to reconnect");
-	}else{
+	} else {
 		upsdebugx(4, " device has been disconnected, try to reconnect");
 	}
 	upsdebugx(4, "===================================================================");
 
 	upsdebugx(4, "Opening comm_driver ...");
-	ret = comm_driver->open(&udev, &curDevice, subdriver_matcher, NULL);
+	ret = comm_driver->open_dev(&udev, &curDevice, subdriver_matcher, NULL);
 	upsdebugx(4, "Opening comm_driver returns ret=%i", ret);
 	if (ret > 0) {
 		return 1;


### PR DESCRIPTION
This is about `*_communication_subdriver_s` fields for function pointers named "open" and "close" - renamed to "*_dev" in order to avoid conflict with `serial.h` macros defined for WIN32 builds.

Relatively "noisy" code change originally proposed in #1524