### PR TITLE
nut-scanner: report same USB matching values as seeked by libusb{0,1}.c

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -146,6 +146,10 @@ https://github.com/networkupstools/nut/milestone/8
    may help monitor several related no-name devices (although without knowing
    reliably which one is which... better than nothing) [#1756]
 
+ - The `nut-scanner` program should now suggest same configuration fields as
+   those used by common USB matching options in (most of the) drivers, e.g.
+   adding "device" to the generated configuration section [#1790]
+
  - Stuck drivers that do not react to `SIGTERM` quickly are now retried with
    `SIGKILL` [#1424]
 

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -983,7 +983,7 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
     # would quickly regenerate Makefile(.in) if you edit Makefile.am
     # TODO: Resolve port-collision reliably (for multi-executor agents)
     # and enable the test for CI runs. Bonus for making it quieter.
-    if [ "${CANBUILD_NIT_TESTS-}" != yes ] ; then
+    if [ "${CANBUILD_NIT_TESTS-}" != no ] ; then
         CONFIG_OPTS+=("--enable-check-NIT")
     else
         echo "WARNING: Build agent does not say it can reliably 'make check-NIT'" >&2

--- a/drivers/libusb0.c
+++ b/drivers/libusb0.c
@@ -289,6 +289,9 @@ static int libusb_open(usb_dev_handle **udevp,
 			free(curDevice->Device);
 			memset(curDevice, '\0', sizeof(*curDevice));
 
+			/* Keep the list of items in sync with those matched by
+			 * drivers/libusb1.c and tools/nut-scanner/scan_usb.c:
+			 */
 			curDevice->VendorID = dev->descriptor.idVendor;
 			curDevice->ProductID = dev->descriptor.idProduct;
 			curDevice->Bus = xstrdup(bus->dirname);

--- a/drivers/libusb0.c
+++ b/drivers/libusb0.c
@@ -37,7 +37,7 @@
 #endif
 
 #define USB_DRIVER_NAME		"USB communication driver (libusb 0.1)"
-#define USB_DRIVER_VERSION	"0.43"
+#define USB_DRIVER_VERSION	"0.44"
 
 /* driver description structure */
 upsdrv_info_t comm_upsdrv_info = {

--- a/drivers/libusb1.c
+++ b/drivers/libusb1.c
@@ -239,6 +239,9 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 		free(curDevice->Device);
 		memset(curDevice, '\0', sizeof(*curDevice));
 
+		/* Keep the list of items in sync with those matched by
+		 * drivers/libusb0.c and tools/nut-scanner/scan_usb.c:
+		 */
 		bus = libusb_get_bus_number(device);
 		curDevice->Bus = (char *)malloc(4);
 		if (curDevice->Bus == NULL) {

--- a/drivers/libusb1.c
+++ b/drivers/libusb1.c
@@ -33,7 +33,7 @@
 #include "nut_stdint.h"
 
 #define USB_DRIVER_NAME		"USB communication driver (libusb 1.0)"
-#define USB_DRIVER_VERSION	"0.43"
+#define USB_DRIVER_VERSION	"0.44"
 
 /* driver description structure */
 upsdrv_info_t comm_upsdrv_info = {

--- a/tools/nut-scanner/scan_usb.c
+++ b/tools/nut-scanner/scan_usb.c
@@ -53,6 +53,7 @@ static int (*nut_usb_get_string_simple)(libusb_device_handle *dev, int index,
  static ssize_t (*nut_usb_get_device_list)(libusb_context *ctx,	libusb_device ***list);
  static void (*nut_usb_free_device_list)(libusb_device **list, int unref_devices);
  static uint8_t (*nut_usb_get_bus_number)(libusb_device *dev);
+ static uint8_t (*nut_usb_get_port_number)(libusb_device *dev);
  static int (*nut_usb_get_device_descriptor)(libusb_device *dev,
 	struct libusb_device_descriptor *desc);
 #else /* => WITH_LIBUSB_0_1 */
@@ -146,6 +147,16 @@ int nutscan_load_usb_library(const char *libname_path)
 			goto err;
 	}
 
+	/* Note: per https://nxmnpg.lemoda.net/3/libusb_get_device_address there
+	 * was a libusb_get_port_path() equivalent with different arguments, but
+	 * not for too long (libusb-1.0.12...1.0.16) and now it is deprecated.
+	 */
+	*(void **) (&nut_usb_get_port_number) = lt_dlsym(dl_handle,
+					"libusb_get_port_number");
+	if ((dl_error = lt_dlerror()) != NULL) {
+			goto err;
+	}
+
 	*(void **) (&nut_usb_get_device_descriptor) = lt_dlsym(dl_handle,
 					"libusb_get_device_descriptor");
 	if ((dl_error = lt_dlerror()) != NULL) {
@@ -222,14 +233,31 @@ nutscan_device_t * nutscan_scan_usb()
 {
 	int ret;
 	char string[256];
+	/* Items below are learned by libusbN version-specific API code
+	 * Keep in sync with items matched by drivers/libusb{0,1}.c
+	 * (nut)libusb_open methods, and fields of USBDevice_t struct
+	 * (drivers/usb-common.h).
+	 */
 	char *driver_name = NULL;
 	char *serialnumber = NULL;
 	char *device_name = NULL;
 	char *vendor_name = NULL;
 	uint8_t iManufacturer = 0, iProduct = 0, iSerialNumber = 0;
-	uint16_t VendorID;
-	uint16_t ProductID;
-	char *busname;
+	uint16_t VendorID = 0;
+	uint16_t ProductID = 0;
+	char *busname = NULL;
+	/* device_port physical meaning: connection port on that bus;
+	 *   different consumers plugged into same socket should have
+	 *   the same port value. However in practice such functionality
+	 *   depends on platform and HW involved.
+	 * In libusb1 API: libusb_get_port_numbers() earlier known
+	 *    as libusb_get_port_path() for physical port number on the bus, see
+	 *    https://libusb.sourceforge.io/api-1.0/group__libusb__dev.html#ga14879a0ea7daccdcddb68852d86c00c4
+	 * In libusb0 API: "device filename"
+	 */
+	char *device_port = NULL;
+	/* bcdDevice: aka "Device release number" - note we currently do not match by it */
+	uint16_t bcdDevice = 0;
 #if WITH_LIBUSB_1_0
 	libusb_device *dev;
 	libusb_device **devlist;
@@ -283,6 +311,7 @@ nutscan_device_t * nutscan_scan_usb()
 		iProduct = dev_desc.iProduct;
 		iSerialNumber = dev_desc.iSerialNumber;
 		bus = (*nut_usb_get_bus_number)(dev);
+
 		busname = (char *)malloc(4);
 		if (busname == NULL) {
 			(*nut_usb_free_device_list)(devlist, 1);
@@ -290,6 +319,22 @@ nutscan_device_t * nutscan_scan_usb()
 			fatal_with_errno(EXIT_FAILURE, "Out of memory");
 		}
 		snprintf(busname, 4, "%03d", bus);
+
+		device_port = (char *)malloc(4);
+		if (device_port == NULL) {
+			(*nut_usb_free_device_list)(devlist, 1);
+			(*nut_usb_exit)(NULL);
+			fatal_with_errno(EXIT_FAILURE, "Out of memory");
+		} else {
+			uint8_t port = (*nut_usb_get_port_number)(dev);
+			if (port > 0) {
+				snprintf(device_port, 4, "%03d", port);
+			} else {
+				snprintf(device_port, 4, ".*");
+			}
+		}
+
+		bcdDevice = dev_desc.bcdDevice;
 #else  /* => WITH_LIBUSB_0_1 */
 # ifndef WIN32
 	for (bus = (*nut_usb_busses); bus; bus = bus->next) {
@@ -305,6 +350,8 @@ nutscan_device_t * nutscan_scan_usb()
 			iProduct = dev->descriptor.iProduct;
 			iSerialNumber = dev->descriptor.iSerialNumber;
 			busname = bus->dirname;
+			device_port = dev->filename;
+			bcdDevice = dev->descriptor.bcdDevice;
 #endif
 			if ((driver_name =
 				is_usb_device_supported(usb_device_table,
@@ -314,9 +361,9 @@ nutscan_device_t * nutscan_scan_usb()
 #if WITH_LIBUSB_1_0
 				ret = (*nut_usb_open)(dev, &udev);
 				if (!udev || ret != LIBUSB_SUCCESS) {
-					fprintf(stderr,"Failed to open device "
-						"bus '%s', skipping: %s\n",
-						busname,
+					fprintf(stderr, "Failed to open device "
+						"bus '%s' device/port '%s', skipping: %s\n",
+						busname, device_port,
 						(*nut_usb_strerror)(ret));
 
 					/* Note: closing is not applicable
@@ -325,7 +372,8 @@ nutscan_device_t * nutscan_scan_usb()
 					 * when e.g. permissions problem)
 					 */
 
-					free (busname);
+					free(busname);
+					free(device_port);
 
 					continue;
 				}
@@ -334,8 +382,8 @@ nutscan_device_t * nutscan_scan_usb()
 				if (!udev) {
 					/* TOTHINK: any errno or similar to test? */
 					fprintf(stderr, "Failed to open device "
-						"bus '%s',skipping: %s\n",
-						busname,
+						"bus '%s' device/port '%s', skipping: %s\n",
+						busname, device_port,
 						(*nut_usb_strerror)());
 					continue;
 				}
@@ -351,6 +399,7 @@ nutscan_device_t * nutscan_scan_usb()
 							(*nut_usb_close)(udev);
 #if WITH_LIBUSB_1_0
 							free(busname);
+							free(device_port);
 							(*nut_usb_free_device_list)(devlist, 1);
 							(*nut_usb_exit)(NULL);
 #endif	/* WITH_LIBUSB_1_0 */
@@ -370,6 +419,7 @@ nutscan_device_t * nutscan_scan_usb()
 							(*nut_usb_close)(udev);
 #if WITH_LIBUSB_1_0
 							free(busname);
+							free(device_port);
 							(*nut_usb_free_device_list)(devlist, 1);
 							(*nut_usb_exit)(NULL);
 #endif	/* WITH_LIBUSB_1_0 */
@@ -390,6 +440,7 @@ nutscan_device_t * nutscan_scan_usb()
 							(*nut_usb_close)(udev);
 #if WITH_LIBUSB_1_0
 							free(busname);
+							free(device_port);
 							(*nut_usb_free_device_list)(devlist, 1);
 							(*nut_usb_exit)(NULL);
 #endif	/* WITH_LIBUSB_1_0 */
@@ -409,6 +460,7 @@ nutscan_device_t * nutscan_scan_usb()
 					(*nut_usb_close)(udev);
 #if WITH_LIBUSB_1_0
 					free(busname);
+					free(device_port);
 					(*nut_usb_free_device_list)(devlist, 1);
 					(*nut_usb_exit)(NULL);
 #endif	/* WITH_LIBUSB_1_0 */
@@ -459,6 +511,16 @@ nutscan_device_t * nutscan_scan_usb()
 					"bus",
 					busname);
 
+				nutscan_add_option_to_device(nut_dev,
+					"device",
+					device_port);
+
+				/* Not currently matched by drivers, hence commented for now: */
+				sprintf(string, "%04X", bcdDevice);
+				nutscan_add_option_to_device(nut_dev,
+					"###NOTMATCHED-YET###bcdDevice",
+					string);
+
 				current_nut_dev = nutscan_add_device_to_device(
 					current_nut_dev,
 					nut_dev);
@@ -472,6 +534,7 @@ nutscan_device_t * nutscan_scan_usb()
 	}
 #else	/* not WITH_LIBUSB_0_1 */
 		free(busname);
+		free(device_port);
 	}
 
 	(*nut_usb_free_device_list)(devlist, 1);


### PR DESCRIPTION
Closes: #1790

Currently nut-scanner did not report a `device` value (should mean physical port number on a hub, where supported and not much guaranteed), so systems connected to two UPSes from same vendor could not discern between them (especially if handled by same USB bus, and lacking a serial number).

Many USB drivers use the common routine (more after #1763 was merged) which checks for `device = NNN` if provided.

For that matter, the common matcher also reports (and considers internally) the "bcdDevice" (version) although does not match it from user-provided configuration. FWIW this change prints that value out, commented.

Example output after the change:
````
:; ./tools/nut-scanner/nut-scanner -U
Scanning USB bus.
[nutdev1]
        driver = "usbhid-ups"
        port = "auto"
        vendorid = "0463"
        productid = "FFFF"
        product = "Ellipse ECO"
        serial = "000000000"
        vendor = "EATON"
        bus = "003"
        device = "002"
        ###NOTMATCHED-YET###bcdDevice = "0100"
````

which matches `lsusb` report:
````
:; lsusb | grep 463
Bus 003 Device 002: ID 0463:ffff MGE UPS Systems UPS
````