### PR TITLE
Debug chroot and setuid

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -61,7 +61,7 @@ https://github.com/networkupstools/nut/milestone/8
      by `configure` script for custom builds [#1467]
 
  - We lacked log information about changes of chroot jail (uncommon) and
-   of uid/gid (everywhere), which makes troubleshooting harder (e.g. lack
+   of UID/GID (everywhere), which makes troubleshooting harder (e.g. lack
    of access to config files or USB device nodes). Now we have it [#1694]
 
  - huawei-ups2000 is now known to support more devices, noted in docs and

--- a/NEWS
+++ b/NEWS
@@ -60,8 +60,12 @@ https://github.com/networkupstools/nut/milestone/8
    * Fixed building of NUT man pages when just a few drivers are selected
      by `configure` script for custom builds [#1467]
 
+ - We lacked log information about changes of chroot jail (uncommon) and
+   of uid/gid (everywhere), which makes troubleshooting harder (e.g. lack
+   of access to config files or USB device nodes). Now we have it [#1694]
+
  - huawei-ups2000 is now known to support more devices, noted in docs and
-   for auto-detection [#1448]
+   for auto-detection [#1448, #1684]
 
  - nutdrv_qx updates:
    * the `voltronic_qs_protocol` should now accept both "V" (as before)

--- a/common/common.c
+++ b/common/common.c
@@ -268,8 +268,12 @@ void become_user(struct passwd *pw)
 {
 #ifndef WIN32
 	/* if we can't switch users, then don't even try */
-	if ((geteuid() != 0) && (getuid() != 0))
+	if ((geteuid() != 0) && (getuid() != 0)) {
+		upsdebugx(1, "Can not become_user(%s): not root initially, "
+			"remaining UID=%jd GID=%jd",
+			pw->pw_name, (intmax_t)getuid(), (intmax_t)getgid());
 		return;
+	}
 
 	if (getuid() == 0)
 		if (seteuid(0))
@@ -283,8 +287,13 @@ void become_user(struct passwd *pw)
 
 	if (setuid(pw->pw_uid) == -1)
 		fatal_with_errno(EXIT_FAILURE, "setuid");
+
+	upsdebugx(1, "Succeeded to become_user(%s): now UID=%jd GID=%jd",
+		pw->pw_name, (intmax_t)getuid(), (intmax_t)getgid());
 #else
 	NUT_UNUSED_VARIABLE(pw);
+
+	upsdebugx(1, "Can not become_user(%s): not implemented on this platform", pw->pw_name);
 #endif
 }
 

--- a/common/common.c
+++ b/common/common.c
@@ -307,11 +307,16 @@ void chroot_start(const char *path)
 	if (chroot(path))
 		fatal_with_errno(EXIT_FAILURE, "chroot(%s)", path);
 
+#else
+	upsdebugx(1, "Can not chroot into %s: not implemented on this platform", path);
 #endif
+
 	if (chdir("/"))
 		fatal_with_errno(EXIT_FAILURE, "chdir(/)");
 
+#ifndef WIN32
 	upsdebugx(1, "chrooted into %s", path);
+#endif
 }
 
 #ifdef WIN32

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3043 utf-8
+personal_ws-1.1 en 3044 utf-8
 AAS
 ABI
 ACFAIL
@@ -383,6 +383,7 @@ Fuß
 GCCVER
 GES
 GETADDRINFO
+GID
 GKrellM
 GND
 GPL

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -322,7 +322,13 @@ STATEPATH "$NUT_STATEPATH"
 LISTEN localhost $NUT_PORT
 EOF
     [ $? = 0 ] || die "Failed to populate temporary FS structure for the NIT: upsd.conf"
-    chmod 640 "$NUT_CONFPATH/upsd.conf"
+
+    if [ "`id -u`" = 0 ]; then
+        log_info "Test script was started by 'root' - expanding permissions for '$NUT_CONFPATH/upsd.conf' so unprivileged daemons (after de-elevation) may read it"
+        chmod 644 "$NUT_CONFPATH/upsd.conf"
+    else
+        chmod 640 "$NUT_CONFPATH/upsd.conf"
+    fi
 
     # Some systems listining on symbolic "localhost" actually
     # only bind to IPv6, and Python telnetlib resolves IPv4
@@ -384,7 +390,13 @@ generatecfg_upsdusers_trivial() {
     upsmon secondary
 EOF
     [ $? = 0 ] || die "Failed to populate temporary FS structure for the NIT: upsd.users"
-    chmod 640 "$NUT_CONFPATH/upsd.users"
+
+    if [ "`id -u`" = 0 ]; then
+        log_info "Test script was started by 'root' - expanding permissions for '$NUT_CONFPATH/upsd.users' so unprivileged daemons (after de-elevation) may read it"
+        chmod 644 "$NUT_CONFPATH/upsd.users"
+    else
+        chmod 640 "$NUT_CONFPATH/upsd.users"
+    fi
 }
 
 ### upsmon.conf: ##################################################
@@ -398,7 +410,13 @@ generatecfg_upsmon_trivial() {
            echo "DEBUG_MIN ${NUT_DEBUG_MIN}" >> "$NUT_CONFPATH/upsmon.conf" || exit
        fi
     ) || die "Failed to populate temporary FS structure for the NIT: upsmon.conf"
-    chmod 640 "$NUT_CONFPATH/upsmon.conf"
+
+    if [ "`id -u`" = 0 ]; then
+        log_info "Test script was started by 'root' - expanding permissions for '$NUT_CONFPATH/upsmon.conf' so unprivileged daemons (after de-elevation) may read it"
+        chmod 644 "$NUT_CONFPATH/upsmon.conf"
+    else
+        chmod 640 "$NUT_CONFPATH/upsmon.conf"
+    fi
 }
 
 generatecfg_upsmon_master() {
@@ -437,8 +455,13 @@ generatecfg_ups_trivial() {
             echo "debug_min = ${NUT_DEBUG_MIN}" >> "$NUT_CONFPATH/ups.conf" || exit
         fi
     ) || die "Failed to populate temporary FS structure for the NIT: ups.conf"
-    chmod 640 "$NUT_CONFPATH/ups.conf"
 
+    if [ "`id -u`" = 0 ]; then
+        log_info "Test script was started by 'root' - expanding permissions for '$NUT_CONFPATH/ups.conf' so unprivileged daemons (after de-elevation) may read it"
+        chmod 644 "$NUT_CONFPATH/ups.conf"
+    else
+        chmod 640 "$NUT_CONFPATH/ups.conf"
+    fi
 }
 
 generatecfg_ups_dummy() {


### PR DESCRIPTION
We lacked log information about changes of chroot jail (uncommon) and uid/gid (everywhere), which makes troubleshooting harder (e.g. lack of access to config files or USB device nodes). Now we have it :)

This PR also enhances `make check-NIT` for builds done as `root` (relaxes permissions to generated test config files, so de-levated `nobody` can read them), so their default `make check` passes.