### PR TITLE
drivers/usbhid-ups.c: try to detect "Driver stale" situations when in "pollonly" mode

### DIFF
--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -1422,11 +1422,23 @@ static bool_t hid_ups_walk(walkmode_t mode)
 
 		case HU_WALKMODE_FULL_UPDATE:
 			/* These don't need polling after initinfo() */
-			if (item->hidflags & (HU_FLAG_ABSENT | HU_TYPE_CMD | HU_FLAG_STATIC))
+			if (item->hidflags & (HU_FLAG_ABSENT | HU_TYPE_CMD))
 				continue;
 
-			/* These need to be polled after user changes (setvar / instcmd) */
-			if ( (item->hidflags & HU_FLAG_SEMI_STATIC) && (data_has_changed == FALSE) )
+			/* These don't need polling after initinfo() normally
+			 * However in "pollonly" mode we use these to detect "Data stale"
+			 * condition (e.g. cable disconnected) by failing the reads:
+			 */
+			if ((item->hidflags & HU_FLAG_STATIC) && use_interrupt_pipe)
+				continue;
+
+			/* These need to be polled after user changes (setvar / instcmd)
+			 * or to detect "Data stale" in "pollonly" mode
+			 */
+			if (   (item->hidflags & HU_FLAG_SEMI_STATIC)
+				&& (data_has_changed == FALSE)
+				&& use_interrupt_pipe
+			)
 				continue;
 
 			break;
@@ -1530,7 +1542,7 @@ static bool_t hid_ups_walk(walkmode_t mode)
 		if (ups_infoval_set(item, value) != 1)
 			continue;
 
-		if (mode == HU_WALKMODE_INIT) {
+		if (mode == HU_WALKMODE_INIT || (!use_interrupt_pipe)) {
 			info_lkp_t	*info_lkp;
 
 			dstate_setflags(item->info_type, item->info_flags);


### PR DESCRIPTION
* drivers/usbhid-ups.c: hid_ups_walk(): for HU_WALKMODE_FULL_UPDATE with "pollonly" mode, re-read HU_FLAG_SEMI_STATIC and HU_FLAG_STATIC entries to detect "Driver stale" situations [#1624]

Currently the driver code does not seem to have any concept of "staleness" if it is not in interrupt mode (and failing those requests). Unplugging the USB cable has no effect on driver's ability and eagerness to report info about the device, even an hour later. I did not yet test if this is a platform issue (seen with Windows builds) or a generic one.

Not sure in practical terms however, if the trick in this PR helps - e.g. it might be prudent to actively re-request static fields known to have been served during initial startup, to make sure they are still served or the device is AWOL (assuming libusb actually requests that, and does not cache responses), but I am not quickly sure how to do that.

More expert eyes are welcome :)