### PR TITLE
Documentation update regarding Network-M2 card

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -174,3 +174,7 @@ D: Author of bcmxcp driver, 3-phase work.
 N: Giuseppe Corbelli
 E: giuseppe.corbelli@copanitalia.com
 D: Author of asem driver
+
+N: zakx
+E: zakx@zakx.de
+D: Updating device support docs after unneccessarily writing a redundant driver first

--- a/AUTHORS
+++ b/AUTHORS
@@ -177,4 +177,4 @@ D: Author of asem driver
 
 N: zakx
 E: zakx@zakx.de
-D: Updating device support docs after unneccessarily writing a redundant driver first
+D: Updating device support docs after unnecessarily writing a redundant driver first

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -371,6 +371,7 @@
 "Eaton"	"ups"	"5"	"various models (SNMP mode)"	"NMC Minislot (ref 66102)"	"snmp-ups (experimental)"
 "Eaton"	"ups"	"5"	"various models (XML/HTTP mode)"	"SNMP/Web Minislot card (ref 66244)"	"netxml-ups (experimental)"
 "Eaton"	"ups"	"5"	"various models (SNMP mode)"	"SNMP/Web Minislot card (ref 66244)"	"snmp-ups (experimental)"
+"Eaton"	"ups"	"5"	"various models (SNMP mode)"	"Eaton Gigabit Network Card (Network-M2)"	"snmp-ups (experimental)"
 "Eaton"	"ups"	"5"	"various models (serial mode)"	"Management Card Contact (ref 66104)"	"mge-shut or mge-utalk"
 "Eaton"	"pdu"	"5"	"ePDU Managed"	""	"snmp-ups"
 "Eaton"	"pdu"	"5"	"ePDU Switched"	""	"snmp-ups"

--- a/docs/man/snmp-ups.txt
+++ b/docs/man/snmp-ups.txt
@@ -35,7 +35,8 @@ as well as any others supporting the APC POWERNET MIB
 Socomec Sicon UPS with Netvision Web/SNMP management card/external box
 
 *pw*::
-Powerware devices with ConnectUPS SNMP cards
+Powerware devices with ConnectUPS SNMP cards, as well as UPSes with
+Eaton Gigabit Network Cards (Network-M2)
 
 *pxgx_ups*::
 Eaton devices with Power Xpert Gateway UPS Card

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3042 utf-8
+personal_ws-1.1 en 3043 utf-8
 AAS
 ABI
 ACFAIL
@@ -3032,6 +3032,7 @@ xxxxAP
 youruid
 yyy
 zaac
+zakx
 zfs
 zinto
 zlib


### PR DESCRIPTION
The Eaton Gigabit Network Card (Network-M2) is already well-supported by the powerware driver. This patch updates the documentation to reflect this.

(Replaces #1676.)