### PR TITLE
CI: Build missing prerequisites for NUT for Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -115,7 +115,7 @@ artifacts:
     name: Bundle of binary files and FOSS dependencies of NUT for Windows
 
   - path: config.log
-    name: config.log
+    name: config.log of recent build of NUT for Windows
 
 # Example optional cache (depends on file change):
 # - C:\msys64 -> appveyor.yml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,7 +61,7 @@ before_build:
       set CHERE_INVOKING=yes
       REM Start a 64 bit Mingw environment:
       set MSYSTEM=MINGW64
-      C:\msys64\usr\bin\bash -lc "date -u; export MSYS2_PATH ; bash -x ./scripts/Windows/build-mingw-prereqs.sh -f"
+      C:\msys64\usr\bin\bash -lc "date -u; export MSYS2_PATH ; bash ./scripts/Windows/build-mingw-prereqs.sh"
 
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,7 +61,7 @@ before_build:
       set CHERE_INVOKING=yes
       REM Start a 64 bit Mingw environment:
       set MSYSTEM=MINGW64
-      C:\msys64\usr\bin\bash -lc "date -u; export MSYS2_PATH ; bash -x ./scripts/Windows/build-mingw-prereqs.sh"
+      C:\msys64\usr\bin\bash -lc "date -u; export MSYS2_PATH ; bash -x ./scripts/Windows/build-mingw-prereqs.sh -f"
 
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,7 +61,7 @@ before_build:
       set CHERE_INVOKING=yes
       REM Start a 64 bit Mingw environment:
       set MSYSTEM=MINGW64
-      C:\msys64\usr\bin\bash -lc 'set +e ; date -u; export PATH="/mingw64/bin:$PATH"; export ARCH="$MINGW_CHOST" ; export PREFIX="$MINGW_PREFIX"; export PKG_CONFIG_PATH="${PREFIX}"/lib/pkgconfig ; pkg-config --exists netsnmp && exit ; export CFLAGS="$CFLAGS -D_POSIX=1 -I${PREFIX}/include/" ; export CXXFLAGS="$CXXFLAGS -D_POSIX=1 -I${PREFIX}/include/" ; export LDFLAGS="$LDFLAGS -L${PREFIX}/lib/" ; DLDIR=~/nut-win-deps ; WSDIR="$DLDIR"/"$ARCH" ; mkdir -p "$WSDIR" "$DLDIR" ; if [ -d "$WSDIR/net-snmp-5.9.1/.inst" ]; then cd "$WSDIR/net-snmp-5.9.1/.inst" && rsync -avPHK ./ / && exit ; fi ; if [ -d "$WSDIR/net-snmp-5.9.1" ]; then cd "$WSDIR/net-snmp-5.9.1" && make install -j 8 && exit ; fi ; set -e ; ( cd "$DLDIR" && wget -c https://sourceforge.net/projects/net-snmp/files/net-snmp/5.9.1/net-snmp-5.9.1.tar.gz ) ; cd "$WSDIR" ; rm -rf net-snmp-5.9.1 || true ; tar xzf "$DLDIR"/net-snmp-5.9.1.tar.gz ; cd net-snmp-5.9.1 ; yes "" | ./configure --prefix="$PREFIX" --with-default-snmp-version=3 --disable-agent --disable-daemon --with-sys-contact="" --with-sys-location="" --with-logfile=none --with-persistent-directory="${PREFIX}/var/net-snmp" --disable-embedded-perl --without-perl-modules --disable-perl-cc-checks --enable-shared || exit ; make LDFLAGS="-no-undefined -lws2_32 -lregex -Xlinker --ignore-unresolved-symbol=_app_name_long -Xlinker --ignore-unresolved-symbol=app_name_long" -j 8 || exit ; make -d "`pwd`/.inst" install -j 8 || exit ; make install ; find . -type f -name "*.dll" -o -name "*.dll.a";'
+      C:\msys64\usr\bin\bash -lc "date -u; export MSYS2_PATH ; bash -x ./scripts/Windows/build-mingw-prereqs.sh"
 
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ install:
         C:\msys64\usr\bin\bash -lc "date -u; pacman --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain autoconf-wrapper automake-wrapper libtool mingw-w64-x86_64-libltdl gcc ccache mingw-w64-x86_64-ccache git aspell aspell-en python mingw-w64-x86_64-python-pygments mingw-w64-x86_64-winpthreads-git mingw-w64-x86_64-libusb mingw-w64-x86_64-libusb-compat-git mingw-w64-x86_64-neon libneon-devel mingw-w64-x86_64-libmodbus-git mingw-w64-x86_64-libgd mingw-w64-x86_64-cppunit"
   - cmd: |
         REM Assorted stats after package processing:
-        C:\msys64\usr\bin\bash -lc "date -u; ls la / ; du -ksx / ; date -u; du -ks /var/cache/pacman/pkg; date -u"
+        C:\msys64\usr\bin\bash -lc "date -u; ls -la / ; du -ksx / ; date -u; du -ks /var/cache/pacman/pkg; date -u"
         REM Preserve the current working directory:
         set CHERE_INVOKING=yes
         REM Start a 64 bit Mingw environment:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,6 +51,19 @@ install:
         C:\msys64\usr\bin\bash -lc 'PATH="/mingw64/bin:$PATH" ; export PATH ; pwd ; ccache -sv || echo "SKIP: Could not query ccache stats"'
 
 
+before_build:
+  - cmd: |
+      REM Ensure we have a net-snmp to build against
+      REM Adapted from scripts/Windows/README document.
+      REM Here we hope to build it once, then use the
+      REM stashed version across Appveyor rebuilds.
+      REM Preserve the current working directory:
+      set CHERE_INVOKING=yes
+      REM Start a 64 bit Mingw environment:
+      set MSYSTEM=MINGW64
+      C:\msys64\usr\bin\bash -lc 'set +e ; date -u; export PATH="/mingw64/bin:$PATH"; export ARCH="$MINGW_CHOST" ; export PREFIX="$MINGW_PREFIX"; export PKG_CONFIG_PATH="${PREFIX}"/lib/pkgconfig ; pkg-config --exists netsnmp && exit ; export CFLAGS="$CFLAGS -D_POSIX=1 -I${PREFIX}/include/" ; export CXXFLAGS="$CXXFLAGS -D_POSIX=1 -I${PREFIX}/include/" ; export LDFLAGS="$LDFLAGS -L${PREFIX}/lib/" ; DLDIR=~/nut-win-deps ; WSDIR="$DLDIR"/"$ARCH" ; mkdir -p "$WSDIR" "$DLDIR" ; if [ -d "$WSDIR/net-snmp-5.9.1/.inst" ]; then cd "$WSDIR/net-snmp-5.9.1/.inst" && rsync -avPHK ./ / && exit ; fi ; if [ -d "$WSDIR/net-snmp-5.9.1" ]; then cd "$WSDIR/net-snmp-5.9.1" && make install -j 8 && exit ; fi ; set -e ; ( cd "$DLDIR" && wget -c https://sourceforge.net/projects/net-snmp/files/net-snmp/5.9.1/net-snmp-5.9.1.tar.gz ) ; cd "$WSDIR" ; rm -rf net-snmp-5.9.1 || true ; tar xzf "$DLDIR"/net-snmp-5.9.1.tar.gz ; cd net-snmp-5.9.1 ; yes "" | ./configure --prefix="$PREFIX" --with-default-snmp-version=3 --disable-agent --disable-daemon --with-sys-contact="" --with-sys-location="" --with-logfile=none --with-persistent-directory="${PREFIX}/var/net-snmp" --disable-embedded-perl --without-perl-modules --disable-perl-cc-checks --enable-shared || exit ; make LDFLAGS="-no-undefined -lws2_32 -lregex -Xlinker --ignore-unresolved-symbol=_app_name_long -Xlinker --ignore-unresolved-symbol=app_name_long" -j 8 || exit ; make -d "`pwd`/.inst" install -j 8 || exit ; make install ; find . -type f -name "*.dll" -o -name "*.dll.a";'
+
+
 build_script:
   - cmd: |
         REM Preserve the current working directory:
@@ -110,6 +123,7 @@ cache:
   - C:\msys64\home\appveyor\.ccache
   - C:\msys64\home\appveyor\ccache # likely missing, no problem - but the name is reported in ccache status
   - C:\msys64\var\cache\pacman\pkg
+  - C:\msys64\home\appveyor\nut-win-deps
 
 # Below we tried to stash binaries of MSYS2 environment
 # so VM deployment is faster on subsequent builds

--- a/scripts/Windows/README
+++ b/scripts/Windows/README
@@ -157,11 +157,11 @@ or
 ------
 
 - prepare the download and build area, e.g. to match copy-paste instructions
-  below, it would be like:
+below, it would be like:
 ------
-:; mkdir -p ~/nut-win-deps/"$ARCH"
 :; DLDIR=~/nut-win-deps
-:; WSDIR=~/nut-win-deps/"$ARCH"
+:; WSDIR="$DLDIR"/"$ARCH"
+:; mkdir -p "$WSDIR" "$DLDIR"
 ------
 
 ================================================================================

--- a/scripts/Windows/README
+++ b/scripts/Windows/README
@@ -110,6 +110,9 @@ or
   variables set by different launchers of MinGW terminal sessions depending
   on the target profile (32/64 bit, gcc/clang, libc implementation...)
 
+** For `sudo make install` in instructions below, you may have to omit the
+   `sudo` part if missing in your MSYS2 MinGW environment;
+
 ** For a "native build" directly for consumption in the currently configured
    environment, you would not use cross-build path in `PREFIX` and not set
    the `HOST_FLAG` value:

--- a/scripts/Windows/build-mingw-prereqs.sh
+++ b/scripts/Windows/build-mingw-prereqs.sh
@@ -15,6 +15,12 @@ prepareEnv() {
 	[ -n "${MAKE-}" ] || MAKE="make -j 8"
 	export MAKE
 
+	if [ -z "${SUDO-}" ] ; then
+		SUDO=" " # avoid reeval
+		if (command -v sudo) ; then SUDO="sudo" ; fi
+	fi
+	export SUDO
+
 	[ -n "${DLDIR-}" ] || DLDIR=~/nut-win-deps
 
 	if [ -n "${ARCH-}" ] && [ -n "${PREFIX-}" ] ; then
@@ -80,14 +86,14 @@ provide_netsnmp() (
 		# Quickly install if prebuilt
 		if [ -d "${WSDIR}/${DEP_DIRNAME}/.inst" ]; then (
 			cd "${WSDIR}/${DEP_DIRNAME}/.inst" || exit
-			(command -v rsync) && rsync -avPHK ./ / && exit
-			cp -pr ./ / && exit
+			(command -v rsync) && $SUDO rsync -avPHK ./ / && exit
+			$SUDO cp -pr ./ / && exit
 			exit 1
 			) && return 0
 		fi
 
 		# no stashed .inst; any Makefile at least?
-		if [ -s "${WSDIR}/${DEP_DIRNAME}/Makefile" ]; then ( cd "${WSDIR}/${DEP_DIRNAME}" && $MAKE install ) && return ; fi
+		if [ -s "${WSDIR}/${DEP_DIRNAME}/Makefile" ]; then ( cd "${WSDIR}/${DEP_DIRNAME}" && $SUDO $MAKE install ) && return ; fi
 	fi
 
 	# (Re-)make and install from scratch
@@ -116,7 +122,7 @@ provide_netsnmp() (
 	# Summarize what we have got
 	find ./ -type f -name "*.dll" -o -name "*.dll.a";
 
-	sudo $MAKE install
+	$SUDO $MAKE install
 )
 
 prepareEnv || exit

--- a/scripts/Windows/build-mingw-prereqs.sh
+++ b/scripts/Windows/build-mingw-prereqs.sh
@@ -98,7 +98,12 @@ provide_netsnmp() (
 
 	# (Re-)make and install from scratch
 	set -e
-	( cd "$DLDIR" && wget -c "https://sourceforge.net/projects/${DEP_PRJNAME}/files/${DEP_PRJNAME}/${DEP_VERSION}/${DEP_ARCHIVE}" )
+
+	# Funny ways to fetch from Sourceforge help get the archive,
+	# not the download page... For some reason, this bites CI
+	# builds on Appveyor but not local runs:
+	( cd "$DLDIR" && curl -vL "https://sourceforge.net/projects/${DEP_PRJNAME}/files/${DEP_PRJNAME}/${DEP_VERSION}/${DEP_ARCHIVE}" > "${DEP_ARCHIVE}" ) || \
+	( cd "$DLDIR" && wget -c "https://sourceforge.net/projects/${DEP_PRJNAME}/files/${DEP_PRJNAME}/${DEP_VERSION}/${DEP_ARCHIVE}" -O "${DEP_ARCHIVE}" )
 
 	cd "${WSDIR}"
 	rm -rf ${DEP_DIRNAME} || echo ""

--- a/scripts/Windows/build-mingw-prereqs.sh
+++ b/scripts/Windows/build-mingw-prereqs.sh
@@ -1,0 +1,126 @@
+#!/bin/sh
+
+# Copyright (C) 2022 by Jim Klimov <jimklimov+nut@gmail.com>
+# Licensed same as NUT
+#
+# Helper automating the nuances from NUT::scripts/Windows/README
+# to provide prerequisites needed in semi-native or cross-builds.
+#
+# NOTE: Currently constrained to providing net-snmp under MSYS2.
+# We can not rely on certain common shell facilities like `true`
+# and `false` programs being available (in PATH or at all).
+# TODO: Support `make uninstall` attempts for older versions?..
+
+prepareEnv() {
+	[ -n "${MAKE-}" ] || MAKE="make -j 8"
+	export MAKE
+
+	[ -n "${DLDIR-}" ] || DLDIR=~/nut-win-deps
+
+	if [ -n "${ARCH-}" ] && [ -n "${PREFIX-}" ] ; then
+		[ -n "${WSDIR-}" ] || WSDIR="$DLDIR"/"$ARCH"
+		mkdir -p "$WSDIR" "$DLDIR"
+		return 0
+	fi
+
+	BUILD_FLAG=""
+	HOST_FLAG=""
+	export HOST_FLAG
+	if [ -n "${MSYS2_PATH-}" ]; then
+		# Assume semi-native build for same env
+		ARCH="$MINGW_CHOST"
+		PREFIX="$MINGW_PREFIX"
+		PATH="$PREFIX/bin:$PATH"
+		export ARCH PATH PREFIX
+
+		if ! (command -v sudo) ; then sudo() ( "$@" ) ; fi
+	else
+		# TODO: Select by args, envvars, directory presence...
+		ARCH="x86_64-w64-mingw32"
+		#ARCH="i686-w64-mingw32"
+
+		# Assumes Ubuntu/Debian with mingw prepared, per README
+		HOST_FLAG="--host=$ARCH"
+        PREFIX="/usr/$ARCH"
+
+		export ARCH PREFIX
+
+		if (command -v dpkg-architecture) ; then
+			BUILD_FLAG="--build=`dpkg-architecture -qDEB_BUILD_GNU_TYPE`"
+		fi
+	fi
+
+	CFLAGS="$CFLAGS -D_POSIX=1 -I${PREFIX}/include/"
+	CXXFLAGS="$CXXFLAGS -D_POSIX=1 -I${PREFIX}/include/"
+	LDFLAGS="$LDFLAGS -L${PREFIX}/lib/"
+	PKG_CONFIG_PATH="${PREFIX}"/lib/pkgconfig
+
+	export CFLAGS CXXFLAGS LDFLAGS PKG_CONFIG_PATH
+
+	[ -n "${WSDIR-}" ] || WSDIR="$DLDIR"/"$ARCH"
+	mkdir -p "$WSDIR" "$DLDIR"
+}
+
+# Provide prerequisites; reentrant (quick skip if installed; quick install if built)
+provide_netsnmp() (
+	PKGCFG_NAME="netsnmp"
+	DEP_PRJNAME="net-snmp"
+	DEP_VERSION="5.9.1"
+	DEP_DIRNAME="${DEP_PRJNAME}-${DEP_VERSION}"
+	DEP_ARCHIVE="${DEP_DIRNAME}.tar.gz"
+
+	FORCE=false
+	if [ x"${1-}" = x"-f" ] ; then FORCE=true ; fi
+
+	set +e
+	if [ x"$FORCE" = x"false" ] ; then
+		# TODO: Check version
+		if pkg-config --exists "$PKGCFG_NAME" ; then return 0 ; fi
+
+		# Quickly install if prebuilt
+		if [ -d "${WSDIR}/${DEP_DIRNAME}/.inst" ]; then (
+			cd "${WSDIR}/${DEP_DIRNAME}/.inst" || exit
+			(command -v rsync) && rsync -avPHK ./ / && exit
+			cp -pr ./ / && exit
+			exit 1
+			) && return 0
+		fi
+
+		# no stashed .inst; any Makefile at least?
+		if [ -s "${WSDIR}/${DEP_DIRNAME}/Makefile" ]; then ( cd "${WSDIR}/${DEP_DIRNAME}" && $MAKE install ) && return ; fi
+	fi
+
+	# (Re-)make and install from scratch
+	set -e
+	( cd "$DLDIR" && wget -c "https://sourceforge.net/projects/${DEP_PRJNAME}/files/${DEP_PRJNAME}/${DEP_VERSION}/${DEP_ARCHIVE}" )
+
+	cd "${WSDIR}"
+	rm -rf ${DEP_DIRNAME} || echo ""
+
+	tar xzf "$DLDIR/${DEP_ARCHIVE}" || exit
+	cd "./${DEP_DIRNAME}"
+
+	yes "" | ./configure --prefix="$PREFIX" --with-default-snmp-version=3 \
+		--disable-agent --disable-daemon --with-sys-contact="" --with-sys-location="" \
+		--with-logfile=none --with-persistent-directory="${PREFIX}/var/net-snmp" \
+		--disable-embedded-perl --without-perl-modules --disable-perl-cc-checks \
+		--enable-shared || exit
+
+	$MAKE LDFLAGS="-no-undefined -lws2_32 -lregex -Xlinker --ignore-unresolved-symbol=_app_name_long -Xlinker --ignore-unresolved-symbol=app_name_long" || exit
+
+	# Beside leaving a pre-install location for future runs,
+	# this may build some more artifacts:
+	rm -rf "`pwd`/.inst" || echo ""
+	$MAKE DESTDIR="`pwd`/.inst" install || exit
+
+	# Summarize what we have got
+	find ./ -type f -name "*.dll" -o -name "*.dll.a";
+
+	sudo $MAKE install
+)
+
+prepareEnv || exit
+
+# TODO: Loop, params, help, etc...
+# For now, let it pass "-f" to the builder
+provide_netsnmp "$@"


### PR DESCRIPTION
Addresses #1475 to distribute more relevant CI-built snapshots of NUT for Windows (made on Appveyor).

Unlike linux+mingw, the MSYS2+mingw builds still fare without augeas, ipmi, avahi... but the snmp-ups is a much more commonly useful feature.

See also #1491 for which this might be a good beginning...