### PR TITLE
common/common.c: avoid realpath() on platforms that lack it

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -25,8 +25,11 @@
 #include <errno.h>
 #include <pwd.h>
 #include <grp.h>
-#include <dirent.h>
 #include <sys/un.h>
+#include <dirent.h>
+#if !HAVE_REALPATH
+# include <sys/stat.h>
+#endif
 
 /* the reason we define UPS_VERSION as a static string, rather than a
 	macro, is to make dependency tracking easier (only common.o depends


### PR DESCRIPTION
Part of this was merged to master earlier, except the header include; follows up from #1524