### PR TITLE
Revisit NUT for Windows v2.8.0 branch after upslog update

### DIFF
--- a/clients/upslog.c
+++ b/clients/upslog.c
@@ -48,7 +48,6 @@
 	static	char	*upsname;
 	static	UPSCONN_t	*ups;
 
-	static	FILE	*logfile;
 	static	char *logfn, *monhost;
 #ifndef WIN32
 	static	sigset_t	nut_upslog_sigmask;
@@ -464,7 +463,11 @@ int main(int argc, char **argv)
 					monhost_ups_current->monhost = xstrdup(strsep(&m_arg, ","));
 					if (!m_arg)
 						fatalx(EXIT_FAILURE, "Argument '-m upsspec,logfile' requires exactly 2 components in the tuple");
+#ifndef WIN32
 					monhost_ups_current->logfn = xstrdup(strsep(&m_arg, ","));
+#else
+					monhost_ups_current->logfn = xstrdup(filter_path(strsep(&m_arg, ",")));
+#endif
 					if (m_arg) /* Had a third comma - also unexpected! */
 						fatalx(EXIT_FAILURE, "Argument '-m upsspec,logfile' requires exactly 2 components in the tuple");
 					if (upscli_splitname(monhost_ups_current->monhost, &(monhost_ups_current->upsname), &(monhost_ups_current->hostname), &(monhost_ups_current->port)) != 0) {

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -46,6 +46,14 @@ libcommon_la_SOURCES += strptime.c
 libcommonclient_la_SOURCES += strptime.c
 endif
 
+if HAVE_STRSEP
+EXTRA_DIST += strsep.c
+else
+# fall back to simple implem
+libcommon_la_SOURCES += strsep.c
+libcommonclient_la_SOURCES += strsep.c
+endif
+
 # TODO: libnutwincompat.la?
 if HAVE_WINDOWS
 libcommon_la_SOURCES += wincompat.c $(top_srcdir)/include/wincompat.h

--- a/common/strsep.c
+++ b/common/strsep.c
@@ -1,0 +1,19 @@
+#include <string.h>
+
+/* Simple implem courtesy of https://stackoverflow.com/a/58244503
+ * Note: like the (BSD) standard implem, this changes the original stringp!
+ * Result is undefined (segfault here) if stringp==NULL
+ * (it is supposed to be address of string after all)
+ */
+char *strsep(char **stringp, const char *delim) {
+	char *rv = *stringp;
+	if (rv) {
+		*stringp += strcspn(*stringp, delim);
+		if (**stringp)
+			*(*stringp)++ = '\0';
+		else
+			*stringp = NULL;
+	}
+	return rv;
+}
+

--- a/configure.ac
+++ b/configure.ac
@@ -335,6 +335,19 @@ AS_IF([test x"${ac_cv_func_strlwr}" = xyes],
     [AC_MSG_WARN([Optional C library routine strlwr not found])]
     )
 
+AC_CACHE_CHECK([for strsep(s1,s2)],
+    [ac_cv_func_strsep],
+    [AX_RUN_OR_LINK_IFELSE(
+        [AC_LANG_PROGRAM([$CODE_STRINGINCL],
+            [char arr@<:@64@:>@ = {"Some,tuple,text"} ; char *s = arr; if (strsep(&s, ",") == NULL) return 1])],
+        [ac_cv_func_strsep=yes], [ac_cv_func_strsep=no]
+    )])
+AS_IF([test x"${ac_cv_func_strsep}" = xyes],
+    [AC_DEFINE([HAVE_STRSEP], 1, [defined if standard library has, and C standard allows, the strsep(s1,s2) method])],
+    [AC_MSG_WARN([Optional C library routine strsep not found])]
+    )
+AM_CONDITIONAL([HAVE_STRSEP], [test x"${ac_cv_func_strsep}" = "xyes"])
+
 AC_CACHE_CHECK([for strstr(s1,s2)],
     [ac_cv_func_strstr],
     [AX_RUN_OR_LINK_IFELSE(

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -2,12 +2,6 @@ dist_noinst_HEADERS = attribute.h common.h extstate.h proto.h			\
     state.h str.h timehead.h upsconf.h nut_float.h nut_stdint.h nut_platform.h	\
     wincompat.h
 
-if WITH_DEV
-include_HEADERS = parseconf.h
-else
-dist_noinst_HEADERS += parseconf.h
-endif
-
 # Optionally deliverable as part of NUT public API:
 if WITH_DEV
 include_HEADERS = parseconf.h

--- a/include/str.h
+++ b/include/str.h
@@ -134,6 +134,12 @@ int	str_to_double_strict(const char *string, double *number, const int base);
  */
 int	str_ends_with(const char *s, const char *suff);
 
+#ifndef HAVE_STRSEP
+/* Makefile should add the implem to libcommon(client).la */
+char *strsep(char **stringp, const char *delim);
+#define HAVE_STRSEP 1
+#endif
+
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 }


### PR DESCRIPTION
GitHub WebUI driven merge had some accidents, and PR #1639 introduced use of `strsep()` which is missing in MSYS2/MinGW.