### PR TITLE
Revisit NUT CI build on CentOS 6

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -4,6 +4,18 @@
 # in a buildable state
 # NOTE: uses cumbersome dumbest-possible shell syntax for extra portability
 
+# perl tends to complain if locale is not set (or its files are absent)
+if [ -z "${LANG-}" ]; then
+	LANG="C"
+	export LANG
+fi
+
+if [ -z "${LC_ALL-}" ] ; then
+	LC_ALL="C"
+	export LC_ALL
+fi
+
+
 if [ -n "${PYTHON-}" ] ; then
 	# May be a name/path of binary, or one with args - check both
 	(command -v "$PYTHON") \

--- a/configure.ac
+++ b/configure.ac
@@ -19,6 +19,7 @@ AM_INIT_AUTOMAKE([subdir-objects])
 
 dnl we need Autoconf 2.61 or better to enable features of Posix that are extensions to C
 dnl (and actually 2.64 or better for m4/ax_check_compile_flag.m4 when it is sourced)
+dnl UPDATE: As tested on CentOS 6, its "autoconf-2.63-5.1.el6.noarch" also suffices.
 AC_MSG_CHECKING(for autoconf macro to enable system extensions)
 m4_version_prereq(2.61, [
 	AC_MSG_RESULT(yes)
@@ -27,7 +28,8 @@ m4_version_prereq(2.61, [
 	AC_MSG_RESULT(no)
 ])
 
-AC_PREREQ([2.64])
+AC_PREREQ([2.63])
+dnl #AC_PREREQ([2.64])
 
 dnl Use "./configure --enable-maintainer-mode" to keep Makefile.in and Makefile
 dnl in sync after Git updates.

--- a/docs/config-prereqs.txt
+++ b/docs/config-prereqs.txt
@@ -290,7 +290,8 @@ NOTE: Below we request to install generic `python` per system defaults.
 You may request specifically `python2` or `python3` (or both): current
 NUT should be compatible with both (2.7+ at least).
 
-NOTE: On CentOS, `libusb` means 0.1.x and `libusbx` means 1.x.x API version.
+NOTE: On CentOS, `libusb` means 0.1.x and `libusbx` means 1.x.x API version
+(latter is not available for CentOS 6).
 
 NOTE: On CentOS, it seems that development against libi2c/smbus is not
 supported. Neither the suitable devel packages were found, nor i2c-based
@@ -332,7 +333,7 @@ drivers in distro packaging of NUT. Resolution and doc PRs are welcome.
 :; yum install \
     systemd-devel
 
-# NOTE: "libusbx" is the CentOS way of naming "libusb-1.0"
+# NOTE: "libusbx" is the CentOS way of naming "libusb-1.0" (not in CentOS 6)
 # vs. the older "libusb" as the package with "libusb-0.1"
 :; yum install \
     cppunit-devel \

--- a/docs/config-prereqs.txt
+++ b/docs/config-prereqs.txt
@@ -208,13 +208,19 @@ NOTE: For Jenkins agents, also need to `apt-get install openjdk-11-jdk-headless`
 You may have to ensure that `/proc` is mounted in the target chroot
 (or do this from the running container).
 
-CentOS 7
-~~~~~~~~
+CentOS 6 and 7
+~~~~~~~~~~~~~~
 
 CentOS is another popular baseline among Linux distributions, being a free
 derivative of the RedHat Linux, upon which many other distros are based as
 well. These systems typically use the RPM package manager, using directly
 `rpm` command, or `yum` or `dnf` front-ends depending on their generation.
+
+For CI farm container setup, prepared root filesystem archives from
+http://download.proxmox.com/images/system/ worked sufficiently well.
+
+Prepare CentOS repository mirrors
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 For CentOS 7 it seems that not all repositories are equally good; some of
 the software below is only served by EPEL (Extra Packages for Enterprise
@@ -237,12 +243,47 @@ file (as the aged distributions become less served by mirrors), such as:
 # lines, and comment away the mirrorlist= lines (if yum hiccups otherwise)
 ------
 
+For systemd support on CentOS 7 (no equivalent found for CentOS 6),
+you can use backports repository below:
+------
+:; curl https://copr.fedorainfracloud.org/coprs/jsynacek/systemd-backports-for-centos-7
+    > /etc/yum.repos.d/systemd-backports-for-centos-7.repo
+------
+
+For CentOS 6 (the oldest I could try) the situation is similar, with sites like
+https://www.getpagespeed.com/server-setup/how-to-fix-yum-after-centos-6-went-eol
+detailing how to replace `/etc/yum.repos.d/` contents (you can wholesale rename
+the existing directory and populate a new one with `curl` downloads from the
+article), and additional key trust for EPEL packages:
+------
+:; yum install https://dl.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm
+------
+
+Set up CentOS packages for NUT
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Instructions below apply to both CentOS 6 and 7 (a few nuances for 6 commented).
+
 General developer system helpers mentioned in link:ci-farm-lxc-setup.txt[]:
 ------
 :; yum update
 
 :; yum install \
-    sudo vim mc p7zip pigz pbzip2
+    sudo vim mc p7zip pigz pbzip2 tar
+------
+
+To have SSH access to the build VM/Container, you may have to install and
+enable it:
+------
+:; yum install \
+    openssh-server openssh-clients
+
+:; chkconfig sshd on
+:; service sshd start
+
+# If there are errors loading generated host keys, remove mentioned files
+# including the one with .pub extension and retry with:
+#:; service sshd restart
 ------
 
 NOTE: Below we request to install generic `python` per system defaults.
@@ -273,6 +314,7 @@ drivers in distro packaging of NUT. Resolution and doc PRs are welcome.
 #   :; yum install python3 python3-3.6.8
 # You can find a list of what is (pre-)installed with:
 #   :; rpm -qa | grep -Ei 'perl|python'
+# Note that CentOS 6 includes python-2.6.x and does not serve newer versions
 
 # For spell-checking, highly recommended if you would propose pull requests:
 :; yum install \
@@ -286,7 +328,7 @@ drivers in distro packaging of NUT. Resolution and doc PRs are welcome.
 :; yum install \
     gd-devel
 
-# Optionally for sd_notify integration:
+# Optionally for sd_notify integration (on CentOS 7+, not on 6):
 :; yum install \
     systemd-devel
 
@@ -328,7 +370,8 @@ other described environments by adding a symlink `/usr/lib/ccache`:
 :; ln -s ../lib64/ccache/ "$ALTROOT"/usr/lib/
 ------
 
-NOTE: For Jenkins agents, also need to `yum install java-11-openjdk-headless`.
+NOTE: For Jenkins agents, also need to `yum install java-11-openjdk-headless`
+(not available for CentOS 6).
 
 Arch Linux
 ~~~~~~~~~~

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3075 utf-8
+personal_ws-1.1 en 3077 utf-8
 AAS
 ABI
 ACFAIL
@@ -1517,6 +1517,7 @@ backends
 backgrounding
 backport
 backported
+backports
 backupspro
 badpassword
 baseurl
@@ -1626,6 +1627,7 @@ charset
 checksum
 chgrp
 chipset
+chkconfig
 chmod
 chown
 chr
@@ -2821,8 +2823,8 @@ testtime
 testuser
 textproc
 th
-timehead
 timeframe
+timehead
 timeline
 timername
 timestamp

--- a/m4/ax_check_compile_flag.m4
+++ b/m4/ax_check_compile_flag.m4
@@ -40,7 +40,10 @@
 #serial 6
 
 AC_DEFUN([AX_CHECK_COMPILE_FLAG],
-[AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
+[
+dnl UPDATE: As tested on CentOS 6, its "autoconf-2.63-5.1.el6.noarch" also suffices.
+AC_PREREQ(2.63)
+dnl #AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
 AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
 AC_CACHE_CHECK([whether _AC_LANG compiler accepts $1], CACHEVAR, [
   ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS


### PR DESCRIPTION
A question on mailing list was raised about testing NUT for someone still running CentOS 6, so here goes... spoils of experimental reconnaissance:

"Surprisingly, it works!" (mostly regarding feature/dependency availability)

With container setup as documented in this PR and downshift to allow autoconf-2.63 (also in the PR), `./ci_build.sh` built and successfully NIT-tested the codebase (without C++11 support due to old GCC-4.4.x; clang-3.4.x refuses to use system-provided C++ headers). 

Although the older `python2.6` is the only one available on the system, `PyNUT` successfully participated in the test; the NUT-Monitor GUI was not tried (headless system).

Java 11 was not available for the platform, so for the time being it can not directly run a Jenkins agent and will not be part of regular NUT CI farm testing.

````
NUT Configuration summary:
==========================

* build serial drivers: yes
* build USB drivers:    yes (libusb-0.1)
* build neon based XML driver:  yes
* enable Avahi support: yes
* build Powerman PDU client driver:     yes
* build Modbus driver:  yes
* build IPMI driver:    yes (FreeIPMI)
* build Mac OS X meta-driver:   no
* build i2c based drivers:      no
* enable SSL support:   yes (OpenSSL)
* enable libwrap (tcp-wrappers) support:        yes
* enable libltdl (Libtool dlopen abstraction) support:  yes
* build nut-scanner:    yes
* build CGI programs:   yes
* install NUT-Monitor desktop application:      no
* install PyNUT binding module: no
* build and install documentation:      skip
* build specific documentation format(s):       no
* build and install the development files:      yes
* consider basic systemd support:       no
* build with tighter systemd support:   no
* build C++11 codebase (client library, etc.):  no
* build C++ tests with CPPUNIT: no
* build SNMP drivers:   yes
* build SNMP drivers with statically linked lib(net)snmp:       no
* User to run as:       nobody
* Group of user to run as:      nobody

NUT Paths:
----------

* Default installation prefix path:     /usr/local/ups
* State file path:      /var/state/ups
* Unprivileged PID file path:   /var/state/ups
* Privileged PID file path:     /run
* Driver program path:  /usr/local/ups/bin
* CGI program path:     /usr/local/ups/cgi-bin
* HTML file path:       /usr/local/ups/html
* Config file path:     /usr/local/ups/etc
* Data file path:       /usr/local/ups/share
* Tool program path:    /usr/local/ups/bin
* System program path:  /usr/local/ups/sbin
* System library path:  /usr/local/ups/lib
* System exec-library path:     /usr/local/ups/libexec

NUT Build/Target system info:
-----------------------------

* host env spec we run on:      x86_64-unknown-linux-gnu
* host env spec we built on:    x86_64-unknown-linux-gnu
* host env spec we built for:   x86_64-unknown-linux-gnu
* host OS short spec we run on: x86_64-linux-gnu
* host OS short spec we built on:       x86_64-linux-gnu
* host OS short spec we built for:      x86_64-linux-gnu

NUT Compiler settings:
----------------------

* CC            : gcc
* CFLAGS        : -isystem /usr/local/include -g -O2 -Wno-reserved-identifier -Wno-unknown-warning-option -std=gnu99 -Wall -Wsign-compare -Wno-error
* CXX           : g++
* CXXFLAGS      : -isystem /usr/local/include -g -O2 -Wno-reserved-identifier -Wno-unknown-warning-option -Wno-error
* CPP           : gcc -E
* CPPFLAGS      :

:; cat /etc/redhat-release
CentOS release 6.10 (Final)

:;  gcc --version
gcc (GCC) 4.4.7 20120313 (Red Hat 4.4.7-23)
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
````