### PR TITLE
Optionally install `sockdebug`, provide a man page

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -212,6 +212,9 @@ cppcheck:
 	@echo "CPPCHECK analysis not available since 'cppcheck' was not found."
 endif !HAVE_CPPCHECK
 
+sockdebug:
+	cd $(builddir)/server && $(MAKE) $(AM_MAKEFLAGS) sockdebug$(EXEEXT)
+
 # ----------------------------------------------------------------------
 # Automatically generate the ChangeLog from Git logs:
 MAINTAINERCLEANFILES += ChangeLog

--- a/NEWS
+++ b/NEWS
@@ -277,6 +277,10 @@ https://github.com/networkupstools/nut/milestone/8
    to toggle whether they want to receive `send_to_all()` updates from a
    driver, or only answers to requests they send [#1914]
 
+ - Added support for `make sockdebug` for easier developer access to the tool;
+   also if `configure --with-dev` is in effect, it would now be installed to
+   the configured `libexec` location. A man page was also added. [#1936]
+
  - Numerous daemons (`upsd`, `upsmon`, drivers, `upsdrvctl`, `upssched`)
    which accepted `-D` option for debug setting previously, now can also
    honour a `NUT_DEBUG_LEVEL=NUM` environment variable if no `-D` arguments

--- a/UPGRADING
+++ b/UPGRADING
@@ -65,6 +65,10 @@ Changes from 2.8.0 to 2.8.1
   the packaging recipes may use NUT source-code facilities and package just
   symlinks as relevant for each distro separately [#1462, #1504]
 
+- Added support for `make sockdebug` for easier developer access to the tool;
+  also if `configure --with-dev` is in effect, it would now be installed to
+  the configured `libexec` location. A man page was also added. [#1936]
+
 - NUT software-only drivers (dummy-ups, clone, clone-outlet) separated from
   serial drivers in respective Makefile and configure script options - this
   may impact packaging decisions on some distributions going forward [#1446]

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -190,6 +190,7 @@ SRC_DEV_PAGES = \
 	nutscan_init.txt \
 	nutscan_get_serial_ports_list.txt \
 	libupsclient-config.txt \
+	sockdebug.txt \
 	skel.txt
 
 if WITH_MANS
@@ -314,10 +315,14 @@ upscli_sendline_timeout.3: upscli_sendline.3
 
 MAN1_DEV_PAGES = \
 	libupsclient-config.1
+
+MAN8_DEV_PAGES = \
+	sockdebug.8
 endif
 
 if WITH_DEV
 man3_MANS = $(MAN3_DEV_PAGES)
+man8_MANS = $(MAN8_DEV_PAGES)
 
 if !WITH_PKG_CONFIG
 man1_MANS = $(MAN1_DEV_PAGES)
@@ -371,6 +376,7 @@ HTML_DEV_MANS = \
 	nutscan_get_serial_ports_list.html \
 	nutscan_init.html \
 	libupsclient-config.html \
+	sockdebug.html \
 	skel.html
 
 
@@ -693,6 +699,7 @@ MAN_MANS += \
 	$(MAN8_CGI_PAGES) \
 	$(MAN1_DEV_PAGES) \
 	$(MAN3_DEV_PAGES) \
+	$(MAN8_DEV_PAGES) \
 	$(MAN_SERIAL_PAGES) \
 	$(MAN_SNMP_PAGES) \
 	$(MAN_USB_LIBUSB_PAGES) \

--- a/docs/man/sockdebug.txt
+++ b/docs/man/sockdebug.txt
@@ -10,17 +10,13 @@ with a NUT driver using the socket protocol
 SYNOPSIS
 --------
 
-POSIX system builds:
-*sockdebug* statefilepath
+*sockdebug* socketname
 
-For example:
-	sockdebug /var/state/ups/dummy-ups-UPS1
-
-WIN32 builds:
-*sockdebug* pipename
-
-For example:
+For example (WIN32 and POSIX builds):
 	sockdebug.exe dummy-ups-UPS1
+
+For example (POSIX-compliant systems using an alternate state path):
+	sockdebug /var/state/ups/dummy-ups-UPS1
 
 DESCRIPTION
 -----------
@@ -49,11 +45,12 @@ OPTIONS
 *libupsclient-config* accepts the following options:
 
 *socketname*::
-Either a full path (in POSIX builds) or the base name of device socket/pipe,
-comprised of a `drivername-devicename` tuple, e.g. `dummy-ups-UPS1` for a
-`dummy-ups` driver instance handling an `UPS1` device configuration (which
-in turn may originate in the `ups.conf` file or be dynamically constructed
-for tests by calling the driver program with a `-s TMP` option).
+Either a full path (in POSIX builds) or the base name of device socket/pipe
+(on all platforms), comprised of a `drivername-devicename` tuple, e.g. some
+`dummy-ups-UPS1` for a `dummy-ups` driver instance handling an `UPS1` device
+configuration (which in turn may originate in the `ups.conf` file or be
+dynamically constructed for tests by calling the driver program with a
+`-s TMP` CLI option).
 
 AUTHORS
 -------

--- a/docs/man/sockdebug.txt
+++ b/docs/man/sockdebug.txt
@@ -1,0 +1,71 @@
+SOCKDEBUG(8)
+============
+
+NAME
+----
+
+sockdebug - simple developer/troubleshooting aid utility to communicate
+with a NUT driver using the socket protocol
+
+SYNOPSIS
+--------
+
+POSIX system builds:
+*sockdebug* statefilepath
+
+For example:
+	sockdebug /var/state/ups/dummy-ups-UPS1
+
+WIN32 builds:
+*sockdebug* pipename
+
+For example:
+	sockdebug.exe dummy-ups-UPS1
+
+DESCRIPTION
+-----------
+
+*sockdebug* is a tool built when NUT `configure --with-dev` is enabled.
+It may alternatively be built by calling `make sockdebug` in the root
+of the build workspace. Actual source files used depend on the platform.
+
+It is used to connect to a NUT driver using the socket protocol on an
+Unix socket or Windows pipe, similarly to how the linkman:upsd[8] data
+server talks to the locally running drivers in order to represent them
+on the network further using the common NUT protocol of the Network UPS
+Tools project, or how driver programs can communicate to their already
+running instances to implement commands like live `reload-or-error`.
+
+This tool allows a developer or troubleshooter to watch the broadcast
+updates emitted by the driver, as well as to issue unicast commands and
+receive replies (during an interactive investigation session, you may
+want to command `NOBROADCAST` first).
+
+For more details see the `docs/sock-protocol.txt` file in NUT sources.
+
+OPTIONS
+-------
+
+*libupsclient-config* accepts the following options:
+
+*socketname*::
+Either a full path (in POSIX builds) or the base name of device socket/pipe,
+comprised of a `drivername-devicename` tuple, e.g. `dummy-ups-UPS1` for a
+`dummy-ups` driver instance handling an `UPS1` device configuration (which
+in turn may originate in the `ups.conf` file or be dynamically constructed
+for tests by calling the driver program with a `-s TMP` option).
+
+AUTHORS
+-------
+
+This manual page was written by Jim Klimov <jimklimov+nut@gmail.com>.
+
+SEE ALSO
+--------
+
+linkman:upsd[8]
+
+Internet resources:
+~~~~~~~~~~~~~~~~~~~
+
+The NUT (Network UPS Tools) home page: http://www.networkupstools.org/

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3127 utf-8
+personal_ws-1.1 en 3133 utf-8
 AAS
 ABI
 ACFAIL
@@ -1775,6 +1775,7 @@ devctl
 devd
 devel
 deviceGetClients
+devicename
 devscan
 dfl
 dhcp
@@ -2322,6 +2323,7 @@ mozilla
 msec
 msi
 msvcrt
+msys
 multi
 multicommands
 multilib
@@ -2506,6 +2508,7 @@ pigz
 pijuice
 pinout
 pinouts
+pipename
 pkg
 pkgconf
 pkgconfig
@@ -2749,6 +2752,7 @@ snprintfcat
 snr
 socat
 sockdebug
+socketname
 socomec
 solaris
 solis
@@ -2774,6 +2778,7 @@ stan
 startIP
 startdelay
 startup
+statefilepath
 statepath
 stayoff
 stderr
@@ -2935,6 +2940,7 @@ unconfigured
 undefine
 undervoltage
 unescaped
+unicast
 uninstall
 uninterruptible
 uniq

--- a/docs/sock-protocol.txt
+++ b/docs/sock-protocol.txt
@@ -20,15 +20,12 @@ to the socket (you may want to enable `NOBROADCAST` mode soon), e.g.
 	socat - UNIX-CONNECT:/var/state/ups/dummy-ups-UPS1
 
 For more insight, NUT provides an optional tool of its own (not built
-by default), the `sockdebug`:
+by default): the `sockdebug` which is built when `configure --with-dev`
+is in effect, or can be requested from the root directory of the build
+workspace:
 
-	# POSIX
-	(cd server && make sockdebug) && \
-	./server/sockdebug /var/state/ups/dummy-ups-UPS1
-
-	# WIN32
-	(cd server && make sockdebug.exe) && \
-	./server/sockdebug.exe dummy-ups-UPS1
+	make sockdebug && \
+	./server/sockdebug dummy-ups-UPS1
 
 Formatting
 ----------

--- a/drivers/upsdrvquery.c
+++ b/drivers/upsdrvquery.c
@@ -350,8 +350,8 @@ ssize_t upsdrvquery_prepare(udq_pipe_conn_t *conn, struct timeval tv) {
 		/* Diminishing timeouts for read() */
 		tv.tv_usec -= difftime(now, start);
 		while (tv.tv_usec < 0) {
-                    tv.tv_sec--;
-                    tv.tv_usec = 1000 - tv.tv_usec;
+			tv.tv_sec--;
+			tv.tv_usec = 1000 - tv.tv_usec;
 		}
 	}
 
@@ -440,7 +440,7 @@ ssize_t upsdrvquery_request(
 			tv.tv_sec++;
 		}
 		upsdebugx(5, "%s: will wait up to %" PRIiMAX
-                        ".%03" PRIiMAX " sec for response to %s",
+			".%03" PRIiMAX " sec for response to %s",
 			__func__, (intmax_t)tv.tv_sec,
 			(intmax_t)tv.tv_usec, query);
 	}
@@ -521,12 +521,12 @@ ssize_t upsdrvquery_oneshot(
 	 * being blocked on other commands, etc. Number so far is
 	 * arbitrary and optimistic. A non-zero setting causes a
 	 * long initial silence to flush incoming buffers after
-         * the NOBROADCAST. In practice, we do not expect messages
-         * from dstate::send_to_all() to be a nuisance, since we
-         * have just connected and posted the NOBROADCAST so there
-         * is little chance that something appears in that short
-         * time. Also now we know to ignore replies that are not
-         *   TRACKING <id of our query>
+	 * the NOBROADCAST. In practice, we do not expect messages
+	 * from dstate::send_to_all() to be a nuisance, since we
+	 * have just connected and posted the NOBROADCAST so there
+	 * is little chance that something appears in that short
+	 * time. Also now we know to ignore replies that are not
+	 *   TRACKING <id of our query>
 	 */
 	tv.tv_sec = 0;
 	tv.tv_usec = 0;

--- a/server/Makefile.am
+++ b/server/Makefile.am
@@ -38,11 +38,17 @@ else !HAVE_WINDOWS
   sockdebug_SOURCES = sockdebug.c
 endif !HAVE_WINDOWS
 
+if WITH_DEV
+# Have it installed properly
+libexec_PROGRAMS = sockdebug
+endif
+
 dummy:
 
 MAINTAINERCLEANFILES = Makefile.in .dirstamp
 
 # NOTE: Do not clean ".deps" in SUBDIRS of the main project,
 # the root Makefile.am takes care of that!
-#clean-local:
+clean-local:
+	$(AM_V_at)rm -rf $(EXTRA_PROGRAMS)
 #	$(AM_V_at)rm -rf $(builddir)/.deps

--- a/server/sockdebug.c
+++ b/server/sockdebug.c
@@ -1,6 +1,8 @@
 /* sockdebug.c - Network UPS Tools driver-server socket debugger
+                 Source variant for POSIX-compliant builds of NUT
 
    Copyright (C) 2003  Russell Kroll <rkroll@exploits.org>
+   Copyright (C) 2023  Jim Klimov <jimklimov+nut@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -63,6 +65,12 @@ static int socket_connect(const char *sockfn)
 	}
 
 	ret = connect(fd, (struct sockaddr *) &sa, sizeof(sa));
+
+	if (ret < 0 && !strchr(sockfn, '/')) {
+		snprintf(sa.sun_path, sizeof(sa.sun_path), "%s/%s",
+			dflt_statepath(), sockfn);
+		ret = connect(fd, (struct sockaddr *) &sa, sizeof(sa));
+	}
 
 	if (ret < 0) {
 		perror("connect");
@@ -128,8 +136,11 @@ int main(int argc, char **argv)
 	|| (argc > 1 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help")))
 	) {
 		fprintf(stderr, "usage: %s <socket name>\n", prog);
-		fprintf(stderr, "       %s /var/state/ups/apcsmart-ttyS1.newsock\n",
+		fprintf(stderr, "       %s /var/state/ups/apcsmart-ttyS1\n",
 			argv[0]);
+		fprintf(stderr, "  or   %s apcsmart-ttyS1\n",
+			argv[0]);
+		fprintf(stderr, "  for socket files placed in the standard location\n");
 		exit(EXIT_SUCCESS);
 	}
 


### PR DESCRIPTION
Also update `upsdrvquery` preparation using `NOBROADCAST` with a `PING/PONG` confirmation.

Follows-up from #1914

Touches upon #1928