### PR TITLE
m4/nut_check_libltdl.m4: fall back to /usr/local/... (e.g. on FreeBSD)…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -93,6 +93,10 @@ https://github.com/networkupstools/nut/milestone/8
    library filenames, hoping that `lt_dlopen()` implementation on the current
    platform would find library files better [#805]
 
+ - detection of `libltdl` in `configure` script updated with fallback code to
+   find it on systems that deliver the library to `/usr/local/lib` (e.g. on
+   FreeBSD) [#1577]
+
  - existing openssl-1.1.0 support added for NUT v2.8.0 release was tested to
    be sufficient without deprecation warnings for builds against openssl-3.0.x
    (but no real-time testing was done yet) [#1547]

--- a/m4/nut_check_libltdl.m4
+++ b/m4/nut_check_libltdl.m4
@@ -1,16 +1,21 @@
 dnl Check for LIBLTDL compiler flags. On success, set nut_have_libltdl="yes"
 dnl and set LIBLTDL_CFLAGS and LIBLTDL_LIBS. On failure, set
 dnl nut_have_libltdl="no". This macro can be run multiple times, but will
-dnl do the checking only once. 
+dnl do the checking only once.
 
-AC_DEFUN([NUT_CHECK_LIBLTDL], 
+AC_DEFUN([NUT_CHECK_LIBLTDL],
 [
 if test -z "${nut_have_libltdl_seen}"; then
 	nut_have_libltdl_seen=yes
+	dnl No NUT_CHECK_PKGCONFIG here: (lib)ltdl.pc was not seen on any OS
 
-	dnl save LIBS
+	dnl save CFLAGS and LIBS
+	CFLAGS_ORIG="${CFLAGS}"
 	LIBS_ORIG="${LIBS}"
 	LIBS=""
+	CFLAGS=""
+	dnl For fallback below:
+	myCFLAGS=""
 
 	AC_MSG_CHECKING(for libltdl cflags)
 	AC_ARG_WITH(libltdl-includes,
@@ -24,7 +29,10 @@ if test -z "${nut_have_libltdl_seen}"; then
 			CFLAGS="${withval}"
 			;;
 		esac
-	], [])
+	], [dnl Best-Effort Fallback (LDFLAGS might make more sense for -L...,
+		dnl but other m4's have it so) to use if probe below fails:
+		myCFLAGS="-I/usr/local/include -I/usr/include -L/usr/local/lib -L/usr/lib"
+	])
 	AC_MSG_RESULT([${CFLAGS}])
 
 	AC_MSG_CHECKING(for libltdl ldflags)
@@ -39,19 +47,29 @@ if test -z "${nut_have_libltdl_seen}"; then
 			LIBS="${withval}"
 			;;
 		esac
-	], [])
+	], [])dnl No fallback here - we probe suitable libs below
 	AC_MSG_RESULT([${LIBS}])
 
 	AC_CHECK_HEADERS(ltdl.h, [nut_have_libltdl=yes], [nut_have_libltdl=no], [AC_INCLUDES_DEFAULT])
-	AC_SEARCH_LIBS(lt_dlinit, ltdl, [], [nut_have_libltdl=no])
+	AS_IF([test x"$nut_have_libltdl" = xyes], [
+		AC_SEARCH_LIBS(lt_dlinit, ltdl, [], [
+			nut_have_libltdl=no
+			AS_IF([test -n "$myCFLAGS"], [
+				CFLAGS="$myCFLAGS"
+				AC_SEARCH_LIBS(lt_dlinit, ltdl, [nut_have_libltdl=yes], [])
+			])
+		])
+	])
 
-	if test "${nut_have_libltdl}" = "yes"; then
+	AS_IF([test "${nut_have_libltdl}" = "yes"], [
 		AC_DEFINE(HAVE_LIBLTDL, 1, [Define to enable libltdl support])
-		LIBLTDL_CFLAGS=""
+		LIBLTDL_CFLAGS="${CFLAGS}"
 		LIBLTDL_LIBS="${LIBS}"
-	fi
+	])
+	unset myCFLAGS
 
-	dnl restore original LIBS
+	dnl restore original CFLAGS and LIBS
+	CFLAGS="${CFLAGS_ORIG}"
 	LIBS="${LIBS_ORIG}"
 fi
 ])


### PR DESCRIPTION
…if no custom CFLAGS were specified and libltdl was not found by default [#1577]