### PR TITLE
Be sure to (eventually) disconnect upsd from dead drivers

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -125,6 +125,10 @@ https://github.com/networkupstools/nut/milestone/8
    * added `listDeviceClients()` and `deviceGetClients(dev)` to `Client`
      classes, and `Device::getClients()` to match PyNUT capabilities [#549]
 
+ - sstate (server state, e.g. upsd) should now "PING" drivers also if they
+   last reported themselves as "stale" (and might later crash) so their
+   connections would be terminated if really no longer active [#1626]
+
 ---------------------------------------------------------------------------
 Release notes for NUT 2.8.0 - what's new since 2.7.4:
 

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 2992 utf-8
+personal_ws-1.1 en 2993 utf-8
 AAS
 ABI
 ACFAIL
@@ -2649,6 +2649,7 @@ ss
 sshd
 ssize
 ssl
+sstate
 stan
 startIP
 startdelay

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -492,7 +492,7 @@ static int sock_arg(conn_t *conn, size_t numarg, char **arg)
 
 	if (!strcasecmp(arg[0], "DUMPALL")) {
 
-		/* first thing: the staleness flag */
+		/* first thing: the staleness flag (see also below) */
 		if ((stale == 1) && !send_to_one(conn, "DATASTALE\n")) {
 			return 1;
 		}

--- a/server/sstate.c
+++ b/server/sstate.c
@@ -54,11 +54,13 @@ static int parse_args(upstype_t *ups, size_t numargs, char **arg)
 	}
 
 	if (!strcasecmp(arg[0], "DATASTALE")) {
+		upsdebugx(3, "UPS [%s]: data is STALE now", ups->name);
 		ups->data_ok = 0;
 		return 1;
 	}
 
 	if (!strcasecmp(arg[0], "DATAOK")) {
+		upsdebugx(3, "UPS [%s]: data is NOT STALE now", ups->name);
 		ups->data_ok = 1;
 		return 1;
 	}


### PR DESCRIPTION
Closes: #1626

Currently if a driver claimed "Data stale" and later crashed or was killed, upsd keeps polling its file descriptor and never closes it (because it quickly bails out on the stale device). This precludes later copies of the driver from being recognized and handled by upsd.