### PR TITLE
upslog: Add support for multiple UPSs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -112,6 +112,9 @@ https://github.com/networkupstools/nut/milestone/8
    be sufficient without deprecation warnings for builds against openssl-3.0.x
    (but no real-time testing was done yet) [#1547]
 
+ - upslog: Added support for logging multiple devices with one call to the
+   program [#1604]
+
  - some fixes applied to Solaris/illumos packaging and SMF service support
    [#1554, #1564]
 

--- a/clients/upslog.c
+++ b/clients/upslog.c
@@ -32,6 +32,10 @@
  */
 
 #include "common.h"
+#include <signal.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/wait.h>
 #include "nut_platform.h"
 #include "upsclient.h"
 
@@ -41,16 +45,31 @@
 #include "upslog.h"
 
 	static	int	reopen_flag = 0, exit_flag = 0;
+	static	int	wait_status;
 	static	uint16_t	port;
 	static	char	*upsname, *hostname;
 	static	UPSCONN_t	ups;
 
 	static	FILE	*logfile;
-	static	const	char *logfn, *monhost;
+	static	char *logfn, *monhost;
 	static	sigset_t	nut_upslog_sigmask;
 	static	char	logbuffer[LARGEBUF], *logformat;
 
 	static	flist_t	*fhead = NULL;
+	struct 	monhost_child {
+		char	*monhost;
+		char	*logfn;
+		char	*pidfilebase;
+		pid_t	pid;
+		struct	monhost_child	*next;
+	};
+	static	struct	monhost_child *monhost_child_anchor = NULL;
+	static	struct	monhost_child *monhost_child_current = NULL;
+	static	struct	monhost_child *monhost_child_prev = NULL;
+	static	struct	sigaction upslog_sigaction;
+	static	int	trapped_signals[] = { SIGHUP, SIGINT, SIGTERM, SIGCHLD };
+	static	pid_t	daemon_pid;
+
 
 #define DEFAULT_LOGFORMAT "%TIME @Y@m@d @H@M@S% %VAR battery.charge% " \
 		"%VAR input.voltage% %VAR ups.load% [%VAR ups.status%] " \
@@ -131,6 +150,8 @@ static void help(const char *prog)
 	printf("  -p <pidbase>  - Base name for PID file (defaults to \"%s\")\n", prog);
 	printf("  -s <ups>	- Monitor UPS <ups> - <upsname>@<host>[:<port>]\n");
 	printf("        	- Example: -s myups@server\n");
+	printf("  -m <tuple>	- Monitor UPS <ups,logfile,pidfile>,\n");
+	printf("		- Example: -m myups@server,/var/log/myups.log,/var/run/myups.pid\n");
 	printf("  -u <user>	- Switch to <user> if started as root\n");
 
 	printf("\n");
@@ -393,9 +414,25 @@ static void run_flist(void)
 	 * -u <username>
 	 */
 
+static void term_handler(int signo)
+{
+	if (signo != SIGCHLD && monhost_child_anchor != NULL) {
+		for (monhost_child_current = monhost_child_anchor;
+		     monhost_child_current != NULL;
+		     monhost_child_current = monhost_child_current->next
+		) {
+			kill(monhost_child_current->pid, signo);
+		}
+
+		if (signo != SIGHUP)
+			fatalx(EXIT_FAILURE, "Killed by user");
+	}
+}
+
 int main(int argc, char **argv)
 {
 	int	interval = 30, i, foreground = -1;
+	size_t	monhost_len = 0, mh;
 	const char	*prog = xbasename(argv[0]);
 	time_t	now, nextpoll = 0;
 	const char	*user = NULL;
@@ -407,7 +444,7 @@ int main(int argc, char **argv)
 
 	printf("Network UPS Tools %s %s\n", prog, UPS_VERSION);
 
-	while ((i = getopt(argc, argv, "+hs:l:i:f:u:Vp:FB")) != -1) {
+	while ((i = getopt(argc, argv, "+hs:l:i:f:u:Vp:FBm:")) != -1) {
 		switch(i) {
 			case 'h':
 				help(prog);
@@ -415,6 +452,33 @@ int main(int argc, char **argv)
 				break;
 #endif
 
+			case 'm': { /* var scope */
+				char *m_arg, *s;
+
+				monhost_child_prev = monhost_child_current;
+				monhost_child_current = xmalloc(sizeof(struct monhost_child));
+				if (monhost_child_anchor == NULL)
+					monhost_child_anchor = monhost_child_current;
+				else
+					monhost_child_prev->next = monhost_child_current;
+				monhost_child_current->next = NULL;
+				monhost_len++;
+
+				/* Be sure to not mangle original optarg, nor rely on its longevity */
+				s = xstrdup(optarg);
+				m_arg = s;
+				monhost_child_current->monhost = xstrdup(strsep(&m_arg, ","));
+				if (!m_arg)
+					fatalx(EXIT_FAILURE, "Argument '-m upsspec,logfile,pidfile' requires exactly 3 components in the tuple");
+				monhost_child_current->logfn = xstrdup(strsep(&m_arg, ","));
+				if (!m_arg)
+					fatalx(EXIT_FAILURE, "Argument '-m upsspec,logfile,pidfile' requires exactly 3 components in the tuple");
+				monhost_child_current->pidfilebase = xstrdup(strsep(&m_arg, ","));
+				if (m_arg) /* Had a third comma - also unexpected! */
+					fatalx(EXIT_FAILURE, "Argument '-m upsspec,logfile,pidfile' requires exactly 3 components in the tuple");
+				free(s);
+				} /* var scope */
+				break;
 			case 's':
 				monhost = optarg;
 				break;
@@ -477,6 +541,41 @@ int main(int argc, char **argv)
 
 		for (i = 3; i < argc; i++)
 			snprintfcat(logformat, LARGEBUF, "%s ", argv[i]);
+	}
+
+	if (monhost_child_anchor != NULL) {
+		if (foreground > 0)
+			daemon_pid = 0;
+		else
+			daemon_pid = fork();
+		if (!daemon_pid) {
+			upsdebugx(1,"Forking to log %" PRIuSIZE " devices", monhost_len);
+			for (monhost_child_current = monhost_child_anchor;
+			     monhost_child_current != NULL;
+			     monhost_child_current = monhost_child_current->next) {
+				if ((monhost_child_current->pid = fork()) == 0) {
+					monhost = monhost_child_current->monhost;
+					logfn = monhost_child_current->logfn;
+					pidfilebase = monhost_child_current->pidfilebase;
+					foreground = 1;
+					break;
+				}
+			}
+			if (monhost_child_anchor->pid) {	/* parent */
+				for (mh = 0; mh < sizeof(trapped_signals)/sizeof(trapped_signals[0]); mh++) {
+					upslog_sigaction.sa_handler = &term_handler;
+					sigfillset(&upslog_sigaction.sa_mask);
+					upslog_sigaction.sa_flags = SA_NOCLDSTOP | SA_NOCLDWAIT;
+					sigaction(trapped_signals[mh], &upslog_sigaction, NULL);
+				}
+				become_user(get_user_pwent(user));
+				writepid(pidfilebase);
+				while(wait(&wait_status) > 0);
+				exit(EXIT_SUCCESS);
+			}
+		} else {
+			exit(EXIT_SUCCESS);
+		}
 	}
 
 	if (!monhost)

--- a/docs/man/upslog.txt
+++ b/docs/man/upslog.txt
@@ -78,6 +78,11 @@ upslog will run in the background, regardless of logging target.
 Monitor this UPS.  The format for this option is
 +upsname[@hostname[:port]]+.  The default hostname is "localhost".
 
+*-m* 'tuple'::
+Monitor multiple UPSs. The format for this option is a tuple of
+ups, logfile, and pidfile separated by commas. An example would be:
+`upsname@hostname:9999,/var/log/nut/cps.log,/var/run/cps.pid`
+
 *-u* 'username'::
 
 If started as root, upslog will *setuid*(2) to the user id

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 2992 utf-8
+personal_ws-1.1 en 2993 utf-8
 AAS
 ABI
 ACFAIL
@@ -2390,6 +2390,7 @@ phoenixcontact
 phoenixtec
 picocom
 pid
+pidfile
 pidpath
 pigz
 pijuice


### PR DESCRIPTION
upslog is a utility that logs UPS status at regular intervals, specified
by the -i option. Unfortunately upslog supports only on UPS. For sites
that need to monitor multiple UPSs the options are to cobble an rc script
for each or doctor up the nut_upslog.in script to support cloning of the
script. Unfortunately an rc script capable of being cloned would become
the source of more PRs and would require significanly more tehcnical
documentation that by itself might become confusing for the average
system administrator.

Therefore a new -m option is added to support multiple UPSs using the
same invocation of upslog. The patch parses a -m option and forks
almost immediately following the getopt(3) invokation to monitor each
individual UPS using a separate upslog process. This is not ideal but
better than scripting. Lightweight threads might be a better solution.

<!-- Comment:
* Please revise the docs/developers.txt for coding style suggestions and
  other considerations applicable to NUT codebase contributions, as well
  as for which text documents to update. See also docs/developer-guide.txt
  for general points on NUT architecture and design.

* The checklist below is more of a reminder of steps to take and "dangers"
  to look out for. PRs to update this template are also welcome :)

* Local build iterations can be augmented with the ci_build.sh script.
-->

## General points

- [x] Described the changes in the PR submission or a separate issue, e.g.
  known published or discovered protocols, applicable hardware (expected
  compatible and actually tested/developed against), limitations, etc.

- [x] There may be multiple commits in the PR, aligned and commented with
  a functional change. Notably, coding style changes better belong in a
  separate PR, but certainly in a dedicated commit to simplify reviews
  of "real" changes in the other commits. Similarly for typo fixes in
  comments or text documents.

## Frequent "underwater rocks" for driver addition/update PRs

- [ ] Revised existing driver families and added a sub-driver if applicable
  (`nutdrv_qx`, `usbhid-ups`...) or added a brand new driver in the other
  case.

- [ ] Did not extend obsoleted drivers with new hardware support features
  (notably `blazer` and other single-device family drivers for Qx protocols,
  except the new `nutdrv_qx` which should cover them all).

- [ ] For updated existing device drivers, bumped the `DRIVER_VERSION` macro
  or its equivalent.

<!-- Comment:
  Some sub-drivers have `SUBDRIVER_VERSION` or customized names like
  e.g. `MEGATEC_VERSION` in `drivers/nutdrv_qx_megatec.c`
-->

- [ ] For USB devices (HID or not), revised that the driver uses unique
  VID/PID combinations, or raised discussions when this is not the case
  (several vendors do use same interface chips for unrelated protocols).

- [ ] For new USB devices, built and committed the changes for the
  `scripts/upower/95-upower-hid.hwdb` file

- [ ] Proposed NUT data mapping is aligned with existing `docs/nut-names.txt`
  file. If the device exposes useful data points not listed in the file, the
  `experimental.*` namespace can be used as documented there, and discussion
  should be raised on the NUT Developers mailing list to standardize the new
  concept.

- [ ] Updated `data/driver.list.in` if applicable (new tested device info)
<!-- Comment:
Also note below, a point about PR posting for NUT DDL
-->

## Frequent "underwater rocks" for general C code PRs

- [x] Did not "blindly assume" default integer type sizes and value ranges,
  structure layout and alignment in memory, endianness (layout of bytes and
  bits in memory for multi-byte numeric types), or use of generic `int` where
  language or libraries dictate the use of `size_t` (or `ssize_t` sometimes).

<!-- Comment:
* NOTE: Casting and/or pragmas (support detected at compile time,
  see `m4/ax_c_pragmas.m4`) to silence warnings may be acceptable,
  but only if coupled with range checks or similar actions.
-->

- [x] Progress and errors are handled with `upsdebugx()`, `upslogx()`,
  `fatalx()` and related methods, not with direct `printf()` or `exit()`.
  Similarly, NUT helpers are used for error-checked memory allocation and
  string operations (except where customized error handling is needed,
  such as unlocking device ports, etc.)

- [x] Coding style (including whitespace for indentations) follows precedent
  in the code of the file, and examples/guide in `docs/developers.txt` file.

- [ ] For newly added files, the `Makefile.am` recipes were updated and the
  `make distcheck` target passes.

## General documentation updates

- [ ] Updated `docs/acknowledgements.txt` (for vendor-backed device support)

- [x] Added or updated manual page information in `docs/man/*.txt` files
  and corresponding recipe lists in `docs/man/Makefile.am` for new pages

- [ ] Passed `make spellcheck`, updated spell-checking dictionary in the
  `docs/nut.dict` file if needed (did not remove any words -- the `make`
  rule printout in case of changes suggests how to maintain it).

## Additional work may be needed after posting this PR

- [ ] Propose a PR for NUT DDL with detailed device data dumps from tests
  against real hardware (the more models, the better).

- [ ] Address NUT CI farm build failures for the PR: testing on numerous
  platforms and toolkits can expose issues not seen on just one system.

<!-- Comment:
* One frequent "offence" is the appearance of unexpected (not git-ignored)
  or modification during build of files tracked in Git.

* Another frequent issue is not tracking newly introduced file names in
  `EXTRA_DIST` of the `Makefile.am` (and for `*.in` templates -- of rules
  in the `configure.ac` script) so the `make distcheck` fails.

* Avoid using GNU-specific constructs in the `Makefile.am`, even if that
  means cumbersome ways to build a target. This should not happen in mere
  driver updates, however.

* Also some third-party libraries or OS headers and method argument types
  and counts can differ -- necessitating m4 code for `configure` script
  probing, and `ifdef`, `typedef`, etc. in C code to adapt to the build
  environment (precedents available in NUT codebase). In extreme cases,
  you may need to spin up a VM or container to reproduce those issues
  and iterate on a fix locally; see `docs/config-prereqs.txt` and
  `docs/ci-farm-lxc-setup.txt` for notes taken during preparation of
  the multi-platform NUT CI farm.
-->

- [ ] Revise suggestions from LGTM.COM analysis about "new issues" with
  the changed codebase.

<!-- Comment:
  Take them with a grain of salt, especially with regard to things like
  architecture-dependent range checks, but many of the complaints from
  the tool are indeed useful.
-->
