### PR TITLE
nutscan-init.c: adjust WIN32 shared library detection for SNMP and NEON

### DIFF
--- a/tools/nut-scanner/nutscan-init.c
+++ b/tools/nut-scanner/nutscan-init.c
@@ -197,6 +197,11 @@ void nutscan_init(void)
 	} else {
 		/* let libtool (lt_dlopen) do its default magic maybe better */
 		nutscan_avail_snmp = nutscan_load_snmp_library("libnetsnmp" SOEXT);
+#ifdef WIN32
+		if (!nutscan_avail_snmp) {
+			nutscan_avail_snmp = nutscan_load_snmp_library("libnetsnmp-40" SOEXT);
+		}
+#endif
 	}
 #endif	/* WITH_SNMP */
 
@@ -214,6 +219,14 @@ void nutscan_init(void)
 		if (!nutscan_avail_xml_http) {
 			nutscan_avail_xml_http = nutscan_load_neon_library("libneon-gnutls" SOEXT);
 		}
+#ifdef WIN32
+		if (!nutscan_avail_xml_http) {
+			nutscan_avail_xml_http = nutscan_load_neon_library("libneon-27" SOEXT);
+		}
+		if (!nutscan_avail_xml_http) {
+			nutscan_avail_xml_http = nutscan_load_neon_library("libneon-gnutls-27" SOEXT);
+		}
+#endif
 	}
 #endif	/* WITH_NEON */
 

--- a/tools/nut-scanner/nutscan-init.c
+++ b/tools/nut-scanner/nutscan-init.c
@@ -147,9 +147,10 @@ void nutscan_init(void)
 # ifdef HAVE_PTHREAD_TRYJOIN
 	pthread_mutex_init(&threadcount_mutex, NULL);
 # endif
-#endif /* HAVE_PTHREAD */
+#endif	/* HAVE_PTHREAD */
 
 	char *libname = NULL;
+
 #ifdef WITH_USB
  #if WITH_LIBUSB_1_0
 	libname = get_libname("libusb-1.0" SOEXT);
@@ -186,7 +187,8 @@ void nutscan_init(void)
 			nutscan_avail_usb = nutscan_load_usb_library("libusb" SOEXT);
 		}
 	}
-#endif
+#endif	/* WITH_USB */
+
 #ifdef WITH_SNMP
 	libname = get_libname("libnetsnmp" SOEXT);
 	if (libname) {
@@ -196,7 +198,8 @@ void nutscan_init(void)
 		/* let libtool (lt_dlopen) do its default magic maybe better */
 		nutscan_avail_snmp = nutscan_load_snmp_library("libnetsnmp" SOEXT);
 	}
-#endif
+#endif	/* WITH_SNMP */
+
 #ifdef WITH_NEON
 	libname = get_libname("libneon" SOEXT);
 	if (!libname) {
@@ -212,7 +215,8 @@ void nutscan_init(void)
 			nutscan_avail_xml_http = nutscan_load_neon_library("libneon-gnutls" SOEXT);
 		}
 	}
-#endif
+#endif	/* WITH_NEON */
+
 #ifdef WITH_AVAHI
 	libname = get_libname("libavahi-client" SOEXT);
 	if (libname) {
@@ -222,7 +226,8 @@ void nutscan_init(void)
 		/* let libtool (lt_dlopen) do its default magic maybe better */
 		nutscan_avail_avahi = nutscan_load_avahi_library("libavahi-client" SOEXT);
 	}
-#endif
+#endif	/* WITH_AVAHI */
+
 #ifdef WITH_FREEIPMI
 	libname = get_libname("libfreeipmi" SOEXT);
 	if (libname) {
@@ -232,7 +237,9 @@ void nutscan_init(void)
 		/* let libtool (lt_dlopen) do its default magic maybe better */
 		nutscan_avail_ipmi = nutscan_load_ipmi_library("libfreeipmi" SOEXT);
 	}
-#endif
+#endif	/* WITH_FREEIPMI */
+
+/* start of libupsclient for "old NUT" (vs. Avahi) protocol - unconditional */
 	libname = get_libname("libupsclient" SOEXT);
 #ifdef WIN32
 	/* TODO: Detect DLL name at build time, or rename it at install time? */
@@ -259,6 +266,8 @@ void nutscan_init(void)
 		}
 #endif
 	}
+/* end of libupsclient for "old NUT" (vs. Avahi) protocol */
+
 }
 
 void nutscan_free(void)


### PR DESCRIPTION
Closes: #1735

Note: libnetsnmp is not bundled in mingw, but can be built additionally as documented in NUT sources - and automated for Appveyor CI builds.