### PR TITLE
Some fixes for Solaris/illumos packaging and SMF support

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -94,6 +94,9 @@ https://github.com/networkupstools/nut/milestone/8
    be sufficient without deprecation warnings for builds against openssl-3.0.x
    (but no real-time testing was done yet) [#1547]
 
+ - some fixes applied to Solaris/illumos packaging and SMF service support
+   [#1554, #1564]
+
 ---------------------------------------------------------------------------
 Release notes for NUT 2.8.0 - what's new since 2.7.4:
 

--- a/configure.ac
+++ b/configure.ac
@@ -2090,34 +2090,8 @@ else
 fi
 AM_CONDITIONAL(WITH_PKG_CONFIG, test -n "${pkgconfigdir}")
 
-AC_MSG_CHECKING(whether to install Solaris SMF files)
-solarissmf="auto"
-AC_ARG_WITH([solaris-smf],
-	AS_HELP_STRING([--with-solaris-smf=(yes|auto|no)], [Enable installation of NUT scripts and manifests for Solaris Service Management Framework (auto)]),
-[
-	case "${withval}" in
-	auto|"")
-		solarissmf="auto"
-		;;
-	yes|no)
-		solarissmf="${withval}"
-		;;
-	*)
-		AC_MSG_ERROR([Unexpected argument for --with-solaris-smf=${withval}])
-		;;
-	esac
-], [])
 
-if test x"$solarissmf" = xauto ; then
-	if test -x /usr/sbin/svcadm && test -x /usr/sbin/svccfg && test -x /usr/bin/svcs ; then
-		solarissmf="yes"
-	else
-		solarissmf="no"
-	fi
-fi
-AC_MSG_RESULT([${solarissmf}])
-AM_CONDITIONAL(WITH_SOLARIS_SMF, test x"$solarissmf" = x"yes")
-
+dnl Options for Solaris/illumos `make install` and `make package`
 AC_MSG_CHECKING(whether to make Solaris SVR4 packages)
 solarispkg_svr4="auto"
 AC_ARG_WITH([solaris-pkg-svr4],
@@ -2146,6 +2120,7 @@ fi
 AC_MSG_RESULT([${solarispkg_svr4}])
 AM_CONDITIONAL(WITH_SOLARIS_PKG_SVR4, test x"$solarispkg_svr4" = x"yes")
 
+
 AC_MSG_CHECKING(whether to make Solaris IPS packages)
 solarispkg_ips="auto"
 AC_ARG_WITH([solaris-pkg-ips],
@@ -2173,6 +2148,81 @@ if test x"$solarispkg_ips" = xauto ; then
 fi
 AC_MSG_RESULT([${solarispkg_ips}])
 AM_CONDITIONAL(WITH_SOLARIS_PKG_IPS, test x"$solarispkg_ips" = x"yes")
+
+
+dnl NOTE: Be sure to customize e.g.  --datarootdir=/usr/share/nut to install
+dnl these scripts not into default location as e.g. /usr/share/solaris-smf
+AC_MSG_CHECKING(whether to install Solaris SMF files)
+solarissmf="auto"
+AC_ARG_WITH([solaris-smf],
+	AS_HELP_STRING([--with-solaris-smf=(yes|auto|no)], [Enable installation of NUT scripts and manifests for Solaris Service Management Framework (auto)]),
+[
+	case "${withval}" in
+	auto|"")
+		solarissmf="auto"
+		;;
+	yes|no)
+		solarissmf="${withval}"
+		;;
+	*)
+		AC_MSG_ERROR([Unexpected argument for --with-solaris-smf=${withval}])
+		;;
+	esac
+], [])
+
+if test x"$solarissmf" = xauto ; then
+	if test -x /usr/sbin/svcadm && test -x /usr/sbin/svccfg && test -x /usr/bin/svcs ; then
+		solarissmf="yes"
+	else
+		case "${solarispkg_ips}${solarispkg_svr4}" in
+			*yes*) solarisinit="yes" ;; dnl Want to install so we can generally package
+			*) solarissmf="no" ;; dnl Target not solarish
+		esac
+	fi
+fi
+AC_MSG_RESULT([${solarissmf}])
+AM_CONDITIONAL(WITH_SOLARIS_SMF, test x"$solarissmf" = x"yes")
+
+
+AC_MSG_CHECKING(whether to install Solaris SVR4 (legacy) init-script files)
+solarisinit="auto"
+AC_ARG_WITH([solaris-init],
+	AS_HELP_STRING([--with-solaris-init=(yes|auto|no)], [Enable installation of NUT legacy init-scripts for Solaris/illumos (auto)]),
+[
+	case "${withval}" in
+	auto|"")
+		solarisinit="auto"
+		;;
+	yes|no)
+		solarisinit="${withval}"
+		;;
+	*)
+		AC_MSG_ERROR([Unexpected argument for --with-solaris-init=${withval}])
+		;;
+	esac
+], [])
+
+if test x"$solarisinit" = xauto ; then
+	dnl Depends on usability of SMF or making for packaging
+	case "${solarispkg_ips}${solarispkg_svr4}" in
+		*yes*) solarisinit="yes" ;; dnl Want to install so we can generally package
+		*)
+			case ${target_os} in
+				solaris*|sunos*|SunOS*|illumos*)
+					if test "$solarissmf" = x"yes" ; then
+						dnl no need on modern OSes
+						solarisinit="no"
+					else
+						solarisinit="yes"
+					fi
+					;;
+				*) solarisinit="no" ;; dnl Some other OS
+			esac
+			;;
+	esac
+fi
+AC_MSG_RESULT([${solarisinit}])
+AM_CONDITIONAL(WITH_SOLARIS_INIT, test x"$solarisinit" = x"yes")
 
 dnl Note: Currently there is no reliable automatic detection -
 dnl users have to ask they want systemd units installed, or

--- a/scripts/Solaris/Makefile.am
+++ b/scripts/Solaris/Makefile.am
@@ -29,23 +29,10 @@ sbin_SCRIPTS = ../upsdrvsvcctl/upsdrvsvcctl
 SOLARIS_CHECK_TARGETS += check-local-solaris-smf
 endif
 
-# FIXME: This is very clumsy - find a better way...
-# maybe move this logic to configure so *it* decides if we are
-# on the right platform to install anything here?
-if WITH_SOLARIS_SMF
+if WITH_SOLARIS_INIT
 solarisinitscriptdir = @datadir@/solaris-init
 solarisinitscript_SCRIPTS = nut reset-ups-usb-solaris.sh.sample
-else !WITH_SOLARIS_SMF
-if WITH_SOLARIS_PKG_IPS
-solarisinitscriptdir = @datadir@/solaris-init
-solarisinitscript_SCRIPTS = nut reset-ups-usb-solaris.sh.sample
-else !WITH_SOLARIS_PKG_IPS
-if WITH_SOLARIS_PKG_SVR4
-solarisinitscriptdir = @datadir@/solaris-init
-solarisinitscript_SCRIPTS = nut reset-ups-usb-solaris.sh.sample
-endif WITH_SOLARIS_PKG_SVR4
-endif !WITH_SOLARIS_PKG_IPS
-endif !WITH_SOLARIS_SMF
+endif
 
 EXTRA_DIST += reset-ups-usb-solaris.sh.sample
 

--- a/scripts/Solaris/nut-driver.xml.in
+++ b/scripts/Solaris/nut-driver.xml.in
@@ -2,14 +2,14 @@
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <!--
 #
-# Copyright 2016 - 2019 Jim Klimov
+# Copyright 2016 - 2022 Jim Klimov
 # Template manifest for instantiated NUT drivers
 #
 -->
 
 <service_bundle type='manifest' name='nut-driver'>
 
-	<service name='system/power/nut-driver' type='service' version='1.1'>
+	<service name='system/power/nut-driver' type='service' version='2'>
 
 	<!--
 	  Wait for all local and usr filesystem to be mounted - project is
@@ -85,7 +85,7 @@
 		<exec_method
 		type='method'
 		name='start'
-		exec='/sbin/sh -c &apos;NUTDEV="`@NUT_LIBEXECDIR@/nut-driver-enumerator.sh --get-device-for-service %i`" &amp;&amp; [ -n "$NUTDEV" ] || { echo "FATAL: Could not find a NUT device section for service unit %i" >&amp;2 ; exit 1 ; } ; @SBINDIR@/upsdrvctl %m "$NUTDEV"&apos;'
+		exec='/sbin/sh -c &apos;NUTDEV="`@NUT_LIBEXECDIR@/nut-driver-enumerator.sh --get-device-for-service %i`" &amp;&amp; [ -n "$NUTDEV" ] || { echo "FATAL: Could not find a NUT device section for service unit %i" >&amp;2 ; exit 1 ; } ; SMF_FMRI=svc:/system/power/nut-server:default @NUT_DATADIR@/solaris-smf/method/svc-nut-server create_run_dir &amp;&amp; @SBINDIR@/upsdrvctl %m "$NUTDEV"&apos;'
 		timeout_seconds='0'/>
 
 		<exec_method

--- a/scripts/Solaris/nut-server.xml.in
+++ b/scripts/Solaris/nut-server.xml.in
@@ -2,14 +2,14 @@
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <!--
 #
-# Copyright 2016-2017 Jim Klimov
+# Copyright 2016-2022 Jim Klimov
 # Service for the upsd daemon (and drivers, if available)
 #
 -->
 
 <service_bundle type='manifest' name='nut-server'>
 
-	<service name='system/power/nut-server' type='service' version='1'>
+	<service name='system/power/nut-server' type='service' version='2'>
 
 	<!--
 	  Configure a default instance for the service since it doesn't
@@ -125,6 +125,14 @@
 			-->
 			<propval name='ignore_error' type='astring'
 			 value='core,signal' />
+		</property_group>
+
+		<!-- Also used by nut-driver.xml to stay in sync regarding the rights -->
+		<property_group name='nut' type='application'>
+			<stability value='Evolving' />
+			<propval name='NUT_RUN_DIR' type='astring' value='@PIDPATH@/nut' />
+			<propval name='NUTUSER' type='astring' value='@RUN_AS_USER@' />
+			<propval name='NUTGROUP' type='astring' value='@RUN_AS_GROUP@' />
 		</property_group>
 
 	<!-- Really unstable - this service should be evolved! -->

--- a/scripts/Solaris/svc-nut-server.in
+++ b/scripts/Solaris/svc-nut-server.in
@@ -16,21 +16,35 @@ prefix="@prefix@"
 NUT_DIR="@prefix@"
 NUT_SBIN_DIR="$NUT_DIR/sbin"
 NUT_LIB_DIR="${NUT_DIR}/lib"
-NUT_RUN_DIR="@PIDPATH@/nut"
+
+NUT_RUN_DIR="`svcprop -p nut/NUT_RUN_DIR $SMF_FMRI`" \
+&& [ -n "$NUT_RUN_DIR" ] \
+|| NUT_RUN_DIR="@PIDPATH@/nut"
+
 CONFIG="@CONFPATH@/nut.conf"
-NUTUSER="@RUN_AS_USER@"
-NUTGROUP="@RUN_AS_GROUP@"
+
+NUTUSER="`svcprop -p nut/NUTUSER $SMF_FMRI`" \
+&& [ -n "$NUTUSER" ] \
+|| NUTUSER="@RUN_AS_USER@"
+
+NUTGROUP="`svcprop -p nut/NUTGROUP $SMF_FMRI`" \
+&& [ -n "$NUTGROUP" ] \
+|| NUTGROUP="@RUN_AS_GROUP@"
 
 if [ -f "$CONFIG" ] ; then
 	. "$CONFIG"
 fi
 
-ups_start () {
+create_run_dir () {
 	# Default rights inspired by NUT scripts/Solaris/postinstall.in
 	mkdir -p "$NUT_RUN_DIR" && \
 	chown "root:$NUTGROUP" "$NUT_RUN_DIR" && \
 	chmod 770 "$NUT_RUN_DIR" \
 	|| exit $SMF_EXIT_ERR_FATAL
+}
+
+ups_start () {
+	create_run_dir
 
 	if [ "$MODE" = "none" ];then
 		echo "No NUT mode set, not starting anything" >&2
@@ -51,6 +65,11 @@ case "$1" in
 
 'refresh'|'reload')
 	LD_LIBRARY_PATH="${NUT_LIB_DIR}:$LD_LIBRARY_PATH" "${NUT_SBIN_DIR}/upsd" -c reload
+	;;
+
+"create_run_dir")
+	# Mostly provided for the sake of nut-driver service
+	create_run_dir
 	;;
 
 *)


### PR DESCRIPTION
Closes: #1554

Closes: #1564

Note: while testing on an older OpenIndiana system, could not get the nut-driver manifest to re-import and see the new `start/exec`. Doing `svccfg delete nut-driver; svccfg import /usr/share/nut/solaris-smf/manifest/nut-driver.xml` helped however.