### PR TITLE
Troubleshoot upsd start for `make check-NIT`: `testcase_upsd_allow_no_device()`

### DIFF
--- a/server/upsd.c
+++ b/server/upsd.c
@@ -1487,6 +1487,8 @@ int main(int argc, char **argv)
 		} else {
 			fatalx(EXIT_FAILURE, "Fatal error: at least one UPS must be defined in ups.conf");
 		}
+	} else {
+		upslogx(LOG_INFO, "Found %d UPS defined in ups.conf", num_ups);
 	}
 
 	/* try to bring in the var/cmd descriptions */

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -447,6 +447,7 @@ testcase_upsd_allow_no_device() {
     generatecfg_upsd_nodev
     generatecfg_upsdusers_trivial
     generatecfg_ups_trivial
+    ls -la "$NUT_CONFPATH/" || true
     upsd -F &
     PID_UPSD="$!"
     log_debug "Tried to start UPSD as PID $PID_UPSD"
@@ -455,6 +456,8 @@ testcase_upsd_allow_no_device() {
     COUNTDOWN=60
     while [ "$COUNTDOWN" -gt 0 ]; do
         if isPidAlive "$PID_UPSD"; then break ; fi
+        # FIXME: If we are here, even once, then PID_UPSD which we
+        # knew has already disappeared... wait() for its exit-code?
         sleep 1
         COUNTDOWN="`expr $COUNTDOWN - 1`"
     done
@@ -490,7 +493,8 @@ testcase_upsd_allow_no_device() {
             PASSED="`expr $PASSED + 1`"
         fi
     else
-        log_error "upsd was expected to be running although no devices are defined"
+        log_error "upsd was expected to be running although no devices are defined; is ups.conf populated?"
+        ls -la "$NUT_CONFPATH/" || true
         FAILED="`expr $FAILED + 1`"
         FAILED_FUNCS="$FAILED_FUNCS testcase_upsd_allow_no_device"
         report_NUT_PORT

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -101,8 +101,9 @@ isBusy_NUT_PORT() {
 		return 1
 	fi
 
+	# Assume not busy to not preclude testing in 100% of the cases
 	log_warn "isBusy_NUT_PORT() can not say, tools for checking NUT_PORT=$NUT_PORT are not available"
-	return 0
+	return 1
 }
 
 die() {

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -498,6 +498,12 @@ testcase_upsd_allow_no_device() {
         FAILED="`expr $FAILED + 1`"
         FAILED_FUNCS="$FAILED_FUNCS testcase_upsd_allow_no_device"
         report_NUT_PORT
+
+        UPSD_RES=0
+        kill -15 $PID_UPSD
+        wait $PID_UPSD || UPSD_RES=$?
+        log_error "upsd exit-code was: $UPSD_RES"
+        return $UPSD_RES
     fi
 
     kill -15 $PID_UPSD

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -88,7 +88,10 @@ isBusy_NUT_PORT() {
 		#   0: 00000000000000000000000000000000:1F46 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000    33        0 37451 1 00000000fa3c0c15 100 0 0 10 0
 		NUT_PORT_HEX="`printf '%04X' "${NUT_PORT}"`"
 		NUT_PORT_HITS="`cat /proc/net/tcp /proc/net/tcp6 2>/dev/null | awk '{print $2}' | grep -E ":${NUT_POR_HEX}\$"`" \
-		&& [ -n "$NUT_PORT_HITS" ] && return
+		&& [ -n "$NUT_PORT_HITS" ] && return 0
+
+		# We had a way to check, and the way said port is available
+		return 1
 	fi
 
     (netstat -an || sockstat -l) 2>/dev/null | grep -E "[:.]${NUT_PORT}(\t| |\$)" > /dev/null && return

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -63,7 +63,8 @@ report_NUT_PORT() {
     [ -n "${NUT_PORT}" ] || return
 
     log_info "Trying to report users of NUT_PORT=${NUT_PORT}"
-    (netstat -anp | sockstat -l) 2>/dev/null | grep -w "${NUT_PORT}" \
+    # Note: on Solarish systems, `netstat -anp` does not report PID info
+    (netstat -an ; netstat -anp || sockstat -l) 2>/dev/null | grep -w "${NUT_PORT}" \
     || (lsof -i :"${NUT_PORT}") 2>/dev/null \
     || true
 


### PR DESCRIPTION
Currently every once in a while `upsd` silently does not start in tests - not reproducible well.

Failed case:
````
[INFO] Test UPSD allowed to run without driver configs
fopen /dev/shm/jenkins-nutci/nut_nut_PR-1527@4/tests/NIT/tmp/run/upsd.pid: No such file or directory
Could not find PID file '/dev/shm/jenkins-nutci/nut_nut_PR-1527@4/tests/NIT/tmp/run/upsd.pid' to see if previous upsd instance is already running!

not listening on ::1 port 35057
not listening on 127.0.0.1 port 35057
not listening on localhost port 35057
no listening interface available
Network UPS Tools upsd 2.8.0-210-g7510847
[WARNING] Had to wait a few retries for the UPSD process to appear
[ERROR] upsd was expected to be running although no devices are defined
[INFO] Trying to report users of NUT_PORT=35057
[INFO] UPSD was last known to start as PID 1187753
/dev/shm/jenkins-nutci/nut_nut_PR-1527@4/tests/NIT/nit.sh: line 499: kill: (1187753) - No such process
````

Expected case:
````
[INFO] Test UPSD allowed to run without driver configs
fopen /dev/shm/jenkins-nutci/nut_nut_PR-1527@4/tests/NIT/tmp/run/upsd.pid: No such file or directory
Could not find PID file '/dev/shm/jenkins-nutci/nut_nut_PR-1527@4/tests/NIT/tmp/run/upsd.pid' to see if previous upsd instance is already running!

listening on ::1 port 34959
listening on 127.0.0.1 port 34959
not listening on localhost port 34959
Warning: no UPS definitions in ups.conf
Normally at least one UPS must be defined in ups.conf, currently there are none (please configure the file and reload the service)
/dev/shm/jenkins-nutci/nut_nut_PR-1527@4/tmp/share/cmdvartab not found - disabling descriptions
Running as foreground process, not saving a PID file
[INFO] OK, upsd is running
````

Suspecting that something fails in `ups.conf` parsing (absent file?) and that maybe `fatalx()` does not spill to `stderr`. Or something else could be in play. This PR adds a few data points to log (did we read `ups.conf` successfully? was it there?) to help next steps.