### PR TITLE
C++11 support tighter check

### DIFF
--- a/clients/nutclient.cpp
+++ b/clients/nutclient.cpp
@@ -194,12 +194,12 @@ std::string SystemException::err()
  * https://lgtm.com/rules/2165180572/ like:
  *   NutException& operator=(NutException& rhs) = default;
  */
-NutException::~NutException() {}
-SystemException::~SystemException() {}
-IOException::~IOException() {}
-UnknownHostException::~UnknownHostException() {}
-NotConnectedException::~NotConnectedException() {}
-TimeoutException::~TimeoutException() {}
+NutException::~NutException() noexcept {}
+SystemException::~SystemException() noexcept {}
+IOException::~IOException() noexcept {}
+UnknownHostException::~UnknownHostException() noexcept {}
+NotConnectedException::~NotConnectedException() noexcept {}
+TimeoutException::~TimeoutException() noexcept {}
 
 
 namespace internal

--- a/clients/nutclient.h
+++ b/clients/nutclient.h
@@ -60,7 +60,7 @@ public:
 	NutException(const std::string& msg):_msg(msg){}
 	NutException(const NutException&) = default;
 	NutException& operator=(NutException& rhs) = default;
-	virtual ~NutException() override;
+	virtual ~NutException() noexcept override;
 	virtual const char * what() const noexcept override {return this->_msg.c_str();}
 	virtual std::string str() const noexcept {return this->_msg;}
 private:
@@ -76,7 +76,7 @@ public:
 	SystemException();
 	SystemException(const SystemException&) = default;
 	SystemException& operator=(SystemException& rhs) = default;
-	virtual ~SystemException() override;
+	virtual ~SystemException() noexcept override;
 private:
 	static std::string err();
 };
@@ -91,7 +91,7 @@ public:
 	IOException(const std::string& msg):NutException(msg){}
 	IOException(const IOException&) = default;
 	IOException& operator=(IOException& rhs) = default;
-	virtual ~IOException() override;
+	virtual ~IOException() noexcept override;
 };
 
 /**
@@ -103,7 +103,7 @@ public:
 	UnknownHostException():IOException("Unknown host"){}
 	UnknownHostException(const UnknownHostException&) = default;
 	UnknownHostException& operator=(UnknownHostException& rhs) = default;
-	virtual ~UnknownHostException() override;
+	virtual ~UnknownHostException() noexcept override;
 };
 
 /**
@@ -115,7 +115,7 @@ public:
 	NotConnectedException():IOException("Not connected"){}
 	NotConnectedException(const NotConnectedException&) = default;
 	NotConnectedException& operator=(NotConnectedException& rhs) = default;
-	virtual ~NotConnectedException() override;
+	virtual ~NotConnectedException() noexcept override;
 };
 
 /**
@@ -127,7 +127,7 @@ public:
 	TimeoutException():IOException("Timeout"){}
 	TimeoutException(const TimeoutException&) = default;
 	TimeoutException& operator=(TimeoutException& rhs) = default;
-	virtual ~TimeoutException() override;
+	virtual ~TimeoutException() noexcept override;
 };
 
 /**

--- a/configure.ac
+++ b/configure.ac
@@ -3258,8 +3258,17 @@ CPLUSPLUS_DECL='
 #if __cplusplus < 201103L
   #error This library needs at least a C++11 compliant compiler
 #endif
+
+/* Make sure it supports modern syntax */
+#include <string>
+#include <map>
 '
-CPLUSPLUS_MAIN='printf("%ld\n", __cplusplus);'
+CPLUSPLUS_MAIN='
+printf("%ld\n", __cplusplus);
+/* Make sure it supports modern syntax */
+std::map<std::string, std::string> map;
+map.emplace("key", "value");
+'
 
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[${CPLUSPLUS_DECL}]], [[${CPLUSPLUS_MAIN}]])],
     [AC_MSG_RESULT([yes, out of the box])

--- a/configure.ac
+++ b/configure.ac
@@ -3267,7 +3267,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[${CPLUSPLUS_DECL}]], [[${CPLUSPLUS_MAIN}]])
     [AS_CASE(["${CXXFLAGS}"],
         [*"-std="*], [
             AC_MSG_RESULT([no, not with the standard already set in CXXFLAGS='${CXXFLAGS}'])
-            have_cxx11=no,
+            have_cxx11=no
         ],[
             CXXFLAGS="$CXXFLAGS -std=c++11"
             AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[${CPLUSPLUS_DECL}]], [[${CPLUSPLUS_MAIN}]])],


### PR DESCRIPTION
Older GCC-4.7.2 (in Debian 7 Wheezy, per #1883 discussion) claims to support the language version we need, but in fact has numerous missing features that a build hits (the whole 4.x line added C++11 support step by step, one minor release after another). This PR fixes a warning that seems useful (about `noexcept` in destructors) -- CI will show if newer systems have a problem with that change.

Primarily this PR extends the `configure.ac` check to bail out on some infractions easier to test (lack of `std::map -> emplace()` for example).

NOTE: A few earlier documentation changes went to master branch without a PR, to follow up on setup of the Debian 7 LXC container, etc.