### PR TITLE
Revise PyNUT self-test to actually fail

### DIFF
--- a/scripts/python/module/PyNUT.py.in
+++ b/scripts/python/module/PyNUT.py.in
@@ -315,7 +315,9 @@ of connection.
             print( "[DEBUG] DeviceLogin called..." )
 
         if ups is None or (ups not in self.GetUPSNames()):
-            raise PyNUTError( "%s is not a valid UPS" % ups )
+            if self.__debug :
+                print( "[DEBUG] DeviceLogin: %s is not a valid UPS" % ups )
+            raise PyNUTError( "ERR UNKNOWN-UPS" )
 
         self.__srv_handler.write( ("LOGIN %s\n" % ups).encode('ascii') )
         result = self.__srv_handler.read_until( b"\n" )
@@ -348,7 +350,9 @@ NOTE: API changed since NUT 2.8.0 to replace MASTER with PRIMARY
             self.__srv_handler.write( ("MASTER %s\n" % ups).encode('ascii') )
             result = self.__srv_handler.read_until( b"\n" )
             if ( result != b"OK MASTER-GRANTED\n" ) :
-                raise PyNUTError( ( "Primary level functions are not available", "" ) )
+                if self.__debug :
+                    print( "[DEBUG] Primary level functions are not available" )
+                raise PyNUTError( "ERR ACCESS-DENIED" )
 
         if self.__debug :
             print( "[DEBUG] FSD called..." )
@@ -390,7 +394,9 @@ The result is a dictionary containing 'key->val' pairs of 'UPSName' and a list o
         # If (!ups) we use this list below to recurse:
         self_ups_list = self.GetUPSNames()
         if ups and (ups not in self_ups_list):
-            raise PyNUTError( "%s is not a valid UPS" % ups )
+            if self.__debug :
+                print( "[DEBUG] ListClients: %s is not a valid UPS" % ups )
+            raise PyNUTError( "ERR UNKNOWN-UPS" )
 
         if ups:
             self.__srv_handler.write( ("LIST CLIENT %s\n" % ups).encode('ascii') )

--- a/scripts/python/module/PyNUT.py.in
+++ b/scripts/python/module/PyNUT.py.in
@@ -48,6 +48,9 @@
 #            Fix ListClients() method to actually work with current NUT protocol
 #            Added DeviceLogin() method
 #            Added GetUPSNames() method
+#            Fixed raised PyNUTError() exceptions to carry a Python string
+#            (suitable for Python2 and Python3), not byte array from protocol,
+#            so exception catchers can process them naturally (see test script).
 
 import telnetlib
 

--- a/scripts/python/module/PyNUT.py.in
+++ b/scripts/python/module/PyNUT.py.in
@@ -118,7 +118,7 @@ if something goes wrong.
             self.__srv_handler.write( ("USERNAME %s\n" % self.__login).encode('ascii') )
             result = self.__srv_handler.read_until( b"\n", self.__timeout )
             if result[:2] != b"OK" :
-                raise PyNUTError( result.replace( b"\n", b"" ) )
+                raise PyNUTError( result.replace( b"\n", b"" ).decode('ascii') )
 
         if self.__password != None :
             self.__srv_handler.write( ("PASSWORD %s\n" % self.__password).encode('ascii') )
@@ -130,9 +130,9 @@ if something goes wrong.
                     self.__srv_handler.write( ("PASSWORD \"%s\"\n" % self.__password).encode('ascii') )
                     result = self.__srv_handler.read_until( b"\n", self.__timeout )
                     if result[:2] != b"OK" :
-                        raise PyNUTError( result.replace( b"\n", b"" ) )
+                        raise PyNUTError( result.replace( b"\n", b"" ).decode('ascii') )
                 else:
-                    raise PyNUTError( result.replace( b"\n", b"" ) )
+                    raise PyNUTError( result.replace( b"\n", b"" ).decode('ascii') )
 
     def GetUPSList( self ) :
         """ Returns the list of available UPS from the NUT server
@@ -149,7 +149,7 @@ which is of little concern for Python2 but is important in Python3
         self.__srv_handler.write( b"LIST UPS\n" )
         result = self.__srv_handler.read_until( b"\n" )
         if result != b"BEGIN LIST UPS\n" :
-            raise PyNUTError( result.replace( b"\n", b"" ) )
+            raise PyNUTError( result.replace( b"\n", b"" ).decode('ascii') )
 
         result = self.__srv_handler.read_until( b"END LIST UPS\n" )
         ups_list = {}
@@ -189,7 +189,7 @@ available vars.
         self.__srv_handler.write( ("LIST VAR %s\n" % ups).encode('ascii') )
         result = self.__srv_handler.read_until( b"\n" )
         if result != ("BEGIN LIST VAR %s\n" % ups).encode('ascii') :
-            raise PyNUTError( result.replace( b"\n", b"" ) )
+            raise PyNUTError( result.replace( b"\n", b"" ).decode('ascii') )
 
         ups_vars   = {}
         result     = self.__srv_handler.read_until( ("END LIST VAR %s\n" % ups).encode('ascii') )
@@ -215,7 +215,7 @@ of the command as value
         self.__srv_handler.write( ("LIST CMD %s\n" % ups).encode('ascii') )
         result = self.__srv_handler.read_until( b"\n" )
         if result != ("BEGIN LIST CMD %s\n" % ups).encode('ascii') :
-            raise PyNUTError( result.replace( b"\n", b"" ) )
+            raise PyNUTError( result.replace( b"\n", b"" ).decode('ascii') )
 
         ups_cmds   = {}
         result     = self.__srv_handler.read_until( ("END LIST CMD %s\n" % ups).encode('ascii') )
@@ -252,7 +252,7 @@ The result is presented as a dictionary containing 'key->val' pairs
         self.__srv_handler.write( ("LIST RW %s\n" % ups).encode('ascii') )
         result = self.__srv_handler.read_until( b"\n" )
         if ( result != ("BEGIN LIST RW %s\n" % ups).encode('ascii') ) :
-            raise PyNUTError( result.replace( b"\n", b"" ) )
+            raise PyNUTError( result.replace( b"\n", b"" ).decode('ascii') )
 
         result     = self.__srv_handler.read_until( ("END LIST RW %s\n" % ups).encode('ascii') )
         offset     = len( ("VAR %s" % ups).encode('ascii') )
@@ -282,7 +282,7 @@ rights to set it (maybe login/password).
         if ( result == b"OK\n" ) :
             return( "OK" )
         else :
-            raise PyNUTError( result.replace( b"\n", b"" ) )
+            raise PyNUTError( result.replace( b"\n", b"" ).decode('ascii') )
 
     def RunUPSCommand( self, ups="", command="" ) :
         """ Send a command to the specified UPS
@@ -298,7 +298,7 @@ Returns OK on success or raises an error
         if ( result == b"OK\n" ) :
             return( "OK" )
         else :
-            raise PyNUTError( result.replace( b"\n", b"" ) )
+            raise PyNUTError( result.replace( b"\n", b"" ).decode('ascii') )
 
     def DeviceLogin( self, ups="") :
         """ Establish a login session with a device (like upsmon does)
@@ -317,7 +317,7 @@ of connection.
         if ups is None or (ups not in self.GetUPSNames()):
             if self.__debug :
                 print( "[DEBUG] DeviceLogin: %s is not a valid UPS" % ups )
-            raise PyNUTError( b"ERR UNKNOWN-UPS" )
+            raise PyNUTError( "ERR UNKNOWN-UPS" )
 
         self.__srv_handler.write( ("LOGIN %s\n" % ups).encode('ascii') )
         result = self.__srv_handler.read_until( b"\n" )
@@ -328,7 +328,7 @@ of connection.
         if ( result == b"OK\n" ) :
             return( "OK" )
         else :
-            raise PyNUTError( result.replace( b"\n", b"" ) )
+            raise PyNUTError( result.replace( b"\n", b"" ).decode('ascii') )
 
     def FSD( self, ups="") :
         """ Send FSD command
@@ -352,7 +352,7 @@ NOTE: API changed since NUT 2.8.0 to replace MASTER with PRIMARY
             if ( result != b"OK MASTER-GRANTED\n" ) :
                 if self.__debug :
                     print( "[DEBUG] Primary level functions are not available" )
-                raise PyNUTError( b"ERR ACCESS-DENIED" )
+                raise PyNUTError( "ERR ACCESS-DENIED" )
 
         if self.__debug :
             print( "[DEBUG] FSD called..." )
@@ -361,7 +361,7 @@ NOTE: API changed since NUT 2.8.0 to replace MASTER with PRIMARY
         if ( result == b"OK FSD-SET\n" ) :
             return( "OK" )
         else :
-            raise PyNUTError( result.replace( b"\n", b"" ) )
+            raise PyNUTError( result.replace( b"\n", b"" ).decode('ascii') )
 
     def help(self) :
         """ Send HELP command
@@ -396,7 +396,7 @@ The result is a dictionary containing 'key->val' pairs of 'UPSName' and a list o
         if ups and (ups not in self_ups_list):
             if self.__debug :
                 print( "[DEBUG] ListClients: %s is not a valid UPS" % ups )
-            raise PyNUTError( b"ERR UNKNOWN-UPS" )
+            raise PyNUTError( "ERR UNKNOWN-UPS" )
 
         if ups:
             self.__srv_handler.write( ("LIST CLIENT %s\n" % ups).encode('ascii') )
@@ -420,7 +420,7 @@ The result is a dictionary containing 'key->val' pairs of 'UPSName' and a list o
             if self.__debug :
                 print( "[DEBUG] ListClients from server got unexpected result: %s" % result )
 
-            raise PyNUTError( result.replace( b"\n", b"" ) )
+            raise PyNUTError( result.replace( b"\n", b"" ).decode('ascii') )
 
         if ups :
             result = self.__srv_handler.read_until( ("END LIST CLIENT %s\n" % ups).encode('ascii') )

--- a/scripts/python/module/PyNUT.py.in
+++ b/scripts/python/module/PyNUT.py.in
@@ -317,7 +317,7 @@ of connection.
         if ups is None or (ups not in self.GetUPSNames()):
             if self.__debug :
                 print( "[DEBUG] DeviceLogin: %s is not a valid UPS" % ups )
-            raise PyNUTError( "ERR UNKNOWN-UPS" )
+            raise PyNUTError( b"ERR UNKNOWN-UPS" )
 
         self.__srv_handler.write( ("LOGIN %s\n" % ups).encode('ascii') )
         result = self.__srv_handler.read_until( b"\n" )
@@ -352,7 +352,7 @@ NOTE: API changed since NUT 2.8.0 to replace MASTER with PRIMARY
             if ( result != b"OK MASTER-GRANTED\n" ) :
                 if self.__debug :
                     print( "[DEBUG] Primary level functions are not available" )
-                raise PyNUTError( "ERR ACCESS-DENIED" )
+                raise PyNUTError( b"ERR ACCESS-DENIED" )
 
         if self.__debug :
             print( "[DEBUG] FSD called..." )
@@ -396,7 +396,7 @@ The result is a dictionary containing 'key->val' pairs of 'UPSName' and a list o
         if ups and (ups not in self_ups_list):
             if self.__debug :
                 print( "[DEBUG] ListClients: %s is not a valid UPS" % ups )
-            raise PyNUTError( "ERR UNKNOWN-UPS" )
+            raise PyNUTError( b"ERR UNKNOWN-UPS" )
 
         if ups:
             self.__srv_handler.write( ("LIST CLIENT %s\n" % ups).encode('ascii') )

--- a/scripts/python/module/README
+++ b/scripts/python/module/README
@@ -26,10 +26,10 @@ versions 2.7, 3.4, 3.5 and 3.7.
 
 [NOTE]
 ======
-Text fields (including NUT protocol error codes quoted into `PyNUTError`
-exceptions) returned by methods are byte sequences (not locale-aware
-strings). This is of little concern for Python 2, but is important in
-Python 3.
+Text fields returned by methods are byte sequences (not locale-aware
+strings), except NUT protocol error codes quoted into `PyNUTError`
+exceptions which are decoded into strings as originally `ascii` text.
+This is of little concern for Python 2, but is important in Python 3.
 
 The `ups` argument to methods is handled as a string, so conversion may
 be needed to compare with names returned in the arrays, e.g.:

--- a/scripts/python/module/README
+++ b/scripts/python/module/README
@@ -32,14 +32,15 @@ exceptions which are decoded into strings as originally `ascii` text.
 This is of little concern for Python 2, but is important in Python 3.
 
 The `ups` argument to methods is handled as a string, so conversion may
-be needed to compare with names returned in the arrays, e.g.:
+be needed to compare with names returned in the lists and dictionaries,
+e.g.:
 ----
 strUps = bUps.decode('ascii')
 bUps = strUps.encode('ascii')
 ----
 
-Names returned by `GetUPSNames()` are specifically converted into string
-type.
+Only the names returned by `GetUPSNames()` method specifically are
+converted into string type.
 
 Since Python 3 support was added just recently, module code may later be
 converted to use string types like `str` or `unicode` in the returned
@@ -81,7 +82,7 @@ class PyNUTClient :
   def SetRWVar( self, ups='', var='', value='' ) :
 ------
 
-The module also provides the `PyNUTError` class to represent any excpetions
+The module also provides the `PyNUTError` class to represent any exceptions
 raised by `PyNUTClient` logic.
 
 Documentation

--- a/scripts/python/module/test_nutclient.py.in
+++ b/scripts/python/module/test_nutclient.py.in
@@ -44,6 +44,8 @@ if __name__ == "__main__" :
     print( 80*"-" + "\nTesting 'RunUPSCommand' (Test front panel) :")
     try :
         result = nut.RunUPSCommand( "UPS1", "test.panel.start" )
+        if (NUT_USER is None):
+            raise AssertionError("Secure operation should have failed due to lack of credentials, but did not")
     except :
         ex = str(sys.exc_info()[1])
         result = "EXCEPTION: " + ex
@@ -58,6 +60,8 @@ if __name__ == "__main__" :
     print( 80*"-" + "\nTesting 'SetUPSVar' (set ups.id to test):")
     try :
         result = nut.SetRWVar( "UPS1", "ups.id", "test" )
+        if (NUT_USER is None):
+            raise AssertionError("Secure operation should have failed due to lack of credentials, but did not")
     except :
         ex = str(sys.exc_info()[1])
         result = "EXCEPTION: " + ex
@@ -97,6 +101,8 @@ if __name__ == "__main__" :
     print( 80*"-" + "\nTesting 'DeviceLogin' for 'dummy' (should be registered in upsd.conf; current credentials should have an upsmon role in upsd.users) :")
     try :
         result = nut.DeviceLogin( "dummy" )
+        if (NUT_USER is None):
+            raise AssertionError("Secure operation should have failed due to lack of credentials, but did not")
         loggedIntoDummy = True
     except :
         ex = str(sys.exc_info()[1])

--- a/scripts/python/module/test_nutclient.py.in
+++ b/scripts/python/module/test_nutclient.py.in
@@ -8,6 +8,7 @@ import sys
 import os
 
 if __name__ == "__main__" :
+    NUT_HOST = os.getenv('NUT_HOST', '127.0.0.1')
     NUT_PORT = int(os.getenv('NUT_PORT', '3493'))
     NUT_USER = os.getenv('NUT_USER', None)
     NUT_PASS = os.getenv('NUT_PASS', None)
@@ -18,7 +19,7 @@ if __name__ == "__main__" :
 
     print( "PyNUTClient test..." )
     #nut    = PyNUT.PyNUTClient( debug=True, port=NUT_PORT )
-    nut    = PyNUT.PyNUTClient( login=NUT_USER, password=NUT_PASS, debug=True, port=NUT_PORT )
+    nut    = PyNUT.PyNUTClient( login=NUT_USER, password=NUT_PASS, debug=True, host=NUT_HOST, port=NUT_PORT )
     #nut    = PyNUT.PyNUTClient( login="upsadmin", password="upsadmin", debug=True, port=NUT_PORT )
 
     print( 80*"-" + "\nTesting 'GetUPSList' :")

--- a/scripts/python/module/test_nutclient.py.in
+++ b/scripts/python/module/test_nutclient.py.in
@@ -117,11 +117,11 @@ if __name__ == "__main__" :
         else:
             if (loggedIntoDummy):
                 if (len(result) < 1):
-                    raise ValueError("ListClients() returned an empty dict where at least one client was expected on 'dummy'")
-                if (type(result['dummy']) is not list):
-                    raise TypeError("ListClients() did not return a dict whose 'dummy' keyed value is a list")
-                if (len(result['dummy']) < 1):
-                    raise ValueError("ListClients() returned a dict where at least one client was expected on 'dummy' but none were reported")
+                    raise ValueError("ListClients() returned an empty dict where at least one client was expected on b'dummy'")
+                if (type(result[b'dummy']) is not list):
+                    raise TypeError("ListClients() did not return a dict whose b'dummy' keyed value is a list")
+                if (len(result[b'dummy']) < 1):
+                    raise ValueError("ListClients() returned a dict where at least one client was expected on b'dummy' but none were reported")
     except :
         ex = str(sys.exc_info()[1])
         result = "EXCEPTION: " + ex

--- a/scripts/python/module/test_nutclient.py.in
+++ b/scripts/python/module/test_nutclient.py.in
@@ -47,10 +47,10 @@ if __name__ == "__main__" :
     except :
         ex = str(sys.exc_info()[1])
         result = "EXCEPTION: " + ex
-        if (NUT_USER is None and ex == b'ERR USERNAME-REQUIRED'):
+        if (NUT_USER is None and ex == 'ERR USERNAME-REQUIRED'):
             result = result + "\n(anticipated error: no credentials were provided)"
         else:
-            if (ex != b'ERR CMD-NOT-SUPPORTED' and (NUT_USER is not None and ex != b'ERR ACCESS-DENIED') ):
+            if (ex != 'ERR CMD-NOT-SUPPORTED' and (NUT_USER is not None and ex != 'ERR ACCESS-DENIED') ):
                 result = result + "\nTEST-CASE FAILED"
                 failed.append('RunUPSCommand')
     print( "\033[01;33m%s\033[0m\n" % result )
@@ -61,10 +61,10 @@ if __name__ == "__main__" :
     except :
         ex = str(sys.exc_info()[1])
         result = "EXCEPTION: " + ex
-        if (NUT_USER is None and ex == b'ERR USERNAME-REQUIRED'):
+        if (NUT_USER is None and ex == 'ERR USERNAME-REQUIRED'):
             result = result + "\n(anticipated error: no credentials were provided)"
         else:
-            if (ex != b'ERR VAR-NOT-SUPPORTED' and (NUT_USER is not None and ex != b'ERR ACCESS-DENIED') ):
+            if (ex != 'ERR VAR-NOT-SUPPORTED' and (NUT_USER is not None and ex != 'ERR ACCESS-DENIED') ):
                 result = result + "\nTEST-CASE FAILED"
                 failed.append('SetUPSVar')
     print( "\033[01;33m%s\033[0m\n" % result )
@@ -86,7 +86,7 @@ if __name__ == "__main__" :
     except :
         ex = str(sys.exc_info()[1])
         result = "EXCEPTION: " + ex
-        if (ex == b'ERR UNKNOWN-UPS'):
+        if (ex == 'ERR UNKNOWN-UPS'):
             result = result + "\n(anticipated error: bogus device name was tested)"
         else:
             result = result + "\nTEST-CASE FAILED"
@@ -101,10 +101,10 @@ if __name__ == "__main__" :
     except :
         ex = str(sys.exc_info()[1])
         result = "EXCEPTION: " + ex
-        if (NUT_USER is None and ex == b'ERR USERNAME-REQUIRED'):
+        if (NUT_USER is None and ex == 'ERR USERNAME-REQUIRED'):
             result = result + "\n(anticipated error: no credentials were provided)"
         else:
-            if (NUT_USER is not None and ex != b'ERR ACCESS-DENIED'):
+            if (NUT_USER is not None and ex != 'ERR ACCESS-DENIED'):
                 result = result + "\nTEST-CASE FAILED"
                 failed.append('DeviceLogin-dummy')
     print( "\033[01;33m%s\033[0m\n" % result )

--- a/scripts/python/module/test_nutclient.py.in
+++ b/scripts/python/module/test_nutclient.py.in
@@ -12,6 +12,10 @@ if __name__ == "__main__" :
     NUT_USER = os.getenv('NUT_USER', None)
     NUT_PASS = os.getenv('NUT_PASS', None)
 
+    # Account "unexpected" failures (more due to coding than circumstances)
+    # e.g. lack of protected access when no credentials were passed is okay
+    failed = []
+
     print( "PyNUTClient test..." )
     #nut    = PyNUT.PyNUTClient( debug=True, port=NUT_PORT )
     nut    = PyNUT.PyNUTClient( login=NUT_USER, password=NUT_PASS, debug=True, port=NUT_PORT )
@@ -41,44 +45,93 @@ if __name__ == "__main__" :
     try :
         result = nut.RunUPSCommand( "UPS1", "test.panel.start" )
     except :
-        result = "EXCEPTION: " + str(sys.exc_info()[1])
+        ex = str(sys.exc_info()[1])
+        result = "EXCEPTION: " + ex
+        if (NUT_USER is None and ex == b'ERR USERNAME-REQUIRED'):
+            result = result + "\n(anticipated error: no credentials were provided)"
+        else:
+            if (ex != b'ERR CMD-NOT-SUPPORTED' and (NUT_USER is not None and ex != b'ERR ACCESS-DENIED') ):
+                result = result + "\nTEST-CASE FAILED"
+                failed.append('RunUPSCommand')
     print( "\033[01;33m%s\033[0m\n" % result )
 
     print( 80*"-" + "\nTesting 'SetUPSVar' (set ups.id to test):")
     try :
         result = nut.SetRWVar( "UPS1", "ups.id", "test" )
     except :
-        result = "EXCEPTION: " + str(sys.exc_info()[1])
+        ex = str(sys.exc_info()[1])
+        result = "EXCEPTION: " + ex
+        if (NUT_USER is None and ex == b'ERR USERNAME-REQUIRED'):
+            result = result + "\n(anticipated error: no credentials were provided)"
+        else:
+            if (ex != b'ERR VAR-NOT-SUPPORTED' and (NUT_USER is not None and ex != b'ERR ACCESS-DENIED') ):
+                result = result + "\nTEST-CASE FAILED"
+                failed.append('SetUPSVar')
     print( "\033[01;33m%s\033[0m\n" % result )
 
     # testing who has an upsmon-like log-in session to a device
-    print( 80*"-" + "\nTesting 'ListClients' for 'dummy' (should be registered in upsd.conf) :")
+    print( 80*"-" + "\nTesting 'ListClients' for 'dummy' (should be registered in upsd.conf) before test client is connected :")
     try :
         result = nut.ListClients( "dummy" )
     except :
-        result = "EXCEPTION: " + str(sys.exc_info()[1])
+        ex = str(sys.exc_info()[1])
+        result = "EXCEPTION: " + ex
+        result = result + "\nTEST-CASE FAILED"
+        failed.append('ListClients-dummy-before')
     print( "\033[01;33m%s\033[0m\n" % result )
 
     print( 80*"-" + "\nTesting 'ListClients' for missing device (should raise an exception) :")
     try :
         result = nut.ListClients( "MissingBogusDummy" )
     except :
-        result = "EXCEPTION: " + str(sys.exc_info()[1])
+        ex = str(sys.exc_info()[1])
+        result = "EXCEPTION: " + ex
+        if (ex == b'ERR UNKNOWN-UPS'):
+            result = result + "\n(anticipated error: bogus device name was tested)"
+        else:
+            result = result + "\nTEST-CASE FAILED"
+            failed.append('ListClients-MissingBogusDummy')
     print( "\033[01;33m%s\033[0m\n" % result )
 
+    loggedIntoDummy = False
     print( 80*"-" + "\nTesting 'DeviceLogin' for 'dummy' (should be registered in upsd.conf; current credentials should have an upsmon role in upsd.users) :")
     try :
         result = nut.DeviceLogin( "dummy" )
+        loggedIntoDummy = True
     except :
-        result = "EXCEPTION: " + str(sys.exc_info()[1])
+        ex = str(sys.exc_info()[1])
+        result = "EXCEPTION: " + ex
+        if (NUT_USER is None and ex == b'ERR USERNAME-REQUIRED'):
+            result = result + "\n(anticipated error: no credentials were provided)"
+        else:
+            if (NUT_USER is not None and ex != b'ERR ACCESS-DENIED'):
+                result = result + "\nTEST-CASE FAILED"
+                failed.append('DeviceLogin-dummy')
     print( "\033[01;33m%s\033[0m\n" % result )
 
     print( 80*"-" + "\nTesting 'ListClients' for None (should list all devices and sessions to them, if any -- e.g. one established above) :")
     try :
         result = nut.ListClients( )
+        if (type(result) is not dict):
+            raise TypeError("ListClients() did not return a dict")
+        else:
+            if (loggedIntoDummy):
+                if (len(result) < 1):
+                    raise ValueError("ListClients() returned an empty dict where at least one client was expected on 'dummy'")
+                if (type(result['dummy']) is not list):
+                    raise TypeError("ListClients() did not return a dict whose 'dummy' keyed value is a list")
+                if (len(result['dummy']) < 1):
+                    raise ValueError("ListClients() returned a dict where at least one client was expected on 'dummy' but none were reported")
     except :
-        result = "EXCEPTION: " + str(sys.exc_info()[1])
+        ex = str(sys.exc_info()[1])
+        result = "EXCEPTION: " + ex
+        result = result + "\nTEST-CASE FAILED"
+        failed.append('ListClients-dummy-after')
     print( "\033[01;33m%s\033[0m\n" % result )
 
     print( 80*"-" + "\nTesting 'PyNUT' instance teardown (end of test script)" )
     # No more tests AFTER this line; add them above the teardown message
+
+    if (len(failed) > 0):
+        print ( "SOME TEST CASES FAILED in an unexpected manner: %s" % failed )
+        sys.exit(1)

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -214,6 +214,11 @@ log_info "Using '$TESTDIR' for generated configs and state files"
 mkdir -p "${TESTDIR}/etc" "${TESTDIR}/run" && chmod 750 "${TESTDIR}/run" \
 || die "Failed to create temporary FS structure for the NIT"
 
+if [ "`id -u`" = 0 ]; then
+	log_info "Test script was started by 'root' - expanding permissions for '${TESTDIR}/run' so unprivileged daemons may create pipes and PID files there"
+	chmod 777 "${TESTDIR}/run"
+fi
+
 stop_daemons() {
     if [ -n "$PID_UPSD$PID_DUMMYUPS$PID_DUMMYUPS1$PID_DUMMYUPS2" ] ; then
         log_info "Stopping test daemons"


### PR DESCRIPTION
Closes: #1589
Closes: #1568

These tests did help find a number of cross-platform regressions (including the differences of Py2 vs Py3) but only as long as someone looked at outputs and made sense of them. This PR lets the test script analyze the outcomes (depending on circumstances - e.g. inability to do secure actions while we lack a login is not a real fault; the opposite is, in fact) and so allows automated tests to produce more relevant outcomes without a human poring over the build logs.