### PR TITLE
scripts/Solaris/Makefile.am: do not install Solaris init files uninvited

### DIFF
--- a/scripts/Solaris/Makefile.am
+++ b/scripts/Solaris/Makefile.am
@@ -29,8 +29,24 @@ sbin_SCRIPTS = ../upsdrvsvcctl/upsdrvsvcctl
 SOLARIS_CHECK_TARGETS += check-local-solaris-smf
 endif
 
+# FIXME: This is very clumsy - find a better way...
+# maybe move this logic to configure so *it* decides if we are
+# on the right platform to install anything here?
+if WITH_SOLARIS_SMF
 solarisinitscriptdir = @datadir@/solaris-init
 solarisinitscript_SCRIPTS = nut reset-ups-usb-solaris.sh.sample
+else !WITH_SOLARIS_SMF
+if WITH_SOLARIS_PKG_IPS
+solarisinitscriptdir = @datadir@/solaris-init
+solarisinitscript_SCRIPTS = nut reset-ups-usb-solaris.sh.sample
+else !WITH_SOLARIS_PKG_IPS
+if WITH_SOLARIS_PKG_SVR4
+solarisinitscriptdir = @datadir@/solaris-init
+solarisinitscript_SCRIPTS = nut reset-ups-usb-solaris.sh.sample
+endif WITH_SOLARIS_PKG_SVR4
+endif !WITH_SOLARIS_PKG_IPS
+endif !WITH_SOLARIS_SMF
+
 EXTRA_DIST += reset-ups-usb-solaris.sh.sample
 
 SOLARIS_PACKAGE_TARGETS =


### PR DESCRIPTION
Hot-fixes a problem found and raised in issue #1488

A cleaner fix is desirable (to consider the build target in configure script), but at least there should be less mess on non-Solaris/illumos systems now already.