### PR TITLE
Debug `nut_report_config_flags()`: report version from AC_INIT vs. Git revision (if available) and compiler version

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -944,7 +944,11 @@ void nut_report_config_flags(void)
 	 * Depending on amount of configuration tunables involved by a particular
 	 * build of NUT, the string can be quite long (over 1KB).
 	 */
-	char *relver = NULL;
+	const char *acinit_ver = NULL;
+	/* Pass these as variables to avoid warning about never reaching one
+	 * of compiled codepaths: */
+	const char *compiler_ver = CC_VERSION;
+	const char *config_flags = CONFIG_FLAGS;
 	if (nut_debug_level < 1)
 		return;
 
@@ -964,20 +968,20 @@ void nut_report_config_flags(void)
 		 * from configure.ac AC_INIT() -- although some distros,
 		 * especially embedders, tend to place their product IDs here),
 		 * or if PACKAGE_VERSION *is NOT* a substring of it: */
-		relver = PACKAGE_VERSION;
+		acinit_ver = PACKAGE_VERSION;
 	}
 
 	if (xbit_test(upslog_flags, UPSLOG_STDERR))
 		fprintf(stderr, "Network UPS Tools version %s%s%s%s%s%s%s %s%s\n",
 			UPS_VERSION,
-			(relver ? " (release/snapshot of " : ""),
-			(relver ? relver : ""),
-			(relver ? ")" : ""),
-			(CC_VERSION && *CC_VERSION != '\0' ? " built with " : ""),
-			(CC_VERSION && *CC_VERSION != '\0' ? CC_VERSION : ""),
-			(CC_VERSION && *CC_VERSION != '\0' ? " and" : ""),
-			(CONFIG_FLAGS && *CONFIG_FLAGS != '\0' ? "configured with flags: " : "configured all by default guesswork"),
-			(CONFIG_FLAGS && *CONFIG_FLAGS != '\0' ? CONFIG_FLAGS : "")
+			(acinit_ver ? " (release/snapshot of " : ""),
+			(acinit_ver ? acinit_ver : ""),
+			(acinit_ver ? ")" : ""),
+			(compiler_ver && *compiler_ver != '\0' ? " built with " : ""),
+			(compiler_ver && *compiler_ver != '\0' ? compiler_ver : ""),
+			(compiler_ver && *compiler_ver != '\0' ? " and" : ""),
+			(config_flags && *config_flags != '\0' ? "configured with flags: " : "configured all by default guesswork"),
+			(config_flags && *config_flags != '\0' ? config_flags : "")
 		);
 
 	/* NOTE: May be ignored or truncated by receiver if that syslog server
@@ -985,14 +989,14 @@ void nut_report_config_flags(void)
 	if (xbit_test(upslog_flags, UPSLOG_SYSLOG))
 		syslog(LOG_DEBUG, "Network UPS Tools version %s%s%s%s%s%s%s %s%s",
 			UPS_VERSION,
-			(relver ? " (release/snapshot of " : ""),
-			(relver ? relver : ""),
-			(relver ? ")" : ""),
-			(CC_VERSION && *CC_VERSION != '\0' ? " built with " : ""),
-			(CC_VERSION && *CC_VERSION != '\0' ? CC_VERSION : ""),
-			(CC_VERSION && *CC_VERSION != '\0' ? " and" : ""),
-			(CONFIG_FLAGS && *CONFIG_FLAGS != '\0' ? "configured with flags: " : "configured all by default guesswork"),
-			(CONFIG_FLAGS && *CONFIG_FLAGS != '\0' ? CONFIG_FLAGS : "")
+			(acinit_ver ? " (release/snapshot of " : ""),
+			(acinit_ver ? acinit_ver : ""),
+			(acinit_ver ? ")" : ""),
+			(compiler_ver && *compiler_ver != '\0' ? " built with " : ""),
+			(compiler_ver && *compiler_ver != '\0' ? compiler_ver : ""),
+			(compiler_ver && *compiler_ver != '\0' ? " and" : ""),
+			(config_flags && *config_flags != '\0' ? "configured with flags: " : "configured all by default guesswork"),
+			(config_flags && *config_flags != '\0' ? config_flags : "")
 		);
 }
 

--- a/common/common.c
+++ b/common/common.c
@@ -944,32 +944,35 @@ void nut_report_config_flags(void)
 	 * Depending on amount of configuration tunables involved by a particular
 	 * build of NUT, the string can be quite long (over 1KB).
 	 */
-	char *gitrev = NULL;
+	char *relver = NULL;
 	if (nut_debug_level < 1)
 		return;
 
-	/* Only report git revision if remarkably different from UPS_VERSION
-	 * which may be e.g. "2.8.0.1" or already include the source revision
+	/* Only report git revision if NUT_VERSION_MACRO in nut_version.h aka
+	 * UPS_VERSION here is remarkably different from PACKAGE_VERSION from
+	 * configure.ac AC_INIT() -- which may be e.g. "2.8.0.1" although some
+	 * distros, especially embedders, tend to place their product IDs here).
+	 * The macro may be that fixed version or refer to git source revision,
 	 * as decided when generating nut_version.h (and if it was re-generated
-	 * in case of rebuilds while developers are locally iterating).
-	 * If the same version string is indeed present, gitrev is "v<UPS_VERSION>".
+	 * in case of rebuilds while developers are locally iterating -- this
+	 * may be disabled for faster local iterations at a cost of a little lie).
 	 */
-	if (NUT_SOURCE_GITREV && UPS_VERSION &&
-		(strlen(UPS_VERSION) < 12 || !strstr(NUT_SOURCE_GITREV, UPS_VERSION))
+	if (PACKAGE_VERSION && UPS_VERSION &&
+		(strlen(UPS_VERSION) < 12 || !strstr(UPS_VERSION, PACKAGE_VERSION))
 	) {
 		/* If UPS_VERSION is too short (so likely a static string
 		 * from configure.ac AC_INIT() -- although some distros,
 		 * especially embedders, tend to place their product IDs here),
-		 * or if it is NOT a substring of NUT_SOURCE_GITREV: */
-		gitrev = NUT_SOURCE_GITREV;
+		 * or if PACKAGE_VERSION *is NOT* a substring of it: */
+		relver = PACKAGE_VERSION;
 	}
 
 	if (xbit_test(upslog_flags, UPSLOG_STDERR))
 		fprintf(stderr, "Network UPS Tools version %s%s%s%s configured with flags: %s\n",
 			UPS_VERSION,
-			(gitrev ? " (git revision " : ""),
-			(gitrev ? gitrev : ""),
-			(gitrev ? ")" : ""),
+			(relver ? " (release/snapshot of " : ""),
+			(relver ? relver : ""),
+			(relver ? ")" : ""),
 			CONFIG_FLAGS);
 
 	/* NOTE: May be ignored or truncated by receiver if that syslog server
@@ -977,9 +980,9 @@ void nut_report_config_flags(void)
 	if (xbit_test(upslog_flags, UPSLOG_SYSLOG))
 		syslog(LOG_DEBUG, "Network UPS Tools version %s%s%s%s configured with flags: %s",
 			UPS_VERSION,
-			(gitrev ? " (git revision " : ""),
-			(gitrev ? gitrev : ""),
-			(gitrev ? ")" : ""),
+			(relver ? " (release/snapshot of " : ""),
+			(relver ? relver : ""),
+			(relver ? ")" : ""),
 			CONFIG_FLAGS);
 }
 

--- a/common/common.c
+++ b/common/common.c
@@ -968,21 +968,27 @@ void nut_report_config_flags(void)
 	}
 
 	if (xbit_test(upslog_flags, UPSLOG_STDERR))
-		fprintf(stderr, "Network UPS Tools version %s%s%s%s configured with flags: %s\n",
+		fprintf(stderr, "Network UPS Tools version %s%s%s%s%s%s%s configured with flags: %s\n",
 			UPS_VERSION,
 			(relver ? " (release/snapshot of " : ""),
 			(relver ? relver : ""),
 			(relver ? ")" : ""),
+			(CC_VERSION && *CC_VERSION != '\0' ? " built with " : ""),
+			(CC_VERSION && *CC_VERSION != '\0' ? CC_VERSION : ""),
+			(CC_VERSION && *CC_VERSION != '\0' ? " and" : ""),
 			CONFIG_FLAGS);
 
 	/* NOTE: May be ignored or truncated by receiver if that syslog server
 	 * (and/or OS sender) does not accept messages of such length */
 	if (xbit_test(upslog_flags, UPSLOG_SYSLOG))
-		syslog(LOG_DEBUG, "Network UPS Tools version %s%s%s%s configured with flags: %s",
+		syslog(LOG_DEBUG, "Network UPS Tools version %s%s%s%s%s%s%s configured with flags: %s",
 			UPS_VERSION,
 			(relver ? " (release/snapshot of " : ""),
 			(relver ? relver : ""),
 			(relver ? ")" : ""),
+			(CC_VERSION && *CC_VERSION != '\0' ? " built with " : ""),
+			(CC_VERSION && *CC_VERSION != '\0' ? CC_VERSION : ""),
+			(CC_VERSION && *CC_VERSION != '\0' ? " and" : ""),
 			CONFIG_FLAGS);
 }
 

--- a/common/common.c
+++ b/common/common.c
@@ -968,7 +968,7 @@ void nut_report_config_flags(void)
 	}
 
 	if (xbit_test(upslog_flags, UPSLOG_STDERR))
-		fprintf(stderr, "Network UPS Tools version %s%s%s%s%s%s%s configured with flags: %s\n",
+		fprintf(stderr, "Network UPS Tools version %s%s%s%s%s%s%s %s%s\n",
 			UPS_VERSION,
 			(relver ? " (release/snapshot of " : ""),
 			(relver ? relver : ""),
@@ -976,12 +976,14 @@ void nut_report_config_flags(void)
 			(CC_VERSION && *CC_VERSION != '\0' ? " built with " : ""),
 			(CC_VERSION && *CC_VERSION != '\0' ? CC_VERSION : ""),
 			(CC_VERSION && *CC_VERSION != '\0' ? " and" : ""),
-			CONFIG_FLAGS);
+			(CONFIG_FLAGS && *CONFIG_FLAGS != '\0' ? "configured with flags: " : "configured all by default guesswork"),
+			(CONFIG_FLAGS && *CONFIG_FLAGS != '\0' ? CONFIG_FLAGS : "")
+		);
 
 	/* NOTE: May be ignored or truncated by receiver if that syslog server
 	 * (and/or OS sender) does not accept messages of such length */
 	if (xbit_test(upslog_flags, UPSLOG_SYSLOG))
-		syslog(LOG_DEBUG, "Network UPS Tools version %s%s%s%s%s%s%s configured with flags: %s",
+		syslog(LOG_DEBUG, "Network UPS Tools version %s%s%s%s%s%s%s %s%s",
 			UPS_VERSION,
 			(relver ? " (release/snapshot of " : ""),
 			(relver ? relver : ""),
@@ -989,7 +991,9 @@ void nut_report_config_flags(void)
 			(CC_VERSION && *CC_VERSION != '\0' ? " built with " : ""),
 			(CC_VERSION && *CC_VERSION != '\0' ? CC_VERSION : ""),
 			(CC_VERSION && *CC_VERSION != '\0' ? " and" : ""),
-			CONFIG_FLAGS);
+			(CONFIG_FLAGS && *CONFIG_FLAGS != '\0' ? "configured with flags: " : "configured all by default guesswork"),
+			(CONFIG_FLAGS && *CONFIG_FLAGS != '\0' ? CONFIG_FLAGS : "")
+		);
 }
 
 static void vupslog(int priority, const char *fmt, va_list va, int use_strerror)

--- a/configure.ac
+++ b/configure.ac
@@ -15,9 +15,14 @@ dnl without reconfiguration, detailed version in the binaries will differ.
 && NUT_SOURCE_GITREV="`git describe --tags 2>/dev/null | sed -e 's/^v\([0-9]\)/\1/' -e 's,^.*/,,'`" \
 || NUT_SOURCE_GITREV=""
 
-AS_IF([test -n "${NUT_SOURCE_GITREV-}"],
-    [AC_DEFINE_UNQUOTED([NUT_SOURCE_GITREV], ["${NUT_SOURCE_GITREV}"], [NUT source revision when the build was configured])],
-    [AC_DEFINE([NUT_SOURCE_GITREV], [NULL], [NUT source revision when the build was configured: not detected])])
+dnl Note: except for experiments, do not pass this into config.h - use
+dnl the NUT_VERSION_MACRO from nut_version.h instead. Developers may
+dnl want to disable their "force-nut-version-header" configure option
+dnl to reduce rebuild scope and so speed up the iterations with ccache.
+dnl New "config.h" contents for every reconfig would defeat that purpose!
+dnl ### AS_IF([test -n "${NUT_SOURCE_GITREV-}"],
+dnl ###     [AC_DEFINE_UNQUOTED([NUT_SOURCE_GITREV], ["${NUT_SOURCE_GITREV}"], [NUT source revision when the build was configured])],
+dnl ###     [AC_DEFINE([NUT_SOURCE_GITREV], [NULL], [NUT source revision when the build was configured: not detected])])
 
 dnl Keep track of command-line options passed to this script:
 AC_MSG_CHECKING([for CONFIG_FLAGS])

--- a/configure.ac
+++ b/configure.ac
@@ -393,12 +393,12 @@ dnl Note: the compiler/pragma/attr methods below are custom for NUT codebase:
 NUT_COMPILER_FAMILY
 
 dnl Note: DO NOT AC_DEFINE the "FULL" items: they are generally multi-line.
-dnl NUT_REPORT_TARGET([CC_VERSION_FULL],  [${CC_VERSION_FULL}],  [Version and other details of C compiler])
-dnl NUT_REPORT_TARGET([CXX_VERSION_FULL], [${CXX_VERSION_FULL}], [Version and other details of C++ compiler])
-dnl NUT_REPORT_TARGET([CPP_VERSION_FULL], [${CPP_VERSION_FULL}], [Version and other details of C preprocessor])
-NUT_REPORT_TARGET([CC_VERSION],  [${CC_VERSION}],  [Compact version of C compiler])
-NUT_REPORT_TARGET([CXX_VERSION], [${CXX_VERSION}], [Compact version of C++ compiler])
-NUT_REPORT_TARGET([CPP_VERSION], [${CPP_VERSION}], [Compact version of C preprocessor])
+dnl NUT_REPORT_TARGET([CC_VERSION_FULL],  ["${CC_VERSION_FULL}"],  [Version and other details of C compiler])
+dnl NUT_REPORT_TARGET([CXX_VERSION_FULL], ["${CXX_VERSION_FULL}"], [Version and other details of C++ compiler])
+dnl NUT_REPORT_TARGET([CPP_VERSION_FULL], ["${CPP_VERSION_FULL}"], [Version and other details of C preprocessor])
+NUT_REPORT_TARGET([CC_VERSION],  ["${CC_VERSION}"],  [Compact version of C compiler])
+NUT_REPORT_TARGET([CXX_VERSION], ["${CXX_VERSION}"], [Compact version of C++ compiler])
+NUT_REPORT_TARGET([CPP_VERSION], ["${CPP_VERSION}"], [Compact version of C preprocessor])
 
 dnl Help find warning/error details in a wall of text (must be processed before NUT_COMPILER_FAMILY_FLAGS):
 NUT_ARG_ENABLE([Wcolor],

--- a/configure.ac
+++ b/configure.ac
@@ -3067,9 +3067,8 @@ AS_IF([test x"$have_PKG_CONFIG" = xyes],
          AS_IF([test "${have_cppunit}" != "yes"],
             [AC_MSG_WARN([libcppunit not found - those C++ tests will not be built.])
              have_cppunit=no],
-            [AS_IF([test -n "$CXX"],
-                [AS_IF([$CXX --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
-                    [CPPUNIT_NUT_CXXFLAGS="-g -O0"])])
+            [AS_IF([test "x$GXX" = xyes],
+             [CPPUNIT_NUT_CXXFLAGS="-g -O0"])
             ])
         ])
     ], [AC_MSG_WARN([pkg-config not found, can not look properly for libcppunit - those C++ tests will not be built.])
@@ -3721,7 +3720,7 @@ AS_CASE(["${nut_enable_warnings}"],
             [AS_IF([test "${GCC}" = "yes"], [
                 AS_CASE(["${CFLAGS}"],
                     [*89*|*90*|*ansi*], [nut_enable_warnings="gcc-minimal"],
-                    [AS_CASE(["`$CC --version | grep -i gcc`"],
+                    [AS_CASE(["$CC_VERSION"],
                         [*" "1.*|*" "2.*|3.*|*" "4.0*|*" "4.1*|*" "4.2*|*" "4.3*], [
                             AC_MSG_WARN([Very old GCC in use, disabling warnings])
                             dnl #AS_IF([test x"${nut_enable_Werror}" = xauto], [nut_enable_Werror="no"])

--- a/configure.ac
+++ b/configure.ac
@@ -12,8 +12,12 @@ dnl primarily for better messaging in the script itself.
 dnl If the NUT codebase in this workspace is being developed and rebuilt
 dnl without reconfiguration, detailed version in the binaries will differ.
 (command -v git >/dev/null 2>/dev/null) \
-&& GITREV="`git describe --tags 2>/dev/null | sed -e 's/^v\([0-9]\)/\1/' -e 's,^.*/,,'`" \
-|| GITREV=""
+&& NUT_SOURCE_GITREV="`git describe --tags 2>/dev/null | sed -e 's/^v\([0-9]\)/\1/' -e 's,^.*/,,'`" \
+|| NUT_SOURCE_GITREV=""
+
+AS_IF([test -n "${NUT_SOURCE_GITREV-}"],
+    [AC_DEFINE_UNQUOTED([NUT_SOURCE_GITREV], ["${NUT_SOURCE_GITREV}"], [NUT source revision when the build was configured])],
+    [AC_DEFINE([NUT_SOURCE_GITREV], [NULL], [NUT source revision when the build was configured: not detected])])
 
 dnl Keep track of command-line options passed to this script:
 AC_MSG_CHECKING([for CONFIG_FLAGS])
@@ -62,9 +66,9 @@ AC_SUBST(CONFIG_FLAGS)
 AC_CONFIG_AUX_DIR([.])
 AC_CONFIG_SRCDIR(server/upsd.c)
 AC_CONFIG_MACRO_DIR([m4])
-AS_IF([test x"${GITREV}" = x],
+AS_IF([test x"${NUT_SOURCE_GITREV}" = x],
     [echo "Network UPS Tools version ${PACKAGE_VERSION}"],
-    [echo "Network UPS Tools version ${PACKAGE_VERSION} (${GITREV})"])
+    [echo "Network UPS Tools version ${PACKAGE_VERSION} (${NUT_SOURCE_GITREV})"])
 AC_CANONICAL_TARGET
 NUT_CHECK_OS
 NUT_STASH_WARNINGS
@@ -376,9 +380,9 @@ NUT_ARG_ENABLE([keep_nut_report_feature],
     [Request that we keep config.nut_report_feature.log (normally deleted by configure script after displaying)],
     [no])
 
-AS_IF([test x"${GITREV}" = x],
+AS_IF([test x"${NUT_SOURCE_GITREV}" = x],
     [NUT_REPORT([configured version], [${PACKAGE_VERSION}])],
-    [NUT_REPORT([configured version], [${PACKAGE_VERSION} (${GITREV})])])
+    [NUT_REPORT([configured version], [${PACKAGE_VERSION} (${NUT_SOURCE_GITREV})])])
 
 dnl Note: the compiler/pragma/attr methods below are custom for NUT codebase:
 NUT_COMPILER_FAMILY

--- a/configure.ac
+++ b/configure.ac
@@ -391,6 +391,15 @@ AS_IF([test x"${NUT_SOURCE_GITREV}" = x],
 
 dnl Note: the compiler/pragma/attr methods below are custom for NUT codebase:
 NUT_COMPILER_FAMILY
+
+dnl Note: DO NOT AC_DEFINE the "FULL" items: they are generally multi-line.
+dnl NUT_REPORT_TARGET([CC_VERSION_FULL],  [${CC_VERSION_FULL}],  [Version and other details of C compiler])
+dnl NUT_REPORT_TARGET([CXX_VERSION_FULL], [${CXX_VERSION_FULL}], [Version and other details of C++ compiler])
+dnl NUT_REPORT_TARGET([CPP_VERSION_FULL], [${CPP_VERSION_FULL}], [Version and other details of C preprocessor])
+NUT_REPORT_TARGET([CC_VERSION],  [${CC_VERSION}],  [Compact version of C compiler])
+NUT_REPORT_TARGET([CXX_VERSION], [${CXX_VERSION}], [Compact version of C++ compiler])
+NUT_REPORT_TARGET([CPP_VERSION], [${CPP_VERSION}], [Compact version of C preprocessor])
+
 dnl Help find warning/error details in a wall of text (must be processed before NUT_COMPILER_FAMILY_FLAGS):
 NUT_ARG_ENABLE([Wcolor],
     [Request that compiler output is colorized (no = leave it up to compiler defaults)],

--- a/m4/nut_compiler_family.m4
+++ b/m4/nut_compiler_family.m4
@@ -2,61 +2,90 @@ dnl detect if current compiler is clang or gcc (or...)
 
 AC_DEFUN([NUT_COMPILER_FAMILY],
 [
+  CC_VERSION_FULL="`LANG=C LC_ALL=C $CC --version 2>&1`"   || CC_VERSION_FULL=""
+  CXX_VERSION_FULL="`LANG=C LC_ALL=C $CXX --version 2>&1`" || CXX_VERSION_FULL=""
+  CPP_VERSION_FULL="`LANG=C LC_ALL=C $CPP --version 2>&1`" || CPP_VERSION_FULL=""
+  CC_VERSION=""
+  CXX_VERSION=""
+  CPP_VERSION=""
+
   AC_CACHE_CHECK([if CC compiler family is GCC],
     [nut_cv_GCC],
-    [AS_IF([test -n "$CC"],
-        [AS_IF([$CC --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+    [AS_IF([test -n "$CC" && test -n "$CC_VERSION_FULL"],
+        [AS_IF([echo "${CC_VERSION_FULL}" | grep 'Free Software Foundation' > /dev/null],
             [nut_cv_GCC=yes],[nut_cv_GCC=no])],
         [AC_MSG_ERROR([CC is not set])]
     )])
 
   AC_CACHE_CHECK([if CXX compiler family is GCC],
     [nut_cv_GXX],
-    [AS_IF([test -n "$CXX"],
-        [AS_IF([$CXX --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+    [AS_IF([test -n "$CXX" && test -n "$CXX_VERSION_FULL"],
+        [AS_IF([echo "${CXX_VERSION_FULL}" | grep 'Free Software Foundation' > /dev/null],
             [nut_cv_GXX=yes],[nut_cv_GXX=no])],
         [AC_MSG_ERROR([CXX is not set])]
     )])
 
   AC_CACHE_CHECK([if CPP preprocessor family is GCC],
     [nut_cv_GPP],
-    [AS_IF([test -n "$CPP"],
-        [AS_IF([$CPP --version 2>&1 | grep 'Free Software Foundation' > /dev/null],
+    [AS_IF([test -n "$CPP" && test -n "$CPP_VERSION_FULL"],
+        [AS_IF([echo "${CPP_VERSION_FULL}" | grep 'Free Software Foundation' > /dev/null],
             [nut_cv_GPP=yes],[nut_cv_GPP=no])],
         [AC_MSG_ERROR([CPP is not set])]
     )])
 
-  AS_IF([test "x$GCC" = "x" && test "$nut_cv_GCC" = yes],   [GCC=yes])
-  AS_IF([test "x$GXX" = "x" && test "$nut_cv_GXX" = yes],   [GXX=yes])
-  AS_IF([test "x$GPP" = "x" && test "$nut_cv_GPP" = yes],   [GPP=yes])
+  AS_IF([test "x$GCC" = "x" && test "$nut_cv_GCC" = yes],   [GCC=yes
+    CC_VERSION="`echo "${CC_VERSION_FULL}" | grep -i gcc | head -1`" \
+    && test -n "${CC_VERSION}" || CC_VERSION=""
+    ])
+  AS_IF([test "x$GXX" = "x" && test "$nut_cv_GXX" = yes],   [GXX=yes
+    CXX_VERSION="`echo "${CXX_VERSION_FULL}" | grep -i -E 'g++|gcc' | head -1`" \
+    && test -n "${CXX_VERSION}" || CXX_VERSION=""
+    ])
+  AS_IF([test "x$GPP" = "x" && test "$nut_cv_GPP" = yes],   [GPP=yes
+    CPP_VERSION="`echo "${CPP_VERSION_FULL}" | grep -i -E 'cpp|gcc' | head -1`" \
+    && test -n "${CPP_VERSION}" || CPP_VERSION=""
+    ])
 
   AC_CACHE_CHECK([if CC compiler family is clang],
     [nut_cv_CLANGCC],
-    [AS_IF([test -n "$CC"],
-        [AS_IF([$CC --version 2>&1 | grep -E '(clang version|Apple LLVM version .*clang-)' > /dev/null],
+    [AS_IF([test -n "$CC" && test -n "$CC_VERSION_FULL"],
+        [AS_IF([echo "${CC_VERSION_FULL}" | grep -E '(clang version|Apple LLVM version .*clang-)' > /dev/null],
             [nut_cv_CLANGCC=yes],[nut_cv_CLANGCC=no])],
         [AC_MSG_ERROR([CC is not set])]
     )])
 
   AC_CACHE_CHECK([if CXX compiler family is clang],
     [nut_cv_CLANGXX],
-    [AS_IF([test -n "$CXX"],
-        [AS_IF([$CXX --version 2>&1 | grep -E '(clang version|Apple LLVM version .*clang-)' > /dev/null],
+    [AS_IF([test -n "$CXX" && test -n "$CXX_VERSION_FULL"],
+        [AS_IF([echo "${CXX_VERSION_FULL}" | grep -E '(clang version|Apple LLVM version .*clang-)' > /dev/null],
             [nut_cv_CLANGXX=yes],[nut_cv_CLANGXX=no])],
         [AC_MSG_ERROR([CXX is not set])]
     )])
 
   AC_CACHE_CHECK([if CPP preprocessor family is clang],
     [nut_cv_CLANGPP],
-    [AS_IF([test -n "$CPP"],
-        [AS_IF([$CPP --version 2>&1 | grep -E '(clang version|Apple LLVM version .*clang-)' > /dev/null],
+    [AS_IF([test -n "$CPP" && test -n "$CPP_VERSION_FULL"],
+        [AS_IF([echo "${CPP_VERSION_FULL}" | grep -E '(clang version|Apple LLVM version .*clang-)' > /dev/null],
             [nut_cv_CLANGPP=yes],[nut_cv_CLANGPP=no])],
         [AC_MSG_ERROR([CPP is not set])]
     )])
 
-  AS_IF([test "x$CLANGCC" = "x" && test "$nut_cv_CLANGCC" = yes],   [CLANGCC=yes])
-  AS_IF([test "x$CLANGXX" = "x" && test "$nut_cv_CLANGXX" = yes],   [CLANGXX=yes])
-  AS_IF([test "x$CLANGPP" = "x" && test "$nut_cv_CLANGPP" = yes],   [CLANGPP=yes])
+  AS_IF([test "x$CLANGCC" = "x" && test "$nut_cv_CLANGCC" = yes],   [CLANGCC=yes
+    CC_VERSION="`echo "${CC_VERSION_FULL}" | grep -v "Dir:" | tr '\n' ';' | sed -e 's, *;,;,g' -e 's,;$,,' -e 's,;,; ,g'`" \
+    && test -n "${CC_VERSION}" || CC_VERSION=""
+    ])
+  AS_IF([test "x$CLANGXX" = "x" && test "$nut_cv_CLANGXX" = yes],   [CLANGXX=yes
+    CXX_VERSION="`echo "${CXX_VERSION_FULL}" | grep -v "Dir:" | tr '\n' ';' | sed -e 's, *;,;,g' -e 's,;$,,' -e 's,;,; ,g'`" \
+    && test -n "${CXX_VERSION}" || CXX_VERSION=""
+    ])
+  AS_IF([test "x$CLANGPP" = "x" && test "$nut_cv_CLANGPP" = yes],   [CLANGPP=yes
+    CPP_VERSION="`echo "${CPP_VERSION_FULL}" | grep -v "Dir:" | tr '\n' ';' | sed -e 's, *;,;,g' -e 's,;$,,' -e 's,;,; ,g'`" \
+    && test -n "${CPP_VERSION}" || CPP_VERSION=""
+    ])
+
+  AS_IF([test "x$CC_VERSION" = x],  [CC_VERSION="`echo "${CC_VERSION_FULL}" | head -1`"])
+  AS_IF([test "x$CXX_VERSION" = x], [CXX_VERSION="`echo "${CXX_VERSION_FULL}" | head -1`"])
+  AS_IF([test "x$CPP_VERSION" = x], [CPP_VERSION="`echo "${CPP_VERSION_FULL}" | head -1`"])
 ])
 
 AC_DEFUN([NUT_CHECK_COMPILE_FLAG],

--- a/m4/nut_report_feature.m4
+++ b/m4/nut_report_feature.m4
@@ -114,7 +114,10 @@ AC_DEFUN([NUT_REPORT_TARGET],
     dnl arg#3 = summary/config.log/autoconf description
     AC_MSG_CHECKING([$3])
     AC_MSG_RESULT([$2])
-    NUT_REPORT_FILE([$3], [$2], [8], "NUT Build/Target system info:")
+    dnl FIXME: value here is already quoted by caller (for AC_DEFINE_UNQUOTED
+    dnl with multi-token strings). Then quotes are added in NUT_REPORT_FILE()
+    dnl and turn it into multiple single-token strings. So we neuter that here:
+    NUT_REPORT_FILE([$3], ["$2"], [8], "NUT Build/Target system info:")
 
     dnl Note: unlike features, target info does not imply an AutoMake toggle
     AC_DEFINE_UNQUOTED($1, $2, $3)

--- a/m4/nut_report_feature.m4
+++ b/m4/nut_report_feature.m4
@@ -24,7 +24,7 @@ AC_DEFUN([NUT_REPORT_FILE],
             echo ""
         fi > "config.nut_report_feature.log.$3"
     ])
-    printf "* $1:\t$2\n" >> "config.nut_report_feature.log.$3"
+    printf "* %s:\t%s\n" "$1" "$2" >> "config.nut_report_feature.log.$3"
 ])
 
 AC_DEFUN([NUT_REPORT],


### PR DESCRIPTION
Examples:

* No `configure` options at all:
````
:; ./autogen.sh && ./configure && make -j 8
:; ./server/upsd -DV
Network UPS Tools upsd 2.8.0-Windows-565-g2e973e674
Network UPS Tools version 2.8.0-Windows-565-g2e973e674 (release/snapshot of 2.8.0.1) built with gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0 and configured all by default guesswork
````

* With options (provided by `ci_build.sh` helper scenario):
````
:; rm -f Makefile configure include/nut_version.h; CC=clang CXX=clang++ ./ci_build.sh
:; ./server/upsd -DV
Network UPS Tools upsd 2.8.0-Windows-566-g55a5dca9f
Network UPS Tools version 2.8.0-Windows-566-g55a5dca9f (release/snapshot of 2.8.0.1) built with clang version 10.0.0-4ubuntu1; Target: x86_64-pc-linux-gnu; Thread model: posix and configured with flags: --enable-Wcolor --enable-keep_nut_report_feature --with-all=auto --with-cgi=auto --with-serial=auto --with-dev=auto --with-doc=skip --with-nut_monitor=auto --with-pynut=auto --disable-force-nut-version-header --enable-check-NIT --enable-maintainer-mode --disable-silent-rules
````
