### PR TITLE
common/common.c: get_libname_in_dir(): check for exact filename match…

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -1087,7 +1087,9 @@ static char * get_libname_in_dir(const char* base_libname, size_t base_libname_l
 
 		upsdebugx(5,"Comparing lib %s with dirpath entry %s", base_libname, dirp->d_name);
 		int compres = strncmp(dirp->d_name, base_libname, base_libname_length);
-		if(compres == 0) {
+		if (compres == 0
+		&&  dirp->d_name[base_libname_length] == '\0' /* avoid "*.dll.a" etc. */
+		) {
 			snprintf(current_test_path, LARGEBUF, "%s/%s", dirname, dirp->d_name);
 #if HAVE_REALPATH
 			libname_path = realpath(current_test_path, NULL);


### PR DESCRIPTION
… (not just common start of string)

Small bug due to `strNcmp()` involved - matching just starts of strings (up to N chars), which caused matches like `../lib/libsomething.dll.a` for `libsomething.dll` requested patterns, as found during NUT for Windows testing.

In POSIX world, this would preclude matching a `libsomething.so.1.2.3` which happens to be first seen, over a `libsomething.so` specific preferred symlink. (Note that recently added support for `LD_LIBRARY_PATH` etc. can be used for custom, non-system, preferences to be provided to a NUT bundle).