### PR TITLE
Extend support to CPS devices which report the shorter Vendor OID as their sysOID

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -153,6 +153,8 @@ as part of https://github.com/networkupstools/nut/issues/1410 solution.
      driver [#1716]
    * `baytech-mib.c` subdriver: fixed `baytech_outlet_status_info[]` set
      of valid outlet status values [#1871]
+   * `cyberpower-mib.c` subdriver: support devices which report the shorter
+     Vendor OID as their sysOID, e.g. "CyberPower PowerPanel Personal" [#1997]
 
  - The `bestfortress` driver shutdown handling was fixed to use a non-trivial
    default timeout [#1820]

--- a/drivers/cyberpower-mib.c
+++ b/drivers/cyberpower-mib.c
@@ -24,11 +24,16 @@
 
 #include "cyberpower-mib.h"
 
-#define CYBERPOWER_MIB_VERSION		"0.52"
+#define CYBERPOWER_MIB_VERSION		"0.53"
 #define CYBERPOWER_OID_MODEL_NAME	".1.3.6.1.4.1.3808.1.1.1.1.1.1.0"
 
 /* CPS-MIB::ups */
 #define CYBERPOWER_SYSOID			".1.3.6.1.4.1.3808.1.1.1"
+
+/* Per https://github.com/networkupstools/nut/issues/1997
+ * some CPS devices offer the shorter vendor OID as sysOID
+ */
+#define CYBERPOWER_SYSOID2			".1.3.6.1.4.1.3808"
 
 /* https://www.cyberpowersystems.com/products/software/mib-files/ */
 /* Per CPS MIB 2.9 upsBaseOutputStatus OBJECT-TYPE: */
@@ -177,3 +182,6 @@ static snmp_info_t cyberpower_mib[] = {
 
 mib2nut_info_t	cyberpower = { "cyberpower", CYBERPOWER_MIB_VERSION, NULL,
 	CYBERPOWER_OID_MODEL_NAME, cyberpower_mib, CYBERPOWER_SYSOID, NULL };
+
+mib2nut_info_t	cyberpower2 = { "cyberpower", CYBERPOWER_MIB_VERSION, NULL,
+	CYBERPOWER_OID_MODEL_NAME, cyberpower_mib, CYBERPOWER_SYSOID2, NULL };

--- a/drivers/cyberpower-mib.h
+++ b/drivers/cyberpower-mib.h
@@ -5,5 +5,6 @@
 #include "snmp-ups.h"
 
 extern mib2nut_info_t	cyberpower;
+extern mib2nut_info_t	cyberpower2;
 
 #endif /* CYBERPOWER_MIB_H */

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -104,6 +104,7 @@ static mib2nut_info_t *mib2nut[] = {
 	&bestpower,			/* This struct comes from : bestpower-mib.c */
 	&compaq,			/* This struct comes from : compaq-mib.c */
 	&cyberpower,		/* This struct comes from : cyberpower-mib.c */
+	&cyberpower2,		/* This struct comes from : cyberpower-mib.c */
 	&delta_ups,			/* This struct comes from : delta_ups-mib.c */
 	&eaton_ats16_nmc,		/* This struct comes from : eaton-ats16-nmc-mib.c */
 	&eaton_ats16_nm2,	/* This struct comes from : eaton-ats16-nm2-mib.c */
@@ -173,7 +174,7 @@ static const char *mibname;
 static const char *mibvers;
 
 #define DRIVER_NAME	"Generic SNMP UPS driver"
-#define DRIVER_VERSION	"1.29"
+#define DRIVER_VERSION	"1.30"
 
 /* driver description structure */
 upsdrv_info_t	upsdrv_info = {


### PR DESCRIPTION
Closes: #1997