### PR TITLE
configure.ac: move detection of TIME_WITH_SYS_TIME to before we use it

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -160,6 +160,18 @@ NUT_COMPILER_FAMILY_FLAGS
 AX_C_PRAGMAS
 AX_C___ATTRIBUTE__
 AX_C_PRINTF_STRING_NULL
+
+dnl All current systems provide time.h; it need not be checked for.
+dnl Not all systems provide sys/time.h, but those that do, all allow
+dnl you to include it and time.h simultaneously.
+dnl NUT codebase provides the include/timehead.h to wrap these nuances.
+AC_CHECK_HEADERS_ONCE([sys/time.h time.h sys/types.h sys/socket.h netdb.h])
+dnl ###obsolete### AC_HEADER_TIME
+AS_IF([test "$ac_cv_header_sys_time_h" = yes],
+    [AC_DEFINE([TIME_WITH_SYS_TIME],[1],[Define to 1 if you can safely include both <sys/time.h>
+         and <time.h>.  This macro is deemed obsolete by autotools.])
+    ], [])
+
 AC_CHECK_FUNCS(flock lockf fcvt fcvtl pow10 round abs_val abs)
 
 AC_CHECK_HEADER([float.h],
@@ -583,16 +595,6 @@ AC_CHECK_DECLS(__func__, [], [
 dnl Solaris compatibility - check for -lnsl and -lsocket
 AC_SEARCH_LIBS(gethostbyname, nsl)
 AC_SEARCH_LIBS(connect, socket)
-
-dnl All current systems provide time.h; it need not be checked for.
-dnl Not all systems provide sys/time.h, but those that do, all allow
-dnl you to include it and time.h simultaneously.
-dnl NUT codebase provides the include/timehead.h to wrap these nuances.
-AC_CHECK_HEADERS_ONCE([sys/time.h time.h sys/types.h sys/socket.h netdb.h])
-AS_IF([test "$ac_cv_header_sys_time_h" = yes],
-    [AC_DEFINE([TIME_WITH_SYS_TIME],[1],[Define to 1 if you can safely include both <sys/time.h>
-	     and <time.h>.  This macro is deemed obsolete by autotools.])
-    ], [])
 
 AC_CHECK_HEADERS(sys/modem.h stdarg.h varargs.h, [], [], [AC_INCLUDES_DEFAULT])
 


### PR DESCRIPTION
This should help find strptime() in particular on systems that have both time.h and sys/time.h files, and one does not include the other (e.g. Arch Linux as seen in #1279 testing).

Arguably a regression with Windows branch merge that introduced the fallback code and need to check for its presence in the OS.