### PR TITLE
Refactor fcntl(..., FD_CLOEXEC) as set_close_on_exec() where possible

### DIFF
--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -1638,7 +1638,7 @@ static int try_connect(utype_t *ups)
 	setflag(&ups->status, ST_CONNECTED);
 
 	/* prevent connection leaking to NOTIFYCMD */
-	fcntl(upscli_fd(&ups->conn), F_SETFD, FD_CLOEXEC);
+	set_close_on_exec(upscli_fd(&ups->conn));
 
 	/* now try to authenticate to upsd */
 
@@ -1945,7 +1945,7 @@ static void start_pipe(void)
 	close(pipefd[0]);
 
 	/* prevent pipe leaking to NOTIFYCMD */
-	fcntl(pipefd[1], F_SETFD, FD_CLOEXEC);
+	set_close_on_exec(pipefd[1]);
 }
 
 static void delete_ups(utype_t *target)

--- a/clients/upssched.c
+++ b/clients/upssched.c
@@ -301,7 +301,7 @@ static int open_sock(void)
 		fatal_with_errno(EXIT_FAILURE, "listen(%d, %d) failed", fd, US_LISTEN_BACKLOG);
 
 	/* don't leak socket to CMDSCRIPT */
-	fcntl(fd, F_SETFD, FD_CLOEXEC);
+	set_close_on_exec(fd);
 
 	return fd;
 }
@@ -400,7 +400,7 @@ static void conn_add(int sockfd)
 	}
 
 	/* don't leak connection to CMDSCRIPT */
-	fcntl(acc, F_SETFD, FD_CLOEXEC);
+	set_close_on_exec(acc);
 
 	/* enable nonblocking I/O */
 

--- a/common/common.c
+++ b/common/common.c
@@ -1077,3 +1077,19 @@ char * get_libname(const char* base_libname)
 	upsdebugx(1,"Looking for lib %s, found %s", base_libname, (libname_path!=NULL)?libname_path:"NULL");
 	return libname_path;
 }
+
+/* TODO: Extend for TYPE_FD and WIN32 eventually? */
+void set_close_on_exec(int fd) {
+	/* prevent fd leaking to child processes */
+#ifndef FD_CLOEXEC
+	/* Find a way, if possible at all old platforms */
+	NUT_UNUSED_VARIABLE(fd);
+#else
+# ifdef WIN32
+	/* Find a way, if possible at all (WIN32: get INT fd from the HANDLE?) */
+	NUT_UNUSED_VARIABLE(fd);
+# else
+	fcntl(fd, F_SETFD, FD_CLOEXEC);
+# endif
+#endif
+}

--- a/common/parseconf.c
+++ b/common/parseconf.c
@@ -452,7 +452,7 @@ int pconf_file_begin(PCONF_CTX_t *ctx, const char *fn)
 	}
 
 	/* prevent fd leaking to child processes */
-	fcntl(fileno(ctx->f), F_SETFD, FD_CLOEXEC);
+	set_close_on_exec(fileno(ctx->f));
 
 	return 1;	/* OK */
 }

--- a/include/common.h
+++ b/include/common.h
@@ -240,6 +240,10 @@ extern int optind;
 #	define setegid(x) setresgid(-1,x,-1)    /* Works for HP-UX 10.20 */
 #endif
 
+/* Not all platforms support the flag; this method abstracts
+ * its use (or not) to simplify calls in the actual codebase */
+void set_close_on_exec(int fd);
+
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 }


### PR DESCRIPTION
Originally proposed as part of #1524 and earlier as a way to isolate Windows-vs-POSIX code.