### PR TITLE
Spell Guesstimation consistently

### DIFF
--- a/docs/man/upscode2.txt
+++ b/docs/man/upscode2.txt
@@ -83,7 +83,7 @@ NOTES
 
 The Powerware UPS models that this driver has been tested against until now
 have not returned a value for 'battery.charge'. Therefore, the driver will
-guestimate a value based on the nominal battery min/max and the current
+guesstimate a value based on the nominal battery min/max and the current
 battery voltage.
 
 AUTHORS

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1924,7 +1924,7 @@ groupname
 gtk
 guardpend
 guardpstart
-guestimate
+guesstimate
 guez
 gufw
 gui

--- a/drivers/blazer.c
+++ b/drivers/blazer.c
@@ -88,7 +88,7 @@ static const struct {
 
 /*
  * Do whatever we think is needed when we read a battery voltage from the UPS.
- * Basically all it does now, is guestimating the battery charge, but this
+ * Basically all it does now, is guesstimating the battery charge, but this
  * could be extended.
  */
 static double blazer_battery(const char *ptr, char **endptr)
@@ -616,7 +616,7 @@ static void blazer_initbattery(void)
 		dstate_setinfo("battery.voltage.low", "%.2f", batt.volt.low);
 		dstate_setinfo("battery.voltage.high", "%.2f", batt.volt.high);
 
-		upslogx(LOG_INFO, "Using 'guestimation' (low: %f, high: %f)!", batt.volt.low, batt.volt.high);
+		upslogx(LOG_INFO, "Using 'guesstimation' (low: %f, high: %f)!", batt.volt.low, batt.volt.high);
 	}
 
 	val = getval("runtimecal");

--- a/drivers/eaton-pdu-pulizzi-mib.c
+++ b/drivers/eaton-pdu-pulizzi-mib.c
@@ -95,7 +95,7 @@ static snmp_info_t eaton_pulizzi_switched_mib[] = {
 		"", SU_FLAG_STATIC | SU_FLAG_OK, NULL },
 
 	/* Outlet page */
-	/* Note: outlet.count is deduced, with guestimate_outlet_count() */
+	/* Note: outlet.count is deduced, with guesstimate_outlet_count() */
 	{ "outlet.id", 0, 1, NULL, "0", SU_FLAG_STATIC | SU_FLAG_ABSENT | SU_FLAG_OK, NULL },
 	{ "outlet.desc", ST_FLAG_RW | ST_FLAG_STRING, 20, NULL, "All outlets",
 		SU_FLAG_STATIC | SU_FLAG_ABSENT | SU_FLAG_OK, NULL },

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -2390,7 +2390,7 @@ static int base_snmp_template_index(const snmp_info_t *su_info_p)
 /* Try to determine the number of items (outlets, outlet groups, ...),
  * using a template definition. Walk through the template until we can't
  * get anymore values. I.e., if we can iterate up to 8 item, return 8 */
-static int guestimate_template_count(snmp_info_t *su_info_p)
+static int guesstimate_template_count(snmp_info_t *su_info_p)
 {
 	int base_index = 0;
 	char test_OID[SU_INFOSIZE];
@@ -2478,8 +2478,8 @@ static bool_t process_template(int mode, const char* type, snmp_info_t *su_info_
 	if(dstate_getinfo(template_count_var) == NULL) {
 		/* FIXME: should we disable it?
 		 * su_info_p->flags &= ~SU_FLAG_OK;
-		 * or rely on guestimation? */
-		template_count = guestimate_template_count(su_info_p);
+		 * or rely on guesstimation? */
+		template_count = guesstimate_template_count(su_info_p);
 		/* Publish the count estimation */
 		if (template_count > 0) {
 			dstate_setinfo(template_count_var, "%i", template_count);
@@ -2860,7 +2860,7 @@ bool_t daisychain_init()
 		 * the number of devices present */
 		else
 		{
-			devices_count = guestimate_template_count(su_info_p);
+			devices_count = guesstimate_template_count(su_info_p);
 			upsdebugx(1, "Guesstimation: there are %ld device(s) present", devices_count);
 		}
 


### PR DESCRIPTION
Online dictionaries suggest that both single-S and double-S versions are correct. But it is messy seeing both on the same page. There can be only one! (Or two in this case)