### PR TITLE
Improve Best Fortress driver

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -136,6 +136,9 @@ https://github.com/networkupstools/nut/milestone/8
      was tied to non-existent OIDs, not well handled in some parts of the
      driver [#1716]
 
+ - The `bestfortress` driver shutdown handling was fixed to use a non-trivial
+   default timeout [#1820]
+
  - Added support for `make install` of PyNUT module and NUT-Monitor desktop
    application [#1462, #1504]
 

--- a/drivers/bestfortress.c
+++ b/drivers/bestfortress.c
@@ -274,7 +274,7 @@ static ssize_t upsrecv(char *buf,size_t bufsize,char ec,const char *ic)
 			     SER_WAIT_SEC, SER_WAIT_USEC);
 
 	/* \todo is buf null terminated? */
-	upsdebugx(4, "%s: read %d <%s>", __func__, (int) nread, buf);
+	upsdebugx(4, "%s: read %" PRIiSIZE " <%s>", __func__, nread, buf);
 
 	return nread;
 }
@@ -470,7 +470,7 @@ static void autorestart (int restart)
 static int upsdrv_setvar (const char *var, const char * data) {
 	int parameter;
 	size_t len = strlen(data);
-	upsdebugx(1, "%s: %s %s (%d bytes)", __func__, var, data, (int) len);
+	upsdebugx(1, "%s: %s %s (%" PRIuSIZE " bytes)", __func__, var, data, len);
 	if (strcmp("input.transfer.low", var) == 0) {
 		parameter = 7;
 	}


### PR DESCRIPTION
This PR does two main things:
  - rationalize and improve logging, and add/update comments
  - improve shutdown process, fixing a serious bug where the intended 10s delay was not honored, resulting in a way-too-short 1s delay.  Bump driver version because of this.  Fixes #1817.

I have tested a functionally equivalent earlier version on a Fortress LI660 including `upsmom -c fsd`, and this version with `-D -D -D -D -D`.

Changes are entirely in `drivers/bestfortress.c`; interfaces are not changed.
 
Things that I think can be done later (not in this PR):
  - More substantial comment improvements, including about the protocol.
  - Enable setting more parameters (there are 10).
  - Enable setting the shutdown delay (internal to driver; not a UPS parameter).
  - More logging rototilling.
  - Reorder functions to match order of being called from driver/main.c.
  - Cleanup of ssize_t/unsigned/int in various code (this PR does no harm, I believe).