### PR TITLE
scripts/python/app/NUT-Monitor-py3qt5.in: fix __find_icon_file()...

### DIFF
--- a/scripts/python/app/NUT-Monitor-py3qt5.in
+++ b/scripts/python/app/NUT-Monitor-py3qt5.in
@@ -216,13 +216,25 @@ class interface :
 
     def __find_icon_file( self ) :
         filename = 'nut-monitor.png'
+
         # TODO: Skip checking application directory if installed
         path = os.path.join( os.path.dirname( sys.argv[0] ), "icons", "256x256", filename )
         if os.path.exists(path):
             return path
+
+        # Normally icons should be installed to OS location by packaging:
+        path = QStandardPaths.locate(QStandardPaths.GenericDataLocation, os.path.join( "icons", "hicolor", "256x256", "apps", filename ) )
+        if os.path.exists(path):
+            return path
+
+        # Fall back to NUT-specific area where `make install` might put them,
+        # e.g. /usr/share/nut/nut-monitor/icons/... or some such, if not the
+        # same location as checked in first attempt above:
         path = QStandardPaths.locate(QStandardPaths.AppDataLocation, os.path.join( "icons", "hicolor", "256x256", "apps", filename ) )
         if os.path.exists(path):
             return path
+
+        # No banana!
         raise RuntimeError("Cannot find %s resource %s" % ('icon', filename))
 
     # Check if correct fields are filled to enable connection to the UPS


### PR DESCRIPTION
...to look also for package-installed icons (in OS location)

Thanks to @Perlovka for noticing and proposing a fix, and to @lukejr for confirming it as correct.

Closes: #1567