### PR TITLE
snmp-ups: fix "Warning: excessive poll failures"

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -117,6 +117,9 @@ https://github.com/networkupstools/nut/milestone/8
    * Better manage the slight nuances (especially in ups.status) between
      Eaton UPSs, and rename mibs from 'pw' to 'eaton_pw_nm2', and from
      'pxgx_ups' to 'eaton_pxg_ups' 
+   * Fixed the long standing "Warning: excessive poll failures" issue, that
+     was tied to non-existent OIDs, not well handled in some part of the driver
+
 
  - Added support for `make install` of PyNUT module and NUT-Monitor desktop
    application [#1462, #1504]


### PR DESCRIPTION
Fix that long standing issue, which was tied to non-existent OIDs, not well handled in some part of the driver

Closes: #743

Signed-off-by: Arnaud Quette <ArnaudQuette@eaton.com>