### PR TITLE
Update USB matching options in man pages

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -138,7 +138,7 @@ https://github.com/networkupstools/nut/milestone/8
    serial drivers in respective Makefile and configure script options [#1446]
 
  - Fixed support for common USB matching options ("vendor", "device", "bus",
-   etc.) for `riello_usb`, `richcomm_usb` and `nutdrv_atcl_usb` [#1763]
+   etc.) for `riello_usb` and `richcomm_usb` [#1763]
 
  - Stuck drivers that do not react to `SIGTERM` quickly are now retried with
    `SIGKILL` [#1424]

--- a/NEWS
+++ b/NEWS
@@ -138,7 +138,9 @@ https://github.com/networkupstools/nut/milestone/8
    serial drivers in respective Makefile and configure script options [#1446]
 
  - Fixed support for common USB matching options ("vendor", "device", "bus",
-   etc.) for `riello_usb` and `richcomm_usb` [#1763]
+   etc.) for `riello_usb` and `richcomm_usb` [#1763] and updated man pages
+   of all USB drivers using these options to include the same description
+   [#1766]
 
  - Stuck drivers that do not react to `SIGTERM` quickly are now retried with
    `SIGKILL` [#1424]

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -528,11 +528,13 @@ SRC_USB_LIBUSB_PAGES = \
 	blazer-common.txt	\
 	blazer_usb.txt	\
 	nutdrv_atcl_usb.txt \
+	nut_usb_addvars.txt \
 	richcomm_usb.txt \
 	riello_usb.txt	\
 	tripplite_usb.txt \
 	usbhid-ups.txt
 
+# NOTE: nut_usb_addvars and blazer-common are not standalone man pages
 if WITH_MANS
 MAN_USB_LIBUSB_PAGES = \
 	bcmxcp_usb.8 \

--- a/docs/man/bcmxcp_usb.txt
+++ b/docs/man/bcmxcp_usb.txt
@@ -27,9 +27,24 @@ EXTRA ARGUMENTS
 This driver supports the following optional settings in the
 linkman:ups.conf[5].
 
-*shutdown_delay=*'delay'::
+*shutdown_delay =* 'delay'::
 The number of seconds that the UPS should wait between receiving the
 shutdown command and actually shutting off.
+
+NOTE: This driver does not currently support USB-matching settings common
+to other drivers, such as *vendor*, *vendorid*, *product*, *productid*,
+*serial*, *device* or *bus*.
+
+////////
+The note above may be addressed by
+https://github.com/networkupstools/nut/issues/1764
+When that happens, replace it by the following lines:
+
+USB INTERFACE ONLY
+~~~~~~~~~~~~~~~~~~
+
+include::nut_usb_addvars.txt[]
+////////
 
 DEFAULT VALUES FOR THE EXTRA ARGUMENTS
 --------------------------------------

--- a/docs/man/blazer-common.txt
+++ b/docs/man/blazer-common.txt
@@ -136,38 +136,7 @@ ifdef::blazer_usb[]
 USB INTERFACE ONLY
 ~~~~~~~~~~~~~~~~~~
 
-*vendorid =* 'regex'::
-*productid =* 'regex'::
-*vendor =* 'regex'::
-*product =* 'regex'::
-*serial =* 'regex'::
-
-Select a specific UPS, in case there is more than one connected via
-USB. Each option specifies an extended regular expression (see
-*regex(7)*) that must match the UPS's entire vendor/product/serial
-string (minus any surrounding whitespace), or the whole 4-digit
-hexadecimal code for vendorid and productid. Try *-DD* for
-finding out the strings to match.
-+
-Examples:
-
- - `-x vendor="Foo.Corporation.*"`
- - `-x vendorid=051d*` (APC)
- - `-x product=".*(Smart|Back)-?UPS.*"`
-
-*bus =* 'regex'::
-
-Select a UPS on a specific USB bus or group of buses. The argument is
-a regular expression that must match the bus name where the UPS is
-connected (e.g. bus="002", bus="00[2-3]").
-
-*device =* 'regex'::
-
-Select a UPS on a specific USB device or group of devices. The argument is
-a regular expression that must match the device name where the UPS is
-connected (e.g. device="001", device="00[1-2]").
-Note that device numbers are not guaranteed by the OS to be stable across
-re-boots or device re-plugging.
+include::nut_usb_addvars.txt[]
 
 *subdriver =* 'string'::
 

--- a/docs/man/nut_usb_addvars.txt
+++ b/docs/man/nut_usb_addvars.txt
@@ -9,6 +9,16 @@ Keep in sync with nut_usb_addvars() method provided by
 * drivers/usb-common.h
 ////////
 
+*port =* 'string'::
+
+Some 'value' must be set, typically *auto*.
++
+NOTE: This could be a device filesystem path like `/dev/usb/hiddev0` but current
+use of libusb API precludes knowing and matching by such identifiers.  They may
+also be inherently unreliable (dependent on re-plugging and enumeration order).
+At this time the actual 'value' is ignored, but some 'port' must be there
+syntactically.
+
 *vendorid =* 'regex'::
 *productid =* 'regex'::
 *vendor =* 'regex'::

--- a/docs/man/nut_usb_addvars.txt
+++ b/docs/man/nut_usb_addvars.txt
@@ -19,6 +19,11 @@ also be inherently unreliable (dependent on re-plugging and enumeration order).
 At this time the actual 'value' is ignored, but some 'port' must be there
 syntactically.
 
+It is possible to control multiple UPS units simultaneously by running several
+instances of this driver, provided they can be uniquely distinguished by setting
+some combination of the *vendor*, *product*, *vendorid*, *productid*, *serial*,
+*bus* and/or *device* options detailed below.
+
 *vendorid =* 'regex'::
 *productid =* 'regex'::
 *vendor =* 'regex'::

--- a/docs/man/nut_usb_addvars.txt
+++ b/docs/man/nut_usb_addvars.txt
@@ -27,10 +27,13 @@ syntactically.
 
 Select a specific UPS, in case there is more than one connected via
 USB. Each option specifies an extended regular expression (see
-*regex(7)* that must match the UPS's entire vendor/product/serial
-string (minus any surrounding whitespace), or the whole 4-digit
-hexadecimal code for `vendorid` and `productid`. Try *-DD* for
-finding out the strings to match.
+*regex(7)* for more information on regular expressions), which
+must match the UPS's entire respective vendor/product/serial string
+(minus any surrounding whitespace), or the whole 4-digit
+hexadecimal code for `vendorid` and `productid`.
++
+Try *lsusb(8)* or running this NUT driver with *-DD* command-line
+argument for finding out the strings to match.
 +
 Examples:
 
@@ -42,12 +45,14 @@ Examples:
 
 Select a UPS on a specific USB bus or group of buses. The argument is
 a regular expression that must match the bus name where the UPS is
-connected (e.g. `bus="002"` or `bus="00[2-3]"`).
+connected (e.g. `bus="002"` or `bus="00[2-3]"`) as seen in
+`/proc/bus/usb/devices` or *lsusb(8)*; including leading zeroes.
 
 *device =* 'regex'::
 
 Select a UPS on a specific USB device or group of devices. The argument is
 a regular expression that must match the device name where the UPS is
-connected (e.g. `device="001"` or `device="00[1-2]"`).
+connected (e.g. `device="001"` or `device="00[1-2]"`) as seen in
+`/proc/bus/usb/devices` or *lsusb(8)*; including leading zeroes.
 Note that device numbers are not guaranteed by the OS to be stable across
 re-boots or device re-plugging.

--- a/docs/man/nut_usb_addvars.txt
+++ b/docs/man/nut_usb_addvars.txt
@@ -61,3 +61,9 @@ connected (e.g. `device="001"` or `device="00[1-2]"`) as seen in
 `/proc/bus/usb/devices` or *lsusb(8)*; including leading zeroes.
 Note that device numbers are not guaranteed by the OS to be stable across
 re-boots or device re-plugging.
+
+*usb_set_altinterface =* 'bAlternateSetting'::
+
+Force redundant call to `usb_set_altinterface()`, especially if needed
+for devices serving multiple USB roles where the UPS is not represented
+by the interface number `0` (default).

--- a/docs/man/nut_usb_addvars.txt
+++ b/docs/man/nut_usb_addvars.txt
@@ -1,0 +1,43 @@
+////////
+This file is included into other man pages, where appropriate,
+by their choice of markup and sectioning (usually lands into
+"USB INTERFACE ONLY" for serial/usb or "EXTRA ARGUMENTS").
+
+Keep in sync with nut_usb_addvars() method provided by
+* drivers/libusb0.c
+* drivers/libusb1.c
+* drivers/usb-common.h
+////////
+
+*vendorid =* 'regex'::
+*productid =* 'regex'::
+*vendor =* 'regex'::
+*product =* 'regex'::
+*serial =* 'regex'::
+
+Select a specific UPS, in case there is more than one connected via
+USB. Each option specifies an extended regular expression (see
+*regex(7)* that must match the UPS's entire vendor/product/serial
+string (minus any surrounding whitespace), or the whole 4-digit
+hexadecimal code for `vendorid` and `productid`. Try *-DD* for
+finding out the strings to match.
++
+Examples:
+
+- `-x vendor="Foo.Corporation.*"`
+- `-x vendorid="051d*"` (APC)
+- `-x product=".*(Smart|Back)-?UPS.*"`
+
+*bus =* 'regex'::
+
+Select a UPS on a specific USB bus or group of buses. The argument is
+a regular expression that must match the bus name where the UPS is
+connected (e.g. `bus="002"` or `bus="00[2-3]"`).
+
+*device =* 'regex'::
+
+Select a UPS on a specific USB device or group of devices. The argument is
+a regular expression that must match the device name where the UPS is
+connected (e.g. `device="001"` or `device="00[1-2]"`).
+Note that device numbers are not guaranteed by the OS to be stable across
+re-boots or device re-plugging.

--- a/docs/man/nutdrv_atcl_usb.txt
+++ b/docs/man/nutdrv_atcl_usb.txt
@@ -34,11 +34,18 @@ EXTRA ARGUMENTS
 
 This driver supports the following optional setting:
 
-*vendor*='name'::
+*vendor =* 'name'::
+
 In case your iManufacturer (Vendor) string does not exactly match
-+ATCL FOR UPS+, you may provide an alternate string here. Note that a more
-likely case is that your device is handled by another driver for +0001:0000+
-devices, such as linkman:nutdrv_qx[8].
++ATCL FOR UPS+, you may provide an alternate string here (or specify "NULL" if
+the device does not provide a vendor string but you want this driver to match).
++
+Note that a more likely case for mismatch is that your device is handled by
+another driver for +0001:0000+ devices, such as linkman:nutdrv_qx[8].
++
+NOTE: This driver does not intend to support USB-matching settings common to
+other drivers, such as *vendorid*, *product*, *productid*, *serial*, *device*
+or *bus*; also the *vendor* setting supported here is not a regular expression.
 
 BUGS
 ----

--- a/docs/man/nutdrv_qx.txt
+++ b/docs/man/nutdrv_qx.txt
@@ -319,32 +319,7 @@ If you find that your UPS isn't detected or the communication with the UPS is un
 USB INTERFACE ONLY
 ~~~~~~~~~~~~~~~~~~
 
-*port =* 'string'::
-You must set 'value' to *auto*.
-
-*vendorid =* 'regex'::
-*productid =* 'regex'::
-*vendor =* 'regex'::
-*product =* 'regex'::
-*serial =* 'regex'::
-Select a specific UPS, in case there is more than one connected via USB.
-Each option specifies an extended regular expression (see *regex(7)*) that must match the UPS's entire vendor/product/serial string (minus any surrounding whitespace), or the whole 4-digit hexadecimal code for vendorid and productid.
-Try *-DD* for finding out the strings to match.
-+
-Examples:
-
- - `-x vendor="Foo.Corporation.*"`
- - `-x vendorid=051d*` (APC)
- - `-x product=".*(Smart|Back)-?UPS.*"`
-
-*bus =* 'regex'::
-Select a UPS on a specific USB bus or group of buses.
-The argument is a regular expression that must match the bus name where the UPS is connected (e.g. +bus="002"+, +bus="00[2-3]"+).
-
-*device =* 'regex'::
-Select a UPS on a specific USB device or group of devices.
-The argument is a regular expression that must match the device name where the UPS is connected (e.g. +device="001"+, +device="00[1-2]"+).
-Note that device numbers are not guaranteed by the OS to be stable across re-boots or device re-plugging.
+include::nut_usb_addvars.txt[]
 
 *subdriver =* 'string'::
 Select a serial-over-USB subdriver to use.

--- a/docs/man/richcomm_usb.txt
+++ b/docs/man/richcomm_usb.txt
@@ -22,6 +22,11 @@ As such, all the limitations of the underlying contact closure interface
 apply.  This means that you will only get the essentials in ups.status: OL,
 OB, and LB.  See also linkman:genericups[8].
 
+EXTRA ARGUMENTS
+---------------
+
+include::nut_usb_addvars.txt[]
+
 BUGS
 ----
 

--- a/docs/man/richcomm_usb.txt
+++ b/docs/man/richcomm_usb.txt
@@ -22,10 +22,14 @@ As such, all the limitations of the underlying contact closure interface
 apply.  This means that you will only get the essentials in ups.status: OL,
 OB, and LB.  See also linkman:genericups[8].
 
+////////
+TODO: Uncomment after solving https://github.com/networkupstools/nut/issues/1768
+
 EXTRA ARGUMENTS
 ---------------
 
 include::nut_usb_addvars.txt[]
+////////
 
 BUGS
 ----

--- a/docs/man/riello_usb.txt
+++ b/docs/man/riello_usb.txt
@@ -24,6 +24,10 @@ riello_usb supports all recent Riello UPS with USB.
 
 Older Riello UPS products are not supported.
 
+EXTRA ARGUMENTS
+---------------
+
+include::nut_usb_addvars.txt[]
 
 AUTHOR
 ------

--- a/docs/man/tripplite_usb.txt
+++ b/docs/man/tripplite_usb.txt
@@ -61,6 +61,31 @@ EXTRA ARGUMENTS
 This driver supports the following optional settings in the linkman:ups.conf[5]
 file (or with '-x' on the command line):
 
+include::nut_usb_addvars.txt[]
+
+[NOTE]
+.Notes for `tripplite_usb` driver handling of common USB matching settings:
+======
+* *product* is a regular expression to match the product string for the UPS.
+This would be useful if you have two different Tripp Lite UPS models connected
+to the same monitoring system, and you want to be sure that you shut them down
+in the correct order.
++
+This regex is matched against the full USB product string as seen in
+lsusb(8). The `ups.model` in the linkman:upsc[1] output only lists the name
+after `TRIPP LITE`, so to match a SMART2200RMXL2U, you could use the regex
+`.*SMART2200.*`.
+
+* The *productid* is a regular expression which matches the UPS PID as four
+hexadecimal digits.  So far, the only known devices that work with this driver
+have PID `0001`.
+
+* The *serial* option may be or not be helpful: it does not appear that these
+particular Tripp Lite UPSes supported by this driver use the `iSerial`
+descriptor field to return a serial number.  However, in case your unit does,
+you may specify it here.
+======
+
 *offdelay*::
 
 This setting controls the delay between receiving the "kill" command ('-k')
@@ -74,43 +99,6 @@ state-of-charge.  The calculated battery.charge value will be clamped to the
 range of 10% through 100%, so the resting voltage of the charged battery can be
 used for *battery_max*, and the higher float charge voltage should not cause
 problems.
-
-*bus*::
-
-This regular expression is used to match the USB bus (as seen in
-`/proc/bus/usb/devices` or lsusb(8); including leading zeroes).
-
-*device*::
-
-This regular expression is used to match the USB device (as seen in
-`/proc/bus/usb/devices` or lsusb(8); including leading zeroes).
-Note that device numbers are not guaranteed by the OS to be stable across
-re-boots or device re-plugging.
-
-*product*::
-
-A regular expression to match the product string for the UPS.  This would be
-useful if you have two different Tripp Lite UPS models connected to the
-system, and you want to be sure that you shut them down in the correct order.
-
-NOTE: This regex is matched against the full USB product string as seen in
-lsusb(8). The `ups.model` in the linkman:upsc[1] output only lists the name after
-`TRIPP LITE`, so to match a SMART2200RMXL2U, you could use the regex
-`.*SMART2200.*`.
-
-*productid*::
-
-The productid is a regular expression which matches the UPS PID as four
-hexadecimal digits.  So far, the only devices that work with this driver have
-PID `0001`.
-
-*serial*::
-
-It does not appear that these particular Tripp Lite UPSes use the `iSerial`
-descriptor field to return a serial number.  However, in case your unit does,
-you may specify it here.
-
-For more information on regular expressions, see regex(7)
 
 RUNTIME VARIABLES
 -----------------

--- a/docs/man/usbhid-ups.txt
+++ b/docs/man/usbhid-ups.txt
@@ -52,6 +52,8 @@ EXTRA ARGUMENTS
 
 This driver also supports the following optional settings:
 
+include::nut_usb_addvars.txt[]
+
 *offdelay*='num'::
 Set the timer before the UPS is turned off after the kill power command is
 sent (via the *-k* switch).
@@ -110,39 +112,6 @@ It is also always possible that NUT fix-ups cause issues on some devices,
 whether due to NUT bugs or because the vendor protocol implementation is
 broken in more than one place.
 
-*vendor*='regex'::
-*product*='regex'::
-*serial*='regex'::
-*vendorid*='regex'::
-*productid*='regex'::
-
-Select a specific UPS, in case there is more than one connected via
-USB. Each option specifies an extended regular expression (see
-regex(7)) that must match the UPS's entire vendor/product/serial
-string (minus any surrounding whitespace), or the whole 4-digit
-hexadecimal code for vendorid and productid. Try *-DD* for
-finding out the strings to match.
-+
-Examples:
-
- -  `-x vendor="Foo.Corporation.*"`
- -  `-x vendorid=051d*` (APC)
- -  `-x product=".*(Smart|Back)-?UPS.*"`
-
-*bus*='regex'::
-
-Select a UPS on a specific USB bus or group of buses. The argument is
-a regular expression that must match the bus name where the UPS is
-connected (e.g. bus="002", bus="00[2-3]").
-
-*device =* 'regex'::
-
-Select a UPS on a specific USB device or group of devices. The argument is
-a regular expression that must match the device name where the UPS is
-connected (e.g. device="001", device="00[1-2]").
-Note that device numbers are not guaranteed by the OS to be stable across
-re-boots or device re-plugging.
-
 *explore*::
 With this option, the driver will connect to any device, including
 ones that are not yet supported. This must always be combined with the
@@ -194,11 +163,11 @@ IMPLEMENTATION
 Selecting a specific UPS
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-The driver ignores the "port" value in *ups.conf*. Unlike previous
-versions of this driver, it is now possible to control multiple UPS
-units simultaneously with this driver, provided they can be distinguished
-by setting some combination of the "vendor", "product", "serial",
-"vendorid", and "productid" options. For instance:
+As mentioned above, the driver ignores the "port" value in *ups.conf*.
+Unlike previous versions of this driver, it is now possible to control
+multiple UPS units simultaneously with this driver, provided they can
+be distinguished by setting some combination of the device-matching options.
+For instance:
 
 	[mge]
 		driver = usbhid-ups

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3062 utf-8
+personal_ws-1.1 en 3063 utf-8
 AAS
 ABI
 ACFAIL
@@ -1408,6 +1408,7 @@ addenum
 addinfo
 addr
 addrange
+addvars
 adelsystem
 adkorte
 adm

--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -212,7 +212,7 @@ bcmxcp_usb_LDADD = $(LDADD_DRIVERS) $(LIBUSB_LIBS) -lm
 blazer_usb_SOURCES = blazer.c blazer_usb.c $(LIBUSB_IMPL) usb-common.c
 blazer_usb_LDADD = $(LDADD_DRIVERS) $(LIBUSB_LIBS) -lm
 
-nutdrv_atcl_usb_SOURCES = nutdrv_atcl_usb.c $(LIBUSB_IMPL) usb-common.c
+nutdrv_atcl_usb_SOURCES = nutdrv_atcl_usb.c usb-common.c
 nutdrv_atcl_usb_LDADD = $(LDADD_DRIVERS) $(LIBUSB_LIBS)
 
 richcomm_usb_SOURCES = richcomm_usb.c $(LIBUSB_IMPL) usb-common.c

--- a/drivers/nutdrv_atcl_usb.c
+++ b/drivers/nutdrv_atcl_usb.c
@@ -24,12 +24,11 @@
  */
 
 #include "main.h"
-#include "nut_libusb.h"
 #include "usb-common.h"
 
 /* driver version */
 #define DRIVER_NAME	"'ATCL FOR UPS' USB driver"
-#define DRIVER_VERSION	"1.17"
+#define DRIVER_VERSION	"1.16"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -680,6 +679,8 @@ void upsdrv_help(void)
 
 void upsdrv_makevartable(void)
 {
-	/* allow -x vendor=X, vendorid=X, product=X, productid=X, serial=X */
-	nut_usb_addvars();
+	/* NOTE: This driver uses a very custom device matching method,
+	 * so does not involve nut_usb_addvars() method like others do.
+	 */
+	addvar(VAR_VALUE, "vendor", "USB vendor string (or NULL if none)");
 }

--- a/drivers/nutdrv_atcl_usb.c
+++ b/drivers/nutdrv_atcl_usb.c
@@ -82,7 +82,8 @@ static int device_match_func(USBDevice_t *device, void *privdata)
 					return 1;
 				}
 			}
-			upsdebugx(1, "To keep trying (in case your device does not have a vendor string), use vendor=NULL");
+			upsdebugx(0, "To keep trying (in case your device does not have a vendor string), use vendor=NULL. "
+				"Have you tried the nutdrv_qx driver?");
 			return 0;
 		}
 
@@ -97,15 +98,16 @@ static int device_match_func(USBDevice_t *device, void *privdata)
 				upsdebugx(3, "Matched device with vendor='%s'.", requested_vendor);
 				return 1;
 			} else {
-				upsdebugx(2, "idVendor=%04x and idProduct=%04x, "
-					"but provided vendor '%s' does not match device: '%s'.",
+				upsdebugx(0, "idVendor=%04x and idProduct=%04x, "
+					"but provided vendor '%s' does not match device: '%s'. "
+					"Have you tried the nutdrv_qx driver?",
 					device->VendorID, device->ProductID, requested_vendor, device->Vendor);
 				return 0;
 			}
 		}
 
 		/* TODO: automatic way of suggesting other drivers? */
-		upsdebugx(2, "idVendor=%04x and idProduct=%04x, "
+		upsdebugx(0, "idVendor=%04x and idProduct=%04x, "
 			"but device vendor string '%s' does not match expected string '%s'. "
 			"Have you tried the nutdrv_qx driver?",
 			device->VendorID, device->ProductID, device->Vendor, USB_VENDOR_STRING);

--- a/drivers/richcomm_usb.c
+++ b/drivers/richcomm_usb.c
@@ -736,5 +736,7 @@ void upsdrv_help(void)
 void upsdrv_makevartable(void)
 {
 	/* allow -x vendor=X, vendorid=X, product=X, productid=X, serial=X */
+	/* TODO: Uncomment while addressing https://github.com/networkupstools/nut/issues/1768
 	nut_usb_addvars();
+	*/
 }


### PR DESCRIPTION
Refactored docs to include same description file, and combined different pieces of knowledge into it.

Follows up from #1763 (and adds a comment for #1764 in the text).