### PR TITLE
Add SNMP apc easy pdu support

### DIFF
--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -231,7 +231,7 @@ mge_shut_LDADD = $(LDADD) -lm
 # Please keep the MIB table below sorted roughly alphabetically (incidentally
 # by vendor too) to ease maintenance and codebase fork resynchronisations
 snmp_ups_SOURCES = snmp-ups.c snmp-ups-helpers.c \
- apc-mib.c apc-pdu-mib.c \
+ apc-mib.c apc-pdu-mib.c apc-epdu-mib.c \
  baytech-mib.c bestpower-mib.c \
  compaq-mib.c cyberpower-mib.c \
  delta_ups-mib.c \
@@ -339,7 +339,7 @@ dist_noinst_HEADERS = apc-mib.h apc-iem-mib.h apc-hid.h arduino-hid.h baytech-mi
  nutdrv_qx_megatec.h nutdrv_qx_megatec-old.h nutdrv_qx_mustek.h nutdrv_qx_q1.h nutdrv_qx_hunnox.h	\
  nutdrv_qx_voltronic.h nutdrv_qx_voltronic-qs.h nutdrv_qx_voltronic-qs-hex.h nutdrv_qx_zinto.h \
  xppc-mib.h huawei-mib.h eaton-ats16-nmc-mib.h eaton-ats16-nm2-mib.h apc-ats-mib.h raritan-px2-mib.h eaton-ats30-mib.h \
- apc-pdu-mib.h ever-hid.h eaton-pdu-genesis2-mib.h eaton-pdu-marlin-mib.h eaton-pdu-marlin-helpers.h \
+ apc-pdu-mib.h apc-epdu-mib.h ever-hid.h eaton-pdu-genesis2-mib.h eaton-pdu-marlin-mib.h eaton-pdu-marlin-helpers.h \
  eaton-pdu-pulizzi-mib.h eaton-pdu-revelation-mib.h emerson-avocent-pdu-mib.h legrand-hid.h \
  hpe-pdu-mib.h powervar-hid.h delta_ups-hid.h generic_modbus.h salicru-hid.h adelsystem_cbi.h
 

--- a/drivers/apc-epdu-mib.c
+++ b/drivers/apc-epdu-mib.c
@@ -1,0 +1,221 @@
+/* apc-epdu-mib.c - subdriver to monitor apc SNMP easy pdu with NUT
+ *
+ *  Copyright (C)
+ *  2011 - 2022	Eric Clappier <EricClappier@eaton.com>
+ *
+ *  Note: this subdriver was initially generated as a "stub" by the
+ *  gen-snmp-subdriver script. It must be customized!
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#include "apc-epdu-mib.h"
+
+#define APC_EPDU_MIB_VERSION  "0.1"
+
+#define APC_EPDU_MIB_SYSOID   ".1.3.6.1.4.1.318.1.3.4.9"
+
+static info_lkp_t apc_epdu_sw_outlet_status_info[] = {
+	{ 1, "off", NULL, NULL },
+	{ 2, "on", NULL, NULL },
+	{ 0, NULL, NULL, NULL }
+};
+
+static info_lkp_t apc_epdu_sw_outlet_switchability_info[] = {
+	{ 1, "yes", NULL, NULL },
+	{ 2, "yes", NULL, NULL },
+	{ 0, NULL, NULL, NULL }
+};
+
+/* POWERNET-MIB Snmp2NUT lookup table */
+static snmp_info_t apc_epdu_mib[] = {
+
+	/* Device page */
+	{ "device.mfr", ST_FLAG_STRING, SU_INFOSIZE, NULL, "APC", SU_FLAG_STATIC | SU_FLAG_ABSENT | SU_FLAG_OK, NULL },
+	/* ePDUDeviceStatusModelNumber.1 = STRING: "EPDU1016M" */
+	{ "device.model", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.318.1.1.30.2.1.1.4.1", "Easy ePDU", SU_FLAG_STATIC | SU_FLAG_OK, NULL },
+	{ "device.type", ST_FLAG_STRING, SU_INFOSIZE, NULL, "pdu", SU_FLAG_STATIC | SU_FLAG_ABSENT | SU_FLAG_OK, NULL },
+	{ "device.contact", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.2.1.1.4.0", NULL, SU_FLAG_STALE | SU_FLAG_OK, NULL },
+	{ "device.description", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.2.1.1.5.0", NULL, SU_FLAG_STALE | SU_FLAG_OK, NULL },
+	{ "device.location", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.2.1.1.6.0", NULL, SU_FLAG_STALE | SU_FLAG_OK, NULL },
+	/* FIXME: to be RFC'ed */
+	{ "device.uptime", 0, 1, ".1.3.6.1.2.1.1.3.0", NULL, SU_FLAG_OK | SU_FLAG_NEGINVALID, NULL },
+	/* ePDUDeviceStatusSerialNumber.1 = STRING: "506255604729" */
+	{ "device.serial", ST_FLAG_STRING, SU_INFOSIZE, " .1.3.6.1.4.1.318.1.1.30.2.1.1.5.1", NULL, SU_FLAG_STATIC | SU_FLAG_OK, NULL },
+	/* ePDUDeviceStatusModelNumber.1 = STRING: "EPDU1016M" */
+	{ "device.part", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.318.1.1.30.2.1.1.4.1", NULL, SU_FLAG_STATIC | SU_FLAG_OK, NULL },
+	/* ePDUDeviceStatusVersion.1 = STRING: "Ver16.10" */
+	{ "device.version", ST_FLAG_STRING, SU_INFOSIZE, " .1.3.6.1.4.1.318.1.1.30.2.1.1.3.1", NULL, SU_FLAG_STATIC | SU_FLAG_OK, NULL },
+
+	/* Input */
+	/* ePDUDeviceStatusActivePower.1 = INTEGER: 785 */
+	{ "input.realpower", 0, 1, ".1.3.6.1.4.1.318.1.1.30.2.1.1.7.1", NULL, SU_FLAG_OK | SU_FLAG_NEGINVALID, NULL },
+	/* FIXME: Take first phase for global */
+	/* ePDUPhaseStatusVoltage.1 = INTEGER: 2304 */
+	{ "input.voltage", 0, 0.1, ".1.3.6.1.4.1.318.1.1.30.4.2.1.4.1", NULL, SU_FLAG_OK | SU_FLAG_NEGINVALID, NULL },
+	/* ePDUPhaseTableSize = INTEGER: 1 */
+	{ "input.phases", 0, 1, ".1.3.6.1.4.1.318.1.1.30.3.0", NULL, SU_FLAG_OK, NULL },
+	/* ePDUPhaseStatusVoltage.1 = INTEGER: 2304 */
+	{ "input.L1-N.voltage", 0, 0.1, ".1.3.6.1.4.1.318.1.1.30.4.2.1.4.1", NULL, SU_FLAG_OK | SU_FLAG_NEGINVALID, NULL },
+	/* ePDUPhaseStatusVoltage.2 = INTEGER: 2304 */
+	{ "input.L2-N.voltage", 0, 0.1, ".1.3.6.1.4.1.318.1.1.30.4.2.1.4.2", NULL, SU_FLAG_OK | SU_FLAG_NEGINVALID, NULL },
+	/* ePDUPhaseStatusVoltage.3 = INTEGER: 2304 */
+	{ "input.L3-N.voltage", 0, 0.1, ".1.3.6.1.4.1.318.1.1.30.4.2.1.4.3", NULL, SU_FLAG_OK | SU_FLAG_NEGINVALID, NULL },
+	/* ePDUPhaseStatusCurrent.1 = INTEGER: 355 */
+	{ "input.L1.current", 0, 0.01, ".1.3.6.1.4.1.318.1.1.30.4.2.1.5.1", NULL, SU_FLAG_OK | SU_FLAG_NEGINVALID, NULL },
+	/* ePDUPhaseStatusCurrent.2 = INTEGER: 355 */
+	{ "input.L2.current", 0, 0.01, ".1.3.6.1.4.1.318.1.1.30.4.2.1.5.2", NULL, SU_FLAG_OK | SU_FLAG_NEGINVALID, NULL },
+	/* ePDUPhaseStatusCurrent.3 = INTEGER: 355 */
+	{ "input.L3.current", 0, 0.01, ".1.3.6.1.4.1.318.1.1.30.4.2.1.5.3", NULL, SU_FLAG_OK | SU_FLAG_NEGINVALID, NULL },
+	/* ePDUPhaseStatusActivePower.1 = INTEGER: 785 */
+	{ "input.L1.realpower", 0, 1, ".1.3.6.1.4.1.318.1.1.30.4.2.1.6.1", NULL, SU_FLAG_OK | SU_FLAG_NEGINVALID, NULL },
+	/* ePDUPhaseStatusActivePower.2 = INTEGER: 785 */
+	{ "input.L2.realpower", 0, 1, ".1.3.6.1.4.1.318.1.1.30.4.2.1.6.2", NULL, SU_FLAG_OK | SU_FLAG_NEGINVALID, NULL },
+	/* ePDUPhaseStatusActivePower.3 = INTEGER: 785 */
+	{ "input.L3.realpower", 0, 1, ".1.3.6.1.4.1.318.1.1.30.4.2.1.6.3", NULL, SU_FLAG_OK | SU_FLAG_NEGINVALID, NULL },
+
+	/* Outlets */
+	/* ePDUOutletTableSize.0 = INTEGER: 1 */
+	{ "outlet.count", 0, 1, ".1.3.6.1.4.1.318.1.1.30.5.0", NULL, SU_FLAG_STATIC | SU_FLAG_OK, NULL },
+	/* ePDUOutletStatusIndex.%i = INTEGER: 1 */
+	{ "outlet.%i.id", 0, 1, ".1.3.6.1.4.1.318.1.1.30.6.1.1.1.%i", "%i", SU_FLAG_STATIC | SU_FLAG_OK | SU_FLAG_NEGINVALID | SU_OUTLET, NULL },
+	/* ePDUOutletStatusNumber.%i = INTEGER: 1 */
+	{ "outlet.%i.desc", ST_FLAG_RW | ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.318.1.1.30.6.1.1.3.%i", NULL, SU_FLAG_OK | SU_FLAG_NEGINVALID | SU_OUTLET, NULL },
+	/* ePDUOutletStatusState.%i = INTEGER: off(1) */
+	{ "outlet.%i.status", ST_FLAG_RW | ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.318.1.1.30.6.1.1.4.%i", NULL, SU_FLAG_OK | SU_FLAG_NEGINVALID | SU_OUTLET, &apc_epdu_sw_outlet_status_info[0] },
+	/* Also use this OID to determine switchability ; its presence means "yes" */
+	/* ePDUOutletStatusState.%i = INTEGER: off(1) */
+	{ "outlet.%i.switchable", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.318.1.1.30.6.1.1.4.%i", "yes",  SU_FLAG_STATIC | SU_FLAG_ABSENT | SU_FLAG_OK | SU_OUTLET, &apc_epdu_sw_outlet_switchability_info[0] },
+
+#if 0 /* keep following scan for future development */
+	/* iso.3.6.1.4.1.318.1.1.30.1.0 = INTEGER: 1 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.1.0", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.2.1.1.1.1 = INTEGER: 1 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.2.1.1.1.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.2.1.1.2.1 = INTEGER: 1 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.2.1.1.2.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.2.1.1.3.1 = STRING: "Ver16.10" */
+	{ "unmapped.iso", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.318.1.1.30.2.1.1.3.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.2.1.1.4.1 = STRING: "EPDU1016M" */
+	{ "unmapped.iso", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.318.1.1.30.2.1.1.4.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.2.1.1.5.1 = STRING: "506255604717" */
+	{ "unmapped.iso", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.318.1.1.30.2.1.1.5.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.2.1.1.6.1 = INTEGER: 1 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.2.1.1.6.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.2.1.1.7.1 = INTEGER: 785 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.2.1.1.7.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.2.1.1.8.1 = INTEGER: -1 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.2.1.1.8.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.2.1.1.9.1 = INTEGER: -1 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.2.1.1.9.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.2.1.1.10.1 = INTEGER: 965 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.2.1.1.10.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.2.1.1.11.1 = INTEGER: 9114157 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.2.1.1.11.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.2.1.1.12.1 = INTEGER: 49988 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.2.1.1.12.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.2.2.1.1.1 = INTEGER: 1 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.2.2.1.1.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.2.2.1.2.1 = INTEGER: 1 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.2.2.1.2.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.2.2.1.3.1 = INTEGER: 0 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.2.2.1.3.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.2.2.1.4.1 = INTEGER: 0 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.2.2.1.4.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.2.2.1.5.1 = INTEGER: 2 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.2.2.1.5.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.3.0 = INTEGER: 1 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.3.0", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.4.1.1.1.1 = INTEGER: 1 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.4.1.1.1.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.4.1.1.2.1 = INTEGER: 1 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.4.1.1.2.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.4.1.1.3.1 = INTEGER: 1 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.4.1.1.3.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.4.1.1.4.1 = INTEGER: 3000 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.4.1.1.4.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.4.1.1.5.1 = INTEGER: 0 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.4.1.1.5.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.4.1.1.6.1 = INTEGER: 3200 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.4.1.1.6.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.4.1.1.7.1 = INTEGER: 0 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.4.1.1.7.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.4.2.1.1.1 = INTEGER: 1 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.4.2.1.1.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.4.2.1.2.1 = INTEGER: 1 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.4.2.1.2.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.4.2.1.3.1 = INTEGER: 1 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.4.2.1.3.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.4.2.1.4.1 = INTEGER: 2304 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.4.2.1.4.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.4.2.1.5.1 = INTEGER: 353 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.4.2.1.5.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.4.2.1.6.1 = INTEGER: 785 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.4.2.1.6.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.4.2.1.7.1 = INTEGER: -1 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.4.2.1.7.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.4.2.1.8.1 = INTEGER: -1 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.4.2.1.8.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.4.2.1.9.1 = INTEGER: 965 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.4.2.1.9.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.4.2.1.10.1 = INTEGER: 9114157 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.4.2.1.10.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.5.0 = INTEGER: 0 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.5.0", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.6.1.1.1.1 = INTEGER: -1 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.6.1.1.1.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.6.1.1.2.1 = INTEGER: -1 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.6.1.1.2.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.6.1.1.3.1 = INTEGER: -1 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.6.1.1.3.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.6.1.1.4.1 = INTEGER: -1 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.6.1.1.4.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.6.2.1.1.1 = INTEGER: -1 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.6.2.1.1.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.6.2.1.2.1 = INTEGER: -1 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.6.2.1.2.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.6.2.1.3.1 = INTEGER: -1 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.6.2.1.3.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.6.2.1.4.1 = INTEGER: -1 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.6.2.1.4.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.7.0 = INTEGER: 1 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.7.0", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.8.1.1.1.1 = INTEGER: 1 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.8.1.1.1.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.8.1.1.2.1 = INTEGER: 1 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.8.1.1.2.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.8.1.1.3.1 = INTEGER: 900 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.8.1.1.3.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.8.1.1.4.1 = INTEGER: 0 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.8.1.1.4.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.8.1.1.5.1 = INTEGER: 900 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.8.1.1.5.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.8.1.1.6.1 = INTEGER: 0 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.8.1.1.6.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.8.2.1.1.1 = INTEGER: 1 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.8.2.1.1.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.8.2.1.2.1 = INTEGER: 1 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.8.2.1.2.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.8.2.1.3.1 = INTEGER: 0 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.8.2.1.3.1", NULL, SU_FLAG_OK, NULL },
+	/* iso.3.6.1.4.1.318.1.1.30.8.2.1.4.1 = INTEGER: 0 */
+	{ "unmapped.iso", 0, 1, ".1.3.6.1.4.1.318.1.1.30.8.2.1.4.1", NULL, SU_FLAG_OK, NULL },
+#endif
+
+	/* end of structure. */
+	{ NULL, 0, 0, NULL, NULL, 0, NULL }
+};
+
+mib2nut_info_t  apc_pdu_epdu = { "apc", APC_EPDU_MIB_VERSION, NULL, NULL, apc_epdu_mib, APC_EPDU_MIB_SYSOID, NULL };

--- a/drivers/apc-epdu-mib.h
+++ b/drivers/apc-epdu-mib.h
@@ -1,0 +1,29 @@
+/* apc-epdu-mib.h - subdriver to monitor apc SNMP easy pdu with NUT
+ *
+ *  Copyright (C)
+ *  2011 - 2022	Eric Clappier <EricClappier@eaton.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#ifndef APC_EPDU_MIB_H
+#define APC_EPDU_MIB_H
+
+#include "main.h"
+#include "snmp-ups.h"
+
+extern mib2nut_info_t apc_pdu_epdu;
+
+#endif /* APC_EPDU_MIB_H */

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -63,6 +63,7 @@
 #include "eaton-ats16-nm2-mib.h"
 #include "apc-ats-mib.h"
 #include "apc-pdu-mib.h"
+#include "apc-epdu-mib.h"
 #include "eaton-ats30-mib.h"
 #include "emerson-avocent-pdu-mib.h"
 #include "hpe-pdu-mib.h"
@@ -94,6 +95,7 @@ static mib2nut_info_t *mib2nut[] = {
 	&apc_pdu_rpdu,		/* This struct comes from : apc-pdu-mib.c */
 	&apc_pdu_rpdu2,		/* This struct comes from : apc-pdu-mib.c */
 	&apc_pdu_msp,		/* This struct comes from : apc-pdu-mib.c */
+	&apc_pdu_epdu,		/* This struct comes from : apc-epdu-mib.c */
 	&apc,				/* This struct comes from : apc-mib.c */
 	&baytech,			/* This struct comes from : baytech-mib.c */
 	&bestpower,			/* This struct comes from : bestpower-mib.c */
@@ -166,7 +168,7 @@ static const char *mibname;
 static const char *mibvers;
 
 #define DRIVER_NAME	"Generic SNMP UPS driver"
-#define DRIVER_VERSION		"1.22"
+#define DRIVER_VERSION		"1.23"
 
 /* driver description structure */
 upsdrv_info_t	upsdrv_info = {


### PR DESCRIPTION
<!-- Comment:
* Please revise the docs/developers.txt for coding style suggestions and
  other considerations applicable to NUT codebase contributions, as well
  as for which text documents to update. See also docs/developer-guide.txt
  for general points on NUT architecture and design.

* The checklist below is more of a reminder of steps to take and "dangers"
  to look out for. PRs to update this template are also welcome :)

* Local build iterations can be augmented with the ci_build.sh script.
-->

## General points

- [ ] Described the changes in the PR submission or a separate issue, e.g.
  known published or discovered protocols, applicable hardware (expected
  compatible and actually tested/developed against), limitations, etc.

- [ ] There may be multiple commits in the PR, aligned and commented with
  a functional change. Notably, coding style changes better belong in a
  separate PR, but certainly in a dedicated commit to simplify reviews
  of "real" changes in the other commits. Similarly for typo fixes in
  comments or text documents.

## Frequent "underwater rocks" for driver addition/update PRs

- [ ] Revised existing driver families and added a sub-driver if applicable
  (`nutdrv_qx`, `usbhid-ups`...) or added a brand new driver in the other
  case.

- [ ] Did not extend obsoleted drivers with new hardware support features
  (notably `blazer` and other single-device family drivers for Qx protocols,
  except the new `nutdrv_qx` which should cover them all).

- [ ] For updated existing device drivers, bumped the `DRIVER_VERSION` macro
  or its equivalent.

<!-- Comment:
  Some sub-drivers have `SUBDRIVER_VERSION` or customized names like
  e.g. `MEGATEC_VERSION` in `drivers/nutdrv_qx_megatec.c`
-->

- [ ] For USB devices (HID or not), revised that the driver uses unique
  VID/PID combinations, or raised discussions when this is not the case
  (several vendors do use same interface chips for unrelated protocols).

- [ ] For new USB devices, built and committed the changes for the
  `scripts/upower/95-upower-hid.hwdb` file

- [ ] Proposed NUT data mapping is aligned with existing `docs/nut-names.txt`
  file. If the device exposes useful data points not listed in the file, the
  `experimental.*` namespace can be used as documented there, and discussion
  should be raised on the NUT Developers mailing list to standardize the new
  concept.

- [ ] Updated `data/driver.list.in` if applicable (new tested device info)
<!-- Comment:
Also note below, a point about PR posting for NUT DDL
-->

## Frequent "underwater rocks" for general C code PRs

- [ ] Did not "blindly assume" default integer type sizes and value ranges,
  structure layout and alignment in memory, endianness (layout of bytes and
  bits in memory for multi-byte numeric types), or use of generic `int` where
  language or libraries dictate the use of `size_t` (or `ssize_t` sometimes).

<!-- Comment:
* NOTE: Casting and/or pragmas (support detected at compile time,
  see `m4/ax_c_pragmas.m4`) to silence warnings may be acceptable,
  but only if coupled with range checks or similar actions.
-->

- [ ] Progress and errors are handled with `upsdebugx()`, `upslogx()`,
  `fatalx()` and related methods, not with direct `printf()` or `exit()`.
  Similarly, NUT helpers are used for error-checked memory allocation and
  string operations (except where customized error handling is needed,
  such as unlocking device ports, etc.)

- [ ] Coding style (including whitespace for indentations) follows precedent
  in the code of the file, and examples/guide in `docs/developers.txt` file.

- [ ] For newly added files, the `Makefile.am` recipes were updated and the
  `make distcheck` target passes.

## General documentation updates

- [ ] Updated `docs/acknowledgements.txt` (for vendor-backed device support)

- [ ] Added or updated manual page information in `docs/man/*.txt` files
  and corresponding recipe lists in `docs/man/Makefile.am` for new pages

- [ ] Passed `make spellcheck`, updated spell-checking dictionary in the
  `docs/nut.dict` file if needed (did not remove any words -- the `make`
  rule printout in case of changes suggests how to maintain it).

## Additional work may be needed after posting this PR

- [ ] Propose a PR for NUT DDL with detailed device data dumps from tests
  against real hardware (the more models, the better).

- [ ] Address NUT CI farm build failures for the PR: testing on numerous
  platforms and toolkits can expose issues not seen on just one system.

<!-- Comment:
* One frequent "offence" is the appearance of unexpected (not git-ignored)
  or modification during build of files tracked in Git.

* Another frequent issue is not tracking newly introduced file names in
  `EXTRA_DIST` of the `Makefile.am` (and for `*.in` templates -- of rules
  in the `configure.ac` script) so the `make distcheck` fails.

* Avoid using GNU-specific constructs in the `Makefile.am`, even if that
  means cumbersome ways to build a target. This should not happen in mere
  driver updates, however.

* Also some third-party libraries or OS headers and method argument types
  and counts can differ -- necessitating m4 code for `configure` script
  probing, and `ifdef`, `typedef`, etc. in C code to adapt to the build
  environment (precedents available in NUT codebase). In extreme cases,
  you may need to spin up a VM or container to reproduce those issues
  and iterate on a fix locally; see `docs/config-prereqs.txt` and
  `docs/ci-farm-lxc-setup.txt` for notes taken during preparation of
  the multi-platform NUT CI farm.
-->

- [ ] Revise suggestions from LGTM.COM analysis about "new issues" with
  the changed codebase.

<!-- Comment:
  Take them with a grain of salt, especially with regard to things like
  architecture-dependent range checks, but many of the complaints from
  the tool are indeed useful.
-->
