### PR TITLE
Document LXC setup for NUT builds with Arch Linux

### DIFF
--- a/docs/ci-farm-lxc-setup.txt
+++ b/docs/ci-farm-lxc-setup.txt
@@ -165,6 +165,99 @@ lxc.arch = x86_64
 Also note the container/system naming without underscore in "x86_64" --
    the deployed system discards the character when assigning its hostname.
    Using "amd64" is another reasonable choice here.
+** For Arch Linux you would need `pacman` tools on the host system, so see
+   https://wiki.archlinux.org/title/Install_Arch_Linux_from_existing_Linux#Using_pacman_from_the_host_system
+   for details.
+   On a Debian/Ubuntu host (assumed ready for NUT builds per
+   linkdoc:config-prereqs.txt) it would start like this:
++
+------
+:; apt-get update
+:; apt-get install meson ninja-build cmake
+
+# Some dependencies for pacman itself; note there are several libcurl builds;
+# pick another if your system constraints require you to:
+:; apt-get install libarchive-dev libcurl4-nss-dev gpg libgpgme-dev
+
+:; git clone https://gitlab.archlinux.org/pacman/pacman.git
+:; cd pacman
+
+# Iterate something like this until all needed dependencies fall
+# into line (note libdir for your host architecture):
+:; rm -rf build; mkdir build && meson build --libdir=/usr/lib/x86_64-linux-gnu
+
+:; ninja -C build
+# Depending on your asciidoc version, it may require that `--asciidoc-opts` are
+# passed as equation to a vale (not space-separated from it). Then apply this:
+#   diff --git a/doc/meson.build b/doc/meson.build
+#   -      '--asciidoc-opts', ' '.join(asciidoc_opts),
+#   +      '--asciidoc-opts='+' '.join(asciidoc_opts),
+# and re-run (meson and) ninja.
+
+# Finally when all succeeded:
+:; sudo ninja -C build install
+:; cd
+------
++
+You will also need `pacstrap` and Debian `arch-install-scripts` package
+does not deliver it. It is however simply achieved:
+------
+:; git clone https://github.com/archlinux/arch-install-scripts
+:; cd arch-install-scripts
+:; make && sudo make PREFIX=/usr install
+:; cd
+------
++
+It will also want an `/etc/pacman.d/mirrorlist` which you can populate for
+your geographic location from https://archlinux.org/mirrorlist/ service,
+or just fetch them all (don't forget to uncomment some `Server =` lines):
+------
+:; mkdir -p /etc/pacman.d/
+:; curl https://archlinux.org/mirrorlist/all/ > /etc/pacman.d/mirrorlist
+------
++
+And to reference it from your host `/etc/pacman.conf` by un-commenting the
+`[core]` section and `Include` instruction, as well as adding `[community]`
+and `[extra]` sections with same reference, e.g.:
+------
+[core]
+### SigLevel = Never
+SigLevel = PackageRequired
+Include = /etc/pacman.d/mirrorlist
+
+[extra]
+### SigLevel = Never
+SigLevel = PackageRequired
+Include = /etc/pacman.d/mirrorlist
+
+[community]
+### SigLevel = Never
+SigLevel = PackageRequired
+Include = /etc/pacman.d/mirrorlist
+------
++
+And just then you can proceed with LXC:
+------
+:; lxc-create -P /srv/libvirt/rootfs \
+    -n jenkins-archlinux-amd64 -t archlinux -- \
+    -a x86_64 -P openssh,sudo
+------
++
+In my case, it had problems with GPG keyring missing (using one in host
+system, as well as the package cache outside the container, it seems)
+so I had to run `pacman-key --init; pacman-key --refresh-keys` on the
+host itself. Even so, `lxc-create` complained about updating some keyring
+entries and I had to go one by one picking key servers (serving different
+metadata) like this:
+------
+:; pacman-key --keyserver keyserver.ubuntu.com --recv-key 6D1655C14CE1C13E
+------
++
+In the worst case, see `SigLevel = Never` for `pacman.conf` to not check
+package integrity (seems too tied into thinking that host OS is Arch)...
++
+It seems that pre-fetching the package databases with `pacman -Sy` on
+the host was also important.
 
 * Add the "name,IP" line for this container to `/etc/lxc/dnsmasq-hosts.conf`
   on the host, e.g.:
@@ -372,6 +465,32 @@ is usable in the chroot environment. This can be achieved with e.g.:
 
 TODO: Test and document a working NAT and firewall setup for this, to allow
 SSH access to the containers via dedicated TCP ports exposed on the host.
+
+Arch Linux containers
+^^^^^^^^^^^^^^^^^^^^^
+
+Arch Linux containers prepared by procedure above include only a minimal
+footprint, and if you missed the `-P pkg,list` argument, they can lack
+even an SSH server. Suggestions below assume this path to container:
+------
+:; ALTROOT=/srv/libvirt/rootfs/jenkins-archlinux-amd64/rootfs/
+------
+
+Let `pacman` know current package database:
+------
+:; grep 8.8.8.8 $ALTROOT/etc/resolv.conf || (echo 'nameserver 8.8.8.8' > $ALTROOT/etc/resolv.conf)
+:; chroot $ALTROOT pacman -Syu
+:; chroot $ALTROOT pacman -S openssh sudo
+:; chroot $ALTROOT systemctl enable sshd
+:; chroot $ALTROOT systemctl start sshd
+------
+
+This may require that you perform bind-mounts above, as well as "passthrough"
+the `/var/cache/pacman/pkg` from host to guest environment (in `virsh edit`,
+and bind-mount for `chroot` like for `/proc` et al above).
+
+It is possible that `virsh console` would serve you better than `chroot`.
+Note you may have to first `chroot` to set the `root` password anyhow.
 
 
 Troubleshooting

--- a/docs/config-prereqs.txt
+++ b/docs/config-prereqs.txt
@@ -322,6 +322,102 @@ other described environments by adding a symlink `/usr/lib/ccache`:
 
 NOTE: For Jenkins agents, also need to `yum install java-11-openjdk-headless`.
 
+Arch Linux
+~~~~~~~~~~
+
+Update the lower-level OS and package databases:
+------
+:; pacman -Syu
+------
+
+Install tools and prerequisites for NUT:
+------
+:; pacman -S --needed \
+    base-devel \
+    autoconf automake libtool libltdl \
+    clang gcc \
+    ccache \
+    git \
+    vim python perl \
+    pkgconf \
+    cppcheck valgrind
+
+# For spell-checking, highly recommended if you would propose pull requests:
+:; pacman -S --needed \
+    aspell en-aspell
+
+# For man-page doc types generation:
+:; pacman -S --needed \
+    asciidoc
+
+# For other doc types (PDF, HTML) generation - massive packages (TEX, X11):
+:; pacman -S --needed \
+    source-highlight dblatex
+
+# For CGI graph generation - massive packages (X11):
+:; pacman -S --needed \
+    gd
+
+:; pacman -S --needed \
+    cppunit \
+    openssl nss \
+    augeas \
+    libusb \
+    neon \
+    net-snmp \
+    freeipmi \
+    avahi
+
+:; pacman -S --needed \
+    lua51
+
+:; pacman -S --needed \
+    bash dash busybox ksh93
+------
+
+Recommended for NUT CI farm integration (matching specific toolkit versions
+in a build matrix), and note the unusual location of `/usr/lib/ccache/bin/`
+for symlinks:
+------
+:; gcc --version
+gcc (GCC) 12.2.0
+...
+
+# Note: this distro delivers "gcc" et al as file names
+# so symlinks like this may erode after upgrades.
+# TODO: Rename and then link?..
+:; (cd /usr/bin \
+    && for V in 12 12.2.0 ; do for T in gcc g++ cpp ; do \
+        ln -fsr $T $T-$V ; \
+    done; done)
+:; (cd /usr/lib/ccache/bin/ \
+    && for V in 12 12.2.0 ; do for T in gcc g++ ; do \
+        ln -fsr /usr/bin/ccache $T-$V ; \
+    done; done)
+
+
+:; clang --version
+clang version 14.0.6
+...
+
+:; (cd /usr/bin && ln -fs clang-14 clang++-14 && ln -fs clang-14 clang-cpp-14)
+:; (cd /usr/lib/ccache/bin/ \
+    && for V in 14 ; do for T in clang clang++ ; do \
+        ln -fsr /usr/bin/ccache $T-$V ; \
+    done; done)
+------
+
+Also for CI build agents, a Java environment (JDK11+ since summer 2022) is
+required:
+------
+# Search for available Java versions:
+:; pacman -Ss | egrep 'jre|jdk'
+
+# Pick one:
+:; pacman -S --needed \
+    jre11-openjdk-headless
+------
+
 FreeBSD 12.2
 ~~~~~~~~~~~~
 

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3026 utf-8
+personal_ws-1.1 en 3040 utf-8
 AAS
 ABI
 ACFAIL
@@ -872,6 +872,7 @@ PWR
 PXG
 PaaS
 Pac
+PackageRequired
 Parisi
 Patrik
 Pavel
@@ -1131,6 +1132,7 @@ Shutdn
 Sibbald
 Sicon
 Sidorov
+SigLevel
 Signetic
 Silvino
 Sinline
@@ -1169,6 +1171,7 @@ Sublicensing
 SunOS
 SuperPower
 Sweex
+Sy
 Sycon
 Symmetra
 Symmetras
@@ -1439,6 +1442,7 @@ apctest
 apcupsd
 aphel
 ar
+archlinux
 arduino
 arg
 argc
@@ -1628,6 +1632,7 @@ clepple
 clicky
 cls
 clueful
+cmake
 cmd
 cmdline
 cmdname
@@ -2055,6 +2060,8 @@ kde
 keyclick
 keygen
 keyout
+keyring
+keyserver
 killall
 killpower
 kludgy
@@ -2072,16 +2079,19 @@ ldd
 le
 len
 lf
+libarchive
 libaugeas
 libavahi
 libc
 libcommon
 libcppunit
 libcrypto
+libcurl
 libdir
 libexec
 libfreeipmi
 libgd
+libgpgme
 libhid
 libhidups
 libi
@@ -2266,6 +2276,7 @@ mysecurityname
 myups
 myupsname
 nabcd
+nameserver
 namespace
 nanosleep
 nashkaminski
@@ -2386,6 +2397,7 @@ otheruser
 outliers
 pF
 pacman
+pacstrap
 param
 paramkeywords
 parsable
@@ -2523,6 +2535,7 @@ rebootdelay
 rebranded
 receivexhs
 reconnection
+recv
 redistributors
 reentrancy
 refactored
@@ -2536,6 +2549,7 @@ reposurgeon
 repotec
 req
 resistive
+resolv
 resync
 ret
 retrydelay

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3040 utf-8
+personal_ws-1.1 en 3042 utf-8
 AAS
 ABI
 ACFAIL
@@ -1794,6 +1794,7 @@ eco
 edb
 edl
 ef
+egrep
 ei
 el
 emacs
@@ -1876,6 +1877,7 @@ frob
 frontends
 fs
 fsd
+fsr
 ftdi
 fuji
 fullload


### PR DESCRIPTION
Part of investigation for #1279 - needed a platform to reproduce user build failure. That is tangentially related to #1650 (also exposes `strptime` issues).