### PR TITLE
Avoid `upssched` infinite tight loops with (probably) closed sockets

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -303,6 +303,10 @@ as part of https://github.com/networkupstools/nut/issues/1410 solution.
    * Note that unlike some other NUT daemons, `upssched` with enabled
      debug does not stop reporting on `stderr`! [#1965]
 
+ - A bug in `upssched` was discovered and fixed, where it ran a tight loop
+   stressing the CPU; it was presumably introduced between NUT v2.7.4 and
+   v2.8.0 releases [#1964, #1965]
+
  - Implemented generic support for INSTCMD and SETVAR use-cases shared by
    all drivers, and in particular to see and change active debug verbosity
    using the driver-server and server-client protocol (at higher priority

--- a/NEWS
+++ b/NEWS
@@ -300,6 +300,8 @@ as part of https://github.com/networkupstools/nut/issues/1410 solution.
    honour a `NUT_DEBUG_LEVEL=NUM` environment variable if no `-D` arguments
    were provided. Unlike those arguments, the environment variable does
    not enforce that daemons run in foreground mode by default [#1915]
+   * Note that unlike some other NUT daemons, `upssched` with enabled
+     debug does not stop reporting on `stderr`! [#1965]
 
  - Implemented generic support for INSTCMD and SETVAR use-cases shared by
    all drivers, and in particular to see and change active debug verbosity

--- a/clients/upssched.c
+++ b/clients/upssched.c
@@ -1474,7 +1474,7 @@ static void help(const char *arg_progname)
 	printf("Practical behavior is managed by UPSNAME and NOTIFYTYPE envvars\n");
 
 	printf("\nUsage: %s [OPTIONS]\n\n", arg_progname);
-	printf("  -D		raise debugging level\n");
+	printf("  -D		raise debugging level (NOTE: keeps reporting when daemonized)\n");
 	printf("  -V		display the version of this software\n");
 	printf("  -h		display this help\n");
 

--- a/clients/upssched.c
+++ b/clients/upssched.c
@@ -775,8 +775,13 @@ static void start_daemon(TYPE_FD lockfd)
 			fatal_with_errno(EXIT_FAILURE, "re-open /dev/null as STDIN");
 		if (dup2(devnull, STDOUT_FILENO) != STDOUT_FILENO)
 			fatal_with_errno(EXIT_FAILURE, "re-open /dev/null as STDOUT");
-		if (dup2(devnull, STDERR_FILENO) != STDERR_FILENO)
-			fatal_with_errno(EXIT_FAILURE, "re-open /dev/null as STDERR");
+
+		if (nut_debug_level) {
+			upsdebugx(1, "Keeping stderr open due to debug verbosity %d", nut_debug_level);
+		} else {
+			if (dup2(devnull, STDERR_FILENO) != STDERR_FILENO)
+				fatal_with_errno(EXIT_FAILURE, "re-open /dev/null as STDERR");
+		}
 
 		close(devnull);
 	}
@@ -791,9 +796,13 @@ static void start_daemon(TYPE_FD lockfd)
 	if (dup(STDIN_FILENO) != STDOUT_FILENO)
 		fatal_with_errno(EXIT_FAILURE, "dup /dev/null as STDOUT");
 
-	close(STDERR_FILENO);
-	if (dup(STDIN_FILENO) != STDERR_FILENO)
-		fatal_with_errno(EXIT_FAILURE, "dup /dev/null as STDERR");
+	if (nut_debug_level) {
+		upsdebugx(1, "Keeping stderr open due to debug verbosity %d", nut_debug_level);
+	} else {
+		close(STDERR_FILENO);
+		if (dup(STDIN_FILENO) != STDERR_FILENO)
+			fatal_with_errno(EXIT_FAILURE, "dup /dev/null as STDERR");
+	}
 # else
 	close(STDIN_FILENO);
 	if (open("/dev/null", O_RDWR) != STDIN_FILENO)
@@ -803,9 +812,13 @@ static void start_daemon(TYPE_FD lockfd)
 	if (open("/dev/null", O_RDWR) != STDOUT_FILENO)
 		fatal_with_errno(EXIT_FAILURE, "re-open /dev/null as STDOUT");
 
-	close(STDERR_FILENO);
-	if (open("/dev/null", O_RDWR) != STDERR_FILENO)
-		fatal_with_errno(EXIT_FAILURE, "re-open /dev/null as STDERR");
+	if (nut_debug_level) {
+		upsdebugx(1, "Keeping stderr open due to debug verbosity %d", nut_debug_level);
+	} else {
+		close(STDERR_FILENO);
+		if (open("/dev/null", O_RDWR) != STDERR_FILENO)
+			fatal_with_errno(EXIT_FAILURE, "re-open /dev/null as STDERR");
+	}
 # endif
 #endif
 

--- a/clients/upssched.c
+++ b/clients/upssched.c
@@ -170,6 +170,7 @@ static void checktimers(void)
 		sleep(15);
 #endif
 
+		upsdebugx(1, "Timer queue empty, closing pipe and exiting upssched daemon");
 		unlink(pipefn);
 		exit(EXIT_SUCCESS);
 	}
@@ -1444,7 +1445,7 @@ int main(int argc, char **argv)
 	notify_type = getenv("NOTIFYTYPE");
 
 	if ((!upsname) || (!notify_type)) {
-		printf("Error: UPSNAME and NOTIFYTYPE must be set.\n");
+		printf("Error: environment variables UPSNAME and NOTIFYTYPE must be set.\n");
 		printf("This program should only be run from upsmon.\n");
 		exit(EXIT_FAILURE);
 	}
@@ -1456,5 +1457,6 @@ int main(int argc, char **argv)
 	 */
 	checkconf();
 
+	upsdebugx(1, "Exiting upssched (CLI process)");
 	exit(EXIT_SUCCESS);
 }

--- a/docs/man/upssched.txt
+++ b/docs/man/upssched.txt
@@ -108,6 +108,11 @@ ENVIRONMENT VARIABLES
 were provided on command line, but does not request that the daemon
 runs in foreground mode.
 
+NOTE: Unlike some other NUT daemons, `upssched` with enabled debug
+does not stop reporting on `stderr`! It forks a background process
+with the first call as an event handler, which exits soon after all
+tracked timers have elapsed and were handled (if needed).
+
 *UPSNAME* and *NOTIFYTYPE* are required, as detailed above. They are
 set by `upsmon` when it calls `upssched` as its choice of `NOTIFYCMD`.
 


### PR DESCRIPTION
Closes: #1964
Probably fallout from #1274 - CC @dtsecon for review

Now it is all quiet ([literally](https://m.xkcd.com/1172/), my fans whirred up without the fix):
````
:; killall upssched ; make -s -j 8 && \
    UPSNAME=heartbeat@localhost NOTIFYTYPE=ONBATT \
    NUT_STATEPATH=/dev/shm NUT_CONFPATH=`pwd`/tests/NIT/tmp/etc \
    ./clients/upssched -DDDDD

   0.000000     [D2] parse_at: is 'heartbeat@localhost' in AT command the 'heartbeat@localhost' we were launched to process?
   0.000052     [D1] parse_at: 'heartbeat@localhost' in AT command matched the 'heartbeat@localhost' UPSNAME we were launched to process
   0.000064     [D1] parse_at: processing CANCEL-TIMER
   0.000087     [D2] parse_at: is 'heartbeat@localhost' in AT command the 'heartbeat@localhost' we were launched to process?
   0.000094     [D1] parse_at: 'heartbeat@localhost' in AT command matched the 'heartbeat@localhost' UPSNAME we were launched to process
   0.000101     [D1] parse_at: processing START-TIMER
   0.000211     [D1] Keeping stderr open due to debug verbosity 5
   0.000257     Timer daemon started
   0.000265     [D2] Timer daemon waiting for connections on pipefd 10
   0.250397     [D3] new connection on fd 7
   0.250466     New timer: heartbeat-failure-timer (15 seconds)
   0.250513     [D1] Exiting upssched (CLI process)
   0.250586     [D4] read() from fd 7 returned 0 too many times in a row, aborting sock_read(); errno=0: Success
   0.250594     [D3] closing connection on fd 7
````

And that is it, the daemon is holding the clock.

````
  15.263748   Event: heartbeat-failure-timer
  30.311007     Timer queue empty, exiting
  30.311052     [D1] Timer queue empty, closing pipe and exiting upssched daemon
````

And it has truly exited:
````
:; ps -ef | grep -v grep | grep upssch
````