### PR TITLE
m4/nut_check_libusb.m4: when on Windows, prefer libusb-0.1 [#1507]

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -321,11 +321,13 @@ AS_IF([test x"${ac_cv_func_strncasecmp}" = xyes],
     [AC_MSG_WARN([Required C library routine strncasecmp not found; try adding __EXTENSIONS__])]
     )
 
+dnl Note: this changes the original string in argument!
+dnl Do not pass it constants (strdup them if needed)!
 AC_CACHE_CHECK([for strlwr(s)],
     [ac_cv_func_strlwr],
     [AX_RUN_OR_LINK_IFELSE(
         [AC_LANG_PROGRAM([$CODE_STRINGINCL],
-            [if (strlwr("Some STR1 text") == NULL) return 1])],
+            [char s@<:@64@:>@ = {"Some STR1 text"} ; if (strlwr(s) == NULL) return 1])],
         [ac_cv_func_strlwr=yes], [ac_cv_func_strlwr=no]
     )])
 AS_IF([test x"${ac_cv_func_strlwr}" = xyes],

--- a/drivers/libusb0.c
+++ b/drivers/libusb0.c
@@ -51,7 +51,7 @@ upsdrv_info_t comm_upsdrv_info = {
 #define MAX_REPORT_SIZE         0x1800
 #define MAX_RETRY               3
 
-#if (!HAVE_STRCASESTR) && (HAVE_STRSTR && HAVE_STRLWR)
+#if (!HAVE_STRCASESTR) && (HAVE_STRSTR && HAVE_STRLWR && HAVE_STRDUP)
 /* Only used in this file of all NUT codebase, so not in str.{c,h}
  * where it happens to conflict with netsnmp-provided variant for
  * some of our build products.
@@ -802,7 +802,7 @@ static void libusb_close(usb_dev_handle *udev)
 	usb_close(udev);
 }
 
-#if (!HAVE_STRCASESTR) && (HAVE_STRSTR && HAVE_STRLWR)
+#if (!HAVE_STRCASESTR) && (HAVE_STRSTR && HAVE_STRLWR && HAVE_STRDUP)
 static char *strcasestr(const char *haystack, const char *needle) {
 	/* work around "const char *" and guarantee the original is not
 	 * touched... not efficient but we have few uses for this method */

--- a/m4/nut_check_libusb.m4
+++ b/m4/nut_check_libusb.m4
@@ -79,6 +79,18 @@ if test -z "${nut_have_libusb_seen}"; then
 	AS_IF([test x"${LIBUSB_1_0_VERSION}" != xnone],
 		[LIBUSB_VERSION="${LIBUSB_1_0_VERSION}"
 		 nut_usb_lib="(libusb-1.0)"
+		 dnl ...except on Windows, where we support libusb-0.1(-compat)
+		 dnl better so far (allow manual specification though, to let
+		 dnl someone finally develop the on-par support):
+		 AS_IF([test x"${LIBUSB_0_1_VERSION}" != xnone], [
+			AS_CASE(["${target_os}"],
+				[*mingw*], [
+					AC_MSG_NOTICE([mingw builds prefer libusb-0.1(-compat) if available])
+					LIBUSB_VERSION="${LIBUSB_0_1_VERSION}"
+					nut_usb_lib="(libusb-0.1)"
+					])
+				]
+			)
 		],
 		[AS_IF([test x"${LIBUSB_0_1_VERSION}" != xnone],
 			[LIBUSB_VERSION="${LIBUSB_0_1_VERSION}"


### PR DESCRIPTION
Not really sure if this would help (checking) but the Windows branch was originally developed before libusb-1.0 effort started, so tweaks to code applied to what is now `libusb0.c` should be more successful.

In limited dev-testing so far, builds with plain libusb-1.0 and with it wrapped as libusb-0.1-compat (mis-)behave in a similar manner, claiming I/O errors with interrupt processing mode, and nearly no data collected with polling mode. Maybe snatching the device from "kernel" should be done differently (Windows does represent the "USB HID Battery" and probably holds the critical resources).

Have yet to try with original libusb-win32 project the branch was built against.