### PR TITLE
Support NUT_QUIET_INIT_SSL envvar to hide "Init SSL without certificate database" message

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -150,6 +150,10 @@ https://github.com/networkupstools/nut/milestone/8
    * added `listDeviceClients()` and `deviceGetClients(dev)` to `Client`
      classes, and `Device::getClients()` to match PyNUT capabilities [#549]
 
+ - upsclient C library:
+   * added support for `NUT_QUIET_INIT_SSL` environment variable to hide
+     the infamous "Init SSL without certificate database" warning [#1662]
+
  - sstate (server state, e.g. upsd) should now "PING" drivers also if they
    last reported themselves as "stale" (and might later crash) so their
    connections would be terminated if really no longer active [#1626]

--- a/clients/upsclient.c
+++ b/clients/upsclient.c
@@ -405,7 +405,7 @@ int upscli_init(int certverify, const char *certpath,
 	PK11_SetPasswordFunc(nss_password_callback);
 
 	if (certpath) {
-		upslogx(LOG_INFO, "Init SSL with cerificate database located at %s", certpath);
+		upslogx(LOG_INFO, "Init SSL with certificate database located at %s", certpath);
 		status = NSS_Init(certpath);
 	} else {
 		upslogx(LOG_NOTICE, "Init SSL without certificate database");

--- a/docs/man/upscli_init.txt
+++ b/docs/man/upscli_init.txt
@@ -18,7 +18,7 @@ DESCRIPTION
 -----------
 
 The *upscli_init()* function initialize upsclient module and set many
-SSL-related properties: 'certverify' to 1 makes certificate verification
+TLS/SSL-related properties: 'certverify' to 1 makes certificate verification
 required for all SSL connections and 'certpath' is the location of
 certificate database.
 
@@ -41,6 +41,15 @@ files.
 If compiled with NSS and using SSL, you can specify 'certname' the name
 of the certificate to send to upsd and 'certpasswd' the password used
 to decrypt certificate private key.
+
+If compiled with NSS, it would normally log either the infamous message
+"Init SSL without certificate database" if no 'certpath' was provided,
+or "Init SSL with certificate database located at %s" otherwise.
+Since some programmatic consumers become confused by such extra text on
+the `stderr` of tools they call (such as monitoring systems doing `upsc`
+queries), you can export an environment variable `NUT_QUIET_INIT_SSL`
+with string values "true", "TRUE" or "1", to avoid logging these messages
+and just emit them as debug stream (at verbosity 1 or higher).
 
 You can call linkman:upscli_add_host_cert[3] to register specific host
 security policy before initialize connections to them.

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -31,6 +31,9 @@ LANG=C
 LC_ALL=C
 export TZ LANG LC_ALL
 
+NUT_QUIET_INIT_SSL="true"
+export NUT_QUIET_INIT_SSL
+
 log_separator() {
     echo "" >&2
     echo "================================" >&2


### PR DESCRIPTION
Follows up from discussion for PR #1662