### PR TITLE
configure.ac, drivers/libusb0.c: fix detection of strlwr() and fallback strcasestr() implem

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -321,11 +321,13 @@ AS_IF([test x"${ac_cv_func_strncasecmp}" = xyes],
     [AC_MSG_WARN([Required C library routine strncasecmp not found; try adding __EXTENSIONS__])]
     )
 
+dnl Note: this changes the original string in argument!
+dnl Do not pass it constants (strdup them if needed)!
 AC_CACHE_CHECK([for strlwr(s)],
     [ac_cv_func_strlwr],
     [AX_RUN_OR_LINK_IFELSE(
         [AC_LANG_PROGRAM([$CODE_STRINGINCL],
-            [if (strlwr("Some STR1 text") == NULL) return 1])],
+            [char s@<:@64@:>@ = {"Some STR1 text"} ; if (strlwr(s) == NULL) return 1])],
         [ac_cv_func_strlwr=yes], [ac_cv_func_strlwr=no]
     )])
 AS_IF([test x"${ac_cv_func_strlwr}" = xyes],

--- a/drivers/libusb0.c
+++ b/drivers/libusb0.c
@@ -51,7 +51,7 @@ upsdrv_info_t comm_upsdrv_info = {
 #define MAX_REPORT_SIZE         0x1800
 #define MAX_RETRY               3
 
-#if (!HAVE_STRCASESTR) && (HAVE_STRSTR && HAVE_STRLWR)
+#if (!HAVE_STRCASESTR) && (HAVE_STRSTR && HAVE_STRLWR && HAVE_STRDUP)
 /* Only used in this file of all NUT codebase, so not in str.{c,h}
  * where it happens to conflict with netsnmp-provided variant for
  * some of our build products.
@@ -802,7 +802,7 @@ static void libusb_close(usb_dev_handle *udev)
 	usb_close(udev);
 }
 
-#if (!HAVE_STRCASESTR) && (HAVE_STRSTR && HAVE_STRLWR)
+#if (!HAVE_STRCASESTR) && (HAVE_STRSTR && HAVE_STRLWR && HAVE_STRDUP)
 static char *strcasestr(const char *haystack, const char *needle) {
 	/* work around "const char *" and guarantee the original is not
 	 * touched... not efficient but we have few uses for this method */


### PR DESCRIPTION
Avoid changing the string literal.

Used just for WIN32 libusb-0.1(-compat) builds at the moment.