### PR TITLE
CI/Legalese: Require DCO (`Signed-off-by:` git tags) in commits

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,11 @@
   as for which text documents to update. See also docs/developer-guide.txt
   for general points on NUT architecture and design.
 
+* Please note that we require "Signed-Off-By" tags in each Git Commit
+  message, to conform to the common DCO (Developer Certificate of Origin)
+  as posted in LICENSE-DCO at root of NUT codebase as well as published
+  at https://developercertificate.org/
+
 * The checklist below is more of a reminder of steps to take and "dangers"
   to look out for. PRs to update this template are also welcome :)
 

--- a/LICENSE-DCO
+++ b/LICENSE-DCO
@@ -1,0 +1,34 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/docs/developers.txt
+++ b/docs/developers.txt
@@ -1300,6 +1300,43 @@ You may notice that some older commits have `[[SVN:####]]` tags and Fossil-ID
 footers. These were lifted from the old SVN commit messages using reposurgeon,
 and should *not* be used as a guide for future commits.
 
+Commit sign-off
+---------------
+
+Please also note that since 2023 we explicitly ask for contributions to be
+"Signed Off" according to "Developer Certificate of Origin" as represented
+in the `LICENSE-DCO` file in the root of NUT source tree (verbatim copy of
+Version 1.1 of DCO published at https://developercertificate.org/ web site).
+This is exactly the same one created and used by the Linux kernel developers.
+
+This is a developer's certification that he or she has the right to submit
+the patch for inclusion into the project. Simply submitting a contribution
+implies this agreement, however, please include a "Signed-off-by" tag in
+every patch (this tag is a conventional way to confirm that you agree to
+the DCO). In other words, this tag certifies that committer has the rights
+to submit this work under the same license as the project and agrees to the
+terms of a Developer Certificate of Origin.
+
+Note that while git commit hook tricks are available to automatically sign
+off all commits, these signatures are intended to be a conscious (legally
+meaningful) act -- hence they are not automated in git core with an easy
+configuration option.
+
+For more details see:
+
+* https://github.com/networkupstools/nut/issues/1994
+* https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for
+* https://stackoverflow.com/questions/15015894/git-add-signed-off-by-line-using-format-signoff-not-working
+
+You are also encouraged to set up a PGP key, make its public part known, and
+use it to sign your git commits (in addition to the `Signed-Off-By` tag) by
+also passing a `-S` option or calling `git config commit.gpgsign true` once.
+Numerous public articles can walk you through this ordeal, including:
+
+* https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
+* https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key
+* https://www.kernel.org/doc/html/v4.19/process/maintainer-pgp-guide.html
+
 Repository etiquette and quality assurance
 ------------------------------------------
 
@@ -1350,11 +1387,11 @@ Here is an example workflow:
 	# Hack away
 
 	git add changed-file.c
-	git commit
+	git commit -s
 
 	# Fix a typo in a file or commit message:
 
-	git commit -a --amend
+	git commit -s -a --amend
 
 	# Someone committed something to the central repository. Fetch it.
 

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3189 utf-8
+personal_ws-1.1 en 3191 utf-8
 AAS
 ABI
 ACFAIL
@@ -240,6 +240,7 @@ DATACABLE
 DATAPATH
 DCE
 DCF
+DCO
 DDD
 DDDDD
 DDDDDD
@@ -1999,6 +2000,7 @@ google
 goto
 gotos
 gpg
+gpgsign
 gpio
 gpiochip
 graphviz


### PR DESCRIPTION
Closes: #1994