### PR TITLE
Add experimental prefix missed in 7ef2874e81

### DIFF
--- a/drivers/nutdrv_qx_masterguard.c
+++ b/drivers/nutdrv_qx_masterguard.c
@@ -936,11 +936,11 @@ static int masterguard_claim(void) {
 	item_t *item;
 	/* mandatory values */
 	char *mandatory[] = {
-		"series",		/* SKIP */
+		"experimental.series",	/* SKIP */
 		"device.model",		/* minimal number of battery packs */
 		"ups.power.nominal",	/* load computation */
 		"ups.id",		/* slave address */
-		"output_voltages",	/* output voltages enum */
+		"experimental.output_voltages",	/* output voltages enum */
 #if 0
 		"battery.packs",	/* battery voltage computation */
 #endif


### PR DESCRIPTION
Add `experimental.` prefix in `masterguard_claim()`. Needed because that prefix had been added (in 7ef2874e81952fac532014a8840a217cf1d636b6 to the variable names in the `masterguard_qx2nut[]` table.
