### PR TITLE
Fix PyNUT ListClients() and DeviceLogin() for Python 3 string API

### DIFF
--- a/scripts/python/module/PyNUT.py.in
+++ b/scripts/python/module/PyNUT.py.in
@@ -261,7 +261,7 @@ rights to set it (maybe login/password).
         if ( result == b"OK\n" ) :
             return( "OK" )
         else :
-            raise PyNUTError( result )
+            raise PyNUTError( result.replace( b"\n", b"" ) )
 
     def RunUPSCommand( self, ups="", command="" ) :
         """ Send a command to the specified UPS

--- a/scripts/python/module/PyNUT.py.in
+++ b/scripts/python/module/PyNUT.py.in
@@ -47,6 +47,7 @@
 # 2022-08-12 Jim Klimov <jimklimov+nut@gmail.com> - Version 1.5.0
 #            Fix ListClients() method to actually work with current NUT protocol
 #            Added DeviceLogin() method
+#            Added GetUPSNames() method
 
 import telnetlib
 
@@ -137,6 +138,10 @@ if something goes wrong.
         """ Returns the list of available UPS from the NUT server
 
 The result is a dictionary containing 'key->val' pairs of 'UPSName' and 'UPS Description'
+
+Note that fields here are byte sequences (not locale-aware strings)
+which is of little concern for Python2 but is important in Python3
+(e.g. when we use "str" type `ups` variables or check their "validity").
         """
         if self.__debug :
             print( "[DEBUG] GetUPSList from server" )
@@ -155,6 +160,22 @@ The result is a dictionary containing 'key->val' pairs of 'UPSName' and 'UPS Des
                 ups_list[ ups.replace( b" ", b"" ) ] = desc
 
         return( ups_list )
+
+    def GetUPSNames( self ) :
+        """ Returns the list of available UPS names from the NUT server as strings
+
+The result is a set of str objects (comparable with ups="somename" and
+useful as arguments to other methods). Helps work around Python2/Python3
+string API changes.
+        """
+        if self.__debug :
+            print( "[DEBUG] GetUPSNames from server" )
+
+        self_ups_list = []
+        for b in self.GetUPSList():
+            self_ups_list.append(b.decode('ascii'))
+
+        return self_ups_list
 
     def GetUPSVars( self, ups="" ) :
         """ Get all available vars from the specified UPS
@@ -293,12 +314,12 @@ of connection.
         if self.__debug :
             print( "[DEBUG] DeviceLogin called..." )
 
-        if ups is None or (ups not in self.GetUPSList()):
+        if ups is None or (ups not in self.GetUPSNames()):
             raise PyNUTError( "%s is not a valid UPS" % ups )
 
         self.__srv_handler.write( ("LOGIN %s\n" % ups).encode('ascii') )
         result = self.__srv_handler.read_until( b"\n" )
-        if ( result.startswith(b"User %s@" % self.__login) and result.endswith (b"[%s]\n" % ups) ):
+        if ( result.startswith( ("User %s@" % self.__login).encode('ascii')) and result.endswith (("[%s]\n" % ups).encode('ascii')) ):
             # User dummy-user@127.0.0.1 logged into UPS [dummy]
             # Read next line then
             result = self.__srv_handler.read_until( b"\n" )
@@ -366,7 +387,8 @@ The result is a dictionary containing 'key->val' pairs of 'UPSName' and a list o
         if self.__debug :
             print( "[DEBUG] ListClients from server: %s" % ups )
 
-        self_ups_list = self.GetUPSList()
+        # If (!ups) we use this list below to recurse:
+        self_ups_list = self.GetUPSNames()
         if ups and (ups not in self_ups_list):
             raise PyNUTError( "%s is not a valid UPS" % ups )
 
@@ -377,7 +399,7 @@ The result is a dictionary containing 'key->val' pairs of 'UPSName' and a list o
             # (not providing an "ups" argument) => NUT_ERR_INVALID_ARGUMENT
             self.__srv_handler.write( b"LIST CLIENT\n" )
         result = self.__srv_handler.read_until( b"\n" )
-        if ( (ups and result != (b"BEGIN LIST CLIENT %s\n" % ups)) or (ups is None and result != b"BEGIN LIST CLIENT\n") ):
+        if ( (ups and result != ("BEGIN LIST CLIENT %s\n" % ups).encode('ascii')) or (ups is None and result != b"BEGIN LIST CLIENT\n") ):
             if ups is None and (result == b"ERR INVALID-ARGUMENT\n") :
                 # For ups==None, list all upses, list their clients
                 if self.__debug :
@@ -395,7 +417,7 @@ The result is a dictionary containing 'key->val' pairs of 'UPSName' and a list o
             raise PyNUTError( result.replace( b"\n", b"" ) )
 
         if ups :
-            result = self.__srv_handler.read_until( b"END LIST CLIENT %s\n" % ups )
+            result = self.__srv_handler.read_until( ("END LIST CLIENT %s\n" % ups).encode('ascii') )
         else:
             # Should not get here with current NUT:
             result = self.__srv_handler.read_until( b"END LIST CLIENT\n" )

--- a/scripts/python/module/README
+++ b/scripts/python/module/README
@@ -24,6 +24,32 @@ of the original project, allowing to develop other classes nearby later.
 Currently the module is regularly tested to work with Python interpreter
 versions 2.7, 3.4, 3.5 and 3.7.
 
+[NOTE]
+======
+Text fields (including NUT protocol error codes quoted into `PyNUTError`
+exceptions) returned by methods are byte sequences (not locale-aware
+strings). This is of little concern for Python 2, but is important in
+Python 3.
+
+The `ups` argument to methods is handled as a string, so conversion may
+be needed to compare with names returned in the arrays, e.g.:
+----
+strUps = bUps.decode('ascii')
+bUps = strUps.encode('ascii')
+----
+
+Names returned by `GetUPSNames()` are specifically converted into string
+type.
+
+Since Python 3 support was added just recently, module code may later be
+converted to use string types like `str` or `unicode` in the returned
+dictionaries and sets instead, if the community deems this to be more
+idiomatic.
+
+Examples below *do not* specify the `b'some text'` markup that would be
+pedantically correct (for Python 3 at least).
+======
+
 .List of methods in the class
 ------
 class PyNUTClient :

--- a/scripts/python/module/README
+++ b/scripts/python/module/README
@@ -70,6 +70,8 @@ class PyNUTClient :
 
   def GetUPSList( self ) :
 
+  def GetUPSNames( self ) :
+
   def GetUPSVars( self, ups='' ) :
 
   def ListClients( self, ups = None ) :
@@ -214,6 +216,29 @@ Returns the list of UPSes represented by the NUT server, as a dictionary of
 
     >> {'UPS1': 'Smart UPS 3000 File server',
         'UPS2': 'Smart UPS 1000 Serveur de mail'}
+-----
+
+
+GetUPSNames
+~~~~~~~~~~~
+
+Returns just the list of available UPS names from the NUT server.
+
+The result is a set of `str` objects (comparable with `ups="somename"` and
+useful as arguments to other methods). Helps work around Python2/Python3
+string API changes (where `b'string' != 'string'` and not even a type
+comparable to it), and is primarily used as a helper internally in some
+methods.
+
+.Example
+-----
+    import PyNUT
+
+    ups    = PyNUT.PyNUTClient( host='serveur', login='upsadmin', password='upspass' )
+    result = ups.GetUPSNames()
+    print( result )
+
+    >> ['UPS1', 'UPS2']
 -----
 
 

--- a/scripts/python/module/README
+++ b/scripts/python/module/README
@@ -111,7 +111,7 @@ help
 ~~~~
 
 Sends the `HELP` command to the NUT data server and returns whatever bits of
-wizdom it has to offer.
+wisdom it has to offer.
 
 
 ver

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -1090,14 +1090,15 @@ fi
 # Allow to leave the sandbox daemons running for a while,
 # to experiment with them interactively:
 if [ -n "${DEBUG_SLEEP-}" ] ; then
-    log_separator
-    log_info "Sleeping now as asked, so you can play with the driver and server running; hint: export NUT_PORT=$NUT_PORT"
-    log_separator
-    if [ "${DEBUG_SLEEP-}" -gt 0 ] ; then
-        sleep "${DEBUG_SLEEP}"
-    else
-        sleep 60
+    if ! [ "${DEBUG_SLEEP-}" -gt 0 ] ; then
+        DEBUG_SLEEP=60
     fi
+
+    log_separator
+    log_info "Sleeping now as asked (for ${DEBUG_SLEEP} seconds starting `date -u`), so you can play with the driver and server running; hint: export NUT_PORT=$NUT_PORT"
+    log_separator
+
+    sleep "${DEBUG_SLEEP}"
     log_info "Sleep finished"
     log_separator
 fi


### PR DESCRIPTION
Follow up to #549 (and #746 which dealt with dual py2/py3 compatibility)