### PR TITLE
Suggest in docs and daemon messages how command-signals vs. PID files vs. systemd units interact

### DIFF
--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -2371,6 +2371,7 @@ int main(int argc, char *argv[])
 	}
 
 	if (cmd) {
+		int reported = 0;
 #ifndef WIN32
 		if (oldpid < 0) {
 			cmdret = sendsignal(prog, cmd);
@@ -2402,11 +2403,23 @@ int main(int argc, char *argv[])
 						(oldpid < 0 ? " or add '-P $PID' argument" : ""));
 					break;
 			}
+			reported = 1;
 		}
 # endif
 #else
 		cmdret = sendsignal(UPSMON_PIPE_NAME, cmd);
 #endif
+
+		if (cmdret != 0 && !reported) {
+			/* sendsignal*() above might have logged more details
+			 * for troubleshooting, e.g. about lack of PID file
+			 */
+			upslogx(LOG_NOTICE, "Failed to signal the currently running daemon");
+			if (oldpid < 0) {
+				upslogx(LOG_NOTICE, "Try to add '-P $PID' argument");
+			}
+		}
+
 		/* exit(EXIT_SUCCESS); */
 		exit((cmdret == 0) ? EXIT_SUCCESS : EXIT_FAILURE);
 	}

--- a/common/common.c
+++ b/common/common.c
@@ -229,7 +229,7 @@ struct passwd *get_user_pwent(const char *name)
 	   some implementations of getpwnam() do not set errno when this
 	   happens. */
 	if (errno == 0)
-		fatalx(EXIT_FAILURE, "user %s not found", name);
+		fatalx(EXIT_FAILURE, "OS user %s not found", name);
 	else
 		fatal_with_errno(EXIT_FAILURE, "getpwnam(%s)", name);
 #else

--- a/conf/ups.conf.sample
+++ b/conf/ups.conf.sample
@@ -32,12 +32,12 @@
 # On a system called "doghouse", the line in your upsmon.conf to monitor
 # and manage it would look something like this:
 #
-#   MONITOR snoopy@doghouse 1 upsmonuser mypassword primary
+#   MONITOR snoopy@doghouse 1 monuser mypassword primary
 #
 # It might look like this if monitoring in "secondary" mode (without any
 # ability to directly manage the UPS) from a different system:
 #
-#   MONITOR snoopy@doghouse 1 upsmonuser mypassword secondary
+#   MONITOR snoopy@doghouse 1 monuser mypassword secondary
 #
 # Configuration directives
 # ------------------------

--- a/conf/upsd.users.sample
+++ b/conf/upsd.users.sample
@@ -59,9 +59,9 @@
 #
 # --- Configuring for upsmon
 #
-# To add a user for your upsmon, use this example:
+# To add a NUT user for your upsmon, with a particular role, use this example:
 #
-#   [upsmon]
+#   [monuser]
 #       password  = pass
 #       upsmon primary
 # or
@@ -69,7 +69,7 @@
 #
 # The matching MONITOR line in your upsmon.conf would look like this:
 #
-# MONITOR myups@localhost 1 upsmon pass primary	(or secondary)
+# MONITOR myups@localhost 1 monuser pass primary	(or secondary)
 #
 # See comments in the upsmon.conf(.sample) file for details about this
 # keyword and the difference of NUT secondary and primary systems.

--- a/conf/upsmon.conf.sample.in
+++ b/conf/upsmon.conf.sample.in
@@ -27,6 +27,7 @@
 #
 # This user should not have write access to upsmon.conf.
 #
+# (Unprivileged) OS account to run as:
 # RUN_AS_USER @RUN_AS_USER@
 
 # --------------------------------------------------------------------------

--- a/conf/upsmon.conf.sample.in
+++ b/conf/upsmon.conf.sample.in
@@ -66,10 +66,10 @@
 # changes for a given UPS without shutting down when it goes critical.
 #
 # <username> and <password> must match an entry in that system's
-# upsd.users.  If your username is "upsmon" and your password is
+# upsd.users.  If your NUT username is "monuser" and your password is
 # "blah", the upsd.users would look like this:
 #
-#	[upsmon]
+#	[monuser]
 #		password  = blah
 #		upsmon primary 	# (or secondary)
 #
@@ -113,8 +113,8 @@
 # Examples:
 #
 # MONITOR myups@bigserver 1 upswired blah primary
-# MONITOR su700@server.example.com 1 upsmon secretpass secondary
-# MONITOR myups@localhost 1 upsmon pass primary	# (or secondary)
+# MONITOR su700@server.example.com 1 monuser secretpass secondary
+# MONITOR myups@localhost 1 monuser pass primary	# (or secondary)
 
 # --------------------------------------------------------------------------
 # MINSUPPLIES <num>

--- a/configure.ac
+++ b/configure.ac
@@ -2506,11 +2506,17 @@ case "${systemdsystemunitdir}" in
 esac
 if test "${systemdsystemunitdir}" = "auto" ; then systemdsystemunitdir=""; fi
 if test -n "${systemdsystemunitdir}"; then
+	have_systemd="yes"
 	AC_MSG_RESULT(using ${systemdsystemunitdir})
 else
+	have_systemd="no"
 	AC_MSG_RESULT(no)
 fi
-AM_CONDITIONAL(HAVE_SYSTEMD, test "$systemdsystemunitdir" != "")
+dnl Note: we may want tighter integration, e.g. systemd-notify support at
+dnl a later point. That would be a further option/flag. This one is a very
+dnl basic yes/no toggle.
+NUT_REPORT_FEATURE([consider systemd support], [${have_systemd}], [],
+					[HAVE_SYSTEMD], [Define to consider systemd support])
 dnl This option is only provided so that make distcheck can override it,
 dnl otherwise we ask pkg-config whenever --with-systemdsystemunitdir is
 dnl given

--- a/docs/FAQ.txt
+++ b/docs/FAQ.txt
@@ -535,12 +535,20 @@ Or a variation like...
 == How do you make upsd reload the config file?
 
 Either find the pid of the background process and send it a SIGHUP,
-or just start it again with '-c reload'.
+or just start it again with '-c reload' (requires that the previously
+started daemon saves a PID file).
 
 If you send the signals yourself instead of using -c, be sure you
 hit the right process.  There are usually two upsmon processes, and you
 should only send signals to one of them.  To be safe, read the pid
 file.
+
+If your daemons are managed as systemd units, it is more idiomatic to
+use the framework commands, e.g. `systemctl reload nut-server` (upsd)
+or `systemctl reload nut-monitor` (upsmon). Note that the implementation
+of `nut-server.service` by default starts `upsd -F` and does not save a
+PID file; if your workflow requires to use plain `upsd -c reload`, you
+should customize the unit (with a drop-in file) to start `upsd -FF`.
 
 == I just bought a new WhizBang UPS that has a USB connector.  How do I monitor it?
 

--- a/docs/config-notes.txt
+++ b/docs/config-notes.txt
@@ -585,7 +585,8 @@ Reloading the data server
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Reload `upsd`.  Depending on your configuration, you may be able to
-do this without stopping the `upsd` daemon process:
+do this without stopping the `upsd` daemon process (if it had saved
+a PID file earlier):
 
 	upsd -c reload
 
@@ -596,7 +597,10 @@ If that doesn't work (check the syslog), just restart it:
 
 For systems with integrated service management (Linux systemd,
 illumos/Solaris SMF) their corresponding `reload` or `refresh`
-service actions should handle this as well.
+service actions should handle this as well. Note that such integration
+generally forgoes saving of PID files, so `upsd -c <cmd>` would not work.
+If your workflow requires to manage these daemons beside the OS provided
+framework, you can customize it to start `upsd -FF` and save the PID file.
 
 NOTE: If you want to make reloading work later, see the entry in the
 link:FAQ.html[FAQ] about starting `upsd` as a different user.

--- a/docs/man/upsd.txt
+++ b/docs/man/upsd.txt
@@ -87,7 +87,10 @@ RELOADING
 
 upsd can reload its configuration files without shutting down the process
 if you send it a SIGHUP or start it again with `-c reload`.  This only works
-if the background process is able to read those files.
+if the background process is able to read those files, and if the daemon did
+save a PID file when it started (e.g. service instances wrapped by systemd
+or SMF do not save them by default -- use respective `reload`/`refresh`
+framework actions instead).
 
 If you think that upsd can't reload, check your syslog for error messages.
 If it's complaining about not being able to read the files, then you need

--- a/scripts/systemd/nut-server.service.in
+++ b/scripts/systemd/nut-server.service.in
@@ -20,8 +20,9 @@ PartOf=nut.target
 [Service]
 EnvironmentFile=-@CONFPATH@/nut.conf
 SyslogIdentifier=%N
-# Note: foreground mode by default skips writing a PID file (and
-# needs Type=simple); can use "-FF" here to create one anyway:
+# Note: foreground mode "-F" by default skips writing a PID file (and
+# needs default Type=simple); we can use "-FF" here to create the file
+# anyway, so that old "upsd -c reload" works rather than systemd action:
 ExecStart=@SBINDIR@/upsd -F
 ExecReload=@SBINDIR@/upsd -c reload -P $MAINPID
 

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -1686,92 +1686,66 @@ int main(int argc, char **argv)
 		}
 	}
 
-	if (cmd) {
-		int reported = 0;
+	/* Note: "cmd" may be non-trivial to command that instance by
+	 * explicit PID number or lookup in PID file (error if absent).
+	 * Otherwise, we are being asked to start and "cmd" is 0/NULL -
+	 * for probing whether a competing older instance of this program
+	 * is running (error if it is).
+	 */
 #ifndef WIN32
-		if (oldpid < 0) {
-			cmdret = sendsignalfn(pidfn, cmd);
-		} else {
-			cmdret = sendsignalpid(oldpid, cmd);
-		}
+	/* If cmd == 0 we are starting and check if a previous instance
+	 * is running by sending signal '0' (i.e. 'kill <pid> 0' equivalent)
+	 */
 
-# ifdef HAVE_SYSTEMD
-		if (cmdret != 0) {
-			switch (cmd) {
-				case SIGCMD_RELOAD:
-					upslogx(LOG_NOTICE, "Try 'systemctl reload %s'%s",
-						SERVICE_UNIT_NAME,
-						(oldpid < 0 ? " or add '-P $PID' argument" : ""));
-					break;
-				case SIGCMD_STOP:
-					upslogx(LOG_NOTICE, "Try 'systemctl stop %s'%s",
-						SERVICE_UNIT_NAME,
-						(oldpid < 0 ? " or add '-P $PID' argument" : ""));
-					break;
-				default:
-					upslogx(LOG_NOTICE, "Try 'systemctl <command> %s'%s",
-						SERVICE_UNIT_NAME,
-						(oldpid < 0 ? " or add '-P $PID' argument" : ""));
-					break;
-			}
-			/* ... or edit nut-server.service locally to start `upsd -FF`
-			 * and so save the PID file for ability to manage the daemon
-			 * beside the service framework, possibly confusing things...
-			 */
-			reported = 1;
-		}
-# endif
-#else
-		cmdret = sendsignal(UPSD_PIPE_NAME, cmd);
-#endif
-
-		if (cmdret != 0 && !reported) {
-			/* sendsignal*() above might have logged more details
-			 * for troubleshooting, e.g. about lack of PID file
-			 */
-			upslogx(LOG_NOTICE, "Failed to signal the currently running daemon");
-			if (oldpid < 0) {
-				upslogx(LOG_NOTICE, "Try to add '-P $PID' argument");
-			}
-		}
-
-		exit((cmdret == 0) ? EXIT_SUCCESS : EXIT_FAILURE);
-	}
-
-	/* otherwise, we are being asked to start.
-	 * so check if a previous instance is running by sending signal '0'
-	 * (Ie 'kill <pid> 0') */
-#ifndef WIN32
 	if (oldpid < 0) {
-		cmdret = sendsignalfn(pidfn, 0);
+		cmdret = sendsignalfn(pidfn, cmd);
 	} else {
-		cmdret = sendsignalpid(oldpid, 0);
+		cmdret = sendsignalpid(oldpid, cmd);
 	}
-#else
-	mutex = CreateMutex(NULL,TRUE,UPSD_PIPE_NAME);
-	if (mutex == NULL) {
-		if (GetLastError() != ERROR_ACCESS_DENIED) {
-			fatalx(EXIT_FAILURE, "Can not create mutex %s : %d.\n",UPSD_PIPE_NAME,(int)GetLastError());
+#else	/* if WIN32 */
+	if (cmd) {
+		/* Command the running daemon, it should be there */
+		cmdret = sendsignal(UPSD_PIPE_NAME, cmd);
+	} else {
+		/* Starting new daemon, check for competition */
+		mutex = CreateMutex(NULL, TRUE, UPSD_PIPE_NAME);
+		if (mutex == NULL) {
+			if (GetLastError() != ERROR_ACCESS_DENIED) {
+				fatalx(EXIT_FAILURE,
+					"Can not create mutex %s : %d.\n",
+					UPSD_PIPE_NAME, (int)GetLastError());
+			}
+		}
+
+		cmdret = -1; /* unknown, maybe ok */
+		if (GetLastError() == ERROR_ALREADY_EXISTS
+		||  GetLastError() == ERROR_ACCESS_DENIED
+		) {
+			cmdret = 0; /* known conflict */
 		}
 	}
-
-	cmdret = -1; /* unknown, maybe ok */
-	if (GetLastError() == ERROR_ALREADY_EXISTS
-	||  GetLastError() == ERROR_ACCESS_DENIED)
-		cmdret = 0; /* known conflict */
-#endif
+#endif	/* WIN32 */
 
 	switch (cmdret) {
 	case 0:
-		printf("Fatal error: A previous upsd instance is already running!\n");
-		printf("Either stop the previous instance first, or use the 'reload' command.\n");
-		exit(EXIT_FAILURE);
+		if (cmd) {
+			upsdebugx(1, "Signaled old daemon OK");
+		} else {
+			printf("Fatal error: A previous upsd instance is already running!\n");
+			printf("Either stop the previous instance first, or use the 'reload' command.\n");
+			exit(EXIT_FAILURE);
+		}
+		break;
 
 	case -3:
 	case -2:
+		/* if starting new daemon, no competition running -
+		 *    maybe OK (or failed to detect it => problem)
+		 * if signaling old daemon - certainly have a problem
+		 */
 		upslogx(LOG_WARNING, "Could not %s PID file '%s' "
 			"to see if previous upsd instance is "
-			"already running!\n",
+			"already running!",
 			(cmdret == -3 ? "find" : "parse"),
 			pidfn);
 		break;
@@ -1779,8 +1753,50 @@ int main(int argc, char **argv)
 	case -1:
 	case 1:	/* WIN32 */
 	default:
-		/* Just failed to send signal, no competitor running */
+		/* if cmd was nontrivial - speak up below, else be quiet */
+		upsdebugx(1, "Just failed to send signal, no daemon was running");
 		break;
+	}
+
+	if (cmd) {
+		/* We were signalling a daemon, successfully or not - exit now... */
+		if (cmdret != 0) {
+			/* sendsignal*() above might have logged more details
+			 * for troubleshooting, e.g. about lack of PID file
+			 */
+			upslogx(LOG_NOTICE, "Failed to signal the currently running daemon (if any)");
+#ifndef WIN32
+# ifdef HAVE_SYSTEMD
+			switch (cmd) {
+			case SIGCMD_RELOAD:
+				upslogx(LOG_NOTICE, "Try 'systemctl reload %s'%s",
+					SERVICE_UNIT_NAME,
+					(oldpid < 0 ? " or add '-P $PID' argument" : ""));
+				break;
+			case SIGCMD_STOP:
+				upslogx(LOG_NOTICE, "Try 'systemctl stop %s'%s",
+					SERVICE_UNIT_NAME,
+					(oldpid < 0 ? " or add '-P $PID' argument" : ""));
+				break;
+			default:
+				upslogx(LOG_NOTICE, "Try 'systemctl <command> %s'%s",
+					SERVICE_UNIT_NAME,
+					(oldpid < 0 ? " or add '-P $PID' argument" : ""));
+				break;
+			}
+			/* ... or edit nut-server.service locally to start `upsd -FF`
+			 * and so save the PID file for ability to manage the daemon
+			 * beside the service framework, possibly confusing things...
+			 */
+# else
+			if (oldpid < 0) {
+				upslogx(LOG_NOTICE, "Try to add '-P $PID' argument");
+			}
+# endif
+#endif	/* not WIN32 */
+		}
+
+		exit((cmdret == 0) ? EXIT_SUCCESS : EXIT_FAILURE);
 	}
 
 	argc -= optind;


### PR DESCRIPTION
Follow-up from #1721 discussions, mostly to clarify docs and messages to be more actionable with regard to changes in NUT 2.8.0 and systemd unit wrapping (e.g. that by default it starts `upsd -F` and so does not save PID files).

Also clarifies some example texts to be more consistent between files (e.g. NUT user for upsmon).