### PR TITLE
upsmon: Introduce POLLFAIL_LOG_THROTTLE_MAX

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -220,7 +220,8 @@ https://github.com/networkupstools/nut/milestone/8
  - Several fixes for `upsmon` behavior [#1761, #1680...], including new
    ability to configure default POWERDOWNFLAG location -- packagers are
    encouraged to pick optimal location for their distributions (which
-   remains mounted at least read-only late in shutdown) [#529]
+   remains mounted at least read-only late in shutdown) and a new optional
+   POLLFAIL_LOG_THROTTLE_MAX setting [#529, #506]
 
  - Further revision of public headers delivered by NUT was done, particularly
    to address lack of common data types (`size_t`, `ssize_t`, `uint16_t`,

--- a/clients/upsclient.h
+++ b/clients/upsclient.h
@@ -134,6 +134,8 @@ int upscli_ssl(UPSCONN_t *ups);
 
 /* upsclient error list */
 
+#define UPSCLI_ERR_NONE		-1	/* No known error (internally used in tools like upsmon, not set by upsclient.c) */
+
 #define UPSCLI_ERR_UNKNOWN	0	/* Unknown error */
 #define UPSCLI_ERR_VARNOTSUPP	1	/* Variable not supported by UPS */
 #define UPSCLI_ERR_NOSUCHHOST	2	/* No such host */

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -55,6 +55,18 @@ static	int deadtime = 15;
 	/* default polling interval = 5 sec */
 static	unsigned int	pollfreq = 5, pollfreqalert = 5;
 
+	/* If pollfail_log_throttle_max > 0, error messages for same
+	 * state of an UPS (e.g. "Data stale" or "Driver not connected")
+	 * will only be repeated every so many POLLFREQ loops.
+	 * If pollfail_log_throttle_max == 0, such error messages will
+	 * only be reported once when that situation starts, and ends.
+	 * By default it is logged every pollfreq (which can abuse syslog
+	 * and its storage).
+	 * To support this, each utype_t (UPS) structure tracks individual
+	 * pollfail_log_throttle_count and pollfail_log_throttle_state
+	 */
+static	int	pollfail_log_throttle_max = -1;
+
 	/* secondary hosts are given 15 sec by default to logout from upsd */
 static	int	hostsync = 15;
 
@@ -1050,6 +1062,11 @@ static void drop_connection(utype_t *ups)
 
 	ups->commstate = 0;
 	ups->linestate = 0;
+
+	/* forget poll-failure logging throttling */
+	ups->pollfail_log_throttle_count = -1;
+	ups->pollfail_log_throttle_state = UPSCLI_ERR_NONE;
+
 	clearflag(&ups->status, ST_LOGIN);
 	clearflag(&ups->status, ST_CLICONNECTED);
 
@@ -1241,6 +1258,10 @@ static void addups(int reloading, const char *sys, const char *pvs,
 	tmp->commstate = -1;
 	tmp->linestate = -1;
 
+	/* forget poll-failure logging throttling */
+	tmp->pollfail_log_throttle_count = -1;
+	tmp->pollfail_log_throttle_state = UPSCLI_ERR_NONE;
+
 	tmp->lastpoll = 0;
 	tmp->lastnoncrit = 0;
 	tmp->lastrbwarn = 0;
@@ -1428,6 +1449,17 @@ static int parse_conf_arg(size_t numargs, char **arg)
 			upsdebugx(0, "Ignoring invalid POLLFREQALERT value: %d", ipollfreqalert);
 		} else {
 			pollfreqalert = (unsigned int)ipollfreqalert;
+		}
+		return 1;
+	}
+
+	/* POLLFAIL_LOG_THROTTLE_MAX <num> */
+	if (!strcmp(arg[0], "POLLFAIL_LOG_THROTTLE_MAX")) {
+		int ipollfail_log_throttle_max = atoi(arg[1]);
+		if (ipollfail_log_throttle_max < 0 || ipollfail_log_throttle_max == INT_MAX) {
+			upsdebugx(0, "Ignoring invalid POLLFAIL_LOG_THROTTLE_MAX value: %d", ipollfail_log_throttle_max);
+		} else {
+			pollfail_log_throttle_max = ipollfail_log_throttle_max;
 		}
 		return 1;
 	}
@@ -1639,6 +1671,12 @@ static void loadconfig(void)
 				"original command line arguments",
 				nut_debug_level_args);
 			nut_debug_level = nut_debug_level_args;
+		}
+
+		if (pollfail_log_throttle_max >= 0) {
+			upslogx(LOG_INFO,
+				"Applying pollfail_log_throttle_max=%d from upsmon.conf",
+				pollfail_log_throttle_max);
 		}
 	}
 
@@ -1902,11 +1940,15 @@ static void parse_status(utype_t *ups, char *status)
 static void pollups(utype_t *ups)
 {
 	char	status[SMALLBUF];
+	int	pollfail_log = 0;	/* if we throttle, only upsdebugx() but not upslogx() the failures */
+	int	upserror;
 
 	/* try a reconnect here */
-	if (!flag_isset(ups->status, ST_CLICONNECTED))
-		if (try_connect(ups) != 1)
+	if (!flag_isset(ups->status, ST_CLICONNECTED)) {
+		if (try_connect(ups) != 1) {
 			return;
+		}
+	}
 
 	if (upscli_ssl(&ups->conn) == 1)
 		upsdebugx(2, "%s: %s [SSL]", __func__, ups->sys);
@@ -1917,6 +1959,27 @@ static void pollups(utype_t *ups)
 
 	if (get_var(ups, "status", status, sizeof(status)) == 0) {
 		clear_alarm();
+
+		/* reset pollfail log throttling */
+#if 0
+		/* Note: last error is never cleared, so we reset it below */
+		upserror = upscli_upserror(&ups->conn);
+		upsdebugx(3, "%s: Poll UPS [%s] after getvar(status) okay: upserror=%d: %s",
+			__func__, ups->sys, upserror, upscli_strerror(&ups->conn));
+#endif
+		upserror = UPSCLI_ERR_NONE;
+		if (pollfail_log_throttle_max >= 0
+		&&  ups->pollfail_log_throttle_state != upserror
+		) {
+			/* Notify throttled log that we are okay now */
+			upslogx(LOG_ERR, "Poll UPS [%s] recovered from "
+				"failure state code %d - now %d",
+				ups->sys, ups->pollfail_log_throttle_state,
+				upserror);
+		}
+		ups->pollfail_log_throttle_state = upserror;
+		ups->pollfail_log_throttle_count = -1;
+
 		parse_status(ups, status);
 		return;
 	}
@@ -1925,17 +1988,75 @@ static void pollups(utype_t *ups)
 	clear_alarm();
 
 	/* try to make some of these a little friendlier */
+	upserror = upscli_upserror(&ups->conn);
+	upsdebugx(3, "%s: Poll UPS [%s] after getvar(status) failed: upserror=%d",
+		__func__, ups->sys, upserror);
+	if (pollfail_log_throttle_max < 0) {
+		/* Log properly on each loop */
+		pollfail_log = 1;
+	} else {
+		if (ups->pollfail_log_throttle_state == upserror) {
+			/* known issue, no syslog spam now... maybe */
+			if (pollfail_log_throttle_max == 0) {
+				/* Only log once for start or end of the same
+				 * failure state */
+				pollfail_log = 0;
+			} else {
+				/* Only log once for start, every MAX iterations,
+				 * and end of the same failure state */
+				if (ups->pollfail_log_throttle_count++ >= pollfail_log_throttle_max) {
+					/* ping... */
+					pollfail_log = 1;
+					ups->pollfail_log_throttle_count = 0;
+				} else {
+					pollfail_log = 0;
+				}
+			}
+		} else {
+			/* new error => reset pollfail log throttling and log it
+			 * now (numeric states here, string for new state below) */
+			if (pollfail_log_throttle_max == 0) {
+				upslogx(LOG_ERR, "Poll UPS [%s] failure state code "
+					"changed from %d to %d; "
+					"report below will not be repeated to syslog:",
+					ups->sys, ups->pollfail_log_throttle_state,
+					upserror);
+			} else {
+				upslogx(LOG_ERR, "Poll UPS [%s] failure state code "
+					"changed from %d to %d; "
+					"report below will only be repeated to syslog "
+					"every %d polling loop cycles:",
+					ups->sys, ups->pollfail_log_throttle_state,
+					upserror, pollfail_log_throttle_max);
+			}
 
-	switch (upscli_upserror(&ups->conn)) {
+			ups->pollfail_log_throttle_state = upserror;
+			ups->pollfail_log_throttle_count = 0;
+			pollfail_log = 1;
+		}
+	}
+
+	switch (upserror) {
 		case UPSCLI_ERR_UNKNOWNUPS:
-			upslogx(LOG_ERR, "Poll UPS [%s] failed - [%s] "
-				"does not exist on server %s",
-				ups->sys, ups->upsname,	ups->hostname);
+			if (pollfail_log) {
+				upslogx(LOG_ERR, "Poll UPS [%s] failed - [%s] "
+					"does not exist on server %s",
+					ups->sys, ups->upsname,	ups->hostname);
+			} else {
+				upsdebugx(1, "Poll UPS [%s] failed - [%s] "
+					"does not exist on server %s",
+					ups->sys, ups->upsname,	ups->hostname);
+			}
 			break;
 
 		default:
-			upslogx(LOG_ERR, "Poll UPS [%s] failed - %s",
-				ups->sys, upscli_strerror(&ups->conn));
+			if (pollfail_log) {
+				upslogx(LOG_ERR, "Poll UPS [%s] failed - %s",
+					ups->sys, upscli_strerror(&ups->conn));
+			} else {
+				upsdebugx(1, "Poll UPS [%s] failed - [%s]",
+					ups->sys, upscli_strerror(&ups->conn));
+			}
 			break;
 	}
 

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -1927,13 +1927,12 @@ static void pollups(utype_t *ups)
 	/* try to make some of these a little friendlier */
 
 	switch (upscli_upserror(&ups->conn)) {
-
 		case UPSCLI_ERR_UNKNOWNUPS:
 			upslogx(LOG_ERR, "Poll UPS [%s] failed - [%s] "
-			"does not exist on server %s",
-			ups->sys, ups->upsname,	ups->hostname);
-
+				"does not exist on server %s",
+				ups->sys, ups->upsname,	ups->hostname);
 			break;
+
 		default:
 			upslogx(LOG_ERR, "Poll UPS [%s] failed - %s",
 				ups->sys, upscli_strerror(&ups->conn));

--- a/clients/upsmon.h
+++ b/clients/upsmon.h
@@ -61,6 +61,12 @@ typedef struct {
 	int	commstate;		/* these start at -1, and only	*/
 	int	linestate;		/* fire on a 0->1 transition	*/
 
+	/* see detailed comment for pollfail_log_throttle_max in upsmon.c
+	 * about handling of poll failure log throttling (syslog storage I/O)
+	 */
+	int	pollfail_log_throttle_state;	/* Last (error) state which we throttle */
+	int	pollfail_log_throttle_count;	/* How many pollfreq loops this UPS was in this state since last logged report? */
+
 	time_t	lastpoll;		/* time of last successful poll	*/
 	time_t  lastnoncrit;		/* time of last non-crit poll	*/
 	time_t	lastrbwarn;		/* time of last REPLBATT warning*/

--- a/conf/upsmon.conf.sample.in
+++ b/conf/upsmon.conf.sample.in
@@ -349,6 +349,20 @@ RBWARNTIME 43200
 NOCOMMWARNTIME 300
 
 # --------------------------------------------------------------------------
+# POLLFAIL_LOG_THROTTLE_MAX - device poll failure logging throttle
+#
+# upsmon normally reports polling failures for each device that are in place
+# for each POLLFREQ loop (e.g. "Data stale" or "Driver not connected") to
+# system log as configured.  If your devices are expected to be AWOL for an
+# extended timeframe, you can use this throttle to reduce the stress on
+# syslog traffic and storage, by posting these messages only once in every
+# several loop cycles, and when the error condition has changed or cleared.
+# A negative value means standard behavior, and a zero value means to never
+# repeat the message (log only on start and end/change of the failure state).
+#
+#POLLFAIL_LOG_THROTTLE_MAX 100
+
+# --------------------------------------------------------------------------
 # FINALDELAY - last sleep interval before shutting down the system
 #
 # On a primary, upsmon will wait this long after sending the NOTIFY_SHUTDOWN

--- a/docs/man/upsmon.conf.txt
+++ b/docs/man/upsmon.conf.txt
@@ -163,6 +163,18 @@ reach any of the UPS entries in this configuration file.  It keeps
 warning you until the situation is fixed.  By default this is 300
 seconds.
 
+*POLLFAIL_LOG_THROTTLE_MAX* 'count'::
+
+upsmon normally reports polling failures for each device that are in place
+for each POLLFREQ loop (e.g. "Data stale" or "Driver not connected") to
+system log as configured.  If your devices are expected to be AWOL for an
+extended timeframe, you can use this throttle to reduce the stress on
+syslog traffic and storage, by posting these messages only once in every
+several loop cycles, and when the error condition has changed or cleared.
+
+A negative value means standard behavior, and a zero value means to never
+repeat the message (log only on start and end/change of the failure state).
+
 *NOTIFYCMD* 'command'::
 
 upsmon calls this to send messages when things happen.

--- a/docs/man/upsmon.txt
+++ b/docs/man/upsmon.txt
@@ -441,6 +441,16 @@ upsmon will alert you to a UPS that can't be contacted for monitoring
 with a "NOCOMM" notifier by default every 300 seconds.  This can be
 changed with the NOCOMMWARNTIME setting.
 
+Also upsmon normally reports polling failures for each device that are in place
+for each POLLFREQ loop (e.g. "Data stale" or "Driver not connected") to
+system log as configured.  If your devices are expected to be AWOL for an
+extended timeframe, you can use POLLFAIL_LOG_THROTTLE_MAX to reduce the
+stress on syslog traffic and storage, by posting these messages only once
+in every several loop cycles, and when the error condition has changed or
+cleared. A negative value means standard behavior, and a zero value means
+to never repeat the message (log only on start and end/change of the failure
+state).
+
 RELOADING NUANCES
 -----------------
 

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3067 utf-8
+personal_ws-1.1 en 3069 utf-8
 AAS
 ABI
 ACFAIL
@@ -846,6 +846,7 @@ PIPEFN
 PLD
 PLL
 PLVn
+POLLFAIL
 POLLFREQALERT
 POMode
 POSIX
@@ -2818,6 +2819,7 @@ testuser
 textproc
 th
 timehead
+timeframe
 timeline
 timername
 timestamp


### PR DESCRIPTION
Closes: #506

````
Jan 07 22:49:50 pve nut-monitor[4103053]:   97.199079        Reloading configuration
Jan 07 22:49:50 pve nut-monitor[4103053]:   97.199178        Applying debug_min=2 from upsmon.conf
...

Jan 07 22:50:26 pve nut-monitor[4106871]:    0.001183        [D1] Trying to connect to UPS [eco650]
Jan 07 22:50:26 pve nut-monitor[4106871]:    0.001410        [D1] Logged into UPS eco650
Jan 07 22:50:26 pve nut-monitor[4106871]:    0.001440        [D2] pollups: eco650
Jan 07 22:50:26 pve nut-monitor[4106871]:    0.001472        Poll UPS [eco650] failure state code changed from -1 to 39; report below will only be repeated to syslog every 5 polling loop cycles:
Jan 07 22:50:26 pve nut-monitor[4106871]:    0.001476        Poll UPS [eco650] failed - Driver not connected
Jan 07 22:50:26 pve nut-monitor[4106871]:    0.001478        [D2] do_notify: ntype 0x0005 (COMMBAD)
Jan 07 22:50:26 pve nut-monitor[4106871]:    0.001480        Communications with UPS eco650 lost
Jan 07 22:50:26 pve nut-monitor[4106872]: Network UPS Tools upsmon 2.8.0-Windows-313-gc7ba2a673
Jan 07 22:50:31 pve nut-monitor[4106871]:    5.001613        [D2] pollups: eco650
Jan 07 22:50:31 pve nut-monitor[4106871]:    5.001689        [D1] Poll UPS [eco650] failed - [Driver not connected]
Jan 07 22:50:31 pve nut-monitor[4106871]:    5.001694        [D2] do_notify: ntype 0x0008 (NOCOMM)
Jan 07 22:50:31 pve nut-monitor[4106871]:    5.001697        UPS eco650 is unavailable
Jan 07 22:50:31 pve nut-monitor[4107029]: Network UPS Tools upsmon 2.8.0-Windows-313-gc7ba2a673
Jan 07 22:50:36 pve nut-monitor[4106871]:   10.001866        [D2] pollups: eco650
Jan 07 22:50:36 pve nut-monitor[4106871]:   10.001972        [D1] Poll UPS [eco650] failed - [Driver not connected]
Jan 07 22:50:41 pve nut-monitor[4106871]:   15.002068        [D2] pollups: eco650
Jan 07 22:50:41 pve nut-monitor[4106871]:   15.002133        [D1] Poll UPS [eco650] failed - [Driver not connected]
Jan 07 22:50:46 pve nut-monitor[4106871]:   20.002220        [D2] pollups: eco650
Jan 07 22:50:46 pve nut-monitor[4106871]:   20.002326        [D1] Poll UPS [eco650] failed - [Driver not connected]
Jan 07 22:50:51 pve nut-monitor[4106871]:   25.002396        [D2] pollups: eco650
Jan 07 22:50:51 pve nut-monitor[4106871]:   25.002458        [D1] Poll UPS [eco650] failed - [Driver not connected]
Jan 07 22:50:56 pve nut-monitor[4106871]:   30.002529        [D2] pollups: eco650
Jan 07 22:50:56 pve nut-monitor[4106871]:   30.002652        Poll UPS [eco650] failed - Driver not connected
Jan 07 22:51:01 pve nut-monitor[4106871]:   35.002721        [D2] pollups: eco650
Jan 07 22:51:01 pve nut-monitor[4106871]:   35.002797        [D1] Poll UPS [eco650] failed - [Driver not connected]
Jan 07 22:51:06 pve nut-monitor[4106871]:   40.002868        [D2] pollups: eco650
Jan 07 22:51:06 pve nut-monitor[4106871]:   40.002966        [D1] Poll UPS [eco650] failed - [Driver not connected]
Jan 07 22:51:11 pve nut-monitor[4106871]:   45.003034        [D2] pollups: eco650
Jan 07 22:51:11 pve nut-monitor[4106871]:   45.003094        [D1] Poll UPS [eco650] failed - [Driver not connected]
Jan 07 22:51:16 pve nut-monitor[4106871]:   50.003166        [D2] pollups: eco650
Jan 07 22:51:16 pve nut-monitor[4106871]:   50.003258        [D1] Poll UPS [eco650] failed - [Driver not connected]
Jan 07 22:51:21 pve nut-monitor[4106871]:   55.003337        [D2] pollups: eco650
Jan 07 22:51:21 pve nut-monitor[4106871]:   55.003404        [D1] Poll UPS [eco650] failed - [Driver not connected]
Jan 07 22:51:26 pve nut-monitor[4106871]:   60.003473        [D2] pollups: eco650
Jan 07 22:51:26 pve nut-monitor[4106871]:   60.003572        Poll UPS [eco650] failed - Driver not connected
Jan 07 22:51:31 pve nut-monitor[4106871]:   65.003641        [D2] pollups: eco650
Jan 07 22:51:31 pve nut-monitor[4106871]:   65.003702        [D1] Poll UPS [eco650] failed - [Driver not connected]
````

So now "poll failed" messages go to syslog (without the `[D<LEVEL>]` prefix) only every 5 polls as configured; 0 disables repetitions for syslog completely.

Eventually it flips when reconnected:

````
Jan 07 22:56:21 pve nut-monitor[4110240]:  251.417998        [D2] pollups: eco650
Jan 07 22:56:21 pve nut-monitor[4110240]:  251.418075        [D1] Poll UPS [eco650] failed - [Driver not connected]
Jan 07 22:56:22 pve systemd[1]: Starting Network UPS Tools - device driver for NUT device 'eco650'...
Jan 07 22:56:25 pve nut-driver@eco650[4114867]: Using subdriver: MGE HID 1.46
Jan 07 22:56:25 pve nut-driver@eco650[4114867]: Network UPS Tools - Generic HID driver 0.49 (2.8.0-Windows-313-gc7ba2a673)
Jan 07 22:56:25 pve nut-driver@eco650[4114867]: USB communication driver (libusb 1.0) 0.43
Jan 07 22:56:26 pve nut-monitor[4110240]:  256.418145        [D2] pollups: eco650
Jan 07 22:56:26 pve nut-monitor[4110240]:  256.418244        [D1] Poll UPS [eco650] failed - [Driver not connected]
Jan 07 22:56:27 pve usbhid-ups[4114956]: Startup successful
Jan 07 22:56:27 pve nut-driver@eco650[4114866]: Network UPS Tools - UPS driver controller 2.8.0-Windows-313-gc7ba2a673
Jan 07 22:56:27 pve systemd[1]: Started Network UPS Tools - device driver for NUT device 'eco650'.
Jan 07 22:56:28 pve nut-server[3986705]: Connected to UPS [eco650]: usbhid-ups-eco650
Jan 07 22:56:28 pve usbhid-ups[4114956]: sock_connect: enabling asynchronous mode (auto)
Jan 07 22:56:28 pve upsd[3986705]: Connected to UPS [eco650]: usbhid-ups-eco650
Jan 07 22:56:31 pve nut-monitor[4110240]:  261.418312        [D2] pollups: eco650
Jan 07 22:56:31 pve nut-monitor[4110240]:  261.418411        Poll UPS [eco650] recovered from failure state code 39 - now -1
Jan 07 22:56:31 pve nut-monitor[4110240]:  261.418415        [D2] parse_status: [OL]
Jan 07 22:56:31 pve nut-monitor[4110240]:  261.418418        [D2] do_notify: ntype 0x0004 (COMMOK)
Jan 07 22:56:31 pve nut-monitor[4110240]:  261.418422        Communications with UPS eco650 established
Jan 07 22:56:31 pve nut-monitor[4115036]: Network UPS Tools upsmon 2.8.0-Windows-313-gc7ba2a673
Jan 07 22:56:36 pve nut-monitor[4110240]:  266.418589        [D2] pollups: eco650
Jan 07 22:56:36 pve nut-monitor[4110240]:  266.418698        [D2] parse_status: [OL]
Jan 07 22:56:41 pve nut-monitor[4110240]:  271.418782        [D2] pollups: eco650
Jan 07 22:56:41 pve nut-monitor[4110240]:  271.418864        [D2] parse_status: [OL]
````