### PR TITLE
CI: add NIT tests for nut-scanner/libupsclient

### DIFF
--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -1152,7 +1152,7 @@ testcase_sandbox_nutscanner_list() {
         log_info "OK, nut-scanner found all expected devices"
         PASSED="`expr $PASSED + 1`"
     else
-        if ( echo "$CMDERR" | grep -E "Cannot load NUT library.*libupsclient.*The specified module could not be found.*NUT search disabled" ) ; then
+        if ( echo "$CMDERR" | grep -E "Cannot load NUT library.*libupsclient.*found.*NUT search disabled" ) ; then
             log_warn "SKIP: ${TOP_BUILDDIR}/tools/nut-scanner/nut-scanner: $CMDERR"
         else
             log_error "nut-scanner complained or did not return all expected data, check above"

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -1162,6 +1162,13 @@ testcase_sandbox_nutscanner_list() {
         && echo "$CMDOUT" | grep 'port = "dummy@' \
         || return
 
+        if [ "${NUT_PORT}" = 3493 ] || [ x"$NUT_PORT" = x ]; then
+            echo "Note: not testing for suffixed port number" >&2
+        else
+            echo "$CMDOUT" | grep -E 'dummy@.*'":${NUT_PORT}" \
+            || return
+        fi
+
         if [ x"${TOP_SRCDIR}" = x ]; then
             echo "Note: only testing one dummy device" >&2
         else

--- a/tools/nut-scanner/scan_avahi.c
+++ b/tools/nut-scanner/scan_avahi.c
@@ -264,6 +264,8 @@ static void update_device(const char * host_name, const char *ip, uint16_t port,
 			device_found = 1;
 			dev = nutscan_new_device();
 			dev->type = TYPE_NUT;
+			/* NOTE: There is no driver by such name, in practice it could
+			 * be a dummy-ups relay, a clone driver, or part of upsmon config */
 			dev->driver = strdup("nutclient");
 			if (proto == AVAHI_PROTO_INET) {
 				nutscan_add_option_to_device(dev, "desc", "IPv4");
@@ -282,7 +284,7 @@ static void update_device(const char * host_name, const char *ip, uint16_t port,
 					5 + 1 + 1 + 1;
 				dev->port = malloc(buf_size);
 				if (dev->port) {
-					snprintf(dev->port, buf_size, "%s@%s:%u",
+					snprintf(dev->port, buf_size, "%s@%s:%" PRIu16,
 						device, host_name, port);
 				}
 			}

--- a/tools/nut-scanner/scan_avahi.c
+++ b/tools/nut-scanner/scan_avahi.c
@@ -519,7 +519,7 @@ nutscan_device_t * nutscan_scan_avahi(useconds_t usec_timeout)
 
 	/* Allocate main loop object */
 	if (!(simple_poll = (*nut_avahi_simple_poll_new)())) {
-		fprintf(stderr, "Failed to create simple poll object.\n");
+		fprintf(stderr, "Failed to create Avahi simple poll object.\n");
 		goto fail;
 	}
 
@@ -541,7 +541,7 @@ nutscan_device_t * nutscan_scan_avahi(useconds_t usec_timeout)
 	/* Check wether creating the client object succeeded */
 	if (!client) {
 		fprintf(stderr,
-			"Failed to create client: %s\n",
+			"Failed to create Avahi client: %s\n",
 			(*nut_avahi_strerror)(error));
 		goto fail;
 	}
@@ -560,7 +560,7 @@ nutscan_device_t * nutscan_scan_avahi(useconds_t usec_timeout)
 # pragma GCC diagnostic pop
 #endif
 		fprintf(stderr,
-			"Failed to create service browser: %s\n",
+			"Failed to create Avahi service browser: %s\n",
 			(*nut_avahi_strerror)((*nut_avahi_client_errno)(client)));
 		goto fail;
 	}

--- a/tools/nut-scanner/scan_nut.c
+++ b/tools/nut-scanner/scan_nut.c
@@ -193,11 +193,30 @@ static void * list_nut_devices(void * arg)
 		dev->driver = strdup("nutclient");
 		/* +1+1 is for '@' character and terminating 0 */
 		buf_size = strlen(answer[1]) + strlen(hostname) + 1 + 1;
+#if (defined PORT) && (PORT > 0)
+		if (port != PORT) {
+#else
+		if (port != 3493) {
+#endif
+			/* colon and up to 5 digits */
+			buf_size += 6;
+		}
+
 		dev->port = malloc(buf_size);
 
 		if (dev->port) {
-			snprintf(dev->port, buf_size, "%s@%s", answer[1],
-					hostname);
+#if (defined PORT) && (PORT > 0)
+			if (port != PORT) {
+#else
+			if (port != 3493) {
+#endif
+				snprintf(dev->port, buf_size, "%s@%s:%" PRIu16,
+					answer[1], hostname, port);
+			} else {
+				/* Standard port, not suffixed */
+				snprintf(dev->port, buf_size, "%s@%s",
+					answer[1], hostname);
+			}
 #ifdef HAVE_PTHREAD
 			pthread_mutex_lock(&dev_mutex);
 #endif

--- a/tools/nut-scanner/scan_nut.c
+++ b/tools/nut-scanner/scan_nut.c
@@ -190,6 +190,8 @@ static void * list_nut_devices(void * arg)
 		 * - for upsmon.conf or ups.conf (using dummy-ups)? */
 		dev = nutscan_new_device();
 		dev->type = TYPE_NUT;
+		/* NOTE: There is no driver by such name, in practice it could
+		 * be a dummy-ups relay, a clone driver, or part of upsmon config */
 		dev->driver = strdup("nutclient");
 		/* +1+1 is for '@' character and terminating 0 */
 		buf_size = strlen(answer[1]) + strlen(hostname) + 1 + 1;

--- a/tools/nut-scanner/scan_nut.c
+++ b/tools/nut-scanner/scan_nut.c
@@ -195,11 +195,7 @@ static void * list_nut_devices(void * arg)
 		dev->driver = strdup("nutclient");
 		/* +1+1 is for '@' character and terminating 0 */
 		buf_size = strlen(answer[1]) + strlen(hostname) + 1 + 1;
-#if (defined PORT) && (PORT > 0)
 		if (port != PORT) {
-#else
-		if (port != 3493) {
-#endif
 			/* colon and up to 5 digits */
 			buf_size += 6;
 		}
@@ -207,11 +203,7 @@ static void * list_nut_devices(void * arg)
 		dev->port = malloc(buf_size);
 
 		if (dev->port) {
-#if (defined PORT) && (PORT > 0)
 			if (port != PORT) {
-#else
-			if (port != 3493) {
-#endif
 				snprintf(dev->port, buf_size, "%s@%s:%" PRIu16,
 					answer[1], hostname, port);
 			} else {

--- a/tools/nut-scanner/scan_nut.c
+++ b/tools/nut-scanner/scan_nut.c
@@ -33,8 +33,8 @@
 static lt_dlhandle dl_handle = NULL;
 static const char *dl_error = NULL;
 
-static int (*nut_upscli_splitaddr)(const char *buf, char **hostname, int *port);
-static int (*nut_upscli_tryconnect)(UPSCONN_t *ups, const char *host, int port,
+static int (*nut_upscli_splitaddr)(const char *buf, char **hostname, uint16_t *port);
+static int (*nut_upscli_tryconnect)(UPSCONN_t *ups, const char *host, uint16_t port,
 					int flags, struct timeval * timeout);
 static int (*nut_upscli_list_start)(UPSCONN_t *ups, size_t numq,
 					const char **query);
@@ -137,7 +137,7 @@ static void * list_nut_devices(void * arg)
 	struct scan_nut_arg * nut_arg = (struct scan_nut_arg*)arg;
 	char *target_hostname = nut_arg->hostname;
 	struct timeval tv;
-	int port;
+	uint16_t port;
 	size_t numq, numa;
 	const char *query[4];
 	char **answer;


### PR DESCRIPTION
While the test is rudimentary, it allows to check that `nut-scanner` tool basically works, and the C client library talks to upsd well. In practice during tests in build tree it often depends a lot on libtool wrapper preparing the environment that allows (or not) to find the library at run-time search, so the tests are skipped (not failed) when it says the library could not be found.

Also addresses a poorly-understood message on console when "NewNUT" (avahi) discovery fails.

Note: initially hoped this would be a test for sanity-checker from #1811, with dummy-ups configs providing some bogus or duplicate data, but NUT discovery only reports the client/relay connection point, not further details of the already running driver's config or data.

Closes: #1815