### PR TITLE
snmp-ups: split Eaton pw and pxgx_ups implementation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -114,6 +114,9 @@ https://github.com/networkupstools/nut/milestone/8
      SNMP v3 to get both read and write rights [#1713]
    * Fixed processing loop for large SNMPv2/SNMPv3 responses where one item
      in the middle has a type error [#1682]
+   * Better manage the slight nuances (especially in ups.status) between
+     Eaton UPSs, and rename mibs from 'pw' to 'eaton_pw_nm2', and from
+     'pxgx_ups' to 'eaton_pxg_ups' 
 
  - Added support for `make install` of PyNUT module and NUT-Monitor desktop
    application [#1462, #1504]

--- a/UPGRADING
+++ b/UPGRADING
@@ -53,6 +53,9 @@ Changes from 2.8.0 to 2.8.1
   or explicitly forfeit building the tool (some distro packages missed it
   quietly in the past) [#1560]
 
+- snmp-ups: some subdrivers (addressed using the driver parameter `mibs`)
+  were renamed: 'pw' is now 'eaton_pw_nm2', and 'pxgx_ups' is 'eaton_pxg_ups' 
+
 Changes from 2.7.4 to 2.8.0
 ---------------------------
 

--- a/docs/man/snmp-ups.txt
+++ b/docs/man/snmp-ups.txt
@@ -34,12 +34,12 @@ as well as any others supporting the APC POWERNET MIB
 *netvision*::
 Socomec Sicon UPS with Netvision Web/SNMP management card/external box
 
-*pw*::
+*eaton_pw_nm2*::
 Powerware devices with ConnectUPS SNMP cards, as well as UPSes with
-Eaton Gigabit Network Cards (Network-M2)
+Eaton Gigabit Network Cards (Network-M2) (renamed from pw)
 
-*pxgx_ups*::
-Eaton devices with Power Xpert Gateway UPS Card
+*eaton_pxg_ups*::
+Eaton devices with Power Xpert Gateway UPS Card (renamed from pxgx_ups)
 
 *aphel_genesisII*::
 Eaton Powerware ePDU Monitored

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -2321,6 +2321,7 @@ nlb
 nlogic
 nn
 nnn
+nm
 noAuthNoPriv
 nobody's
 nobt
@@ -2516,6 +2517,7 @@ pwl
 pwmib
 pwro
 px
+pxg
 pxgx
 py
 pycparser

--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -238,12 +238,12 @@ snmp_ups_SOURCES = snmp-ups.c snmp-ups-helpers.c \
  eaton-pdu-genesis2-mib.c eaton-pdu-marlin-mib.c eaton-pdu-marlin-helpers.c \
  eaton-pdu-pulizzi-mib.c eaton-pdu-revelation-mib.c eaton-pdu-nlogic-mib.c \
  eaton-ats16-nmc-mib.c eaton-ats16-nm2-mib.c apc-ats-mib.c eaton-ats30-mib.c \
+ eaton-ups-pwnm2-mib.c eaton-ups-pxg-mib.c \
  emerson-avocent-pdu-mib.c \
  hpe-pdu-mib.c hpe-pdu3-cis-mib.c huawei-mib.c \
  ietf-mib.c \
  mge-mib.c \
  netvision-mib.c \
- powerware-mib.c \
  raritan-pdu-mib.c raritan-px2-mib.c \
  xppc-mib.c
 snmp_ups_CFLAGS = $(AM_CFLAGS)
@@ -329,7 +329,7 @@ dist_noinst_HEADERS = apc-mib.h apc-iem-mib.h apc-hid.h arduino-hid.h baytech-mi
  hidparser.h hidtypes.h ietf-mib.h libhid.h libshut.h nut_libusb.h liebert-hid.h	\
  main.h mge-hid.h mge-mib.h mge-utalk.h		\
  mge-xml.h microdowell.h microsol-apc.h microsol-common.h netvision-mib.h netxml-ups.h nut-ipmi.h oneac.h		\
- powercom.h powerpanel.h powerp-bin.h powerp-txt.h powerware-mib.h raritan-pdu-mib.h	\
+ powercom.h powerpanel.h powerp-bin.h powerp-txt.h raritan-pdu-mib.h	\
  safenet.h serial.h snmp-ups.h solis.h tripplite.h tripplite-hid.h 			\
  upshandler.h usb-common.h usbhid-ups.h powercom-hid.h compaq-mib.h idowell-hid.h \
  apcsmart.h apcsmart_tabs.h apcsmart-old.h apcupsd-ups.h cyberpower-mib.h riello.h openups-hid.h \
@@ -340,7 +340,7 @@ dist_noinst_HEADERS = apc-mib.h apc-iem-mib.h apc-hid.h arduino-hid.h baytech-mi
  nutdrv_qx_voltronic.h nutdrv_qx_voltronic-qs.h nutdrv_qx_voltronic-qs-hex.h nutdrv_qx_zinto.h \
  xppc-mib.h huawei-mib.h eaton-ats16-nmc-mib.h eaton-ats16-nm2-mib.h apc-ats-mib.h raritan-px2-mib.h eaton-ats30-mib.h \
  apc-pdu-mib.h apc-epdu-mib.h ever-hid.h eaton-pdu-genesis2-mib.h eaton-pdu-marlin-mib.h eaton-pdu-marlin-helpers.h \
- eaton-pdu-pulizzi-mib.h eaton-pdu-revelation-mib.h emerson-avocent-pdu-mib.h legrand-hid.h \
+ eaton-pdu-pulizzi-mib.h eaton-pdu-revelation-mib.h emerson-avocent-pdu-mib.h eaton-ups-pwnm2-mib.h eaton-ups-pxg-mib.h legrand-hid.h \
  hpe-pdu-mib.h hpe-pdu3-cis-mib.h powervar-hid.h delta_ups-hid.h generic_modbus.h salicru-hid.h adelsystem_cbi.h eaton-pdu-nlogic-mib.h
 
 # Define a dummy library so that Automake builds rules for the

--- a/drivers/eaton-ups-pwnm2-mib.c
+++ b/drivers/eaton-ups-pwnm2-mib.c
@@ -1,10 +1,10 @@
-/*  powerware-mib.c - data to monitor Powerware UPS with NUT
+/*  eaton-ups-pwnm2-mib.c - data to monitor Powerware and Eaton NM2 UPS with NUT
  *  (using MIBs described in stdupsv1.mib and Xups.mib)
  *
  *  Copyright (C)
  *       2005-2006 Olli Savia <ops@iki.fi>
  *       2005-2006 Niels Baggesen <niels@baggesen.net>
- *       2015-2019 Eaton (author: Arnaud Quette <ArnaudQuette@Eaton.com>)
+ *       2015-2022 Eaton (author: Arnaud Quette <ArnaudQuette@Eaton.com>)
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -23,27 +23,17 @@
  *
  */
 
-#include "powerware-mib.h"
+#include "eaton-ups-pwnm2-mib.h"
 #if WITH_SNMP_LKP_FUN
 /* FIXME: shared helper code, need to be put in common */
 #include "eaton-pdu-marlin-helpers.h"
 #endif
 
-#define PW_MIB_VERSION "0.104"
-
-/* TODO: more sysOID and MIBs support:
- *
- * Powerware UPS (Ingrasys X-SLOT and BD-SLOT): ".1.3.6.1.4.1.534.1"
- * Powerware PXGX cards: ".1.3.6.1.4.1.534.2.12"
- *		PXGX 2000 cards (UPS): Get xupsIdentModel (".1.3.6.1.4.1.534.1.1.2.0")
- * 		PXGX 1000 cards (PDU/RPP/RPM): Get pduNumPanels ".1.3.6.1.4.1.534.6.6.4.1.1.1.4.0"
- */
+#define PW_MIB_VERSION "0.105"
 
 /* Powerware UPS (Ingrasys X-SLOT and BD-SLOT)
  * Eaton Gigabit Network Card (Genepi) */
 #define POWERWARE_SYSOID	".1.3.6.1.4.1.534.1"
-/* Powerware UPS newer PXGX UPS cards (BladeUPS, ...) */
-#define EATON_PXGX_SYSOID	".1.3.6.1.4.1.534.2.12"
 
 /* SNMP OIDs set */
 #define PW_OID_MFR_NAME		"1.3.6.1.4.1.534.1.1.1.0"	/* XUPS-MIB::xupsIdentManufacturer.0 */
@@ -129,16 +119,11 @@ static info_lkp_t pw_pwr_info[] = {
 	{   8, "OL"        /* parallel capacity */, NULL, NULL },
 	{   9, "OL"        /* parallel redundancy */, NULL, NULL },
 	{  10, "OL"        /* high efficiency */, NULL, NULL },
-	/* Extended status values */
-	{ 240, "OB"        /* battery (0xF0) */, NULL, NULL },
-	{ 100, "BYPASS"    /* maintenanceBypass (0x64) */, NULL, NULL },
-	{  96, "BYPASS"    /* Bypass (0x60) */, NULL, NULL },
-	{  81, "OL"        /* high efficiency (0x51) */, NULL, NULL },
-	{  80, "OL"        /* normal (0x50) */, NULL, NULL },
-	{  64, "OL"        /* UPS supporting load, normal degraded mode (0x40) */, NULL, NULL },
-	{  16, "OFF"       /* none (0x10) */, NULL, NULL },
+	{  11, "BYPASS"    /* maintenanceBypass */, NULL, NULL },
+	{  11, "OL"        /* essMode */, NULL, NULL },
+	
 	{ 0, NULL, NULL, NULL }
-};
+};             
 
 /* FIXME: mapped to (experimental.)ups.type, but
  * should be output.source or ups.mode (need RFC)
@@ -814,5 +799,4 @@ static alarms_info_t pw_alarms[] = {
 } ;
 
 
-mib2nut_info_t	powerware = { "pw", PW_MIB_VERSION, NULL, PW_OID_MODEL_NAME, pw_mib, POWERWARE_SYSOID , pw_alarms };
-mib2nut_info_t	pxgx_ups = { "pxgx_ups", PW_MIB_VERSION, NULL, PW_OID_MODEL_NAME, pw_mib, EATON_PXGX_SYSOID , pw_alarms };
+mib2nut_info_t	eaton_pw_nm2 = { "eaton_pw_nm2", PW_MIB_VERSION, NULL, PW_OID_MODEL_NAME, pw_mib, POWERWARE_SYSOID , pw_alarms };

--- a/drivers/eaton-ups-pwnm2-mib.h
+++ b/drivers/eaton-ups-pwnm2-mib.h
@@ -1,0 +1,9 @@
+#ifndef EATON_UPS_PWNM2_MIB_H
+#define EATON_UPS_PWNM2_MIB_H
+
+#include "main.h"
+#include "snmp-ups.h"
+
+extern mib2nut_info_t	eaton_pw_nm2;
+
+#endif /* EATON_UPS_PWNM2_MIB_H */

--- a/drivers/eaton-ups-pxg-mib.c
+++ b/drivers/eaton-ups-pxg-mib.c
@@ -1,0 +1,827 @@
+/*  eaton-ups-pxg-mib.c - data to monitor Eaton / Powerware PXG UPS with NUT
+ *  (using MIBs described in stdupsv1.mib and Xups.mib)
+ *
+ *  Copyright (C)
+ *       2005-2006 Olli Savia <ops@iki.fi>
+ *       2005-2006 Niels Baggesen <niels@baggesen.net>
+ *       2015-2022 Eaton (author: Arnaud Quette <ArnaudQuette@Eaton.com>)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ */
+
+#include "eaton-ups-pxg-mib.h"
+#if WITH_SNMP_LKP_FUN
+/* FIXME: shared helper code, need to be put in common */
+#include "eaton-pdu-marlin-helpers.h"
+#endif
+
+#define EATON_PXG_MIB_VERSION "0.105"
+
+/* Powerware UPS newer PXGX UPS cards (BladeUPS, ...) */
+#define EATON_PXGX_SYSOID	".1.3.6.1.4.1.534.2.12"
+
+/* SNMP OIDs set */
+#define PW_OID_MFR_NAME		"1.3.6.1.4.1.534.1.1.1.0"	/* XUPS-MIB::xupsIdentManufacturer.0 */
+#define PW_OID_MODEL_NAME	"1.3.6.1.4.1.534.1.1.2.0"	/* XUPS-MIB::xupsIdentModel.0 */
+#define PW_OID_FIRMREV		"1.3.6.1.4.1.534.1.1.3.0"	/* XUPS-MIB::xupsIdentSoftwareVersion.0 */
+
+#define PW_OID_BATT_RUNTIME	"1.3.6.1.4.1.534.1.2.1.0"	/* XUPS-MIB::xupsBatTimeRemaining.0 */
+#define PW_OID_BATT_VOLTAGE	"1.3.6.1.4.1.534.1.2.2.0"	/* XUPS-MIB::xupsBatVoltage.0 */
+#define PW_OID_BATT_CURRENT	"1.3.6.1.4.1.534.1.2.3.0"	/* XUPS-MIB::xupsBatCurrent.0 */
+#define PW_OID_BATT_CHARGE	"1.3.6.1.4.1.534.1.2.4.0"	/* XUPS-MIB::xupsBatCapacity.0 */
+#define PW_OID_BATT_STATUS	"1.3.6.1.4.1.534.1.2.5.0"	/* XUPS-MIB::xupsBatteryAbmStatus.0 */
+
+#define PW_OID_IN_FREQUENCY	"1.3.6.1.4.1.534.1.3.1.0"	/* XUPS-MIB::xupsInputFrequency.0 */
+#define PW_OID_IN_LINE_BADS	"1.3.6.1.4.1.534.1.3.2.0"	/* XUPS-MIB::xupsInputLineBads.0 */
+#define PW_OID_IN_LINES		"1.3.6.1.4.1.534.1.3.3.0"	/* XUPS-MIB::xupsInputNumPhases.0 */
+#define PW_OID_IN_VOLTAGE	"1.3.6.1.4.1.534.1.3.4.1.2"	/* XUPS-MIB::xupsInputVoltage */
+#define PW_OID_IN_CURRENT	"1.3.6.1.4.1.534.1.3.4.1.3"	/* XUPS-MIB::xupsInputCurrent */
+#define PW_OID_IN_POWER		"1.3.6.1.4.1.534.1.3.4.1.4"	/* XUPS-MIB::xupsInputWatts */
+
+#define PW_OID_OUT_LOAD		"1.3.6.1.4.1.534.1.4.1.0"	/* XUPS-MIB::xupsOutputLoad.0 */
+#define PW_OID_OUT_FREQUENCY	"1.3.6.1.4.1.534.1.4.2.0"	/* XUPS-MIB::xupsOutputFrequency.0 */
+#define PW_OID_OUT_LINES	"1.3.6.1.4.1.534.1.4.3.0"	/* XUPS-MIB::xupsOutputNumPhases.0 */
+#define PW_OID_OUT_VOLTAGE	"1.3.6.1.4.1.534.1.4.4.1.2"	/* XUPS-MIB::xupsOutputVoltage */
+#define PW_OID_OUT_CURRENT	"1.3.6.1.4.1.534.1.4.4.1.3"	/* XUPS-MIB::xupsOutputCurrent */
+#define PW_OID_OUT_POWER	"1.3.6.1.4.1.534.1.4.4.1.4"	/* XUPS-MIB::xupsOutputWatts */
+#define PW_OID_POWER_STATUS	"1.3.6.1.4.1.534.1.4.5.0"	/* XUPS-MIB::xupsOutputSource.0 */
+
+#define PW_OID_BY_FREQUENCY	"1.3.6.1.4.1.534.1.5.1.0"	/* XUPS-MIB::xupsBypassFrequency.0 */
+#define PW_OID_BY_LINES		"1.3.6.1.4.1.534.1.5.2.0"	/* XUPS-MIB::xupsBypassNumPhases.0 */
+#define PW_OID_BY_VOLTAGE	"1.3.6.1.4.1.534.1.5.3.1.2"	/* XUPS-MIB::xupsBypassVoltage */
+
+#define PW_OID_BATTEST_START	"1.3.6.1.4.1.534.1.8.1"		/* XUPS-MIB::xupsTestBattery   set to startTest(1) to initiate test*/
+
+#define PW_OID_CONT_OFFDELAY	"1.3.6.1.4.1.534.1.9.1.0"		/* XUPS-MIB::xupsControlOutputOffDelay */
+#define PW_OID_CONT_ONDELAY	"1.3.6.1.4.1.534.1.9.2.0"		/* XUPS-MIB::xupsControlOutputOnDelay */
+#define PW_OID_CONT_OFFT_DEL	"1.3.6.1.4.1.534.1.9.3"		/* XUPS-MIB::xupsControlOutputOffTrapDelay */
+#define PW_OID_CONT_ONT_DEL	"1.3.6.1.4.1.534.1.9.4"		/* XUPS-MIB::xupsControlOutputOnTrapDelay */
+#define PW_OID_CONT_LOAD_SHED_AND_RESTART	"1.3.6.1.4.1.534.1.9.6"		/* XUPS-MIB::xupsLoadShedSecsWithRestart */
+
+#define PW_OID_CONF_OVOLTAGE	"1.3.6.1.4.1.534.1.10.1.0"	/* XUPS-MIB::xupsConfigOutputVoltage.0 */
+#define PW_OID_CONF_IVOLTAGE	"1.3.6.1.4.1.534.1.10.2.0"	/* XUPS-MIB::xupsConfigInputVoltage.0 */
+#define PW_OID_CONF_POWER	"1.3.6.1.4.1.534.1.10.3.0"	/* XUPS-MIB::xupsConfigOutputWatts.0 */
+#define PW_OID_CONF_FREQ	"1.3.6.1.4.1.534.1.10.4.0"	/* XUPS-MIB::xupsConfigOutputFreq.0 */
+
+#define PW_OID_ALARMS		"1.3.6.1.4.1.534.1.7.1.0"		/* XUPS-MIB::xupsAlarms */
+#define PW_OID_ALARM_OB		"1.3.6.1.4.1.534.1.7.3"		/* XUPS-MIB::xupsOnBattery */
+#define PW_OID_ALARM_LB		"1.3.6.1.4.1.534.1.7.4"		/* XUPS-MIB::xupsLowBattery */
+
+#define IETF_OID_AGENTREV	"1.3.6.1.2.1.33.1.1.4.0"	/* UPS-MIB::upsIdentAgentSoftwareVersion.0 */
+#define IETF_OID_IDENT		"1.3.6.1.2.1.33.1.1.5.0"	/* UPS-MIB::upsIdentName.0 */
+#define IETF_OID_CONF_OUT_VA	"1.3.6.1.2.1.33.1.9.5.0"	/* UPS-MIB::upsConfigOutputVA.0 */
+#define IETF_OID_CONF_RUNTIME_LOW	"1.3.6.1.2.1.33.1.9.7.0"	/* UPS-MIB::upsConfigLowBattTime.0 */
+#define IETF_OID_LOAD_LEVEL	"1.3.6.1.2.1.33.1.4.4.1.5"	/* UPS-MIB::upsOutputPercentLoad */
+#define IETF_OID_AUTO_RESTART	"1.3.6.1.2.1.33.1.8.5.0"	/* UPS-MIB::upsAutoRestart */
+
+/* Delay before powering off in seconds */
+#define DEFAULT_OFFDELAY	30
+/* Delay before powering on in seconds */
+#define DEFAULT_ONDELAY	20
+/* Default shutdown.return delay in seconds */
+#define DEFAULT_SHUTDOWNDELAY	0
+
+static info_lkp_t pw_alarm_ob[] = {
+	{ 1, "OB", NULL, NULL },
+	{ 2, "", NULL, NULL },
+	{ 0, NULL, NULL, NULL }
+};
+
+static info_lkp_t pw_alarm_lb[] = {
+	{ 1, "LB", NULL, NULL },
+	{ 2, "", NULL, NULL },
+	{ 0, NULL, NULL, NULL }
+};
+
+static info_lkp_t pw_pwr_info[] = {
+
+	{   0, "OFF"        /* off */, NULL, NULL },
+	{   1, "OL"         /* systemNormal */, NULL, NULL },
+	{   2, "OL"         /* systemNormalUPSRedundant */, NULL, NULL },
+	{   3, "OL"         /* systemNormalNotRedundant */, NULL, NULL },
+	{   4, "OB"         /* systemOnDCSource*/, NULL, NULL },
+	{   5, "OB LB"      /* systemOnDCSourceShutdownImminent */, NULL, NULL },
+	{   6, "OL"         /* systemNormalBypassNotAvailable */, NULL, NULL },
+	{   7, "OL"         /* systemNormalOnLine */, NULL, NULL },
+	{   8, "OL"         /* systemNormalEnergySaverSystem */, NULL, NULL },
+	{   9, "OL"         /* systemNormalVMMS */, NULL, NULL },
+	{  10, "OL"         /* systemNormalHRS */, NULL, NULL },
+	{  13, "OL OVER"    /* outputOverload */, NULL, NULL },
+	{  14, "OL TRIM"    /* systemNormalOnBuck */, NULL, NULL },
+	{  15, "OL BOOST"   /* systemNormalOnBoost */, NULL, NULL },
+	{  16, "BYPASS"     /* onBypass */, NULL, NULL },
+	{  17, "BYPASS"     /* onBypassStarting */, NULL, NULL },
+	{  18, "BYPASS"     /* onBypassReady */, NULL, NULL },
+	{  32, "BYPASS"     /* onMaintenanceBypass */, NULL, NULL },
+	{  33, "OL BYPASS"  /* onMBSUPSOnLine */, NULL, NULL },
+	{  34, "BYPASS"     /* onMBSUPSOnBypass */, NULL, NULL },
+	{  35, "OFF BYPASS" /* onMBSUPSOff */, NULL, NULL },
+	{  36, "OB BYPASS"  /* onMBSUPSOnBattery */, NULL, NULL },
+	{  37, "OL"         /* onMBSUPSOnLineESS */, NULL, NULL },
+	{  38, "OL"         /* onMBSUPSOnLineVMMS */, NULL, NULL },
+	{  39, "OL"         /* onMBSUPSOnLineHRS */, NULL, NULL },
+	{  40, "OL"         /* onMBSStarting */, NULL, NULL },
+	{  41, "OL"         /* onMBSReady */, NULL, NULL },
+	{  48, "OFF"        /* loadOff */, NULL, NULL },
+	{  49, "OFF"        /* loadOffStarting */, NULL, NULL },
+	{  50, "OFF"        /* loadOffReady */, NULL, NULL },
+	{  64, "OL"         /* supportingLoad */, NULL, NULL },
+	{  80, "OL"         /* systemNormalSP */, NULL, NULL },
+	{  81, "OL"         /* systemNormalEnergySaverSystemSP */, NULL, NULL },
+	{  96, "BYPASS"     /* systemOnBypassSP */, NULL, NULL },
+	{ 100, "BYPASS"     /* systemOnManualMaintenanceBypassSP (0x64) */, NULL, NULL },
+	{ 224, "OL OVER"    /* loadSegmentOverload (0x64) */, NULL, NULL },
+	{ 240, "OB"         /* systemOnDCSourceSP */, NULL, NULL },
+	{ 241, "OFF"        /* systemOffSP */, NULL, NULL },
+	{ 0, NULL, NULL, NULL }
+};
+
+/* FIXME: mapped to (experimental.)ups.type, but
+ * should be output.source or ups.mode (need RFC)
+ * to complement the above ups.status
+ * along with having ups.type as described hereafter*/
+/* FIXME: should be used by ups.mode or output.source (need RFC);
+ * Note: this define is not set via project options; code was hidden with
+ * original commit to "snmp-ups: support newer Genepi management cards";
+ * un-hidden to make it "experimental.*" namespace during backporting
+ */
+#ifndef USE_PW_MODE_INFO
+# define USE_PW_MODE_INFO 1
+#endif
+
+#if USE_PW_MODE_INFO
+static info_lkp_t pw_mode_info[] = {
+	{   1, "", NULL, NULL },
+	{   2, "", NULL, NULL },
+	{   3, "normal", NULL, NULL },
+	{   4, "", NULL, NULL },
+	{   5, "", NULL, NULL },
+	{   6, "", NULL, NULL },
+	{   7, "", NULL, NULL },
+	{   8, "parallel capacity", NULL, NULL },
+	{   9, "parallel redundancy", NULL, NULL },
+	{  10, "high efficiency", NULL, NULL },
+	/* Extended status values,
+	 * FIXME: check for source and completion */
+	{ 240, ""                /* battery (0xF0) */, NULL, NULL },
+	{ 100, ""                /* maintenanceBypass (0x64) */, NULL, NULL },
+	{  96, ""                /* Bypass (0x60) */, NULL, NULL },
+	{  81, "high efficiency" /* high efficiency (0x51) */, NULL, NULL },
+	{  80, "normal"          /* normal (0x50) */, NULL, NULL },
+	{  64, ""                /* UPS supporting load, normal degraded mode (0x40) */, NULL, NULL },
+	{  16, ""                /* none (0x10) */, NULL, NULL },
+	{   0, NULL, NULL, NULL }
+};
+#endif /* USE_PW_MODE_INFO */
+
+/* FIXME: may be standardized
+ * extracted from bcmxcp.c->BCMXCP_TOPOLOGY_*, Make some common definitions */
+static info_lkp_t pw_topology_info[] = {
+	{ 0x0000, "", NULL, NULL }, /* None; use the Table of Elements */
+	{ 0x0010, "Off-line switcher, Single Phase", NULL, NULL },
+	{ 0x0020, "Line-Interactive UPS, Single Phase", NULL, NULL },
+	{ 0x0021, "Line-Interactive UPS, Two Phase", NULL, NULL },
+	{ 0x0022, "Line-Interactive UPS, Three Phase", NULL, NULL },
+	{ 0x0030, "Dual AC Input, On-Line UPS, Single Phase", NULL, NULL },
+	{ 0x0031, "Dual AC Input, On-Line UPS, Two Phase", NULL, NULL },
+	{ 0x0032, "Dual AC Input, On-Line UPS, Three Phase", NULL, NULL },
+	{ 0x0040, "On-Line UPS, Single Phase", NULL, NULL },
+	{ 0x0041, "On-Line UPS, Two Phase", NULL, NULL },
+	{ 0x0042, "On-Line UPS, Three Phase", NULL, NULL },
+	{ 0x0050, "Parallel Redundant On-Line UPS, Single Phase", NULL, NULL },
+	{ 0x0051, "Parallel Redundant On-Line UPS, Two Phase", NULL, NULL },
+	{ 0x0052, "Parallel Redundant On-Line UPS, Three Phase", NULL, NULL },
+	{ 0x0060, "Parallel for Capacity On-Line UPS, Single Phase", NULL, NULL },
+	{ 0x0061, "Parallel for Capacity On-Line UPS, Two Phase", NULL, NULL },
+	{ 0x0062, "Parallel for Capacity On-Line UPS, Three Phase", NULL, NULL },
+	{ 0x0102, "System Bypass Module, Three Phase", NULL, NULL },
+	{ 0x0122, "Hot-Tie Cabinet, Three Phase", NULL, NULL },
+	{ 0x0200, "Outlet Controller, Single Phase", NULL, NULL },
+	{ 0x0222, "Dual AC Input Static Switch Module, 3 Phase", NULL, NULL },
+	{ 0, NULL, NULL, NULL }
+};
+
+/* Legacy implementation */
+static info_lkp_t pw_battery_abm_status[] = {
+	{ 1, "CHRG", NULL, NULL },
+	{ 2, "DISCHRG", NULL, NULL },
+/*	{ 3, "Floating", NULL, NULL }, */
+/*	{ 4, "Resting", NULL, NULL }, */
+/*	{ 5, "Unknown", NULL, NULL }, */
+	{ 0, NULL, NULL, NULL }
+};
+
+static info_lkp_t pw_abm_status_info[] = {
+	{ 1, "charging", NULL, NULL },
+	{ 2, "discharging", NULL, NULL },
+	{ 3, "floating", NULL, NULL },
+	{ 4, "resting", NULL, NULL },
+	{ 5, "unknown", NULL, NULL },   /* Undefined - ABM is not activated */
+	{ 6, "disabled", NULL, NULL },  /* ABM Charger Disabled */
+	{ 0, NULL, NULL, NULL }
+};
+
+static info_lkp_t pw_batt_test_info[] = {
+	{ 1, "Unknown", NULL, NULL },
+	{ 2, "Done and passed", NULL, NULL },
+	{ 3, "Done and error", NULL, NULL },
+	{ 4, "In progress", NULL, NULL },
+	{ 5, "Not supported", NULL, NULL },
+	{ 6, "Inhibited", NULL, NULL },
+	{ 7, "Scheduled", NULL, NULL },
+	{ 0, NULL, NULL, NULL }
+};
+
+static info_lkp_t pw_yes_no_info[] = {
+	{ 1, "yes", NULL, NULL },
+	{ 2, "no", NULL, NULL },
+	{ 0, NULL, NULL, NULL }
+};
+
+static info_lkp_t pw_outlet_status_info[] = {
+	{ 1, "on", NULL, NULL },
+	{ 2, "off", NULL, NULL },
+	{ 3, "on", NULL, NULL },  /* pendingOff, transitional status */
+	{ 4, "off", NULL, NULL }, /* pendingOn, transitional status */
+	/* { 5, "", NULL, NULL },  unknown */
+	/* { 6, "", NULL, NULL },  reserved */
+	{ 7, "off", NULL, NULL }, /* Failed in Closed position */
+	{ 8, "on", NULL, NULL },  /* Failed in Open position */
+	{ 0, NULL, NULL, NULL }
+};
+
+static info_lkp_t pw_ambient_drycontacts_info[] = {
+	{ -1, "unknown", NULL, NULL },
+	{ 1, "opened", NULL, NULL },
+	{ 2, "closed", NULL, NULL },
+	{ 3, "opened", NULL, NULL }, /* openWithNotice   */
+	{ 4, "closed", NULL, NULL }, /* closedWithNotice */
+	{ 0, NULL, NULL, NULL }
+};
+
+#if WITH_SNMP_LKP_FUN
+/* Note: eaton_sensor_temperature_unit_fun() is defined in eaton-pdu-marlin-helpers.c
+ * and su_temperature_read_fun() is in snmp-ups.c
+ * Future work for DMF might provide same-named routines via LUA-C gateway.
+ */
+
+# if WITH_SNMP_LKP_FUN_DUMMY
+/* Temperature unit consideration */
+const char *eaton_sensor_temperature_unit_fun(void *raw_snmp_value) {
+	/* snmp_value here would be a (long*) */
+	NUT_UNUSED_VARIABLE(raw_snmp_value);
+	return "unknown";
+}
+/* FIXME: please DMF, though this should be in snmp-ups.c or equiv. */
+const char *su_temperature_read_fun(void *raw_snmp_value) {
+	/* snmp_value here would be a (long*) */
+	NUT_UNUSED_VARIABLE(raw_snmp_value);
+	return "dummy";
+};
+# endif /* WITH_SNMP_LKP_FUN_DUMMY */
+
+static info_lkp_t pw_sensor_temperature_unit_info[] = {
+	{ 0, "dummy", eaton_sensor_temperature_unit_fun, NULL },
+	{ 0, NULL, NULL, NULL }
+};
+
+static info_lkp_t pw_sensor_temperature_read_info[] = {
+	{ 0, "dummy", su_temperature_read_fun, NULL },
+	{ 0, NULL, NULL, NULL }
+};
+
+#else /* if not WITH_SNMP_LKP_FUN: */
+
+/* FIXME: For now, DMF codebase falls back to old implementation with static
+ * lookup/mapping tables for this, which can easily go into the DMF XML file.
+ */
+static info_lkp_t pw_sensor_temperature_unit_info[] = {
+	{ 0, "kelvin", NULL, NULL },
+	{ 1, "celsius", NULL, NULL },
+	{ 2, "fahrenheit", NULL, NULL },
+	{ 0, NULL, NULL, NULL }
+};
+
+#endif /* WITH_SNMP_LKP_FUN */
+
+static info_lkp_t pw_ambient_drycontacts_polarity_info[] = {
+	{ 0, "normal-opened", NULL, NULL },
+	{ 1, "normal-closed", NULL, NULL },
+	{ 0, NULL, NULL, NULL }
+};
+
+static info_lkp_t pw_ambient_drycontacts_state_info[] = {
+	{ 0, "inactive", NULL, NULL },
+	{ 1, "active", NULL, NULL },
+	{ 0, NULL, NULL, NULL }
+};
+
+static info_lkp_t pw_emp002_ambient_presence_info[] = {
+	{ 0, "unknown", NULL, NULL },
+	{ 2, "yes", NULL, NULL },     /* communicationOK */
+	{ 3, "no", NULL, NULL },      /* communicationLost */
+	{ 0, NULL, NULL, NULL }
+};
+
+/* extracted from drivers/eaton-pdu-marlin-mib.c -> marlin_threshold_status_info */
+static info_lkp_t pw_threshold_status_info[] = {
+	{ 0, "good", NULL, NULL },          /* No threshold triggered */
+	{ 1, "warning-low", NULL, NULL },   /* Warning low threshold triggered */
+	{ 2, "critical-low", NULL, NULL },  /* Critical low threshold triggered */
+	{ 3, "warning-high", NULL, NULL },  /* Warning high threshold triggered */
+	{ 4, "critical-high", NULL, NULL }, /* Critical high threshold triggered */
+	{ 0, NULL, NULL, NULL }
+};
+
+/* extracted from drivers/eaton-pdu-marlin-mib.c -> marlin_threshold_xxx_alarms_info */
+static info_lkp_t pw_threshold_temperature_alarms_info[] = {
+	{ 0, "", NULL, NULL },                           /* No threshold triggered */
+	{ 1, "low temperature warning!", NULL, NULL },   /* Warning low threshold triggered */
+	{ 2, "low temperature critical!", NULL, NULL },  /* Critical low threshold triggered */
+	{ 3, "high temperature warning!", NULL, NULL },  /* Warning high threshold triggered */
+	{ 4, "high temperature critical!", NULL, NULL }, /* Critical high threshold triggered */
+	{ 0, NULL, NULL, NULL }
+};
+
+static info_lkp_t pw_threshold_humidity_alarms_info[] = {
+	{ 0, "", NULL, NULL },                        /* No threshold triggered */
+	{ 1, "low humidity warning!", NULL, NULL },   /* Warning low threshold triggered */
+	{ 2, "low humidity critical!", NULL, NULL },  /* Critical low threshold triggered */
+	{ 3, "high humidity warning!", NULL, NULL },  /* Warning high threshold triggered */
+	{ 4, "high humidity critical!", NULL, NULL }, /* Critical high threshold triggered */
+	{ 0, NULL, NULL, NULL }
+};
+
+/* Snmp2NUT lookup table */
+
+static snmp_info_t eaton_pxg_mib[] = {
+
+	/* standard MIB items */
+	{ "device.description", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.1.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.contact", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.4.0", NULL, SU_FLAG_OK, NULL },
+	{ "device.location", ST_FLAG_STRING | ST_FLAG_RW, SU_INFOSIZE, ".1.3.6.1.2.1.1.6.0", NULL, SU_FLAG_OK, NULL },
+
+	/* FIXME: miss device page! */
+	/* UPS page */
+	/* info_type, info_flags, info_len, OID, dfl, flags, oid2info, setvar */
+	{ "ups.mfr", ST_FLAG_STRING, SU_INFOSIZE, PW_OID_MFR_NAME, "",
+		SU_FLAG_STATIC, NULL },
+	{ "ups.model", ST_FLAG_STRING, SU_INFOSIZE, PW_OID_MODEL_NAME, "",
+		SU_FLAG_STATIC, NULL },
+	/* FIXME: the 2 "firmware" entries below should be SU_FLAG_SEMI_STATIC */
+	{ "ups.firmware", ST_FLAG_STRING, SU_INFOSIZE, PW_OID_FIRMREV, "",
+		0, NULL },
+	{ "ups.firmware.aux", ST_FLAG_STRING, SU_INFOSIZE, IETF_OID_AGENTREV, "",
+		0, NULL },
+	{ "ups.serial", ST_FLAG_STRING, SU_INFOSIZE, IETF_OID_IDENT, "",
+		SU_FLAG_STATIC, NULL },
+	{ "ups.load", 0, 1.0, PW_OID_OUT_LOAD, "",
+		0, NULL },
+	/* FIXME: should be removed in favor of output.power */
+	{ "ups.power", 0, 1.0, PW_OID_OUT_POWER ".1", "",
+		0, NULL },
+	/* Duplicate of the above entry, but pointing at the first index */
+	/* xupsOutputWatts.1.0; Value (Integer): 300 */
+	{ "ups.power", 0, 1.0, "1.3.6.1.4.1.534.1.4.4.1.4.1.0", "",
+		0, NULL },
+
+	{ "ups.status", ST_FLAG_STRING, SU_INFOSIZE, PW_OID_POWER_STATUS, "OFF",
+		SU_STATUS_PWR, &pw_pwr_info[0] },
+	{ "ups.status", ST_FLAG_STRING, SU_INFOSIZE, PW_OID_ALARM_OB, "",
+		SU_STATUS_BATT, &pw_alarm_ob[0] },
+	{ "ups.status", ST_FLAG_STRING, SU_INFOSIZE, PW_OID_ALARM_LB, "",
+		SU_STATUS_BATT, &pw_alarm_lb[0] },
+	{ "ups.status", ST_FLAG_STRING, SU_INFOSIZE, PW_OID_BATT_STATUS, "",
+		SU_STATUS_BATT, &pw_battery_abm_status[0] },
+#if USE_PW_MODE_INFO
+	/* FIXME: should be ups.mode or output.source (need RFC) */
+	/* Note: this define is not set via project options; code hidden with
+	 * commit to "snmp-ups: support newer Genepi management cards" */
+	{ "experimental.ups.type", ST_FLAG_STRING, SU_INFOSIZE, PW_OID_POWER_STATUS, "",
+		SU_FLAG_STATIC | SU_FLAG_OK, &pw_mode_info[0] },
+#endif /* USE_PW_MODE_INFO */
+	/* xupsTopologyType.0; Value (Integer): 32 */
+	{ "ups.type", ST_FLAG_STRING, SU_INFOSIZE, "1.3.6.1.4.1.534.1.13.1.0", "",
+		SU_FLAG_STATIC | SU_FLAG_OK, &pw_topology_info[0] },
+	/* FIXME: should be removed in favor of their output. equivalent! */
+	{ "ups.realpower.nominal", 0, 1.0, PW_OID_CONF_POWER, "",
+		0, NULL },
+	/* FIXME: should be removed in favor of output.power.nominal */
+	{ "ups.power.nominal", 0, 1.0, IETF_OID_CONF_OUT_VA, "",
+		0, NULL },
+	/* XUPS-MIB::xupsEnvAmbientTemp.0 */
+	{ "ups.temperature", 0, 1.0, "1.3.6.1.4.1.534.1.6.1.0", "", 0, NULL },
+	/* FIXME: These 2 data needs RFC! */
+	/* XUPS-MIB::xupsEnvAmbientLowerLimit.0 */
+	{ "ups.temperature.low", ST_FLAG_RW, 1.0, "1.3.6.1.4.1.534.1.6.2.0", "", 0, NULL },
+	/* XUPS-MIB::xupsEnvAmbientUpperLimit.0 */
+	{ "ups.temperature.high", ST_FLAG_RW, 1.0, "1.3.6.1.4.1.534.1.6.3.0", "", 0, NULL },
+	/* XUPS-MIB::xupsTestBatteryStatus */
+	{ "ups.test.result", ST_FLAG_STRING, SU_INFOSIZE, "1.3.6.1.4.1.534.1.8.2.0", "", 0, &pw_batt_test_info[0] },
+	/* UPS-MIB::upsAutoRestart */
+	{ "ups.start.auto", ST_FLAG_RW | ST_FLAG_STRING, SU_INFOSIZE, "1.3.6.1.2.1.33.1.8.5.0", "", SU_FLAG_OK, &pw_yes_no_info[0] },
+	/* XUPS-MIB::xupsBatteryAbmStatus.0 */
+	{ "battery.charger.status", ST_FLAG_STRING, SU_INFOSIZE, "1.3.6.1.4.1.534.1.2.5.0", "", SU_STATUS_BATT, &pw_abm_status_info[0] },
+
+	/* Battery page */
+	{ "battery.charge", 0, 1.0, PW_OID_BATT_CHARGE, "",
+		0, NULL },
+	{ "battery.runtime", 0, 1.0, PW_OID_BATT_RUNTIME, "",
+		0, NULL },
+	{ "battery.voltage", 0, 1.0, PW_OID_BATT_VOLTAGE, "",
+		0, NULL },
+	{ "battery.current", 0, 0.1, PW_OID_BATT_CURRENT, "",
+		0, NULL },
+	{ "battery.runtime.low", 0, 60.0, IETF_OID_CONF_RUNTIME_LOW, "",
+		0, NULL },
+	{ "battery.date", ST_FLAG_RW | ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.534.1.2.6.0", NULL, SU_FLAG_OK, &su_convert_to_iso_date_info[FUNMAP_USDATE_TO_ISODATE] },
+
+	/* Output page */
+	{ "output.phases", 0, 1.0, PW_OID_OUT_LINES, "", 0, NULL },
+	/* XUPS-MIB::xupsOutputFrequency.0 */
+	{ "output.frequency", 0, 0.1, "1.3.6.1.4.1.534.1.4.2.0", "", 0, NULL },
+	/* XUPS-MIB::xupsConfigOutputFreq.0 */
+	{ "output.frequency.nominal", 0, 0.1, "1.3.6.1.4.1.534.1.10.4.0", "", 0, NULL },
+	/* XUPS-MIB::xupsOutputVoltage.1 */
+	{ "output.voltage", 0, 1.0, "1.3.6.1.4.1.534.1.4.4.1.2.1", "", SU_OUTPUT_1, NULL },
+	/* Duplicate of the above entry, but pointing at the first index */
+	/* xupsOutputVoltage.1.0; Value (Integer): 230 */
+	{ "output.voltage", 0, 1.0, "1.3.6.1.4.1.534.1.4.4.1.2.1.0", "", SU_OUTPUT_1, NULL },
+	/* XUPS-MIB::xupsConfigOutputVoltage.0 */
+	{ "output.voltage.nominal", 0, 1.0, "1.3.6.1.4.1.534.1.10.1.0", "", 0, NULL },
+	/* XUPS-MIB::xupsConfigLowOutputVoltageLimit.0 */
+	{ "output.voltage.low", 0, 1.0, ".1.3.6.1.4.1.534.1.10.6.0", "", 0, NULL },
+	/* XUPS-MIB::xupsConfigHighOutputVoltageLimit.0 */
+	{ "output.voltage.high", 0, 1.0, ".1.3.6.1.4.1.534.1.10.7.0", "", 0, NULL },
+	{ "output.current", 0, 1.0, PW_OID_OUT_CURRENT ".1", "",
+		SU_OUTPUT_1, NULL },
+	/* Duplicate of the above entry, but pointing at the first index */
+	/* xupsOutputCurrent.1.0; Value (Integer): 0 */
+	{ "output.current", 0, 1.0, "1.3.6.1.4.1.534.1.4.4.1.3.1.0", "",
+		SU_OUTPUT_1, NULL },
+	{ "output.realpower", 0, 1.0, PW_OID_OUT_POWER ".1", "",
+		SU_OUTPUT_1, NULL },
+	/* Duplicate of the above entry, but pointing at the first index */
+	/* Name/OID: xupsOutputWatts.1.0; Value (Integer): 1200 */
+	{ "output.realpower", 0, 1.0, "1.3.6.1.4.1.534.1.4.4.1.4.1.0", "",
+		0, NULL },
+	/* Duplicate of "ups.realpower.nominal"
+	 * FIXME: map either ups or output, but not both (or have an auto-remap) */
+	{ "output.realpower.nominal", 0, 1.0, PW_OID_CONF_POWER, "",
+		0, NULL },
+	{ "output.L1-N.voltage", 0, 1.0, PW_OID_OUT_VOLTAGE ".1", "",
+		SU_OUTPUT_3, NULL },
+	{ "output.L2-N.voltage", 0, 1.0, PW_OID_OUT_VOLTAGE ".2", "",
+		SU_OUTPUT_3, NULL },
+	{ "output.L3-N.voltage", 0, 1.0, PW_OID_OUT_VOLTAGE ".3", "",
+		SU_OUTPUT_3, NULL },
+	{ "output.L1.current", 0, 1.0, PW_OID_OUT_CURRENT ".1", "",
+		SU_OUTPUT_3, NULL },
+	{ "output.L2.current", 0, 1.0, PW_OID_OUT_CURRENT ".2", "",
+		SU_OUTPUT_3, NULL },
+	{ "output.L3.current", 0, 1.0, PW_OID_OUT_CURRENT ".3", "",
+		SU_OUTPUT_3, NULL },
+	{ "output.L1.realpower", 0, 1.0, PW_OID_OUT_POWER ".1", "",
+		SU_OUTPUT_3, NULL },
+	{ "output.L2.realpower", 0, 1.0, PW_OID_OUT_POWER ".2", "",
+		SU_OUTPUT_3, NULL },
+	{ "output.L3.realpower", 0, 1.0, PW_OID_OUT_POWER ".3", "",
+		SU_OUTPUT_3, NULL },
+	/* FIXME: should better be output.Lx.load */
+	{ "output.L1.power.percent", 0, 1.0, IETF_OID_LOAD_LEVEL ".1", "",
+		SU_OUTPUT_3, NULL },
+	{ "output.L2.power.percent", 0, 1.0, IETF_OID_LOAD_LEVEL ".2", "",
+		SU_OUTPUT_3, NULL },
+	{ "output.L3.power.percent", 0, 1.0, IETF_OID_LOAD_LEVEL ".3", "",
+		SU_OUTPUT_3, NULL },
+	{ "output.voltage.nominal", 0, 1.0, PW_OID_CONF_OVOLTAGE, "",
+		0, NULL },
+
+	/* Input page */
+	{ "input.phases", 0, 1.0, PW_OID_IN_LINES, "",
+		0, NULL },
+	{ "input.frequency", 0, 0.1, PW_OID_IN_FREQUENCY, "",
+		0, NULL },
+	{ "input.voltage", 0, 1.0, PW_OID_IN_VOLTAGE ".0", "",
+		SU_INPUT_1, NULL },
+	/* Duplicate of the above entry, but pointing at the first index */
+	/* xupsInputVoltage.1[.0]; Value (Integer): 245 */
+	{ "input.voltage", 0, 1.0, "1.3.6.1.4.1.534.1.3.4.1.2.1", "",
+		SU_INPUT_1, NULL },
+
+	/* XUPS-MIB::xupsConfigInputVoltage.0 */
+	{ "input.voltage.nominal", 0, 1.0, "1.3.6.1.4.1.534.1.10.2.0", "", 0, NULL },
+	{ "input.current", 0, 0.1, PW_OID_IN_CURRENT ".0", "",
+		SU_INPUT_1, NULL },
+	{ "input.L1-N.voltage", 0, 1.0, PW_OID_IN_VOLTAGE ".1", "",
+		SU_INPUT_3, NULL },
+	{ "input.L2-N.voltage", 0, 1.0, PW_OID_IN_VOLTAGE ".2", "",
+		SU_INPUT_3, NULL },
+	{ "input.L3-N.voltage", 0, 1.0, PW_OID_IN_VOLTAGE ".3", "",
+		SU_INPUT_3, NULL },
+	{ "input.L1.current", 0, 1.0, PW_OID_IN_CURRENT ".1", "",
+		SU_INPUT_3, NULL },
+	{ "input.L2.current", 0, 1.0, PW_OID_IN_CURRENT ".2", "",
+		SU_INPUT_3, NULL },
+	{ "input.L3.current", 0, 1.0, PW_OID_IN_CURRENT ".3", "",
+		SU_INPUT_3, NULL },
+	{ "input.L1.realpower", 0, 1.0, PW_OID_IN_POWER ".1", "",
+		SU_INPUT_3, NULL },
+	{ "input.L2.realpower", 0, 1.0, PW_OID_IN_POWER ".2", "",
+		SU_INPUT_3, NULL },
+	{ "input.L3.realpower", 0, 1.0, PW_OID_IN_POWER ".3", "",
+		SU_INPUT_3, NULL },
+	{ "input.quality", 0, 1.0, PW_OID_IN_LINE_BADS, "",
+		0, NULL },
+
+	/* FIXME: this segfaults! do we assume the same number of bypass phases as input phases?
+	{ "input.bypass.phases", 0, 1.0, PW_OID_BY_LINES, "", 0, NULL }, */
+	{ "input.bypass.frequency", 0, 0.1, PW_OID_BY_FREQUENCY, "", 0, NULL },
+	{ "input.bypass.voltage", 0, 1.0, PW_OID_BY_VOLTAGE ".0", "",
+		SU_INPUT_1, NULL },
+	/* Duplicate of the above entry, but pointing at the first index */
+	/* xupsBypassVoltage.1.0; Value (Integer): 244 */
+	{ "input.bypass.voltage", 0, 1.0, "1.3.6.1.4.1.534.1.5.3.1.2.1.0", "",
+		SU_INPUT_1, NULL },
+	{ "input.bypass.L1-N.voltage", 0, 1.0, PW_OID_BY_VOLTAGE ".1", "",
+		SU_INPUT_3, NULL },
+	{ "input.bypass.L2-N.voltage", 0, 1.0, PW_OID_BY_VOLTAGE ".2", "",
+		SU_INPUT_3, NULL },
+	{ "input.bypass.L3-N.voltage", 0, 1.0, PW_OID_BY_VOLTAGE ".3", "",
+		SU_INPUT_3, NULL },
+
+	/* Outlet page */
+    /* Master outlet id always equal to 0 */
+	{ "outlet.id", 0, 1, NULL, "0", SU_FLAG_STATIC , NULL },
+    /* XUPS-MIB:: xupsSwitchable.0 */
+	{ "outlet.switchable", 0, 1, ".1.3.6.1.4.1.534.1.9.7.0", NULL, SU_FLAG_STATIC , &pw_yes_no_info[0] },
+	/* XUPS-MIB::xupsNumReceptacles; Value (Integer): 2 */
+	{ "outlet.count", 0, 1, ".1.3.6.1.4.1.534.1.12.1.0", NULL, SU_FLAG_STATIC, NULL },
+	/* XUPS-MIB::xupsRecepIndex.X; Value (Integer): X */
+	{ "outlet.%i.id", 0, 1, ".1.3.6.1.4.1.534.1.12.2.1.1.%i", NULL, SU_FLAG_STATIC | SU_OUTLET, NULL },
+	/* This MIB does not provide outlets switchability info. So map to a nearby
+		OID, for data activation, and map all values to "yes" */
+	{ "outlet.%i.switchable", 0, 1, ".1.3.6.1.4.1.534.1.12.2.1.1.%i", NULL, SU_FLAG_STATIC | SU_OUTLET, NULL },
+	/* XUPS-MIB::xupsRecepStatus.X; Value (Integer): 1 */
+	{ "outlet.%i.status", 0, 1, ".1.3.6.1.4.1.534.1.12.2.1.2.%i", NULL, SU_OUTLET, &pw_outlet_status_info[0] },
+
+	/* Ambient collection */
+	/* EMP001 (legacy) mapping */
+	/* XUPS-MIB::xupsEnvRemoteTemp.0 */
+	{ "ambient.temperature", 0, 1.0, "1.3.6.1.4.1.534.1.6.5.0", "", 0, NULL },
+	/* XUPS-MIB::xupsEnvRemoteTempLowerLimit.0 */
+	{ "ambient.temperature.low", ST_FLAG_RW, 1.0, "1.3.6.1.4.1.534.1.6.9.0", "", 0, NULL },
+	/* XUPS-MIB::xupsEnvRemoteTempUpperLimit.0 */
+	{ "ambient.temperature.high", ST_FLAG_RW, 1.0, "1.3.6.1.4.1.534.1.6.10.0", "", 0, NULL },
+	/* XUPS-MIB::xupsEnvRemoteHumidity.0 */
+	{ "ambient.humidity", 0, 1.0, "1.3.6.1.4.1.534.1.6.6.0", "", 0, NULL },
+	/* XUPS-MIB::xupsEnvRemoteHumidityLowerLimit.0 */
+	{ "ambient.humidity.low", ST_FLAG_RW, 1.0, "1.3.6.1.4.1.534.1.6.11.0", "", 0, NULL },
+	/* XUPS-MIB::xupsEnvRemoteHumidityUpperLimit.0 */
+	{ "ambient.humidity.high", ST_FLAG_RW, 1.0, "1.3.6.1.4.1.534.1.6.12.0", "", 0, NULL },
+	/* XUPS-MIB::xupsContactDescr.n */
+	{ "ambient.contacts.1.name", ST_FLAG_STRING, 1.0, ".1.3.6.1.4.1.534.1.6.8.1.4.1", "", 0, NULL },
+	{ "ambient.contacts.2.name", ST_FLAG_STRING, 1.0, ".1.3.6.1.4.1.534.1.6.8.1.4.2", "", 0, NULL },
+	/* XUPS-MIB::xupsContactState.n */
+	{ "ambient.contacts.1.status", ST_FLAG_STRING, 1.0, ".1.3.6.1.4.1.534.1.6.8.1.3.1", "", 0, &pw_ambient_drycontacts_info[0] },
+	{ "ambient.contacts.2.status", ST_FLAG_STRING, 1.0, ".1.3.6.1.4.1.534.1.6.8.1.3.2", "", 0, &pw_ambient_drycontacts_info[0] },
+
+	/* EMP002 (EATON EMP MIB) mapping, including daisychain support */
+	/* Warning: indexes start at '1' not '0'! */
+	/* sensorCount.0 */
+	{ "ambient.count", ST_FLAG_RW, 1.0, ".1.3.6.1.4.1.534.6.8.1.1.1.0", "", 0, NULL },
+	/* CommunicationStatus.n */
+	{ "ambient.%i.present", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.534.6.8.1.1.4.1.1.%i",
+		NULL, SU_AMBIENT_TEMPLATE, &pw_emp002_ambient_presence_info[0] },
+	/* sensorName.n: OctetString EMPDT1H1C2 @1 */
+	{ "ambient.%i.name", ST_FLAG_STRING, 1.0, ".1.3.6.1.4.1.534.6.8.1.1.3.1.1.%i", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* sensorManufacturer.n */
+	{ "ambient.%i.mfr", ST_FLAG_STRING, 1.0, ".1.3.6.1.4.1.534.6.8.1.1.2.1.6.%i", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* sensorModel.n */
+	{ "ambient.%i.model", ST_FLAG_STRING, 1.0, ".1.3.6.1.4.1.534.6.8.1.1.2.1.7.%i", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* sensorSerialNumber.n */
+	{ "ambient.%i.serial", ST_FLAG_STRING, 1.0, ".1.3.6.1.4.1.534.6.8.1.1.2.1.9.%i", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* sensorUuid.n */
+	{ "ambient.%i.id", ST_FLAG_STRING, 1.0, ".1.3.6.1.4.1.534.6.8.1.1.2.1.2.%i", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* sensorAddress.n */
+	{ "ambient.%i.address", 0, 1, ".1.3.6.1.4.1.534.6.8.1.1.2.1.4.%i", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* sensorFirmwareVersion.n */
+	{ "ambient.%i.firmware", ST_FLAG_STRING, 1.0, ".1.3.6.1.4.1.534.6.8.1.1.2.1.10.%i", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* temperatureUnit.1
+	 * MUST be before the temperature data reading! */
+	{ "ambient.%i.temperature.unit", 0, 1.0, ".1.3.6.1.4.1.534.6.8.1.2.5.0", "", SU_AMBIENT_TEMPLATE, &pw_sensor_temperature_unit_info[0] },
+	/* temperatureValue.n.1 */
+	{ "ambient.%i.temperature", 0, 0.1, ".1.3.6.1.4.1.534.6.8.1.2.3.1.3.%i.1", "", SU_AMBIENT_TEMPLATE,
+#if WITH_SNMP_LKP_FUN
+	&pw_sensor_temperature_read_info[0]
+#else
+	NULL
+#endif
+	},
+	{ "ambient.%i.temperature.status", ST_FLAG_STRING, SU_INFOSIZE,
+		".1.3.6.1.4.1.534.6.8.1.2.3.1.1.%i.1",
+		NULL, SU_AMBIENT_TEMPLATE, &pw_threshold_status_info[0] },
+	{ "ups.alarm", ST_FLAG_STRING, SU_INFOSIZE,
+		".1.3.6.1.4.1.534.6.8.1.2.3.1.1.%i.1",
+		NULL, SU_AMBIENT_TEMPLATE, &pw_threshold_temperature_alarms_info[0] },
+	/* FIXME: ambient.n.temperature.{minimum,maximum} */
+	/* temperatureThresholdLowCritical.n.1 */
+	{ "ambient.%i.temperature.low.critical", ST_FLAG_RW, 0.1, ".1.3.6.1.4.1.534.6.8.1.2.2.1.6.%i.1", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* temperatureThresholdLowWarning.n.1 */
+	{ "ambient.%i.temperature.low.warning", ST_FLAG_RW, 0.1, ".1.3.6.1.4.1.534.6.8.1.2.2.1.5.%i.1", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* temperatureThresholdHighWarning.n.1 */
+	{ "ambient.%i.temperature.high.warning", ST_FLAG_RW, 0.1, ".1.3.6.1.4.1.534.6.8.1.2.2.1.7.%i.1", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* temperatureThresholdHighCritical.n.1 */
+	{ "ambient.%i.temperature.high.critical", ST_FLAG_RW, 0.1, ".1.3.6.1.4.1.534.6.8.1.2.2.1.8.%i.1", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* humidityValue.n.1 */
+	{ "ambient.%i.humidity", 0, 0.1, ".1.3.6.1.4.1.534.6.8.1.3.3.1.3.%i.1", "", SU_AMBIENT_TEMPLATE, NULL },
+	{ "ambient.%i.humidity.status", ST_FLAG_STRING, SU_INFOSIZE,
+		".1.3.6.1.4.1.534.6.8.1.3.3.1.1.%i.1",
+		NULL, SU_AMBIENT_TEMPLATE, &pw_threshold_status_info[0] },
+	{ "ups.alarm", ST_FLAG_STRING, SU_INFOSIZE,
+		".1.3.6.1.4.1.534.6.8.1.3.3.1.1.%i.1",
+		NULL, SU_AMBIENT_TEMPLATE, &pw_threshold_humidity_alarms_info[0] },
+	/* FIXME: consider ambient.n.humidity.{minimum,maximum} */
+	/* humidityThresholdLowCritical.n.1 */
+	{ "ambient.%i.humidity.low.critical", ST_FLAG_RW, 0.1, ".1.3.6.1.4.1.534.6.8.1.3.2.1.6.%i.1", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* humidityThresholdLowWarning.n.1 */
+	{ "ambient.%i.humidity.low.warning", ST_FLAG_RW, 0.1, ".1.3.6.1.4.1.534.6.8.1.3.2.1.5.%i.1", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* humidityThresholdHighWarning.n.1 */
+	{ "ambient.%i.humidity.high.warning", ST_FLAG_RW, 0.1, ".1.3.6.1.4.1.534.6.8.1.3.2.1.7.%i.1", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* humidityThresholdHighCritical.n.1 */
+	{ "ambient.%i.humidity.high.critical", ST_FLAG_RW, 0.1, ".1.3.6.1.4.1.534.6.8.1.3.2.1.8.%i.1", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* digitalInputName.n.{1,2} */
+	{ "ambient.%i.contacts.1.name", ST_FLAG_STRING, 1.0, ".1.3.6.1.4.1.534.6.8.1.4.2.1.1.%i.1", "", SU_AMBIENT_TEMPLATE, NULL },
+	{ "ambient.%i.contacts.2.name", ST_FLAG_STRING, 1.0, ".1.3.6.1.4.1.534.6.8.1.4.2.1.1.%i.2", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* digitalInputPolarity.n */
+	{ "ambient.%i.contacts.1.config", ST_FLAG_RW | ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.534.6.8.1.4.2.1.3.%i.1", "", SU_AMBIENT_TEMPLATE, &pw_ambient_drycontacts_polarity_info[0] },
+	{ "ambient.%i.contacts.2.config", ST_FLAG_RW | ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.534.6.8.1.4.2.1.3.%i.2", "", SU_AMBIENT_TEMPLATE, &pw_ambient_drycontacts_polarity_info[0] },
+	/* XUPS-MIB::xupsContactState.n */
+	{ "ambient.%i.contacts.1.status", ST_FLAG_STRING, 1.0, ".1.3.6.1.4.1.534.6.8.1.4.3.1.3.%i.1", "", SU_AMBIENT_TEMPLATE, &pw_ambient_drycontacts_state_info[0] },
+	{ "ambient.%i.contacts.2.status", ST_FLAG_STRING, 1.0, ".1.3.6.1.4.1.534.6.8.1.4.3.1.3.%i.2", "", SU_AMBIENT_TEMPLATE, &pw_ambient_drycontacts_state_info[0] },
+
+	/* instant commands */
+	{ "test.battery.start.quick", 0, 1, PW_OID_BATTEST_START, "",
+		SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	/* Shed load and restart when line power back on; cannot be canceled */
+	{ "shutdown.return", 0, DEFAULT_SHUTDOWNDELAY, PW_OID_CONT_LOAD_SHED_AND_RESTART, "",
+		SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	/* Cancel output off, by writing 0 to xupsControlOutputOffDelay */
+	{ "shutdown.stop", 0, 0, PW_OID_CONT_OFFDELAY, "",
+		SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	/* XUPS-MIB::xupsControlOutputOffDelay */
+	/* load off after 1 sec, shortest possible delay; 0 cancels */
+	{ "load.off", 0, 1, PW_OID_CONT_OFFDELAY, "1",
+		SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	/* Delayed version, parameter is mandatory (so dfl is NULL)! */
+	{ "load.off.delay", 0, 1, PW_OID_CONT_OFFDELAY, NULL,
+		SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	/* XUPS-MIB::xupsControlOutputOnDelay */
+	/* load on after 1 sec, shortest possible delay; 0 cancels */
+	{ "load.on", 0, 1, PW_OID_CONT_ONDELAY, "1",
+		SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	/* Delayed version, parameter is mandatory (so dfl is NULL)! */
+	{ "load.on.delay", 0, 1, PW_OID_CONT_ONDELAY, NULL,
+		SU_TYPE_CMD | SU_FLAG_OK, NULL },
+
+	/* Delays handling:
+	 * 0-n :Time in seconds until the command is issued
+	 * -1:Cancel a pending Off/On command */
+	/* XUPS-MIB::xupsRecepOffDelaySecs.n */
+	{ "outlet.%i.load.off", 0, 1, ".1.3.6.1.4.1.534.1.12.2.1.3.%i",
+		"0", SU_TYPE_CMD | SU_OUTLET, NULL },
+	/* XUPS-MIB::xupsRecepOnDelaySecs.n */
+	{ "outlet.%i.load.on", 0, 1, ".1.3.6.1.4.1.534.1.12.2.1.4.%i",
+		"0", SU_TYPE_CMD | SU_OUTLET, NULL },
+	/* Delayed version, parameter is mandatory (so dfl is NULL)! */
+	{ "outlet.%i.load.off.delay", 0, 1, ".1.3.6.1.4.1.534.1.12.2.1.3.%i",
+		NULL, SU_TYPE_CMD | SU_OUTLET, NULL },
+	/* XUPS-MIB::xupsRecepOnDelaySecs.n */
+	{ "outlet.%i.load.on.delay", 0, 1, ".1.3.6.1.4.1.534.1.12.2.1.4.%i",
+		NULL, SU_TYPE_CMD | SU_OUTLET, NULL },
+
+	{ "ups.alarms", 0, 1.0, PW_OID_ALARMS, "",
+		0, NULL },
+
+	/* end of structure. */
+	{ NULL, 0, 0, NULL, NULL, 0, NULL }
+} ;
+
+static alarms_info_t eaton_pxg_alarms[] = {
+	/* xupsLowBattery */
+	{ PW_OID_ALARM_LB, "LB", NULL },
+	/* xupsOutputOverload */
+	{ ".1.3.6.1.4.1.534.1.7.7", "OVER", "Output overload!" },
+	/* xupsInternalFailure */
+	{ ".1.3.6.1.4.1.534.1.7.8", NULL, "Internal failure!" },
+	/* xupsBatteryDischarged */
+	{ ".1.3.6.1.4.1.534.1.7.9", NULL, "Battery discharged!" },
+	/* xupsInverterFailure */
+	{ ".1.3.6.1.4.1.534.1.7.10", NULL, "Inverter failure!" },
+	/* xupsOnBypass
+	 * FIXME: informational (not an alarm),
+	 * to RFC'ed for device.event? */
+	{ ".1.3.6.1.4.1.534.1.7.11", "BYPASS", "On bypass!" },
+	/* xupsBypassNotAvailable
+	 * FIXME: informational (not an alarm),
+	 * to RFC'ed for device.event? */
+	{ ".1.3.6.1.4.1.534.1.7.12", NULL, "Bypass not available!" },
+	/* xupsOutputOff
+	 * FIXME: informational (not an alarm),
+	 * to RFC'ed for device.event? */
+	{ ".1.3.6.1.4.1.534.1.7.13", "OFF", "Output off!" },
+	/* xupsInputFailure
+	 * FIXME: informational (not an alarm),
+	 * to RFC'ed for device.event? */
+	{ ".1.3.6.1.4.1.534.1.7.14", NULL, "Input failure!" },
+	/* xupsBuildingAlarm
+	 * FIXME: informational (not an alarm),
+	 * to RFC'ed for device.event? */
+	{ ".1.3.6.1.4.1.534.1.7.15", NULL, "Building alarm!" },
+	/* xupsShutdownImminent */
+	{ ".1.3.6.1.4.1.534.1.7.16", NULL, "Shutdown imminent!" },
+	/* xupsOnInverter
+	 * FIXME: informational (not an alarm),
+	 * to RFC'ed for device.event? */
+	{ ".1.3.6.1.4.1.534.1.7.17", NULL, "On inverter!" },
+	/* xupsBreakerOpen
+	 * FIXME: informational (not an alarm),
+	 * to RFC'ed for device.event? */
+	{ ".1.3.6.1.4.1.534.1.7.20", NULL, "Breaker open!" },
+	/* xupsAlarmBatteryBad */
+	{ ".1.3.6.1.4.1.534.1.7.23", "RB", "Battery bad!" },
+	/* xupsOutputOffAsRequested
+	 * FIXME: informational (not an alarm),
+	 * to RFC'ed for device.event? */
+	{ ".1.3.6.1.4.1.534.1.7.24", "OFF", "Output off as requested!" },
+	/* xupsDiagnosticTestFailed
+	 * FIXME: informational (not an alarm),
+	 * to RFC'ed for device.event? */
+	{ ".1.3.6.1.4.1.534.1.7.25", NULL, "Diagnostic test failure!" },
+	/* xupsCommunicationsLost */
+	{ ".1.3.6.1.4.1.534.1.7.26", NULL, "Communication with UPS lost!" },
+	/* xupsUpsShutdownPending */
+	{ ".1.3.6.1.4.1.534.1.7.27", NULL, "Shutdown pending!" },
+	/* xupsAmbientTempBad */
+	{ ".1.3.6.1.4.1.534.1.7.29", NULL, "Bad ambient temperature!" },
+	/* xupsLossOfRedundancy */
+	{ ".1.3.6.1.4.1.534.1.7.30", NULL, "Redundancy lost!" },
+	/* xupsAlarmTempBad */
+	{ ".1.3.6.1.4.1.534.1.7.31", NULL, "Bad temperature!" },
+	/* xupsAlarmChargerFailed */
+	{ ".1.3.6.1.4.1.534.1.7.32", NULL, "Charger failure!" },
+	/* xupsAlarmFanFailure */
+	{ ".1.3.6.1.4.1.534.1.7.33", NULL, "Fan failure!" },
+	/* xupsAlarmFuseFailure */
+	{ ".1.3.6.1.4.1.534.1.7.34", NULL, "Fuse failure!" },
+	/* xupsPowerSwitchBad */
+	{ ".1.3.6.1.4.1.534.1.7.35", NULL, "Powerswitch failure!" },
+	/* xupsModuleFailure */
+	{ ".1.3.6.1.4.1.534.1.7.36", NULL, "Parallel or composite module failure!" },
+	/* xupsOnAlternatePowerSource
+	 * FIXME: informational (not an alarm),
+	 * to RFC'ed for device.event? */
+	{ ".1.3.6.1.4.1.534.1.7.37", NULL, "Using alternative power source!" },
+	/* xupsAltPowerNotAvailable
+	 * FIXME: informational (not an alarm),
+	 * to RFC'ed for device.event? */
+	{ ".1.3.6.1.4.1.534.1.7.38", NULL, "Alternative power source unavailable!" },
+	/* xupsRemoteTempBad */
+	{ ".1.3.6.1.4.1.534.1.7.40", NULL, "Bad remote temperature!" },
+	/* xupsRemoteHumidityBad */
+	{ ".1.3.6.1.4.1.534.1.7.41", NULL, "Bad remote humidity!" },
+	/* xupsAlarmOutputBad */
+	{ ".1.3.6.1.4.1.534.1.7.42", NULL, "Bad output condition!" },
+	/* xupsAlarmAwaitingPower
+	 * FIXME: informational (not an alarm),
+	 * to RFC'ed for device.event? */
+	{ ".1.3.6.1.4.1.534.1.7.43", NULL, "Awaiting power!" },
+	/* xupsOnMaintenanceBypass
+	 * FIXME: informational (not an alarm),
+	 * to RFC'ed for device.event?
+	 * FIXME: NUT currently doesn't distinguish between Maintenance and
+	 * Automatic Bypass (both published as "ups.alarm: BYPASS)
+	 * Should we make the distinction? */
+	{ ".1.3.6.1.4.1.534.1.7.44", "BYPASS", "On maintenance bypass!" },
+
+
+	/* end of structure. */
+	{ NULL, NULL, NULL }
+} ;
+
+
+mib2nut_info_t	eaton_pxg_ups = { "eaton_pxg_ups", EATON_PXG_MIB_VERSION, NULL, PW_OID_MODEL_NAME, eaton_pxg_mib, EATON_PXGX_SYSOID , eaton_pxg_alarms };

--- a/drivers/eaton-ups-pxg-mib.h
+++ b/drivers/eaton-ups-pxg-mib.h
@@ -4,7 +4,6 @@
 #include "main.h"
 #include "snmp-ups.h"
 
-extern mib2nut_info_t	powerware;
-extern mib2nut_info_t	pxgx_ups;
+extern mib2nut_info_t	eaton_pxg_ups;
 
 #endif /* POWERWARE_MIB_H */

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -44,7 +44,6 @@
 #include "apc-mib.h"
 #include "mge-mib.h"
 #include "netvision-mib.h"
-#include "powerware-mib.h"
 #include "eaton-pdu-genesis2-mib.h"
 #include "eaton-pdu-marlin-mib.h"
 #include "eaton-pdu-pulizzi-mib.h"
@@ -69,6 +68,8 @@
 #include "hpe-pdu-mib.h"
 #include "hpe-pdu3-cis-mib.h"
 #include "eaton-pdu-nlogic-mib.h"
+#include "eaton-ups-pwnm2-mib.h"
+#include "eaton-ups-pxg-mib.h"
 
 /* Address API change */
 #if ( ! NUT_HAVE_LIBNETSNMP_usmAESPrivProtocol ) && ( ! defined usmAESPrivProtocol )
@@ -109,6 +110,8 @@ static mib2nut_info_t *mib2nut[] = {
 	&eaton_ats30,		/* This struct comes from : eaton-ats30-mib.c */
 	&eaton_marlin,		/* This struct comes from : eaton-mib.c */
 	&eaton_pdu_nlogic,	/* This struct comes from : eaton-pdu-nlogic-mib.c */
+	&eaton_pxg_ups,		/* This struct comes from : eaton-ups-pxg-mib.c */
+	&eaton_pw_nm2, 		/* This struct comes from : eaton-ups-pwnm2-mib.c */
 	&emerson_avocent_pdu,	/* This struct comes from : emerson-avocent-pdu-mib.c */
 	&aphel_revelation,	/* This struct comes from : eaton-mib.c */
 	&aphel_genesisII,	/* This struct comes from : eaton-mib.c */
@@ -119,8 +122,6 @@ static mib2nut_info_t *mib2nut[] = {
 	&huawei,			/* This struct comes from : huawei-mib.c */
 	&mge,				/* This struct comes from : mge-mib.c */
 	&netvision,			/* This struct comes from : netvision-mib.c */
-	&powerware,			/* This struct comes from : powerware-mib.c */
-	&pxgx_ups,			/* This struct comes from : powerware-mib.c */
 	&raritan,			/* This struct comes from : raritan-pdu-mib.c */
 	&raritan_px2,		/* This struct comes from : raritan-px2-mib.c */
 	&xppc,				/* This struct comes from : xppc-mib.c */
@@ -172,7 +173,7 @@ static const char *mibname;
 static const char *mibvers;
 
 #define DRIVER_NAME	"Generic SNMP UPS driver"
-#define DRIVER_VERSION		"1.26"
+#define DRIVER_VERSION		"1.27"
 
 /* driver description structure */
 upsdrv_info_t	upsdrv_info = {


### PR DESCRIPTION
To better manage the slight nuances (especially in ups.status), between Eaton UPSs, implementation file was split in 2 files, and mib name were renamed from 'pw' to 'eaton_pw_nm2', and from 'pxgx_ups' to 'eaton_pxg_ups'

Thanks to Quentin Renard (Eaton) for discovering the bug

Signed-off-by: Arnaud Quette <ArnaudQuette@eaton.com>