### PR TITLE
Windows branch: fix builds against libusb-win32

### DIFF
--- a/drivers/usb-common.h
+++ b/drivers/usb-common.h
@@ -377,7 +377,7 @@
 
 /* Note: Checked above that in practice we handle some one libusb API */
 #if WITH_LIBUSB_0_1
-# ifdef HAVE_LIBUSB_H
+# ifdef HAVE_USB_H
 #  include <usb.h>
 # else
 #  ifdef HAVE_LUSB0_USB_H

--- a/drivers/usb-common.h
+++ b/drivers/usb-common.h
@@ -377,7 +377,13 @@
 
 /* Note: Checked above that in practice we handle some one libusb API */
 #if WITH_LIBUSB_0_1
-# include <usb.h>
+# ifdef HAVE_LIBUSB_H
+#  include <usb.h>
+# else
+#  ifdef HAVE_LUSB0_USB_H
+#   include <lusb0_usb.h>
+#  endif
+# endif
  /* Structures */
  /* See detailed comments above, in libusb-1.0 definitions
   * FIXME: It may make sense to constrain the limits to lowest common

--- a/drivers/usb-common.h
+++ b/drivers/usb-common.h
@@ -382,6 +382,8 @@
 # else
 #  ifdef HAVE_LUSB0_USB_H
 #   include <lusb0_usb.h>
+#  else
+#   error "configure script error: Neither HAVE_USB_H nor HAVE_LUSB0_USB_H is set for the WITH_LIBUSB_0_1 build"
 #  endif
 # endif
  /* Structures */

--- a/tools/nut-usbinfo.pl
+++ b/tools/nut-usbinfo.pl
@@ -142,7 +142,7 @@ sub gen_usb_files
 	print $outputDevScanner "# include <libusb.h>\n";
 	print $outputDevScanner "#endif\n";
 	print $outputDevScanner "#if WITH_LIBUSB_0_1\n";
-	print $outputDevScanner "# ifdef HAVE_LIBUSB_H\n";
+	print $outputDevScanner "# ifdef HAVE_USB_H\n";
 	print $outputDevScanner "#  include <usb.h>\n";
 	print $outputDevScanner "# else\n";
 	print $outputDevScanner "#  ifdef HAVE_LUSB0_USB_H\n";

--- a/tools/nut-usbinfo.pl
+++ b/tools/nut-usbinfo.pl
@@ -1,8 +1,9 @@
 #!/usr/bin/env perl
-#   Current Version : 1.3
+#   Current Version : 1.4
 #   Copyright (C) 2008 - 2012 dloic (loic.dardant AT gmail DOT com)
 #   Copyright (C) 2008 - 2015 Arnaud Quette <arnaud.quette@free.fr>
 #   Copyright (C) 2013 - 2014 Charles Lepple <clepple+nut@gmail.com>
+#   Copyright (C) 2014 - 2022 Jim Klimov <jimklimov+nut@gmail.com>
 #
 #	Based on the usbdevice.pl script, made for the Ubuntu Media Center
 #   for the final use of the LIRC project.
@@ -138,10 +139,16 @@ sub gen_usb_files
 	print $outputDevScanner "#error \"configure script error: Both WITH_LIBUSB_1_0 and WITH_LIBUSB_0_1 are set\"\n";
 	print $outputDevScanner "#endif\n\n";
 	print $outputDevScanner "#if WITH_LIBUSB_1_0\n";
-	print $outputDevScanner " #include <libusb.h>\n";
+	print $outputDevScanner "# include <libusb.h>\n";
 	print $outputDevScanner "#endif\n";
 	print $outputDevScanner "#if WITH_LIBUSB_0_1\n";
-	print $outputDevScanner " #include <usb.h>\n";
+	print $outputDevScanner "# ifdef HAVE_LIBUSB_H\n";
+	print $outputDevScanner "#  include <usb.h>\n";
+	print $outputDevScanner "# else\n";
+	print $outputDevScanner "#  ifdef HAVE_LUSB0_USB_H\n";
+	print $outputDevScanner "#   include <lusb0_usb.h>\n";
+	print $outputDevScanner "#  endif\n";
+	print $outputDevScanner "# endif\n";
 	print $outputDevScanner " /* simple remap to avoid bloating structures */\n";
 	print $outputDevScanner " typedef usb_dev_handle libusb_device_handle;\n";
 	print $outputDevScanner "#endif\n";

--- a/tools/nut-usbinfo.pl
+++ b/tools/nut-usbinfo.pl
@@ -147,6 +147,8 @@ sub gen_usb_files
 	print $outputDevScanner "# else\n";
 	print $outputDevScanner "#  ifdef HAVE_LUSB0_USB_H\n";
 	print $outputDevScanner "#   include <lusb0_usb.h>\n";
+	print $outputDevScanner "#  else\n";
+	print $outputDevScanner "#   error \"configure script error: Neither HAVE_USB_H nor HAVE_LUSB0_USB_H is set for the WITH_LIBUSB_0_1 build\"\n";
 	print $outputDevScanner "#  endif\n";
 	print $outputDevScanner "# endif\n";
 	print $outputDevScanner " /* simple remap to avoid bloating structures */\n";


### PR DESCRIPTION
Note: this is currently somewhat hardcoded for MSYS2 packaging of `mingw-w64-x86_64-libusb-win32` so if other environments (32-bit MSYS2, cross-builds on Linux, etc) would be pursued, changes to `m4` scripts here should get refactored for more flexibility.

Currently this allows to build against "modern" (post 2011) releases of libusb-win32, to let someone iterate on making it functional as a variant of libusb-0.1 implementation.

Currently the driver quickly refuses to start:
````
> usbhid-ups.exe -a nutdev1 -DDDDDD
Network UPS Tools - Generic HID driver 0.49 (Windows-v2.8.0-alpha3-754-g7ecd1949d)
USB communication driver (libusb 0.1) 0.43
   0.000000     [D1] debug level is '6'
   0.001401     [D5] send_to_all: SETINFO device.type "ups"
   0.003262     [D2] Initializing an USB-connected UPS with library libusb-0.1 (or compat) (NUT subdriver name='USB communication driver (libusb 0.1)' ver='0.43')
   0.007734     [D1] upsdrv_initups (non-SHUT)...
   0.009838     [D3] usb_busses=0000023602509310
   0.011122     [D2] libusb0: No appropriate HID device found
   0.012719     libusb0: Could not open any HID devices: no USB buses found
   0.015937     No matching HID UPS found
````
...making such builds less useful than libusb-1.0 (and 0.1-compat over it) which at least try to collect data.

Possibly `libusb0.c` and/or driver code has to grow some more `ifdef`s to differentiate assumptions about libusb implementation when building for `WIN32` (perhaps `ifdef HAVE_LUSB0_USB_H` is a decent quick start for this use-case). In particular, seems another `usb_busses` detection method should be tried (library method vs. library public variable).

See also #1507