### PR TITLE
tools/Makefile.am: Add missing dependency

### DIFF
--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -60,7 +60,7 @@ $(GENERATED_SNMP_FILES): $(top_srcdir)/drivers/*-mib.c
 		echo "----------------------------------------------------------------------"; \
 	fi
 
-$(GENERATED_USB_FILES): $(top_srcdir)/drivers/*-hid.c $(top_srcdir)/drivers/*usb*.c $(top_srcdir)/drivers/nutdrv_qx.c
+$(GENERATED_USB_FILES) $(GENERATED_USB_OS_FILES): $(top_srcdir)/drivers/*-hid.c $(top_srcdir)/drivers/*usb*.c $(top_srcdir)/drivers/nutdrv_qx.c
 	@if perl -e 1; then \
 		echo "Regenerating the USB helper files in SRC dir."; \
 		TOP_SRCDIR="$(top_srcdir)" ; export TOP_SRCDIR; \


### PR DESCRIPTION
The files in GENERATED_USB_OS_FILES are created by nut-usbinfo.pl, but this was not expressed.

Fixes #1831, a make -j2 failure.  My guess is that because serial order requires GENERATED_USB_FILES first, that this rule typically fired before the GENERATED_USB_OS_FILES rules fired, avoiding the problem.  I have no theory why it worked with GNU make.
