### PR TITLE
Further revise NUT public API headers

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -132,6 +132,12 @@ https://github.com/networkupstools/nut/milestone/8
    last reported themselves as "stale" (and might later crash) so their
    connections would be terminated if really no longer active [#1626]
 
+ - Further revision of public headers delivered by NUT was done, particularly
+   to address lack of common data types (`size_t`, `ssize_t`, `uint16_t`,
+   `time_t` etc.) in third-party client code that earlier sufficed to only
+   include NUT headers. Sort of regression by NUT 2.8.0 (note those consumers
+   still have to re-declare some numeric variable types used) [#1638, #1615]
+
 ---------------------------------------------------------------------------
 Release notes for NUT 2.8.0 - what's new since 2.7.4:
 

--- a/UPGRADING
+++ b/UPGRADING
@@ -19,6 +19,12 @@ Changes from 2.8.0 to 2.8.1
 
 - PLANNED: Keep track of any further API clean-up?
 
+- Further revision of public headers delivered by NUT was done, particularly
+  to address lack of common data types (`size_t`, `ssize_t`, `uint16_t`,
+  `time_t` etc.) in third-party client code that earlier sufficed to only
+  include NUT headers. Sort of regression by NUT 2.8.0 (note those consumers
+  still have to re-declare some numeric variable types used) [#1638]
+
 - Added support for `make install` of PyNUT module and NUT-Monitor desktop
   application -- such activity was earlier done by packages directly; now
   the packaging recipes may use NUT source-code facilities and package just

--- a/UPGRADING
+++ b/UPGRADING
@@ -25,6 +25,9 @@ Changes from 2.8.0 to 2.8.1
   include NUT headers. Sort of regression by NUT 2.8.0 (note those consumers
   still have to re-declare some numeric variable types used) [#1638]
 
+  * For practical example of NUT consumer adaptation (to cater to both old and
+    new API types) please see https://github.com/collectd/collectd/pull/4043
+
 - Added support for `make install` of PyNUT module and NUT-Monitor desktop
   application -- such activity was earlier done by packages directly; now
   the packaging recipes may use NUT source-code facilities and package just

--- a/clients/Makefile.am
+++ b/clients/Makefile.am
@@ -37,6 +37,8 @@ if HAVE_CXX11
   lib_LTLIBRARIES += libnutclient.la
   lib_LTLIBRARIES += libnutclientstub.la
 endif
+
+# Optionally deliverable as part of NUT public API:
 if WITH_DEV
  include_HEADERS = upsclient.h
 if HAVE_CXX11

--- a/clients/upsclient.h
+++ b/clients/upsclient.h
@@ -41,6 +41,18 @@
 	#include <limits.h>
 #endif
 
+/* Not including NUT timehead.h because this is part of end-user API */
+#ifdef TIME_WITH_SYS_TIME
+# include <sys/time.h>
+# include <time.h>
+#else
+# ifdef HAVE_SYS_TIME_H
+#  include <sys/time.h>
+# else
+#  include <time.h>
+# endif
+#endif
+
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 extern "C" {

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -1,6 +1,7 @@
 dist_noinst_HEADERS = attribute.h common.h extstate.h proto.h			\
     state.h str.h timehead.h upsconf.h nut_float.h nut_stdint.h nut_platform.h
 
+# Optionally deliverable as part of NUT public API:
 if WITH_DEV
 include_HEADERS = parseconf.h
 else

--- a/include/parseconf.h
+++ b/include/parseconf.h
@@ -22,6 +22,19 @@
 
 #include <stdio.h>
 
+/* Not including nut_stdint.h because this is part of end-user API */
+#if defined HAVE_INTTYPES_H
+	#include <inttypes.h>
+#endif
+
+#if defined HAVE_STDINT_H
+	#include <stdint.h>
+#endif
+
+#if defined HAVE_LIMITS_H
+	#include <limits.h>
+#endif
+
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 extern "C" {

--- a/tools/nut-scanner/Makefile.am
+++ b/tools/nut-scanner/Makefile.am
@@ -111,6 +111,7 @@ endif
 # C is not a header, but there is no dist_noinst_SOURCES
 dist_noinst_HEADERS = $(NUT_SCANNER_DEPS_H) $(NUT_SCANNER_DEPS_C)
 
+# Optionally deliverable as part of NUT public API:
 if WITH_DEV
  include_HEADERS = nut-scan.h nutscan-device.h nutscan-ip.h nutscan-init.h nutscan-serial.h
 else

--- a/tools/nut-scanner/nut-scan.h
+++ b/tools/nut-scanner/nut-scan.h
@@ -46,6 +46,18 @@
 #  include <limits.h>
 #endif
 
+/* Ensure useconds_t et al: */
+#ifdef TIME_WITH_SYS_TIME
+# include <sys/time.h>
+# include <time.h>
+#else
+# ifdef HAVE_SYS_TIME_H
+#  include <sys/time.h>
+# else
+#  include <time.h>
+# endif
+#endif
+
 #include "nutscan-init.h"
 #include "nutscan-device.h"
 #include "nutscan-ip.h"


### PR DESCRIPTION
Pull in system-provided headers for int types (`uint16_t`, `size_t`, `ssize_t` etc.), as well as `useconds_t` and the `time_t` as required by NUT API since 2.8.0 release, so the delivered headers are instantly usable (at least, with build systems which declare `HAVE_SOMETHING_H` like GNU autotools do).

Follows up from #1615/#1616 and should address #1638