### PR TITLE
Some small enhancements on gitlog2changelog.py 

### DIFF
--- a/tools/gitlog2changelog.py.in
+++ b/tools/gitlog2changelog.py.in
@@ -114,7 +114,7 @@ for line in fin:
     elif "Signed-off-by" in line:
         continue
     # Extract the actual commit message for this commit
-    elif authorFound & dateFound & messageFound is False:
+    elif authorFound and dateFound and messageFound is False:
         # Find the commit message if we can
         if len(line) == fin_chop:
             if messageNL:
@@ -133,7 +133,7 @@ for line in fin:
         filesFound = True
         continue
     # Collect the files for this commit. FIXME: Still need to add +/- to files
-    elif authorFound & dateFound & messageFound:
+    elif authorFound and dateFound and messageFound:
         fileList = re.split(r' \| ', line, 2)
         if len(fileList) > 1:
             if len(files) > 0:
@@ -141,7 +141,7 @@ for line in fin:
             else:
                 files = fileList[0].strip()
     # All of the parts of the commit have been found - write out the entry
-    if authorFound & dateFound & messageFound & filesFound:
+    if authorFound and dateFound and messageFound and filesFound:
         # First the author line, only outputted if it is the first for that
         # author on this day
         authorLine = date + "  " + author

--- a/tools/gitlog2changelog.py.in
+++ b/tools/gitlog2changelog.py.in
@@ -8,11 +8,11 @@ from textwrap import TextWrapper
 import sys
 import subprocess
 
-rev_range = 'HEAD'
+rev_range = "HEAD"
 
 if len(sys.argv) > 1:
     base = sys.argv[1]
-    rev_range = '%s..HEAD' % base
+    rev_range = "%s..HEAD" % base
 
 # Execute git log with the desired command line options.
 # Support Python2 and Python3 (esp. 3.6 and earlier) semantics
@@ -22,25 +22,41 @@ fin_mode = 0
 fin_chop = 0
 try:
     p = subprocess.Popen(
-        ['git', 'log', '--pretty=medium', '--summary', '--stat', '--no-merges', '--date=short', ('%s' % rev_range)],
-        encoding='utf-8', close_fds = True,
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        [
+            "git",
+            "log",
+            "--pretty=medium",
+            "--summary",
+            "--stat",
+            "--no-merges",
+            "--date=short",
+            ("%s" % rev_range),
+        ],
+        encoding="utf-8",
+        close_fds=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
     fin, ferr = p.communicate()
     if p.wait() != 0:
-        print ("ERROR getting git changelog")
+        print("ERROR getting git changelog")
         system.exit(1)
     fin = fin.splitlines()
     fin_mode = 3
 except TypeError:
-    fin = os.popen('git log --pretty=medium --summary --stat --no-merges --date=short %s' % rev_range, 'r')
+    fin = os.popen(
+        "git log --pretty=medium --summary --stat --no-merges --date=short %s"
+        % rev_range,
+        "r",
+    )
     fin_mode = 2
     fin_chop = 1
 
 # Create a ChangeLog file in the current directory.
 if fin_mode == 3:
-    fout = open('ChangeLog', 'w', encoding='UTF-8')
+    fout = open("ChangeLog", "w", encoding="UTF-8")
 else:
-    fout = open('ChangeLog', 'w')
+    fout = open("ChangeLog", "w")
 
 # Set up the loop variables in order to locate the blocks we want
 authorFound = False
@@ -57,7 +73,7 @@ wrapper = TextWrapper(initial_indent="\t", subsequent_indent="\t  ")
 # The main part of the loop
 for line in fin:
     # The commit line marks the start of a new commit object.
-    if line.startswith('commit'):
+    if line.startswith("commit"):
         # Start all over again...
         authorFound = False
         dateFound = False
@@ -69,32 +85,32 @@ for line in fin:
         continue
     # Match the author line and extract the part we want
     # (Don't use startswith to allow Author override inside commit message.)
-    elif 'Author:' in line:
-        authorList = re.split(': ', line, 1)
+    elif "Author:" in line:
+        authorList = re.split(": ", line, 1)
         try:
             author = authorList[1]
-            author = author[0:len(author) - fin_chop]
+            author = author[0 : len(author) - fin_chop]
             authorFound = True
         except:
-            print ("Could not parse authorList = '%s'" % (line))
+            print("Could not parse authorList = '%s'" % (line))
 
     # Match the date line
-    elif line.startswith('Date:'):
-        dateList = re.split(':   ', line, 1)
+    elif line.startswith("Date:"):
+        dateList = re.split(":   ", line, 1)
         try:
             date = dateList[1]
-            date = date[0:len(date) - fin_chop]
+            date = date[0 : len(date) - fin_chop]
             dateFound = True
         except:
-            print ("Could not parse dateList = '%s'" % (line))
+            print("Could not parse dateList = '%s'" % (line))
     # The Fossil-IDs are ignored:
-    elif line.startswith('    Fossil-ID:') or line.startswith('    [[SVN:'):
+    elif line.startswith("    Fossil-ID:") or line.startswith("    [[SVN:"):
         continue
     # The svn-id lines are ignored
-    elif '    git-svn-id:' in line:
+    elif "    git-svn-id:" in line:
         continue
     # The sign off line is ignored too
-    elif 'Signed-off-by' in line:
+    elif "Signed-off-by" in line:
         continue
     # Extract the actual commit message for this commit
     elif authorFound & dateFound & messageFound == False:
@@ -112,12 +128,12 @@ for line in fin:
             else:
                 message = message + " " + line.strip()
     # If this line is hit all of the files have been stored for this commit
-    elif re.search('files? changed', line):
+    elif re.search("files? changed", line):
         filesFound = True
         continue
     # Collect the files for this commit. FIXME: Still need to add +/- to files
     elif authorFound & dateFound & messageFound:
-        fileList = re.split(' \| ', line, 2)
+        fileList = re.split(" \| ", line, 2)
         if len(fileList) > 1:
             if len(files) > 0:
                 files = files + ", " + fileList[0].strip()
@@ -145,8 +161,8 @@ for line in fin:
             namesF = None
             namesM = None
             try:
-                namesM = sorted(re.split(r'[ ,]', message.split(":")[0]))
-                namesF = sorted(re.split(r'[ ,]', files))
+                namesM = sorted(re.split(r"[ ,]", message.split(":")[0]))
+                namesF = sorted(re.split(r"[ ,]", files))
             except:
                 pass
 
@@ -158,7 +174,7 @@ for line in fin:
         # Write out the commit line
         fout.write(wrapper.fill(commitLine) + "\n")
 
-        #Now reset all the variables ready for a new commit block.
+        # Now reset all the variables ready for a new commit block.
         authorFound = False
         dateFound = False
         messageFound = False

--- a/tools/gitlog2changelog.py.in
+++ b/tools/gitlog2changelog.py.in
@@ -22,7 +22,7 @@ fin_mode = 0
 fin_chop = 0
 try:
     p = subprocess.Popen(
-        ['git', 'log', '--summary', '--stat', '--no-merges', '--date=short', ('%s' % rev_range)],
+        ['git', 'log', '--pretty=medium', '--summary', '--stat', '--no-merges', '--date=short', ('%s' % rev_range)],
         encoding='utf-8', close_fds = True,
         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     fin, ferr = p.communicate()
@@ -32,7 +32,7 @@ try:
     fin = fin.splitlines()
     fin_mode = 3
 except TypeError:
-    fin = os.popen('git log --summary --stat --no-merges --date=short %s' % rev_range, 'r')
+    fin = os.popen('git log --pretty=medium --summary --stat --no-merges --date=short %s' % rev_range, 'r')
     fin_mode = 2
     fin_chop = 1
 

--- a/tools/gitlog2changelog.py.in
+++ b/tools/gitlog2changelog.py.in
@@ -3,7 +3,8 @@
 # Minor changes for NUT by Charles Lepple
 # Distributed under the terms of the GNU General Public License v2 or later
 
-import string, re, os
+import re
+import os
 from textwrap import TextWrapper
 import sys
 import subprocess
@@ -40,7 +41,7 @@ try:
     fin, ferr = p.communicate()
     if p.wait() != 0:
         print("ERROR getting git changelog")
-        system.exit(1)
+        sys.exit(1)
     fin = fin.splitlines()
     fin_mode = 3
 except TypeError:
@@ -113,7 +114,7 @@ for line in fin:
     elif "Signed-off-by" in line:
         continue
     # Extract the actual commit message for this commit
-    elif authorFound & dateFound & messageFound == False:
+    elif authorFound & dateFound & messageFound is False:
         # Find the commit message if we can
         if len(line) == fin_chop:
             if messageNL:
@@ -133,7 +134,7 @@ for line in fin:
         continue
     # Collect the files for this commit. FIXME: Still need to add +/- to files
     elif authorFound & dateFound & messageFound:
-        fileList = re.split(" \| ", line, 2)
+        fileList = re.split(r' \| ', line, 2)
         if len(fileList) > 1:
             if len(files) > 0:
                 files = files + ", " + fileList[0].strip()


### PR DESCRIPTION
I am using the `gitlog2changelog.py` utility from this repository for [my project](https://github.com/cea-hpc/modules). As it is really useful, I am pleased to contribute back by proposing a few enhancements on `gitlog2changelog.py` tools:

* First is to make it resilient to specific git log format configured in user's git configuration.
* Second is to apply code change suggested by Black Python code formatter
* Third is to fix code issues spotted by Flake8 Python utility