### PR TITLE
Revise use of `VAR_SENSITIVE` and other minor issues in new GPIO drivers

### DIFF
--- a/docs/man/generic_gpio.txt
+++ b/docs/man/generic_gpio.txt
@@ -82,7 +82,7 @@ Here is an example of GPIO driver configuration in *ups.conf* file:
 [CyberPower12v]
   driver = GENERIC_GPIO
   port = gpiochip0
-  description = "Modem and DNS server UPS"
+  desc = "Modem and DNS server UPS"
   mfr = CyberPower
   model = "CyberShield CSN27U12V"
   rules = "OL=^0;OB=0;LB=3;RB=1;DISCHRG=0&^6;BYPASS=6;"

--- a/drivers/generic_gpio_common.c
+++ b/drivers/generic_gpio_common.c
@@ -460,9 +460,6 @@ void upsdrv_initinfo(void)
 	if(testvar("model")) {
 		dstate_setinfo("device.model", "%s", getval("model"));
 	}
-	if(testvar("description")) {
-		dstate_setinfo("device.description", "%s", getval("description"));
-	}
 }
 
 void upsdrv_updateinfo(void)
@@ -492,11 +489,9 @@ void upsdrv_help(void)
 /* list flags and values that you want to receive via -x */
 void upsdrv_makevartable(void)
 {
-	addvar(VAR_SENSITIVE, "mfr", "UPS manufacturer");
-	addvar(VAR_SENSITIVE, "model", "UPS model");
+	addvar(VAR_VALUE, "mfr", "Override UPS manufacturer name");
+	addvar(VAR_VALUE, "model", "Override UPS model name");
 	addvar(VAR_VALUE, "rules", "Line rules to produce status strings");
-	addvar(VAR_SENSITIVE, "description", "Device description");
-	addvar(VAR_SENSITIVE, "desc", "Device description");
 }
 
 void upsdrv_initups(void)

--- a/drivers/generic_gpio_common.c
+++ b/drivers/generic_gpio_common.c
@@ -173,13 +173,12 @@ void get_ups_rules(struct gpioups_t *upsfdlocal, unsigned char *rulesString) {
 	int	i, j, k;
 	int	tranformationDelta;
 
-	upsdebugx(LOG_DEBUG, "rules = [%s]", rulesString);
+	upsdebugx(4, "rules = [%s]", rulesString);
 	/* state machine to process rules definition */
 	while((lexType=get_rule_lex(rulesString, &startPos, &endPos)) > 0 && lexStatus >= 0) {
 		memset(lexBuff, 0, sizeof(lexBuff));
 		strncpy(lexBuff, (char *)(rulesString+startPos), endPos-startPos);
-		upsdebugx(
-			LOG_DEBUG,
+		upsdebugx(4,
 			"rules start %d, end %d, lexType %d, lex [%s]",
 			startPos,
 			endPos,
@@ -256,17 +255,15 @@ void get_ups_rules(struct gpioups_t *upsfdlocal, unsigned char *rulesString) {
 		fatalx(LOG_ERR, "Line processing rule error at position %d", startPos);
 
 	/* debug printout for extracted rules */
-	upsdebugx(LOG_DEBUG, "rules count [%d]", upsfdlocal->rulesCount);
+	upsdebugx(4, "rules count [%d]", upsfdlocal->rulesCount);
 	for(i = 0; i < upsfdlocal->rulesCount; i++) {
-		upsdebugx(
-			LOG_DEBUG,
+		upsdebugx(4,
 			"rule state name [%s], subcount %d",
 			upsfdlocal->rules[i]->stateName,
 			upsfdlocal->rules[i]->subCount
 		);
 		for(j = 0; j<upsfdlocal->rules[i]->subCount; j++) {
-			upsdebugx(
-				LOG_DEBUG,
+			upsdebugx(4,
 				"[%s] substate %d [%d]",
 				upsfdlocal->rules[i]->stateName,
 				j,
@@ -299,9 +296,9 @@ void get_ups_rules(struct gpioups_t *upsfdlocal, unsigned char *rulesString) {
 		}
 	}
 
-	upsdebugx(LOG_DEBUG, "UPS line count = %d", upsfdlocal->upsLinesCount);
+	upsdebugx(4, "UPS line count = %d", upsfdlocal->upsLinesCount);
 	for(i = 0; i < upsfdlocal->upsLinesCount; i++) {
-		upsdebugx(LOG_DEBUG, "UPS line%d number %d", i, upsfdlocal->upsLines[i]);
+		upsdebugx(4, "UPS line%d number %d", i, upsfdlocal->upsLines[i]);
 	}
 
 	/* transform lines to indexes for easier state calculation */
@@ -324,17 +321,15 @@ void get_ups_rules(struct gpioups_t *upsfdlocal, unsigned char *rulesString) {
 	}
 
 	/* debug printout of transformed lines numbers */
-	upsdebugx(LOG_DEBUG, "rules count [%d] translated", upsfdlocal->rulesCount);
+	upsdebugx(4, "rules count [%d] translated", upsfdlocal->rulesCount);
 	for(i = 0; i < upsfdlocal->rulesCount; i++) {
-		upsdebugx(
-			LOG_DEBUG,
+		upsdebugx(4,
 			"rule state name [%s], subcount %d translated",
 			upsfdlocal->rules[i]->stateName,
 			upsfdlocal->rules[i]->subCount
 		);
 		for(j = 0; j < upsfdlocal->rules[i]->subCount; j++) {
-			upsdebugx(
-				LOG_DEBUG,
+			upsdebugx(4,
 				"[%s] substate %d [%d]",
 				upsfdlocal->rules[i]->stateName, j,
 				upsfdlocal->rules[i]->cRules[j]

--- a/drivers/generic_gpio_libgpiod.c
+++ b/drivers/generic_gpio_libgpiod.c
@@ -71,7 +71,7 @@ static void reserve_lines_libgpiod(struct gpioups_t *gpioupsfd, int inner);
  */
 static void reserve_lines_libgpiod(struct gpioups_t *gpioupsfdlocal, int inner) {
 	struct libgpiod_data_t *libgpiod_data = (struct libgpiod_data_t *)(gpioupsfdlocal->lib_data);
-	upsdebugx(LOG_DEBUG, "reserve_lines_libgpiod runOptions 0x%x, inner %d", gpioupsfdlocal->runOptions, inner);
+	upsdebugx(5, "reserve_lines_libgpiod runOptions 0x%x, inner %d", gpioupsfdlocal->runOptions, inner);
 
 	if(((gpioupsfdlocal->runOptions&ROPT_REQRES) != 0) == inner) {
 		struct gpiod_line_request_config config;
@@ -79,10 +79,10 @@ static void reserve_lines_libgpiod(struct gpioups_t *gpioupsfdlocal, int inner) 
 		config.consumer=upsdrv_info.name;
 		if(gpioupsfdlocal->runOptions&ROPT_EVMODE) {
 			config.request_type = GPIOD_LINE_REQUEST_EVENT_BOTH_EDGES;
-			upsdebugx(LOG_DEBUG, "reserve_lines_libgpiod GPIOD_LINE_REQUEST_EVENT_BOTH_EDGES");
+			upsdebugx(5, "reserve_lines_libgpiod GPIOD_LINE_REQUEST_EVENT_BOTH_EDGES");
 		} else {
 			config.request_type = GPIOD_LINE_REQUEST_DIRECTION_INPUT;
-			upsdebugx(LOG_DEBUG, "reserve_lines_libgpiod GPIOD_LINE_REQUEST_DIRECTION_INPUT");
+			upsdebugx(5, "reserve_lines_libgpiod GPIOD_LINE_REQUEST_DIRECTION_INPUT");
 		}
 		config.flags = 0;	/*	GPIOD_LINE_REQUEST_FLAG_OPEN_DRAIN;	*/
 		gpioRc = gpiod_line_request_bulk(&libgpiod_data->gpioLines, &config, NULL);
@@ -91,8 +91,7 @@ static void reserve_lines_libgpiod(struct gpioups_t *gpioupsfdlocal, int inner) 
 				LOG_ERR,
 				"GPIO gpiod_line_request_bulk call failed, check for other applications that may have reserved GPIO lines"
 			);
-		upsdebugx(
-			LOG_DEBUG,
+		upsdebugx(5,
 			"GPIO gpiod_line_request_bulk with type %d return code %d",
 			config.request_type,
 			gpioRc
@@ -143,7 +142,7 @@ void gpio_open(struct gpioups_t *gpioupsfdlocal) {
 				"GPIO line reservation (gpiod_chip_get_lines call) failed with code %d, check for possible issue in rules parameter",
 				gpioRc
 			);
-		upsdebugx(LOG_DEBUG, "GPIO gpiod_chip_get_lines return code %d", gpioRc);
+		upsdebugx(5, "GPIO gpiod_chip_get_lines return code %d", gpioRc);
 		reserve_lines_libgpiod(gpioupsfdlocal, 0);
 	}
 }
@@ -177,8 +176,7 @@ void gpio_get_lines_states(struct gpioups_t *gpioupsfdlocal) {
 		struct timespec timeoutLong = {1,0};
 		struct gpiod_line_event event;
 		int monRes;
-		upsdebugx(
-			LOG_DEBUG,
+		upsdebugx(5,
 			"gpio_get_lines_states_libgpiod initial %d, timeout %ld",
 			gpioupsfdlocal->initial,
 			timeoutLong.tv_sec
@@ -188,8 +186,7 @@ void gpio_get_lines_states(struct gpioups_t *gpioupsfdlocal) {
 		} else {
 			gpioupsfdlocal->initial = 1;
 		}
-		upsdebugx(
-			LOG_DEBUG,
+		upsdebugx(5,
 			"gpio_get_lines_states_libgpiod initial %d, timeout %ld",
 			gpioupsfdlocal->initial,
 			timeoutLong.tv_sec
@@ -200,8 +197,7 @@ void gpio_get_lines_states(struct gpioups_t *gpioupsfdlocal) {
 			&timeoutLong,
 			&libgpiod_data->gpioEventLines
 		);
-		upsdebugx(
-			LOG_DEBUG,
+		upsdebugx(5,
 			"gpiod_line_event_wait_bulk completed with %d return code and timeout %ld s",
 			monRes,
 			timeoutLong.tv_sec
@@ -217,8 +213,7 @@ void gpio_get_lines_states(struct gpioups_t *gpioupsfdlocal) {
 				int eventRc=gpiod_line_event_read(eLine, &event);
 				unsigned int lineOffset = gpiod_line_offset(eLine);
 				event.event_type=0;
-				upsdebugx(
-					LOG_DEBUG,
+				upsdebugx(5,
 					"Event read return code %d and event type %d for line %d",
 					eventRc,
 					event.event_type,
@@ -238,15 +233,13 @@ void gpio_get_lines_states(struct gpioups_t *gpioupsfdlocal) {
 	if (gpioRc < 0)
 		fatal_with_errno(LOG_ERR, "GPIO line status read call failed");
 
-	upsdebugx(
-		LOG_DEBUG,
+	upsdebugx(5,
 		"GPIO gpiod_line_get_value_bulk completed with %d return code, status values:",
 		gpioRc
 	);
 
 	for(i=0; i < gpioupsfdlocal->upsLinesCount; i++) {
-		upsdebugx(
-			LOG_DEBUG,
+		upsdebugx(5,
 			"Line%d state = %d",
 			i,
 			gpioupsfdlocal->upsLinesStates[i]

--- a/tests/generic_gpio_utest.c
+++ b/tests/generic_gpio_utest.c
@@ -287,12 +287,11 @@ int main(int argc, char **argv) {
 						addvar(VAR_VALUE, "rules", "");
 						storeval("rules", rules);
 					}
-					addvar(VAR_SENSITIVE, "mfr", MFR);
+					addvar(VAR_VALUE, "mfr", MFR);
 					storeval("mfr", MFR);
-					addvar(VAR_SENSITIVE, "model", MODEL);
+					addvar(VAR_VALUE, "model", MODEL);
 					storeval("model", MODEL);
-					addvar(VAR_SENSITIVE, "description", DESCRIPTION);
-					storeval("description", DESCRIPTION);
+					dstate_setinfo("device.description", DESCRIPTION);
 					upsdrv_initups();
 					if(!strcmp(subType, "initinfo")) {
 						upsdrv_makevartable();


### PR DESCRIPTION
Closes: #1892

CC @modrisb to check if removed `addvar()` cases do practically impact your setup?

TBH, I'd drop the "mfr" and "model" addvars too (in favor of `default.mfr` or `override.model` syntax), but these at least make sense from the point of view that we probably can not get those strings via "protocol" from the device itself, right? Or can we?

At least there is precedent for those in a few other drivers, where they are dubbed "overrides" for probably something the driver can find from the device, but not always or in a buggy fashion.