### PR TITLE
Bump all driver versions before NUT v2.8.1 release [#1951]

### DIFF
--- a/drivers/adelsystem_cbi.c
+++ b/drivers/adelsystem_cbi.c
@@ -30,7 +30,7 @@
 #include <timehead.h>
 
 #define DRIVER_NAME "NUT ADELSYSTEM DC-UPS CB/CBI driver"
-#define DRIVER_VERSION "0.01"
+#define DRIVER_VERSION "0.02"
 
 /* variables */
 static modbus_t *mbctx = NULL;							/* modbus memory context */

--- a/drivers/al175.c
+++ b/drivers/al175.c
@@ -52,7 +52,7 @@ typedef	uint8_t byte_t;
 
 
 #define DRIVER_NAME	"Eltek AL175/COMLI driver"
-#define DRIVER_VERSION	"0.13"
+#define DRIVER_VERSION	"0.14"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/apcsmart-old.c
+++ b/drivers/apcsmart-old.c
@@ -25,7 +25,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"APC Smart protocol driver"
-#define DRIVER_VERSION	"2.2"
+#define DRIVER_VERSION	"2.30"
 
 static upsdrv_info_t table_info = {
 	"APC command table",

--- a/drivers/apcsmart.c
+++ b/drivers/apcsmart.c
@@ -35,6 +35,9 @@
 #include "apcsmart.h"
 #include "apcsmart_tabs.h"
 
+#define DRIVER_NAME	"APC Smart protocol driver"
+#define DRIVER_VERSION	"3.30"
+
 #ifdef WIN32
 # ifndef ECANCELED
 #  define ECANCELED ERROR_CANCELLED

--- a/drivers/apcsmart.h
+++ b/drivers/apcsmart.h
@@ -24,7 +24,7 @@
 #define NUT_APCSMART_H_SEEN 1
 
 #define DRIVER_NAME	"APC Smart protocol driver"
-#define DRIVER_VERSION	"3.2"
+#define DRIVER_VERSION	"3.30"
 
 #define ALT_CABLE_1 "940-0095B"
 

--- a/drivers/apcsmart.h
+++ b/drivers/apcsmart.h
@@ -23,9 +23,6 @@
 #ifndef NUT_APCSMART_H_SEEN
 #define NUT_APCSMART_H_SEEN 1
 
-#define DRIVER_NAME	"APC Smart protocol driver"
-#define DRIVER_VERSION	"3.30"
-
 #define ALT_CABLE_1 "940-0095B"
 
 /*

--- a/drivers/apcupsd-ups.c
+++ b/drivers/apcupsd-ups.c
@@ -39,7 +39,7 @@ typedef unsigned long int nfds_t;
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"apcupsd network client UPS driver"
-#define DRIVER_VERSION	"0.6"
+#define DRIVER_VERSION	"0.70"
 
 #define POLL_INTERVAL_MIN 10
 

--- a/drivers/asem.c
+++ b/drivers/asem.c
@@ -67,7 +67,7 @@
 #endif
 
 #define DRIVER_NAME	"ASEM"
-#define DRIVER_VERSION	"0.11"
+#define DRIVER_VERSION	"0.12"
 
 /* Valid on ASEM PB1300 UPS */
 #define BQ2060_ADDRESS	0x0B

--- a/drivers/bcmxcp.c
+++ b/drivers/bcmxcp.c
@@ -118,7 +118,7 @@ TODO List:
 #include "bcmxcp.h"
 
 #define DRIVER_NAME    "BCMXCP UPS driver"
-#define DRIVER_VERSION "0.32"
+#define DRIVER_VERSION "0.33"
 
 #define MAX_NUT_NAME_LENGTH 128
 #define NUT_OUTLET_POSITION   7

--- a/drivers/bcmxcp_ser.c
+++ b/drivers/bcmxcp_ser.c
@@ -6,7 +6,7 @@
 #include "nut_stdint.h"
 
 #define SUBDRIVER_NAME    "RS-232 communication subdriver"
-#define SUBDRIVER_VERSION "0.21"
+#define SUBDRIVER_VERSION "0.22"
 
 /* communication driver description structure */
 upsdrv_info_t comm_upsdrv_info = {

--- a/drivers/belkin.c
+++ b/drivers/belkin.c
@@ -29,7 +29,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"Belkin Smart protocol driver"
-#define DRIVER_VERSION	"0.25"
+#define DRIVER_VERSION	"0.26"
 
 static ssize_t init_communication(void);
 static ssize_t get_belkin_reply(char *buf);

--- a/drivers/belkinunv.c
+++ b/drivers/belkinunv.c
@@ -94,7 +94,7 @@
 #include "serial.h"
 
 #define DRIVER_NAME	"Belkin 'Universal UPS' driver"
-#define DRIVER_VERSION	"0.08"
+#define DRIVER_VERSION	"0.09"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/bestfcom.c
+++ b/drivers/bestfcom.c
@@ -45,7 +45,7 @@
 #include "serial.h"
 
 #define DRIVER_NAME	"Best Ferrups/Fortress driver"
-#define DRIVER_VERSION	"0.13"
+#define DRIVER_VERSION	"0.14"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/bestfortress.c
+++ b/drivers/bestfortress.c
@@ -35,7 +35,7 @@
 #endif
 
 #define DRIVER_NAME     "Best Fortress UPS driver"
-#define DRIVER_VERSION  "0.07"
+#define DRIVER_VERSION  "0.08"
 
 /* driver description structure */
 upsdrv_info_t   upsdrv_info = {

--- a/drivers/bestuferrups.c
+++ b/drivers/bestuferrups.c
@@ -33,7 +33,7 @@
 #include "serial.h"
 
 #define DRIVER_NAME	"Best Ferrups Series ME/RE/MD driver"
-#define DRIVER_VERSION	"0.04"
+#define DRIVER_VERSION	"0.05"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/bestups.c
+++ b/drivers/bestups.c
@@ -29,7 +29,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"Best UPS driver"
-#define DRIVER_VERSION	"1.07"
+#define DRIVER_VERSION	"1.08"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/blazer_ser.c
+++ b/drivers/blazer_ser.c
@@ -31,7 +31,7 @@
 #include "blazer.h"
 
 #define DRIVER_NAME	"Megatec/Q1 protocol serial driver"
-#define DRIVER_VERSION	"1.58"
+#define DRIVER_VERSION	"1.59"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/blazer_usb.c
+++ b/drivers/blazer_usb.c
@@ -37,7 +37,7 @@
 #endif
 
 #define DRIVER_NAME	"Megatec/Q1 protocol USB driver"
-#define DRIVER_VERSION	"0.14"
+#define DRIVER_VERSION	"0.15"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/clone-outlet.c
+++ b/drivers/clone-outlet.c
@@ -29,7 +29,7 @@
 #endif
 
 #define DRIVER_NAME	"clone outlet UPS Driver"
-#define DRIVER_VERSION	"0.02"
+#define DRIVER_VERSION	"0.03"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/clone.c
+++ b/drivers/clone.c
@@ -31,7 +31,7 @@
 #endif
 
 #define DRIVER_NAME	"Clone UPS driver"
-#define DRIVER_VERSION	"0.03"
+#define DRIVER_VERSION	"0.04"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/dummy-ups.c
+++ b/drivers/dummy-ups.c
@@ -47,7 +47,7 @@
 #include "dummy-ups.h"
 
 #define DRIVER_NAME	"Device simulation and repeater driver"
-#define DRIVER_VERSION	"0.15"
+#define DRIVER_VERSION	"0.16"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info =

--- a/drivers/etapro.c
+++ b/drivers/etapro.c
@@ -55,7 +55,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"ETA PRO driver"
-#define DRIVER_VERSION	"0.05"
+#define DRIVER_VERSION	"0.06"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/everups.c
+++ b/drivers/everups.c
@@ -21,7 +21,7 @@
 #include "serial.h"
 
 #define DRIVER_NAME	"Ever UPS driver (serial)"
-#define DRIVER_VERSION	"0.04"
+#define DRIVER_VERSION	"0.05"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/gamatronic.c
+++ b/drivers/gamatronic.c
@@ -33,7 +33,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"Gamatronic UPS driver"
-#define DRIVER_VERSION	"0.03"
+#define DRIVER_VERSION	"0.04"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/generic_gpio_common.h
+++ b/drivers/generic_gpio_common.h
@@ -1,5 +1,3 @@
-#ifndef GENERIC_GPIO_COMMON_H
-#define GENERIC_GPIO_COMMON_H
 /*  generic_gpio_common.h - common NUT driver definitions for GPIO attached UPS devices
  *
  *  Copyright (C)
@@ -22,47 +20,50 @@
  *
  */
 
+#ifndef GENERIC_GPIO_COMMON_H_SEEN
+#define GENERIC_GPIO_COMMON_H_SEEN
+
 #include <stdlib.h>
 #include <regex.h>
 #include <ctype.h>
 
 /*  rules commands definition    */
-#define RULES_CMD_NOT   -2
-#define RULES_CMD_AND   -3
-#define RULES_CMD_OR    -4
-#define RULES_CMD_OBR   -5
-#define RULES_CMD_CBR   -6
-#define RULES_CMD_LAST  RULES_CMD_CBR
+#define RULES_CMD_NOT	-2
+#define RULES_CMD_AND	-3
+#define RULES_CMD_OR	-4
+#define RULES_CMD_OBR	-5
+#define RULES_CMD_CBR	-6
+#define RULES_CMD_LAST	RULES_CMD_CBR
 
 /*  run option definitions      */
-#define ROPT_REQRES 0x00000001  /* reserve GPIO lines only during request processing    */
-#define ROPT_EVMODE 0x00000002  /* event driven run                                     */
+#define ROPT_REQRES	0x00000001  /* reserve GPIO lines only during request processing    */
+#define ROPT_EVMODE	0x00000002  /* event driven run                                     */
 
 /*  buffer size for chipName arrays */
 #define NUT_GPIO_CHIPNAMEBUF	32
-#define NUT_GPIO_SUBTYPEBUF 	16
+#define NUT_GPIO_SUBTYPEBUF	16
 
 typedef struct rulesint_t { /* structure to store processed rules configuration per each state */
-    char    stateName[12];  /* NUT state name for rules in cRules */
-    int     archVal;        /* previous state value */
-    int     currVal;        /* current state value  */
-    int     subCount;       /* element count in translated rules subitem */
-    int     cRules[];       /* translated rules subitem - rules commands followed by line number(s) */
-}   rulesint;
+	char	stateName[12];	/* NUT state name for rules in cRules */
+	int	archVal;	/* previous state value */
+	int	currVal;	/* current state value  */
+	int	subCount;	/* element count in translated rules subitem */
+	int	cRules[];	/* translated rules subitem - rules commands followed by line number(s) */
+} rulesint;
 
 typedef struct gpioups_t {
-    void    *lib_data;  /* pointer to driver's gpio support library data structure */
-    const char    *chipName;  /* port or file name to reference GPIO chip */
-    int     initial;    /* initialization flag - 0 on 1st entry */
-    int     runOptions; /* run options, not yet used */
-    int     aInfoAvailable; /* non-zero if previous state information is available */
-    int     chipLinesCount; /* gpio chip lines count, set after sucessful open */
-    int     upsLinesCount;  /* no of lines used in rules */
-    int     *upsLines;      /* lines numbers */
-    int     *upsLinesStates;    /* lines states */
-    int     upsMaxLine;     /* maximum line number referenced in rules */
-    int     rulesCount;     /* rules subitem count: no of NUT states defined in rules*/
-    struct rulesint_t **rules;
+	void	*lib_data;	/* pointer to driver's gpio support library data structure */
+	const char *chipName;	/* port or file name to reference GPIO chip */
+	int	initial;	/* initialization flag - 0 on 1st entry */
+	int	runOptions;	/* run options, not yet used */
+	int	aInfoAvailable;	/* non-zero if previous state information is available */
+	int	chipLinesCount;	/* gpio chip lines count, set after sucessful open */
+	int	upsLinesCount;	/* no of lines used in rules */
+	int	*upsLines;	/* lines numbers */
+	int	*upsLinesStates;	/* lines states */
+	int	upsMaxLine;	/* maximum line number referenced in rules */
+	int	rulesCount;	/* rules subitem count: no of NUT states defined in rules*/
+	struct rulesint_t **rules;
 } gpioups;
 
 extern struct gpioups_t *gpioupsfd;
@@ -82,4 +83,4 @@ int calc_rule_states(int upsLinesStates[], int cRules[], int subCount, int sInde
 void update_ups_states(struct gpioups_t *gpioupsfd);
 # endif /* DRIVERS_MAIN_WITHOUT_MAIN */
 
-#endif	/* GENERIC_GPIO_COMMON_H */
+#endif	/* GENERIC_GPIO_COMMON_H_SEEN */

--- a/drivers/generic_gpio_libgpiod.c
+++ b/drivers/generic_gpio_libgpiod.c
@@ -26,6 +26,9 @@
 #include "generic_gpio_common.h"
 #include "generic_gpio_libgpiod.h"
 
+#define DRIVER_NAME	"GPIO UPS driver"
+#define DRIVER_VERSION	"1.01"
+
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
 	DRIVER_NAME,

--- a/drivers/generic_gpio_libgpiod.h
+++ b/drivers/generic_gpio_libgpiod.h
@@ -1,5 +1,3 @@
-#ifndef GENERIC_GPIO_LIBGPIOD_H
-#define GENERIC_GPIO_LIBGPIOD_H
 /*  generic_gpio_libgpiod.h - gpiod based NUT driver definitions for GPIO attached UPS devices
  *
  *  Copyright (C)
@@ -22,10 +20,10 @@
  *
  */
 
-#include <gpiod.h>
+#ifndef GENERIC_GPIO_LIBGPIOD_H
+#define GENERIC_GPIO_LIBGPIOD_H
 
-#define DRIVER_NAME	"GPIO UPS driver"
-#define DRIVER_VERSION	"1.01"
+#include <gpiod.h>
 
 typedef struct libgpiod_data_t {
     struct gpiod_chip *gpioChipHandle;      /* libgpiod chip handle when opened */

--- a/drivers/generic_gpio_libgpiod.h
+++ b/drivers/generic_gpio_libgpiod.h
@@ -20,15 +20,15 @@
  *
  */
 
-#ifndef GENERIC_GPIO_LIBGPIOD_H
-#define GENERIC_GPIO_LIBGPIOD_H
+#ifndef GENERIC_GPIO_LIBGPIOD_H_SEEN
+#define GENERIC_GPIO_LIBGPIOD_H_SEEN
 
 #include <gpiod.h>
 
 typedef struct libgpiod_data_t {
-    struct gpiod_chip *gpioChipHandle;      /* libgpiod chip handle when opened */
-    struct gpiod_line_bulk gpioLines;       /* libgpiod lines to monitor */
-    struct gpiod_line_bulk gpioEventLines;  /* libgpiod lines for event monitoring */
+	struct gpiod_chip	*gpioChipHandle;	/* libgpiod chip handle when opened */
+	struct gpiod_line_bulk	gpioLines;	/* libgpiod lines to monitor */
+	struct gpiod_line_bulk	gpioEventLines;	/* libgpiod lines for event monitoring */
 } libgpiod_data;
 
-#endif	/* GENERIC_GPIO_LIBGPIOD_H */
+#endif	/* GENERIC_GPIO_LIBGPIOD_H_SEEN */

--- a/drivers/generic_gpio_libgpiod.h
+++ b/drivers/generic_gpio_libgpiod.h
@@ -25,7 +25,7 @@
 #include <gpiod.h>
 
 #define DRIVER_NAME	"GPIO UPS driver"
-#define DRIVER_VERSION	"1.00"
+#define DRIVER_VERSION	"1.01"
 
 typedef struct libgpiod_data_t {
     struct gpiod_chip *gpioChipHandle;      /* libgpiod chip handle when opened */

--- a/drivers/generic_modbus.c
+++ b/drivers/generic_modbus.c
@@ -27,7 +27,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME "NUT Generic Modbus driver"
-#define DRIVER_VERSION  "0.03"
+#define DRIVER_VERSION  "0.04"
 
 /* variables */
 static modbus_t *mbctx = NULL;                             /* modbus memory context */

--- a/drivers/genericups.c
+++ b/drivers/genericups.c
@@ -31,7 +31,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"Generic contact-closure UPS driver"
-#define DRIVER_VERSION	"1.38"
+#define DRIVER_VERSION	"1.39"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/huawei-ups2000.c
+++ b/drivers/huawei-ups2000.c
@@ -51,7 +51,7 @@
 #include "timehead.h"   /* fallback gmtime_r() variants if needed (e.g. some WIN32) */
 
 #define DRIVER_NAME	"NUT Huawei UPS2000 (1kVA-3kVA) RS-232 Modbus driver"
-#define DRIVER_VERSION	"0.04"
+#define DRIVER_VERSION	"0.05"
 
 #define CHECK_BIT(var,pos) ((var) & (1<<(pos)))
 #define MODBUS_SLAVE_ID 1

--- a/drivers/isbmex.c
+++ b/drivers/isbmex.c
@@ -27,7 +27,7 @@
 #include <string.h>
 
 #define DRIVER_NAME	"ISBMEX UPS driver"
-#define DRIVER_VERSION	"0.07"
+#define DRIVER_VERSION	"0.08"
 
 /* driver description structure */
 upsdrv_info_t	upsdrv_info = {

--- a/drivers/ivtscd.c
+++ b/drivers/ivtscd.c
@@ -25,7 +25,7 @@
 #include "attribute.h"
 
 #define DRIVER_NAME	"IVT Solar Controller driver"
-#define DRIVER_VERSION	"0.03"
+#define DRIVER_VERSION	"0.04"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/liebert-esp2.c
+++ b/drivers/liebert-esp2.c
@@ -28,7 +28,8 @@
 #define IsBitSet(val, bit) ((val) & (1 << (bit)))
 
 #define DRIVER_NAME	"Liebert ESP-II serial UPS driver"
-#define DRIVER_VERSION	"0.05"
+#define DRIVER_VERSION	"0.06"
+
 #define UPS_SHUTDOWN_DELAY 12 /* it means UPS will be shutdown 120 sec */
 #define SHUTDOWN_CMD_LEN  8
 

--- a/drivers/liebert.c
+++ b/drivers/liebert.c
@@ -27,7 +27,7 @@
 #include "attribute.h"
 
 #define DRIVER_NAME	"Liebert MultiLink UPS driver"
-#define DRIVER_VERSION	"1.03"
+#define DRIVER_VERSION	"1.04"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/macosx-ups.c
+++ b/drivers/macosx-ups.c
@@ -29,7 +29,7 @@
 #include "IOKit/ps/IOPSKeys.h"
 
 #define DRIVER_NAME	"Mac OS X UPS meta-driver"
-#define DRIVER_VERSION	"1.3"
+#define DRIVER_VERSION	"1.40"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/masterguard.c
+++ b/drivers/masterguard.c
@@ -29,7 +29,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"MASTERGUARD UPS driver"
-#define DRIVER_VERSION	"0.25"
+#define DRIVER_VERSION	"0.26"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/metasys.c
+++ b/drivers/metasys.c
@@ -28,7 +28,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"Metasystem UPS driver"
-#define DRIVER_VERSION	"0.08"
+#define DRIVER_VERSION	"0.09"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/mge-utalk.c
+++ b/drivers/mge-utalk.c
@@ -69,7 +69,7 @@
 /* --------------------------------------------------------------- */
 
 #define DRIVER_NAME	"MGE UPS SYSTEMS/U-Talk driver"
-#define DRIVER_VERSION	"0.94"
+#define DRIVER_VERSION	"0.95"
 
 
 /* driver description structure */

--- a/drivers/microdowell.c
+++ b/drivers/microdowell.c
@@ -44,7 +44,7 @@
 #define MAX_SHUTDOWN_DELAY_LEN 5
 
 #define DRIVER_NAME	"MICRODOWELL UPS driver"
-#define DRIVER_VERSION	"0.02"
+#define DRIVER_VERSION	"0.03"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/microsol-apc.c
+++ b/drivers/microsol-apc.c
@@ -35,7 +35,7 @@
 #include "microsol-apc.h"
 
 #define DRIVER_NAME	"APC Back-UPS BR series UPS driver"
-#define DRIVER_VERSION	"0.69"
+#define DRIVER_VERSION	"0.70"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/netxml-ups.c
+++ b/drivers/netxml-ups.c
@@ -42,7 +42,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"network XML UPS"
-#define DRIVER_VERSION	"0.44"
+#define DRIVER_VERSION	"0.45"
 
 /** *_OBJECT query multi-part body boundary */
 #define FORM_POST_BOUNDARY "NUT-NETXML-UPS-OBJECTS"

--- a/drivers/nut-ipmipsu.c
+++ b/drivers/nut-ipmipsu.c
@@ -27,7 +27,7 @@
 #include "nut-ipmi.h"
 
 #define DRIVER_NAME	"IPMI PSU driver"
-#define DRIVER_VERSION	"0.31"
+#define DRIVER_VERSION	"0.32"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/nutdrv_atcl_usb.c
+++ b/drivers/nutdrv_atcl_usb.c
@@ -28,7 +28,7 @@
 
 /* driver version */
 #define DRIVER_NAME	"'ATCL FOR UPS' USB driver"
-#define DRIVER_VERSION	"1.16"
+#define DRIVER_VERSION	"1.17"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -38,8 +38,6 @@
  *
  */
 
-#define DRIVER_VERSION	"0.32"
-
 #include "config.h"
 #include "main.h"
 #include "attribute.h"
@@ -58,6 +56,8 @@
 #else
 	#define DRIVER_NAME	"Generic Q* Serial driver"
 #endif	/* QX_USB */
+
+#define DRIVER_VERSION	"0.33"
 
 #ifdef QX_SERIAL
 	#include "serial.h"

--- a/drivers/nutdrv_siemens_sitop.c
+++ b/drivers/nutdrv_siemens_sitop.c
@@ -56,7 +56,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"Siemens SITOP UPS500 series driver"
-#define DRIVER_VERSION	"0.03"
+#define DRIVER_VERSION	"0.04"
 
 #define RX_BUFFER_SIZE 100
 

--- a/drivers/oneac.c
+++ b/drivers/oneac.c
@@ -48,7 +48,7 @@ int setcmd(const char* varname, const char* setvalue);
 int instcmd(const char *cmdname, const char *extra);
 
 #define DRIVER_NAME	"Oneac EG/ON/OZ/OB UPS driver"
-#define DRIVER_VERSION	"0.81"
+#define DRIVER_VERSION	"0.82"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/optiups.c
+++ b/drivers/optiups.c
@@ -28,7 +28,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"Opti-UPS driver"
-#define DRIVER_VERSION "1.02"
+#define DRIVER_VERSION "1.03"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/phoenixcontact_modbus.c
+++ b/drivers/phoenixcontact_modbus.c
@@ -24,7 +24,7 @@
 #include <modbus.h>
 
 #define DRIVER_NAME	"NUT PhoenixContact Modbus driver"
-#define DRIVER_VERSION	"0.02"
+#define DRIVER_VERSION	"0.03"
 
 #define CHECK_BIT(var,pos) ((var) & (1<<(pos)))
 #define MODBUS_SLAVE_ID 192

--- a/drivers/pijuice.c
+++ b/drivers/pijuice.c
@@ -218,7 +218,7 @@ static inline __u8* i2c_smbus_read_i2c_block_data(int file, __u8 command, __u8 l
 #define NOMINAL_BATTERY_VOLTAGE             4.18
 
 #define DRIVER_NAME                         "PiJuice UPS driver"
-#define DRIVER_VERSION                      "0.10"
+#define DRIVER_VERSION                      "0.11"
 
 static uint8_t i2c_address    = 0x14;
 static uint8_t shutdown_delay = 30;

--- a/drivers/powercom.c
+++ b/drivers/powercom.c
@@ -85,8 +85,8 @@
 #include "powercom.h"
 #include "math.h"
 
-#define DRIVER_NAME		"PowerCom protocol UPS driver"
-#define DRIVER_VERSION	"0.20"
+#define DRIVER_NAME	"PowerCom protocol UPS driver"
+#define DRIVER_VERSION	"0.21"
 
 /* driver description structure */
 upsdrv_info_t	upsdrv_info = {

--- a/drivers/powerman-pdu.c
+++ b/drivers/powerman-pdu.c
@@ -23,7 +23,7 @@
 #include <libpowerman.h>	/* pm_err_t and other beasts */
 
 #define DRIVER_NAME	"Powerman PDU client driver"
-#define DRIVER_VERSION	"0.12"
+#define DRIVER_VERSION	"0.13"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/powerpanel.c
+++ b/drivers/powerpanel.c
@@ -36,7 +36,7 @@ static subdriver_t *subdriver[] = {
 };
 
 #define DRIVER_NAME	"CyberPower text/binary protocol UPS driver"
-#define DRIVER_VERSION	"0.28"
+#define DRIVER_VERSION	"0.29"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/rhino.c
+++ b/drivers/rhino.c
@@ -37,8 +37,8 @@
 #include "nut_stdint.h"
 #include "timehead.h"
 
-#define DRIVER_NAME		"Microsol Rhino UPS driver"
-#define DRIVER_VERSION	"0.52"
+#define DRIVER_NAME	"Microsol Rhino UPS driver"
+#define DRIVER_VERSION	"0.53"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/richcomm_usb.c
+++ b/drivers/richcomm_usb.c
@@ -30,7 +30,7 @@
 
 /* driver version */
 #define DRIVER_NAME	"Richcomm dry-contact to USB driver"
-#define DRIVER_VERSION	"0.11"
+#define DRIVER_VERSION	"0.12"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/riello_ser.c
+++ b/drivers/riello_ser.c
@@ -46,7 +46,7 @@
 #include "riello.h"
 
 #define DRIVER_NAME	"Riello serial driver"
-#define DRIVER_VERSION	"0.07"
+#define DRIVER_VERSION	"0.08"
 
 #define DEFAULT_OFFDELAY   5
 #define DEFAULT_BOOTDELAY  5

--- a/drivers/riello_usb.c
+++ b/drivers/riello_usb.c
@@ -34,7 +34,7 @@
 #include "riello.h"
 
 #define DRIVER_NAME	"Riello USB driver"
-#define DRIVER_VERSION	"0.08"
+#define DRIVER_VERSION	"0.09"
 
 #define DEFAULT_OFFDELAY   5  /*!< seconds (max 0xFF) */
 #define DEFAULT_BOOTDELAY  5  /*!< seconds (max 0xFF) */

--- a/drivers/safenet.c
+++ b/drivers/safenet.c
@@ -41,7 +41,7 @@
 #include "safenet.h"
 
 #define DRIVER_NAME	"Generic SafeNet UPS driver"
-#define DRIVER_VERSION	"1.7"
+#define DRIVER_VERSION	"1.80"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/skel.c
+++ b/drivers/skel.c
@@ -22,7 +22,7 @@
 /* #define IGNCHARS	""	*/
 
 #define DRIVER_NAME	"Skeleton UPS driver"
-#define DRIVER_VERSION	"0.03"
+#define DRIVER_VERSION	"0.04"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -173,7 +173,7 @@ static const char *mibname;
 static const char *mibvers;
 
 #define DRIVER_NAME	"Generic SNMP UPS driver"
-#define DRIVER_VERSION		"1.28"
+#define DRIVER_VERSION	"1.29"
 
 /* driver description structure */
 upsdrv_info_t	upsdrv_info = {

--- a/drivers/socomec_jbus.c
+++ b/drivers/socomec_jbus.c
@@ -31,7 +31,7 @@
 #include <modbus.h>
 
 #define DRIVER_NAME	"Socomec jbus driver"
-#define DRIVER_VERSION	"0.06"
+#define DRIVER_VERSION	"0.07"
 
 #define CHECK_BIT(var,pos) ((var) & (1<<(pos)))
 #define MODBUS_SLAVE_ID 1

--- a/drivers/solis.c
+++ b/drivers/solis.c
@@ -48,7 +48,7 @@
 #include "timehead.h"
 
 #define DRIVER_NAME	"Microsol Solis UPS driver"
-#define DRIVER_VERSION	"0.68"
+#define DRIVER_VERSION	"0.69"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/tripplite.c
+++ b/drivers/tripplite.c
@@ -117,7 +117,7 @@
 #include <ctype.h>
 
 #define DRIVER_NAME	"Tripp-Lite SmartUPS driver"
-#define DRIVER_VERSION	"0.93"
+#define DRIVER_VERSION	"0.94"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -135,8 +135,8 @@
 #include <ctype.h>
 #include "usb-common.h"
 
-#define DRIVER_NAME		"Tripp Lite OMNIVS / SMARTPRO driver"
-#define DRIVER_VERSION	"0.33"
+#define DRIVER_NAME	"Tripp Lite OMNIVS / SMARTPRO driver"
+#define DRIVER_VERSION	"0.34"
 
 /* driver description structure */
 upsdrv_info_t	upsdrv_info = {

--- a/drivers/tripplitesu.c
+++ b/drivers/tripplitesu.c
@@ -125,8 +125,8 @@
 #include "serial.h"
 #include "nut_stdint.h"
 
-#define DRIVER_NAME		"Tripp Lite SmartOnline driver"
-#define DRIVER_VERSION	"0.06"
+#define DRIVER_NAME	"Tripp Lite SmartOnline driver"
+#define DRIVER_VERSION	"0.07"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/upscode2.c
+++ b/drivers/upscode2.c
@@ -43,7 +43,7 @@
 #include "nut_float.h"
 
 #define DRIVER_NAME	"UPScode II UPS driver"
-#define DRIVER_VERSION	"0.90"
+#define DRIVER_VERSION	"0.91"
 
 /* driver description structure */
 upsdrv_info_t	upsdrv_info = {

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -28,7 +28,8 @@
  */
 
 #define DRIVER_NAME	"Generic HID driver"
-#define DRIVER_VERSION		"0.49"
+#define DRIVER_VERSION	"0.50"
+
 #define HU_VAR_WAITBEFORERECONNECT "waitbeforereconnect"
 
 #include "main.h"

--- a/drivers/victronups.c
+++ b/drivers/victronups.c
@@ -32,7 +32,7 @@
 #include "serial.h"
 
 #define DRIVER_NAME	"GE/IMV/Victron UPS driver"
-#define DRIVER_VERSION	"0.21"
+#define DRIVER_VERSION	"0.22"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {


### PR DESCRIPTION
Follow-up after core driver changes (main.c etc.) with `driver.state` #1767, driver reload command #1903, driver inter-instance communications via socket #1922, and others.

Also convert remaining single-digit X.Y versions to X.<Y+1>0 double-digits.

Also minor cosmetic clean-up.

Closes: #1951