### PR TITLE
CI: Set up regular native (MSYS2/MinGW) NUT for Windows builds with AppVeyor

### DIFF
--- a/INSTALL.nut
+++ b/INSTALL.nut
@@ -351,7 +351,9 @@ Windows
 Windows binary package
 ^^^^^^^^^^^^^^^^^^^^^^
 
-NOTE: NUT binary package built for Windows platform was last issued for
+[NOTE]
+======
+NUT binary package built for Windows platform was last issued for
 a much older codebase (using NUT v2.6.5 as a baseline). While the current
 state of the codebase you are looking at aims to refresh the effort of
 delivering NUT on Windows, the aim at the moment is to help developers
@@ -360,6 +362,22 @@ are not being regularly produced yet. Functionality of such builds varies
 a lot depending on build environment used. This effort is generally
 tracked at https://github.com/orgs/networkupstools/projects/2/views/1
 and help would be welcome!
+
+It should currently be possible to build the codebase in native Windows
+with MSYS2/MinGW and cross-building from Linux with mingw (preferably
+in a Debian/Ubuntu container). Refer to
+link:config-prereqs.txt[Prerequisites for building NUT on different OSes]
+and link:scripts/Windows/README[scripts/Windows/README file] for respective
+build environment preparation instructions.
+
+Note that to use NUT for Windows, non-system dependency DLL files must
+be located in same directory as each EXE file that uses them. This can be
+accomplished for FOSS libraries (copying them from the build environment)
+by calling `make install-win-bundle DESTDIR=/some/valid/location` easily.
+======
+
+*Information below may be currently obsolete, but the NUT project wishes
+it to become actual and factual again :)*
 
 NUT binary package built for Windows platform comes in a `.msi` file.
 

--- a/INSTALL.nut
+++ b/INSTALL.nut
@@ -374,6 +374,9 @@ Note that to use NUT for Windows, non-system dependency DLL files must
 be located in same directory as each EXE file that uses them. This can be
 accomplished for FOSS libraries (copying them from the build environment)
 by calling `make install-win-bundle DESTDIR=/some/valid/location` easily.
+
+Archives with binaries built by recent iterations of continuous integration
+jobs should be available for exploration on the respective CI platforms.
 ======
 
 *Information below may be currently obsolete, but the NUT project wishes

--- a/Makefile.am
+++ b/Makefile.am
@@ -397,7 +397,7 @@ install-win-bundle-thirdparty:
 	        ln -f '$(DESTDIR)/$(bindir)'/"`basename "$$D"`" ./ ; \
         done ; \
 	 ) || exit ; \
-	 (  if test -z "$(cgiexecdir)" -o ! -d "./$(cgiexecdir)" ; then exit 0 ; fi ; \
+	 (  if test -z "$(cgiexecdir)" -o ! -d "$(DESTDIR)/$(cgiexecdir)" ; then exit 0 ; fi ; \
 	    if test x"$(cgiexecdir)" = x"$(bindir)" ; then exit 0 ; fi ; \
 	    if test x"$(cgiexecdir)" = x"$(sbindir)" ; then exit 0 ; fi ; \
 	    if test x"$(driverexecdir)" = x"$(cgiexecdir)" ; then exit 0 ; fi ; \

--- a/Makefile.am
+++ b/Makefile.am
@@ -381,7 +381,7 @@ install-win-bundle-thirdparty:
 	    '$(abs_top_srcdir)/scripts/Windows/dllldd.sh' dllldddir . \
 	    | while read D ; do \
 	        echo "   DLL->sbin  $$D" 2>&1 ; \
-	        ln '$(DESTDIR)/$(bindir)'/"`basename "$$D"`" ./ ; \
+	        ln -f '$(DESTDIR)/$(bindir)'/"`basename "$$D"`" ./ ; \
         done ; \
 	 ) || exit ; \
 	 (  if test x"$(driverexecdir)" = x"$(bindir)" ; then exit 0 ; fi ; \
@@ -390,7 +390,7 @@ install-win-bundle-thirdparty:
 	    '$(abs_top_srcdir)/scripts/Windows/dllldd.sh' dllldddir . \
 	    | while read D ; do \
 	        echo "   DLL->drv   $$D" 2>&1 ; \
-	        ln '$(DESTDIR)/$(bindir)'/"`basename "$$D"`" ./ ; \
+	        ln -f '$(DESTDIR)/$(bindir)'/"`basename "$$D"`" ./ ; \
         done ; \
 	 ) || exit
 	@echo "CHECKING if any executable files were installed to locations other than those covered by this recipe, so might not have needed DLLs bundled near them" >&2 ; \

--- a/Makefile.am
+++ b/Makefile.am
@@ -394,7 +394,7 @@ install-win-bundle-thirdparty:
 	        ln -f '$(DESTDIR)/$(bindir)'/"`basename "$$D"`" ./ ; \
         done ; \
 	 ) || exit ; \
-	 (  if test -z "$(cgiexecdir)" ; then exit 0 ; fi ; \
+	 (  if test -z "$(cgiexecdir)" -o ! -d "$(cgiexecdir)" ; then exit 0 ; fi ; \
 	    if test x"$(cgiexecdir)" = x"$(bindir)" ; then exit 0 ; fi ; \
 	    if test x"$(cgiexecdir)" = x"$(sbindir)" ; then exit 0 ; fi ; \
 	    if test x"$(driverexecdir)" = x"$(cgiexecdir)" ; then exit 0 ; fi ; \

--- a/Makefile.am
+++ b/Makefile.am
@@ -352,6 +352,9 @@ if HAVE_WINDOWS
 # TOTHINK: Are there more dirs to consider? So far we cover bindir, sbindir and
 # driverexecdir (e.g. some Linux distros place drivers to /lib/nut while tools
 # and daemons are in /usr/bin and /usr/sbin), and cgiexecdir; anything else?..
+# Note we hold existance of cgiexecdir as optional, but the name is expected to
+# be defined. Other dirs are "just assumed" to exist (that we are not packaging
+# some NUT build without drivers/tools/daemons). Subject to change if needed.
 # Currently this is handled by a CHECKING... step that should fail if it hits
 # anything.
 install-win-bundle: all
@@ -394,7 +397,7 @@ install-win-bundle-thirdparty:
 	        ln -f '$(DESTDIR)/$(bindir)'/"`basename "$$D"`" ./ ; \
         done ; \
 	 ) || exit ; \
-	 (  if test -z "$(cgiexecdir)" -o ! -d "$(cgiexecdir)" ; then exit 0 ; fi ; \
+	 (  if test -z "$(cgiexecdir)" -o ! -d "./$(cgiexecdir)" ; then exit 0 ; fi ; \
 	    if test x"$(cgiexecdir)" = x"$(bindir)" ; then exit 0 ; fi ; \
 	    if test x"$(cgiexecdir)" = x"$(sbindir)" ; then exit 0 ; fi ; \
 	    if test x"$(driverexecdir)" = x"$(cgiexecdir)" ; then exit 0 ; fi ; \

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,6 +8,10 @@ ACLOCAL_AMFLAGS = -I m4
 SUBDIRS = include common clients conf data docs drivers tools \
   lib scripts server tests
 
+bindir = @bindir@
+sbindir = @sbindir@
+driverexecdir = @driverexecdir@
+
 # Automatically update the libtool script if it becomes out-of-date
 # See https://www.gnu.org/software/libtool/manual/html_node/LT_005fINIT.html
 LIBTOOL_DEPS = @LIBTOOL_DEPS@
@@ -339,6 +343,72 @@ package: dist
 		mv /usr/src/packages/RPMS/nut*rpm $(abs_top_builddir)/ ;; \
 	*)	echo "Unsupported OS for 'make $@' (no recipe bound)" >&2; exit 1;; \
 	esac
+
+if HAVE_WINDOWS
+# Steam-roll over all executables/libs we have placed in DESTDIR and copy over
+# any resolved dependencies from the cross-build (or native MSYS2) environment.
+# Then hardlink libraries for sbin... (alternative: all bins in one dir)
+# TOTHINK: Are there more dirs to consider? So far we cover bindir, sbindir and
+# driverexecdir (e.g. some Linux distros place drivers to /lib/nut while tools
+# and daemons are in /usr/bin and /usr/sbin); anything else?..
+# Currently this is handled by a CHECKING... step that should fail if it hits
+# anything.
+install-win-bundle: all
+	@if test -z "$(DESTDIR)" ; then echo "ERROR: '$@': Bundle may only be installed to some DESTDIR prototype area'" >&2 ; exit 1; fi
+	$(MAKE) $(AM_MAKEFLAGS) DESTDIR='$(DESTDIR)' install
+	$(MAKE) $(AM_MAKEFLAGS) DESTDIR='$(DESTDIR)' install-win-bundle-thirdparty
+
+install-win-bundle-thirdparty:
+	@if test -z "$(DESTDIR)" ; then echo "ERROR: '$@': Bundle may only be installed to some DESTDIR prototype area'" >&2 ; exit 1; fi
+	@echo "Searching which DLLs need to be bundled with NUT for Windows..." >&2
+	 if test -z "$$ARCH" ; then \
+	    if test -n "$(target)" ; then \
+	        ARCH='$(target)' \
+        ; else \
+            if test -n "$(target_triplet)" ; then ARCH='$(target_triplet)' ; fi ; \
+        fi ; \
+     fi ; \
+     if test -n "$$ARCH" ; then export ARCH ; fi ; \
+	 (  cd '$(DESTDIR)' || exit ; \
+	    '$(abs_top_srcdir)/scripts/Windows/dllldd.sh' dllldddir . \
+	    | while read D ; do \
+	        echo "   DLL->bin   $$D" 2>&1 ; \
+	        cp -pf "$$D" './$(bindir)/' ; \
+        done ; \
+	 ) || exit ; \
+	 (  if test x"$(bindir)" = x"$(sbindir)" ; then exit 0 ; fi ; \
+	    cd '$(DESTDIR)/$(sbindir)' || exit ; \
+	    '$(abs_top_srcdir)/scripts/Windows/dllldd.sh' dllldddir . \
+	    | while read D ; do \
+	        echo "   DLL->sbin  $$D" 2>&1 ; \
+	        ln '$(DESTDIR)/$(bindir)'/"`basename "$$D"`" ./ ; \
+        done ; \
+	 ) || exit ; \
+	 (  if test x"$(driverexecdir)" = x"$(bindir)" ; then exit 0 ; fi ; \
+	    if test x"$(driverexecdir)" = x"$(sbindir)" ; then exit 0 ; fi ; \
+	    cd '$(DESTDIR)/$(driverexecdir)' || exit ; \
+	    '$(abs_top_srcdir)/scripts/Windows/dllldd.sh' dllldddir . \
+	    | while read D ; do \
+	        echo "   DLL->drv   $$D" 2>&1 ; \
+	        ln '$(DESTDIR)/$(bindir)'/"`basename "$$D"`" ./ ; \
+        done ; \
+	 ) || exit
+	@echo "CHECKING if any executable files were installed to locations other than those covered by this recipe, so might not have needed DLLs bundled near them" >&2 ; \
+	 relbindir="`echo './$(bindir)/' | sed 's,//*,/,g'`" ; \
+	 relsbindir="`echo './$(sbindir)/' | sed 's,//*,/,g'`" ; \
+	 reldriverexecdir="`echo './$(driverexecdir)/' | sed 's,//*,/,g'`" ; \
+	 cd '$(DESTDIR)' || exit ; \
+	 find . -type f | grep -Ei '\.(exe|dll)$$' \
+	 | grep -vE "^($${relbindir}|$${relsbindir}|$${reldriverexecdir})" \
+	 | ( RES=0 ; while IFS= read LINE ; do echo "$$LINE" ; RES=1; done; exit $$RES )
+
+else
+install-win-bundle:
+	@echo "SKIP: '$@' not enabled for current build configuration"
+
+install-win-bundle-thirdparty:
+	@echo "SKIP: '$@' not enabled for current build configuration"
+endif
 
 print-MAINTAINERCLEANFILES print-REALCLEANFILES:
 	@echo $(MAINTAINERCLEANFILES)

--- a/Makefile.am
+++ b/Makefile.am
@@ -382,8 +382,9 @@ install-win-bundle-thirdparty:
 	 ) || exit ; \
 	 (  if test x"$(bindir)" = x"$(sbindir)" ; then exit 0 ; fi ; \
 	    cd '$(DESTDIR)/$(sbindir)' || exit ; \
-	    '$(abs_top_srcdir)/scripts/Windows/dllldd.sh' dllldddir . \
-	    | while read D ; do \
+	    ( '$(abs_top_srcdir)/scripts/Windows/dllldd.sh' dllldddir . ; \
+	      ls -1 '$(DESTDIR)/$(bindir)'/libups*.dll '$(DESTDIR)/$(bindir)'/libnut*.dll 2>/dev/null || true ; \
+	    ) | while read D ; do \
 	        echo "   DLL->sbin  $$D" 2>&1 ; \
 	        ln -f '$(DESTDIR)/$(bindir)'/"`basename "$$D"`" ./ ; \
         done ; \
@@ -391,8 +392,9 @@ install-win-bundle-thirdparty:
 	 (  if test x"$(driverexecdir)" = x"$(bindir)" ; then exit 0 ; fi ; \
 	    if test x"$(driverexecdir)" = x"$(sbindir)" ; then exit 0 ; fi ; \
 	    cd '$(DESTDIR)/$(driverexecdir)' || exit ; \
-	    '$(abs_top_srcdir)/scripts/Windows/dllldd.sh' dllldddir . \
-	    | while read D ; do \
+	    ( '$(abs_top_srcdir)/scripts/Windows/dllldd.sh' dllldddir . ; \
+	      ls -1 '$(DESTDIR)/$(bindir)'/libups*.dll '$(DESTDIR)/$(bindir)'/libnut*.dll 2>/dev/null || true ; \
+	    ) | while read D ; do \
 	        echo "   DLL->drv   $$D" 2>&1 ; \
 	        ln -f '$(DESTDIR)/$(bindir)'/"`basename "$$D"`" ./ ; \
         done ; \
@@ -402,8 +404,9 @@ install-win-bundle-thirdparty:
 	    if test x"$(cgiexecdir)" = x"$(sbindir)" ; then exit 0 ; fi ; \
 	    if test x"$(driverexecdir)" = x"$(cgiexecdir)" ; then exit 0 ; fi ; \
 	    cd '$(DESTDIR)/$(cgiexecdir)' || exit ; \
-	    '$(abs_top_srcdir)/scripts/Windows/dllldd.sh' dllldddir . \
-	    | while read D ; do \
+	    ( '$(abs_top_srcdir)/scripts/Windows/dllldd.sh' dllldddir . ; \
+	      ls -1 '$(DESTDIR)/$(bindir)'/libups*.dll '$(DESTDIR)/$(bindir)'/libnut*.dll 2>/dev/null || true ; \
+	    ) | while read D ; do \
 	        echo "   DLL->cgi   $$D" 2>&1 ; \
 	        ln -f '$(DESTDIR)/$(bindir)'/"`basename "$$D"`" ./ ; \
         done ; \

--- a/Makefile.am
+++ b/Makefile.am
@@ -382,9 +382,8 @@ install-win-bundle-thirdparty:
 	 ) || exit ; \
 	 (  if test x"$(bindir)" = x"$(sbindir)" ; then exit 0 ; fi ; \
 	    cd '$(DESTDIR)/$(sbindir)' || exit ; \
-	    ( '$(abs_top_srcdir)/scripts/Windows/dllldd.sh' dllldddir . ; \
-	      ls -1 '$(DESTDIR)/$(bindir)'/libups*.dll '$(DESTDIR)/$(bindir)'/libnut*.dll 2>/dev/null || true ; \
-	    ) | while read D ; do \
+	    '$(abs_top_srcdir)/scripts/Windows/dllldd.sh' dllldddir . \
+	    | while read D ; do \
 	        echo "   DLL->sbin  $$D" 2>&1 ; \
 	        ln -f '$(DESTDIR)/$(bindir)'/"`basename "$$D"`" ./ ; \
         done ; \
@@ -392,9 +391,8 @@ install-win-bundle-thirdparty:
 	 (  if test x"$(driverexecdir)" = x"$(bindir)" ; then exit 0 ; fi ; \
 	    if test x"$(driverexecdir)" = x"$(sbindir)" ; then exit 0 ; fi ; \
 	    cd '$(DESTDIR)/$(driverexecdir)' || exit ; \
-	    ( '$(abs_top_srcdir)/scripts/Windows/dllldd.sh' dllldddir . ; \
-	      ls -1 '$(DESTDIR)/$(bindir)'/libups*.dll '$(DESTDIR)/$(bindir)'/libnut*.dll 2>/dev/null || true ; \
-	    ) | while read D ; do \
+	    '$(abs_top_srcdir)/scripts/Windows/dllldd.sh' dllldddir . \
+	    | while read D ; do \
 	        echo "   DLL->drv   $$D" 2>&1 ; \
 	        ln -f '$(DESTDIR)/$(bindir)'/"`basename "$$D"`" ./ ; \
         done ; \
@@ -404,9 +402,8 @@ install-win-bundle-thirdparty:
 	    if test x"$(cgiexecdir)" = x"$(sbindir)" ; then exit 0 ; fi ; \
 	    if test x"$(driverexecdir)" = x"$(cgiexecdir)" ; then exit 0 ; fi ; \
 	    cd '$(DESTDIR)/$(cgiexecdir)' || exit ; \
-	    ( '$(abs_top_srcdir)/scripts/Windows/dllldd.sh' dllldddir . ; \
-	      ls -1 '$(DESTDIR)/$(bindir)'/libups*.dll '$(DESTDIR)/$(bindir)'/libnut*.dll 2>/dev/null || true ; \
-	    ) | while read D ; do \
+	    '$(abs_top_srcdir)/scripts/Windows/dllldd.sh' dllldddir . \
+	    | while read D ; do \
 	        echo "   DLL->cgi   $$D" 2>&1 ; \
 	        ln -f '$(DESTDIR)/$(bindir)'/"`basename "$$D"`" ./ ; \
         done ; \

--- a/Makefile.am
+++ b/Makefile.am
@@ -11,6 +11,7 @@ SUBDIRS = include common clients conf data docs drivers tools \
 bindir = @bindir@
 sbindir = @sbindir@
 driverexecdir = @driverexecdir@
+cgiexecdir = @cgiexecdir@
 
 # Automatically update the libtool script if it becomes out-of-date
 # See https://www.gnu.org/software/libtool/manual/html_node/LT_005fINIT.html
@@ -350,7 +351,7 @@ if HAVE_WINDOWS
 # Then hardlink libraries for sbin... (alternative: all bins in one dir)
 # TOTHINK: Are there more dirs to consider? So far we cover bindir, sbindir and
 # driverexecdir (e.g. some Linux distros place drivers to /lib/nut while tools
-# and daemons are in /usr/bin and /usr/sbin); anything else?..
+# and daemons are in /usr/bin and /usr/sbin), and cgiexecdir; anything else?..
 # Currently this is handled by a CHECKING... step that should fail if it hits
 # anything.
 install-win-bundle: all
@@ -392,14 +393,26 @@ install-win-bundle-thirdparty:
 	        echo "   DLL->drv   $$D" 2>&1 ; \
 	        ln -f '$(DESTDIR)/$(bindir)'/"`basename "$$D"`" ./ ; \
         done ; \
+	 ) || exit ; \
+	 (  if test -z "$(cgiexecdir)" ; then exit 0 ; fi ; \
+	    if test x"$(cgiexecdir)" = x"$(bindir)" ; then exit 0 ; fi ; \
+	    if test x"$(cgiexecdir)" = x"$(sbindir)" ; then exit 0 ; fi ; \
+	    if test x"$(driverexecdir)" = x"$(cgiexecdir)" ; then exit 0 ; fi ; \
+	    cd '$(DESTDIR)/$(cgiexecdir)' || exit ; \
+	    '$(abs_top_srcdir)/scripts/Windows/dllldd.sh' dllldddir . \
+	    | while read D ; do \
+	        echo "   DLL->cgi   $$D" 2>&1 ; \
+	        ln -f '$(DESTDIR)/$(bindir)'/"`basename "$$D"`" ./ ; \
+        done ; \
 	 ) || exit
 	@echo "CHECKING if any executable files were installed to locations other than those covered by this recipe, so might not have needed DLLs bundled near them" >&2 ; \
 	 relbindir="`echo './$(bindir)/' | sed 's,//*,/,g'`" ; \
 	 relsbindir="`echo './$(sbindir)/' | sed 's,//*,/,g'`" ; \
 	 reldriverexecdir="`echo './$(driverexecdir)/' | sed 's,//*,/,g'`" ; \
+	 relcgiexecdir="`echo './$(cgiexecdir)/' | sed 's,//*,/,g'`" ; \
 	 cd '$(DESTDIR)' || exit ; \
 	 find . -type f | grep -Ei '\.(exe|dll)$$' \
-	 | grep -vE "^($${relbindir}|$${relsbindir}|$${reldriverexecdir})" \
+	 | grep -vE "^($${relbindir}|$${relsbindir}|$${reldriverexecdir}|$${relcgiexecdir})" \
 	 | ( RES=0 ; while IFS= read LINE ; do echo "$$LINE" ; RES=1; done; exit $$RES )
 
 else

--- a/Makefile.am
+++ b/Makefile.am
@@ -373,8 +373,9 @@ install-win-bundle-thirdparty:
         fi ; \
      fi ; \
      if test -n "$$ARCH" ; then export ARCH ; fi ; \
+     DESTDIR='$(DESTDIR)' ; export DESTDIR ; \
 	 (  cd '$(DESTDIR)' || exit ; \
-	    '$(abs_top_srcdir)/scripts/Windows/dllldd.sh' dllldddir . \
+	    DESTDIR="" '$(abs_top_srcdir)/scripts/Windows/dllldd.sh' dllldddir . \
 	    | while read D ; do \
 	        echo "   DLL->bin   $$D" 2>&1 ; \
 	        cp -pf "$$D" './$(bindir)/' ; \

--- a/Makefile.am
+++ b/Makefile.am
@@ -362,7 +362,7 @@ install-win-bundle: all
 install-win-bundle-thirdparty:
 	@if test -z "$(DESTDIR)" ; then echo "ERROR: '$@': Bundle may only be installed to some DESTDIR prototype area'" >&2 ; exit 1; fi
 	@echo "Searching which DLLs need to be bundled with NUT for Windows..." >&2
-	 if test -z "$$ARCH" ; then \
+	@if test -z "$$ARCH" ; then \
 	    if test -n "$(target)" ; then \
 	        ARCH='$(target)' \
         ; else \

--- a/NEWS
+++ b/NEWS
@@ -70,6 +70,12 @@ https://github.com/networkupstools/nut/milestone/8
  - Ability to build NUT for Windows, last tackled with a branch based on
    NUT v2.6.5 a decade ago, has been revived with the 2.8.x era codebase [#5]
 
+ - Native NUT for Windows builds with MSYS2/MinGW x64 environment are now
+   regularly tested on AppVeyor with the same `ci_build.sh` script and
+   `Makefile` checks as used across the board for local developer builds,
+   Linux/illumos/FreeBSD/OpenBSD/... on dedicated NUT CI farm on Fosshost,
+   and MacOS on CircleCI [#1552]
+
  - snmp-ups IETF MIB mapping updated for data points where negative readings
    are invalid [#1558]
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -79,8 +79,9 @@ test_script:
         set CHERE_INVOKING=yes
         REM Start a 64 bit Mingw environment:
         set MSYSTEM=MINGW64
-        C:\msys64\usr\bin\bash -lc 'date -u; PATH="/mingw64/bin:$PATH" make -s install-win-bundle DESTDIR="`pwd`/.inst"'
-        7z a NUT-for-Windows-SNAPSHOT-%APPVEYOR_BUILD_VERSION%.zip .inst
+        C:\msys64\usr\bin\bash -lc 'date -u; rm -rf "`pwd`/.inst" || true ; PATH="/mingw64/bin:$PATH" make -s install-win-bundle DESTDIR="`pwd`/.inst/NUT-for-Windows-SNAPSHOT-%APPVEYOR_BUILD_VERSION%" ; ln -fs "NUT-for-Windows-SNAPSHOT-%APPVEYOR_BUILD_VERSION%" NUT-for-Windows-SNAPSHOT '
+        cd .inst
+        7z a ../NUT-for-Windows-SNAPSHOT-%APPVEYOR_BUILD_VERSION%.zip NUT*
 
 artifacts:
   - path: 'NUT-for-Windows-SNAPSHOT*.zip'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ install:
         C:\msys64\usr\bin\bash -lc "date -u; pacman --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain autoconf-wrapper automake-wrapper libtool mingw-w64-x86_64-libltdl gcc ccache mingw-w64-x86_64-ccache git aspell aspell-en python mingw-w64-x86_64-python-pygments mingw-w64-x86_64-winpthreads-git mingw-w64-x86_64-libusb mingw-w64-x86_64-libusb-compat-git mingw-w64-x86_64-neon libneon-devel mingw-w64-x86_64-libmodbus-git mingw-w64-x86_64-libgd"
   - cmd: |
         REM Assorted stats after packaging:
-        C:\msys64\usr\bin\bash -lc "date -u; du -ks / ; date -u; du -ks /var/cache/pacman/pkg; date"
+        C:\msys64\usr\bin\bash -lc "date -u; du -ksx / ; date -u; du -ks /var/cache/pacman/pkg; date"
 
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -80,14 +80,14 @@ test_script:
         REM Start a 64 bit Mingw environment:
         set MSYSTEM=MINGW64
         REM Oh the joys of shell scripting with strings passed through CMD:
+        REM Note: currently Python installation path with MSYS is buggy [#1584]
         C:\msys64\usr\bin\bash -lxc 'date -u; if ! rm -rf ".inst" ; then echo "WARNING: Failed to clean away .inst" ; fi  ; PATH="/mingw64/bin:$PATH" make -s install-win-bundle DESTDIR="`pwd`/.inst/NUT-for-Windows-SNAPSHOT-%APPVEYOR_BUILD_VERSION%" ; ln -fs "NUT-for-Windows-SNAPSHOT-%APPVEYOR_BUILD_VERSION%" ./.inst/NUT-for-Windows-SNAPSHOT '
         cd .inst
-        7z a ../NUT-for-Windows-SNAPSHOT-%APPVEYOR_BUILD_VERSION%.zip NUT*
+        7z a ../NUT-for-Windows-SNAPSHOT-%APPVEYOR_BUILD_VERSION%.7z NUT*
 
 artifacts:
-  - path: 'NUT-for-Windows-SNAPSHOT*.zip'
+  - path: 'NUT-for-Windows-SNAPSHOT*.7z'
     name: Bundle of binary files and FOSS dependencies of NUT for Windows
-    type: zip
 
   - path: config.log
     name: config.log

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,13 +73,13 @@ test_script:
         set CHERE_INVOKING=yes
         REM Start a 64 bit Mingw environment:
         set MSYSTEM=MINGW64
-        C:\msys64\usr\bin\bash -lc 'date -u; PATH="/mingw64/bin:$PATH" make check'
+        C:\msys64\usr\bin\bash -lc 'date -u; PATH="/mingw64/bin:$PATH" make -s check'
   - cmd: |
         REM Preserve the current working directory:
         set CHERE_INVOKING=yes
         REM Start a 64 bit Mingw environment:
         set MSYSTEM=MINGW64
-        C:\msys64\usr\bin\bash -lc 'date -u; PATH="/mingw64/bin:$PATH" make install-win-bundle DESTDIR="`pwd`/.inst"'
+        C:\msys64\usr\bin\bash -lc 'date -u; PATH="/mingw64/bin:$PATH" make -s install-win-bundle DESTDIR="`pwd`/.inst"'
         7z a NUT-for-Windows-SNAPSHOT-{version}.zip .inst
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -79,7 +79,7 @@ test_script:
         set CHERE_INVOKING=yes
         REM Start a 64 bit Mingw environment:
         set MSYSTEM=MINGW64
-        C:\msys64\usr\bin\bash -lc 'date -u; PATH="/mingw64/bin:$PATH" make --trace install-win-bundle DESTDIR="`pwd`/.inst"'
+        C:\msys64\usr\bin\bash -lc 'date -u; PATH="/mingw64/bin:$PATH" make -s install-win-bundle DESTDIR="`pwd`/.inst"'
         7z a NUT-for-Windows-SNAPSHOT-%APPVEYOR_BUILD_VERSION%.zip .inst
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,14 +22,26 @@ platform: x64
 
 # https://github.com/networkupstools/nut/blob/Windows-v2.8.0-1/docs/config-prereqs.txt#L951
 install:
-  - ps: C:\msys64\usr\bin\bash -lc "mkdir -p /var/cache/pacman/pkg"
-  - ps: C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Syuu"  # Core update (in case any core packages are outdated)
-  - ps: C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Syuu"  # Normal update
-  - ps: C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain autoconf-wrapper automake-wrapper libtool mingw-w64-x86_64-libltdl gcc ccache mingw-w64-x86_64-ccache git aspell aspell-en python mingw-w64-x86_64-python-pygments mingw-w64-x86_64-winpthreads-git mingw-w64-x86_64-libusb mingw-w64-x86_64-libusb-compat-git mingw-w64-x86_64-neon libneon-devel mingw-w64-x86_64-libmodbus-git mingw-w64-x86_64-libgd"
+  - ps: |
+        $ErrorActionPreference = 'Continue' # stderr not fatal
+        C:\msys64\usr\bin\bash -lc "mkdir -p /var/cache/pacman/pkg"
+  - ps: |
+        $ErrorActionPreference = 'Continue' # stderr not fatal
+        C:\msys64\usr\bin\bash -lc "time pacman --noconfirm -Syuu"  # Core update (in case any core packages are outdated)
+  - ps: |
+        $ErrorActionPreference = 'Continue' # stderr not fatal
+        C:\msys64\usr\bin\bash -lc "time pacman --noconfirm -Syuu"  # Normal update
+  - ps: |
+        $ErrorActionPreference = 'Continue' # stderr not fatal
+        C:\msys64\usr\bin\bash -lc "time pacman --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain autoconf-wrapper automake-wrapper libtool mingw-w64-x86_64-libltdl gcc ccache mingw-w64-x86_64-ccache git aspell aspell-en python mingw-w64-x86_64-python-pygments mingw-w64-x86_64-winpthreads-git mingw-w64-x86_64-libusb mingw-w64-x86_64-libusb-compat-git mingw-w64-x86_64-neon libneon-devel mingw-w64-x86_64-libmodbus-git mingw-w64-x86_64-libgd"
+  - ps: |
+        $ErrorActionPreference = 'Continue' # stderr not fatal
+        C:\msys64\usr\bin\bash -lc "time du -ks / ; time du -ks /var/cache/pacman/pkg"
 
 
 build_script:
   - ps: |
+        $ErrorActionPreference = 'Continue' # stderr not fatal
         $env:CHERE_INVOKING = 'yes'  # Preserve the current working directory
         $env:MSYSTEM = 'MINGW64'  # Start a 64 bit Mingw environment
         C:\msys64\usr\bin\bash -lc 'PATH="/mingw64/bin:$PATH" ./ci_build.sh'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -79,7 +79,7 @@ test_script:
         set CHERE_INVOKING=yes
         REM Start a 64 bit Mingw environment:
         set MSYSTEM=MINGW64
-        C:\msys64\usr\bin\bash -lc 'date -u; PATH="/mingw64/bin:$PATH" make -s install-win-bundle DESTDIR="`pwd`/.inst"'
+        C:\msys64\usr\bin\bash -lc 'date -u; PATH="/mingw64/bin:$PATH" make --trace install-win-bundle DESTDIR="`pwd`/.inst"'
         7z a NUT-for-Windows-SNAPSHOT-%APPVEYOR_BUILD_VERSION%.zip .inst
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,7 +57,7 @@ build_script:
         set CHERE_INVOKING=yes
         REM Start a 64 bit Mingw environment:
         set MSYSTEM=MINGW64
-        C:\msys64\usr\bin\bash -lc 'date -u; PATH="/mingw64/bin:$PATH" ./ci_build.sh'
+        C:\msys64\usr\bin\bash -lc 'date -u; PATH="/mingw64/bin:$PATH" CI_SKIP_CHECK=true ./ci_build.sh'
 
 after_build:
   - cmd: |
@@ -66,6 +66,14 @@ after_build:
         REM Start a 64 bit Mingw environment:
         set MSYSTEM=MINGW64
         C:\msys64\usr\bin\bash -lc 'date -u; PATH="/mingw64/bin:$PATH" ; export PATH ; ccache -sv || ccache -s || echo "SKIP: Could not query ccache stats"'
+
+test_script:
+  - cmd: |
+        REM Preserve the current working directory:
+        set CHERE_INVOKING=yes
+        REM Start a 64 bit Mingw environment:
+        set MSYSTEM=MINGW64
+        C:\msys64\usr\bin\bash -lc 'date -u; PATH="/mingw64/bin:$PATH" make check'
 
 # Example optional cache (depends on file change):
 # - C:\msys64 -> appveyor.yml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -79,7 +79,8 @@ test_script:
         set CHERE_INVOKING=yes
         REM Start a 64 bit Mingw environment:
         set MSYSTEM=MINGW64
-        C:\msys64\usr\bin\bash -lc 'date -u; rm -rf "`pwd`/.inst" || true ; PATH="/mingw64/bin:$PATH" make -s install-win-bundle DESTDIR="`pwd`/.inst/NUT-for-Windows-SNAPSHOT-%APPVEYOR_BUILD_VERSION%" ; ln -fs "NUT-for-Windows-SNAPSHOT-%APPVEYOR_BUILD_VERSION%" NUT-for-Windows-SNAPSHOT '
+        REM Oh the joys of shell scripting with strings passed through CMD:
+        C:\msys64\usr\bin\bash -lxc 'date -u; if ! rm -rf ".inst" ; then echo "WARNING: Failed to clean away .inst" ; fi  ; PATH="/mingw64/bin:$PATH" make -s install-win-bundle DESTDIR="`pwd`/.inst/NUT-for-Windows-SNAPSHOT-%APPVEYOR_BUILD_VERSION%" ; ln -fs "NUT-for-Windows-SNAPSHOT-%APPVEYOR_BUILD_VERSION%" ./.inst/NUT-for-Windows-SNAPSHOT '
         cd .inst
         7z a ../NUT-for-Windows-SNAPSHOT-%APPVEYOR_BUILD_VERSION%.zip NUT*
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,19 +29,19 @@ install:
   - ps: |
         $ErrorActionPreference = 'Continue' # stderr not fatal
         $ErrorAction = 'Continue' # stderr not fatal
-        C:\msys64\usr\bin\bash -lc "time pacman --noconfirm -Syuu" 2>&1 | %{ "$_" } # Core update (in case any core packages are outdated)
+        C:\msys64\usr\bin\bash -lc "date -u; pacman --noconfirm -Syuu" 2>&1 | %{ "$_" } # Core update (in case any core packages are outdated)
   - ps: |
         $ErrorActionPreference = 'Continue' # stderr not fatal
         $ErrorAction = 'Continue' # stderr not fatal
-        C:\msys64\usr\bin\bash -lc "time pacman --noconfirm -Syuu" 2>&1 | %{ "$_" } # Normal update
+        C:\msys64\usr\bin\bash -lc "date -u; pacman --noconfirm -Syuu" 2>&1 | %{ "$_" } # Normal update
   - ps: |
         $ErrorActionPreference = 'Continue' # stderr not fatal
         $ErrorAction = 'Continue' # stderr not fatal
-        C:\msys64\usr\bin\bash -lc "time pacman --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain autoconf-wrapper automake-wrapper libtool mingw-w64-x86_64-libltdl gcc ccache mingw-w64-x86_64-ccache git aspell aspell-en python mingw-w64-x86_64-python-pygments mingw-w64-x86_64-winpthreads-git mingw-w64-x86_64-libusb mingw-w64-x86_64-libusb-compat-git mingw-w64-x86_64-neon libneon-devel mingw-w64-x86_64-libmodbus-git mingw-w64-x86_64-libgd"2>&1 | %{ "$_" }
+        C:\msys64\usr\bin\bash -lc "date -u; pacman --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain autoconf-wrapper automake-wrapper libtool mingw-w64-x86_64-libltdl gcc ccache mingw-w64-x86_64-ccache git aspell aspell-en python mingw-w64-x86_64-python-pygments mingw-w64-x86_64-winpthreads-git mingw-w64-x86_64-libusb mingw-w64-x86_64-libusb-compat-git mingw-w64-x86_64-neon libneon-devel mingw-w64-x86_64-libmodbus-git mingw-w64-x86_64-libgd"2>&1 | %{ "$_" }
   - ps: |
         $ErrorActionPreference = 'Continue' # stderr not fatal
         $ErrorAction = 'Continue' # stderr not fatal
-        C:\msys64\usr\bin\bash -lc "time du -ks / ; time du -ks /var/cache/pacman/pkg"2>&1 | %{ "$_" }
+        C:\msys64\usr\bin\bash -lc "date -u; du -ks / ; date -u; du -ks /var/cache/pacman/pkg; date" 2>&1 | %{ "$_" }
 
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -80,12 +80,15 @@ test_script:
         REM Start a 64 bit Mingw environment:
         set MSYSTEM=MINGW64
         C:\msys64\usr\bin\bash -lc 'date -u; PATH="/mingw64/bin:$PATH" make -s install-win-bundle DESTDIR="`pwd`/.inst"'
-        7z a NUT-for-Windows-SNAPSHOT-{version}.zip .inst
+        7z a NUT-for-Windows-SNAPSHOT-%APPVEYOR_BUILD_VERSION%.zip .inst
 
 artifacts:
   - path: 'NUT-for-Windows-SNAPSHOT*.zip'
     name: Bundle of binary files and FOSS dependencies of NUT for Windows
     type: zip
+
+  - path: config.log
+    name: config.log
 
 # Example optional cache (depends on file change):
 # - C:\msys64 -> appveyor.yml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,35 +21,33 @@ branches:
 platform: x64
 
 # https://github.com/networkupstools/nut/blob/Windows-v2.8.0-1/docs/config-prereqs.txt#L951
+# Note: not using `time` in scripts currently - they did upset
+# AppVeyor console log scanner with a /^sys.*/ match (apparently)
 install:
-  - ps: |
-        $ErrorActionPreference = 'Continue' # stderr not fatal
-        $ErrorAction = 'Continue' # stderr not fatal
-        C:\msys64\usr\bin\bash -lc "mkdir -p /var/cache/pacman/pkg" 2>&1 | %{ "$_" }
-  - ps: |
-        $ErrorActionPreference = 'Continue' # stderr not fatal
-        $ErrorAction = 'Continue' # stderr not fatal
-        C:\msys64\usr\bin\bash -lc "date -u; pacman --noconfirm -Syuu" 2>&1 | %{ "$_" } # Core update (in case any core packages are outdated)
-  - ps: |
-        $ErrorActionPreference = 'Continue' # stderr not fatal
-        $ErrorAction = 'Continue' # stderr not fatal
-        C:\msys64\usr\bin\bash -lc "date -u; pacman --noconfirm -Syuu" 2>&1 | %{ "$_" } # Normal update
-  - ps: |
-        $ErrorActionPreference = 'Continue' # stderr not fatal
-        $ErrorAction = 'Continue' # stderr not fatal
-        C:\msys64\usr\bin\bash -lc "date -u; pacman --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain autoconf-wrapper automake-wrapper libtool mingw-w64-x86_64-libltdl gcc ccache mingw-w64-x86_64-ccache git aspell aspell-en python mingw-w64-x86_64-python-pygments mingw-w64-x86_64-winpthreads-git mingw-w64-x86_64-libusb mingw-w64-x86_64-libusb-compat-git mingw-w64-x86_64-neon libneon-devel mingw-w64-x86_64-libmodbus-git mingw-w64-x86_64-libgd"2>&1 | %{ "$_" }
-  - ps: |
-        $ErrorActionPreference = 'Continue' # stderr not fatal
-        $ErrorAction = 'Continue' # stderr not fatal
-        C:\msys64\usr\bin\bash -lc "date -u; du -ks / ; date -u; du -ks /var/cache/pacman/pkg; date" 2>&1 | %{ "$_" }
+  - cmd: |
+        REM Do not give pacman cause for complaints:
+        C:\msys64\usr\bin\bash -lc "mkdir -p /var/cache/pacman/pkg"
+  - cmd: |
+        REM Core update (in case any core packages are outdated):
+        C:\msys64\usr\bin\bash -lc "date -u; pacman --noconfirm -Syuu"
+  - cmd: |
+        REM Normal update (same command again):
+        C:\msys64\usr\bin\bash -lc "date -u; pacman --noconfirm -Syuu"
+  - cmd: |
+        REM Prerequisites for NUT per https://github.com/networkupstools/nut/blob/Windows-v2.8.0-1/docs/config-prereqs.txt :
+        C:\msys64\usr\bin\bash -lc "date -u; pacman --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain autoconf-wrapper automake-wrapper libtool mingw-w64-x86_64-libltdl gcc ccache mingw-w64-x86_64-ccache git aspell aspell-en python mingw-w64-x86_64-python-pygments mingw-w64-x86_64-winpthreads-git mingw-w64-x86_64-libusb mingw-w64-x86_64-libusb-compat-git mingw-w64-x86_64-neon libneon-devel mingw-w64-x86_64-libmodbus-git mingw-w64-x86_64-libgd"
+  - cmd: |
+        REM Assorted stats after packaging:
+        C:\msys64\usr\bin\bash -lc "date -u; du -ks / ; date -u; du -ks /var/cache/pacman/pkg; date"
 
 
 build_script:
-  - ps: |
-        $ErrorActionPreference = 'Continue' # stderr not fatal
-        $env:CHERE_INVOKING = 'yes'  # Preserve the current working directory
-        $env:MSYSTEM = 'MINGW64'  # Start a 64 bit Mingw environment
-        C:\msys64\usr\bin\bash -lc 'PATH="/mingw64/bin:$PATH" ./ci_build.sh' 2>&1 | %{ "$_" }
+  - cmd: |
+        REM Preserve the current working directory:
+        set CHERE_INVOKING=yes
+        REM Start a 64 bit Mingw environment:
+        set MSYSTEM=MINGW64
+        C:\msys64\usr\bin\bash -lc 'PATH="/mingw64/bin:$PATH" ./ci_build.sh'
 
 cache:
   - C:\msys64\var\cache\pacman\pkg # -> appveyor.yml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,19 +24,24 @@ platform: x64
 install:
   - ps: |
         $ErrorActionPreference = 'Continue' # stderr not fatal
-        C:\msys64\usr\bin\bash -lc "mkdir -p /var/cache/pacman/pkg"
+        $ErrorAction = 'Continue' # stderr not fatal
+        C:\msys64\usr\bin\bash -lc "mkdir -p /var/cache/pacman/pkg" 2>&1 | %{ "$_" }
   - ps: |
         $ErrorActionPreference = 'Continue' # stderr not fatal
-        C:\msys64\usr\bin\bash -lc "time pacman --noconfirm -Syuu"  # Core update (in case any core packages are outdated)
+        $ErrorAction = 'Continue' # stderr not fatal
+        C:\msys64\usr\bin\bash -lc "time pacman --noconfirm -Syuu" 2>&1 | %{ "$_" } # Core update (in case any core packages are outdated)
   - ps: |
         $ErrorActionPreference = 'Continue' # stderr not fatal
-        C:\msys64\usr\bin\bash -lc "time pacman --noconfirm -Syuu"  # Normal update
+        $ErrorAction = 'Continue' # stderr not fatal
+        C:\msys64\usr\bin\bash -lc "time pacman --noconfirm -Syuu" 2>&1 | %{ "$_" } # Normal update
   - ps: |
         $ErrorActionPreference = 'Continue' # stderr not fatal
-        C:\msys64\usr\bin\bash -lc "time pacman --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain autoconf-wrapper automake-wrapper libtool mingw-w64-x86_64-libltdl gcc ccache mingw-w64-x86_64-ccache git aspell aspell-en python mingw-w64-x86_64-python-pygments mingw-w64-x86_64-winpthreads-git mingw-w64-x86_64-libusb mingw-w64-x86_64-libusb-compat-git mingw-w64-x86_64-neon libneon-devel mingw-w64-x86_64-libmodbus-git mingw-w64-x86_64-libgd"
+        $ErrorAction = 'Continue' # stderr not fatal
+        C:\msys64\usr\bin\bash -lc "time pacman --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain autoconf-wrapper automake-wrapper libtool mingw-w64-x86_64-libltdl gcc ccache mingw-w64-x86_64-ccache git aspell aspell-en python mingw-w64-x86_64-python-pygments mingw-w64-x86_64-winpthreads-git mingw-w64-x86_64-libusb mingw-w64-x86_64-libusb-compat-git mingw-w64-x86_64-neon libneon-devel mingw-w64-x86_64-libmodbus-git mingw-w64-x86_64-libgd"2>&1 | %{ "$_" }
   - ps: |
         $ErrorActionPreference = 'Continue' # stderr not fatal
-        C:\msys64\usr\bin\bash -lc "time du -ks / ; time du -ks /var/cache/pacman/pkg"
+        $ErrorAction = 'Continue' # stderr not fatal
+        C:\msys64\usr\bin\bash -lc "time du -ks / ; time du -ks /var/cache/pacman/pkg"2>&1 | %{ "$_" }
 
 
 build_script:
@@ -44,7 +49,7 @@ build_script:
         $ErrorActionPreference = 'Continue' # stderr not fatal
         $env:CHERE_INVOKING = 'yes'  # Preserve the current working directory
         $env:MSYSTEM = 'MINGW64'  # Start a 64 bit Mingw environment
-        C:\msys64\usr\bin\bash -lc 'PATH="/mingw64/bin:$PATH" ./ci_build.sh'
+        C:\msys64\usr\bin\bash -lc 'PATH="/mingw64/bin:$PATH" ./ci_build.sh' 2>&1 | %{ "$_" }
 
 cache:
   - C:\msys64\var\cache\pacman\pkg # -> appveyor.yml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,13 +20,18 @@ branches:
 
 platform: x64
 
+# https://www.appveyor.com/docs/build-cache/
+environment:
+  APPVEYOR_SAVE_CACHE_ON_ERROR: true
+  APPVEYOR_CACHE_ENTRY_ZIP_ARGS: -t7z -m0=lzma -mx=9
+
 # https://github.com/networkupstools/nut/blob/Windows-v2.8.0-1/docs/config-prereqs.txt#L951
 # Note: not using `time` in scripts currently - they did upset
 # AppVeyor console log scanner with a /^sys.*/ match (apparently)
 install:
   - cmd: |
         REM Do not give pacman cause for complaints:
-        C:\msys64\usr\bin\bash -lc "mkdir -p /var/cache/pacman/pkg"
+        C:\msys64\usr\bin\bash -lc "mkdir -p /var/cache/pacman/pkg; ls -la /"
   - cmd: |
         REM Core update (in case any core packages are outdated):
         C:\msys64\usr\bin\bash -lc "date -u; pacman --noconfirm -Syuu"
@@ -38,7 +43,7 @@ install:
         C:\msys64\usr\bin\bash -lc "date -u; pacman --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain autoconf-wrapper automake-wrapper libtool mingw-w64-x86_64-libltdl gcc ccache mingw-w64-x86_64-ccache git aspell aspell-en python mingw-w64-x86_64-python-pygments mingw-w64-x86_64-winpthreads-git mingw-w64-x86_64-libusb mingw-w64-x86_64-libusb-compat-git mingw-w64-x86_64-neon libneon-devel mingw-w64-x86_64-libmodbus-git mingw-w64-x86_64-libgd"
   - cmd: |
         REM Assorted stats after package processing:
-        C:\msys64\usr\bin\bash -lc "date -u; du -ksx / ; date -u; du -ks /var/cache/pacman/pkg; date -u"
+        C:\msys64\usr\bin\bash -lc "date -u; ls la / ; du -ksx / ; date -u; du -ks /var/cache/pacman/pkg; date -u"
         REM Preserve the current working directory:
         set CHERE_INVOKING=yes
         REM Start a 64 bit Mingw environment:
@@ -62,7 +67,29 @@ after_build:
         set MSYSTEM=MINGW64
         C:\msys64\usr\bin\bash -lc 'date -u; PATH="/mingw64/bin:$PATH" ; export PATH ; ccache -sv || ccache -s || echo "SKIP: Could not query ccache stats"'
 
+# Example optional cache (depends on file change):
+# - C:\msys64 -> appveyor.yml
 cache:
-  - C:\msys64\var\cache\pacman\pkg # -> appveyor.yml
-  - C:\msys64\home\%USER\.ccache
+  - C:\msys64\home\appveyor\.ccache
+  - C:\msys64\home\appveyor\ccache # likely missing, no problem - but the name is reported in ccache status
+  - C:\msys64\var\cache\pacman\pkg
 
+# Below we tried to stash binaries of MSYS2 environment
+# so VM deployment is faster on subsequent builds
+# (update/install "from scratch" costs about 3 min),
+# but unstashing the archive takes comparable time
+# and often leads to conflicts in pacman book-keeping,
+# while creating/updating the archive costs ~10 min.
+  #- C:\msys64\var\lib\pacman
+  #- C:\msys64\var\lib
+  #- C:\msys64\mingw64
+  #- C:\msys64\mingw32
+  #- C:\msys64\ucrt64
+  #- C:\msys64\clang32
+  #- C:\msys64\clang64
+  #- C:\msys64\clangarm64
+  #- C:\msys64\usr
+  #- C:\msys64\bin
+  #- C:\msys64\etc
+  #- C:\msys64\*.*
+  #- C:\msys64\installerResources

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -74,6 +74,18 @@ test_script:
         REM Start a 64 bit Mingw environment:
         set MSYSTEM=MINGW64
         C:\msys64\usr\bin\bash -lc 'date -u; PATH="/mingw64/bin:$PATH" make check'
+  - cmd: |
+        REM Preserve the current working directory:
+        set CHERE_INVOKING=yes
+        REM Start a 64 bit Mingw environment:
+        set MSYSTEM=MINGW64
+        C:\msys64\usr\bin\bash -lc 'date -u; PATH="/mingw64/bin:$PATH" make install-win-bundle DESTDIR="`pwd`/.inst"'
+        7z a NUT-for-Windows-SNAPSHOT-{version}.zip .inst
+
+artifacts:
+  - path: 'NUT-for-Windows-SNAPSHOT*.zip'
+    name: Bundle of binary files and FOSS dependencies of NUT for Windows
+    type: zip
 
 # Example optional cache (depends on file change):
 # - C:\msys64 -> appveyor.yml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,8 +37,13 @@ install:
         REM Prerequisites for NUT per https://github.com/networkupstools/nut/blob/Windows-v2.8.0-1/docs/config-prereqs.txt :
         C:\msys64\usr\bin\bash -lc "date -u; pacman --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain autoconf-wrapper automake-wrapper libtool mingw-w64-x86_64-libltdl gcc ccache mingw-w64-x86_64-ccache git aspell aspell-en python mingw-w64-x86_64-python-pygments mingw-w64-x86_64-winpthreads-git mingw-w64-x86_64-libusb mingw-w64-x86_64-libusb-compat-git mingw-w64-x86_64-neon libneon-devel mingw-w64-x86_64-libmodbus-git mingw-w64-x86_64-libgd"
   - cmd: |
-        REM Assorted stats after packaging:
-        C:\msys64\usr\bin\bash -lc "date -u; du -ksx / ; date -u; du -ks /var/cache/pacman/pkg; date"
+        REM Assorted stats after package processing:
+        C:\msys64\usr\bin\bash -lc "date -u; du -ksx / ; date -u; du -ks /var/cache/pacman/pkg; date -u"
+        REM Preserve the current working directory:
+        set CHERE_INVOKING=yes
+        REM Start a 64 bit Mingw environment:
+        set MSYSTEM=MINGW64
+        C:\msys64\usr\bin\bash -lc 'PATH="/mingw64/bin:$PATH" ; export PATH ; pwd ; ccache -sv || echo "SKIP: Could not query ccache stats"'
 
 
 build_script:
@@ -47,7 +52,15 @@ build_script:
         set CHERE_INVOKING=yes
         REM Start a 64 bit Mingw environment:
         set MSYSTEM=MINGW64
-        C:\msys64\usr\bin\bash -lc 'PATH="/mingw64/bin:$PATH" ./ci_build.sh'
+        C:\msys64\usr\bin\bash -lc 'date -u; PATH="/mingw64/bin:$PATH" ./ci_build.sh'
+
+after_build:
+  - cmd: |
+        REM Preserve the current working directory:
+        set CHERE_INVOKING=yes
+        REM Start a 64 bit Mingw environment:
+        set MSYSTEM=MINGW64
+        C:\msys64\usr\bin\bash -lc 'date -u; PATH="/mingw64/bin:$PATH" ; export PATH ; ccache -sv || ccache -s || echo "SKIP: Could not query ccache stats"'
 
 cache:
   - C:\msys64\var\cache\pacman\pkg # -> appveyor.yml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ platform: x64
 
 # https://github.com/networkupstools/nut/blob/Windows-v2.8.0-1/docs/config-prereqs.txt#L951
 install:
+  - ps: C:\msys64\usr\bin\bash -lc "mkdir -p /var/cache/pacman/pkg"
   - ps: C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Syuu"  # Core update (in case any core packages are outdated)
   - ps: C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Syuu"  # Normal update
   - ps: C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain autoconf-wrapper automake-wrapper libtool mingw-w64-x86_64-libltdl gcc ccache mingw-w64-x86_64-ccache git aspell aspell-en python mingw-w64-x86_64-python-pygments mingw-w64-x86_64-winpthreads-git mingw-w64-x86_64-libusb mingw-w64-x86_64-libusb-compat-git mingw-w64-x86_64-neon libneon-devel mingw-w64-x86_64-libmodbus-git mingw-w64-x86_64-libgd"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -81,7 +81,7 @@ test_script:
         set MSYSTEM=MINGW64
         REM Oh the joys of shell scripting with strings passed through CMD:
         REM Note: currently Python installation path with MSYS is buggy [#1584]
-        C:\msys64\usr\bin\bash -lxc 'date -u; if ! rm -rf ".inst" ; then echo "WARNING: Failed to clean away .inst" ; fi  ; PATH="/mingw64/bin:$PATH" make -s install-win-bundle DESTDIR="`pwd`/.inst/NUT-for-Windows-SNAPSHOT-%APPVEYOR_BUILD_VERSION%" ; ln -fs "NUT-for-Windows-SNAPSHOT-%APPVEYOR_BUILD_VERSION%" ./.inst/NUT-for-Windows-SNAPSHOT '
+        C:\msys64\usr\bin\bash -lxc 'date -u; if ! rm -rf ".inst" ; then echo "WARNING: Failed to clean away .inst" ; fi ; PATH="/mingw64/bin:$PATH" make -s install-win-bundle DESTDIR="`pwd`/.inst/NUT-for-Windows-SNAPSHOT-%APPVEYOR_BUILD_VERSION%" ; ln -fs "NUT-for-Windows-SNAPSHOT-%APPVEYOR_BUILD_VERSION%" ./.inst/NUT-for-Windows-SNAPSHOT '
         cd .inst
         7z a ../NUT-for-Windows-SNAPSHOT-%APPVEYOR_BUILD_VERSION%.7z NUT*
 

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -1669,9 +1669,9 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
     # Quiet parallel make, redo loud sequential if that failed
     build_to_only_catch_errors_target all
 
-    # Can be noisy if regen is needed (DMF branch)
+    # Can be noisy if regen is needed (DMF branch with this or that BUILD_TGT)
     # Bail out due to DMF will (optionally) happen in the next check
-    GIT_DIFF_SHOW=false FILE_DESCR="DMF" FILE_REGEX='\.dmf$' FILE_GLOB='*.dmf' check_gitignore "$BUILD_TGT" || true
+    #GIT_DIFF_SHOW=false FILE_DESCR="DMF" FILE_REGEX='\.dmf$' FILE_GLOB='*.dmf' check_gitignore "$BUILD_TGT" || true
 
     # TODO (when merging DMF branch, not a problem before then):
     # this one check should not-list the "*.dmf" files even if
@@ -1698,7 +1698,7 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
         MAKEFLAGS="${MAKEFLAGS-} $MAKE_FLAGS_QUIET" \
         $CI_TIME $MAKE DISTCHECK_FLAGS="$DISTCHECK_FLAGS" $PARMAKE_FLAGS distcheck
 
-        FILE_DESCR="DMF" FILE_REGEX='\.dmf$' FILE_GLOB='*.dmf' check_gitignore "$BUILD_TGT" || true
+        #FILE_DESCR="DMF" FILE_REGEX='\.dmf$' FILE_GLOB='*.dmf' check_gitignore "$BUILD_TGT" || true
         check_gitignore "distcheck" || exit
         )
     fi

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -1780,6 +1780,15 @@ bindings)
     #$MAKE all || \
     $MAKE $PARMAKE_FLAGS all || exit
     if [ "${CI_SKIP_CHECK}" != true ] ; then $MAKE check || exit ; fi
+
+    case "$CI_OS_NAME" in
+        windows*)
+            echo "INFO: Build and tests succeeded. If you plan to install a NUT bundle now" >&2
+            echo "for practical usage or testing on a native Windows system, consider calling" >&2
+            echo "    make install-win-bundle DESTDIR=`pwd`/.inst/NUT4Win" >&2
+            echo "(or some other valid DESTDIR) to co-bundle dependency FOSS DLL files there." >&2
+            ;;
+    esac
     ;;
 
 # These mingw modes below are currently experimental and not too integrated

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -1777,9 +1777,9 @@ bindings)
     # NOTE: Currently parallel builds are expected to succeed (as far
     # as recipes are concerned), and the builds without a BUILD_TYPE
     # are aimed at developer iterations so not tweaking verbosity.
-    #$MAKE all && \
-    $MAKE $PARMAKE_FLAGS all && \
-    if [ "${CI_SKIP_CHECK}" != true ] ; then $MAKE check ; fi
+    #$MAKE all || \
+    $MAKE $PARMAKE_FLAGS all || exit
+    if [ "${CI_SKIP_CHECK}" != true ] ; then $MAKE check || exit ; fi
     ;;
 
 # These mingw modes below are currently experimental and not too integrated

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -1096,6 +1096,7 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
 
     if [ "$HAVE_CCACHE" = yes ] && [ "${COMPILER_FAMILY}" = GCC -o "${COMPILER_FAMILY}" = CLANG ]; then
         if [ -n "${CI_CCACHE_SYMLINKDIR}" ]; then
+            echo "INFO: Using ccache via PATH preferring tool names in ${CI_CCACHE_SYMLINKDIR}" >&2
             PATH="${CI_CCACHE_SYMLINKDIR}:$PATH"
             export PATH
         else
@@ -1722,7 +1723,7 @@ bindings)
         CCACHE_PATH="$PATH"
         CCACHE_DIR="${HOME}/.ccache"
         if (command -v ccache || which ccache) && ls -la "${CI_CCACHE_SYMLINKDIR}" && mkdir -p "${CCACHE_DIR}"/ ; then
-            echo "INFO: Using ccache via ${CI_CCACHE_SYMLINKDIR}" >&2
+            echo "INFO: Using ccache via PATH preferring tool names in ${CI_CCACHE_SYMLINKDIR}" >&2
             PATH="${CI_CCACHE_SYMLINKDIR}:$PATH"
             export CCACHE_PATH CCACHE_DIR PATH
         fi

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -1799,6 +1799,8 @@ bindings)
 # Note that semi-native builds with e.g. MSYS2 on Windows should "just work" as
 # on any other supported platform (more details in docs/config-prereqs.txt).
 cross-windows-mingw*)
+    echo "INFO: When using build-mingw-nut.sh consider 'export INSTALL_WIN_BUNDLE=true' to use mainstream DLL co-bundling recipe" >&2
+
     ./autogen.sh
     cd scripts/Windows || exit
 

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -67,6 +67,7 @@ Angelone
 Antonino
 Apodaca
 AppData
+AppVeyor
 Arjen
 Arkadiusz
 Armin

--- a/m4/nut_check_python.m4
+++ b/m4/nut_check_python.m4
@@ -39,7 +39,7 @@ AC_DEFUN([NUT_CHECK_PYTHON],
         PYTHON_VERSION_REPORT=""
         AS_IF([test -n "${PYTHON}"], [
             AS_IF([test x"`$PYTHON -c 'import sys; print (sys.version_info >= (2, 6))'`" = xTrue],
-                [PYTHON_VERSION_REPORT=" (`$PYTHON -c 'import sys; print ("%s.%s.%s" % sys.version_info[:3])'`)"], [PYTHON=no])
+                [PYTHON_VERSION_REPORT=" (`$PYTHON -c 'import sys; print (sys.version_info)'`)"], [PYTHON=no])
             ])
 
         AC_MSG_CHECKING([python interpeter to call])
@@ -101,7 +101,7 @@ AC_DEFUN([NUT_CHECK_PYTHON2],
         PYTHON2_VERSION_REPORT=""
         AS_IF([test -n "${PYTHON2}"], [
             AS_IF([test x"`$PYTHON2 -c 'import sys; print (sys.version_info >= (2, 6) and sys.version_info < (3, 0))'`" = xTrue],
-                [PYTHON2_VERSION_REPORT=" (`$PYTHON2 -c 'import sys; print ("%s.%s.%s" % sys.version_info[:3])'`)"], [PYTHON2=no])
+                [PYTHON2_VERSION_REPORT=" (`$PYTHON2 -c 'import sys; print (sys.version_info)'`)"], [PYTHON2=no])
             ])
 
         AC_MSG_CHECKING([python2 interpeter to call])
@@ -163,7 +163,7 @@ AC_DEFUN([NUT_CHECK_PYTHON3],
         PYTHON3_VERSION_REPORT=""
         AS_IF([test -n "${PYTHON3}"], [
             AS_IF([test x"`$PYTHON3 -c 'import sys; print (sys.version_info >= (3, 0))'`" = xTrue],
-                [PYTHON3_VERSION_REPORT=" (`$PYTHON3 -c 'import sys; print ("%s.%s.%s" % sys.version_info[:3])'`)"], [PYTHON3=no])
+                [PYTHON3_VERSION_REPORT=" (`$PYTHON3 -c 'import sys; print (sys.version_info)'`)"], [PYTHON3=no])
             ])
 
         AC_MSG_CHECKING([python3 interpeter to call])

--- a/m4/nut_check_python.m4
+++ b/m4/nut_check_python.m4
@@ -46,7 +46,7 @@ AC_DEFUN([NUT_CHECK_PYTHON],
         AC_MSG_RESULT([${PYTHON}${PYTHON_VERSION_REPORT}])
         AC_SUBST([PYTHON], [${PYTHON}])
         AM_CONDITIONAL([HAVE_PYTHON], [test "${PYTHON}" != "no"])
-        AS_IF([test -n "${PYTHON}"], [
+        AS_IF([test -n "${PYTHON}" && test "${PYTHON}" != "no"], [
             export PYTHON
             AC_MSG_CHECKING([python site-packages location])
             PYTHON_SITE_PACKAGES="`${PYTHON} -c 'import site; print(site.getsitepackages().pop(0))'`"
@@ -108,7 +108,7 @@ AC_DEFUN([NUT_CHECK_PYTHON2],
         AC_MSG_RESULT([${PYTHON2}${PYTHON2_VERSION_REPORT}])
         AC_SUBST([PYTHON2], [${PYTHON2}])
         AM_CONDITIONAL([HAVE_PYTHON2], [test "${PYTHON2}" != "no"])
-        AS_IF([test -n "${PYTHON2}"], [
+        AS_IF([test -n "${PYTHON2}" && test "${PYTHON2}" != "no"], [
             export PYTHON2
             AC_MSG_CHECKING([python2 site-packages location])
             PYTHON2_SITE_PACKAGES="`${PYTHON2} -c 'import site; print(site.getsitepackages().pop(0))'`"
@@ -170,7 +170,7 @@ AC_DEFUN([NUT_CHECK_PYTHON3],
         AC_MSG_RESULT([${PYTHON3}${PYTHON3_VERSION_REPORT}])
         AC_SUBST([PYTHON3], [${PYTHON3}])
         AM_CONDITIONAL([HAVE_PYTHON3], [test "${PYTHON3}" != "no"])
-        AS_IF([test -n "${PYTHON3}"], [
+        AS_IF([test -n "${PYTHON3}" && test "${PYTHON3}" != "no"], [
             export PYTHON3
             AC_MSG_CHECKING([python3 site-packages location])
             PYTHON3_SITE_PACKAGES="`${PYTHON3} -c 'import site; print(site.getsitepackages().pop(0))'`"

--- a/m4/nut_check_python.m4
+++ b/m4/nut_check_python.m4
@@ -39,7 +39,9 @@ AC_DEFUN([NUT_CHECK_PYTHON],
         PYTHON_VERSION_REPORT=""
         AS_IF([test -n "${PYTHON}"], [
             AS_IF([test x"`$PYTHON -c 'import sys; print (sys.version_info >= (2, 6))'`" = xTrue],
-                [PYTHON_VERSION_REPORT=" (`$PYTHON -c 'import sys; print (sys.version_info)'`)"], [PYTHON=no])
+                [PYTHON_VERSION_REPORT=" (`$PYTHON -c 'import sys; print (sys.version_info)'`)"],
+                [AC_MSG_WARN([Version reported by ${PYTHON} was not suitable])
+                 PYTHON=no])
             ])
 
         AC_MSG_CHECKING([python interpeter to call])
@@ -101,7 +103,9 @@ AC_DEFUN([NUT_CHECK_PYTHON2],
         PYTHON2_VERSION_REPORT=""
         AS_IF([test -n "${PYTHON2}"], [
             AS_IF([test x"`$PYTHON2 -c 'import sys; print (sys.version_info >= (2, 6) and sys.version_info < (3, 0))'`" = xTrue],
-                [PYTHON2_VERSION_REPORT=" (`$PYTHON2 -c 'import sys; print (sys.version_info)'`)"], [PYTHON2=no])
+                [PYTHON2_VERSION_REPORT=" (`$PYTHON2 -c 'import sys; print (sys.version_info)'`)"],
+                [AC_MSG_WARN([Version reported by ${PYTHON2} was not suitable])
+                 PYTHON2=no])
             ])
 
         AC_MSG_CHECKING([python2 interpeter to call])
@@ -163,7 +167,9 @@ AC_DEFUN([NUT_CHECK_PYTHON3],
         PYTHON3_VERSION_REPORT=""
         AS_IF([test -n "${PYTHON3}"], [
             AS_IF([test x"`$PYTHON3 -c 'import sys; print (sys.version_info >= (3, 0))'`" = xTrue],
-                [PYTHON3_VERSION_REPORT=" (`$PYTHON3 -c 'import sys; print (sys.version_info)'`)"], [PYTHON3=no])
+                [PYTHON3_VERSION_REPORT=" (`$PYTHON3 -c 'import sys; print (sys.version_info)'`)"],
+                [AC_MSG_WARN([Version reported by ${PYTHON3} was not suitable])
+                 PYTHON3=no])
             ])
 
         AC_MSG_CHECKING([python3 interpeter to call])

--- a/m4/nut_check_python.m4
+++ b/m4/nut_check_python.m4
@@ -52,6 +52,7 @@ AC_DEFUN([NUT_CHECK_PYTHON],
             PYTHON_SITE_PACKAGES="`${PYTHON} -c 'import site; print(site.getsitepackages().pop(0))'`"
             AC_MSG_RESULT([${PYTHON_SITE_PACKAGES}])
             ])
+        dnl Note: on Windows MSYS2 this embeds "C:\msys64\mingw..." into the string [nut#1584]
         AC_SUBST([PYTHON_SITE_PACKAGES], [${PYTHON_SITE_PACKAGES}])
         AM_CONDITIONAL([HAVE_PYTHON_SITE_PACKAGES], [test x"${PYTHON_SITE_PACKAGES}" != "x"])
     ])
@@ -108,6 +109,7 @@ AC_DEFUN([NUT_CHECK_PYTHON2],
             PYTHON2_SITE_PACKAGES="`${PYTHON2} -c 'import site; print(site.getsitepackages().pop(0))'`"
             AC_MSG_RESULT([${PYTHON2_SITE_PACKAGES}])
             ])
+        dnl Note: on Windows MSYS2 this embeds "C:\msys64\mingw..." into the string [nut#1584]
         AC_SUBST([PYTHON2_SITE_PACKAGES], [${PYTHON2_SITE_PACKAGES}])
         AM_CONDITIONAL([HAVE_PYTHON2_SITE_PACKAGES], [test x"${PYTHON2_SITE_PACKAGES}" != "x"])
     ])
@@ -164,6 +166,7 @@ AC_DEFUN([NUT_CHECK_PYTHON3],
             PYTHON3_SITE_PACKAGES="`${PYTHON3} -c 'import site; print(site.getsitepackages().pop(0))'`"
             AC_MSG_RESULT([${PYTHON3_SITE_PACKAGES}])
             ])
+        dnl Note: on Windows MSYS2 this embeds "C:\msys64\mingw..." into the string [nut#1584]
         AC_SUBST([PYTHON3_SITE_PACKAGES], [${PYTHON3_SITE_PACKAGES}])
         AM_CONDITIONAL([HAVE_PYTHON3_SITE_PACKAGES], [test x"${PYTHON3_SITE_PACKAGES}" != "x"])
     ])

--- a/m4/nut_check_python.m4
+++ b/m4/nut_check_python.m4
@@ -50,9 +50,14 @@ AC_DEFUN([NUT_CHECK_PYTHON],
             export PYTHON
             AC_MSG_CHECKING([python site-packages location])
             PYTHON_SITE_PACKAGES="`${PYTHON} -c 'import site; print(site.getsitepackages().pop(0))'`"
+            AS_CASE(["$PYTHON_SITE_PACKAGES"],
+                [*:*], [
+                    dnl Note: on Windows MSYS2 this embeds "C:/msys64/mingw..." into the string [nut#1584]
+                    PYTHON_SITE_PACKAGES="`cd "$PYTHON_SITE_PACKAGES" && pwd`"
+                    ]
+                )
             AC_MSG_RESULT([${PYTHON_SITE_PACKAGES}])
             ])
-        dnl Note: on Windows MSYS2 this embeds "C:\msys64\mingw..." into the string [nut#1584]
         AC_SUBST([PYTHON_SITE_PACKAGES], [${PYTHON_SITE_PACKAGES}])
         AM_CONDITIONAL([HAVE_PYTHON_SITE_PACKAGES], [test x"${PYTHON_SITE_PACKAGES}" != "x"])
     ])
@@ -107,9 +112,14 @@ AC_DEFUN([NUT_CHECK_PYTHON2],
             export PYTHON2
             AC_MSG_CHECKING([python2 site-packages location])
             PYTHON2_SITE_PACKAGES="`${PYTHON2} -c 'import site; print(site.getsitepackages().pop(0))'`"
+            AS_CASE(["$PYTHON2_SITE_PACKAGES"],
+                [*:*], [
+                    dnl Note: on Windows MSYS2 this embeds "C:/msys64/mingw..." into the string [nut#1584]
+                    PYTHON2_SITE_PACKAGES="`cd "$PYTHON2_SITE_PACKAGES" && pwd`"
+                    ]
+                )
             AC_MSG_RESULT([${PYTHON2_SITE_PACKAGES}])
             ])
-        dnl Note: on Windows MSYS2 this embeds "C:\msys64\mingw..." into the string [nut#1584]
         AC_SUBST([PYTHON2_SITE_PACKAGES], [${PYTHON2_SITE_PACKAGES}])
         AM_CONDITIONAL([HAVE_PYTHON2_SITE_PACKAGES], [test x"${PYTHON2_SITE_PACKAGES}" != "x"])
     ])
@@ -164,9 +174,14 @@ AC_DEFUN([NUT_CHECK_PYTHON3],
             export PYTHON3
             AC_MSG_CHECKING([python3 site-packages location])
             PYTHON3_SITE_PACKAGES="`${PYTHON3} -c 'import site; print(site.getsitepackages().pop(0))'`"
+            AS_CASE(["$PYTHON3_SITE_PACKAGES"],
+                [*:*], [
+                    dnl Note: on Windows MSYS2 this embeds "C:/msys64/mingw..." into the string [nut#1584]
+                    PYTHON3_SITE_PACKAGES="`cd "$PYTHON3_SITE_PACKAGES" && pwd`"
+                    ]
+                )
             AC_MSG_RESULT([${PYTHON3_SITE_PACKAGES}])
             ])
-        dnl Note: on Windows MSYS2 this embeds "C:\msys64\mingw..." into the string [nut#1584]
         AC_SUBST([PYTHON3_SITE_PACKAGES], [${PYTHON3_SITE_PACKAGES}])
         AM_CONDITIONAL([HAVE_PYTHON3_SITE_PACKAGES], [test x"${PYTHON3_SITE_PACKAGES}" != "x"])
     ])

--- a/m4/nut_check_python.m4
+++ b/m4/nut_check_python.m4
@@ -36,8 +36,14 @@ AC_DEFUN([NUT_CHECK_PYTHON],
             [*], [PYTHON="/usr/bin/env ${PYTHON}"]
         )
 
+        PYTHON_VERSION_REPORT=""
+        AS_IF([test -n "${PYTHON}"], [
+            AS_IF([test x"`$PYTHON -c 'import sys; print (sys.version_info >= (2, 6))'`" = xTrue],
+                [PYTHON_VERSION_REPORT=" (`$PYTHON -c 'import sys; print ("%s.%s.%s" % sys.version_info[:3])'`)"], [PYTHON=no])
+            ])
+
         AC_MSG_CHECKING([python interpeter to call])
-        AC_MSG_RESULT([${PYTHON}])
+        AC_MSG_RESULT([${PYTHON}${PYTHON_VERSION_REPORT}])
         AC_SUBST([PYTHON], [${PYTHON}])
         AM_CONDITIONAL([HAVE_PYTHON], [test "${PYTHON}" != "no"])
         AS_IF([test -n "${PYTHON}"], [
@@ -86,8 +92,14 @@ AC_DEFUN([NUT_CHECK_PYTHON2],
             [*], [PYTHON2="/usr/bin/env ${PYTHON2}"]
         )
 
+        PYTHON2_VERSION_REPORT=""
+        AS_IF([test -n "${PYTHON2}"], [
+            AS_IF([test x"`$PYTHON2 -c 'import sys; print (sys.version_info >= (2, 6) and sys.version_info < (3, 0))'`" = xTrue],
+                [PYTHON2_VERSION_REPORT=" (`$PYTHON2 -c 'import sys; print ("%s.%s.%s" % sys.version_info[:3])'`)"], [PYTHON2=no])
+            ])
+
         AC_MSG_CHECKING([python2 interpeter to call])
-        AC_MSG_RESULT([${PYTHON2}])
+        AC_MSG_RESULT([${PYTHON2}${PYTHON2_VERSION_REPORT}])
         AC_SUBST([PYTHON2], [${PYTHON2}])
         AM_CONDITIONAL([HAVE_PYTHON2], [test "${PYTHON2}" != "no"])
         AS_IF([test -n "${PYTHON2}"], [
@@ -136,8 +148,14 @@ AC_DEFUN([NUT_CHECK_PYTHON3],
             [*], [PYTHON3="/usr/bin/env ${PYTHON3}"]
         )
 
+        PYTHON3_VERSION_REPORT=""
+        AS_IF([test -n "${PYTHON3}"], [
+            AS_IF([test x"`$PYTHON3 -c 'import sys; print (sys.version_info >= (3, 0))'`" = xTrue],
+                [PYTHON3_VERSION_REPORT=" (`$PYTHON3 -c 'import sys; print ("%s.%s.%s" % sys.version_info[:3])'`)"], [PYTHON3=no])
+            ])
+
         AC_MSG_CHECKING([python3 interpeter to call])
-        AC_MSG_RESULT([${PYTHON3}])
+        AC_MSG_RESULT([${PYTHON3}${PYTHON3_VERSION_REPORT}])
         AC_SUBST([PYTHON3], [${PYTHON3}])
         AM_CONDITIONAL([HAVE_PYTHON3], [test "${PYTHON3}" != "no"])
         AS_IF([test -n "${PYTHON3}"], [

--- a/scripts/Windows/build-mingw-nut.sh
+++ b/scripts/Windows/build-mingw-nut.sh
@@ -71,6 +71,11 @@ esac
 
 cd $BUILD_DIR || exit
 
+if [ -z "$INSTALL_WIN_BUNDLE" ]; then
+	echo "NOTE: You might want to export INSTALL_WIN_BUNDLE=true to use main NUT Makefile"
+	echo "recipe for DLL co-bundling (default: false to use logic maintained in $0"
+fi >&2
+
 if [ "$cmd" == "all64" ] || [ "$cmd" == "b64" ] || [ "$cmd" == "all32" ] || [ "$cmd" == "b32" ] ; then
 	ARCH="x86_64-w64-mingw32"
 	if [ "$cmd" == "all32" ] || [ "$cmd" == "b32" ] ; then
@@ -105,9 +110,16 @@ if [ "$cmd" == "all64" ] || [ "$cmd" == "b64" ] || [ "$cmd" == "all32" ] || [ "$
 	make 1>/dev/null || exit
 
 	if [ "x$INSTALL_WIN_BUNDLE" = xtrue ] ; then
+		# Going forward, this should be the main mode - "legacy code"
+		# below picked up and transplanted into main build scenarios:
+		echo "NOTE: INSTALL_WIN_BUNDLE==true so using main NUT Makefile logic for DLL co-bundling" >&2
 		make install-win-bundle DESTDIR="${INSTALL_DIR}" || exit
 	else
-		make install DESTDIR="${INSTALL_DIR}"  || exit
+		# Legacy code from when NUT for Windows effort started;
+		# there is no plan to maintain it much (this script is PoC):
+		echo "NOTE: INSTALL_WIN_BUNDLE!=true so using built-in logic for DLL co-bundling" >&2
+
+		make install DESTDIR="${INSTALL_DIR}" || exit
 
 		# Per docs, Windows loads DLLs from EXE file's dir or some
 		# system locations or finally PATH, so unless the caller set

--- a/scripts/Windows/build-mingw-nut.sh
+++ b/scripts/Windows/build-mingw-nut.sh
@@ -144,10 +144,10 @@ if [ "$cmd" == "all64" ] || [ "$cmd" == "b64" ] || [ "$cmd" == "all32" ] || [ "$
 		(cd $INSTALL_DIR && { dllldddir . | while read D ; do cp -pf "$D" ./bin/ ; done ; } ) || true
 
 		# Hardlink libraries for sbin (alternative: all bins in one dir):
-		(cd $INSTALL_DIR/sbin && { dllldddir . | while read D ; do ln ../bin/"`basename "$D"`" ./ ; done ; } ) || true
+		(cd $INSTALL_DIR/sbin && { DESTDIR="$INSTALL_DIR" dllldddir . | while read D ; do ln -f ../bin/"`basename "$D"`" ./ ; done ; } ) || true
 
 		# Hardlink libraries for cgi-bin if present:
-		(cd $INSTALL_DIR/cgi-bin && { dllldddir . | while read D ; do ln ../bin/"`basename "$D"`" ./ ; done ; } ) || true
+		(cd $INSTALL_DIR/cgi-bin && { DESTDIR="$INSTALL_DIR" dllldddir . | while read D ; do ln -f ../bin/"`basename "$D"`" ./ ; done ; } ) || true
 	fi
 
 	cd ..

--- a/scripts/Windows/build-mingw-nut.sh
+++ b/scripts/Windows/build-mingw-nut.sh
@@ -131,6 +131,7 @@ if [ "$cmd" == "all64" ] || [ "$cmd" == "b64" ] || [ "$cmd" == "all32" ] || [ "$
 		# on a modern Windows one could go to their installed "sbin" to
 		#   mklink .\libupsclient-3.dll ..\bin\libupsclient-3.dll
 		(cd $INSTALL_DIR/bin && ln libupsclient*.dll ../sbin/)
+		(cd $INSTALL_DIR/bin && ln libupsclient*.dll ../cgi-bin/) || true
 
 		# Cover dependencies for nut-scanner (not pre-linked)
 		# Note: lib*snmp*.dll not listed below, it is
@@ -144,6 +145,9 @@ if [ "$cmd" == "all64" ] || [ "$cmd" == "b64" ] || [ "$cmd" == "all32" ] || [ "$
 
 		# Hardlink libraries for sbin (alternative: all bins in one dir):
 		(cd $INSTALL_DIR/sbin && { dllldddir . | while read D ; do ln ../bin/"`basename "$D"`" ./ ; done ; } ) || true
+
+		# Hardlink libraries for cgi-bin if present:
+		(cd $INSTALL_DIR/cgi-bin && { dllldddir . | while read D ; do ln ../bin/"`basename "$D"`" ./ ; done ; } ) || true
 	fi
 
 	cd ..

--- a/scripts/Windows/build-mingw-nut.sh
+++ b/scripts/Windows/build-mingw-nut.sh
@@ -122,10 +122,10 @@ if [ "$cmd" == "all64" ] || [ "$cmd" == "b64" ] || [ "$cmd" == "all32" ] || [ "$
 
 	# Steam-roll over all executables/libs we have here and copy
 	# over resolved dependencies from the cross-build environment:
-	(cd $INSTALL_DIR && { find . -type f | grep -Ei '\.(exe|dll)$' | while read E ; do dlllddrec "$E" ; done | sort | uniq | while read D ; do cp -pf "$D" ./bin/ ; done ; } ) || true
+	(cd $INSTALL_DIR && { dllldddir . | while read D ; do cp -pf "$D" ./bin/ ; done ; } ) || true
 
 	# Hardlink libraries for sbin (alternative: all bins in one dir):
-	(cd $INSTALL_DIR/sbin && { find . -type f | grep -Ei '\.(exe|dll)$' | while read E ; do dlllddrec "$E" ; done | sort | uniq | while read D ; do ln ../bin/"`basename "$D"`" ./ ; done ; } ) || true
+	(cd $INSTALL_DIR/sbin && { dllldddir . | while read D ; do ln ../bin/"`basename "$D"`" ./ ; done ; } ) || true
 	cd ..
 else
 	echo "Usage:"

--- a/scripts/Windows/build-mingw-nut.sh
+++ b/scripts/Windows/build-mingw-nut.sh
@@ -4,6 +4,11 @@
 
 #set -x
 
+SCRIPTDIR="`dirname "$0"`"
+SCRIPTDIR="`cd "$SCRIPTDIR" && pwd`"
+
+DLLLDD_SOURCED=true . "${SCRIPTDIR}/dllldd.sh"
+
 # default to update source then build
 WINDIR=$(pwd)
 TOP_DIR=$WINDIR/../..
@@ -65,36 +70,6 @@ out-of-tree)
 esac
 
 cd $BUILD_DIR || exit
-
-REGEX_WS="`printf '[\t ]'`"
-REGEX_NOT_WS="`printf '[^\t ]'`"
-dllldd() {
-  # Traverse an EXE or DLL file for DLLs it needs directly,
-  # which are provided in the cross-build env (not system ones).
-  # Assume no whitespaces in paths and filenames of interest.
-
-  # if `ldd` handles Windows PE, we are lucky:
-  #         libiconv-2.dll => /mingw64/bin/libiconv-2.dll (0x7ffd26c90000)
-  OUT="`ldd "$1" 2>/dev/null | grep -Ei '\.dll' | grep -E '/(bin|lib)/' | sed "s,^${REGEX_WS}*\(${REGEX_NOT_WS}${REGEX_NOT_WS}*\)${REGEX_WS}${REGEX_WS}*=>${REGEX_WS}${REGEX_WS}*\(${REGEX_NOT_WS}${REGEX_NOT_WS}*\)${REGEX_WS}.*\$,\2,"`" \
-  && [ -n "$OUT" ] && { echo "$OUT" ; return 0 ; }
-
-  # Otherwise try objdump
-  for OD in objdump "$ARCH-objdump" ; do
-    (command -v "$OD" >/dev/null 2>/dev/null) || continue
-    OUT="`$OD -x "$1" 2>/dev/null | grep -Ei "DLL Name:" | awk '{print $NF}' | while read F ; do ls -1 "/usr/$ARCH/"{bin,lib}/"$F" 2>/dev/null || true ; done`" \
-    && [ -n "$OUT" ] && { echo "$OUT" ; return 0 ; }
-  done
-
-  return 1
-}
-
-dlllddrec() (
-  # Recurse to find the (mingw-provided) tree of dependencies
-  dllldd "$1" | while read D ; do
-    echo "$D"
-    dlllddrec "$D"
-  done | sort | uniq
-)
 
 if [ "$cmd" == "all64" ] || [ "$cmd" == "b64" ] || [ "$cmd" == "all32" ] || [ "$cmd" == "b32" ] ; then
 	ARCH="x86_64-w64-mingw32"

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -26,7 +26,7 @@ dllldd() (
 		for OD in objdump "$ARCH-objdump" ; do
 			(command -v "$OD" >/dev/null 2>/dev/null) || continue
 
-			ODOUT="`$OD -x "$@" 2>/dev/null | grep -Ei "DLL Name:" | awk '{print $NF}' | sort | uniq | grep -vEi '^(|/.*/)(msvcrt|(advapi|kernel|user|wsock|ws2_)(32|64))\.dll$'`" \
+			ODOUT="`$OD -x "$@" 2>/dev/null | grep -Ei "DLL Name:" | awk '{print $NF}' | sort | uniq | grep -vEi '^(|/.*/)(msvcrt|userenv|bcrypt|rpcrt4|usp10|(advapi|kernel|user|wsock|ws2_|gdi|ole||shell)(32|64))\.dll$'`" \
 			&& [ -n "$ODOUT" ] || continue
 
 			for F in $ODOUT ; do

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -65,7 +65,7 @@ dlllddrec() (
 # even if hidden by conditionals or separate method like this (might
 # optionally source it from another file though?)
 #diffvars_bash() {
-#	diff -bu <(echo "$1") <(echo "$2") | grep -E '^\+[^+]'
+#	diff -bu <(echo "$1") <(echo "$2") | grep -E '^\+[^+]' | sed 's,^\+,,'
 #}
 
 dllldddir() (
@@ -102,7 +102,7 @@ dllldddir() (
 		#else
 			echo "$SEENDLLS" > "$TMP1"
 			echo "$MOREDLLS" > "$TMP2"
-			NEXTDLLS="`diff -bu "$TMP1" "$TMP2" | grep -E '^\+[^+]'`"
+			NEXTDLLS="`diff -bu "$TMP1" "$TMP2" | grep -E '^\+[^+]' | sed 's,^\+,,'`"
 		#fi
 
 		if [ -n "$NEXTDLLS" ] ; then

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+# This is a helper script to find Windows DLL library files used by another
+# Portable Executable (DLL or EXE) file, restricted to paths in the MinGW
+# environment. It can do so recursively, to facilitate installation of NUT
+# for Windows, bundled with open-source dependencies.
+#
+# Copyright (C)
+#   2022  Jim Klimov <jimklimov+nut@gmail.com>
+
+REGEX_WS="`printf '[\t ]'`"
+REGEX_NOT_WS="`printf '[^\t ]'`"
+dllldd() {
+	# Traverse an EXE or DLL file for DLLs it needs directly,
+	# which are provided in the cross-build env (not system ones).
+	# Assume no whitespaces in paths and filenames of interest.
+
+	# if `ldd` handles Windows PE, we are lucky:
+	#         libiconv-2.dll => /mingw64/bin/libiconv-2.dll (0x7ffd26c90000)
+	OUT="`ldd "$1" 2>/dev/null | grep -Ei '\.dll' | grep -E '/(bin|lib)/' | sed "s,^${REGEX_WS}*\(${REGEX_NOT_WS}${REGEX_NOT_WS}*\)${REGEX_WS}${REGEX_WS}*=>${REGEX_WS}${REGEX_WS}*\(${REGEX_NOT_WS}${REGEX_NOT_WS}*\)${REGEX_WS}.*\$,\2,"`" \
+	&& [ -n "$OUT" ] && { echo "$OUT" ; return 0 ; }
+
+	# Otherwise try objdump
+	for OD in objdump "$ARCH-objdump" ; do
+		(command -v "$OD" >/dev/null 2>/dev/null) || continue
+		OUT="`$OD -x "$1" 2>/dev/null | grep -Ei "DLL Name:" | awk '{print $NF}' | while read F ; do ls -1 "/usr/$ARCH/"{bin,lib}/"$F" 2>/dev/null || true ; done`" \
+		&& [ -n "$OUT" ] && { echo "$OUT" ; return 0 ; }
+	done
+
+	return 1
+}
+
+dlllddrec() (
+	# Recurse to find the (mingw-provided) tree of dependencies
+	dllldd "$1" | while read D ; do
+		echo "$D"
+		dlllddrec "$D"
+	done | sort | uniq
+)
+
+if [ x"${DLLLDD_SOURCED-}" != xtrue ] ; then
+	# Work like a command-line tool:
+	case "$1" in
+		""|-h|-help|--help)
+			cat << EOF
+Tool to find DLLs needed by an EXE or another DLL
+
+Directly used libraries:
+	$0 dllldd FILE.EXE
+
+Recursively used libraries:
+	$0 dlllddrec FILE.EXE
+EOF
+			;;
+		dlllddrec|dllldd) "$@" ;;
+		*) dlllddrec "$1" ;;
+	esac
+
+	exit 0
+fi
+
+# Caller said DLLLDD_SOURCED=true
+echo "SOURCED dllldd methods"

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -29,15 +29,15 @@ dllldd() (
 			&& [ -n "$ODOUT" ] || continue
 
 			if [ -n "$ARCH" ] ; then
-				OUT="`for F in $ODOUT ; do ls -1 "/usr/${ARCH}/"{bin,lib}/"$F" 2>/dev/null || true ; done`" \
+				OUT="`for F in $ODOUT ; do ls -1 "/usr/${ARCH}/bin/$F" "/usr/${ARCH}/lib/$F" 2>/dev/null || true ; done`" \
 				&& [ -n "$OUT" ] && { echo "$OUT" ; return 0 ; }
 			fi
 			if [ -n "$MSYSTEM_PREFIX" ] ; then
-				OUT="`for F in $ODOUT ; do ls -1 "${MSYSTEM_PREFIX}/"{bin,lib}/"$F" 2>/dev/null || true ; done`" \
+				OUT="`for F in $ODOUT ; do ls -1 "${MSYSTEM_PREFIX}/bin/$F" "${MSYSTEM_PREFIX}/lib/$F" 2>/dev/null || true ; done`" \
 				&& [ -n "$OUT" ] && { echo "$OUT" ; return 0 ; }
 			fi
 			if [ -n "$MINGW_PREFIX" ] && [ "$MINGW_PREFIX" != "$MSYSTEM_PREFIX" ] ; then
-				OUT="`for F in $ODOUT ; do ls -1 "${MINGW_PREFIX}/"{bin,lib}/"$F" 2>/dev/null || true ; done`" \
+				OUT="`for F in $ODOUT ; do ls -1 "${MINGW_PREFIX}/bin/$F" "${MINGW_PREFIX}/lib/$F" 2>/dev/null || true ; done`" \
 				&& [ -n "$OUT" ] && { echo "$OUT" ; return 0 ; }
 			fi
 		done

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -31,7 +31,7 @@ dllldd() (
 
 			for F in $ODOUT ; do
 				if [ -n "$DESTDIR" -a -d "${DESTDIR}" ] ; then
-					OUT="`find "$DESTDIR" -type f -name "$F" 2>/dev/null`" \
+					OUT="`find "$DESTDIR" -type f -name "$F" 2>/dev/null | head -1`" \
 					&& [ -n "$OUT" ] && { echo "$OUT" ; SEEN="`expr $SEEN + 1`" ; continue ; }
 				fi
 				if [ -n "$ARCH" -a -d "/usr/${ARCH}" ] ; then

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -62,7 +62,12 @@ dllldddir() (
 		return
 	fi
 
-	find "$@" -type f | grep -Ei '\.(exe|dll)$' | while read E ; do dlllddrec "$E" ; done | sort | uniq
+	# Two passes: one finds direct dependencies of all EXE/DLL under the
+	# specified location(s); then trims this list to be unique, and then
+	# the second pass recurses those libraries for their dependencies:
+	find "$@" -type f | grep -Ei '\.(exe|dll)$' \
+	| while read E ; do dllldd "$E" ; done | sort | uniq \
+	| while read D ; do echo "$D"; dlllddrec "$D" ; done | sort | uniq
 )
 
 if [ x"${DLLLDD_SOURCED-}" != xtrue ] ; then

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -25,7 +25,7 @@ dllldd() (
 		for OD in objdump "$ARCH-objdump" ; do
 			(command -v "$OD" >/dev/null 2>/dev/null) || continue
 
-			ODOUT="`$OD -x "$@" 2>/dev/null | grep -Ei "DLL Name:" | awk '{print $NF}' | sort | uniq | grep -vEi '^(|/.*/)(msvcrt|(advapi|kernel|ws2_)(32|64))\.dll$'`" \
+			ODOUT="`$OD -x "$@" 2>/dev/null | grep -Ei "DLL Name:" | awk '{print $NF}' | sort | uniq | grep -vEi '^(|/.*/)(msvcrt|(advapi|kernel|user|wsock|ws2_)(32|64))\.dll$'`" \
 			&& [ -n "$ODOUT" ] || continue
 
 			if [ -n "$ARCH" -a -d ""/usr/${ARCH}"" ] ; then

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -10,10 +10,15 @@
 
 REGEX_WS="`printf '[\t ]'`"
 REGEX_NOT_WS="`printf '[^\t ]'`"
-dllldd() {
+dllldd() (
 	# Traverse an EXE or DLL file for DLLs it needs directly,
 	# which are provided in the cross-build env (not system ones).
 	# Assume no whitespaces in paths and filenames of interest.
+
+	# grep for standard-language strings where needed:
+	LANG=C
+	LC_ALL=C
+	export LANG LC_ALL
 
 	# if `ldd` handles Windows PE (e.g. on MSYS2), we are lucky:
 	#         libiconv-2.dll => /mingw64/bin/libiconv-2.dll (0x7ffd26c90000)
@@ -44,7 +49,7 @@ dllldd() {
 	fi
 
 	return 1
-}
+)
 
 dlllddrec() (
 	# Recurse to find the (mingw-provided) tree of dependencies

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -14,6 +14,9 @@ dllldd() (
 	# Traverse an EXE or DLL file for DLLs it needs directly,
 	# which are provided in the cross-build env (not system ones).
 	# Assume no whitespaces in paths and filenames of interest.
+	# WARNING: Does not concern about (not report) dependencies built and
+	# delivered by the project itself (e.g. libupsclient or libnutclient)!
+	# TODO: Search nearby? Which DESTDIR and its subdir tree then?..
 
 	# grep for standard-language strings where needed:
 	LANG=C

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -28,15 +28,15 @@ dllldd() (
 			ODOUT="`$OD -x "$@" 2>/dev/null | grep -Ei "DLL Name:" | awk '{print $NF}' | sort | uniq | grep -vEi '^(|/.*/)(msvcrt|(advapi|kernel|ws2_)(32|64))\.dll$'`" \
 			&& [ -n "$ODOUT" ] || continue
 
-			if [ -n "$ARCH" ] ; then
+			if [ -n "$ARCH" -a -d ""/usr/${ARCH}"" ] ; then
 				OUT="`for F in $ODOUT ; do ls -1 "/usr/${ARCH}/bin/$F" "/usr/${ARCH}/lib/$F" 2>/dev/null || true ; done`" \
 				&& [ -n "$OUT" ] && { echo "$OUT" ; return 0 ; }
 			fi
-			if [ -n "$MSYSTEM_PREFIX" ] ; then
+			if [ -n "$MSYSTEM_PREFIX" -a -d "$MSYSTEM_PREFIX" ] ; then
 				OUT="`for F in $ODOUT ; do ls -1 "${MSYSTEM_PREFIX}/bin/$F" "${MSYSTEM_PREFIX}/lib/$F" 2>/dev/null || true ; done`" \
 				&& [ -n "$OUT" ] && { echo "$OUT" ; return 0 ; }
 			fi
-			if [ -n "$MINGW_PREFIX" ] && [ "$MINGW_PREFIX" != "$MSYSTEM_PREFIX" ] ; then
+			if [ -n "$MINGW_PREFIX" -a "$MINGW_PREFIX" != "$MSYSTEM_PREFIX" -a -d "$MINGW_PREFIX" ] ; then
 				OUT="`for F in $ODOUT ; do ls -1 "${MINGW_PREFIX}/bin/$F" "${MINGW_PREFIX}/lib/$F" 2>/dev/null || true ; done`" \
 				&& [ -n "$OUT" ] && { echo "$OUT" ; return 0 ; }
 			fi

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -15,17 +15,33 @@ dllldd() {
 	# which are provided in the cross-build env (not system ones).
 	# Assume no whitespaces in paths and filenames of interest.
 
-	# if `ldd` handles Windows PE, we are lucky:
+	# if `ldd` handles Windows PE (e.g. on MSYS2), we are lucky:
 	#         libiconv-2.dll => /mingw64/bin/libiconv-2.dll (0x7ffd26c90000)
 	OUT="`ldd "$1" 2>/dev/null | grep -Ei '\.dll' | grep -E '/(bin|lib)/' | sed "s,^${REGEX_WS}*\(${REGEX_NOT_WS}${REGEX_NOT_WS}*\)${REGEX_WS}${REGEX_WS}*=>${REGEX_WS}${REGEX_WS}*\(${REGEX_NOT_WS}${REGEX_NOT_WS}*\)${REGEX_WS}.*\$,\2,"`" \
 	&& [ -n "$OUT" ] && { echo "$OUT" ; return 0 ; }
 
-	# Otherwise try objdump
-	for OD in objdump "$ARCH-objdump" ; do
-		(command -v "$OD" >/dev/null 2>/dev/null) || continue
-		OUT="`$OD -x "$1" 2>/dev/null | grep -Ei "DLL Name:" | awk '{print $NF}' | while read F ; do ls -1 "/usr/$ARCH/"{bin,lib}/"$F" 2>/dev/null || true ; done`" \
-		&& [ -n "$OUT" ] && { echo "$OUT" ; return 0 ; }
-	done
+	# Otherwise try objdump, if ARCH is known (linux+mingw builds) or not (MSYS2 builds)
+	if [ -n "${ARCH-}${MINGW_PREFIX-}${MSYSTEM_PREFIX-}" ] ; then
+		for OD in objdump "$ARCH-objdump" ; do
+			(command -v "$OD" >/dev/null 2>/dev/null) || continue
+
+			ODOUT="`$OD -x "$1" 2>/dev/null | grep -Ei "DLL Name:" | awk '{print $NF}'`" \
+			&& [ -n "$ODOUT" ] || continue
+
+			if [ -n "$ARCH" ] ; then
+				OUT="`for F in $ODOUT ; do ls -1 "/usr/${ARCH}/"{bin,lib}/"$F" 2>/dev/null || true ; done`" \
+				&& [ -n "$OUT" ] && { echo "$OUT" ; return 0 ; }
+			fi
+			if [ -n "$MSYSTEM_PREFIX" ] ; then
+				OUT="`for F in $ODOUT ; do ls -1 "${MSYSTEM_PREFIX}/"{bin,lib}/"$F" 2>/dev/null || true ; done`" \
+				&& [ -n "$OUT" ] && { echo "$OUT" ; return 0 ; }
+			fi
+			if [ -n "$MINGW_PREFIX" ] && [ "$MINGW_PREFIX" != "$MSYSTEM_PREFIX" ] ; then
+				OUT="`for F in $ODOUT ; do ls -1 "${MINGW_PREFIX}/"{bin,lib}/"$F" 2>/dev/null || true ; done`" \
+				&& [ -n "$OUT" ] && { echo "$OUT" ; return 0 ; }
+			fi
+		done
+	fi
 
 	return 1
 }

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -20,13 +20,6 @@ dllldd() (
 	LC_ALL=C
 	export LANG LC_ALL
 
-	# if `ldd` handles Windows PE (e.g. on MSYS2), we are lucky:
-	#         libiconv-2.dll => /mingw64/bin/libiconv-2.dll (0x7ffd26c90000)
-	# but it tends to say "not a dynamic executable"
-	# or that file type is not supported
-	OUT="`ldd "$@" 2>/dev/null | grep -Ei '\.dll' | grep -E '/(bin|lib)/' | sed "s,^${REGEX_WS}*\(${REGEX_NOT_WS}${REGEX_NOT_WS}*\)${REGEX_WS}${REGEX_WS}*=>${REGEX_WS}${REGEX_WS}*\(${REGEX_NOT_WS}${REGEX_NOT_WS}*\)${REGEX_WS}.*\$,\2," | sort | uniq | grep -Ei '\.dll$'`" \
-	&& [ -n "$OUT" ] && { echo "$OUT" ; return 0 ; }
-
 	# Otherwise try objdump, if ARCH is known (linux+mingw builds) or not (MSYS2 builds)
 	if [ -n "${ARCH-}${MINGW_PREFIX-}${MSYSTEM_PREFIX-}" ] ; then
 		for OD in objdump "$ARCH-objdump" ; do
@@ -49,6 +42,13 @@ dllldd() (
 			fi
 		done
 	fi
+
+	# if `ldd` handles Windows PE (e.g. on MSYS2), we are lucky:
+	#         libiconv-2.dll => /mingw64/bin/libiconv-2.dll (0x7ffd26c90000)
+	# but it tends to say "not a dynamic executable"
+	# or that file type is not supported
+	OUT="`ldd "$@" 2>/dev/null | grep -Ei '\.dll' | grep -E '/(bin|lib)/' | sed "s,^${REGEX_WS}*\(${REGEX_NOT_WS}${REGEX_NOT_WS}*\)${REGEX_WS}${REGEX_WS}*=>${REGEX_WS}${REGEX_WS}*\(${REGEX_NOT_WS}${REGEX_NOT_WS}*\)${REGEX_WS}.*\$,\2," | sort | uniq | grep -Ei '\.dll$'`" \
+	&& [ -n "$OUT" ] && { echo "$OUT" ; return 0 ; }
 
 	return 1
 )

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -28,7 +28,7 @@ dllldd() (
 			ODOUT="`$OD -x "$@" 2>/dev/null | grep -Ei "DLL Name:" | awk '{print $NF}' | sort | uniq | grep -vEi '^(|/.*/)(msvcrt|(advapi|kernel|user|wsock|ws2_)(32|64))\.dll$'`" \
 			&& [ -n "$ODOUT" ] || continue
 
-			if [ -n "$ARCH" -a -d ""/usr/${ARCH}"" ] ; then
+			if [ -n "$ARCH" -a -d "/usr/${ARCH}" ] ; then
 				OUT="`for F in $ODOUT ; do ls -1 "/usr/${ARCH}/bin/$F" "/usr/${ARCH}/lib/$F" 2>/dev/null || true ; done`" \
 				&& [ -n "$OUT" ] && { echo "$OUT" ; return 0 ; }
 			fi

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -31,7 +31,7 @@ dllldd() (
 
 			for F in $ODOUT ; do
 				if [ -n "$DESTDIR" -a -d "${DESTDIR}" ] ; then
-					OUT="`find "$DESTDIR" -type f -name "$F" 2>/dev/null | head -1`" \
+					OUT="`find "$DESTDIR" -type f -name "$F" \! -size 0 2>/dev/null | head -1`" \
 					&& [ -n "$OUT" ] && { echo "$OUT" ; SEEN="`expr $SEEN + 1`" ; continue ; }
 				fi
 				if [ -n "$ARCH" -a -d "/usr/${ARCH}" ] ; then

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -54,6 +54,17 @@ dlllddrec() (
 	done | sort | uniq
 )
 
+dllldddir() (
+	# Recurse the current (or specified) directory, find all EXE/DLL here,
+	# and locate their dependency DLLs, and produce a unique-item list
+	if [ $# = 0 ]; then
+		dllldddir .
+		return
+	fi
+
+	find "$@" -type f | grep -Ei '\.(exe|dll)$' | while read E ; do dlllddrec "$E" ; done | sort | uniq
+)
+
 if [ x"${DLLLDD_SOURCED-}" != xtrue ] ; then
 	# Work like a command-line tool:
 	case "$1" in
@@ -62,13 +73,17 @@ if [ x"${DLLLDD_SOURCED-}" != xtrue ] ; then
 Tool to find DLLs needed by an EXE or another DLL
 
 Directly used libraries:
-	$0 dllldd FILE.EXE
+	$0 dllldd ONEFILE.EXE
 
 Recursively used libraries:
-	$0 dlllddrec FILE.EXE
+	$0 dlllddrec ONEFILE.EXE
+
+Find all EXE/DLL files under specified (or current) dir,
+and list their set of required DLLs
+	$0 dllldddir [DIRNAME]
 EOF
 			;;
-		dlllddrec|dllldd) "$@" ;;
+		dlllddrec|dllldd|dllldddir) "$@" ;;
 		*) dlllddrec "$1" ;;
 	esac
 

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -30,7 +30,7 @@ dllldd() (
 		for OD in objdump "$ARCH-objdump" ; do
 			(command -v "$OD" >/dev/null 2>/dev/null) || continue
 
-			ODOUT="`$OD -x "$1" 2>/dev/null | grep -Ei "DLL Name:" | awk '{print $NF}'`" \
+			ODOUT="`$OD -x "$1" 2>/dev/null | grep -Ei "DLL Name:" | awk '{print $NF}' | grep -vEi '^(|/.*/)(msvcrt|(advapi|kernel|ws2_)(32|64))\.dll$'`" \
 			&& [ -n "$ODOUT" ] || continue
 
 			if [ -n "$ARCH" ] ; then


### PR DESCRIPTION
After the merge of #1580 the Windows-v2.8.0-1 branch is finally sailworthy enough to pass `make check check-NIT` in MSYS2/MinGW build environment (natively on Windows)! And AppVeyor is kind enough to provide Windows builders (among others) to FOSS projects. So what are we waiting for? Let's make the two meet!

Example run log: https://ci.appveyor.com/project/jimklimov/nut/builds/44493334

Closes: #1552

CC:
* #869
* #5 
* #917

UPDATE: As part of the exercise, this also integrates third-party DLL bundling with main Makefile and separate helper script to find them, so addresses a new spin on #1492 as well. Now `make  DESTDIR='/tmp/nut_install' install-win-bundle` is a thing!

UPDATE: Also some python packaging issues were noted...
Closes: #1583
Closes: #1584
