### PR TITLE
Driver `reload` - basic support

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -272,6 +272,12 @@ https://github.com/networkupstools/nut/milestone/8
    `nut-server.service` as `upsd.service`, and `nut-monitor.service` as
    `upsmon.service` (so simple `systemctl reload upsd` can work) [#1777]
 
+ - Implemented basic support for `ups.conf` reloading in NUT drivers,
+   currently limited to `SIGHUP` handling and with a goal of changing
+   `debug_min` setting for a running driver. As currently implemented,
+   would not fully benefit the drivers on systems managed by real-time
+   `nut-driver-enumerator` (it needs to be taught to play well) [#1903]
+
  - Recipes and `main.c` code were enhanced to produce a `libdummy_mockdrv.la`
    helper library during build (not intended to be installed nor distributed),
    in order to facilitate creation of test programs which behave like a driver

--- a/NEWS
+++ b/NEWS
@@ -278,6 +278,10 @@ https://github.com/networkupstools/nut/milestone/8
    would not fully benefit the drivers on systems managed by real-time
    `nut-driver-enumerator` (it needs to be taught to play well) [#1903]
 
+ - Drivers should now accept `SIGUSR1` to dump their current state information
+   (to `stdout` of the driver process, may be disconnected when background
+   mode is used) and move on -- this can help with troubleshooting [#1907]
+
  - Recipes and `main.c` code were enhanced to produce a `libdummy_mockdrv.la`
    helper library during build (not intended to be installed nor distributed),
    in order to facilitate creation of test programs which behave like a driver

--- a/common/common.c
+++ b/common/common.c
@@ -659,7 +659,7 @@ const char *xbasename(const char *file)
 	return p + 1;
 }
 
-#if HAVE_CLOCK_GETTIME && HAVE_CLOCK_MONOTONIC
+#if defined(HAVE_CLOCK_GETTIME) && defined(HAVE_CLOCK_MONOTONIC) && HAVE_CLOCK_GETTIME && HAVE_CLOCK_MONOTONIC
 /* From https://github.com/systemd/systemd/blob/main/src/basic/time-util.c
  * and  https://github.com/systemd/systemd/blob/main/src/basic/time-util.h
  */
@@ -703,7 +703,7 @@ static nsec_t timespec_load_nsec(const struct timespec *ts) {
 
 	return (nsec_t) ts->tv_sec * NSEC_PER_SEC + (nsec_t) ts->tv_nsec;
 }
-#endif
+#endif	/* HAVE_CLOCK_GETTIME && HAVE_CLOCK_MONOTONIC */
 
 /* Send (daemon) state-change notifications to an
  * external service management framework such as systemd
@@ -716,14 +716,14 @@ int upsnotify(upsnotify_state_t state, const char *fmt, ...)
 	char	msgbuf[LARGEBUF];
 	size_t	msglen = 0;
 
-#if HAVE_CLOCK_GETTIME && HAVE_CLOCK_MONOTONIC
+#if defined(HAVE_CLOCK_GETTIME) && defined(HAVE_CLOCK_MONOTONIC) && HAVE_CLOCK_GETTIME && HAVE_CLOCK_MONOTONIC
 	/* In current systemd, this is only used for RELOADING/READY after
 	 * a reload action for Type=notify-reload; for more details see
 	 * https://github.com/systemd/systemd/blob/main/src/core/service.c#L2618
 	 */
 	struct timespec monoclock_ts;
 	int got_monoclock = clock_gettime(CLOCK_MONOTONIC, &monoclock_ts);
-#endif
+#endif	/* HAVE_CLOCK_GETTIME && HAVE_CLOCK_MONOTONIC */
 
 	/* Prepare the message (if any) as a string */
 	msgbuf[0] = '\0';
@@ -777,7 +777,7 @@ int upsnotify(upsnotify_state_t state, const char *fmt, ...)
 #  ifdef HAVE_SD_NOTIFY
 		char monoclock_str[SMALLBUF];
 		monoclock_str[0] = '\0';
-#if HAVE_CLOCK_GETTIME && HAVE_CLOCK_MONOTONIC
+#   if defined(HAVE_CLOCK_GETTIME) && defined(HAVE_CLOCK_MONOTONIC) && HAVE_CLOCK_GETTIME && HAVE_CLOCK_MONOTONIC
 		if (got_monoclock == 0) {
 			usec_t monots = timespec_load(&monoclock_ts);
 			ret = snprintf(monoclock_str + 1, sizeof(monoclock_str) - 1, "MONOTONIC_USEC=%" PRI_USEC, monots);
@@ -790,7 +790,7 @@ int upsnotify(upsnotify_state_t state, const char *fmt, ...)
 				monoclock_str[0] = '\n';
 			}
 		}
-#endif
+#   endif	/* HAVE_CLOCK_GETTIME && HAVE_CLOCK_MONOTONIC */
 
 #   if ! DEBUG_SYSTEMD_WATCHDOG
 		if (state != NOTIFY_STATE_WATCHDOG || !upsnotify_reported_watchdog_systemd)

--- a/common/common.c
+++ b/common/common.c
@@ -19,6 +19,7 @@
 */
 
 #include "common.h"
+#include "timehead.h"
 
 #include <ctype.h>
 #ifndef WIN32
@@ -658,6 +659,52 @@ const char *xbasename(const char *file)
 	return p + 1;
 }
 
+#if HAVE_CLOCK_GETTIME && HAVE_CLOCK_MONOTONIC
+/* From https://github.com/systemd/systemd/blob/main/src/basic/time-util.c
+ * and  https://github.com/systemd/systemd/blob/main/src/basic/time-util.h
+ */
+typedef uint64_t usec_t;
+typedef uint64_t nsec_t;
+#define PRI_NSEC PRIu64
+#define PRI_USEC PRIu64
+
+#define USEC_INFINITY ((usec_t) UINT64_MAX)
+#define NSEC_INFINITY ((nsec_t) UINT64_MAX)
+
+#define MSEC_PER_SEC  1000ULL
+#define USEC_PER_SEC  ((usec_t) 1000000ULL)
+#define USEC_PER_MSEC ((usec_t) 1000ULL)
+#define NSEC_PER_SEC  ((nsec_t) 1000000000ULL)
+#define NSEC_PER_MSEC ((nsec_t) 1000000ULL)
+#define NSEC_PER_USEC ((nsec_t) 1000ULL)
+
+static usec_t timespec_load(const struct timespec *ts) {
+	assert(ts);
+
+	if (ts->tv_sec < 0 || ts->tv_nsec < 0)
+		return USEC_INFINITY;
+
+	if ((usec_t) ts->tv_sec > (UINT64_MAX - (ts->tv_nsec / NSEC_PER_USEC)) / USEC_PER_SEC)
+		return USEC_INFINITY;
+
+	return
+		(usec_t) ts->tv_sec * USEC_PER_SEC +
+		(usec_t) ts->tv_nsec / NSEC_PER_USEC;
+}
+
+static nsec_t timespec_load_nsec(const struct timespec *ts) {
+	assert(ts);
+
+	if (ts->tv_sec < 0 || ts->tv_nsec < 0)
+		return NSEC_INFINITY;
+
+	if ((nsec_t) ts->tv_sec >= (UINT64_MAX - ts->tv_nsec) / NSEC_PER_SEC)
+		return NSEC_INFINITY;
+
+	return (nsec_t) ts->tv_sec * NSEC_PER_SEC + (nsec_t) ts->tv_nsec;
+}
+#endif
+
 /* Send (daemon) state-change notifications to an
  * external service management framework such as systemd
  */
@@ -668,6 +715,15 @@ int upsnotify(upsnotify_state_t state, const char *fmt, ...)
 	char	buf[LARGEBUF];
 	char	msgbuf[LARGEBUF];
 	size_t	msglen = 0;
+
+#if HAVE_CLOCK_GETTIME && HAVE_CLOCK_MONOTONIC
+	/* In current systemd, this is only used for RELOADING/READY after
+	 * a reload action for Type=notify-reload; for more details see
+	 * https://github.com/systemd/systemd/blob/main/src/core/service.c#L2618
+	 */
+	struct timespec monoclock_ts;
+	int got_monoclock = clock_gettime(CLOCK_MONOTONIC, &monoclock_ts);
+#endif
 
 	/* Prepare the message (if any) as a string */
 	msgbuf[0] = '\0';
@@ -719,6 +775,22 @@ int upsnotify(upsnotify_state_t state, const char *fmt, ...)
 		upsnotify_reported_disabled_systemd = 1;
 	} else {
 #  ifdef HAVE_SD_NOTIFY
+		char monoclock_str[SMALLBUF];
+		monoclock_str[0] = '\0';
+#if HAVE_CLOCK_GETTIME && HAVE_CLOCK_MONOTONIC
+		if (got_monoclock == 0) {
+			usec_t monots = timespec_load(&monoclock_ts);
+			ret = snprintf(monoclock_str + 1, sizeof(monoclock_str) - 1, "MONOTONIC_USEC=%" PRI_USEC, monots);
+			if ((ret < 0) || (ret >= (int) sizeof(monoclock_str) - 1)) {
+				syslog(LOG_WARNING,
+					"%s (%s:%d): snprintf needed more than %" PRIuSIZE " bytes: %d",
+					__func__, __FILE__, __LINE__, sizeof(monoclock_str), ret);
+				msglen = 0;
+			} else {
+				monoclock_str[0] = '\n';
+			}
+		}
+#endif
 
 #   if ! DEBUG_SYSTEMD_WATCHDOG
 		if (state != NOTIFY_STATE_WATCHDOG || !upsnotify_reported_watchdog_systemd)
@@ -741,8 +813,9 @@ int upsnotify(upsnotify_state_t state, const char *fmt, ...)
 		switch (state) {
 			case NOTIFY_STATE_READY:
 				ret = snprintf(buf + msglen, sizeof(buf) - msglen,
-					"%sREADY=1",
-					msglen ? "\n" : "");
+					"%sREADY=1%s",
+					msglen ? "\n" : "",
+					monoclock_str);
 				break;
 
 			case NOTIFY_STATE_READY_WITH_PID:
@@ -751,9 +824,10 @@ int upsnotify(upsnotify_state_t state, const char *fmt, ...)
 					if (snprintf(pidbuf, sizeof(pidbuf), "%lu", (unsigned long) getpid())) {
 						ret = snprintf(buf + msglen, sizeof(buf) - msglen,
 							"%sREADY=1\n"
-							"MAINPID=%s",
+							"MAINPID=%s%s",
 							msglen ? "\n" : "",
-							pidbuf);
+							pidbuf,
+							monoclock_str);
 						upsdebugx(6, "%s: notifying systemd about MAINPID=%s",
 							__func__, pidbuf);
 						/* https://github.com/systemd/systemd/issues/25961
@@ -768,8 +842,9 @@ int upsnotify(upsnotify_state_t state, const char *fmt, ...)
 							"plain NOTIFY_STATE_READY",
 							__func__);
 						ret = snprintf(buf + msglen, sizeof(buf) - msglen,
-							"%sREADY=1",
-							msglen ? "\n" : "");
+							"%sREADY=1%s",
+							msglen ? "\n" : "",
+							monoclock_str);
 						/* TODO: Maybe revise/drop this tweak if
 						 * loggers other than systemd are used: */
 						state = NOTIFY_STATE_READY;
@@ -778,9 +853,10 @@ int upsnotify(upsnotify_state_t state, const char *fmt, ...)
 				break;
 
 			case NOTIFY_STATE_RELOADING:
-				ret = snprintf(buf + msglen, sizeof(buf) - msglen, "%s%s",
+				ret = snprintf(buf + msglen, sizeof(buf) - msglen, "%s%s%s",
 					msglen ? "\n" : "",
-					"RELOADING=1");
+					"RELOADING=1",
+					monoclock_str);
 				break;
 
 			case NOTIFY_STATE_STOPPING:

--- a/configure.ac
+++ b/configure.ac
@@ -839,10 +839,39 @@ if (p == NULL || *p != '\0') return 1])],
         [ac_cv_func_strptime=yes], [ac_cv_func_strptime=no]
     )])
 AS_IF([test x"${ac_cv_func_strptime}" = xyes],
-    [AC_DEFINE([HAVE_STRPTIME], 1, [defined if standard library has, and C standard allows, the strptime(s1,s2) method])],
+    [AC_DEFINE([HAVE_STRPTIME], 1, [defined if standard library has, and C standard allows, the strptime(s1,s2,tm) method])],
     [AC_MSG_WARN([Optional C library routine strptime not found; a fallback implementation will be built in])]
     )
 AM_CONDITIONAL([HAVE_STRPTIME], [test x"${ac_cv_func_strptime}" = "xyes"])
+
+AC_CACHE_CHECK([for clock_gettime(CLOCK_MONOTONIC,ts)],
+    [ac_cv_func_clock_gettime],
+    [AX_RUN_OR_LINK_IFELSE(
+        [AC_LANG_PROGRAM([$CODE_STRINGINCL
+#ifdef TIME_WITH_SYS_TIME
+# include <sys/time.h>
+# include <time.h>
+#else
+# ifdef HAVE_SYS_TIME_H
+#  include <sys/time.h>
+# else
+#  include <time.h>
+# endif
+#endif
+],
+            [struct timespec monoclock_ts;
+int got_monoclock = clock_gettime(CLOCK_MONOTONIC, &monoclock_ts);
+if (ts.tv_sec < 0 || ts.tv_nsec < 0) return 1])],
+        [ac_cv_func_clock_gettime=yes], [ac_cv_func_clock_gettime=no]
+    )])
+AS_IF([test x"${ac_cv_func_clock_gettime}" = xyes],
+    [AC_DEFINE([HAVE_CLOCK_GETTIME], 1, [defined if standard library has, and C standard allows, the clock_gettime(clkid,ts) method])
+     AC_DEFINE([HAVE_CLOCK_MONOTONIC], 1, [defined if standard library has, and C standard allows, the CLOCK_MONOTONIC macro or token])],
+    [AC_MSG_WARN([Optional C library routine clock_gettime not found; will not be used in notifications])]
+    )
+dnl Currently these two are the same for us:
+AM_CONDITIONAL([HAVE_CLOCK_GETTIME], [test x"${ac_cv_func_clock_gettime}" = "xyes"])
+AM_CONDITIONAL([HAVE_CLOCK_MONOTONIC], [test x"${ac_cv_func_clock_gettime}" = "xyes"])
 
 AC_CACHE_CHECK([for strnlen(s1,s2,tm)],
     [ac_cv_func_strnlen],

--- a/configure.ac
+++ b/configure.ac
@@ -3230,7 +3230,7 @@ Description=temp
 ExecStart=/bin/true
 Type=notify
 EOF
-	if "$SYSTEMD_ANALYZE_PROGRAM" verify "$myFILE" ; then
+	if "$SYSTEMD_ANALYZE_PROGRAM" verify "$myFILE" 2>/dev/null >/dev/null ; then
 		SYSTEMD_SUPPORTS_DAEMON_TYPE_NOTIFY=yes
 	fi
 	rm -f "$myFILE"
@@ -3248,7 +3248,7 @@ Description=temp
 ExecStart=/bin/true
 Type=notify-reload
 EOF
-	if "$SYSTEMD_ANALYZE_PROGRAM" verify "$myFILE" ; then
+	if "$SYSTEMD_ANALYZE_PROGRAM" verify "$myFILE" 2>/dev/null >/dev/null ; then
 		SYSTEMD_SUPPORTS_DAEMON_TYPE_NOTIFY_RELOAD=yes
 	fi
 	rm -f "$myFILE"

--- a/configure.ac
+++ b/configure.ac
@@ -3230,7 +3230,9 @@ Description=temp
 ExecStart=/bin/true
 Type=notify
 EOF
-	if "$SYSTEMD_ANALYZE_PROGRAM" verify "$myFILE" 2>/dev/null >/dev/null ; then
+	if myOUT="`"$SYSTEMD_ANALYZE_PROGRAM" verify "$myFILE" 2>&1`" \
+	&& ! (echo "$myOUT" | grep "Failed to parse service type, ignoring") \
+	; then
 		SYSTEMD_SUPPORTS_DAEMON_TYPE_NOTIFY=yes
 	fi
 	rm -f "$myFILE"
@@ -3248,7 +3250,9 @@ Description=temp
 ExecStart=/bin/true
 Type=notify-reload
 EOF
-	if "$SYSTEMD_ANALYZE_PROGRAM" verify "$myFILE" 2>/dev/null >/dev/null ; then
+	if myOUT="`"$SYSTEMD_ANALYZE_PROGRAM" verify "$myFILE" 2>&1`" \
+	&& ! (echo "$myOUT" | grep "Failed to parse service type, ignoring") \
+	; then
 		SYSTEMD_SUPPORTS_DAEMON_TYPE_NOTIFY_RELOAD=yes
 	fi
 	rm -f "$myFILE"

--- a/configure.ac
+++ b/configure.ac
@@ -869,7 +869,8 @@ AS_IF([test x"${ac_cv_func_clock_gettime}" = xyes],
      AC_DEFINE([HAVE_CLOCK_MONOTONIC], 1, [defined if standard library has, and C standard allows, the CLOCK_MONOTONIC macro or token])],
     [AC_MSG_WARN([Optional C library routine clock_gettime not found; will not be used in notifications])]
     )
-dnl Currently these two are the same for us:
+dnl Currently these two are the same for us; note also fallback support for
+dnl older autoconf in SYSTEMD_SUPPORTS_DAEMON_TYPE_NOTIFY_RELOAD way below:
 AM_CONDITIONAL([HAVE_CLOCK_GETTIME], [test x"${ac_cv_func_clock_gettime}" = "xyes"])
 AM_CONDITIONAL([HAVE_CLOCK_MONOTONIC], [test x"${ac_cv_func_clock_gettime}" = "xyes"])
 
@@ -3270,7 +3271,10 @@ AS_IF([test x"${with_libsystemd}" = xyes && test x"${SYSTEMD_SUPPORTS_DAEMON_TYP
 	SYSTEMD_DAEMON_ARGS_DRIVER=""
 	SYSTEMD_DAEMON_TYPE_DRIVER="notify"
 	AS_IF([test x"${SYSTEMD_SUPPORTS_DAEMON_TYPE_NOTIFY_RELOAD}" = xyes], [
-		AM_COND_IF([HAVE_CLOCK_GETTIME], [AM_COND_IF([HAVE_CLOCK_MONOTONIC], [SYSTEMD_DAEMON_TYPE_DRIVER="notify-reload"])])
+		dnl Macro supported since aclocal-1.11:
+		m4_ifdef([AM_COND_IF],
+		[AM_COND_IF([HAVE_CLOCK_GETTIME], [AM_COND_IF([HAVE_CLOCK_MONOTONIC], [SYSTEMD_DAEMON_TYPE_DRIVER="notify-reload"])])],
+		[AS_IF([test x"${ac_cv_func_clock_gettime}" = "xyes"], [SYSTEMD_DAEMON_TYPE_DRIVER="notify-reload"])])
 		])
 	dnl Calling shell, upsdrvctl, driver, and then it forks... ugh!
 	dnl https://github.com/systemd/systemd/issues/25961

--- a/configure.ac
+++ b/configure.ac
@@ -3216,6 +3216,27 @@ AS_CASE(["${nut_with_libsystemd}"],
 	])
 AC_MSG_RESULT(${with_libsystemd})
 
+AC_PATH_PROG([SYSTEMD_ANALYZE_PROGRAM], [systemd-analyze], [/usr/bin/systemd-analyze])
+
+dnl Relevant since 2023: https://github.com/systemd/systemd/pull/25916
+SYSTEMD_SUPPORTS_DAEMON_TYPE_NOTIFY_RELOAD=no
+AS_IF([test -x "$SYSTEMD_ANALYZE_PROGRAM"], [
+	AC_MSG_CHECKING([if your systemd version supports Type=notify-reload])
+	myFILE="`mktemp systemd-analyze-XXXXXX.service`"
+	cat > "$myFILE" << EOF
+[Unit]
+Description=temp
+[Service]
+ExecStart=/bin/true
+Type=notify-reload
+EOF
+	if "$SYSTEMD_ANALYZE_PROGRAM" verify "$myFILE" ; then
+		SYSTEMD_SUPPORTS_DAEMON_TYPE_NOTIFY_RELOAD=yes
+	fi
+	rm -f "$myFILE"
+	AC_MSG_RESULT([${SYSTEMD_SUPPORTS_DAEMON_TYPE_NOTIFY_RELOAD}])
+	])
+
 AS_IF([test x"${with_libsystemd}" = xyes], [
 	dnl Built with sd_notify support
 	dnl Note: `upsd -FF` both runs without forking and leaves a PID file, as
@@ -3226,6 +3247,9 @@ AS_IF([test x"${with_libsystemd}" = xyes], [
 	SYSTEMD_DAEMON_TYPE_UPSMON="notify"
 	SYSTEMD_DAEMON_ARGS_DRIVER=""
 	SYSTEMD_DAEMON_TYPE_DRIVER="notify"
+	AS_IF([test x"${SYSTEMD_SUPPORTS_DAEMON_TYPE_NOTIFY_RELOAD}" = xyes], [
+		AM_COND_IF([HAVE_CLOCK_GETTIME], [AM_COND_IF([HAVE_CLOCK_MONOTONIC], [SYSTEMD_DAEMON_TYPE_DRIVER="notify-reload"])])
+		])
 	dnl Calling shell, upsdrvctl, driver, and then it forks... ugh!
 	dnl https://github.com/systemd/systemd/issues/25961
 	dnl FIXME: if NotifyAccess=cgroup appears, use it (consult SYSTEMD_VERSION)

--- a/configure.ac
+++ b/configure.ac
@@ -3224,9 +3224,9 @@ AS_IF([test -x "$SYSTEMD_ANALYZE_PROGRAM"], [
 	AC_MSG_CHECKING([if your systemd version supports Type=notify])
 	myFILE="`mktemp systemd-analyze-XXXXXX.service`"
 	cat > "$myFILE" << EOF
-[Unit]
+@<:@Unit@:>@
 Description=temp
-[Service]
+@<:@Service@:>@
 ExecStart=/bin/true
 Type=notify
 EOF
@@ -3242,9 +3242,9 @@ AS_IF([test -x "$SYSTEMD_ANALYZE_PROGRAM"], [
 	AC_MSG_CHECKING([if your systemd version supports Type=notify-reload])
 	myFILE="`mktemp systemd-analyze-XXXXXX.service`"
 	cat > "$myFILE" << EOF
-[Unit]
+@<:@Unit@:>@
 Description=temp
-[Service]
+@<:@Service@:>@
 ExecStart=/bin/true
 Type=notify-reload
 EOF

--- a/configure.ac
+++ b/configure.ac
@@ -3219,6 +3219,24 @@ AC_MSG_RESULT(${with_libsystemd})
 AC_PATH_PROG([SYSTEMD_ANALYZE_PROGRAM], [systemd-analyze], [/usr/bin/systemd-analyze])
 
 dnl Relevant since 2023: https://github.com/systemd/systemd/pull/25916
+SYSTEMD_SUPPORTS_DAEMON_TYPE_NOTIFY=no
+AS_IF([test -x "$SYSTEMD_ANALYZE_PROGRAM"], [
+	AC_MSG_CHECKING([if your systemd version supports Type=notify])
+	myFILE="`mktemp systemd-analyze-XXXXXX.service`"
+	cat > "$myFILE" << EOF
+[Unit]
+Description=temp
+[Service]
+ExecStart=/bin/true
+Type=notify
+EOF
+	if "$SYSTEMD_ANALYZE_PROGRAM" verify "$myFILE" ; then
+		SYSTEMD_SUPPORTS_DAEMON_TYPE_NOTIFY=yes
+	fi
+	rm -f "$myFILE"
+	AC_MSG_RESULT([${SYSTEMD_SUPPORTS_DAEMON_TYPE_NOTIFY}])
+	])
+
 SYSTEMD_SUPPORTS_DAEMON_TYPE_NOTIFY_RELOAD=no
 AS_IF([test -x "$SYSTEMD_ANALYZE_PROGRAM"], [
 	AC_MSG_CHECKING([if your systemd version supports Type=notify-reload])
@@ -3237,7 +3255,7 @@ EOF
 	AC_MSG_RESULT([${SYSTEMD_SUPPORTS_DAEMON_TYPE_NOTIFY_RELOAD}])
 	])
 
-AS_IF([test x"${with_libsystemd}" = xyes], [
+AS_IF([test x"${with_libsystemd}" = xyes && test x"${SYSTEMD_SUPPORTS_DAEMON_TYPE_NOTIFY}" = xyes], [
 	dnl Built with sd_notify support
 	dnl Note: `upsd -FF` both runs without forking and leaves a PID file, as
 	dnl needed for `upsd -c reload` in legacy scripts and old habits to work:

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -1309,14 +1309,19 @@ int main(int argc, char **argv)
 	 * or not just dumping data (for discovery) */
 	/* This avoids case where ie /var is unmounted already */
 #ifndef WIN32
-	if ((!do_forceshutdown) && (!dump_data) && (chdir(dflt_statepath())))
-		fatal_with_errno(EXIT_FAILURE, "Can't chdir to %s", dflt_statepath());
+	if ((!do_forceshutdown) && (!dump_data)) {
+		if (chdir(dflt_statepath()))
+			fatal_with_errno(EXIT_FAILURE, "Can't chdir to %s", dflt_statepath());
 
-	/* Setup signals to communicate with driver once backgrounded. */
+		/* Setup signals to communicate with driver which is destined for a long run. */
+		setup_signals();
+	}
+
+	/* Setup PID file to receive signals to communicate with this driver
+	 * instance once backgrounded, and to stop a competing older instance.
+	 */
 	if ((background_flag != 0) && (!do_forceshutdown)) {
 		char	buffer[SMALLBUF];
-
-		setup_signals();
 
 		snprintf(buffer, sizeof(buffer), "%s/%s-%s.pid", altpidpath(), progname, upsname);
 

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -330,10 +330,13 @@ int testvar_reloadable(const char *var, const char *val, int vartype)
 					upsdebugx((reload_flag ? (tmp->reloadable ? 1 : 0) : 1),
 						"%s: setting '%s' exists and differs: "
 						"new type bitmask %d vs. %d, "
-						"new value '%s' vs. '%s'",
+						"new value '%s' vs. '%s'%s",
 						__func__, var,
 						vartype, tmp->vartype,
-						val, tmp->val);
+						val, tmp->val,
+						((!reload_flag || tmp->reloadable) ? "" :
+							" (driver restart is needed to apply)")
+						);
 					return (
 						(!reload_flag)	/* For initial config reads, legacy code trusted what it saw */
 						|| tmp->reloadable	/* set in addvar*() */
@@ -388,9 +391,12 @@ int testval_reloadable(const char *var, const char *oldval, const char *newval, 
 		 * can not change this modified value */
 		upsdebugx((reload_flag ? (reloadable ? 1 : 0) : 1),
 			"%s: setting '%s' exists and differs: "
-			"new value '%s' vs. '%s'",
+			"new value '%s' vs. '%s'%s",
 			__func__, var,
-			newval, oldval);
+			newval, oldval,
+			((!reload_flag || reloadable) ? "" :
+				" (driver restart is needed to apply)")
+			);
 		/* For initial config reads, legacy code trusted what it saw */
 		return ((!reload_flag) || reloadable);
 	}

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -1045,6 +1045,7 @@ static void exit_cleanup(void)
 
 void set_exit_flag(int sig)
 {
+	upsdebugx(1, "%s: raising exit flag due to signal %d", __func__, sig);
 	exit_flag = sig;
 }
 
@@ -1052,7 +1053,7 @@ void set_exit_flag(int sig)
 /* TODO: Equivalent for WIN32 - see SIGCMD_RELOAD in upd and upsmon */
 static void set_reload_flag(int sig)
 {
-	NUT_UNUSED_VARIABLE(sig);
+	upsdebugx(1, "%s: raising reload flag due to signal %d", __func__, sig);
 	reload_flag = 1;
 }
 

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -299,8 +299,8 @@ int testvar(const char *var)
 	return 0;	/* not found */
 }
 
-/* callback from driver - create the table for -x/conf entries */
-void addvar(int vartype, const char *name, const char *desc)
+/* implement callback from driver - create the table for -x/conf entries */
+static void do_addvar(int vartype, const char *name, const char *desc, int reloadable)
 {
 	vartab_t	*tmp, *last;
 
@@ -318,12 +318,25 @@ void addvar(int vartype, const char *name, const char *desc)
 	tmp->val = NULL;
 	tmp->desc = xstrdup(desc);
 	tmp->found = 0;
+	tmp->reloadable = reloadable;
 	tmp->next = NULL;
 
 	if (last)
 		last->next = tmp;
 	else
 		vartab_h = tmp;
+}
+
+/* public callback from driver - create the table for -x/conf entries for reloadable values */
+void addvar_reloadable(int vartype, const char *name, const char *desc)
+{
+	do_addvar(vartype, name, desc, 1);
+}
+
+/* public callback from driver - create the table for -x/conf entries for set-once values */
+void addvar(int vartype, const char *name, const char *desc)
+{
+	do_addvar(vartype, name, desc, 0);
 }
 
 /* handle -x / ups.conf config details that are for this part of the code */

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -319,10 +319,18 @@ int testvar_reloadable(const char *var, const char *val, int vartype)
 	 * away before a reload on the fly). Might load new config info into a
 	 * separate list and then compare missing points?..
 	 */
+	upsdebugx(6, "%s: searching for var=%s, vartype=%d, reload_flag=%d",
+		__func__, NUT_STRARG(var), vartype, reload_flag);
 
 	while (tmp) {
 		if (!strcasecmp(tmp->var, var)) {
 			/* variable name is known */
+			upsdebugx(6, "%s: found var=%s, val='%s' => '%s', vartype=%d => %d, found=%d, reloadable=%d, reload_flag=%d",
+				__func__, NUT_STRARG(var),
+				NUT_STRARG(tmp->val), NUT_STRARG(val),
+				tmp->vartype, vartype,
+				tmp->found, tmp->reloadable, reload_flag);
+
 			if (val && tmp->val) {
 				/* a value is already known by name
 				 * and bitmask for VAR_FLAG/VAR_VALUE matches
@@ -394,6 +402,10 @@ int testvar_reloadable(const char *var, const char *val, int vartype)
  */
 int testval_reloadable(const char *var, const char *oldval, const char *newval, int reloadable)
 {
+	upsdebugx(6, "%s: var=%s, oldval=%s, newval=%s, reloadable=%d, reload_flag=%d",
+		__func__, NUT_STRARG(var), NUT_STRARG(oldval), NUT_STRARG(newval),
+		reloadable, reload_flag);
+
 	/* Nothing saved yet? Okay to store new value! */
 	if (!oldval)
 		return 1;
@@ -438,6 +450,10 @@ int testval_reloadable(const char *var, const char *oldval, const char *newval, 
  */
 int testinfo_reloadable(const char *var, const char *infoname, const char *newval, int reloadable)
 {
+	upsdebugx(6, "%s: var=%s, infoname=%s, newval=%s, reloadable=%d, reload_flag=%d",
+		__func__, NUT_STRARG(var), NUT_STRARG(infoname), NUT_STRARG(newval),
+		reloadable, reload_flag);
+
 	/* Keep legacy behavior: not reloading, trust the initial config */
 	if (!reload_flag || !infoname)
 		return 1;
@@ -770,8 +786,12 @@ void do_upsconf_args(char *confupsname, char *var, char *val)
 {
 	char	tmp[SMALLBUF];
 
+	upsdebugx(5, "%s: confupsname=%s, var=%s, val=%s",
+		__func__, NUT_STRARG(confupsname), NUT_STRARG(var), NUT_STRARG(val));
+
 	/* handle global declarations */
 	if (!confupsname) {
+		upsdebugx(5, "%s: call do_global_args()", __func__);
 		do_global_args(var, val);
 		return;
 	}
@@ -782,11 +802,15 @@ void do_upsconf_args(char *confupsname, char *var, char *val)
 
 	upsname_found = 1;
 
+	upsdebugx(5, "%s: call main_arg()", __func__);
 	if (main_arg(var, val))
 		return;
+	upsdebugx(5, "%s: not a main_arg()", __func__);
 
 	/* flags (no =) now get passed to the driver-level stuff */
 	if (!val) {
+		upsdebugx(5, "%s: process as flag", __func__);
+
 		/* also store this, but it's a bit different */
 		snprintf(tmp, sizeof(tmp), "driver.flag.%s", var);
 
@@ -838,6 +862,7 @@ void do_upsconf_args(char *confupsname, char *var, char *val)
 	/* allow reloading if defined and permitted via addvar()
 	 * or not defined there (FIXME?)
 	 */
+	upsdebugx(5, "%s: process as value", __func__);
 	if (testvar_reloadable(var, val, VAR_VALUE) > 0) {
 		storeval(var, val);
 	}

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -340,7 +340,7 @@ int testvar_reloadable(const char *var, const char *val, int vartype)
 				/* a value is already known by name
 				 * and bitmask for VAR_FLAG/VAR_VALUE matches
 				 */
-				if (vartype && tmp->vartype) {
+				if ((vartype & tmp->vartype) && !strcasecmp(tmp->val, val)) {
 					if ((tmp->vartype & VAR_FLAG) && val == NULL) {
 						if (reload_flag) {
 							upsdebugx(1, "%s: setting '%s' "
@@ -356,15 +356,15 @@ int testvar_reloadable(const char *var, const char *val, int vartype)
 						);
 						goto finish;
 					}
-					if (!strcasecmp(tmp->val, val)) {
-						if (reload_flag) {
-							upsdebugx(1, "%s: setting '%s' "
-								"exists and is unmodified",
-								__func__, var);
-						}
-						verdict = -1;	/* no-op for caller */
-						goto finish;
+
+					if (reload_flag) {
+						upsdebugx(1, "%s: setting '%s' "
+							"exists and is unmodified",
+							__func__, var);
 					}
+
+					verdict = -1;	/* no-op for caller */
+					goto finish;
 				} else {
 					/* warn loudly if we are reloading and
 					 * can not change this modified value */

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -810,6 +810,27 @@ void do_upsconf_args(char *confupsname, char *var, char *val)
 	}
 }
 
+static void assign_debug_level(void) {
+	/* CLI debug level can not be smaller than debug_min specified
+	 * in ups.conf, and value specified for a driver config section
+	 * overrides the global one. Note that non-zero debug_min does
+	 * not impact foreground running mode.
+	 */
+	int nut_debug_level_upsconf = -1;
+
+	if (nut_debug_level_global >= 0 && nut_debug_level_driver >= 0) {
+		nut_debug_level_upsconf = nut_debug_level_driver;
+	} else {
+		if (nut_debug_level_global >= 0) nut_debug_level_upsconf = nut_debug_level_global;
+		if (nut_debug_level_driver >= 0) nut_debug_level_upsconf = nut_debug_level_driver;
+	}
+
+	if (nut_debug_level_upsconf > nut_debug_level)
+		nut_debug_level = nut_debug_level_upsconf;
+
+	upsdebugx(1, "debug level is '%d'", nut_debug_level);
+}
+
 #ifndef DRIVERS_MAIN_WITHOUT_MAIN
 /* split -x foo=bar into 'foo' and 'bar' */
 static void splitxarg(char *inbuf)
@@ -1166,23 +1187,7 @@ int main(int argc, char **argv)
 			"Try -h for help.");
 	}
 
-	/* CLI debug level can not be smaller than debug_min specified
-	 * in ups.conf, and value specified for a driver config section
-	 * overrides the global one. Note that non-zero debug_min does
-	 * not impact foreground running mode.
-	 */
-	{
-		int nut_debug_level_upsconf = -1 ;
-		if ( nut_debug_level_global >= 0 && nut_debug_level_driver >= 0 ) {
-			nut_debug_level_upsconf = nut_debug_level_driver;
-		} else {
-			if ( nut_debug_level_global >= 0 ) nut_debug_level_upsconf = nut_debug_level_global;
-			if ( nut_debug_level_driver >= 0 ) nut_debug_level_upsconf = nut_debug_level_driver;
-		}
-		if ( nut_debug_level_upsconf > nut_debug_level )
-			nut_debug_level = nut_debug_level_upsconf;
-	}
-	upsdebugx(1, "debug level is '%d'", nut_debug_level);
+	assign_debug_level();
 
 	new_uid = get_user_pwent(user);
 

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -533,7 +533,19 @@ static int main_arg(char *var, char *val)
 	}
 
 	/* allow per-driver overrides of the global setting */
-	if (!strcmp(var, "synchronous")) {
+	if (!strcmp(var, "pollinterval")) {
+		int ipv = atoi(val);
+		if (ipv > 0) {
+			poll_interval = (time_t)ipv;
+		} else {
+			fatalx(EXIT_FAILURE, "Error: UPS [%s]: invalid pollinterval: %d",
+				confupsname, ipv);
+		}
+		return 1;	/* handled */
+	}
+
+	/* allow per-driver overrides of the global setting */
+	if (!strcmp(var, "synchronous") {
 		if (!strcmp(val, "yes"))
 			do_synchronous=1;
 		else
@@ -695,18 +707,6 @@ void do_upsconf_args(char *confupsname, char *var, char *val)
 		if (strcmp(val, progname) != 0) {
 			fatalx(EXIT_FAILURE, "Error: UPS [%s] is for driver %s, but I'm %s!\n",
 				confupsname, val, progname);
-		}
-		return;
-	}
-
-	/* allow per-driver overrides of the global setting */
-	if (!strcmp(var, "pollinterval")) {
-		int ipv = atoi(val);
-		if (ipv > 0) {
-			poll_interval = (time_t)ipv;
-		} else {
-			fatalx(EXIT_FAILURE, "Error: UPS [%s]: invalid pollinterval: %d",
-				confupsname, ipv);
 		}
 		return;
 	}

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -911,6 +911,7 @@ void do_upsconf_args(char *confupsname, char *var, char *val)
 	}
 }
 
+#ifndef DRIVERS_MAIN_WITHOUT_MAIN
 static void assign_debug_level(void) {
 	/* CLI debug level can not be smaller than debug_min specified
 	 * in ups.conf, and value specified for a driver config section
@@ -964,7 +965,6 @@ static void assign_debug_level(void) {
 	upsdebugx(1, "debug level is '%d'", nut_debug_level);
 }
 
-#ifndef DRIVERS_MAIN_WITHOUT_MAIN
 /* split -x foo=bar into 'foo' and 'bar' */
 static void splitxarg(char *inbuf)
 {

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -1189,6 +1189,16 @@ static void set_reload_flag(int sig)
 	}
 }
 
+static void handle_dstate_dump(int sig) {
+	/* no set_dump_flag() here, make it instant */
+	upsdebugx(1, "%s: starting driver state dump for [%s] due to signal %d",
+		__func__, upsname, sig);
+	/* FIXME: upslogx() instead of printf() when backgrounded, if STDOUT got closed? */
+	dstate_dump();
+	upsdebugx(1, "%s: finished driver state dump for [%s]",
+		__func__, upsname);
+}
+
 # ifndef DRIVERS_MAIN_WITHOUT_MAIN
 static
 # endif /* DRIVERS_MAIN_WITHOUT_MAIN */
@@ -1220,6 +1230,10 @@ void setup_signals(void)
 	sa.sa_handler = set_reload_flag;
 	sigaction(SIGHUP, &sa, NULL);
 	sigaction(SIGUSR1, &sa, NULL);
+
+	/* handle run-time data dump (may be limited to non-backgrounding lifetimes) */
+	sa.sa_handler = handle_dstate_dump;
+	sigaction(SIGUSR2, &sa, NULL);
 }
 #endif /* WIN32*/
 

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -920,12 +920,13 @@ static void assign_debug_level(void) {
 	int nut_debug_level_upsconf = -1;
 
 	if (nut_debug_level_global >= 0 && nut_debug_level_driver >= 0) {
+		/* Use nearest-defined fit */
 		nut_debug_level_upsconf = nut_debug_level_driver;
 		if (reload_flag) {
 			upslogx(LOG_INFO,
 				"Applying debug_min=%d from ups.conf"
-				" driver section (overriding global)",
-				nut_debug_level_upsconf);
+				" driver section (overriding global %d)",
+				nut_debug_level_upsconf, nut_debug_level_global);
 		}
 	} else {
 		if (nut_debug_level_global >= 0) {
@@ -944,8 +945,9 @@ static void assign_debug_level(void) {
 		}
 	}
 
-	if (reload_flag && nut_debug_level_upsconf == -1) {
-		/* DEBUG_MIN is absent or commented-away in ups.conf */
+	if (reload_flag && nut_debug_level_upsconf <= nut_debug_level_args) {
+		/* DEBUG_MIN is absent or commented-away in ups.conf,
+		 * or is smaller than te CLI arg '-D' count */
 		upslogx(LOG_INFO,
 			"Applying debug level %d from "
 			"original command line arguments",

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -308,7 +308,7 @@ int testvar(const char *var)
  * be done and that is not a failure (e.g. value not modified so we do not
  * care if we may change it or not).
  */
-static int testvar_reloadable(const char *var, const char *val, int vartype)
+int testvar_reloadable(const char *var, const char *val, int vartype)
 {
 	vartab_t	*tmp = vartab_h;
 
@@ -363,7 +363,7 @@ static int testvar_reloadable(const char *var, const char *val, int vartype)
  * Returns "-1" if nothing needs to be done and that is not a failure
  * (e.g. value not modified so we do not care if we may change it or not).
  */
-static int testval_reloadable(const char *var, const char *oldval, const char *newval, int reloadable)
+int testval_reloadable(const char *var, const char *oldval, const char *newval, int reloadable)
 {
 	/* Nothing saved yet? Okay to store new value! */
 	if (!oldval)
@@ -398,20 +398,20 @@ static int testval_reloadable(const char *var, const char *oldval, const char *n
 
 /* Similar to testvar_reloadable() above which is for addvar*() defined
  * entries, but for less streamlined stuff defined right here in main.c.
- * See if <arg> (by name saved in dstate) can be (re-)loaded now: either
- * it is reloadable by parameter definition, or no value has been saved
- * into it yet (<oldval> is NULL).
+ * See if <var> (by <arg> name saved in dstate) can be (re-)loaded now:
+ * either it is reloadable by parameter definition, or no value has been
+ * saved into it yet (<oldval> is NULL).
  * Returns "-1" if nothing needs to be done and that is not a failure
  * (e.g. value not modified so we do not care if we may change it or not).
  */
-static int testarg_reloadable(const char *var, const char *arg, const char *newval, int reloadable)
+int testinfo_reloadable(const char *var, const char *infoname, const char *newval, int reloadable)
 {
 	/* Keep legacy behavior: not reloading, trust the initial config */
-	if (!reload_flag || !arg)
+	if (!reload_flag || !infoname)
 		return 1;
 
 	/* Only if reloading, suffer the overhead of lookups: */
-	return testval_reloadable(var, dstate_getinfo(arg), newval, reloadable);
+	return testval_reloadable(var, dstate_getinfo(infoname), newval, reloadable);
 }
 
 /* implement callback from driver - create the table for -x/conf entries */

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -99,7 +99,9 @@ static int background_flag = -1;
  * value less than that would not have effect, can only
  * have more).
  */
+#ifndef DRIVERS_MAIN_WITHOUT_MAIN
 static int nut_debug_level_args = -1;
+#endif
 static int nut_debug_level_global = -1;
 static int nut_debug_level_driver = -1;
 

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -539,12 +539,16 @@ static int main_arg(char *var, char *val)
 		var ? var : "<null>", /* null should not happen... but... */
 		val ? val : "<null>");
 
-	/* !reload_flag quietly forbids changing this flag on the fly, as
+	/* !reload_flag simply forbids changing this flag on the fly, as
 	 * it would have no effect anyway without a (serial) reconnection
 	 */
-	if (!strcmp(var, "nolock") && !reload_flag) {
-		do_lock_port = 0;
-		dstate_setinfo("driver.flag.nolock", "enabled");
+	if (!strcmp(var, "nolock")) {
+		if (reload_flag) {
+			upsdebugx(6, "%s: SKIP: flag var='%s' can not be reloaded", __func__, var);
+		} else {
+			do_lock_port = 0;
+			dstate_setinfo("driver.flag.nolock", "enabled");
+		}
 		return 1;	/* handled */
 	}
 
@@ -552,8 +556,12 @@ static int main_arg(char *var, char *val)
 	 * out that the flag line was commented away or deleted -- there is
 	 * no setting value to flip in configs here
 	 */
-	if (!strcmp(var, "ignorelb") && !reload_flag) {
-		dstate_setinfo("driver.flag.ignorelb", "enabled");
+	if (!strcmp(var, "ignorelb")) {
+		if (reload_flag) {
+			upsdebugx(6, "%s: SKIP: flag var='%s' currently can not be reloaded", __func__, var);
+		} else {
+			dstate_setinfo("driver.flag.ignorelb", "enabled");
+		}
 		return 1;	/* handled */
 	}
 

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -991,6 +991,42 @@ static void assign_debug_level(void) {
 	upsdebugx(1, "debug level is '%d'", nut_debug_level);
 }
 
+static void handle_reload_flag(void) {
+	if (!reload_flag || exit_flag)
+		return;
+
+	upslogx(LOG_INFO, "Handling requested live reload of NUT driver configuration");
+	dstate_setinfo("driver.state", "reloading");
+	upsnotify(NOTIFY_STATE_RELOADING, NULL);
+
+	/* If commented away or deleted in config, debug_min
+	 * should "disappear" for us (a CLI argument, if any,
+	 * would still be honoured); if it is (re-)defined in
+	 * config, then it gets considered.
+	 */
+	nut_debug_level_global = -1;
+	nut_debug_level_driver = -1;
+
+	/* Call actual config reloading activity */
+	read_upsconf();
+	/* TODO: Callbacks in drivers to re-parse configs?
+	 * Currently this reloadability relies on either
+	 * explicit reload_flag aware code called from the
+	 * read_upsconf() method, or on drivers continuously
+	 * reading dstate_getinfo() and not caching once
+	 * their C variables.
+	 */
+
+	/* Re-mix currently known debug verbosity desires */
+	assign_debug_level();
+
+	/* Wrap it up */
+	reload_flag = 0;
+	dstate_setinfo("driver.state", "quiet");
+	upsnotify(NOTIFY_STATE_READY, NULL);
+	upslogx(LOG_INFO, "Completed requested live reload of NUT driver configuration");
+}
+
 /* split -x foo=bar into 'foo' and 'bar' */
 static void splitxarg(char *inbuf)
 {
@@ -1679,41 +1715,11 @@ int main(int argc, char **argv)
 		else {
 			while (!dstate_poll_fds(timeout, extrafd) && !exit_flag) {
 				/* repeat until time is up or extrafd has data */
+				handle_reload_flag();
 			}
 		}
 
-		if (reload_flag && !exit_flag) {
-			upslogx(LOG_INFO, "Handling requested live reload of NUT driver configuration");
-			dstate_setinfo("driver.state", "reloading");
-			upsnotify(NOTIFY_STATE_RELOADING, NULL);
-
-			/* If commented away or deleted in config, debug_min
-			 * should "disappear" for us (a CLI argument, if any,
-			 * would still be honoured); if it is (re-)defined in
-			 * config, then it gets considered.
-			 */
-			nut_debug_level_global = -1;
-			nut_debug_level_driver = -1;
-
-			/* Call actual config reloading activity */
-			read_upsconf();
-			/* TODO: Callbacks in drivers to re-parse configs?
-			 * Currently this reloadability relies on either
-			 * explicit reload_flag aware code called from the
-			 * read_upsconf() method, or on drivers continuously
-			 * reading dstate_getinfo() and not caching once
-			 * their C variables.
-			 */
-
-			/* Re-mix currently known debug verbosity desires */
-			assign_debug_level();
-
-			/* Wrap it up */
-			reload_flag = 0;
-			dstate_setinfo("driver.state", "quiet");
-			upsnotify(NOTIFY_STATE_READY, NULL);
-			upslogx(LOG_INFO, "Completed requested live reload of NUT driver configuration");
-		}
+		handle_reload_flag();
 	}
 
 	/* if we get here, the exit flag was set by a signal handler */

--- a/drivers/main.h
+++ b/drivers/main.h
@@ -45,6 +45,7 @@ typedef struct vartab_s {
 	char	*val;		/* right side of = 			 */
 	char	*desc;		/* 40 character description for -h text	 */
 	int	found;		/* set once encountered, for testvar()	 */
+	int	reloadable;	/* driver reload may redefine this value */
 	struct vartab_s	*next;
 } vartab_t;
 
@@ -56,6 +57,7 @@ typedef struct vartab_s {
 
 /* callback from driver - create the table for future -x entries */
 void addvar(int vartype, const char *name, const char *desc);
+void addvar_reloadable(int vartype, const char *name, const char *desc);
 
 /* subdriver description structure */
 typedef struct upsdrv_info_s {

--- a/drivers/main.h
+++ b/drivers/main.h
@@ -59,6 +59,30 @@ typedef struct vartab_s {
 void addvar(int vartype, const char *name, const char *desc);
 void addvar_reloadable(int vartype, const char *name, const char *desc);
 
+/* Several helpers for driver configuration reloading follow:
+ * * testval_reloadable() checks if we are currently reloading (or initially
+ *   loading) the configuration, and if strings oldval==newval or not,
+ *   e.g. for values saved straight into driver source code variables;
+ * * testinfo_reloadable() checks this for a name saved as dstate_setinfo();
+ * * testvar_reloadable() checks in vartab_t list as maintained by addvar().
+ *
+ * All these methods check if value can be (re-)loaded now:
+ * * either it is reloadable by argument or vartab_t definition,
+ * * or no value has been saved into it yet (e.g. <oldval> is NULL),
+ * * or we are handling initial loading and keep legacy behavior of trusting
+ *   the inputs (e.g. some values may be defined as defaults in global section
+ *   and tuned in a driver section).
+ *
+ * Return values:
+ * * -1 -- if nothing needs to be done and that is not a failure
+ *   (e.g. value not modified so we do not care if we may change it or not);
+ * * 0 -- if can not modify this value (but it did change in config);
+ * * 1 -- if we can and should apply a new (maybe initial) value.
+ */
+int testvar_reloadable(const char *var, const char *val, int vartype);
+int testval_reloadable(const char *var, const char *oldval, const char *newval, int reloadable);
+int testinfo_reloadable(const char *var, const char *infoname, const char *newval, int reloadable);
+
 /* subdriver description structure */
 typedef struct upsdrv_info_s {
 	const char	*name;		/* driver full name, for banner printing, ... */

--- a/scripts/Solaris/nut-driver.xml.in
+++ b/scripts/Solaris/nut-driver.xml.in
@@ -2,14 +2,14 @@
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <!--
 #
-# Copyright 2016 - 2022 Jim Klimov
+# Copyright 2016 - 2023 Jim Klimov
 # Template manifest for instantiated NUT drivers
 #
 -->
 
 <service_bundle type='manifest' name='nut-driver'>
 
-	<service name='system/power/nut-driver' type='service' version='2'>
+	<service name='system/power/nut-driver' type='service' version='3'>
 
 	<!--
 	  Wait for all local and usr filesystem to be mounted - project is
@@ -92,6 +92,18 @@
 		type='method'
 		name='stop'
 		exec='/sbin/sh -c &apos;NUTDEV="`@NUT_LIBEXECDIR@/nut-driver-enumerator.sh --get-device-for-service %i`" &amp;&amp; [ -n "$NUTDEV" ] || { echo "FATAL: Could not find a NUT device section for service unit %i" >&amp;2 ; exit 1 ; } ; @SBINDIR@/upsdrvctl %m "$NUTDEV"&apos;'
+		timeout_seconds='60' />
+
+	<!-- Note: reload support is currently limited to configuration options
+	     which allow it. For others a restart would be needed but is not
+	     automated at the moment. Eventually maybe nut-driver-enumerator
+	     would detect and handle this, for example, or some other solution.
+	     See https://github.com/networkupstools/nut/issues/1903
+	-->
+		<exec_method
+		type='method'
+		name='refresh'
+		exec=':kill -HUP'
 		timeout_seconds='60' />
 
 		<property_group name='startd' type='framework'>

--- a/scripts/systemd/nut-driver@.service.in
+++ b/scripts/systemd/nut-driver@.service.in
@@ -51,7 +51,7 @@ ExecStop=/bin/sh -c 'NUTDEV="`@NUT_LIBEXECDIR@/nut-driver-enumerator.sh --get-de
 StartLimitInterval=0
 Restart=always
 # Protract the "hold-off" interval, so if the device connection is
-# lost, the driver does not reapidly restart and fail too many times,
+# lost, the driver does not rapidly restart and fail too many times,
 # and then systemd would keep the unit failed without further retries.
 # Notably, this helps start "dummy-ups" drivers retranslating local
 # devices (so getting a chicken-and-egg problem for driver-upsd-driver

--- a/scripts/systemd/nut-driver@.service.in
+++ b/scripts/systemd/nut-driver@.service.in
@@ -45,6 +45,7 @@ EnvironmentFile=-@CONFPATH@/nut.conf
 SyslogIdentifier=%N
 ExecStartPre=-@SYSTEMD_TMPFILES_PROGRAM@ --create @systemdtmpfilesdir@/nut-common-tmpfiles.conf
 ExecStart=/bin/sh -c 'NUTDEV="`@NUT_LIBEXECDIR@/nut-driver-enumerator.sh --get-device-for-service %i`" && [ -n "$NUTDEV" ] || { echo "FATAL: Could not find a NUT device section for service unit %i" >&2 ; exit 1 ; } ; @SBINDIR@/upsdrvctl @SYSTEMD_DAEMON_ARGS_DRIVER@ start "$NUTDEV"'
+ExecReload=/bin/kill -HUP $MAINPID
 ExecStop=/bin/sh -c 'NUTDEV="`@NUT_LIBEXECDIR@/nut-driver-enumerator.sh --get-device-for-service %i`" && [ -n "$NUTDEV" ] || { echo "FATAL: Could not find a NUT device section for service unit %i" >&2 ; exit 1 ; } ; @SBINDIR@/upsdrvctl stop "$NUTDEV"'
 # Restart really always, do not stop trying:
 StartLimitInterval=0

--- a/server/conf.c
+++ b/server/conf.c
@@ -230,8 +230,15 @@ static int parse_upsd_conf_args(size_t numargs, char **arg)
 
 	/* STATEPATH <dir> */
 	if (!strcmp(arg[0], "STATEPATH")) {
+		const char *sp = getenv("NUT_STATEPATH");
+		if (sp) {
+			upslogx(LOG_WARNING,
+				"Ignoring STATEPATH='%s' from configuration file, "
+				"in favor of NUT_STATEPATH='%s' environment variable",
+				NUT_STRARG(arg[1]), NUT_STRARG(sp));
+		}
 		free(statepath);
-		statepath = xstrdup(arg[1]);
+		statepath = xstrdup(sp ? sp : arg[1]);
 		return 1;
 	}
 

--- a/server/sstate.c
+++ b/server/sstate.c
@@ -201,6 +201,7 @@ TYPE_FD sstate_connect(upstype_t *ups)
 	ssize_t	ret;
 	struct sockaddr_un	sa;
 
+	upsdebugx(2, "%s: preparing UNIX socket %s", __func__, NUT_STRARG(ups->fn));
 	check_unix_socket_filename(ups->fn);
 
 	memset(&sa, '\0', sizeof(sa));
@@ -219,6 +220,8 @@ TYPE_FD sstate_connect(upstype_t *ups)
 	if (ret < 0) {
 		time_t	now;
 
+		upsdebugx(2, "%s: failed to connect() UNIX socket %s (%s)",
+			__func__, NUT_STRARG(ups->fn), sa.sun_path);
 		close(fd);
 
 		/* rate-limit complaints - don't spam the syslog */
@@ -263,11 +266,14 @@ TYPE_FD sstate_connect(upstype_t *ups)
 	const char	*dumpcmd = "DUMPALL\n";
 	BOOL  result = FALSE;
 
+	upsdebugx(2, "%s: preparing Windows pipe %s", __func__, NUT_STRARG(ups->fn));
 	snprintf(pipename, sizeof(pipename), "\\\\.\\pipe\\%s", ups->fn);
 
 	result = WaitNamedPipe(pipename,NMPWAIT_USE_DEFAULT_WAIT);
 
 	if (result == FALSE) {
+		upsdebugx(2, "%s: failed to WaitNamedPipe(%s)",
+			__func__, pipename);
 		return ERROR_FD;
 	}
 

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -1879,6 +1879,8 @@ int main(int argc, char **argv)
 #ifndef WIN32
 	if (chdir(statepath)) {
 		fatal_with_errno(EXIT_FAILURE, "Can't chdir to %s", statepath);
+	} else {
+		upsdebugx(1, "chdired into statepath %s for driver sockets", statepath);
 	}
 #endif
 


### PR DESCRIPTION
Partially addresses #1903 by adding on-the-fly reloading config concept to NUT drivers (e.g. to change `debug_min` settings) via SIGHUP, and enhances #1590 by adding systemd `Type=notify-reload` support (introduced there just recently, in 2023 - https://github.com/systemd/systemd/pull/25916).

Also addresses a few other issues:
Closes: #1907
Closes: #1908

Note that in practical setups with systemd `nut-driver-enumerator.service/.path`, it may detect change of `ups.conf` and cause restart of the driver instead of reload. This would be tackled later. As currently presented, the feature is of practical use for developers (running drivers from a build workspace), and on systems managing the driver population without NDE.

CC/FYI : @clepple @aquette @bigon @svarshavchik 