### PR TITLE
Add usb_resetter documentation for unreliable USB UPS interfaces (Linux, Python)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -209,6 +209,11 @@ https://github.com/networkupstools/nut/milestone/8
  - upslog: Added support for logging multiple devices with one call to the
    program [#1604]
 
+ - Documentation to integrate NUT USB driver startup with `usb_resetter` script
+   has been contributed to `scripts/usb_resetter` (the script itself is tracked
+   externally on GitHub), along with a configuration example for Linux+systemd
+   [#1887]
+
  - Some fixes applied to Solaris/illumos packaging and SMF service support
    [#1554, #1564]
 

--- a/docs/FAQ.txt
+++ b/docs/FAQ.txt
@@ -262,6 +262,8 @@ warnings; try a value like 25 or 30.
 
 == Why do the client programs say 'Driver not connected' when I try to run them?
 
+*Answer 1*
+
 This means that upsd can't connect to the driver for some reason.
 Your ups.conf entry might be wrong, or the driver might not be
 running.  Maybe your state path is not configured properly.
@@ -278,6 +280,15 @@ you might wrap your NUT drivers into individual services instances
 with 'upsdrvsvcctl resync' and then manage those with commands like
 'upsdrvsvcctl stop' and 'upsdrvsvcctl start' (note that on other
 systems this tool may be not pre-installed via packaging).
+
+*Answer 2*
+
+Some USB UPS devices have unreliable USB to serial interfaces.
+In that case, it's advised to unplug / plug the device and try again.
+If that resolves the issue, you should consider resetting the USB hub the device
+is attached to before starting the nut driver, using usb_resetter script from 
+https://github.com/netinvent/usb_resetter
+See scripts/usb_resetter for more information.
 
 == Why don't the pathnames in your documentation match the package I installed?
 

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3116 utf-8
+personal_ws-1.1 en 3117 utf-8
 AAS
 ABI
 ACFAIL
@@ -2616,6 +2616,7 @@ repo
 reposurgeon
 repotec
 req
+resetter
 resistive
 resolv
 resync

--- a/scripts/usb_resetter/README.md
+++ b/scripts/usb_resetter/README.md
@@ -3,52 +3,90 @@ File: scripts/usb_resetter/README
 Date: 30 Mar 2023  
 Auth: Orsiris de Jong <ozy@netpower.fr> - NetInvent SASU  
 
-Some cheaper USB UPS have the same kind of unreliable USB to serial interface, being a Cypress Semiconductor USB to Serial / UNNO TECH USB to Serial.  
-Most of them use `blazer_usb` driver, and sometimes the driver can't start because it can't communicate with the UPS.
+Some cheaper USB UPS have the same kind of unreliable USB to serial interface,
+being a "Cypress Semiconductor USB to Serial" or "INNO TECH USB to Serial"
+(often with the `0665:5161` VendorID/ProductId seen in examples below).
+Most of them use `blazer_usb` or `nutdrv_qx` driver, and sometimes the
+driver can't start because it can't communicate with the UPS.
+
+NOTE: It is believed that in some cases the chip on UPS side can go into a
+sort of power-saving mode after some quiet time, so increasing the NUT driver
+polling frequency may help avoid that particular situation.
 
 Unplugging and plugging the USB port usually fixes this, but that's not convenient.
 
-That's where usb_resetter comes in handy. (see https://github.com/netinvent/usb_resetter for more info)  
-Grab a copy via pip with `pip install usb_resetter` or make a plain install with
+That's where `usb_resetter` comes in handy (see https://github.com/netinvent/usb_resetter
+project page for more info). You would need a Python environment to run it, and it
+is limited to Linux platforms as of this writing.
+
+Grab a copy via `pip` with `pip install usb_resetter`, or make a plain install
+directly from GitHub with e.g.:
+````
+:; curl -o /usr/local/bin/usb_resetter -L \
+    https://raw.githubusercontent.com/netinvent/usb_resetter/main/usb_resetter/usb_resetter.py \
+	&& chmod +x /usr/local/bin/usb_resetter
+````
+
+Once you have got the script, identify the USB UPS with:
 ```
-curl -o /usr/local/bin/usb_resetter -L https://raw.githubusercontent.com/netinvent/usb_resetter/main/usb_resetter/usb_resetter.py && chmod +x /usr/local/bin/usb_resetter
+:; usb_resetter --list
 ```
 
-Once you got the script, identify the USB UPS with
+In our case, we could see something like:
+````
+Found device 0665:5161 at /dev/bus/usb/001/002 Manufacturer=INNO TECH, Product=USB to Serial
+````
 
-```
-usb_resetter --list
-```
-
-In our case, we could find something like `Found device 0665:5161 at /dev/bus/usb/001/002 Manufacturer=INNO TECH, Product=USB to Serial`
-
-usb_restter can work in three different ways:
+The `usb_resetter` can work in three different ways:
 - Reset device itself
 - Reset the hub the device is attached to
 - Reset all USB controllers
 
-A simple USB device reset isn't sufficient for those UPS devices.
+A simple USB device reset typically isn't sufficient for those UPS devices,
+so we would need to reset the hub it's attached to.
 
-We'll need to reset the hub it's attached to.
-
-The command for doing so is:
+The command for doing that is:
 ```
-usb_resetter --reset-hub --device 0665:5161
+:; usb_resetter --reset-hub --device 0665:5161
 ```
 
-Bear in mind that this will reset other devices connected to the same hub. While this isn't a problem for a keyboard / mouse, it might be for a USB storage device.  
-On some hardware, each USB plug gets it's own hub. On others, two or more USB plus share one hub.
-A good practice would be to isolate the USB UPS on a hub without any other device in order to not interfere with other hardware, or associate it on a hub where a non critical device is already plugged.
+Bear in mind that this will reset other devices connected to the same hub.
+While this isn't a problem for a keyboard / mouse, it might be for a USB
+storage device. On some hardware, each USB plug gets it's own hub.
+On others, two or more USB plus share one hub.
+
+A good practice would be to isolate the USB UPS on a hub without any other
+device in order to not interfere with other hardware, or to associate it
+on a hub where a non-critical device is already plugged.
 
 Getting the hub your device is attached to can be done with:
-```
-usb_resetter --list-hubs --device 0665:5161
-```
+````
+:; usb_resetter --list-hubs --device 0665:5161
+````
 
-
-The easiest way to integrate with nut-driver is to modify the systemd service file with the following line:
-```
+The easiest way to integrate this activity with the `nut-driver` service
+is to modify the systemd service file (or ideally use a separate "drop-in"
+snippet file) with the following line:
+````
 ExecStartPre=/usr/local/bin/usb_reset.py --reset-hub --device 0665:5161
-```
+````
+
+An example modified `nut-driver.service` file which may be applicable to a
+NUT v2.7.4 or older release (modulo the paths and the particular VID:PID)
+is provided in this directory. Those releases packaged a single service unit
+for all the drivers you have, managed as one bundle.
+
+With current NUT releases (2.8.0+), a `nut-driver@.service` template is used
+to run each driver in a dedicated instance, declared manually or often by the
+`nut-driver-enumerator` script or service (tracking `ups.conf` sections).
+The added call to `usb_resetter` can then be a systemd drop-in file for that
+particular device named like `/etc/systemd/system/nut-driver@myups.service.d/dropin.conf`,
+so it does not impact others (unless they use the same USB hub).
 
 This way, every time the nut-driver service is reloaded, the USB UPS is reset.
+
+NOTE: In author's testing, there were no additional delays required after
+the `usb_resetter` before starting the driver. Generally however, keep in
+mind that after a (re-)connection, the OS re-discovers the device, then it
+gets owned by kernel, then the udev/upower/... subsystem hands it off to a
+NUT run-time account, and only then can it be opened by a driver.

--- a/scripts/usb_resetter/README.md
+++ b/scripts/usb_resetter/README.md
@@ -1,0 +1,47 @@
+Desc: Method for resetting unreliable USB UPS interfaces  
+File: scripts/usb_resetter/README  
+Date: 30 Mar 2023  
+Auth: Orsiris de Jong <ozy@netpower.fr> - NetInvent SASU  
+
+Some cheaper USB UPS have the same kind of unreliable USB to serial interface, being a Cypress Semiconductor USB to Serial / UNNO TECH USB to Serial.  
+Most of them use `blazer_usb` driver, and sometimes the driver can't start because it can't communicate with the UPS.
+
+Unplugging and plugging the USB port usually fixes this, but that's not convenient.
+
+That's where usb_resetter comes in handy. (see https://github.com/netinvent/usb_resetter for more info)  
+Grab a copy via pip with `pip install usb_resetter` or make a plain install with
+```
+curl -o /usr/local/bin/usb_resetter -L https://raw.githubusercontent.com/netinvent/usb_resetter/main/usb_resetter/usb_resetter.py && chmod +x /usr/local/bin/usb_resetter
+```
+
+Once you got the script, identify the USB UPS with
+
+```
+usb_resetter --list
+```
+
+In our case, we could find something like `Found device 0665:5161 at /dev/bus/usb/001/002 Manufacturer=INNO TECH, Product=USB to Serial`
+
+usb_restter can work in three different ways:
+- Reset device itself
+- Reset the hub the device is attached to
+- Reset all USB controllers
+
+A simple USB device reset isn't sufficient for those UPS devices.
+
+We'll need to reset the hub it's attached to.
+
+The command for doing so is:
+```
+usb_reset.py --reset-hub --device 0665:5161
+```
+
+Bear in mind that this will reset other devices connected to the same hub. While this isn't a problem for a keyboard / mouse, it might be for a USB storage device.  
+A good practice would be to isolate the USB UPS on a hub without any other device in order to not interfere with other hardware, or associate it on a hub where a non critical device is already plugged.
+
+The easiest way to integrate with nut-driver is to modify the systemd service file with the following line:
+```
+ExecStartPre=/usr/local/bin/usb_reset.py --reset-hub --device 0665:5161
+```
+
+This way, every time the nut-driver service is reloaded, the USB UPS is reset.

--- a/scripts/usb_resetter/README.md
+++ b/scripts/usb_resetter/README.md
@@ -9,18 +9,20 @@ being a "Cypress Semiconductor USB to Serial" or "INNO TECH USB to Serial"
 Most of them use `blazer_usb` or `nutdrv_qx` driver, and sometimes the
 driver can't start because it can't communicate with the UPS.
 
-NOTE: It is believed that in some cases the chip on UPS side can go into a
-sort of power-saving mode after some quiet time, so increasing the NUT driver
-polling frequency may help avoid that particular situation.
+NOTE: It is believed that in some cases the chip on UPS side can go into
+a sort of power-saving mode after some quiet time, so increasing the NUT
+driver polling frequency may help avoid that particular situation.
 
-Unplugging and plugging the USB port usually fixes this, but that's not convenient.
+Unplugging and plugging the USB port usually fixes this, but that's not
+convenient.
 
-That's where `usb_resetter` comes in handy (see https://github.com/netinvent/usb_resetter
-project page for more info). You would need a Python environment to run it, and it
-is limited to Linux platforms as of this writing.
+That's where `usb_resetter` comes in handy (see the
+https://github.com/netinvent/usb_resetter project page for more info).
+You would need a Python environment to run the script, and it is limited
+to Linux platforms as of this writing.
 
-Grab a copy via `pip` with `pip install usb_resetter`, or make a plain install
-directly from GitHub with e.g.:
+Grab a copy via `pip` with `pip install usb_resetter`, or make a plain
+install directly from GitHub with e.g.:
 ````
 :; curl -o /usr/local/bin/usb_resetter -L \
     https://raw.githubusercontent.com/netinvent/usb_resetter/main/usb_resetter/usb_resetter.py \
@@ -79,11 +81,13 @@ for all the drivers you have, managed as one bundle.
 With current NUT releases (2.8.0+), a `nut-driver@.service` template is used
 to run each driver in a dedicated instance, declared manually or often by the
 `nut-driver-enumerator` script or service (tracking `ups.conf` sections).
-The added call to `usb_resetter` can then be a systemd drop-in file for that
-particular device named like `/etc/systemd/system/nut-driver@myups.service.d/dropin.conf`,
+The added call to `usb_resetter` can then be a systemd drop-in file
+tailored for that particular device and named like
+`/etc/systemd/system/nut-driver@myups.service.d/dropin.conf`,
 so it does not impact others (unless they use the same USB hub).
 
-This way, every time the nut-driver service is reloaded, the USB UPS is reset.
+This way, every time the nut-driver service is restarted, the USB UPS link
+is reset.
 
 NOTE: In author's testing, there were no additional delays required after
 the `usb_resetter` before starting the driver. Generally however, keep in

--- a/scripts/usb_resetter/README.md
+++ b/scripts/usb_resetter/README.md
@@ -33,11 +33,18 @@ We'll need to reset the hub it's attached to.
 
 The command for doing so is:
 ```
-usb_reset.py --reset-hub --device 0665:5161
+usb_resetter --reset-hub --device 0665:5161
 ```
 
 Bear in mind that this will reset other devices connected to the same hub. While this isn't a problem for a keyboard / mouse, it might be for a USB storage device.  
+On some hardware, each USB plug gets it's own hub. On others, two or more USB plus share one hub.
 A good practice would be to isolate the USB UPS on a hub without any other device in order to not interfere with other hardware, or associate it on a hub where a non critical device is already plugged.
+
+Getting the hub your device is attached to can be done with:
+```
+usb_resetter --list-hubs --device 0665:5161
+```
+
 
 The easiest way to integrate with nut-driver is to modify the systemd service file with the following line:
 ```

--- a/scripts/usb_resetter/nut-driver.service
+++ b/scripts/usb_resetter/nut-driver.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Network UPS Tools - power device driver controller
+After=local-fs.target network.target
+StopWhenUnneeded=no
+
+
+[Service]
+ExecStartPre=-/usr/bin/systemd-tmpfiles --create /usr/lib/tmpfiles.d/nut-client.conf
+ExecStartPre=/usr/local/bin/usb_resetter --reset-hub --device 0665:5161
+ExecStart=/usr/sbin/upsdrvctl start
+ExecStop=/usr/sbin/upsdrvctl stop
+Type=forking
+Restart=on-failure
+RestartSec=5s


### PR DESCRIPTION
This PR adds documentation for a workaround solution for unreliable USB interfaces, as stated in #1688 
I use this on a couple of UPS for months now, without any major issue.

## General points

- [X] Described the changes in the PR submission or a separate issue, e.g.
  known published or discovered protocols, applicable hardware (expected
  compatible and actually tested/developed against), limitations, etc.

- [X] There may be multiple commits in the PR, aligned and commented with
  a functional change. Notably, coding style changes better belong in a
  separate PR, but certainly in a dedicated commit to simplify reviews
  of "real" changes in the other commits. Similarly for typo fixes in
  comments or text documents.

## General documentation updates

- [N/A] Updated `docs/acknowledgements.txt` (for vendor-backed device support)

- [N/A] Added or updated manual page information in `docs/man/*.txt` files
  and corresponding recipe lists in `docs/man/Makefile.am` for new pages

- [N/A] Passed `make spellcheck`, updated spell-checking dictionary in the
  `docs/nut.dict` file if needed (did not remove any words -- the `make`
  rule printout in case of changes suggests how to maintain it).