### PR TITLE
Fix common USB matching options for riello, richcomm and nutdrv_atcl

### DIFF
--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -212,7 +212,7 @@ bcmxcp_usb_LDADD = $(LDADD_DRIVERS) $(LIBUSB_LIBS) -lm
 blazer_usb_SOURCES = blazer.c blazer_usb.c $(LIBUSB_IMPL) usb-common.c
 blazer_usb_LDADD = $(LDADD_DRIVERS) $(LIBUSB_LIBS) -lm
 
-nutdrv_atcl_usb_SOURCES = nutdrv_atcl_usb.c usb-common.c
+nutdrv_atcl_usb_SOURCES = nutdrv_atcl_usb.c $(LIBUSB_IMPL) usb-common.c
 nutdrv_atcl_usb_LDADD = $(LDADD_DRIVERS) $(LIBUSB_LIBS)
 
 richcomm_usb_SOURCES = richcomm_usb.c usb-common.c

--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -215,7 +215,7 @@ blazer_usb_LDADD = $(LDADD_DRIVERS) $(LIBUSB_LIBS) -lm
 nutdrv_atcl_usb_SOURCES = nutdrv_atcl_usb.c $(LIBUSB_IMPL) usb-common.c
 nutdrv_atcl_usb_LDADD = $(LDADD_DRIVERS) $(LIBUSB_LIBS)
 
-richcomm_usb_SOURCES = richcomm_usb.c usb-common.c
+richcomm_usb_SOURCES = richcomm_usb.c $(LIBUSB_IMPL) usb-common.c
 richcomm_usb_LDADD = $(LDADD_DRIVERS) $(LIBUSB_LIBS)
 
 riello_usb_SOURCES = riello.c riello_usb.c $(LIBUSB_IMPL) usb-common.c

--- a/drivers/bcmxcp.h
+++ b/drivers/bcmxcp.h
@@ -2,8 +2,8 @@
  * bcmxcp.h -- header for BCM/XCP module
  */
 
-#ifndef _POWERWARE_H
-#define _POWERWARE_H
+#ifndef NUT_BCMXCP_H_SEEN
+#define NUT_BCMXCP_H_SEEN 1
 
 #include "timehead.h"
 
@@ -622,5 +622,4 @@ typedef enum ebool { FALSE, TRUE } bool_t;
 typedef int bool_t;
 #endif
 
-#endif /*_POWERWARE_H */
-
+#endif	/* NUT_BCMXCP_H_SEEN */

--- a/drivers/blazer_usb.c
+++ b/drivers/blazer_usb.c
@@ -577,6 +577,8 @@ void upsdrv_help(void)
 void upsdrv_makevartable(void)
 {
 	addvar(VAR_VALUE, "subdriver", "Serial-over-USB subdriver selection");
+
+	/* allow -x vendor=X, vendorid=X, product=X, productid=X, serial=X */
 	nut_usb_addvars();
 
 	addvar(VAR_VALUE, "langid_fix", "Apply the language ID workaround to the krauler subdriver (0x409 or 0x4095)");

--- a/drivers/nutdrv_atcl_usb.c
+++ b/drivers/nutdrv_atcl_usb.c
@@ -24,11 +24,12 @@
  */
 
 #include "main.h"
+#include "nut_libusb.h"
 #include "usb-common.h"
 
 /* driver version */
 #define DRIVER_NAME	"'ATCL FOR UPS' USB driver"
-#define DRIVER_VERSION	"1.16"
+#define DRIVER_VERSION	"1.17"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -679,5 +680,6 @@ void upsdrv_help(void)
 
 void upsdrv_makevartable(void)
 {
-        addvar(VAR_VALUE, "vendor", "USB vendor string (or NULL if none)");
+	/* allow -x vendor=X, vendorid=X, product=X, productid=X, serial=X */
+	nut_usb_addvars();
 }

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -2670,6 +2670,7 @@ void	upsdrv_makevartable(void)
 
 #ifdef QX_USB
 	addvar(VAR_VALUE, "subdriver", "Serial-over-USB subdriver selection");
+
 	/* allow -x vendor=X, vendorid=X, product=X, productid=X, serial=X */
 	nut_usb_addvars();
 

--- a/drivers/richcomm_usb.c
+++ b/drivers/richcomm_usb.c
@@ -24,12 +24,13 @@
  */
 
 #include "main.h"
+#include "nut_libusb.h"
 #include "usb-common.h"
 #include "nut_stdint.h"
 
 /* driver version */
 #define DRIVER_NAME	"Richcomm dry-contact to USB driver"
-#define DRIVER_VERSION	"0.10"
+#define DRIVER_VERSION	"0.11"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -734,4 +735,6 @@ void upsdrv_help(void)
 
 void upsdrv_makevartable(void)
 {
+	/* allow -x vendor=X, vendorid=X, product=X, productid=X, serial=X */
+	nut_usb_addvars();
 }

--- a/drivers/riello_usb.c
+++ b/drivers/riello_usb.c
@@ -34,7 +34,7 @@
 #include "riello.h"
 
 #define DRIVER_NAME	"Riello USB driver"
-#define DRIVER_VERSION	"0.07"
+#define DRIVER_VERSION	"0.08"
 
 #define DEFAULT_OFFDELAY   5  /*!< seconds (max 0xFF) */
 #define DEFAULT_BOOTDELAY  5  /*!< seconds (max 0xFF) */
@@ -831,7 +831,8 @@ void upsdrv_help(void)
 
 void upsdrv_makevartable(void)
 {
-
+	/* allow -x vendor=X, vendorid=X, product=X, productid=X, serial=X */
+	nut_usb_addvars();
 }
 
 void upsdrv_initups(void)


### PR DESCRIPTION
Should fix #1754 and #1744 among other issues. Thanks to @shgubar for convincing me that the bug is there, and to trace the code with more attention.

Note: "bcmxcp_usb" driver suffers a similar problem but was not easy to fix in a similar fashion (conflicts with symbols in the built `LIBUSB_IMPL` of the day, and impacts nut-scanner build per different dependency chain), so attempt to fix it along with others was shelved.

A side note from debugging: the regex-matching in usb-common.c is not logged in full detail because array elements are not interactively useful (precompiled regexes, not original strings).