### PR TITLE
Document builds with net-snmp in MSYS2 MinGW (Windows) [#1475]

### DIFF
--- a/docs/config-prereqs.txt
+++ b/docs/config-prereqs.txt
@@ -1173,9 +1173,11 @@ involved is very important.
 * https://github.com/ccache/ccache/discussions/784
 * https://sourceforge.net/p/msys2/tickets/253/
 
-Notable packages not found in the repo:
+Notable packages *not found* in the repo:
 
-* snmp (net-snmp, ucd-snmp)
+* snmp (net-snmp, ucd-snmp) -- instructions in `scripts/Windows/README`
+  document now covers building it from source in MSYS2 MinGW x64 environment,
+  essentially same as for Linux cross builds with proper `ARCH` and `PREFIX`
 * libregex (C version, direct NUT `configure` script support was added by
   the Windows branch); MSYS2 however includes `libpcre` pulled by some
   of the dependencies above...

--- a/scripts/Windows/README
+++ b/scripts/Windows/README
@@ -111,10 +111,10 @@ or
 
 - also export the following compilation flags:
 ------
-:; export CFLAGS="$CFLAGS -D_POSIX=1 -I/usr/$ARCH/include/"
-:; export CXXFLAGS="$CXXFLAGS -D_POSIX=1 -I/usr/$ARCH/include/"
-:; export LDFLAGS="$LDFLAGS -L/usr/$ARCH/lib/"
-:; export PKG_CONFIG_PATH="$PREFIX"/lib/pkgconfig
+:; export CFLAGS="$CFLAGS -D_POSIX=1 -I${PREFIX}/include/"
+:; export CXXFLAGS="$CXXFLAGS -D_POSIX=1 -I${PREFIX}/include/"
+:; export LDFLAGS="$LDFLAGS -L${PREFIX}/lib/"
+:; export PKG_CONFIG_PATH="${PREFIX}"/lib/pkgconfig
 ------
 
 - prepare the download and build area, e.g. to match copy-paste instructions
@@ -155,9 +155,9 @@ You can also compile it (where that is still needed) using:
 	:; tar xzf "$DLDIR"/pthreads-w32-2-8-0-release.tar.gz
 	:; cd pthreads-w32-2-8-0-release/
 	:; make -f GNUmakefile "CROSS=$ARCH-" $BUILD_FLAG GC-inlined
-	:; sudo cp *.dll /usr/$ARCH/pthreads/lib/
-	:; sudo cp *.a /usr/$ARCH/lib/
-	:; sudo cp pthread.h sched.h semaphore.h /usr/$ARCH/pthreads/include
+	:; sudo cp *.dll ${PREFIX}/pthreads/lib/
+	:; sudo cp *.a ${PREFIX}/lib/
+	:; sudo cp pthread.h sched.h semaphore.h ${PREFIX}/pthreads/include
 
 
 MinGW regex library
@@ -473,7 +473,7 @@ net-snmp
 	:; yes "" | ./configure --prefix="$PREFIX" $HOST_FLAG \
 	    --with-default-snmp-version=3 --disable-agent --disable-daemon \
 	    --with-sys-contact="" --with-sys-location="" --with-logfile=none \
-	    --with-persistent-directory=/usr/$ARCH/var/net-snmp \
+	    --with-persistent-directory="${PREFIX}/var/net-snmp" \
 	    --disable-embedded-perl --without-perl-modules --disable-perl-cc-checks \
 	    --enable-shared
 	# NOTE: ./configure script may ask a few questions, or may just print
@@ -488,7 +488,7 @@ NOTE: net-snmp tends to only `make` a static-linking library for Windows
 by default (the shared library only appears with `LDFLAGS` proposed above).
 In this case consumers must link not only with `-lnetsnmp` but also its
 dependencies explicitly -- see `Libs.private` line in `netsnmp.pc` of
-your build (or installation in `/usr/$ARCH/lib/pkgconfig/netsnmp.pc`).
+your build (or installation in `${PREFIX}/lib/pkgconfig/netsnmp.pc`).
 Builds can extract this info with `pkg-config --libs --static netsnmp`
 as NUT scenarios do (for mingw, if shared-linking attempt fails).
 
@@ -540,7 +540,7 @@ Needed for glib2 (further for avahi).
 	:; ./configure --prefix="$PREFIX" $HOST_FLAG
 	:; make all
 	:; sudo make install
-	:; sudo ln -s libpcre2-posix.pc /usr/$ARCH/lib/pkgconfig/libpcre.pc
+	:; sudo ln -s libpcre2-posix.pc ${PREFIX}/lib/pkgconfig/libpcre.pc
 
 
 gettext/libintl
@@ -706,7 +706,7 @@ targets.
 NOTE: For other ways of building and packaging, it might make sense for
 a packaged delivery to also `make install DESTDIR=.../nut_install` from
 the sources of dependency projects built above, or at least to copy the
-built `*.dll` files from `$PREFIX/bin` to `nut_install/bin`. For those
+built `*.dll` files from `${PREFIX}/bin` to `nut_install/bin`. For those
 dependencies that are listed above, the script does this best-effort
 activity (does not fail if some are missing, but running the programs
 can fail later).

--- a/scripts/Windows/README
+++ b/scripts/Windows/README
@@ -12,7 +12,9 @@ test and fix programs, re-enable some code just commented away by ifdefs...)
 
 NOTE: It is possible to prepare a Windows machine with tools and prerequisites
 for building NUT natively, as detailed in `docs/config-prereqs.txt` and easily
-handled by NUT common `ci_build.sh` script. Possibly, the instructions below
+handled by NUT common `ci_build.sh` script. Most prerequisites are already
+packaged in that environment, but notably net-snmp is missing -- but can be
+built from source following this document. Possibly, the instructions below
 would converge there over time to keep it simple.
 
 For additional reference about prerequisite preparation and further ideas for
@@ -100,6 +102,22 @@ or
 ------
 :; export HOST_FLAG="--host=$ARCH"
 :; PREFIX="/usr/$ARCH"
+------
+
+- NOTE: Technically, these instructions may apply to builds with MinGW on
+  Windows semi-natively (e.g. to add the net-snmp libraries which are not
+  packaged currently). Generally you can use environment variables set by
+  different launchers of MinGW terminal sessions depending on the target
+  profile (32/64 bit, gcc/clang, libc implementation...):
+------
+:; export ARCH="$MINGW_CHOST"
+:; PREFIX="$MINGW_PREFIX/$ARCH"
+------
+  You might want to verify that it sets values similar to:
+------
+:; set | grep -E '^(ARCH|PREFIX)='
+#export ARCH="x86_64-w64-mingw32"
+#PREFIX="/mingw64/$ARCH"
 ------
 
 - on Debian/Ubuntu style systems also:
@@ -482,6 +500,7 @@ net-snmp
 	# The following long `LDFLAGS` ensure that shared `libnetsnmp-40.dll`
 	# gets built and later installed (and siblings which NUT does not use):
 	:; make LDFLAGS="-no-undefined -lws2_32 -lregex -Xlinker --ignore-unresolved-symbol=_app_name_long -Xlinker --ignore-unresolved-symbol=app_name_long"
+	:; find . -type f -name '*.dll' -o -name '*.dll.a'
 	:; sudo make install
 
 NOTE: net-snmp tends to only `make` a static-linking library for Windows


### PR DESCRIPTION
Not sure why it is not packaged by MSYS2, but at least checked we can build it (and against it) okay... Mostly resolves what remained of #1475

TODO: Automate in AppVeyor builds?.. #1491?