### PR TITLE
Documentation improvements

### DIFF
--- a/docs/man/bestfcom.txt
+++ b/docs/man/bestfcom.txt
@@ -17,7 +17,8 @@ SUPPORTED HARDWARE
 ------------------
 
 Best Power Fortress/Ferrups implementing the Fortress UPS Protocol
-(f-command set).
+(f-command set).  (For older Fortress units, see
+linkman:bestfortress[8].)
 
 EXTRA ARGUMENTS
 ---------------

--- a/docs/man/bestfortress.txt
+++ b/docs/man/bestfortress.txt
@@ -17,6 +17,7 @@ SUPPORTED HARDWARE
 ------------------
 
 This driver supports old Best Fortress UPS equipment using a serial connection.
+One example is the "Fortress LI660", sold in (at least) 1995.
 
 EXTRA ARGUMENTS
 ---------------

--- a/docs/man/bestups.txt
+++ b/docs/man/bestups.txt
@@ -22,9 +22,9 @@ but if you are running it to try setting up a new device, please
 consider the newer linkman:nutdrv_qx[8] instead, which should
 handle all 'Q*' protocol variants for NUT.
 
-Please do also report if your device works with this driver,
-but linkman:nutdrv_qx[8] would not actually support it with any
-subdriver!
+If your device works with this driver, but does not work with
+linkman:nutdrv_qx[8], please report this via the mailing list or issue
+tracker.
 
 SUPPORTED HARDWARE
 ------------------
@@ -37,7 +37,8 @@ Best 610 is supported using the `ID' option.
 Other UPS hardware using the Phoenixtec protocol should also work, but
 they will generate a warning since their battery information is not known.
 
-This driver does not support some older Best/SOLA units.
+This driver does not support some older Best/SOLA units.  (For older
+Fortress units, see linkman:bestfortress[8].)
 
 EXTRA ARGUMENTS
 ---------------

--- a/docs/man/upsdrvctl.txt
+++ b/docs/man/upsdrvctl.txt
@@ -74,11 +74,15 @@ Start the UPS driver(s). In case of failure, further attempts may be executed
 by using the 'maxretry' and 'retrydelay' options - see linkman:ups.conf[5].
 
 *stop*::
-Stop the UPS driver(s).
+Stop the UPS driver(s).  This does not send commands to the UPS.
 
 *shutdown*::
-Command the UPS driver(s) to run their shutdown sequence.  Drivers are
-stopped according to their sdorder value - see linkman:ups.conf[5].
+Command the UPS driver(s) to run their shutdown sequence.  This
+assumes that the driver is no longer running, and starts a fresh
+instance via "driver -k".  It is intended to be used as the last step
+in system shutdown, after the filesystems are no longer mounted rw.
+Drivers are stopped according to their sdorder value - see
+linkman:ups.conf[5].
 
 WARNING: this will probably power off your computers, so don't
 play around with this option.  Only use it when your systems are prepared

--- a/docs/man/upsmon.txt
+++ b/docs/man/upsmon.txt
@@ -406,6 +406,15 @@ can not guarantee that if a new power outage happens, their UPS would safely
 shut down your systems again. So it is deemed better and safer to stay dark
 until batteries become sufficiently charged.
 
+When it is time to shut down, upsmon creates POWERDOWNFLAG to
+communicate to the operating system that the UPS should be commanded
+off late in the shutdown sequence.  This file is removed if present
+when upsmon starts, so that the next normal shutdown does not cause
+the UPS to be turned off.  (The file can't in general be removed
+during shutdown because the filesystem might be read only.  If the
+file is in a RAM-backed filesystem, the it won't be present and the
+check to remove it won't fire.)
+
 SIMULATING POWER FAILURES
 -------------------------
 


### PR DESCRIPTION
This PR has three documentation changes:
   * Clarify Best driver support for the LI660, as it seemed like newer drivers should be used
   * Explain `upsdrvctl shutdown` better
   * Explain that `upsmon` will remove `POWERDOWNFLAG` on startup