### PR TITLE
Fixes for unreadable "inplace" sysconfdir, and exclusive '-a id'/'-s id' for drivers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -325,6 +325,13 @@ AS_IF([test x"$nut_enable_inplace_runtime" = xyes], [
             ; then
                 sysconfdir="$D"
                 break
+            else
+                if test -d "$D/" && test ! -r "$D/" ; then
+                    dnl Keeping order of preference defined by "for" loop:
+                    AC_MSG_WARN([Picking directory '${D}' which exists but current build user may not read])
+                    sysconfdir="$D"
+                    break
+                fi
             fi
         done
         AC_MSG_RESULT([${sysconfdir}])

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -749,6 +749,10 @@ int main(int argc, char **argv)
 	while ((i = getopt(argc, argv, "+a:s:kFBDd:hx:Lqr:u:g:Vi:")) != -1) {
 		switch (i) {
 			case 'a':
+				if (upsname)
+					fatalx(EXIT_FAILURE, "Error: options '-a id' and '-s id' "
+						"are mutually exclusive and single-use only.");
+
 				upsname = optarg;
 
 				read_upsconf();
@@ -758,6 +762,10 @@ int main(int argc, char **argv)
 						optarg);
 				break;
 			case 's':
+				if (upsname)
+					fatalx(EXIT_FAILURE, "Error: options '-a id' and '-s id' "
+						"are mutually exclusive and single-use only.");
+
 				upsname = optarg;
 				upsname_found = 1;
 				break;


### PR DESCRIPTION
Issues noted during discussion of [#1848](https://github.com/networkupstools/nut/pull/1848#issuecomment-1427692141)