### PR TITLE
add new driver for UPS INVT HT11 1-3KVA series

### DIFF
--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -51,7 +51,7 @@ SERIAL_USB_DRIVERLIST = \
 	nutdrv_qx
 NEONXML_DRIVERLIST = netxml-ups
 MACOSX_DRIVERLIST = macosx-ups
-MODBUS_DRIVERLIST = phoenixcontact_modbus generic_modbus huawei-ups2000 socomec_jbus adelsystem_cbi
+MODBUS_DRIVERLIST = phoenixcontact_modbus generic_modbus huawei-ups2000 socomec_jbus adelsystem_cbi invt_modbus
 LINUX_I2C_DRIVERLIST = asem pijuice
 POWERMAN_DRIVERLIST = powerman-pdu
 IPMI_DRIVERLIST = nut-ipmipsu
@@ -290,6 +290,11 @@ huawei_ups2000_LDADD = $(LDADD_DRIVERS_SERIAL) $(LIBMODBUS_LIBS)
 # (this is a Modbus driver)
 socomec_jbus_SOURCES = socomec_jbus.c
 socomec_jbus_LDADD = $(LDADD_DRIVERS_SERIAL) $(LIBMODBUS_LIBS)
+
+# INVT MODBUS ASCII driver
+# (this is a Modbus driver)
+invt_modbus_SOURCES = invt_modbus.c modbus-ascii.c
+invt_modbus_LDADD = $(LDADD_DRIVERS_SERIAL)
 
 # Linux I2C drivers
 asem_LDADD = $(LDADD_DRIVERS)

--- a/drivers/invt_modbus.c
+++ b/drivers/invt_modbus.c
@@ -1,0 +1,421 @@
+/*  socomec_jbus.c - Driver for Socomec JBUS UPS
+ *
+ *  Copyright (C)
+ *    2021 Thanos Chatziathanassiou <tchatzi@arx.net>
+ *
+ * Based on documentation found freely on 
+ * https://www.socomec.com/files/live/sites/systemsite/files/GB-JBUS-MODBUS-for-Delphys-MP-and-Delphys-MX-operating-manual.pdf
+ * but with dubious legal license. The document itself states:
+ * ``CAUTION : “This is a product for restricted sales distribution to informed partners. 
+ *   Installation restrictions or additional measures may be needed to prevent disturbances''
+ * YMMV
+ * 
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ */
+
+#include "main.h"
+#include "modbus-ascii.h"
+#include "invt_modbus.h"
+
+
+#define DRIVER_NAME "INVT modbus driver"
+#define DRIVER_VERSION  "0.01"
+
+/* Variables */
+static modbus_t *modbus_ctx = NULL;
+static int ser_baud_rate = BAUD_RATE;	/* serial port baud rate */
+static char ser_parity = PARITY;	/* serial port parity */
+static int ser_data_bit = DATA_BIT;	/* serial port data bit */
+static int ser_stop_bit = STOP_BIT;	/* serial port stop bit */
+static int mbio_slave_id = MODBUS_SLAVE_ID;	/* set device ID to default value */
+
+
+
+static int mrir(modbus_t * arg_ctx, int addr, int nb, uint16_t * dest);
+static int mrhr(modbus_t * arg_ctx, int addr, int nb, uint16_t * dest);
+
+/* driver description structure */
+upsdrv_info_t upsdrv_info = {
+	DRIVER_NAME,
+	DRIVER_VERSION,
+	"Michael Manerko <splien.ma@gmail.com>\n",
+	DRV_BETA,
+	{ NULL }
+};
+
+
+
+void upsdrv_initinfo(void)
+{
+	upsdebugx(2, "upsdrv_initinfo");
+
+	uint16_t tab_reg[12];
+	int r;
+
+	dstate_setinfo("device.mfr", "unknown");
+	dstate_setinfo("device.model", "Unknown");
+
+	upsdebugx(2, "initial read");
+
+	/* 
+	   function 0x3, holding register
+	   reg    value
+	   78     7: HT11(6-20 KVA)
+	   8: HT11(1-3 KVA) 
+	   79     1: 3in - 3out phase
+	   2: 3in - 1out phase
+	   3: 1in - 1out phase
+	   4: 1in - 3out phase
+	   5: 2in - 2out phase
+	 */
+
+	r = mrhr(modbus_ctx, 78, 2, tab_reg);
+
+	if (r == -1) {
+		fatalx(EXIT_FAILURE, "failed to read UPS, retcode is %d error %s", r, modbus_strerror(errno));
+	}
+
+	upsdebugx(2, "read UPS Code %d", tab_reg[0]);
+
+	/* known INVT Models */
+	switch (tab_reg[0]) {
+	case 7:
+		dstate_setinfo("ups.model", "HT11(6-20 KVA)");
+		break;
+
+	case 8:
+		dstate_setinfo("ups.model", "HT11(1-3 KVA)");
+		break;
+
+	default:
+		dstate_setinfo("ups.model", "Unknown UPS. Model id %u", tab_reg[0]);
+	}
+
+	/* upsh.instcmd = instcmd; */
+	/* upsh.setvar = setvar; */
+}
+
+
+
+
+void upsdrv_updateinfo(void)
+{
+	upsdebugx(2, "upsdrv_updateinfo");
+
+	uint16_t i_tab_reg[80];
+	uint16_t h_tab_reg[80];
+	int r;
+
+	status_init();
+
+
+	/* measurements and config */
+	r = mrhr(modbus_ctx, 1, 79, h_tab_reg);
+
+	if (r == -1) {
+		upsdebugx(2, "Did not receive any data from the UPS at 0x1 error %s", modbus_strerror(errno));
+	}
+
+
+	dstate_setinfo("battery.charge", "%.2f", (double) h_tab_reg[56 - 1] / 10);
+	upsdebugx(2, "battery.charge %.2f", (double) h_tab_reg[56 - 1] / 10);
+	//dstate_setinfo("battery.capacity", "%u", (tab_reg[56-1]/10) );
+	dstate_setinfo("battery.voltage", "%.2f", (double) h_tab_reg[50 - 1] / 10);
+	upsdebugx(2, "battery.voltage %.2f", (double) h_tab_reg[50 - 1] / 10);
+	dstate_setinfo("battery.current", "%.2f", (double) h_tab_reg[52 - 1] / 10);
+	upsdebugx(2, "battery.current %.2f", (double) h_tab_reg[52 - 1] / 10);
+	dstate_setinfo("battery.runtime", "%.2f", (double) h_tab_reg[55 - 1] / 10);
+	upsdebugx(2, "battery.runtime %.2f", (double) h_tab_reg[55 - 1] / 10);
+
+
+	if (h_tab_reg[79 - 1] == 3) {
+		/* this a 1-phase model */
+		dstate_setinfo("input.phases", "1");
+		dstate_setinfo("ups.load", "%u", h_tab_reg[46 - 1] / 10);
+		upsdebugx(2, "ups.load %u", h_tab_reg[46 - 1] / 10);
+		dstate_setinfo("input.bypass.voltage", "%u", h_tab_reg[1 - 1] / 10);
+		upsdebugx(2, "input.bypass.voltage %u", h_tab_reg[1 - 1] / 10);
+		dstate_setinfo("input.voltage", "%u", h_tab_reg[13 - 1] / 10);
+		upsdebugx(2, "input.voltage %u", h_tab_reg[13 - 1] / 10);
+		dstate_setinfo("input.frequency", "%.2f", (double) h_tab_reg[19 - 1] / 100);
+		upsdebugx(2, "input.frequency %.2f", (double) h_tab_reg[19 - 1] / 100);
+		dstate_setinfo("input.bypass.frequency", "%.2f", (double) h_tab_reg[7 - 1] / 100);
+		upsdebugx(2, "input.bypass.frequency %.2f", (double) h_tab_reg[7 - 1] / 100);
+		dstate_setinfo("input.current", "%.1f", (double) h_tab_reg[16 - 1] / 10);
+		upsdebugx(2, "input.current %.1f", (double) h_tab_reg[16 - 1] / 10);
+
+		dstate_setinfo("output.voltage", "%u", h_tab_reg[25 - 1] / 10);
+		upsdebugx(2, "output.voltage %u", h_tab_reg[25 - 1] / 10);
+		dstate_setinfo("input.frequency", "%.2f", (double) h_tab_reg[19 - 1] / 100);
+		upsdebugx(2, "input.frequency %.2f", (double) h_tab_reg[19 - 1] / 100);
+		dstate_setinfo("output.current", "%.1f", (double) h_tab_reg[28 - 1] / 10);
+		upsdebugx(2, "output.current %.1f", (double) h_tab_reg[28 - 1] / 10);
+	} else {
+		/* this a 3-phase model */
+		dstate_setinfo("input.phases", "3");
+
+		dstate_setinfo("ups.load", "%u", h_tab_reg[46 - 1] / 10);
+
+		dstate_setinfo("ups.L1.load", "%u", h_tab_reg[46 - 1] / 10);
+		dstate_setinfo("ups.L2.load", "%u", h_tab_reg[47 - 1] / 10);
+		dstate_setinfo("ups.L3.load", "%u", h_tab_reg[48 - 1] / 10);
+
+		dstate_setinfo("input.bypass.L1-N.voltage", "%u", h_tab_reg[1 - 1] / 10);
+		dstate_setinfo("input.bypass.L2-N.voltage", "%u", h_tab_reg[2 - 1] / 10);
+		dstate_setinfo("input.bypass.L3-N.voltage", "%u", h_tab_reg[3 - 1] / 10);
+
+		dstate_setinfo("output.L1-N.voltage", "%u", h_tab_reg[25 - 1] / 10);
+		dstate_setinfo("output.L2-N.voltage", "%u", h_tab_reg[26 - 1] / 10);
+		dstate_setinfo("output.L3-N.voltage", "%u", h_tab_reg[27 - 1] / 10);
+
+		dstate_setinfo("output.L1.current", "%u", h_tab_reg[28 - 1] / 10);
+		dstate_setinfo("output.L2.current", "%u", h_tab_reg[29 - 1] / 10);
+		dstate_setinfo("output.L3.current", "%u", h_tab_reg[30 - 1] / 10);
+	}
+
+
+	if (h_tab_reg[49 - 1] != 0) {
+		dstate_setinfo("ambient.1.present", "yes");
+		dstate_setinfo("ambient.1.temperature", "%.1f", (double) h_tab_reg[49 - 1] / 10);
+	}
+
+
+	/* alarms */
+	r = mrir(modbus_ctx, 81, 16, i_tab_reg);
+
+	alarm_init();
+
+	if (r == -1) {
+		upsdebugx(2, "Did not receive any data from the UPS at 81 ! Ignoring ? error %s", modbus_strerror(errno));
+	}
+
+	if (i_tab_reg[85 - 81] == 1) {
+		upsdebugx(2, "Alarm EPO.");
+		alarm_set("EPO.");
+	}
+	if (i_tab_reg[88 - 81] == 1) {
+		upsdebugx(2, "Alarm Input Fail.");
+		alarm_set("Input Fail.");
+	}
+	if (i_tab_reg[89 - 81] == 1) {
+		upsdebugx(2, "Alarm Bypass Sequence Fail.");
+		alarm_set("Bypass Sequence Fail.");
+	}
+	if (i_tab_reg[90 - 81] == 1) {
+		upsdebugx(2, "Alarm Bypass Voltage Fail.");
+		alarm_set("Bypass Voltage Fail.");
+	}
+	if (i_tab_reg[91 - 81] == 1) {
+		upsdebugx(2, "Alarm Bypass Fail.");
+		alarm_set("Bypass Fail.");
+	}
+	if (i_tab_reg[92 - 81] == 1) {
+		upsdebugx(2, "Alarm Bypass Over Load.");
+		alarm_set("Bypass Over Load.");
+	}
+	if (i_tab_reg[93 - 81] == 1) {
+		upsdebugx(2, "Alarm Bypass Over Load Timeout.");
+		alarm_set("Bypass Over Load Timeout.");
+	}
+	if (i_tab_reg[96 - 81] == 1) {
+		upsdebugx(2, "Alarm Output Shorted.");
+		alarm_set("Output Shorted.");
+	}
+	if (i_tab_reg[97 - 81] == 1) {
+		upsdebugx(2, "Alarm Battery EOD.");
+		alarm_set("Battery EOD.");
+	}
+
+
+
+	if ((i_tab_reg[88 - 81] == 0)&&(i_tab_reg[81-81] == 1)) {
+		status_set("OL");
+		upsdebugx(2, "OL");
+	} else if ((i_tab_reg[88 - 81] == 1)&&(i_tab_reg[81-81] == 1)&&(h_tab_reg[55-1] < 50)) {
+		status_set("LB");
+		upsdebugx(2, "LB");
+	} else if ((i_tab_reg[88 - 81] == 1)&&(i_tab_reg[81-81] == 1)) {
+		status_set("OB");
+		upsdebugx(2, "OB");
+	} else if (i_tab_reg[81-81] == 2) {
+		status_set("BYPASS");
+		upsdebugx(2, "BYPASS");
+	}
+	if (i_tab_reg[83-81] == 3) {
+		status_set("DISCHRG");
+	 	upsdebugx(2, "DISCHRG");
+	} else if (i_tab_reg[83-81] == 2) {
+		status_set("CHRG");
+		upsdebugx(2, "CHRG");
+	} 
+	if (i_tab_reg[81-81] == 0) {
+		status_set("OFF");
+		upsdebugx(2, "OFF");
+	}
+
+
+
+	/*TODO:
+	   --essential
+	   ups.status TRIM/BOOST/OVER
+	   ups.alarm
+
+	   --dangerous
+	   ups.shutdown
+	   shutdown.return
+	   shutdown.stop
+	   shutdown.reboot
+	   shutdown.reboot.graceful
+	   bypass.start
+	   beeper.enable
+	   beeper.disable
+	 */
+
+	alarm_commit();
+	status_commit();
+	dstate_dataok();
+
+	return;
+}
+
+void upsdrv_shutdown(void)
+    __attribute__((noreturn));
+
+void upsdrv_shutdown(void)
+{
+	fatalx(EXIT_FAILURE, "shutdown not supported");
+}
+
+void upsdrv_help(void)
+{
+}
+
+/* list flags and values that you want to receive via -x */
+void upsdrv_makevartable(void)
+{
+	addvar(VAR_VALUE, "ser_baud_rate", "serial port baud rate default 9600");
+	addvar(VAR_VALUE, "ser_parity", "serial port parity default N");
+	addvar(VAR_VALUE, "ser_data_bit", "serial port data bit default 8");
+	addvar(VAR_VALUE, "ser_stop_bit", "serial port stop bit default 1");
+	addvar(VAR_VALUE, "rio_slave_id", "RIO modbus slave ID default 1");
+}
+
+void upsdrv_initups(void)
+{
+	int r;
+	upsdebugx(2, "upsdrv_initups");
+
+
+/* check if serial baud rate is set ang get the value */
+	if (testvar("ser_baud_rate")) {
+		ser_baud_rate = (int) strtol(getval("ser_baud_rate"), NULL, 10);
+	}
+	upsdebugx(2, "ser_baud_rate %d", ser_baud_rate);
+
+	/* check if serial parity is set ang get the value */
+	if (testvar("ser_parity")) {
+		/* Dereference the char* we get */
+		char *sp = getval("ser_parity");
+		if (sp) {
+			/* TODO? Sanity-check the char we get? */
+			ser_parity = *sp;
+		} else {
+			upsdebugx(2, "Could not determine ser_parity, will keep default");
+		}
+	}
+	upsdebugx(2, "ser_parity %c", ser_parity);
+
+	/* check if serial data bit is set ang get the value */
+	if (testvar("ser_data_bit")) {
+		ser_data_bit = (int) strtol(getval("ser_data_bit"), NULL, 10);
+	}
+	upsdebugx(2, "ser_data_bit %d", ser_data_bit);
+
+	/* check if serial stop bit is set ang get the value */
+	if (testvar("ser_stop_bit")) {
+		ser_stop_bit = (int) strtol(getval("ser_stop_bit"), NULL, 10);
+	}
+	upsdebugx(2, "ser_stop_bit %d", ser_stop_bit);
+
+	/* check if device ID is set ang get the value */
+	if (testvar("rio_slave_id")) {
+		mbio_slave_id = (int) strtol(getval("rio_slave_id"), NULL, 10);
+	}
+	upsdebugx(2, "rio_slave_id %d", mbio_slave_id);
+
+
+	modbus_ctx = modbus_new_ascii(device_path, ser_baud_rate, ser_parity, ser_data_bit, ser_stop_bit);
+	if (modbus_ctx == NULL)
+		fatalx(EXIT_FAILURE, "Unable to create the libmodbus context");
+
+	r = modbus_set_slave(modbus_ctx, mbio_slave_id);	/* slave ID */
+	if (r < 0) {
+		modbus_free(modbus_ctx);
+		fatalx(EXIT_FAILURE, "Invalid modbus slave ID %d", mbio_slave_id);
+	}
+
+	if (modbus_connect(modbus_ctx) == -1) {
+		modbus_free(modbus_ctx);
+		fatalx(EXIT_FAILURE, "modbus_connect: unable to connect: %s", modbus_strerror(errno));
+	}
+
+}
+
+void upsdrv_cleanup(void)
+{
+	if (modbus_ctx != NULL) {
+		modbus_close(modbus_ctx);
+		modbus_free(modbus_ctx);
+	}
+}
+
+/* Modbus Read Input Registers function 0x4*/
+static int mrir(modbus_t * arg_ctx, int addr, int nb, uint16_t * dest)
+{
+	int r, i;
+
+	/* zero out the thing, because we might have reused it */
+	for (i = 0; i < nb; i++) {
+		dest[i] = 0;
+	}
+
+	/*r = modbus_read_input_registers(arg_ctx, addr, nb, dest); */
+	r = modbus_read_input_registers(arg_ctx, addr, nb, dest);
+	if (r == -1) {
+		upslogx(LOG_ERR, "mrir: modbus_read_input_registers(addr:%d, count:%d): %s (%s)", addr, nb, modbus_strerror(errno), device_path);
+	}
+	return r;
+}
+
+
+/* Modbus Read Holding Registers function 0x3*/
+static int mrhr(modbus_t * arg_ctx, int addr, int nb, uint16_t * dest)
+{
+	int r, i;
+
+	/* zero out the thing, because we might have reused it */
+	for (i = 0; i < nb; i++) {
+		dest[i] = 0;
+	}
+
+	/*r = modbus_read_input_registers(arg_ctx, addr, nb, dest); */
+	r = modbus_read_registers(arg_ctx, addr, nb, dest);
+	if (r == -1) {
+		upslogx(LOG_ERR, "mrhr: modbus_read_holding_registers(addr:%d, count:%d): %s (%s)", addr, nb, modbus_strerror(errno), device_path);
+	}
+	return r;
+}

--- a/drivers/invt_modbus.h
+++ b/drivers/invt_modbus.h
@@ -1,0 +1,331 @@
+/*  invt_modbus.h - Driver for invt UPS hr, ht series connected via modbus ASCII
+ *
+ *  Copyright (C)
+ *    2022 Michael Manerko <splien.ma@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ */
+
+#ifndef NUT_INVT_MODBUS
+#define NUT_INVT_MODBUS
+
+/* serial access parameters */
+#define BAUD_RATE 9600
+#define PARITY 'N'
+#define DATA_BIT 8
+#define STOP_BIT 1
+
+/* modbus access parameters */
+#define MODBUS_SLAVE_ID 1
+
+
+#endif /* NUT_INVT_MODBUS */
+
+/* REGISTER MAP
+
+UPS 
+INVT HR11 series
+INVT HT11 series
+SNR-UPS-ONRT (3000-20000) series
+HIDEN EXPERT UDC9200S-RT 1-3 кВА
+HIDEN EXPERT UDC9200H-RT 6-10 кВА
+
+RS232 MODBUS ASCII
+
+Telemetry (Function code: 0x03)
+No. Name                        Data type(Hi-Lo)    Coefficient Unit Remark
+0   Bypass voltage Phase A      Unsigned int        0.1         V   Used for compatibility
+1   Bypass voltage Phase A      Unsigned int        0.1         V   HT11 series just have phase A, the registers of phase B and C be reserved.
+2   Bypass voltage Phase B      Unsigned int        0.1         V        
+3   Bypass voltage Phase C      Unsigned int        0.1         V        
+4   Bypass current Phase A      Unsigned int        0.1         A        
+5   Bypass current Phase B      Unsigned int        0.1         A        
+6   Bypass current Phase C      Unsigned int        0.1         A
+7   Bypass frequency Phase A    Unsigned int        0.01        Hz        
+8   Bypass frequency Phase B    Unsigned int        0.01        Hz        
+9   Bypass frequency Phase C    Unsigned int        0.01        Hz        
+10  Bypass PF_A                 Unsigned int        0.01                
+11  Bypass PF_B                 Unsigned int        0.01                
+12  Bypass PF_C                 Unsigned int        0.01                
+13  Input voltage Phase A       Unsigned int        0.1         V   HT11 series just have phase A, the registers of phase B and C be reserved.
+14  Input voltage Phase B       Unsigned int        0.1         V        
+15  Input voltage Phase C       Unsigned int        0.1         V        
+16  Input current Phase A       Unsigned int        0.1         A        
+17  Input current Phase B       Unsigned int        0.1         A        
+18  Input current Phase C       Unsigned int        0.1         A        
+19  Input frequency Phase A     Unsigned int        0.01        Hz        
+20  Input frequency Phase B     Unsigned int        0.01        Hz        
+21  Input frequency Phase C     Unsigned int        0.01        Hz        
+22  Input PF_A                  Unsigned int        0.01                
+23  Input PF_B                  Unsigned int        0.01                
+24  Input PF_C                  Unsigned int        0.01                
+25  Output voltage Phase A      Unsigned int        0.1         V   HT11 series just have phase A, the registers of phase B and C be reserved.
+26  Output voltage Phase B      Unsigned int        0.1         V        
+27  Output voltage Phase C      Unsigned int        0.1         V        
+28  Output current Phase A      Unsigned int        0.1         A        
+29  Output current Phase B      Unsigned int        0.1         A        
+30  Output current Phase C      Unsigned int        0.1         A        
+31  Output frequency Phase A    Unsigned int        0.01        Hz        
+32  Output frequency Phase B    Unsigned int        0.01        Hz        
+33  Output frequency Phase C    Unsigned int        0.01        Hz        
+34  Output PF_A                 Unsigned int        0.01        
+35  Output PF_B                 Unsigned int        0.01                
+36  Output PF_C                 Unsigned int        0.01                
+37  Output kVA Phase A          Unsigned int        0.1/1       kVA/VA  HT11 series just have phase A, the registers of phase B and C be reserved. The coefficient of 1-3K is 1，unit is VA, other series coefficient is 0.1，unit is kVA
+38  Output kVA Phase B          Unsigned int        0.1         kVA        
+39  Output kVA Phase C          Unsigned int        0.1         kVA        
+40  Output kW Phase A           Unsigned int        0.1/1       kW/W        
+41  Output kW Phase B           Unsigned int        0.1         kW        
+42  Output kW Phase C           Unsigned int        0.1         kW        
+43  Output kVar Phase A         Unsigned int        0.1/1       kVar/Var        
+44  Output kVar Phase B         Unsigned int        0.1         kVar        
+45  Output kVar Phase C         Unsigned int        0.1         kVar        
+46  Load percent Phase A        Unsigned int        0.1         %        
+47  Load percent Phase B        Unsigned int        0.1         %        
+48  Load percent Phase C        Unsigned int        0.1         %        
+49  Environment temperature     Unsigned int        0.1         ℃        
+50  Battery voltage positive    Unsigned int        0.1         V    HT11 series just have positive, the registers of negative be reserved. Battery current: Charge>0,Discharge<0
+51  Battery voltage negative    Unsigned int        0.1         V        
+52  Battery current positive    int                 0.1         A        
+53  Battery current negative    int                 0.1         A        
+54  Battery temperature         Unsigned int        0.1         ℃        
+55  Battery remain time         Unsigned int        0.1         min        
+56  Battery capacity            Unsigned int        0.1         %        
+57  Bypass fan running time     Unsigned int        1           H        
+58 - 67   Reserved                                
+68  Monitor series number       Unsigned int        1                
+69  First monitor version number  Unsigned int      1                
+70  Second monitor version number Unsigned int      1                
+78  UPS series number           Unsigned int        1                   Bit0-Bit5: UPS series
+                                                                        7:HT11(6-20 KVA)
+                                                                        8:HT11(1-3 KVA)
+                                                                        Bit6-Bit15:Reserved
+79  UPS Type                    Unsigned int        　                  Bit0-Bit2：Input and output phase
+                                                                        1: 3in-3out
+                                                                        2: 3in -1out
+                                                                        3: 1in -1out
+                                                                        4: 1in -3out
+                                                                        5: 2in -2out
+                                                                        Bit3-Bit15:Reserved
+
+Telesignalization (Function code: 0x04)
+No. Name                    Data type(Hi-Lo)    Remark
+81  Load On Source            Unsigned int      0：None
+                                                1：UPS Supply
+                                                2：Bypass Supply
+82  Battery Status            Unsigned int      0：Not Work
+                                                1：Float Charge
+                                                2：Boost Charge
+                                                3：Discharge
+83  Battery Connect Status    Unsigned int      0：Not Connect
+                                                1：Connect
+84  Maintain Cb Status        Unsigned int      0：Open
+                                                1：Close 
+85  EPO                       Unsigned int      0：None
+                                                1：EPO
+86  Invertor Ready Capacity   Unsigned int      0：Enough
+                                                1：Not Enough
+87  Generator Input           Unsigned int      0：Disconnect
+                                                1：Connected
+88  Input Fail                Unsigned int      0：Normal
+                                                1：Abnormal
+89  Bypass Sequence Fail      Unsigned int      0：Normal
+                                                1：Abnormal
+90  Bypass Voltage Fail       Unsigned int      0：Normal
+                                                1：Abnormal
+91  Bypass Fail               Unsigned int      0：Normal
+                                                1：Abnormal
+92  Bypass Over Load          Unsigned int      0：No
+                                                1：Yes
+93  Bypass Over Load Timeout  Unsigned int      0：No
+                                                1：Yes
+94  Bypass Untrack            Unsigned int      0：No
+                                                1：Yes
+95  Tx Time Limit             Unsigned int      0：No
+                                                1：Yes
+96  Output Shorted            Unsigned int      0：No
+                                                1：Yes
+97  Battery EOD               Unsigned int      0：No
+                                                1：Yes
+98  Battery Test Begin (Reserved) Unsigned int  0：No
+                                                1：Yes
+99  Battery Test Result       Unsigned int      0: No Test
+                                                1:Test Success
+                                                2:Test Fail
+                                                3:Testing
+100 Battery Manual Test (Reserved) Unsigned int 0：No
+                                                1：Yes
+101 Battery Maintain Result   Unsigned int      0:No Maintain
+                                                1:Maintain success
+                                                2: Maintain Fail
+                                                3:Maintaining
+102 Stop Test (Reserved)      Unsigned int  
+103 Fault Clear (Reserved)    Unsigned int  
+104 Hislog Clear (Reserved)   Unsigned int  
+105 On Ups Inhibited          Unsigned int      0: Invertor On Enable
+                                                1: Invertor On Disable
+106 Manual Tx Bypass          Unsigned int      0: No
+                                                1: Yes
+107 Battery Volt Low          Unsigned int      0: No
+                                                1: Yes
+108 Battery Reverse           Unsigned int      0: No
+                                                1: Yes
+109 REC Status                Unsigned int      0:OFF
+                                                1:Soft Start
+                                                2:Normal Work
+110 Input Neutral Lost        Unsigned int      0: No Lost
+                                                1: Lost
+111 Bypass Fan Fail           Unsigned int      0: Normal
+                                                1: Fail
+112 Lost N+X Redundant        Unsigned int      0: No Lost
+                                                1: Lost
+113 EOD System Inhibited      Unsigned int      0: No
+                                                1: Inhibited
+114 CT Weld Reverse           Unsigned int      0: Normal
+                                                1: Reverse
+115 Electrolyte Leakage       Unsigned int      0: Normal
+                                                1: Leakage
+116 Sensor status             Unsigned int      Corresponding bit is 1 indicate the sensor is disconnected, 0 means it is connected.
+                                                Bit0: Battery temperature sensor
+                                                Bit1: Environment temperature sensor
+                                                Bit2-Bit15：Reserve
+117 Reserved    
+118 Integrated Alarm          Unsigned int      Bit0：1 Alarm, 0 Normal
+                                                Bit1：1 Fault, 0 Normal
+                                                Bit2-Bit15：Reserve
+121 Unit 1 Pull               Unsigned int      0: Pull Out   1: Join In
+122 Unit 1 REC Fail           Unsigned int      0: Normal   1: Abnormal
+123 Unit 1 INV Fail           Unsigned int      0: Normal   1: Abnormal
+124 Unit 1 REC Over Temperature Unsigned int    0: Normal   1: Abnormal
+125 Unit 1 Fan Fail           Unsigned int      0: Normal     1: Abnormal
+126 Unit 1 INV Over Load      Unsigned int      0: Normal   1: Abnormal
+127 Unit 1 INV Over Load Timeout  Unsigned int  0: Normal   1: Abnormal
+128 Unit 1 INV Over Temperature Unsigned int    0: Normal   1: Abnormal
+129 Unit 1 INV Protect        Unsigned int      0: Normal   1: Abnormal
+130 Unit 1 Manual Shutdown    Unsigned int      0: Normal   1: Shutdown
+131 Reserved    
+132 Reserved    
+133 Unit 2 Pull               Unsigned int  0: Pull Out   1: Join In
+134 Unit 2 REC Fail           Unsigned int  0: Normal   1: Abnormal
+135 Unit 2 INV Fail           Unsigned int  0: Normal   1: Abnormal
+136 Unit 2 REC Over Temperature Unsigned int  0: Normal   1: Abnormal
+137 Unit 2 Fan Fail           Unsigned int  0: Normal   1: Abnormal
+138 Unit 2 INV Over Load      Unsigned int  0: Normal   1: Abnormal
+139 Unit 2 INV Over Load Timeout  Unsigned int  0: Normal   1: Abnormal
+140 Unit 2 INV Over Temperature Unsigned int  0: Normal   1: Abnormal
+141 Unit 2 INV Protect        Unsigned int  0: Normal   1: Abnormal
+142 Unit 2 Manual Shutdown    Unsigned int  0: Normal   1: Shutdown
+143 Reserved    
+144 Reserved    
+145 Unit 3 Pull               Unsigned int  0: Pull Out   1: Join In
+146 Unit 3 REC Fail           Unsigned int  0: Normal   1: Abnormal
+147 Unit 3 INV Fail           Unsigned int  0: Normal   1: Abnormal
+148 Unit 3 REC Over Temperature Unsigned int  0: Normal   1: Abnormal
+149 Unit 3 Fan Fail           Unsigned int  0: Normal   1: Abnormal
+150 Unit 3 INV Over Load      Unsigned int  0: Normal   1: Abnormal
+151 Unit 3 INV Over Load Timeout  Unsigned int  0: Normal   1: Abnormal
+152 Unit 3 INV Over Temperature Unsigned int  0: Normal   1: Abnormal
+153 Unit 3 INV Protect        Unsigned int  0: Normal   1: Abnormal
+154 Unit 3 Manual Shutdown    Unsigned int  0: Normal   1: Shutdown
+155 Reserved    
+156 Reserved    
+157 Unit 4 Pull               Unsigned int  0: Pull Out   1: Join In
+158 Unit 4 REC Fail           Unsigned int  0: Normal   1: Abnormal
+159 Unit 4 INV Fail           Unsigned int  0: Normal   1: Abnormal
+160 Unit 4 REC Over Temperature Unsigned int  0: Normal   1: Abnormal
+161 Unit 4 Fan Fail           Unsigned int  0: Normal   1: Abnormal
+162 Unit 4 INV Over Load      Unsigned int  0: Normal   1: Abnormal
+163 Unit 4 INV Over Load Timeout  Unsigned int  0: Normal   1: Abnormal
+164 Unit 4 INV Over Temperature Unsigned int  0: Normal   1: Abnormal
+165 Unit 4 INV Protect        Unsigned int  0: Normal   1: Abnormal
+166 Unit 4 Manual Shutdown    Unsigned int  0: Normal   1: Shutdown
+167 Reserved    
+168 Reserved    
+169 Unit 5 Pull               Unsigned int  0: Pull Out   1: Join In
+170 Unit 5 REC Fail           Unsigned int  0: Normal   1: Abnormal
+171 Unit 5 INV Fail           Unsigned int  0: Normal   1: Abnormal
+172 Unit 5 REC Over Temperature Unsigned int  0: Normal   1: Abnormal
+173 Unit 5 Fan Fail           Unsigned int  0: Normal   1: Abnormal
+174 Unit 5 INV Over Load      Unsigned int  0: Normal   1: Abnormal
+175 Unit 5 INV Over Load Timeout  Unsigned int  0: Normal   1: Abnormal
+176 Unit 5 INV Over Temperature Unsigned int  0: Normal   1: Abnormal
+177 Unit 5 INV Protect        Unsigned int  0: Normal   1: Abnormal
+178 Unit 5 Manual Shutdown    Unsigned int  0: Normal   1: Shutdown
+179 Reserved    
+180 Reserved    
+181 Unit 6 Pull               Unsigned int  0: Pull Out   1: Join In
+182 Unit 6 REC Fail           Unsigned int  0: Normal   1: Abnormal
+183 Unit 6 INV Fail           Unsigned int  0: Normal   1: Abnormal
+184 Unit 6 REC Over Temperature Unsigned int  0: Normal   1: Abnormal
+185 Unit 6 Fan Fail Unsigned int  0: Normal   1: Abnormal
+186 Unit 6 INV Over Load      Unsigned int  0: Normal   1: Abnormal
+187 Unit 6 INV Over Load Timeout  Unsigned int  0: Normal   1: Abnormal
+188 Unit 6 INV Over Temperature Unsigned int  0: Normal   1: Abnormal
+189 Unit 6 INV Protect        Unsigned int  0: Normal   1: Abnormal
+190 Unit 6 Manual Shutdown    Unsigned int  0: Normal   1: Shutdown
+191 Reserved    
+192 Reserved    
+193 Unit 7 Pull               Unsigned int  0: Pull Out   1: Join In
+194 Unit 7 REC Fail           Unsigned int  0: Normal   1: Abnormal
+195 Unit 7 INV Fail           Unsigned int  0: Normal   1: Abnormal
+196 Unit 7 REC Over Temperature Unsigned int  0: Normal   1: Abnormal
+197 Unit 7 Fan Fail           Unsigned int  0: Normal   1: Abnormal
+198 Unit 7 INV Over Load      Unsigned int  0: Normal   1: Abnormal
+199 Unit 7 INV Over Load Timeout  Unsigned int  0: Normal   1: Abnormal
+200 Unit 7 INV Over Temperature Unsigned int  0: Normal   1: Abnormal
+201 Unit 7 INV Protect        Unsigned int  0: Normal   1: Abnormal
+202 Unit 7 Manual Shutdown    Unsigned int  0: Normal   1: Shutdown
+203 Reserved    
+204 Reserved    
+205 Unit 8 Pull               Unsigned int  0: Pull Out   1: Join In
+206 Unit 8 REC Fail           Unsigned int  0: Normal   1: Abnormal
+207 Unit 8 INV Fail           Unsigned int  0: Normal   1: Abnormal
+208 Unit 8 REC Over Temperature Unsigned int  0: Normal   1: Abnormal
+209 Unit 8 Fan Fail           Unsigned int  0: Normal   1: Abnormal
+210 Unit 8 INV Over Load      Unsigned int  0: Normal   1: Abnormal
+211 Unit 8 INV Over Load Timeout  Unsigned int  0: Normal   1: Abnormal
+212 Unit 8 INV Over Temperature Unsigned int  0: Normal   1: Abnormal
+213 Unit 8 INV Protect        Unsigned int  0: Normal   1: Abnormal
+214 Unit 8 Manual Shutdown    Unsigned int  0: Normal   1: Shutdown
+215 Reserved    
+216 Reserved    
+217 Unit 9 Pull               Unsigned int  0: Pull Out   1: Join In
+218 Unit 9 REC Fail           Unsigned int  0: Normal   1: Abnormal
+219 Unit 9 INV Fail           Unsigned int  0: Normal   1: Abnormal
+220 Unit 9 REC Over Temperature Unsigned int  0: Normal   1: Abnormal
+221 Unit 9 Fan Fail           Unsigned int  0: Normal   1: Abnormal
+222 Unit 9 INV Over Load      Unsigned int  0: Normal   1: Abnormal
+223 Unit 9 INV Over Load Timeout  Unsigned int  0: Normal   1: Abnormal
+224 Unit 9 INV Over Temperature Unsigned int  0: Normal   1: Abnormal
+225 Unit 9 INV Protect        Unsigned int  0: Normal   1: Abnormal
+226 Unit 9 Manual Shutdown    Unsigned int  0: Normal   1: Shutdown
+227 Reserved    
+228 Reserved    
+229 Unit 10 Pull              Unsigned int  0: Pull Out   1: Join In
+230 Unit 10 REC Fail          Unsigned int  0: Normal   1: Abnormal
+231 Unit 10 INV Fail          Unsigned int  0: Normal   1: Abnormal
+232 Unit 10 REC Over Temperature  Unsigned int  0: Normal   1: Abnormal
+233 Unit 10 Fan Fail          Unsigned int  0: Normal   1: Abnormal
+234 Unit 10 INV Over Load     Unsigned int  0: Normal   1: Abnormal
+235 Unit 10 INV Over Load Timeout Unsigned int  0: Normal   1: Abnormal
+236 Unit 10 INV Over Temperature  Unsigned int  0: Normal   1: Abnormal
+237 Unit 10 INV Protect       Unsigned int  0: Normal   1: Abnormal
+238 Unit 10 Manual Shutdown   Unsigned int  0: Normal   1: Shutdown
+239 Reserved    
+240 Reserved    
+
+*/

--- a/drivers/modbus-ascii.c
+++ b/drivers/modbus-ascii.c
@@ -1,0 +1,3301 @@
+/*
+ * Copyright © 2001-2011 Stéphane Raimbault <stephane.raimbault@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif
+#include <assert.h>
+
+#include "modbus-ascii.h"
+
+#if HAVE_DECL_TIOCSRS485
+#include <sys/ioctl.h>
+#endif
+
+#if HAVE_DECL_TIOCSRS485
+#include <linux/serial.h>
+#endif
+
+
+#if defined(HAVE_BYTESWAP_H)
+#  include <byteswap.h>
+#endif
+
+#if defined(__GNUC__)
+#  define GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__ * 10)
+#  if GCC_VERSION >= 430
+// Since GCC >= 4.30, GCC provides __builtin_bswapXX() alternatives so we switch to them
+#    undef bswap_32
+#    define bswap_32 __builtin_bswap32
+#  endif
+#endif
+#if defined(_MSC_VER) && (_MSC_VER >= 1400)
+# define bswap_32 _byteswap_ulong
+#endif
+
+#if !defined(bswap_32)
+
+#if !defined(bswap_16)
+#   warning "Fallback on C functions for bswap_16"
+static inline uint16_t bswap_16(uint16_t x)
+{
+    return (x >> 8) | (x << 8);
+}
+#endif
+
+#   warning "Fallback on C functions for bswap_32"
+static inline uint32_t bswap_32(uint32_t x)
+{
+    return (bswap_16(x & 0xffff) << 16) | (bswap_16(x >> 16));
+}
+#endif
+
+
+/* Internal use */
+#define MSG_LENGTH_UNDEFINED -1
+
+/* Exported version */
+const unsigned int libmodbus_version_major = LIBMODBUS_VERSION_MAJOR;
+const unsigned int libmodbus_version_minor = LIBMODBUS_VERSION_MINOR;
+const unsigned int libmodbus_version_micro = LIBMODBUS_VERSION_MICRO;
+
+/* Max between RTU and TCP max adu length (so TCP) */
+#define MAX_MESSAGE_LENGTH 260
+
+/* 3 steps are used to parse the query */
+typedef enum {
+    _STEP_FUNCTION,
+    _STEP_META,
+    _STEP_DATA
+} _step_t;
+
+const char *modbus_strerror(int errnum) {
+    switch (errnum) {
+    case EMBXILFUN:
+        return "Illegal function";
+    case EMBXILADD:
+        return "Illegal data address";
+    case EMBXILVAL:
+        return "Illegal data value";
+    case EMBXSFAIL:
+        return "Slave device or server failure";
+    case EMBXACK:
+        return "Acknowledge";
+    case EMBXSBUSY:
+        return "Slave device or server is busy";
+    case EMBXNACK:
+        return "Negative acknowledge";
+    case EMBXMEMPAR:
+        return "Memory parity error";
+    case EMBXGPATH:
+        return "Gateway path unavailable";
+    case EMBXGTAR:
+        return "Target device failed to respond";
+    case EMBBADCRC:
+        return "Invalid CRC";
+    case EMBBADDATA:
+        return "Invalid data";
+    case EMBBADEXC:
+        return "Invalid exception code";
+    case EMBMDATA:
+        return "Too many data";
+    case EMBBADSLAVE:
+        return "Response not from requested slave";
+    default:
+        return strerror(errnum);
+    }
+}
+
+void _error_print(modbus_t *ctx, const char *context)
+{
+    if (ctx->debug) {
+        fprintf(stderr, "ERROR %s", modbus_strerror(errno));
+        if (context != NULL) {
+            fprintf(stderr, ": %s\n", context);
+        } else {
+            fprintf(stderr, "\n");
+        }
+    }
+}
+
+static void _sleep_response_timeout(modbus_t *ctx)
+{
+    /* Response timeout is always positive */
+#ifdef _WIN32
+    /* usleep doesn't exist on Windows */
+    Sleep((ctx->response_timeout.tv_sec * 1000) +
+          (ctx->response_timeout.tv_usec / 1000));
+#else
+    /* usleep source code */
+    struct timespec request, remaining;
+    request.tv_sec = ctx->response_timeout.tv_sec;
+    request.tv_nsec = ((long int)ctx->response_timeout.tv_usec) * 1000;
+    while (nanosleep(&request, &remaining) == -1 && errno == EINTR) {
+        request = remaining;
+    }
+#endif
+}
+
+
+
+static int _modbus_ascii_select(modbus_t *ctx, fd_set *rset,
+                       struct timeval *tv, int length_to_read);
+
+static int _modbus_ascii_flush(modbus_t *);
+
+/* Define the slave ID of the remote device to talk in master mode or set the
+ * internal slave ID in slave mode */
+static int _modbus_set_slave(modbus_t *ctx, int slave)
+{
+    /* Broadcast address is 0 (MODBUS_BROADCAST_ADDRESS) */
+    if (slave >= 0 && slave <= 247) {
+        ctx->slave = slave;
+    } else {
+        errno = EINVAL;
+        return -1;
+    }
+
+    return 0;
+}
+
+/* Builds a ascii request header */
+static int _modbus_ascii_build_request_basis(modbus_t *ctx, int function,
+                                           int addr, int nb,
+                                           uint8_t *req)
+{
+    assert(ctx->slave != -1);
+    req[0] = ':';
+    req[1] = ctx->slave;
+    req[2] = function;
+    req[3] = addr >> 8;
+    req[4] = addr & 0x00ff;
+    req[5] = nb >> 8;
+    req[6] = nb & 0x00ff;
+
+
+    return _MODBUS_ASCII_PRESET_REQ_LENGTH;
+}
+
+/* Builds a ascii response header */
+static int _modbus_ascii_build_response_basis(sft_t *sft, uint8_t *rsp)
+{
+    /* In this case, the slave is certainly valid because a check is already
+     * done in _modbus_ascii_listen */
+    rsp[0] = sft->slave;
+    rsp[1] = sft->function;
+
+    return _MODBUS_ASCII_PRESET_RSP_LENGTH;
+}
+
+static uint8_t lcr8(uint8_t *buffer, uint16_t buffer_length)
+{
+    uint8_t lcr = 0; 
+
+    /* pass through message buffer */
+    while (buffer_length--) {
+        lcr += *buffer++; /* calculate the lcr  */
+    }
+
+    return -lcr; /* The sume of all raw databytes is 0 */
+}
+
+static int _modbus_ascii_prepare_response_tid(const uint8_t *req, int *req_length)
+{
+    (*req_length) -= _MODBUS_ASCII_CHECKSUM_LENGTH;
+    /* No TID */
+    return 0;
+}
+
+static int _modbus_ascii_send_msg_pre(uint8_t *req, int req_length)
+{
+    uint8_t lcr = lcr8(req + 1, req_length - 1);
+    req[req_length++] = lcr;
+    req[req_length++] = '\r';
+    req[req_length++] = '\n';
+
+    return req_length;
+}
+
+#if defined(_WIN32)
+
+/* This simple implementation is sort of a substitute of the select() call,
+ * working this way: the win32_ser_select() call tries to read some data from
+ * the serial port, setting the timeout as the select() call would. Data read is
+ * stored into the receive buffer, that is then consumed by the win32_ser_read()
+ * call.  So win32_ser_select() does both the event waiting and the reading,
+ * while win32_ser_read() only consumes the receive buffer.
+ */
+
+static void win32_ser_init(struct win32_ser *ws) {
+    /* Clear everything */
+    memset(ws, 0x00, sizeof(struct win32_ser));
+
+    /* Set file handle to invalid */
+    ws->fd = INVALID_HANDLE_VALUE;
+}
+
+/* FIXME Try to remove length_to_read -> max_len argument, only used by win32 */
+static int win32_ser_select(struct win32_ser *ws, int max_len,
+                            struct timeval *tv) {
+    COMMTIMEOUTS comm_to;
+    unsigned int msec = 0;
+
+    /* Check if some data still in the buffer to be consumed */
+    if (ws->n_bytes > 0) {
+        return 1;
+    }
+
+    /* Setup timeouts like select() would do.
+       FIXME Please someone on Windows can look at this?
+       Does it possible to use WaitCommEvent?
+       When tv is NULL, MAXDWORD isn't infinite!
+     */
+    if (tv == NULL) {
+        msec = MAXDWORD;
+    } else {
+        msec = tv->tv_sec * 1000 + tv->tv_usec / 1000;
+        if (msec < 1)
+            msec = 1;
+    }
+
+    comm_to.ReadIntervalTimeout = msec;
+    comm_to.ReadTotalTimeoutMultiplier = 0;
+    comm_to.ReadTotalTimeoutConstant = msec;
+    comm_to.WriteTotalTimeoutMultiplier = 0;
+    comm_to.WriteTotalTimeoutConstant = 1000;
+    SetCommTimeouts(ws->fd, &comm_to);
+
+    /* Read some bytes */
+    if ((max_len > PY_BUF_SIZE) || (max_len < 0)) {
+        max_len = PY_BUF_SIZE;
+    }
+
+    if (ReadFile(ws->fd, &ws->buf, max_len, &ws->n_bytes, NULL)) {
+        /* Check if some bytes available */
+        if (ws->n_bytes > 0) {
+            /* Some bytes read */
+            return 1;
+        } else {
+            /* Just timed out */
+            return 0;
+        }
+    } else {
+        /* Some kind of error */
+        return -1;
+    }
+}
+
+static int win32_ser_read(struct win32_ser *ws, uint8_t *p_msg,
+                          unsigned int max_len) {
+    unsigned int n = ws->n_bytes;
+
+    if (max_len < n) {
+        n = max_len;
+    }
+
+    if (n > 0) {
+        memcpy(p_msg, ws->buf, n);
+    }
+
+    ws->n_bytes -= n;
+
+    return n;
+}
+#endif
+
+static char nibble_to_hex_ascii(uint8_t nibble) {
+    char c;
+    if (nibble < 10) {
+        c = nibble + '0';
+    } else {
+        c = nibble - 10 + 'A';
+    }
+    return c;
+}
+
+static uint8_t hex_ascii_to_nibble(char digit) {
+    if (digit >= '0' && digit <= '9' ) {
+        return digit - '0'; 
+    } else if (digit >= 'A' && digit <= 'F' ) {
+        return digit - 'A' + 10;
+    } else if (digit >= 'a' && digit <= 'f' ) {
+        return digit - 'a' + 10;
+    }
+    return 0xff; 
+}
+
+
+static ssize_t _modbus_ascii_send(modbus_t *ctx, const uint8_t *req, int req_length)
+{
+    int i;    
+    int k;
+    char ascii_req[3 + (MODBUS_ASCII_MAX_ADU_LENGTH * 2)];
+    int send_lenghth;
+
+    ascii_req[0] = req[0]; // ':'
+    k = 1;
+    for (i = 1; i < req_length - 2; ++i) {
+        ascii_req[k++] = nibble_to_hex_ascii(req[i] >> 4);
+        ascii_req[k++] = nibble_to_hex_ascii(req[i] & 0x0f);
+    }
+    ascii_req[k++] = req[i++]; // '\r'
+    ascii_req[k++] = req[i++]; // '\n'
+    ascii_req[k] = '\0';
+
+#if defined(_WIN32)
+    modbus_ascii_t *ctx_ascii = ctx->backend_data;
+    DWORD n_bytes = 0;
+    send_lenghth = (WriteFile(ctx_ascii->w_ser.fd, ascii_req, k, &n_bytes, NULL)) ? n_bytes : -1;
+#else
+    send_lenghth = write(ctx->s, ascii_req, k);
+#endif
+    send_lenghth = ((send_lenghth - 3) / 2) + 3;
+    return send_lenghth;
+}
+
+static int _modbus_ascii_receive(modbus_t *ctx, uint8_t *req)
+{
+    int rc;
+    modbus_ascii_t *ctx_ascii = ctx->backend_data;
+
+    if (ctx_ascii->confirmation_to_ignore) {
+        _modbus_receive_msg(ctx, req, MSG_CONFIRMATION);
+        /* Ignore errors and reset the flag */
+        ctx_ascii->confirmation_to_ignore = FALSE;
+        rc = 0;
+        if (ctx->debug) {
+            printf("Confirmation to ignore\n");
+        }
+    } else {
+        rc = _modbus_receive_msg(ctx, req, MSG_INDICATION);
+        if (rc == 0) {
+            /* The next expected message is a confirmation to ignore */
+            ctx_ascii->confirmation_to_ignore = TRUE;
+        }
+    }
+    return rc;
+}
+
+static ssize_t _modbus_ascii_recv_char(modbus_t *ctx, char *p_char_rsp, uint8_t with_select)
+{
+    int rc;
+    fd_set rset;
+    struct timeval tv;
+    ssize_t size;
+
+    if (with_select) {
+        FD_ZERO(&rset);
+        FD_SET(ctx->s, &rset);
+
+        if (ctx->byte_timeout.tv_sec >= 0 && ctx->byte_timeout.tv_usec >= 0) {
+            /* Byte timeout can be disabled with negative values */
+            tv.tv_sec = ctx->byte_timeout.tv_sec;
+            tv.tv_usec = ctx->byte_timeout.tv_usec;
+        } else {
+            tv.tv_sec = ctx->response_timeout.tv_sec;
+            tv.tv_usec = ctx->response_timeout.tv_usec;
+        }
+
+        rc = _modbus_ascii_select(ctx, &rset, &tv, 1);
+        if (rc == -1) {
+            return 0;
+        }
+    }
+#if defined(_WIN32)
+    size = win32_ser_read(&((modbus_ascii_t *)ctx->backend_data)->w_ser, p_char_rsp, 1);
+#else
+    size = read(ctx->s, p_char_rsp, 1);
+#endif
+    return size;
+}
+
+
+static ssize_t _modbus_ascii_recv(modbus_t *ctx, uint8_t *rsp, int rsp_length)
+{
+    char char_resp;
+    uint8_t nibble_resp;
+
+    // Call here without select, because we are already selected
+    if (_modbus_ascii_recv_char(ctx, &char_resp, 0) != 1) {
+        return 0;
+    }
+
+    if (char_resp == ':' || char_resp == '\r' || char_resp == '\n') {
+        *rsp = char_resp;
+    } else {
+        nibble_resp = hex_ascii_to_nibble(char_resp);
+        *rsp = nibble_resp << 4;
+        if (_modbus_ascii_recv_char(ctx, &char_resp, 1) != 1) {
+            return 0;
+        }
+        nibble_resp = hex_ascii_to_nibble(char_resp);
+        *rsp |= nibble_resp;
+    }
+    return 1;
+}
+
+static int _modbus_ascii_pre_check_confirmation(modbus_t *ctx, const uint8_t *req,
+                                              const uint8_t *rsp, int rsp_length)
+{
+    /* Check responding slave is the slave we requested (except for broadcast
+     * request) */
+    if (req[1] != rsp[1] && req[1] != MODBUS_BROADCAST_ADDRESS) {
+        if (ctx->debug) {
+            fprintf(stderr,
+                    "The responding slave %d isn't the requested slave %d\n",
+                    rsp[1], req[1]);
+        }
+        errno = EMBBADSLAVE;
+        return -1;
+    } else {
+        return 0;
+    }
+}
+
+/* The check_crc16 function shall return 0 if the message is ignored and the
+   message length if the CRC is valid. Otherwise it shall return -1 and set
+   errno to EMBADCRC. */
+static int _modbus_ascii_check_integrity(modbus_t *ctx, uint8_t *msg,
+                                       const int msg_length)
+{
+    uint8_t lcr;
+    char colon = msg[0];
+    int slave = msg[1];
+
+    /* check for leading colon*/
+    if (colon != ':') {
+        if (ctx->debug) {
+            printf("No leading colon\n");
+        }
+        /* Following call to check_confirmation handles this error */
+        return 0;
+    }
+
+    /* Filter on the Modbus unit identifier (slave) in ascii mode to avoid useless
+     * CRC computing. */
+    if (slave != ctx->slave && slave != MODBUS_BROADCAST_ADDRESS) {
+        if (ctx->debug) {
+            printf("Request for slave %d ignored (not %d)\n", slave, ctx->slave);
+        }
+        /* Following call to check_confirmation handles this error */
+        return 0;
+    }
+
+    lcr = lcr8(msg + 1, msg_length - 3); /* strip ":" and "\r\n" */
+    /* Check CRC of msg */
+    if (lcr == 0) {
+        return msg_length;
+    } else {
+        if (ctx->debug) {
+            fprintf(stderr, "ERROR lcr received %0X != 0\n", lcr);
+        }
+
+        if (ctx->error_recovery & MODBUS_ERROR_RECOVERY_PROTOCOL) {
+            _modbus_ascii_flush(ctx);
+        }
+        errno = EMBBADCRC;
+        return -1;
+    }
+}
+
+/* Sets up a serial port for ascii communications */
+static int _modbus_ascii_connect(modbus_t *ctx)
+{
+#if defined(_WIN32)
+    DCB dcb;
+#else
+    struct termios tios;
+    speed_t speed;
+    int flags;
+#endif
+    modbus_ascii_t *ctx_ascii = ctx->backend_data;
+
+    if (ctx->debug) {
+        printf("Opening %s at %d bauds (%c, %d, %d)\n",
+               ctx_ascii->device, ctx_ascii->baud, ctx_ascii->parity,
+               ctx_ascii->data_bit, ctx_ascii->stop_bit);
+    }
+
+#if defined(_WIN32)
+    /* Some references here:
+     * http://msdn.microsoft.com/en-us/library/aa450602.aspx
+     */
+    win32_ser_init(&ctx_ascii->w_ser);
+
+    /* ctx_ascii->device should contain a string like "COMxx:" xx being a decimal
+     * number */
+    ctx_ascii->w_ser.fd = CreateFileA(ctx_ascii->device,
+                                    GENERIC_READ | GENERIC_WRITE,
+                                    0,
+                                    NULL,
+                                    OPEN_EXISTING,
+                                    0,
+                                    NULL);
+
+    /* Error checking */
+    if (ctx_ascii->w_ser.fd == INVALID_HANDLE_VALUE) {
+        if (ctx->debug) {
+            fprintf(stderr, "ERROR Can't open the device %s (LastError %d)\n",
+                    ctx_ascii->device, (int)GetLastError());
+        }
+        return -1;
+    }
+
+    /* Save params */
+    ctx_ascii->old_dcb.DCBlength = sizeof(DCB);
+    if (!GetCommState(ctx_ascii->w_ser.fd, &ctx_ascii->old_dcb)) {
+        if (ctx->debug) {
+            fprintf(stderr, "ERROR Error getting configuration (LastError %d)\n",
+                    (int)GetLastError());
+        }
+        CloseHandle(ctx_ascii->w_ser.fd);
+        ctx_ascii->w_ser.fd = INVALID_HANDLE_VALUE;
+        return -1;
+    }
+
+    /* Build new configuration (starting from current settings) */
+    dcb = ctx_ascii->old_dcb;
+
+    /* Speed setting */
+    switch (ctx_ascii->baud) {
+    case 110:
+        dcb.BaudRate = CBR_110;
+        break;
+    case 300:
+        dcb.BaudRate = CBR_300;
+        break;
+    case 600:
+        dcb.BaudRate = CBR_600;
+        break;
+    case 1200:
+        dcb.BaudRate = CBR_1200;
+        break;
+    case 2400:
+        dcb.BaudRate = CBR_2400;
+        break;
+    case 4800:
+        dcb.BaudRate = CBR_4800;
+        break;
+    case 9600:
+        dcb.BaudRate = CBR_9600;
+        break;
+    case 14400:
+        dcb.BaudRate = CBR_14400;
+        break;
+    case 19200:
+        dcb.BaudRate = CBR_19200;
+        break;
+    case 38400:
+        dcb.BaudRate = CBR_38400;
+        break;
+    case 57600:
+        dcb.BaudRate = CBR_57600;
+        break;
+    case 115200:
+        dcb.BaudRate = CBR_115200;
+        break;
+    case 230400:
+        /* CBR_230400 - not defined */
+        dcb.BaudRate = 230400;
+        break;
+    case 250000:
+        dcb.BaudRate = 250000;
+        break;
+    case 460800:
+        dcb.BaudRate = 460800;
+        break;
+    case 500000:
+        dcb.BaudRate = 500000;
+        break;
+    case 921600:
+        dcb.BaudRate = 921600;
+        break;
+    case 1000000:
+        dcb.BaudRate = 1000000;
+        break;
+    default:
+        dcb.BaudRate = CBR_9600;
+        if (ctx->debug) {
+            fprintf(stderr, "WARNING Unknown baud rate %d for %s (B9600 used)\n",
+                    ctx_ascii->baud, ctx_ascii->device);
+        }
+    }
+
+    /* Data bits */
+    switch (ctx_ascii->data_bit) {
+    case 5:
+        dcb.ByteSize = 5;
+        break;
+    case 6:
+        dcb.ByteSize = 6;
+        break;
+    case 7:
+        dcb.ByteSize = 7;
+        break;
+    case 8:
+    default:
+        dcb.ByteSize = 8;
+        break;
+    }
+
+    /* Stop bits */
+    if (ctx_ascii->stop_bit == 1)
+        dcb.StopBits = ONESTOPBIT;
+    else /* 2 */
+        dcb.StopBits = TWOSTOPBITS;
+
+    /* Parity */
+    if (ctx_ascii->parity == 'N') {
+        dcb.Parity = NOPARITY;
+        dcb.fParity = FALSE;
+    } else if (ctx_ascii->parity == 'E') {
+        dcb.Parity = EVENPARITY;
+        dcb.fParity = TRUE;
+    } else {
+        /* odd */
+        dcb.Parity = ODDPARITY;
+        dcb.fParity = TRUE;
+    }
+
+    /* Hardware handshaking left as default settings retrieved */
+
+    /* No software handshaking */
+    dcb.fTXContinueOnXoff = TRUE;
+    dcb.fOutX = FALSE;
+    dcb.fInX = FALSE;
+
+    /* Binary mode (it's the only supported on Windows anyway) */
+    dcb.fBinary = TRUE;
+
+    /* Don't want errors to be blocking */
+    dcb.fAbortOnError = FALSE;
+
+    /* Setup port */
+    if (!SetCommState(ctx_ascii->w_ser.fd, &dcb)) {
+        if (ctx->debug) {
+            fprintf(stderr, "ERROR Error setting new configuration (LastError %d)\n",
+                    (int)GetLastError());
+        }
+        CloseHandle(ctx_ascii->w_ser.fd);
+        ctx_ascii->w_ser.fd = INVALID_HANDLE_VALUE;
+        return -1;
+    }
+#else
+    /* The O_NOCTTY flag tells UNIX that this program doesn't want
+       to be the "controlling terminal" for that port. If you
+       don't specify this then any input (such as keyboard abort
+       signals and so forth) will affect your process
+
+       Timeouts are ignored in canonical input mode or when the
+       NDELAY option is set on the file via open or fcntl */
+    flags = O_RDWR | O_NOCTTY | O_NDELAY | O_EXCL;
+#ifdef O_CLOEXEC
+    flags |= O_CLOEXEC;
+#endif
+
+    ctx->s = open(ctx_ascii->device, flags);
+    if (ctx->s == -1) {
+        if (ctx->debug) {
+            fprintf(stderr, "ERROR Can't open the device %s (%s)\n",
+                    ctx_ascii->device, strerror(errno));
+        }
+        return -1;
+    }
+
+    /* Save */
+    tcgetattr(ctx->s, &(ctx_ascii->old_tios));
+
+    memset(&tios, 0, sizeof(struct termios));
+
+    /* C_ISPEED     Input baud (new interface)
+       C_OSPEED     Output baud (new interface)
+    */
+    switch (ctx_ascii->baud) {
+    case 110:
+        speed = B110;
+        break;
+    case 300:
+        speed = B300;
+        break;
+    case 600:
+        speed = B600;
+        break;
+    case 1200:
+        speed = B1200;
+        break;
+    case 2400:
+        speed = B2400;
+        break;
+    case 4800:
+        speed = B4800;
+        break;
+    case 9600:
+        speed = B9600;
+        break;
+    case 19200:
+        speed = B19200;
+        break;
+    case 38400:
+        speed = B38400;
+        break;
+#ifdef B57600
+    case 57600:
+        speed = B57600;
+        break;
+#endif
+#ifdef B115200
+    case 115200:
+        speed = B115200;
+        break;
+#endif
+#ifdef B230400
+    case 230400:
+        speed = B230400;
+        break;
+#endif
+#ifdef B460800
+    case 460800:
+        speed = B460800;
+        break;
+#endif
+#ifdef B500000
+    case 500000:
+        speed = B500000;
+        break;
+#endif
+#ifdef B576000
+    case 576000:
+        speed = B576000;
+        break;
+#endif
+#ifdef B921600
+    case 921600:
+        speed = B921600;
+        break;
+#endif
+#ifdef B1000000
+    case 1000000:
+        speed = B1000000;
+        break;
+#endif
+#ifdef B1152000
+   case 1152000:
+        speed = B1152000;
+        break;
+#endif
+#ifdef B1500000
+    case 1500000:
+        speed = B1500000;
+        break;
+#endif
+#ifdef B2500000
+    case 2500000:
+        speed = B2500000;
+        break;
+#endif
+#ifdef B3000000
+    case 3000000:
+        speed = B3000000;
+        break;
+#endif
+#ifdef B3500000
+    case 3500000:
+        speed = B3500000;
+        break;
+#endif
+#ifdef B4000000
+    case 4000000:
+        speed = B4000000;
+        break;
+#endif
+    default:
+        speed = B9600;
+        if (ctx->debug) {
+            fprintf(stderr,
+                    "WARNING Unknown baud rate %d for %s (B9600 used)\n",
+                    ctx_ascii->baud, ctx_ascii->device);
+        }
+    }
+
+    /* Set the baud rate */
+    if ((cfsetispeed(&tios, speed) < 0) ||
+        (cfsetospeed(&tios, speed) < 0)) {
+        close(ctx->s);
+        ctx->s = -1;
+        return -1;
+    }
+
+    /* C_CFLAG      Control options
+       CLOCAL       Local line - do not change "owner" of port
+       CREAD        Enable receiver
+    */
+    tios.c_cflag |= (CREAD | CLOCAL);
+    /* CSIZE, HUPCL, CRTSCTS (hardware flow control) */
+
+    /* Set data bits (5, 6, 7, 8 bits)
+       CSIZE        Bit mask for data bits
+    */
+    tios.c_cflag &= ~CSIZE;
+    switch (ctx_ascii->data_bit) {
+    case 5:
+        tios.c_cflag |= CS5;
+        break;
+    case 6:
+        tios.c_cflag |= CS6;
+        break;
+    case 7:
+        tios.c_cflag |= CS7;
+        break;
+    case 8:
+    default:
+        tios.c_cflag |= CS8;
+        break;
+    }
+
+    /* Stop bit (1 or 2) */
+    if (ctx_ascii->stop_bit == 1)
+        tios.c_cflag &=~ CSTOPB;
+    else /* 2 */
+        tios.c_cflag |= CSTOPB;
+
+    /* PARENB       Enable parity bit
+       PARODD       Use odd parity instead of even */
+    if (ctx_ascii->parity == 'N') {
+        /* None */
+        tios.c_cflag &=~ PARENB;
+    } else if (ctx_ascii->parity == 'E') {
+        /* Even */
+        tios.c_cflag |= PARENB;
+        tios.c_cflag &=~ PARODD;
+    } else {
+        /* Odd */
+        tios.c_cflag |= PARENB;
+        tios.c_cflag |= PARODD;
+    }
+
+    /* Read the man page of termios if you need more information. */
+
+    /* This field isn't used on POSIX systems
+       tios.c_line = 0;
+    */
+
+    /* C_LFLAG      Line options
+
+       ISIG Enable SIGINTR, SIGSUSP, SIGDSUSP, and SIGQUIT signals
+       ICANON       Enable canonical input (else raw)
+       XCASE        Map uppercase \lowercase (obsolete)
+       ECHO Enable echoing of input characters
+       ECHOE        Echo erase character as BS-SP-BS
+       ECHOK        Echo NL after kill character
+       ECHONL       Echo NL
+       NOFLSH       Disable flushing of input buffers after
+       interrupt or quit characters
+       IEXTEN       Enable extended functions
+       ECHOCTL      Echo control characters as ^char and delete as ~?
+       ECHOPRT      Echo erased character as character erased
+       ECHOKE       BS-SP-BS entire line on line kill
+       FLUSHO       Output being flushed
+       PENDIN       Retype pending input at next read or input char
+       TOSTOP       Send SIGTTOU for background output
+
+       Canonical input is line-oriented. Input characters are put
+       into a buffer which can be edited interactively by the user
+       until a CR (carriage return) or LF (line feed) character is
+       received.
+
+       Raw input is unprocessed. Input characters are passed
+       through exactly as they are received, when they are
+       received. Generally you'll deselect the ICANON, ECHO,
+       ECHOE, and ISIG options when using raw input
+    */
+
+    /* Raw input */
+    tios.c_lflag &= ~(ICANON | ECHO | ECHOE | ISIG);
+
+    /* C_IFLAG      Input options
+
+       Constant     Description
+       INPCK        Enable parity check
+       IGNPAR       Ignore parity errors
+       PARMRK       Mark parity errors
+       ISTRIP       Strip parity bits
+       IXON Enable software flow control (outgoing)
+       IXOFF        Enable software flow control (incoming)
+       IXANY        Allow any character to start flow again
+       IGNBRK       Ignore break condition
+       BRKINT       Send a SIGINT when a break condition is detected
+       INLCR        Map NL to CR
+       IGNCR        Ignore CR
+       ICRNL        Map CR to NL
+       IUCLC        Map uppercase to lowercase
+       IMAXBEL      Echo BEL on input line too long
+    */
+    if (ctx_ascii->parity == 'N') {
+        /* None */
+        tios.c_iflag &= ~INPCK;
+    } else {
+        tios.c_iflag |= INPCK;
+    }
+
+    /* Software flow control is disabled */
+    tios.c_iflag &= ~(IXON | IXOFF | IXANY);
+
+    /* C_OFLAG      Output options
+       OPOST        Postprocess output (not set = raw output)
+       ONLCR        Map NL to CR-NL
+
+       ONCLR ant others needs OPOST to be enabled
+    */
+
+    /* Raw ouput */
+    tios.c_oflag &=~ OPOST;
+
+    /* C_CC         Control characters
+       VMIN         Minimum number of characters to read
+       VTIME        Time to wait for data (tenths of seconds)
+
+       UNIX serial interface drivers provide the ability to
+       specify character and packet timeouts. Two elements of the
+       c_cc array are used for timeouts: VMIN and VTIME. Timeouts
+       are ignored in canonical input mode or when the NDELAY
+       option is set on the file via open or fcntl.
+
+       VMIN specifies the minimum number of characters to read. If
+       it is set to 0, then the VTIME value specifies the time to
+       wait for every character read. Note that this does not mean
+       that a read call for N bytes will wait for N characters to
+       come in. Rather, the timeout will apply to the first
+       character and the read call will return the number of
+       characters immediately available (up to the number you
+       request).
+
+       If VMIN is non-zero, VTIME specifies the time to wait for
+       the first character read. If a character is read within the
+       time given, any read will block (wait) until all VMIN
+       characters are read. That is, once the first character is
+       read, the serial interface driver expects to receive an
+       entire packet of characters (VMIN bytes total). If no
+       character is read within the time allowed, then the call to
+       read returns 0. This method allows you to tell the serial
+       driver you need exactly N bytes and any read call will
+       return 0 or N bytes. However, the timeout only applies to
+       the first character read, so if for some reason the driver
+       misses one character inside the N byte packet then the read
+       call could block forever waiting for additional input
+       characters.
+
+       VTIME specifies the amount of time to wait for incoming
+       characters in tenths of seconds. If VTIME is set to 0 (the
+       default), reads will block (wait) indefinitely unless the
+       NDELAY option is set on the port with open or fcntl.
+    */
+    /* Unused because we use open with the NDELAY option */
+    tios.c_cc[VMIN] = 0;
+    tios.c_cc[VTIME] = 0;
+
+    if (tcsetattr(ctx->s, TCSANOW, &tios) < 0) {
+        close(ctx->s);
+        ctx->s = -1;
+        return -1;
+    }
+#endif
+
+    return 0;
+}
+
+int modbus_ascii_set_serial_mode(modbus_t *ctx, int mode)
+{
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (ctx->backend->backend_type == _MODBUS_BACKEND_TYPE_ASCII) {
+#if HAVE_DECL_TIOCSRS485
+        modbus_ascii_t *ctx_ascii = ctx->backend_data;
+        struct serial_rs485 rs485conf;
+        memset(&rs485conf, 0x0, sizeof(struct serial_rs485));
+
+        if (mode == MODBUS_ASCII_RS485) {
+            rs485conf.flags = SER_RS485_ENABLED;
+            if (ioctl(ctx->s, TIOCSRS485, &rs485conf) < 0) {
+                return -1;
+            }
+
+            ctx_ascii->serial_mode = MODBUS_ASCII_RS485;
+            return 0;
+        } else if (mode == MODBUS_ASCII_RS232) {
+            /* Turn off RS485 mode only if required */
+            if (ctx_ascii->serial_mode == MODBUS_ASCII_RS485) {
+                /* The ioctl call is avoided because it can fail on some RS232 ports */
+                if (ioctl(ctx->s, TIOCSRS485, &rs485conf) < 0) {
+                    return -1;
+                }
+            }
+            ctx_ascii->serial_mode = MODBUS_ASCII_RS232;
+            return 0;
+        }
+#else
+        if (ctx->debug) {
+            fprintf(stderr, "This function isn't supported on your platform\n");
+        }
+        errno = ENOTSUP;
+        return -1;
+#endif
+    }
+
+    /* Wrong backend and invalid mode specified */
+    errno = EINVAL;
+    return -1;
+}
+
+int modbus_ascii_serial_mode(modbus_t *ctx)
+{
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (ctx->backend->backend_type == _MODBUS_BACKEND_TYPE_ASCII) {
+#if HAVE_DECL_TIOCSRS485
+        modbus_ascii_t *ctx_ascii = ctx->backend_data;
+        return ctx_ascii->serial_mode;
+#else
+        if (ctx->debug) {
+            fprintf(stderr, "This function isn't supported on your platform\n");
+        }
+        errno = ENOTSUP;
+        return -1;
+#endif
+    } else {
+        errno = EINVAL;
+        return -1;
+    }
+}
+
+static void _modbus_ascii_close(modbus_t *ctx)
+{
+    /* Restore line settings and close file descriptor in ascii mode */
+    modbus_ascii_t *ctx_ascii = ctx->backend_data;
+
+#if defined(_WIN32)
+    /* Revert settings */
+    if (!SetCommState(ctx_ascii->w_ser.fd, &ctx_ascii->old_dcb) && ctx->debug) {
+        fprintf(stderr, "ERROR Couldn't revert to configuration (LastError %d)\n",
+                (int)GetLastError());
+    }
+
+    if (!CloseHandle(ctx_ascii->w_ser.fd) && ctx->debug) {
+        fprintf(stderr, "ERROR Error while closing handle (LastError %d)\n",
+                (int)GetLastError());
+    }
+#else
+    if (ctx->s != -1) {
+        tcsetattr(ctx->s, TCSANOW, &(ctx_ascii->old_tios));
+        close(ctx->s);
+        ctx->s = -1;
+    }
+#endif
+}
+
+static int _modbus_ascii_flush(modbus_t *ctx)
+{
+#if defined(_WIN32)
+    modbus_ascii_t *ctx_ascii = ctx->backend_data;
+    ctx_ascii->w_ser.n_bytes = 0;
+    return (FlushFileBuffers(ctx_ascii->w_ser.fd) == FALSE);
+#else
+    return tcflush(ctx->s, TCIOFLUSH);
+#endif
+}
+
+static int _modbus_ascii_select(modbus_t *ctx, fd_set *rset,
+                       struct timeval *tv, int length_to_read)
+{
+    int s_rc;
+
+    (void)length_to_read; /* unused */
+
+#if defined(_WIN32)
+    s_rc = win32_ser_select(&(((modbus_ascii_t*)ctx->backend_data)->w_ser),
+                            1, tv);
+    if (s_rc == 0) {
+        errno = ETIMEDOUT;
+        return -1;
+    }
+
+    if (s_rc < 0) {
+        return -1;
+    }
+#else
+    while ((s_rc = select(ctx->s+1, rset, NULL, NULL, tv)) == -1) {
+        if (errno == EINTR) {
+            if (ctx->debug) {
+                fprintf(stderr, "A non blocked signal was caught\n");
+            }
+            /* Necessary after an error */
+            FD_ZERO(rset);
+            FD_SET(ctx->s, rset);
+        } else {
+            return -1;
+        }
+    }
+
+    if (s_rc == 0) {
+        /* Timeout */
+        errno = ETIMEDOUT;
+        return -1;
+    }
+#endif
+
+    return s_rc;
+}
+
+static void _modbus_ascii_free(modbus_t *ctx) {
+    free(((modbus_ascii_t*)ctx->backend_data)->device);
+    free(ctx->backend_data);
+    free(ctx);
+}
+
+const modbus_backend_t _modbus_ascii_backend = {
+    _MODBUS_BACKEND_TYPE_ASCII,
+    _MODBUS_ASCII_HEADER_LENGTH,
+    _MODBUS_ASCII_CHECKSUM_LENGTH,
+    MODBUS_ASCII_MAX_ADU_LENGTH,
+    _modbus_set_slave,
+    _modbus_ascii_build_request_basis,
+    _modbus_ascii_build_response_basis,
+    _modbus_ascii_prepare_response_tid,
+    _modbus_ascii_send_msg_pre,
+    _modbus_ascii_send,
+    _modbus_ascii_receive,
+    _modbus_ascii_recv,
+    _modbus_ascii_check_integrity,
+    _modbus_ascii_pre_check_confirmation,
+    _modbus_ascii_connect,
+    _modbus_ascii_close,
+    _modbus_ascii_flush,
+    _modbus_ascii_select,
+    _modbus_ascii_free
+};
+
+modbus_t* modbus_new_ascii(const char *device,
+                         int baud, char parity, int data_bit,
+                         int stop_bit)
+{
+    modbus_t *ctx;
+    modbus_ascii_t *ctx_ascii;
+
+    ctx = (modbus_t *) malloc(sizeof(modbus_t));
+    _modbus_init_common(ctx);
+    ctx->backend = &_modbus_ascii_backend;
+    ctx->backend_data = (modbus_ascii_t *) malloc(sizeof(modbus_ascii_t));
+    ctx_ascii = (modbus_ascii_t *)ctx->backend_data;
+
+    /* Check device argument */
+    if (device == NULL || (*device) == 0) {
+        fprintf(stderr, "The device string is empty\n");
+        modbus_free(ctx);
+        errno = EINVAL;
+        return NULL;
+    }
+
+    /* Device name and \0 */
+    ctx_ascii->device = (char *) malloc((strlen(device) + 1) * sizeof(char));
+    strcpy(ctx_ascii->device, device);
+
+    ctx_ascii->baud = baud;
+    if (parity == 'N' || parity == 'E' || parity == 'O') {
+        ctx_ascii->parity = parity;
+    } else {
+        modbus_free(ctx);
+        errno = EINVAL;
+        return NULL;
+    }
+    ctx_ascii->data_bit = data_bit;
+    ctx_ascii->stop_bit = stop_bit;
+
+#if HAVE_DECL_TIOCSRS485
+    /* The RS232 mode has been set by default */
+    ctx_ascii->serial_mode = MODBUS_ASCII_RS232;
+#endif
+
+    ctx_ascii->confirmation_to_ignore = FALSE;
+
+    return ctx;
+}
+
+
+int modbus_flush(modbus_t *ctx)
+{
+    int rc;
+
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    rc = ctx->backend->flush(ctx);
+    if (rc > 0 && ctx->debug) {
+        /* Not all backends are able to return the number of bytes flushed */
+        printf("Bytes flushed (%d)\n", rc);
+    }
+    return rc;
+}
+
+/* Computes the length of the expected response */
+static unsigned int compute_response_length_from_request(modbus_t *ctx, uint8_t *req)
+{
+    int length;
+    const int offset = ctx->backend->header_length;
+
+    switch (req[offset]) {
+    case MODBUS_FC_READ_COILS:
+    case MODBUS_FC_READ_DISCRETE_INPUTS: {
+        /* Header + nb values (code from write_bits) */
+        int nb = (req[offset + 3] << 8) | req[offset + 4];
+        length = 2 + (nb / 8) + ((nb % 8) ? 1 : 0);
+    }
+        break;
+    case MODBUS_FC_WRITE_AND_READ_REGISTERS:
+    case MODBUS_FC_READ_HOLDING_REGISTERS:
+    case MODBUS_FC_READ_INPUT_REGISTERS:
+        /* Header + 2 * nb values */
+        length = 2 + 2 * (req[offset + 3] << 8 | req[offset + 4]);
+        break;
+    case MODBUS_FC_READ_EXCEPTION_STATUS:
+        length = 3;
+        break;
+    case MODBUS_FC_REPORT_SLAVE_ID:
+        /* The response is device specific (the header provides the
+           length) */
+        return MSG_LENGTH_UNDEFINED;
+    case MODBUS_FC_MASK_WRITE_REGISTER:
+        length = 7;
+        break;
+    default:
+        length = 5;
+    }
+
+    return offset + length + ctx->backend->checksum_length;
+}
+
+/* Sends a request/response */
+static int send_msg(modbus_t *ctx, uint8_t *msg, int msg_length)
+{
+    int rc;
+    int i;
+
+    if (ctx->error_recovery & MODBUS_ERROR_RECOVERY_PROTOCOL) {
+        modbus_flush(ctx); // Without this we might receive junk
+    }
+
+        
+    msg_length = ctx->backend->send_msg_pre(msg, msg_length);
+
+    
+    //for( i = 0 ; i < msg_length; i++ )
+    //  printf("<%02X>",msg[i]);
+
+    /* -- BEGIN QMODBUS MODIFICATION -- */
+        if (ctx->monitor_raw_data) {
+            ctx->monitor_raw_data(ctx, msg , msg_length, 1 , 0);
+        }
+                /* -- END QMODBUS MODIFICATION -- */
+
+    if (ctx->debug) {
+        for (i = 0; i < msg_length; i++)
+            printf("[%.2X]", msg[i]);
+        printf("\n");
+    }
+
+    /* In recovery mode, the write command will be issued until to be
+       successful! Disabled by default. */
+    do {
+        rc = ctx->backend->send(ctx, msg, msg_length);
+        if (rc == -1) {
+            _error_print(ctx, NULL);
+            if (ctx->error_recovery & MODBUS_ERROR_RECOVERY_LINK) {
+                int saved_errno = errno;
+
+                if ((errno == EBADF || errno == ECONNRESET || errno == EPIPE)) {
+                    modbus_close(ctx);
+                    _sleep_response_timeout(ctx);
+                    modbus_connect(ctx);
+                } else {
+                    _sleep_response_timeout(ctx);
+                    modbus_flush(ctx);
+                }
+                errno = saved_errno;
+            }
+        }
+    } while ((ctx->error_recovery & MODBUS_ERROR_RECOVERY_LINK) &&
+             rc == -1);
+
+    if (rc > 0 && rc != msg_length) {
+        errno = EMBBADDATA;
+        return -1;
+    }
+
+    return rc;
+}
+
+int modbus_send_raw_request(modbus_t *ctx, uint8_t *raw_req, int raw_req_length)
+{
+    sft_t sft;
+    uint8_t req[MAX_MESSAGE_LENGTH];
+    int req_length;
+
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (raw_req_length < 2) {
+        /* The raw request must contain function and slave at least */
+        errno = EINVAL;
+        return -1;
+    }
+
+    sft.slave = raw_req[0];
+    sft.function = raw_req[1];
+    /* The t_id is left to zero */
+    sft.t_id = 0;
+    /* This response function only set the header so it's convenient here */
+    req_length = ctx->backend->build_response_basis(&sft, req);
+
+    if (raw_req_length > 2) {
+        /* Copy data after function code */
+        memcpy(req + req_length, raw_req + 2, raw_req_length - 2);
+        req_length += raw_req_length - 2;
+    }
+
+    return send_msg(ctx, req, req_length);
+}
+
+/*
+ *  ---------- Request     Indication ----------
+ *  | Client | ---------------------->| Server |
+ *  ---------- Confirmation  Response ----------
+ */
+
+/* Computes the length to read after the function received */
+static uint8_t compute_meta_length_after_function(int function,
+                                                  msg_type_t msg_type)
+{
+    int length;
+
+    if (msg_type == MSG_INDICATION) {
+        if (function <= MODBUS_FC_WRITE_SINGLE_REGISTER) {
+            length = 4;
+        } else if (function == MODBUS_FC_WRITE_MULTIPLE_COILS ||
+                   function == MODBUS_FC_WRITE_MULTIPLE_REGISTERS) {
+            length = 5;
+        } else if (function == MODBUS_FC_MASK_WRITE_REGISTER) {
+            length = 6;
+        } else if (function == MODBUS_FC_WRITE_AND_READ_REGISTERS) {
+            length = 9;
+        } else {
+            /* MODBUS_FC_READ_EXCEPTION_STATUS, MODBUS_FC_REPORT_SLAVE_ID */
+            length = 0;
+        }
+    } else {
+        /* MSG_CONFIRMATION */
+        switch (function) {
+        case MODBUS_FC_WRITE_SINGLE_COIL:
+        case MODBUS_FC_WRITE_SINGLE_REGISTER:
+        case MODBUS_FC_WRITE_MULTIPLE_COILS:
+        case MODBUS_FC_WRITE_MULTIPLE_REGISTERS:
+            length = 4;
+            break;
+        case MODBUS_FC_MASK_WRITE_REGISTER:
+            length = 6;
+            break;
+        default:
+            length = 1;
+        }
+    }
+
+    return length;
+}
+
+/* Computes the length to read after the meta information (address, count, etc) */
+static int compute_data_length_after_meta(modbus_t *ctx, uint8_t *msg,
+                                          msg_type_t msg_type)
+{
+    int function = msg[ctx->backend->header_length];
+    int length;
+
+    if (msg_type == MSG_INDICATION) {
+        switch (function) {
+        case MODBUS_FC_WRITE_MULTIPLE_COILS:
+        case MODBUS_FC_WRITE_MULTIPLE_REGISTERS:
+            length = msg[ctx->backend->header_length + 5];
+            break;
+        case MODBUS_FC_WRITE_AND_READ_REGISTERS:
+            length = msg[ctx->backend->header_length + 9];
+            break;
+        default:
+            length = 0;
+        }
+    } else {
+        /* MSG_CONFIRMATION */
+        if (function <= MODBUS_FC_READ_INPUT_REGISTERS ||
+            function == MODBUS_FC_REPORT_SLAVE_ID ||
+            function == MODBUS_FC_WRITE_AND_READ_REGISTERS) {
+            length = msg[ctx->backend->header_length + 1];
+        } else {
+            length = 0;
+        }
+    }
+
+    length += ctx->backend->checksum_length;
+
+    return length;
+}
+
+
+/* Waits a response from a modbus server or a request from a modbus client.
+   This function blocks if there is no replies (3 timeouts).
+
+   The function shall return the number of received characters and the received
+   message in an array of uint8_t if successful. Otherwise it shall return -1
+   and errno is set to one of the values defined below:
+   - ECONNRESET
+   - EMBBADDATA
+   - EMBUNKEXC
+   - ETIMEDOUT
+   - read() or recv() error codes
+*/
+
+int _modbus_receive_msg(modbus_t *ctx, uint8_t *msg, msg_type_t msg_type)
+{
+    int rc;
+    fd_set rset;
+    struct timeval tv;
+    struct timeval *p_tv;
+    int length_to_read;
+    int msg_length = 0;
+    _step_t step;
+
+    if (ctx->debug) {
+        if (msg_type == MSG_INDICATION) {
+            printf("Waiting for a indication...\n");
+        } else {
+            printf("Waiting for a confirmation...\n");
+        }
+    }
+
+    /* Add a file descriptor to the set */
+    FD_ZERO(&rset);
+    FD_SET(ctx->s, &rset);
+
+    /* We need to analyse the message step by step.  At the first step, we want
+     * to reach the function code because all packets contain this
+     * information. */
+    step = _STEP_FUNCTION;
+    length_to_read = ctx->backend->header_length + 1;
+
+#if 0
+    if (msg_type == MSG_INDICATION) {
+#else
+    if (0) {
+#endif
+        /* Wait for a message, we don't know when the message will be
+         * received */
+        p_tv = NULL;
+    } else {
+        tv.tv_sec = ctx->response_timeout.tv_sec;
+        tv.tv_usec = ctx->response_timeout.tv_usec;
+        p_tv = &tv;
+    }
+
+    while (length_to_read != 0) {
+        rc = ctx->backend->select(ctx, &rset, p_tv, length_to_read);
+        if (rc == -1) {
+            _error_print(ctx, "select");
+            if (ctx->error_recovery & MODBUS_ERROR_RECOVERY_LINK) {
+                int saved_errno = errno;
+
+                if (errno == ETIMEDOUT) {
+                    _sleep_response_timeout(ctx);
+                    modbus_flush(ctx);
+                } else if (errno == EBADF) {
+                    modbus_close(ctx);
+                    _sleep_response_timeout(ctx);
+                    modbus_connect(ctx);
+                }
+                errno = saved_errno;
+            }
+            return -1;
+        }
+
+        rc = ctx->backend->recv(ctx, msg + msg_length, length_to_read);
+        if (rc == 0) {
+            errno = ECONNRESET;
+            rc = -1;
+        }
+
+        if (rc == -1) {
+            _error_print(ctx, "read");
+            if ((ctx->error_recovery & MODBUS_ERROR_RECOVERY_LINK) &&
+                (errno == ECONNRESET || errno == ECONNREFUSED ||
+                 errno == EBADF)) {
+                int saved_errno = errno;
+                modbus_close(ctx);
+                modbus_connect(ctx);
+                /* Could be removed by previous calls */
+                errno = saved_errno;
+            }
+            return -1;
+        }
+
+        /* -- BEGIN QMODBUS MODIFICATION -- */
+        if (ctx->monitor_raw_data) {
+            ctx->monitor_raw_data(ctx, msg + msg_length, rc, ( step == _STEP_DATA && length_to_read-rc == 0 ) ? 1 : 0 , 1 );
+        }
+                /* -- END QMODBUS MODIFICATION -- */
+
+        /* Display the hex code of each character received */
+        if (ctx->debug) {
+            int i;
+            for (i=0; i < rc; i++)
+                printf("<%.2X>", msg[msg_length + i]);
+        }
+
+        /* Sums bytes received */
+        msg_length += rc;
+        /* Computes remaining bytes */
+        length_to_read -= rc;
+
+        if (length_to_read == 0) {
+            switch (step) {
+            case _STEP_FUNCTION:
+                /* Function code position */
+                length_to_read = compute_meta_length_after_function(
+                    msg[ctx->backend->header_length],
+                    msg_type);
+                if (length_to_read != 0) {
+                    step = _STEP_META;
+                    break;
+                } /* else switches straight to the next step */
+            case _STEP_META:
+                length_to_read = compute_data_length_after_meta(
+                    ctx, msg, msg_type);
+                if ((msg_length + length_to_read) > (int)ctx->backend->max_adu_length) {
+                    errno = EMBBADDATA;
+                    _error_print(ctx, "too many data");
+                    return -1;
+                }
+                step = _STEP_DATA;
+                break;
+            default:
+                break;
+            }
+        }
+
+        if (length_to_read > 0 &&
+            (ctx->byte_timeout.tv_sec > 0 || ctx->byte_timeout.tv_usec > 0)) {
+            /* If there is no character in the buffer, the allowed timeout
+               interval between two consecutive bytes is defined by
+               byte_timeout */
+            tv.tv_sec = ctx->byte_timeout.tv_sec;
+            tv.tv_usec = ctx->byte_timeout.tv_usec;
+            p_tv = &tv;
+        }
+        /* else timeout isn't set again, the full response must be read before
+           expiration of response timeout (for CONFIRMATION only) */
+    }
+
+    if (ctx->debug)
+        printf("\n");
+
+    return ctx->backend->check_integrity(ctx, msg, msg_length);
+}
+
+/* Receive the request from a modbus master */
+int modbus_receive(modbus_t *ctx, uint8_t *req)
+{
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    return ctx->backend->receive(ctx, req);
+}
+
+/* Receives the confirmation.
+
+   The function shall store the read response in rsp and return the number of
+   values (bits or words). Otherwise, its shall return -1 and errno is set.
+
+   The function doesn't check the confirmation is the expected response to the
+   initial request.
+*/
+int modbus_receive_confirmation(modbus_t *ctx, uint8_t *rsp)
+{
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    return _modbus_receive_msg(ctx, rsp, MSG_CONFIRMATION);
+}
+
+static int check_confirmation(modbus_t *ctx, uint8_t *req,
+                              uint8_t *rsp, int rsp_length)
+{
+    int rc;
+    int rsp_length_computed;
+    const int offset = ctx->backend->header_length;
+    const int function = rsp[offset];
+
+    /* BEGIN QMODBUS MODIFICATION */
+    int s_crc = 0; /* TODO */
+    if (ctx->monitor_add_item) {
+        ctx->monitor_add_item(ctx, 1,
+                req[offset - 1],  /* slave */
+                function,  /* func */
+                ( req[offset + 1] << 8 ) + req[offset + 2], /* addr */
+                ( req[offset + 3] << 8 ) + req[offset + 4], /* nb */
+                s_crc, s_crc );
+    }
+    /* END QMODBUS MODIFICATION */
+
+    if (ctx->backend->pre_check_confirmation) {
+        rc = ctx->backend->pre_check_confirmation(ctx, req, rsp, rsp_length);
+        if (rc == -1) {
+            if (ctx->error_recovery & MODBUS_ERROR_RECOVERY_PROTOCOL) {
+                _sleep_response_timeout(ctx);
+                modbus_flush(ctx);
+            }
+            return -1;
+        }
+    }
+
+    rsp_length_computed = compute_response_length_from_request(ctx, req);
+
+    /* Exception code */
+    if (function >= 0x80) {
+        if (rsp_length == (offset + 2 + (int)ctx->backend->checksum_length) &&
+            req[offset] == (rsp[offset] - 0x80)) {
+            /* Valid exception code received */
+
+            int exception_code = rsp[offset + 1];
+            if (exception_code < MODBUS_EXCEPTION_MAX) {
+                errno = MODBUS_ENOBASE + exception_code;
+            } else {
+                errno = EMBBADEXC;
+            }
+            _error_print(ctx, NULL);
+            return -1;
+        } else {
+            errno = EMBBADEXC;
+            _error_print(ctx, NULL);
+            return -1;
+        }
+    }
+
+    /* Check length */
+    if ((rsp_length == rsp_length_computed ||
+         rsp_length_computed == MSG_LENGTH_UNDEFINED) &&
+        function < 0x80) {
+        int req_nb_value;
+        int rsp_nb_value;
+        int num_items = 1;
+        int addr = (req[offset + 1] << 8) + req[offset + 2];
+
+        /* Check function code */
+        if (function != req[offset]) {
+            if (ctx->debug) {
+                fprintf(stderr,
+                        "Received function not corresponding to the request (0x%X != 0x%X)\n",
+                        function, req[offset]);
+            }
+            if (ctx->error_recovery & MODBUS_ERROR_RECOVERY_PROTOCOL) {
+                _sleep_response_timeout(ctx);
+                modbus_flush(ctx);
+            }
+            errno = EMBBADDATA;
+            return -1;
+        }
+
+        /* Check the number of values is corresponding to the request */
+        switch (function) {
+        case MODBUS_FC_READ_COILS:
+        case MODBUS_FC_READ_DISCRETE_INPUTS:
+            /* Read functions, 8 values in a byte (nb
+             * of values in the request and byte count in
+             * the response. */
+            req_nb_value = (req[offset + 3] << 8) + req[offset + 4];
+            req_nb_value = (req_nb_value / 8) + ((req_nb_value % 8) ? 1 : 0);
+            rsp_nb_value = rsp[offset + 1];
+            break;
+        case MODBUS_FC_WRITE_AND_READ_REGISTERS:
+        case MODBUS_FC_READ_HOLDING_REGISTERS:
+        case MODBUS_FC_READ_INPUT_REGISTERS:
+            /* Read functions 1 value = 2 bytes */
+            req_nb_value = (req[offset + 3] << 8) + req[offset + 4];
+            rsp_nb_value = (rsp[offset + 1] / 2);
+            break;
+        case MODBUS_FC_WRITE_MULTIPLE_COILS:
+        case MODBUS_FC_WRITE_MULTIPLE_REGISTERS:
+            /* N Write functions */
+            req_nb_value = (req[offset + 3] << 8) + req[offset + 4];
+            rsp_nb_value = (rsp[offset + 3] << 8) | rsp[offset + 4];
+            break;
+        case MODBUS_FC_REPORT_SLAVE_ID:
+            /* Report slave ID (bytes received) */
+            req_nb_value = rsp_nb_value = rsp[offset + 1];
+            break;
+        default:
+            /* 1 Write functions & others */
+            req_nb_value = rsp_nb_value = 1;
+        }
+
+        num_items = rsp_nb_value;
+        switch (function)
+        {
+            case MODBUS_FC_READ_COILS:
+            case MODBUS_FC_READ_DISCRETE_INPUTS:
+                num_items = rsp_nb_value * 8;
+                break;
+            case MODBUS_FC_WRITE_MULTIPLE_COILS:
+            case MODBUS_FC_WRITE_MULTIPLE_REGISTERS:
+                addr = (rsp[offset + 1] << 8) | rsp[offset + 2];
+                num_items = rsp_nb_value;
+                break;
+            default:
+                break;
+        }
+        if (ctx->monitor_add_item) {
+            ctx->monitor_add_item(ctx, 0, rsp[offset-1], rsp[offset+0],
+                           addr, num_items,
+                            ctx->last_crc_expected,
+                            ctx->last_crc_received
+                    //      ( rsp[offset+req_nb_value+4] << 8 ) |
+                    //          rsp[offset+req_nb_value+5]
+            );
+        }
+
+        if (req_nb_value == rsp_nb_value) {
+            rc = rsp_nb_value;
+        } else {
+            if (ctx->debug) {
+                fprintf(stderr,
+                        "Quantity not corresponding to the request (%d != %d)\n",
+                        rsp_nb_value, req_nb_value);
+            }
+
+            if (ctx->error_recovery & MODBUS_ERROR_RECOVERY_PROTOCOL) {
+                _sleep_response_timeout(ctx);
+                modbus_flush(ctx);
+            }
+
+            errno = EMBBADDATA;
+            rc = -1;
+        }
+    } else {
+        if (ctx->debug) {
+            fprintf(stderr,
+                    "Message length not corresponding to the computed length (%d != %d)\n",
+                    rsp_length, rsp_length_computed);
+        }
+        if (ctx->error_recovery & MODBUS_ERROR_RECOVERY_PROTOCOL) {
+            _sleep_response_timeout(ctx);
+            modbus_flush(ctx);
+        }
+        errno = EMBBADDATA;
+        rc = -1;
+    }
+
+    return rc;
+}
+
+static int response_io_status(int address, int nb,
+                              uint8_t *tab_io_status,
+                              uint8_t *rsp, int offset)
+{
+    int shift = 0;
+    /* Instead of byte (not allowed in Win32) */
+    int one_byte = 0;
+    int i;
+
+    for (i = address; i < address+nb; i++) {
+        one_byte |= tab_io_status[i] << shift;
+        if (shift == 7) {
+            /* Byte is full */
+            rsp[offset++] = one_byte;
+            one_byte = shift = 0;
+        } else {
+            shift++;
+        }
+    }
+
+    if (shift != 0)
+        rsp[offset++] = one_byte;
+
+    return offset;
+}
+
+/* Build the exception response */
+static int response_exception(modbus_t *ctx, sft_t *sft,
+                              int exception_code, uint8_t *rsp)
+{
+    int rsp_length;
+
+    sft->function = sft->function + 0x80;
+    rsp_length = ctx->backend->build_response_basis(sft, rsp);
+
+    /* Positive exception code */
+    rsp[rsp_length++] = exception_code;
+
+    return rsp_length;
+}
+
+/* Send a response to the received request.
+   Analyses the request and constructs a response.
+
+   If an error occurs, this function construct the response
+   accordingly.
+*/
+int modbus_reply(modbus_t *ctx, const uint8_t *req,
+                 int req_length, modbus_mapping_t *mb_mapping)
+{
+    int offset = ctx->backend->header_length;
+    int slave = req[offset - 1];
+    int function = req[offset];
+    uint16_t address = (req[offset + 1] << 8) + req[offset + 2];
+    uint8_t rsp[MAX_MESSAGE_LENGTH];
+    int rsp_length = 0;
+    sft_t sft;
+
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    sft.slave = slave;
+    sft.function = function;
+    sft.t_id = ctx->backend->prepare_response_tid(req, &req_length);
+
+    switch (function) {
+    case MODBUS_FC_READ_COILS: {
+        int nb = (req[offset + 3] << 8) + req[offset + 4];
+
+        if (nb < 1 || MODBUS_MAX_READ_BITS < nb) {
+            if (ctx->debug) {
+                fprintf(stderr,
+                        "Illegal nb of values %d in read_bits (max %d)\n",
+                        nb, MODBUS_MAX_READ_BITS);
+            }
+            _sleep_response_timeout(ctx);
+            modbus_flush(ctx);
+            rsp_length = response_exception(
+                ctx, &sft,
+                MODBUS_EXCEPTION_ILLEGAL_DATA_VALUE, rsp);
+        } else if ((address + nb) > mb_mapping->nb_bits) {
+            if (ctx->debug) {
+                fprintf(stderr, "Illegal data address %0X in read_bits\n",
+                        address + nb);
+            }
+            rsp_length = response_exception(
+                ctx, &sft,
+                MODBUS_EXCEPTION_ILLEGAL_DATA_ADDRESS, rsp);
+        } else {
+            rsp_length = ctx->backend->build_response_basis(&sft, rsp);
+            rsp[rsp_length++] = (nb / 8) + ((nb % 8) ? 1 : 0);
+            rsp_length = response_io_status(address, nb,
+                                            mb_mapping->tab_bits,
+                                            rsp, rsp_length);
+        }
+    }
+        break;
+    case MODBUS_FC_READ_DISCRETE_INPUTS: {
+        /* Similar to coil status (but too many arguments to use a
+         * function) */
+        int nb = (req[offset + 3] << 8) + req[offset + 4];
+
+        if (nb < 1 || MODBUS_MAX_READ_BITS < nb) {
+            if (ctx->debug) {
+                fprintf(stderr,
+                        "Illegal nb of values %d in read_input_bits (max %d)\n",
+                        nb, MODBUS_MAX_READ_BITS);
+            }
+            _sleep_response_timeout(ctx);
+            modbus_flush(ctx);
+            rsp_length = response_exception(
+                ctx, &sft,
+                MODBUS_EXCEPTION_ILLEGAL_DATA_VALUE, rsp);
+        } else if ((address + nb) > mb_mapping->nb_input_bits) {
+            if (ctx->debug) {
+                fprintf(stderr, "Illegal data address %0X in read_input_bits\n",
+                        address + nb);
+            }
+            rsp_length = response_exception(
+                ctx, &sft,
+                MODBUS_EXCEPTION_ILLEGAL_DATA_ADDRESS, rsp);
+        } else {
+            rsp_length = ctx->backend->build_response_basis(&sft, rsp);
+            rsp[rsp_length++] = (nb / 8) + ((nb % 8) ? 1 : 0);
+            rsp_length = response_io_status(address, nb,
+                                            mb_mapping->tab_input_bits,
+                                            rsp, rsp_length);
+        }
+    }
+        break;
+    case MODBUS_FC_READ_HOLDING_REGISTERS: {
+        int nb = (req[offset + 3] << 8) + req[offset + 4];
+
+        if (nb < 1 || MODBUS_MAX_READ_REGISTERS < nb) {
+            if (ctx->debug) {
+                fprintf(stderr,
+                        "Illegal nb of values %d in read_holding_registers (max %d)\n",
+                        nb, MODBUS_MAX_READ_REGISTERS);
+            }
+            _sleep_response_timeout(ctx);
+            modbus_flush(ctx);
+            rsp_length = response_exception(
+                ctx, &sft,
+                MODBUS_EXCEPTION_ILLEGAL_DATA_VALUE, rsp);
+        } else if ((address + nb) > mb_mapping->nb_registers) {
+            if (ctx->debug) {
+                fprintf(stderr, "Illegal data address %0X in read_registers\n",
+                        address + nb);
+            }
+            rsp_length = response_exception(
+                ctx, &sft,
+                MODBUS_EXCEPTION_ILLEGAL_DATA_ADDRESS, rsp);
+        } else {
+            int i;
+
+            rsp_length = ctx->backend->build_response_basis(&sft, rsp);
+            rsp[rsp_length++] = nb << 1;
+            for (i = address; i < address + nb; i++) {
+                rsp[rsp_length++] = mb_mapping->tab_registers[i] >> 8;
+                rsp[rsp_length++] = mb_mapping->tab_registers[i] & 0xFF;
+            }
+        }
+    }
+        break;
+    case MODBUS_FC_READ_INPUT_REGISTERS: {
+        /* Similar to holding registers (but too many arguments to use a
+         * function) */
+        int nb = (req[offset + 3] << 8) + req[offset + 4];
+
+        if (nb < 1 || MODBUS_MAX_READ_REGISTERS < nb) {
+            if (ctx->debug) {
+                fprintf(stderr,
+                        "Illegal number of values %d in read_input_registers (max %d)\n",
+                        nb, MODBUS_MAX_READ_REGISTERS);
+            }
+            _sleep_response_timeout(ctx);
+            modbus_flush(ctx);
+            rsp_length = response_exception(
+                ctx, &sft,
+                MODBUS_EXCEPTION_ILLEGAL_DATA_VALUE, rsp);
+        } else if ((address + nb) > mb_mapping->nb_input_registers) {
+            if (ctx->debug) {
+                fprintf(stderr, "Illegal data address %0X in read_input_registers\n",
+                        address + nb);
+            }
+            rsp_length = response_exception(
+                ctx, &sft,
+                MODBUS_EXCEPTION_ILLEGAL_DATA_ADDRESS, rsp);
+        } else {
+            int i;
+
+            rsp_length = ctx->backend->build_response_basis(&sft, rsp);
+            rsp[rsp_length++] = nb << 1;
+            for (i = address; i < address + nb; i++) {
+                rsp[rsp_length++] = mb_mapping->tab_input_registers[i] >> 8;
+                rsp[rsp_length++] = mb_mapping->tab_input_registers[i] & 0xFF;
+            }
+        }
+    }
+        break;
+    case MODBUS_FC_WRITE_SINGLE_COIL:
+        if (address >= mb_mapping->nb_bits) {
+            if (ctx->debug) {
+                fprintf(stderr,
+                        "Illegal data address %0X in write_bit\n",
+                        address);
+            }
+            _sleep_response_timeout(ctx);
+            modbus_flush(ctx);
+            rsp_length = response_exception(
+                ctx, &sft,
+                MODBUS_EXCEPTION_ILLEGAL_DATA_ADDRESS, rsp);
+        } else {
+            int data = (req[offset + 3] << 8) + req[offset + 4];
+
+            if (data == 0xFF00 || data == 0x0) {
+                mb_mapping->tab_bits[address] = (data) ? ON : OFF;
+                memcpy(rsp, req, req_length);
+                rsp_length = req_length;
+            } else {
+                if (ctx->debug) {
+                    fprintf(stderr,
+                            "Illegal data value %0X in write_bit request at address %0X\n",
+                            data, address);
+                }
+                rsp_length = response_exception(
+                    ctx, &sft,
+                    MODBUS_EXCEPTION_ILLEGAL_DATA_VALUE, rsp);
+            }
+        }
+        break;
+    case MODBUS_FC_WRITE_SINGLE_REGISTER:
+        if (address >= mb_mapping->nb_registers) {
+            if (ctx->debug) {
+                fprintf(stderr, "Illegal data address %0X in write_register\n",
+                        address);
+            }
+            _sleep_response_timeout(ctx);
+            modbus_flush(ctx);
+            rsp_length = response_exception(
+                ctx, &sft,
+                MODBUS_EXCEPTION_ILLEGAL_DATA_ADDRESS, rsp);
+        } else {
+            int data = (req[offset + 3] << 8) + req[offset + 4];
+
+            mb_mapping->tab_registers[address] = data;
+            memcpy(rsp, req, req_length);
+            rsp_length = req_length;
+        }
+        break;
+    case MODBUS_FC_WRITE_MULTIPLE_COILS: {
+        int nb = (req[offset + 3] << 8) + req[offset + 4];
+
+        if (nb < 1 || MODBUS_MAX_WRITE_BITS < nb) {
+            if (ctx->debug) {
+                fprintf(stderr,
+                        "Illegal number of values %d in write_bits (max %d)\n",
+                        nb, MODBUS_MAX_WRITE_BITS);
+            }
+            /* May be the indication has been truncated on reading because of
+             * invalid address (eg. nb is 0 but the request contains values to
+             * write) so it's necessary to flush. */
+            _sleep_response_timeout(ctx);
+            modbus_flush(ctx);
+            rsp_length = response_exception(
+                ctx, &sft,
+                MODBUS_EXCEPTION_ILLEGAL_DATA_VALUE, rsp);
+        } else if ((address + nb) > mb_mapping->nb_bits) {
+            if (ctx->debug) {
+                fprintf(stderr, "Illegal data address %0X in write_bits\n",
+                        address + nb);
+            }
+            rsp_length = response_exception(
+                ctx, &sft,
+                MODBUS_EXCEPTION_ILLEGAL_DATA_ADDRESS, rsp);
+        } else {
+            /* 6 = byte count */
+            modbus_set_bits_from_bytes(mb_mapping->tab_bits, address, nb, &req[offset + 6]);
+
+            rsp_length = ctx->backend->build_response_basis(&sft, rsp);
+            /* 4 to copy the bit address (2) and the quantity of bits */
+            memcpy(rsp + rsp_length, req + rsp_length, 4);
+            rsp_length += 4;
+        }
+    }
+        break;
+    case MODBUS_FC_WRITE_MULTIPLE_REGISTERS: {
+        int nb = (req[offset + 3] << 8) + req[offset + 4];
+        if (nb < 1 || MODBUS_MAX_WRITE_REGISTERS < nb) {
+            if (ctx->debug) {
+                fprintf(stderr,
+                        "Illegal number of values %d in write_registers (max %d)\n",
+                        nb, MODBUS_MAX_WRITE_REGISTERS);
+            }
+            /* May be the indication has been truncated on reading because of
+             * invalid address (eg. nb is 0 but the request contains values to
+             * write) so it's necessary to flush. */
+            _sleep_response_timeout(ctx);
+            modbus_flush(ctx);
+            rsp_length = response_exception(
+                ctx, &sft,
+                MODBUS_EXCEPTION_ILLEGAL_DATA_VALUE, rsp);
+        } else if ((address + nb) > mb_mapping->nb_registers) {
+            if (ctx->debug) {
+                fprintf(stderr, "Illegal data address %0X in write_registers\n",
+                        address + nb);
+            }
+            rsp_length = response_exception(
+                ctx, &sft,
+                MODBUS_EXCEPTION_ILLEGAL_DATA_ADDRESS, rsp);
+        } else {
+            int i, j;
+            for (i = address, j = 6; i < address + nb; i++, j += 2) {
+                /* 6 and 7 = first value */
+                mb_mapping->tab_registers[i] =
+                    (req[offset + j] << 8) + req[offset + j + 1];
+            }
+
+            rsp_length = ctx->backend->build_response_basis(&sft, rsp);
+            /* 4 to copy the address (2) and the no. of registers */
+            memcpy(rsp + rsp_length, req + rsp_length, 4);
+            rsp_length += 4;
+        }
+    }
+        break;
+    case MODBUS_FC_REPORT_SLAVE_ID: {
+        int str_len;
+        int byte_count_pos;
+
+        rsp_length = ctx->backend->build_response_basis(&sft, rsp);
+        /* Skip byte count for now */
+        byte_count_pos = rsp_length++;
+        rsp[rsp_length++] = _REPORT_SLAVE_ID;
+        /* Run indicator status to ON */
+        rsp[rsp_length++] = 0xFF;
+        /* LMB + length of LIBMODBUS_VERSION_STRING */
+        str_len = 3 + strlen(LIBMODBUS_VERSION_STRING);
+        memcpy(rsp + rsp_length, "LMB" LIBMODBUS_VERSION_STRING, str_len);
+        rsp_length += str_len;
+        rsp[byte_count_pos] = rsp_length - byte_count_pos - 1;
+    }
+        break;
+    case MODBUS_FC_READ_EXCEPTION_STATUS:
+        if (ctx->debug) {
+            fprintf(stderr, "FIXME Not implemented\n");
+        }
+        errno = ENOPROTOOPT;
+        return -1;
+        break;
+    case MODBUS_FC_MASK_WRITE_REGISTER:
+        if (address >= mb_mapping->nb_registers) {
+            if (ctx->debug) {
+                fprintf(stderr, "Illegal data address %0X in write_register\n",
+                        address);
+            }
+            rsp_length = response_exception(
+                ctx, &sft,
+                MODBUS_EXCEPTION_ILLEGAL_DATA_ADDRESS, rsp);
+        } else {
+            uint16_t data = mb_mapping->tab_registers[address];
+            uint16_t and = (req[offset + 3] << 8) + req[offset + 4];
+            uint16_t or = (req[offset + 5] << 8) + req[offset + 6];
+
+            data = (data & and) | (or & (~and));
+            mb_mapping->tab_registers[address] = data;
+            memcpy(rsp, req, req_length);
+            rsp_length = req_length;
+        }
+        break;
+    case MODBUS_FC_WRITE_AND_READ_REGISTERS: {
+        int nb = (req[offset + 3] << 8) + req[offset + 4];
+        uint16_t address_write = (req[offset + 5] << 8) + req[offset + 6];
+        int nb_write = (req[offset + 7] << 8) + req[offset + 8];
+        int nb_write_bytes = req[offset + 9];
+
+        if (nb_write < 1 || MODBUS_MAX_WR_WRITE_REGISTERS < nb_write ||
+            nb < 1 || MODBUS_MAX_WR_READ_REGISTERS < nb ||
+            nb_write_bytes != nb_write * 2) {
+            if (ctx->debug) {
+                fprintf(stderr,
+                        "Illegal nb of values (W%d, R%d) in write_and_read_registers (max W%d, R%d)\n",
+                        nb_write, nb,
+                        MODBUS_MAX_WR_WRITE_REGISTERS, MODBUS_MAX_WR_READ_REGISTERS);
+            }
+            _sleep_response_timeout(ctx);
+            modbus_flush(ctx);
+            rsp_length = response_exception(
+                ctx, &sft,
+                MODBUS_EXCEPTION_ILLEGAL_DATA_VALUE, rsp);
+        } else if ((address + nb) > mb_mapping->nb_registers ||
+                   (address_write + nb_write) > mb_mapping->nb_registers) {
+            if (ctx->debug) {
+                fprintf(stderr,
+                        "Illegal data read address %0X or write address %0X write_and_read_registers\n",
+                        address + nb, address_write + nb_write);
+            }
+            rsp_length = response_exception(ctx, &sft,
+                                            MODBUS_EXCEPTION_ILLEGAL_DATA_ADDRESS, rsp);
+        } else {
+            int i, j;
+            rsp_length = ctx->backend->build_response_basis(&sft, rsp);
+            rsp[rsp_length++] = nb << 1;
+
+            /* Write first.
+               10 and 11 are the offset of the first values to write */
+            for (i = address_write, j = 10; i < address_write + nb_write; i++, j += 2) {
+                mb_mapping->tab_registers[i] =
+                    (req[offset + j] << 8) + req[offset + j + 1];
+            }
+
+            /* and read the data for the response */
+            for (i = address; i < address + nb; i++) {
+                rsp[rsp_length++] = mb_mapping->tab_registers[i] >> 8;
+                rsp[rsp_length++] = mb_mapping->tab_registers[i] & 0xFF;
+            }
+        }
+    }
+        break;
+
+    default:
+        rsp_length = response_exception(ctx, &sft,
+                                        MODBUS_EXCEPTION_ILLEGAL_FUNCTION,
+                                        rsp);
+        break;
+    }
+
+    return send_msg(ctx, rsp, rsp_length);
+}
+
+int modbus_reply_exception(modbus_t *ctx, const uint8_t *req,
+                           unsigned int exception_code)
+{
+    int offset = ctx->backend->header_length;
+    int slave = req[offset - 1];
+    int function = req[offset];
+    uint8_t rsp[MAX_MESSAGE_LENGTH];
+    int rsp_length;
+    int dummy_length = 99;
+    sft_t sft;
+
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    sft.slave = slave;
+    sft.function = function + 0x80;;
+    sft.t_id = ctx->backend->prepare_response_tid(req, &dummy_length);
+    rsp_length = ctx->backend->build_response_basis(&sft, rsp);
+
+    /* Positive exception code */
+    if (exception_code < MODBUS_EXCEPTION_MAX) {
+        rsp[rsp_length++] = exception_code;
+        return send_msg(ctx, rsp, rsp_length);
+    } else {
+        errno = EINVAL;
+        return -1;
+    }
+}
+
+/* Reads IO status */
+static int read_io_status(modbus_t *ctx, int function,
+                          int addr, int nb, uint8_t *dest)
+{
+    int rc;
+    int req_length;
+
+    uint8_t req[_MIN_REQ_LENGTH];
+    uint8_t rsp[MAX_MESSAGE_LENGTH];
+
+    req_length = ctx->backend->build_request_basis(ctx, function, addr, nb, req);
+
+    rc = send_msg(ctx, req, req_length);
+    if (rc > 0) {
+        int i, temp, bit;
+        int pos = 0;
+        int offset;
+        int offset_end;
+
+        rc = _modbus_receive_msg(ctx, rsp, MSG_CONFIRMATION);
+        if (rc == -1)
+            return -1;
+
+        rc = check_confirmation(ctx, req, rsp, rc);
+        if (rc == -1)
+            return -1;
+
+        offset = ctx->backend->header_length + 2;
+        offset_end = offset + rc;
+        for (i = offset; i < offset_end; i++) {
+            /* Shift reg hi_byte to temp */
+            temp = rsp[i];
+
+            for (bit = 0x01; (bit & 0xff) && (pos < nb);) {
+                dest[pos++] = (temp & bit) ? TRUE : FALSE;
+                bit = bit << 1;
+            }
+
+        }
+    }
+
+    return rc;
+}
+
+/* Reads the boolean status of bits and sets the array elements
+   in the destination to TRUE or FALSE (single bits). */
+int modbus_read_bits(modbus_t *ctx, int addr, int nb, uint8_t *dest)
+{
+    int rc;
+
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (nb > MODBUS_MAX_READ_BITS) {
+        if (ctx->debug) {
+            fprintf(stderr,
+                    "ERROR Too many bits requested (%d > %d)\n",
+                    nb, MODBUS_MAX_READ_BITS);
+        }
+        errno = EMBMDATA;
+        return -1;
+    }
+
+    rc = read_io_status(ctx, MODBUS_FC_READ_COILS, addr, nb, dest);
+
+    if (rc == -1)
+        return -1;
+    else
+        return nb;
+}
+
+
+/* Same as modbus_read_bits but reads the remote device input table */
+int modbus_read_input_bits(modbus_t *ctx, int addr, int nb, uint8_t *dest)
+{
+    int rc;
+
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (nb > MODBUS_MAX_READ_BITS) {
+        if (ctx->debug) {
+            fprintf(stderr,
+                    "ERROR Too many discrete inputs requested (%d > %d)\n",
+                    nb, MODBUS_MAX_READ_BITS);
+        }
+        errno = EMBMDATA;
+        return -1;
+    }
+
+    rc = read_io_status(ctx, MODBUS_FC_READ_DISCRETE_INPUTS, addr, nb, dest);
+
+    if (rc == -1)
+        return -1;
+    else
+        return nb;
+}
+
+/* Reads the data from a remove device and put that data into an array */
+static int read_registers(modbus_t *ctx, int function, int addr, int nb,
+                          uint16_t *dest)
+{
+    int rc;
+    int req_length;
+    uint8_t req[_MIN_REQ_LENGTH];
+    uint8_t rsp[MAX_MESSAGE_LENGTH];
+
+    if (nb > MODBUS_MAX_READ_REGISTERS) {
+        if (ctx->debug) {
+            fprintf(stderr,
+                    "ERROR Too many registers requested (%d > %d)\n",
+                    nb, MODBUS_MAX_READ_REGISTERS);
+        }
+        errno = EMBMDATA;
+        return -1;
+    }
+
+    req_length = ctx->backend->build_request_basis(ctx, function, addr, nb, req);
+
+    rc = send_msg(ctx, req, req_length);
+    if (rc > 0) {
+        int offset;
+        int i;
+
+        rc = _modbus_receive_msg(ctx, rsp, MSG_CONFIRMATION);
+        if (rc == -1)
+            return -1;
+
+        rc = check_confirmation(ctx, req, rsp, rc);
+        if (rc == -1)
+            return -1;
+
+        offset = ctx->backend->header_length;
+
+        for (i = 0; i < rc; i++) {
+            /* shift reg hi_byte to temp OR with lo_byte */
+            dest[i] = (rsp[offset + 2 + (i << 1)] << 8) |
+                rsp[offset + 3 + (i << 1)];
+        }
+    }
+
+    return rc;
+}
+
+/* Reads the holding registers of remote device and put the data into an
+   array */
+int modbus_read_registers(modbus_t *ctx, int addr, int nb, uint16_t *dest)
+{
+    int status;
+
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (nb > MODBUS_MAX_READ_REGISTERS) {
+        if (ctx->debug) {
+            fprintf(stderr,
+                    "ERROR Too many registers requested (%d > %d)\n",
+                    nb, MODBUS_MAX_READ_REGISTERS);
+        }
+        errno = EMBMDATA;
+        return -1;
+    }
+
+    status = read_registers(ctx, MODBUS_FC_READ_HOLDING_REGISTERS,
+                            addr, nb, dest);
+    return status;
+}
+
+/* Reads the input registers of remote device and put the data into an array */
+int modbus_read_input_registers(modbus_t *ctx, int addr, int nb,
+                                uint16_t *dest)
+{
+    int status;
+
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (nb > MODBUS_MAX_READ_REGISTERS) {
+        fprintf(stderr,
+                "ERROR Too many input registers requested (%d > %d)\n",
+                nb, MODBUS_MAX_READ_REGISTERS);
+        errno = EMBMDATA;
+        return -1;
+    }
+
+    status = read_registers(ctx, MODBUS_FC_READ_INPUT_REGISTERS,
+                            addr, nb, dest);
+
+    return status;
+}
+
+/* Write a value to the specified register of the remote device.
+   Used by write_bit and write_register */
+static int write_single(modbus_t *ctx, int function, int addr, int value)
+{
+    int rc;
+    int req_length;
+    uint8_t req[_MIN_REQ_LENGTH];
+
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    req_length = ctx->backend->build_request_basis(ctx, function, addr, value, req);
+
+    rc = send_msg(ctx, req, req_length);
+    if (rc > 0) {
+        /* Used by write_bit and write_register */
+        uint8_t rsp[MAX_MESSAGE_LENGTH];
+
+        rc = _modbus_receive_msg(ctx, rsp, MSG_CONFIRMATION);
+        if (rc == -1)
+            return -1;
+
+        rc = check_confirmation(ctx, req, rsp, rc);
+    }
+
+    return rc;
+}
+
+/* Turns ON or OFF a single bit of the remote device */
+int modbus_write_bit(modbus_t *ctx, int addr, int status)
+{
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    return write_single(ctx, MODBUS_FC_WRITE_SINGLE_COIL, addr,
+                        status ? 0xFF00 : 0);
+}
+
+/* Writes a value in one register of the remote device */
+int modbus_write_register(modbus_t *ctx, int addr, int value)
+{
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    return write_single(ctx, MODBUS_FC_WRITE_SINGLE_REGISTER, addr, value);
+}
+
+/* Write the bits of the array in the remote device */
+int modbus_write_bits(modbus_t *ctx, int addr, int nb, const uint8_t *src)
+{
+    int rc;
+    int i;
+    int byte_count;
+    int req_length;
+    int bit_check = 0;
+    int pos = 0;
+    uint8_t req[MAX_MESSAGE_LENGTH];
+
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (nb > MODBUS_MAX_WRITE_BITS) {
+        if (ctx->debug) {
+            fprintf(stderr, "ERROR Writing too many bits (%d > %d)\n",
+                    nb, MODBUS_MAX_WRITE_BITS);
+        }
+        errno = EMBMDATA;
+        return -1;
+    }
+
+    req_length = ctx->backend->build_request_basis(ctx,
+                                                   MODBUS_FC_WRITE_MULTIPLE_COILS,
+                                                   addr, nb, req);
+    byte_count = (nb / 8) + ((nb % 8) ? 1 : 0);
+    req[req_length++] = byte_count;
+
+    for (i = 0; i < byte_count; i++) {
+        int bit;
+
+        bit = 0x01;
+        req[req_length] = 0;
+
+        while ((bit & 0xFF) && (bit_check++ < nb)) {
+            if (src[pos++])
+                req[req_length] |= bit;
+            else
+                req[req_length] &=~ bit;
+
+            bit = bit << 1;
+        }
+        req_length++;
+    }
+
+    rc = send_msg(ctx, req, req_length);
+    if (rc > 0) {
+        uint8_t rsp[MAX_MESSAGE_LENGTH];
+
+        rc = _modbus_receive_msg(ctx, rsp, MSG_CONFIRMATION);
+        if (rc == -1)
+            return -1;
+
+        rc = check_confirmation(ctx, req, rsp, rc);
+    }
+
+
+    return rc;
+}
+
+/* Write the values from the array to the registers of the remote device */
+int modbus_write_registers(modbus_t *ctx, int addr, int nb, const uint16_t *src)
+{
+    int rc;
+    int i;
+    int req_length;
+    int byte_count;
+    uint8_t req[MAX_MESSAGE_LENGTH];
+
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (nb > MODBUS_MAX_WRITE_REGISTERS) {
+        if (ctx->debug) {
+            fprintf(stderr,
+                    "ERROR Trying to write to too many registers (%d > %d)\n",
+                    nb, MODBUS_MAX_WRITE_REGISTERS);
+        }
+        errno = EMBMDATA;
+        return -1;
+    }
+
+    req_length = ctx->backend->build_request_basis(ctx,
+                                                   MODBUS_FC_WRITE_MULTIPLE_REGISTERS,
+                                                   addr, nb, req);
+    byte_count = nb * 2;
+    req[req_length++] = byte_count;
+
+    for (i = 0; i < nb; i++) {
+        req[req_length++] = src[i] >> 8;
+        req[req_length++] = src[i] & 0x00FF;
+    }
+
+    rc = send_msg(ctx, req, req_length);
+    if (rc > 0) {
+        uint8_t rsp[MAX_MESSAGE_LENGTH];
+
+        rc = _modbus_receive_msg(ctx, rsp, MSG_CONFIRMATION);
+        if (rc == -1)
+            return -1;
+
+        rc = check_confirmation(ctx, req, rsp, rc);
+    }
+
+    return rc;
+}
+
+int modbus_mask_write_register(modbus_t *ctx, int addr, uint16_t and_mask, uint16_t or_mask)
+{
+    int rc;
+    int req_length;
+    uint8_t req[_MIN_REQ_LENGTH];
+
+    req_length = ctx->backend->build_request_basis(ctx,
+                                                   MODBUS_FC_MASK_WRITE_REGISTER,
+                                                   addr, 0, req);
+
+    /* HACKISH, count is not used */
+    req_length -=2;
+
+    req[req_length++] = and_mask >> 8;
+    req[req_length++] = and_mask & 0x00ff;
+    req[req_length++] = or_mask >> 8;
+    req[req_length++] = or_mask & 0x00ff;
+
+    rc = send_msg(ctx, req, req_length);
+    if (rc > 0) {
+        /* Used by write_bit and write_register */
+        uint8_t rsp[MAX_MESSAGE_LENGTH];
+
+        rc = _modbus_receive_msg(ctx, rsp, MSG_CONFIRMATION);
+        if (rc == -1)
+            return -1;
+
+        rc = check_confirmation(ctx, req, rsp, rc);
+    }
+
+    return rc;
+}
+
+/* Write multiple registers from src array to remote device and read multiple
+   registers from remote device to dest array. */
+int modbus_write_and_read_registers(modbus_t *ctx,
+                                    int write_addr, int write_nb,
+                                    const uint16_t *src,
+                                    int read_addr, int read_nb,
+                                    uint16_t *dest)
+
+{
+    int rc;
+    int req_length;
+    int i;
+    int byte_count;
+    uint8_t req[MAX_MESSAGE_LENGTH];
+    uint8_t rsp[MAX_MESSAGE_LENGTH];
+
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (write_nb > MODBUS_MAX_WR_WRITE_REGISTERS) {
+        if (ctx->debug) {
+            fprintf(stderr,
+                    "ERROR Too many registers to write (%d > %d)\n",
+                    write_nb, MODBUS_MAX_WR_WRITE_REGISTERS);
+        }
+        errno = EMBMDATA;
+        return -1;
+    }
+
+    if (read_nb > MODBUS_MAX_WR_READ_REGISTERS) {
+        if (ctx->debug) {
+            fprintf(stderr,
+                    "ERROR Too many registers requested (%d > %d)\n",
+                    read_nb, MODBUS_MAX_WR_READ_REGISTERS);
+        }
+        errno = EMBMDATA;
+        return -1;
+    }
+    req_length = ctx->backend->build_request_basis(ctx,
+                                                   MODBUS_FC_WRITE_AND_READ_REGISTERS,
+                                                   read_addr, read_nb, req);
+
+    req[req_length++] = write_addr >> 8;
+    req[req_length++] = write_addr & 0x00ff;
+    req[req_length++] = write_nb >> 8;
+    req[req_length++] = write_nb & 0x00ff;
+    byte_count = write_nb * 2;
+    req[req_length++] = byte_count;
+
+    for (i = 0; i < write_nb; i++) {
+        req[req_length++] = src[i] >> 8;
+        req[req_length++] = src[i] & 0x00FF;
+    }
+
+    rc = send_msg(ctx, req, req_length);
+    if (rc > 0) {
+        int offset;
+
+        rc = _modbus_receive_msg(ctx, rsp, MSG_CONFIRMATION);
+        if (rc == -1)
+            return -1;
+
+        rc = check_confirmation(ctx, req, rsp, rc);
+        if (rc == -1)
+            return -1;
+
+        offset = ctx->backend->header_length;
+        for (i = 0; i < rc; i++) {
+            /* shift reg hi_byte to temp OR with lo_byte */
+            dest[i] = (rsp[offset + 2 + (i << 1)] << 8) |
+                rsp[offset + 3 + (i << 1)];
+        }
+    }
+
+    return rc;
+}
+
+/* Send a request to get the slave ID of the device (only available in serial
+   communication). */
+int modbus_report_slave_id(modbus_t *ctx, int max_dest, uint8_t *dest)
+{
+    int rc;
+    int req_length;
+    uint8_t req[_MIN_REQ_LENGTH];
+
+    if (ctx == NULL || max_dest <= 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    req_length = ctx->backend->build_request_basis(ctx, MODBUS_FC_REPORT_SLAVE_ID,
+                                                   0, 0, req);
+
+    /* HACKISH, addr and count are not used */
+    req_length -= 4;
+
+    rc = send_msg(ctx, req, req_length);
+    if (rc > 0) {
+        int i;
+        int offset;
+        uint8_t rsp[MAX_MESSAGE_LENGTH];
+
+        rc = _modbus_receive_msg(ctx, rsp, MSG_CONFIRMATION);
+        if (rc == -1)
+            return -1;
+
+        rc = check_confirmation(ctx, req, rsp, rc);
+        if (rc == -1)
+            return -1;
+
+        offset = ctx->backend->header_length + 2;
+
+        /* Byte count, slave id, run indicator status and
+           additional data. Truncate copy to max_dest. */
+        for (i=0; i < rc && i < max_dest; i++) {
+            dest[i] = rsp[offset + i];
+        }
+    }
+
+    return rc;
+}
+
+void _modbus_init_common(modbus_t *ctx)
+{
+    /* Slave and socket are initialized to -1 */
+    ctx->slave = -1;
+    ctx->s = -1;
+
+    ctx->debug = FALSE;
+    ctx->error_recovery = MODBUS_ERROR_RECOVERY_NONE;
+
+    ctx->response_timeout.tv_sec = 0;
+    ctx->response_timeout.tv_usec = _RESPONSE_TIMEOUT;
+
+    ctx->byte_timeout.tv_sec = 0;
+    ctx->byte_timeout.tv_usec = _BYTE_TIMEOUT;
+
+    ctx->monitor_add_item = NULL;
+    ctx->monitor_raw_data = NULL;
+}
+
+/* Define the slave number */
+int modbus_set_slave(modbus_t *ctx, int slave)
+{
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    return ctx->backend->set_slave(ctx, slave);
+}
+
+int modbus_set_error_recovery(modbus_t *ctx,
+                              modbus_error_recovery_mode error_recovery)
+{
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    /* The type of modbus_error_recovery_mode is unsigned enum */
+    ctx->error_recovery = (uint8_t) error_recovery;
+    return 0;
+}
+
+int modbus_set_socket(modbus_t *ctx, int s)
+{
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    ctx->s = s;
+    return 0;
+}
+
+int modbus_get_socket(modbus_t *ctx)
+{
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    return ctx->s;
+}
+
+/* Get the timeout interval used to wait for a response */
+int modbus_get_response_timeout(modbus_t *ctx, uint32_t *to_sec, uint32_t *to_usec)
+{
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    *to_sec = ctx->response_timeout.tv_sec;
+    *to_usec = ctx->response_timeout.tv_usec;
+    return 0;
+}
+
+int modbus_set_response_timeout(modbus_t *ctx, uint32_t to_sec, uint32_t to_usec)
+{
+    if (ctx == NULL ||
+        (to_sec == 0 && to_usec == 0) || to_usec > 999999) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    ctx->response_timeout.tv_sec = to_sec;
+    ctx->response_timeout.tv_usec = to_usec;
+    return 0;
+}
+
+/* Get the timeout interval between two consecutive bytes of a message */
+int modbus_get_byte_timeout(modbus_t *ctx, uint32_t *to_sec, uint32_t *to_usec)
+{
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    *to_sec = ctx->byte_timeout.tv_sec;
+    *to_usec = ctx->byte_timeout.tv_usec;
+    return 0;
+}
+
+int modbus_set_byte_timeout(modbus_t *ctx, uint32_t to_sec, uint32_t to_usec)
+{
+    /* Byte timeout can be disabled when both values are zero */
+    if (ctx == NULL || to_usec > 999999) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    ctx->byte_timeout.tv_sec = to_sec;
+    ctx->byte_timeout.tv_usec = to_usec;
+    return 0;
+}
+
+int modbus_get_header_length(modbus_t *ctx)
+{
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    return ctx->backend->header_length;
+}
+
+int modbus_connect(modbus_t *ctx)
+{
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    return ctx->backend->connect(ctx);
+}
+
+void modbus_close(modbus_t *ctx)
+{
+    if (ctx == NULL)
+        return;
+
+    ctx->backend->close(ctx);
+}
+
+void modbus_free(modbus_t *ctx)
+{
+    if (ctx == NULL)
+        return;
+
+    ctx->backend->free(ctx);
+}
+
+int modbus_set_debug(modbus_t *ctx, int flag)
+{
+    if (ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    ctx->debug = flag;
+    return 0;
+}
+
+/* Allocates 4 arrays to store bits, input bits, registers and inputs
+   registers. The pointers are stored in modbus_mapping structure.
+
+   The modbus_mapping_new() function shall return the new allocated structure if
+   successful. Otherwise it shall return NULL and set errno to ENOMEM. */
+modbus_mapping_t* modbus_mapping_new(int nb_bits, int nb_input_bits,
+                                     int nb_registers, int nb_input_registers)
+{
+    modbus_mapping_t *mb_mapping;
+
+    mb_mapping = (modbus_mapping_t *)malloc(sizeof(modbus_mapping_t));
+    if (mb_mapping == NULL) {
+        return NULL;
+    }
+
+    /* 0X */
+    mb_mapping->nb_bits = nb_bits;
+    if (nb_bits == 0) {
+        mb_mapping->tab_bits = NULL;
+    } else {
+        /* Negative number raises a POSIX error */
+        mb_mapping->tab_bits =
+            (uint8_t *) malloc(nb_bits * sizeof(uint8_t));
+        if (mb_mapping->tab_bits == NULL) {
+            free(mb_mapping);
+            return NULL;
+        }
+        memset(mb_mapping->tab_bits, 0, nb_bits * sizeof(uint8_t));
+    }
+
+    /* 1X */
+    mb_mapping->nb_input_bits = nb_input_bits;
+    if (nb_input_bits == 0) {
+        mb_mapping->tab_input_bits = NULL;
+    } else {
+        mb_mapping->tab_input_bits =
+            (uint8_t *) malloc(nb_input_bits * sizeof(uint8_t));
+        if (mb_mapping->tab_input_bits == NULL) {
+            free(mb_mapping->tab_bits);
+            free(mb_mapping);
+            return NULL;
+        }
+        memset(mb_mapping->tab_input_bits, 0, nb_input_bits * sizeof(uint8_t));
+    }
+
+    /* 4X */
+    mb_mapping->nb_registers = nb_registers;
+    if (nb_registers == 0) {
+        mb_mapping->tab_registers = NULL;
+    } else {
+        mb_mapping->tab_registers =
+            (uint16_t *) malloc(nb_registers * sizeof(uint16_t));
+        if (mb_mapping->tab_registers == NULL) {
+            free(mb_mapping->tab_input_bits);
+            free(mb_mapping->tab_bits);
+            free(mb_mapping);
+            return NULL;
+        }
+        memset(mb_mapping->tab_registers, 0, nb_registers * sizeof(uint16_t));
+    }
+
+    /* 3X */
+    mb_mapping->nb_input_registers = nb_input_registers;
+    if (nb_input_registers == 0) {
+        mb_mapping->tab_input_registers = NULL;
+    } else {
+        mb_mapping->tab_input_registers =
+            (uint16_t *) malloc(nb_input_registers * sizeof(uint16_t));
+        if (mb_mapping->tab_input_registers == NULL) {
+            free(mb_mapping->tab_registers);
+            free(mb_mapping->tab_input_bits);
+            free(mb_mapping->tab_bits);
+            free(mb_mapping);
+            return NULL;
+        }
+        memset(mb_mapping->tab_input_registers, 0,
+               nb_input_registers * sizeof(uint16_t));
+    }
+
+    return mb_mapping;
+}
+
+/* Frees the 4 arrays */
+void modbus_mapping_free(modbus_mapping_t *mb_mapping)
+{
+    if (mb_mapping == NULL) {
+        return;
+    }
+
+    free(mb_mapping->tab_input_registers);
+    free(mb_mapping->tab_registers);
+    free(mb_mapping->tab_input_bits);
+    free(mb_mapping->tab_bits);
+    free(mb_mapping);
+}
+
+#ifndef HAVE_STRLCPY
+/*
+ * Function strlcpy was originally developed by
+ * Todd C. Miller <Todd.Miller@courtesan.com> to simplify writing secure code.
+ * See ftp://ftp.openbsd.org/pub/OpenBSD/src/lib/libc/string/strlcpy.3
+ * for more information.
+ *
+ * Thank you Ulrich Drepper... not!
+ *
+ * Copy src to string dest of size dest_size.  At most dest_size-1 characters
+ * will be copied.  Always NUL terminates (unless dest_size == 0).  Returns
+ * strlen(src); if retval >= dest_size, truncation occurred.
+ */
+size_t strlcpy(char *dest, const char *src, size_t dest_size)
+{
+    register char *d = dest;
+    register const char *s = src;
+    register size_t n = dest_size;
+
+    /* Copy as many bytes as will fit */
+    if (n != 0 && --n != 0) {
+        do {
+            if ((*d++ = *s++) == 0)
+                break;
+        } while (--n != 0);
+    }
+
+    /* Not enough room in dest, add NUL and traverse rest of src */
+    if (n == 0) {
+        if (dest_size != 0)
+            *d = '\0'; /* NUL-terminate dest */
+        while (*s++)
+            ;
+    }
+
+    return (s - src - 1); /* count does not include NUL */
+}
+#endif
+
+
+void modbus_register_monitor_add_item_fnc(modbus_t *ctx,
+                                         modbus_monitor_add_item_fnc_t cb) 
+{
+    if (ctx) {      
+        ctx->monitor_add_item = cb; 
+    }
+}
+
+void modbus_register_monitor_raw_data_fnc(modbus_t *ctx,
+                                         modbus_monitor_raw_data_fnc_t cb) 
+{
+    if (ctx) {
+        ctx->monitor_raw_data = cb;
+    } 
+} 
+
+void modbus_poll(modbus_t* ctx)
+{
+    uint8_t msg[MAX_MESSAGE_LENGTH];
+    uint8_t msg_len = 0;
+
+        if (ctx == NULL) {
+            return;
+        }
+
+    modbus_set_response_timeout( ctx, 0, 500);
+    const int ret = _modbus_receive_msg( ctx, &msg_len, MSG_CONFIRMATION ); /* wait for 0.5 ms */
+    modbus_set_response_timeout( ctx, 0, _RESPONSE_TIMEOUT);
+    if( ( ret < 0 && msg_len > 0 ) || ret >= 0 )
+    {
+        const int o = ctx->backend->header_length;
+        const int slave = msg[o+0];
+        const int func = msg[o+1];
+        const int datalen = msg_len - ctx->backend->header_length - ctx->backend->checksum_length - 2;
+        int addr = 0;
+        int nb = -1;
+        int isQuery = 1;
+        switch( func )
+        {
+            case MODBUS_FC_READ_COILS:
+            case MODBUS_FC_READ_DISCRETE_INPUTS:
+                if( msg[o+2] == datalen-1 )
+                {
+                    isQuery = 0;
+                    nb = (datalen-1) * 8;
+                }
+                break;
+            case MODBUS_FC_READ_HOLDING_REGISTERS:
+            case MODBUS_FC_READ_INPUT_REGISTERS:
+                if( msg[o+2] == datalen-1 )
+                {
+                    isQuery = 0;
+                    nb = (datalen-1) / 2;
+                }
+                break;
+            case MODBUS_FC_WRITE_SINGLE_COIL:
+            case MODBUS_FC_WRITE_SINGLE_REGISTER:
+                /* can't decide from message whether it is a query or response */
+                isQuery = 0;
+                nb = 1;
+                addr = ( msg[o+2] << 8 ) | msg[o+3];
+                break;
+            case MODBUS_FC_REPORT_SLAVE_ID:
+                nb = 0;
+            case MODBUS_FC_WRITE_MULTIPLE_REGISTERS:
+            case MODBUS_FC_WRITE_MULTIPLE_COILS:
+            default:
+                /* can't decide from message whether it is a query or response */
+                isQuery = 0;
+                break;
+        }
+        if( nb == -1 )  /* is query or a write-response? */
+        {
+            addr = ( msg[o+2] << 8 ) | msg[o+3];
+            nb = ( msg[o+4] << 8 ) | msg[o+5];
+        }
+        if (ctx->monitor_add_item) {
+            ctx->monitor_add_item(ctx, isQuery,             /* is query */
+                    slave,              /* slave */
+                    func,               /* func */
+                    addr,               /* addr */
+                    nb,             /* nb */
+                    ctx->last_crc_expected,
+                    ctx->last_crc_received
+                    /*( msg[msg_len-2] << 8 ) | msg[msg_len-1]   CRC */
+                );
+        }
+    }
+}
+
+/* Sets many bits from a single byte value (all 8 bits of the byte value are
+   set) */
+void modbus_set_bits_from_byte(uint8_t *dest, int idx, const uint8_t value)
+{
+    int i;
+
+    for (i=0; i < 8; i++) {
+        dest[idx+i] = (value & (1 << i)) ? 1 : 0;
+    }
+}
+
+/* Sets many bits from a table of bytes (only the bits between idx and
+   idx + nb_bits are set) */
+void modbus_set_bits_from_bytes(uint8_t *dest, int idx, unsigned int nb_bits,
+                                const uint8_t *tab_byte)
+{
+    unsigned int i;
+    int shift = 0;
+
+    for (i = idx; i < idx + nb_bits; i++) {
+        dest[i] = tab_byte[(i - idx) / 8] & (1 << shift) ? 1 : 0;
+        /* gcc doesn't like: shift = (++shift) % 8; */
+        shift++;
+        shift %= 8;
+    }
+}
+
+/* Gets the byte value from many bits.
+   To obtain a full byte, set nb_bits to 8. */
+uint8_t modbus_get_byte_from_bits(const uint8_t *src, int idx,
+                                  unsigned int nb_bits)
+{
+    unsigned int i;
+    uint8_t value = 0;
+
+    if (nb_bits > 8) {
+        /* Assert is ignored if NDEBUG is set */
+        assert(nb_bits < 8);
+        nb_bits = 8;
+    }
+
+    for (i=0; i < nb_bits; i++) {
+        value |= (src[idx+i] << i);
+    }
+
+    return value;
+}
+
+/* Get a float from 4 bytes in Modbus format (ABCD) */
+float modbus_get_float(const uint16_t *src)
+{
+    float f;
+    uint32_t i;
+
+    i = (((uint32_t)src[1]) << 16) + src[0];
+    memcpy(&f, &i, sizeof(float));
+
+    return f;
+}
+
+/* Get a float from 4 bytes in inversed Modbus format (DCBA) */
+float modbus_get_float_dcba(const uint16_t *src)
+{
+    float f;
+    uint32_t i;
+
+    i = bswap_32((((uint32_t)src[1]) << 16) + src[0]);
+    memcpy(&f, &i, sizeof(float));
+
+    return f;
+}
+
+/* Set a float to 4 bytes in Modbus format (ABCD) */
+void modbus_set_float(float f, uint16_t *dest)
+{
+    uint32_t i;
+
+    memcpy(&i, &f, sizeof(uint32_t));
+    dest[0] = (uint16_t)i;
+    dest[1] = (uint16_t)(i >> 16);
+}
+
+/* Set a float to 4 bytes in inversed Modbus format (DCBA) */
+void modbus_set_float_dcba(float f, uint16_t *dest)
+{
+    uint32_t i;
+
+    memcpy(&i, &f, sizeof(uint32_t));
+    i = bswap_32(i);
+    dest[0] = (uint16_t)i;
+    dest[1] = (uint16_t)(i >> 16);
+}
+
+
+

--- a/drivers/modbus-ascii.h
+++ b/drivers/modbus-ascii.h
@@ -1,0 +1,599 @@
+/*
+ * Copyright © 2001-2011 Stéphane Raimbault <stephane.raimbault@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+
+
+
+#ifndef MODBUS_VERSION_H
+#define MODBUS_VERSION_H
+
+/* The major version, (1, if %LIBMODBUS_VERSION is 1.2.3) */
+#define LIBMODBUS_VERSION_MAJOR (3)
+
+/* The minor version (2, if %LIBMODBUS_VERSION is 1.2.3) */
+#define LIBMODBUS_VERSION_MINOR (1)
+
+/* The micro version (3, if %LIBMODBUS_VERSION is 1.2.3) */
+#define LIBMODBUS_VERSION_MICRO (1)
+
+/* The full version, like 1.2.3 */
+#define LIBMODBUS_VERSION        3.1.1
+
+/* The full version, in string form (suited for string concatenation)
+ */
+#define LIBMODBUS_VERSION_STRING "3.1.1"
+
+/* Numerically encoded version, like 0x010203 */
+#define LIBMODBUS_VERSION_HEX ((LIBMODBUS_VERSION_MAJOR << 24) |  \
+                               (LIBMODBUS_VERSION_MINOR << 16) |  \
+                               (LIBMODBUS_VERSION_MICRO << 8))
+
+/* Evaluates to True if the version is greater than @major, @minor and @micro
+ */
+#define LIBMODBUS_VERSION_CHECK(major,minor,micro)      \
+    (LIBMODBUS_VERSION_MAJOR > (major) ||               \
+     (LIBMODBUS_VERSION_MAJOR == (major) &&             \
+      LIBMODBUS_VERSION_MINOR > (minor)) ||             \
+     (LIBMODBUS_VERSION_MAJOR == (major) &&             \
+      LIBMODBUS_VERSION_MINOR == (minor) &&             \
+      LIBMODBUS_VERSION_MICRO >= (micro)))
+
+#endif /* MODBUS_VERSION_H */
+
+#ifndef MODBUS_H
+#define MODBUS_H
+
+/* Add this for macros that defined unix flavor */
+#if (defined(__unix__) || defined(unix)) && !defined(USG)
+#include <sys/param.h>
+#endif
+
+#ifndef _MSC_VER
+#include <stdint.h>
+#else
+#include "stdint.h"
+#endif
+
+#if defined(_MSC_VER)
+# if defined(DLLBUILD)
+/* define DLLBUILD when building the DLL */
+#  define MODBUS_API __declspec(dllexport)
+# else
+#  define MODBUS_API __declspec(dllimport)
+# endif
+#else
+# define MODBUS_API
+#endif
+
+#ifdef  __cplusplus
+# define MODBUS_BEGIN_DECLS  extern "C" {
+# define MODBUS_END_DECLS    }
+#else
+# define MODBUS_BEGIN_DECLS
+# define MODBUS_END_DECLS
+#endif
+
+MODBUS_BEGIN_DECLS
+
+#ifndef FALSE
+#define FALSE 0
+#endif
+
+#ifndef TRUE
+#define TRUE 1
+#endif
+
+#ifndef OFF
+#define OFF 0
+#endif
+
+#ifndef ON
+#define ON 1
+#endif
+
+/* Modbus function codes */
+#define MODBUS_FC_READ_COILS                0x01
+#define MODBUS_FC_READ_DISCRETE_INPUTS      0x02
+#define MODBUS_FC_READ_HOLDING_REGISTERS    0x03
+#define MODBUS_FC_READ_INPUT_REGISTERS      0x04
+#define MODBUS_FC_WRITE_SINGLE_COIL         0x05
+#define MODBUS_FC_WRITE_SINGLE_REGISTER     0x06
+#define MODBUS_FC_READ_EXCEPTION_STATUS     0x07
+#define MODBUS_FC_WRITE_MULTIPLE_COILS      0x0F
+#define MODBUS_FC_WRITE_MULTIPLE_REGISTERS  0x10
+#define MODBUS_FC_REPORT_SLAVE_ID           0x11
+#define MODBUS_FC_MASK_WRITE_REGISTER       0x16
+#define MODBUS_FC_WRITE_AND_READ_REGISTERS  0x17
+
+#define MODBUS_BROADCAST_ADDRESS    0
+
+/* Modbus_Application_Protocol_V1_1b.pdf (chapter 6 section 1 page 12)
+ * Quantity of Coils to read (2 bytes): 1 to 2000 (0x7D0)
+ * (chapter 6 section 11 page 29)
+ * Quantity of Coils to write (2 bytes): 1 to 1968 (0x7B0)
+ */
+#define MODBUS_MAX_READ_BITS              2000
+#define MODBUS_MAX_WRITE_BITS             1968
+
+/* Modbus_Application_Protocol_V1_1b.pdf (chapter 6 section 3 page 15)
+ * Quantity of Registers to read (2 bytes): 1 to 125 (0x7D)
+ * (chapter 6 section 12 page 31)
+ * Quantity of Registers to write (2 bytes) 1 to 123 (0x7B)
+ * (chapter 6 section 17 page 38)
+ * Quantity of Registers to write in R/W registers (2 bytes) 1 to 121 (0x79)
+ */
+#define MODBUS_MAX_READ_REGISTERS          125
+#define MODBUS_MAX_WRITE_REGISTERS         123
+#define MODBUS_MAX_WR_WRITE_REGISTERS      121
+#define MODBUS_MAX_WR_READ_REGISTERS       125
+
+/* The size of the MODBUS PDU is limited by the size constraint inherited from
+ * the first MODBUS implementation on Serial Line network (max. RS485 ADU = 256
+ * bytes). Therefore, MODBUS PDU for serial line communication = 256 - Server
+ * address (1 byte) - CRC (2 bytes) = 253 bytes.
+ *
+ * Consequently:
+ * - RS232 / RS485 ADU = 253 bytes + Server address (1 byte) + CRC (2 bytes) =
+ *   256 bytes.
+ * - TCP MODBUS ADU = 253 bytes + MBAP (7 bytes) = 260 bytes.
+ */
+#define MODBUS_MAX_PDU_LENGTH              253
+
+/* Random number to avoid errno conflicts */
+#define MODBUS_ENOBASE 112345678
+
+/* Protocol exceptions */
+enum {
+    MODBUS_EXCEPTION_ILLEGAL_FUNCTION = 0x01,
+    MODBUS_EXCEPTION_ILLEGAL_DATA_ADDRESS,
+    MODBUS_EXCEPTION_ILLEGAL_DATA_VALUE,
+    MODBUS_EXCEPTION_SLAVE_OR_SERVER_FAILURE,
+    MODBUS_EXCEPTION_ACKNOWLEDGE,
+    MODBUS_EXCEPTION_SLAVE_OR_SERVER_BUSY,
+    MODBUS_EXCEPTION_NEGATIVE_ACKNOWLEDGE,
+    MODBUS_EXCEPTION_MEMORY_PARITY,
+    MODBUS_EXCEPTION_NOT_DEFINED,
+    MODBUS_EXCEPTION_GATEWAY_PATH,
+    MODBUS_EXCEPTION_GATEWAY_TARGET,
+    MODBUS_EXCEPTION_MAX
+};
+
+#define EMBXILFUN  (MODBUS_ENOBASE + MODBUS_EXCEPTION_ILLEGAL_FUNCTION)
+#define EMBXILADD  (MODBUS_ENOBASE + MODBUS_EXCEPTION_ILLEGAL_DATA_ADDRESS)
+#define EMBXILVAL  (MODBUS_ENOBASE + MODBUS_EXCEPTION_ILLEGAL_DATA_VALUE)
+#define EMBXSFAIL  (MODBUS_ENOBASE + MODBUS_EXCEPTION_SLAVE_OR_SERVER_FAILURE)
+#define EMBXACK    (MODBUS_ENOBASE + MODBUS_EXCEPTION_ACKNOWLEDGE)
+#define EMBXSBUSY  (MODBUS_ENOBASE + MODBUS_EXCEPTION_SLAVE_OR_SERVER_BUSY)
+#define EMBXNACK   (MODBUS_ENOBASE + MODBUS_EXCEPTION_NEGATIVE_ACKNOWLEDGE)
+#define EMBXMEMPAR (MODBUS_ENOBASE + MODBUS_EXCEPTION_MEMORY_PARITY)
+#define EMBXGPATH  (MODBUS_ENOBASE + MODBUS_EXCEPTION_GATEWAY_PATH)
+#define EMBXGTAR   (MODBUS_ENOBASE + MODBUS_EXCEPTION_GATEWAY_TARGET)
+
+/* Native libmodbus error codes */
+#define EMBBADCRC  (EMBXGTAR + 1)
+#define EMBBADDATA (EMBXGTAR + 2)
+#define EMBBADEXC  (EMBXGTAR + 3)
+#define EMBUNKEXC  (EMBXGTAR + 4)
+#define EMBMDATA   (EMBXGTAR + 5)
+#define EMBBADSLAVE (EMBXGTAR + 6)
+
+extern const unsigned int libmodbus_version_major;
+extern const unsigned int libmodbus_version_minor;
+extern const unsigned int libmodbus_version_micro;
+
+typedef struct _modbus modbus_t;
+
+typedef struct {
+    int nb_bits;
+    int nb_input_bits;
+    int nb_input_registers;
+    int nb_registers;
+    uint8_t *tab_bits;
+    uint8_t *tab_input_bits;
+    uint16_t *tab_input_registers;
+    uint16_t *tab_registers;
+} modbus_mapping_t;
+
+typedef enum
+{
+    MODBUS_ERROR_RECOVERY_NONE          = 0,
+    MODBUS_ERROR_RECOVERY_LINK          = (1<<1),
+    MODBUS_ERROR_RECOVERY_PROTOCOL      = (1<<2)
+} modbus_error_recovery_mode;
+
+
+typedef void (*modbus_monitor_add_item_fnc_t)(modbus_t *ctx,
+        uint8_t isOut, uint8_t slave, uint8_t func, uint16_t addr, uint16_t nb, 
+        uint16_t expectedCRC, uint16_t actualCRC );
+typedef void (*modbus_monitor_raw_data_fnc_t)(modbus_t *ctx,
+        uint8_t *data, uint8_t dataLen, uint8_t addNewline,uint8_t);
+
+MODBUS_API int modbus_set_slave(modbus_t *ctx, int slave);
+MODBUS_API int modbus_set_error_recovery(modbus_t *ctx, modbus_error_recovery_mode error_recovery);
+MODBUS_API int modbus_set_socket(modbus_t *ctx, int s);
+MODBUS_API int modbus_get_socket(modbus_t *ctx);
+
+MODBUS_API int modbus_get_response_timeout(modbus_t *ctx, uint32_t *to_sec, uint32_t *to_usec);
+MODBUS_API int modbus_set_response_timeout(modbus_t *ctx, uint32_t to_sec, uint32_t to_usec);
+
+MODBUS_API int modbus_get_byte_timeout(modbus_t *ctx, uint32_t *to_sec, uint32_t *to_usec);
+MODBUS_API int modbus_set_byte_timeout(modbus_t *ctx, uint32_t to_sec, uint32_t to_usec);
+
+MODBUS_API int modbus_get_header_length(modbus_t *ctx);
+
+MODBUS_API int modbus_connect(modbus_t *ctx);
+MODBUS_API void modbus_close(modbus_t *ctx);
+
+MODBUS_API void modbus_free(modbus_t *ctx);
+
+MODBUS_API int modbus_flush(modbus_t *ctx);
+MODBUS_API int modbus_set_debug(modbus_t *ctx, int flag);
+
+MODBUS_API const char *modbus_strerror(int errnum);
+
+MODBUS_API int modbus_read_bits(modbus_t *ctx, int addr, int nb, uint8_t *dest);
+MODBUS_API int modbus_read_input_bits(modbus_t *ctx, int addr, int nb, uint8_t *dest);
+MODBUS_API int modbus_read_registers(modbus_t *ctx, int addr, int nb, uint16_t *dest);
+MODBUS_API int modbus_read_input_registers(modbus_t *ctx, int addr, int nb, uint16_t *dest);
+MODBUS_API int modbus_write_bit(modbus_t *ctx, int coil_addr, int status);
+MODBUS_API int modbus_write_register(modbus_t *ctx, int reg_addr, int value);
+MODBUS_API int modbus_write_bits(modbus_t *ctx, int addr, int nb, const uint8_t *data);
+MODBUS_API int modbus_write_registers(modbus_t *ctx, int addr, int nb, const uint16_t *data);
+MODBUS_API int modbus_mask_write_register(modbus_t *ctx, int addr, uint16_t and_mask, uint16_t or_mask);
+MODBUS_API int modbus_write_and_read_registers(modbus_t *ctx, int write_addr, int write_nb,
+                                               const uint16_t *src, int read_addr, int read_nb,
+                                               uint16_t *dest);
+MODBUS_API int modbus_report_slave_id(modbus_t *ctx, int max_dest, uint8_t *dest);
+
+MODBUS_API modbus_mapping_t* modbus_mapping_new(int nb_bits, int nb_input_bits,
+                                            int nb_registers, int nb_input_registers);
+MODBUS_API void modbus_mapping_free(modbus_mapping_t *mb_mapping);
+
+MODBUS_API int modbus_send_raw_request(modbus_t *ctx, uint8_t *raw_req, int raw_req_length);
+
+MODBUS_API int modbus_receive(modbus_t *ctx, uint8_t *req);
+
+MODBUS_API int modbus_receive_confirmation(modbus_t *ctx, uint8_t *rsp);
+
+MODBUS_API int modbus_reply(modbus_t *ctx, const uint8_t *req,
+                            int req_length, modbus_mapping_t *mb_mapping);
+MODBUS_API int modbus_reply_exception(modbus_t *ctx, const uint8_t *req,
+                                      unsigned int exception_code);
+MODBUS_API void modbus_register_monitor_add_item_fnc(modbus_t *ctx,
+                                                    modbus_monitor_add_item_fnc_t cb); 
+MODBUS_API void modbus_register_monitor_raw_data_fnc(modbus_t *ctx,
+                                                    modbus_monitor_raw_data_fnc_t cb); 
+
+void modbus_poll(modbus_t *ctx);
+
+
+/**
+ * UTILS FUNCTIONS
+ **/
+
+#define MODBUS_GET_HIGH_BYTE(data) (((data) >> 8) & 0xFF)
+#define MODBUS_GET_LOW_BYTE(data) ((data) & 0xFF)
+#define MODBUS_GET_INT32_FROM_INT16(tab_int16, index) ((tab_int16[(index)] << 16) + tab_int16[(index) + 1])
+#define MODBUS_GET_INT16_FROM_INT8(tab_int8, index) ((tab_int8[(index)] << 8) + tab_int8[(index) + 1])
+#define MODBUS_SET_INT16_TO_INT8(tab_int8, index, value) \
+    do { \
+        tab_int8[(index)] = (value) >> 8;  \
+        tab_int8[(index) + 1] = (value) & 0xFF; \
+    } while (0)
+
+MODBUS_API void modbus_set_bits_from_byte(uint8_t *dest, int idx, const uint8_t value);
+MODBUS_API void modbus_set_bits_from_bytes(uint8_t *dest, int idx, unsigned int nb_bits,
+                                       const uint8_t *tab_byte);
+MODBUS_API uint8_t modbus_get_byte_from_bits(const uint8_t *src, int idx, unsigned int nb_bits);
+MODBUS_API float modbus_get_float(const uint16_t *src);
+MODBUS_API float modbus_get_float_dcba(const uint16_t *src);
+MODBUS_API void modbus_set_float(float f, uint16_t *dest);
+MODBUS_API void modbus_set_float_dcba(float f, uint16_t *dest);
+
+MODBUS_END_DECLS
+
+#endif  /* MODBUS_H */
+
+
+#ifndef MODBUS_RTU_H
+#define MODBUS_RTU_H
+
+
+MODBUS_BEGIN_DECLS
+
+/* Modbus_Application_Protocol_V1_1b.pdf Chapter 4 Section 1 Page 5
+ * RS232 / RS485 ADU = 253 bytes + slave (1 byte) + CRC (2 bytes) = 256 bytes
+ */
+#define MODBUS_RTU_MAX_ADU_LENGTH  256
+
+MODBUS_API modbus_t* modbus_new_rtu(const char *device, int baud, char parity,
+                                int data_bit, int stop_bit);
+
+#define MODBUS_RTU_RS232 0
+#define MODBUS_RTU_RS485 1
+
+MODBUS_API int modbus_rtu_set_serial_mode(modbus_t *ctx, int mode);
+MODBUS_API int modbus_rtu_get_serial_mode(modbus_t *ctx);
+
+#define MODBUS_RTU_RTS_NONE   0
+#define MODBUS_RTU_RTS_UP     1
+#define MODBUS_RTU_RTS_DOWN   2
+
+MODBUS_API int modbus_rtu_set_rts(modbus_t *ctx, int mode);
+MODBUS_API int modbus_rtu_get_rts(modbus_t *ctx);
+
+MODBUS_END_DECLS
+
+#endif /* MODBUS_RTU_H */
+
+
+
+#ifndef MODBUS_TCP_H
+#define MODBUS_TCP_H
+
+MODBUS_BEGIN_DECLS
+
+#if defined(_WIN32) && !defined(__CYGWIN__)
+/* Win32 with MinGW, supplement to <errno.h> */
+#include <winsock2.h>
+#if !defined(ECONNRESET)
+#define ECONNRESET   WSAECONNRESET
+#endif
+#if !defined(ECONNREFUSED)
+#define ECONNREFUSED WSAECONNREFUSED
+#endif
+#if !defined(ETIMEDOUT)
+#define ETIMEDOUT    WSAETIMEDOUT
+#endif
+#if !defined(ENOPROTOOPT)
+#define ENOPROTOOPT  WSAENOPROTOOPT
+#endif
+#if !defined(EINPROGRESS)
+#define EINPROGRESS  WSAEINPROGRESS
+#endif
+#endif
+
+#define MODBUS_TCP_DEFAULT_PORT   502
+#define MODBUS_TCP_SLAVE         0xFF
+
+/* Modbus_Application_Protocol_V1_1b.pdf Chapter 4 Section 1 Page 5
+ * TCP MODBUS ADU = 253 bytes + MBAP (7 bytes) = 260 bytes
+ */
+#define MODBUS_TCP_MAX_ADU_LENGTH  260
+
+MODBUS_API modbus_t* modbus_new_tcp(const char *ip_address, int port);
+MODBUS_API int modbus_tcp_listen(modbus_t *ctx, int nb_connection);
+MODBUS_API int modbus_tcp_accept(modbus_t *ctx, int *s);
+
+MODBUS_API modbus_t* modbus_new_tcp_pi(const char *node, const char *service);
+MODBUS_API int modbus_tcp_pi_listen(modbus_t *ctx, int nb_connection);
+MODBUS_API int modbus_tcp_pi_accept(modbus_t *ctx, int *s);
+
+MODBUS_END_DECLS
+
+#endif /* MODBUS_TCP_H */
+
+
+
+
+#ifndef _MODBUS_ASCII_H_
+#define _MODBUS_ASCII_H_
+
+
+MODBUS_BEGIN_DECLS
+
+/* Modbus_Application_Protocol_V1_1b.pdf Chapter 4 Section 1 Page 5
+ * RS232 / RS485 ADU = 253 bytes + slave (1 byte) + CRC (2 bytes) = 256 bytes
+ */
+#define MODBUS_ASCII_MAX_ADU_LENGTH  256
+
+MODBUS_API modbus_t* modbus_new_ascii(const char *device, int baud, char parity,
+                                int data_bit, int stop_bit);
+
+#define MODBUS_ASCII_RS232 0
+#define MODBUS_ASCII_RS485 1
+
+MODBUS_API int modbus_ascii_set_serial_mode(modbus_t *ctx, int mode);
+MODBUS_API int modbus_ascii_get_serial_mode(modbus_t *ctx);
+
+MODBUS_END_DECLS
+
+#endif /* _MODBUS_ASCII_H_ */
+
+#ifndef _MODBUS_ASCII_PRIVATE_H_
+#define _MODBUS_ASCII_PRIVATE_H_
+
+#ifndef _MSC_VER
+#include <stdint.h>
+#else
+#include "stdint.h"
+#endif
+
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <termios.h>
+#endif
+
+#define _MODBUS_ASCII_HEADER_LENGTH      2
+#define _MODBUS_ASCII_PRESET_REQ_LENGTH  7
+#define _MODBUS_ASCII_PRESET_RSP_LENGTH  2
+
+#define _MODBUS_ASCII_CHECKSUM_LENGTH    3 /* lcr8 + \r\n */
+
+#if defined(_WIN32)
+#if !defined(ENOTSUP)
+#define ENOTSUP WSAEOPNOTSUPP
+#endif
+
+/* WIN32: struct containing serial handle and a receive buffer */
+#define PY_BUF_SIZE 512
+struct win32_ser {
+    /* File handle */
+    HANDLE fd;
+    /* Receive buffer */
+    uint8_t buf[PY_BUF_SIZE];
+    /* Received chars */
+    DWORD n_bytes;
+};
+#endif /* _WIN32 */
+
+typedef struct _modbus_rtu {
+    /* Device: "/dev/ttyS0", "/dev/ttyUSB0" or "/dev/tty.USA19*" on Mac OS X. */
+    char *device;
+    /* Bauds: 9600, 19200, 57600, 115200, etc */
+    int baud;
+    /* Data bit */
+    uint8_t data_bit;
+    /* Stop bit */
+    uint8_t stop_bit;
+    /* Parity: 'N', 'O', 'E' */
+    char parity;
+#if defined(_WIN32)
+    struct win32_ser w_ser;
+    DCB old_dcb;
+#else
+    /* Save old termios settings */
+    struct termios old_tios;
+#endif
+/* #if HAVE_DECL_TIOCSRS485 */
+    int serial_mode;
+/* #endif */
+#if HAVE_DECL_TIOCM_RTS
+    int rts;
+    int onebyte_time;
+#endif
+    /* To handle many slaves on the same link */
+    int confirmation_to_ignore;
+} modbus_ascii_t;
+
+#endif /* _MODBUS_RTU_PRIVATE_H_ */
+
+#ifndef MODBUS_PRIVATE_H
+#define MODBUS_PRIVATE_H
+
+#ifndef _MSC_VER
+# include <stdint.h>
+# include <sys/time.h>
+#else
+# include "stdint.h"
+# include <time.h>
+typedef int ssize_t;
+#endif
+#include <sys/types.h>
+#include <config.h>
+
+MODBUS_BEGIN_DECLS
+
+/* It's not really the minimal length (the real one is report slave ID
+ * in RTU (4 bytes)) but it's a convenient size to use in RTU or TCP
+ * communications to read many values or write a single one.
+ * Maximum between :
+ * - HEADER_LENGTH_TCP (7) + function (1) + address (2) + number (2)
+ * - HEADER_LENGTH_RTU (1) + function (1) + address (2) + number (2) + CRC (2)
+ */
+#define _MIN_REQ_LENGTH 12
+
+#define _REPORT_SLAVE_ID 180
+
+#define _MODBUS_EXCEPTION_RSP_LENGTH 5
+
+/* Timeouts in microsecond (0.5 s) */
+#define _RESPONSE_TIMEOUT    500000
+#define _BYTE_TIMEOUT        500000
+
+typedef enum {
+    _MODBUS_BACKEND_TYPE_RTU=0,
+    _MODBUS_BACKEND_TYPE_TCP, 
+    _MODBUS_BACKEND_TYPE_ASCII
+} modbus_backend_type_t;
+
+/*
+ *  ---------- Request     Indication ----------
+ *  | Client | ---------------------->| Server |
+ *  ---------- Confirmation  Response ----------
+ */
+typedef enum {
+    /* Request message on the server side */
+    MSG_INDICATION,
+    /* Request message on the client side */
+    MSG_CONFIRMATION
+} msg_type_t;
+
+/* This structure reduces the number of params in functions and so
+ * optimizes the speed of execution (~ 37%). */
+typedef struct _sft {
+    int slave;
+    int function;
+    int t_id;
+} sft_t;
+
+
+typedef struct _modbus_backend {
+    unsigned int backend_type;
+    unsigned int header_length;
+    unsigned int checksum_length;
+    unsigned int max_adu_length;
+    int (*set_slave) (modbus_t *ctx, int slave);
+    int (*build_request_basis) (modbus_t *ctx, int function, int addr,
+                                int nb, uint8_t *req);
+    int (*build_response_basis) (sft_t *sft, uint8_t *rsp);
+    int (*prepare_response_tid) (const uint8_t *req, int *req_length);
+    int (*send_msg_pre) (uint8_t *req, int req_length);
+    ssize_t (*send) (modbus_t *ctx, const uint8_t *req, int req_length);
+    int (*receive) (modbus_t *ctx, uint8_t *req);
+    ssize_t (*recv) (modbus_t *ctx, uint8_t *rsp, int rsp_length);
+    int (*check_integrity) (modbus_t *ctx, uint8_t *msg,
+                            const int msg_length);
+    int (*pre_check_confirmation) (modbus_t *ctx, const uint8_t *req,
+                                   const uint8_t *rsp, int rsp_length);
+    int (*connect) (modbus_t *ctx);
+    void (*close) (modbus_t *ctx);
+    int (*flush) (modbus_t *ctx);
+    int (*select) (modbus_t *ctx, fd_set *rset, struct timeval *tv, int msg_length);
+    void (*free) (modbus_t *ctx);
+} modbus_backend_t;
+
+struct _modbus {
+    /* Slave address */
+    int slave;
+    /* Socket or file descriptor */
+    int s;
+    int debug;
+    int error_recovery;
+    struct timeval response_timeout;
+    struct timeval byte_timeout;
+  uint16_t last_crc_expected;
+  uint16_t last_crc_received;
+    const modbus_backend_t *backend;
+    void *backend_data;
+    modbus_monitor_add_item_fnc_t monitor_add_item;
+    modbus_monitor_raw_data_fnc_t monitor_raw_data;
+};
+
+void _modbus_init_common(modbus_t *ctx);
+void _error_print(modbus_t *ctx, const char *context);
+int _modbus_receive_msg(modbus_t *ctx, uint8_t *msg, msg_type_t msg_type);
+
+#ifndef HAVE_STRLCPY
+size_t strlcpy(char *dest, const char *src, size_t dest_size);
+#endif
+
+MODBUS_END_DECLS
+
+#endif  /* MODBUS_PRIVATE_H */


### PR DESCRIPTION
INVT HR11 series
INVT HT11 series
SNR-UPS-ONRT (3000-20000) series
HIDEN EXPERT UDC9200S-RT 1-3 кВА
HIDEN EXPERT UDC9200H-RT 6-10 кВА

<!-- Comment:
* Please revise the docs/developers.txt for coding style suggestions and
  other considerations applicable to NUT codebase contributions, as well
  as for which text documents to update. See also docs/developer-guide.txt
  for general points on NUT architecture and design.

* The checklist below is more of a reminder of steps to take and "dangers"
  to look out for. PRs to update this template are also welcome :)

* Local build iterations can be augmented with the ci_build.sh script.
-->

## General points

- [ ] Described the changes in the PR submission or a separate issue, e.g.
  known published or discovered protocols, applicable hardware (expected
  compatible and actually tested/developed against), limitations, etc.

- [ ] There may be multiple commits in the PR, aligned and commented with
  a functional change. Notably, coding style changes better belong in a
  separate PR, but certainly in a dedicated commit to simplify reviews
  of "real" changes in the other commits. Similarly for typo fixes in
  comments or text documents.

## Frequent "underwater rocks" for driver addition/update PRs

- [ ] Revised existing driver families and added a sub-driver if applicable
  (`nutdrv_qx`, `usbhid-ups`...) or added a brand new driver in the other
  case.

- [ ] Did not extend obsoleted drivers with new hardware support features
  (notably `blazer` and other single-device family drivers for Qx protocols,
  except the new `nutdrv_qx` which should cover them all).

- [ ] For updated existing device drivers, bumped the `DRIVER_VERSION` macro
  or its equivalent.

<!-- Comment:
  Some sub-drivers have `SUBDRIVER_VERSION` or customized names like
  e.g. `MEGATEC_VERSION` in `drivers/nutdrv_qx_megatec.c`
-->

- [ ] For USB devices (HID or not), revised that the driver uses unique
  VID/PID combinations, or raised discussions when this is not the case
  (several vendors do use same interface chips for unrelated protocols).

- [ ] For new USB devices, built and committed the changes for the
  `scripts/upower/95-upower-hid.hwdb` file

- [ ] Proposed NUT data mapping is aligned with existing `docs/nut-names.txt`
  file. If the device exposes useful data points not listed in the file, the
  `experimental.*` namespace can be used as documented there, and discussion
  should be raised on the NUT Developers mailing list to standardize the new
  concept.

- [ ] Updated `data/driver.list.in` if applicable (new tested device info)
<!-- Comment:
Also note below, a point about PR posting for NUT DDL
-->

## Frequent "underwater rocks" for general C code PRs

- [ ] Did not "blindly assume" default integer type sizes and value ranges,
  structure layout and alignment in memory, endianness (layout of bytes and
  bits in memory for multi-byte numeric types), or use of generic `int` where
  language or libraries dictate the use of `size_t` (or `ssize_t` sometimes).

<!-- Comment:
* NOTE: Casting and/or pragmas (support detected at compile time,
  see `m4/ax_c_pragmas.m4`) to silence warnings may be acceptable,
  but only if coupled with range checks or similar actions.
-->

- [ ] Progress and errors are handled with `upsdebugx()`, `upslogx()`,
  `fatalx()` and related methods, not with direct `printf()` or `exit()`.
  Similarly, NUT helpers are used for error-checked memory allocation and
  string operations (except where customized error handling is needed,
  such as unlocking device ports, etc.)

- [ ] Coding style (including whitespace for indentations) follows precedent
  in the code of the file, and examples/guide in `docs/developers.txt` file.

- [ ] For newly added files, the `Makefile.am` recipes were updated and the
  `make distcheck` target passes.

## General documentation updates

- [ ] Updated `docs/acknowledgements.txt` (for vendor-backed device support)

- [ ] Added or updated manual page information in `docs/man/*.txt` files
  and corresponding recipe lists in `docs/man/Makefile.am` for new pages

- [ ] Passed `make spellcheck`, updated spell-checking dictionary in the
  `docs/nut.dict` file if needed (did not remove any words -- the `make`
  rule printout in case of changes suggests how to maintain it).

## Additional work may be needed after posting this PR

- [ ] Propose a PR for NUT DDL with detailed device data dumps from tests
  against real hardware (the more models, the better).

- [ ] Address NUT CI farm build failures for the PR: testing on numerous
  platforms and toolkits can expose issues not seen on just one system.

<!-- Comment:
* One frequent "offence" is the appearance of unexpected (not git-ignored)
  or modification during build of files tracked in Git.

* Another frequent issue is not tracking newly introduced file names in
  `EXTRA_DIST` of the `Makefile.am` (and for `*.in` templates -- of rules
  in the `configure.ac` script) so the `make distcheck` fails.

* Avoid using GNU-specific constructs in the `Makefile.am`, even if that
  means cumbersome ways to build a target. This should not happen in mere
  driver updates, however.

* Also some third-party libraries or OS headers and method argument types
  and counts can differ -- necessitating m4 code for `configure` script
  probing, and `ifdef`, `typedef`, etc. in C code to adapt to the build
  environment (precedents available in NUT codebase). In extreme cases,
  you may need to spin up a VM or container to reproduce those issues
  and iterate on a fix locally; see `docs/config-prereqs.txt` and
  `docs/ci-farm-lxc-setup.txt` for notes taken during preparation of
  the multi-platform NUT CI farm.
-->

- [ ] Revise suggestions from LGTM.COM analysis about "new issues" with
  the changed codebase.

<!-- Comment:
  Take them with a grain of salt, especially with regard to things like
  architecture-dependent range checks, but many of the complaints from
  the tool are indeed useful.
-->
