### PR TITLE
tools/gitlog2changelog.py.in: update TextWrapper settings to not break up file paths

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -352,6 +352,11 @@ and a `driver.killpower` instant command (for safety, must be unlocked by
  - The `COPYING` file was updated with licenses and attribution for certain
    source code files and blocks coming from the Internet originally [#1758]
 
+ - The `tools/gitlog2changelog.py.in` script was revised, in particular to
+   generate the `ChangeLog` file more consistently with different versions
+   of Python interpreter, and without breaking the long file paths in the
+   resulting mark-up text [#1945, #1955]
+
 ---------------------------------------------------------------------------
 Release notes for NUT 2.8.0 - what's new since 2.7.4:
 

--- a/UPGRADING
+++ b/UPGRADING
@@ -112,6 +112,14 @@ Changes from 2.8.0 to 2.8.1
   were renamed: `pw` is now `eaton_pw_nm2`, and `pxgx_ups` is `eaton_pxg_ups`
   [#1715]
 
+- The `tools/gitlog2changelog.py.in` script was revised, in particular to
+  generate the `ChangeLog` file more consistently with different versions
+  of Python interpreter, and without breaking the long file paths in the
+  resulting mark-up text. Due to this, a copy of this file distributed with
+  NUT release archives is expected to considerably differ on first glance
+  from its earlier released versions (not just adding lines for the new
+  release, but changing lines in the older releases too) [#1945, #1955]
+
 Changes from 2.7.4 to 2.8.0
 ---------------------------
 

--- a/tools/gitlog2changelog.py.in
+++ b/tools/gitlog2changelog.py.in
@@ -69,7 +69,8 @@ messageNL = False
 files = ""
 prevAuthorLine = ""
 
-wrapper = TextWrapper(initial_indent="\t", subsequent_indent="\t  ")
+# See also: https://github.com/python/cpython/blob/main/Lib/textwrap.py
+wrapper = TextWrapper(initial_indent="\t", subsequent_indent="\t  ", break_on_hyphens=False, break_long_words=False)
 
 # The main part of the loop
 for line in fin:


### PR DESCRIPTION
Follows up from #1945

@xdelaruelle : Seems the long-words policy for `TextWrapper()` does it, thanks for the hint. Now the python2/3 generated files are almost identical, and differ a lot from those generated without this change (no longer broken at slashes and dashes in the path names).

````
 diff -bu ChangeLog*n
--- ChangeLog2n 2023-06-02 12:11:58.987738723 +0200
+++ ChangeLog3n 2023-06-02 12:12:10.797738492 +0200
@@ -22992,12 +22992,11 @@

 2014-02-14  Arnaud Quette <arnaud.quette@free.fr>

-       * docs/acknowledgements.txt: Update NUT team membership for
-         Frédéric Bohe  Frederic Bohe, NUT senior developer and Eaton
-         contractor from 2009 to 2013, is now a retired member. Thanks for
-         all the hard work on the Windows port, nut-scanner, Unix packaging,
-         support, ... Also update the developers membership page, from
-         Alioth to GitHub
+       * docs/acknowledgements.txt: Update NUT team membership for Frédéric
+         Bohe  Frederic Bohe, NUT senior developer and Eaton contractor from
+         2009 to 2013, is now a retired member. Thanks for all the hard work
+         on the Windows port, nut-scanner, Unix packaging, support, ... Also
+         update the developers membership page, from Alioth to GitHub

 2013-02-24  Charles Lepple <clepple+nut@gmail.com>

@@ -23319,8 +23318,8 @@
          environment on ships (and we don't need shutdown there -- in
          critical situations the system has to operate as long as possible,
          untill the battery is empty)  Also, all of the previous issues
-         listed below are now fixed in this al175 version:  - ‘return’
-         with a value, in function returning void (2x) - anonymous variadic
+         listed below are now fixed in this al175 version:  - ‘return’ with
+         a value, in function returning void (2x) - anonymous variadic
          macros were introduced in C99 - C++ style comments are not allowed
          in ISO C90 - ISO C forbids braced-groups within expressions (5x) -
          ISO C90 forbids specifying subobject to initialize (16x) - ISO C99
````

Nearby context of both changes seems to be non-ASCII unicode, so maybe that's why they wrapped differently.