### PR TITLE
nut-monitor.appdata.xml: add launchable=nut-monitor.desktop

### DIFF
--- a/scripts/python/app/nut-monitor.appdata.xml
+++ b/scripts/python/app/nut-monitor.appdata.xml
@@ -2,6 +2,7 @@
 <!-- Copyright 2014 Arnaud Quette <arnaud.quette@free.fr> -->
 <component type="desktop-application">
  <id>nut-monitor.desktop</id>
+ <launchable type="desktop-id">nut-monitor.desktop</launchable>
  <metadata_license>CC0-1.0</metadata_license>
  <project_license>GPL-3.0+</project_license>
  <name>NUT Monitor</name>


### PR DESCRIPTION
Inspired by https://salsa.debian.org/debian/nut/-/blob/a009ca10a327d7db383f5d7726091050ceb4d60f/debian/patches/appdata-launchable.patch from @bigon but adjusted for general version-agnostic dispatcher (py2 or py3, whatever is installed for this end-user deployment)