### PR TITLE
Introduce state entry timestamping and use it to fix `apcupsd-ups`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -788,22 +788,22 @@ Release notes for NUT 2.7.4 - what's new since 2.7.3:
      input, output, outlet and outlet.group)
 
  - support for new devices:
-   AEG PROTECT B / NAS
-   APC ATS AP7724 (should be supported)
-   Asium P700
-   Eaton ATS
-   Eaton 5E 1100iUSB
-   Eaton E Series DX UPS 1-20 kVA
-   Eaton Powerware 9125-5000g
-   Electrys UPS 2500
-   Fideltronic INIGO Viper 1200
-   Legrand Keor Multiplug
-   LYONN CTB-800V
-   Micropower LCD 1000
-   NHS Laser Senoidal 5000VA
-   Sweex model P220
-   TS Shara
-   Various APCUPSD-controlled APC devices
+   * AEG PROTECT B / NAS
+   * APC ATS AP7724 (should be supported)
+   * Asium P700
+   * Eaton ATS
+   * Eaton 5E 1100iUSB
+   * Eaton E Series DX UPS 1-20 kVA
+   * Eaton Powerware 9125-5000g
+   * Electrys UPS 2500
+   * Fideltronic INIGO Viper 1200
+   * Legrand Keor Multiplug
+   * LYONN CTB-800V
+   * Micropower LCD 1000
+   * NHS Laser Senoidal 5000VA
+   * Sweex model P220
+   * TS Shara
+   * Various APCUPSD-controlled APC devices
 
  - snmp-ups:
    * Improve automatic detection algorithm

--- a/NEWS
+++ b/NEWS
@@ -121,6 +121,11 @@ as part of https://github.com/networkupstools/nut/issues/1410 solution.
 
  - powercom driver should now try harder to refresh data from device [#356]
 
+ - apcupsd-ups:
+   * improvement for `POLL_INTERVAL_MIN` from PR #797 was buggy [#2007]
+   * fix to clean obsoleted readings (if any) AFTER getting new info from an
+     `apcupsd` daemon, to avoid the gap when NUT driver knows nothing [#2007]
+
  - NUT for Windows:
    * Ability to build NUT for Windows, last tackled with a branch based on
      NUT v2.6.5 a decade ago, has been revived with the 2.8.x era codebase [#5].
@@ -619,11 +624,6 @@ refer to this change set (too long in the making) as NUT 2.7.5.
 
  - the powerpanel driver now also supports CyberPower OR1500LCDRTXL2U with
    serial cable [PR #538]
-
- - apcupsd-ups:
-   * improvement for `POLL_INTERVAL_MIN` from PR #797 was buggy [#2007]
-   * fix to clean obsoleted readings (if any) AFTER getting new info from an
-     `apcupsd` daemon, to avoid the gap when NUT driver knows nothing [#2007]
 
  - powercom driver: implement `nobt` config parameter to skip battery check
    on initialization/startup [PR #1256]

--- a/NEWS
+++ b/NEWS
@@ -615,6 +615,9 @@ refer to this change set (too long in the making) as NUT 2.7.5.
  - the powerpanel driver now also supports CyberPower OR1500LCDRTXL2U with
    serial cable [PR #538]
 
+ - apcupsd-ups:
+   * improvement for `POLL_INTERVAL_MIN` from PR #797 was buggy [#2007]
+
  - powercom driver: implement `nobt` config parameter to skip battery check
    on initialization/startup [PR #1256]
 

--- a/NEWS
+++ b/NEWS
@@ -617,6 +617,8 @@ refer to this change set (too long in the making) as NUT 2.7.5.
 
  - apcupsd-ups:
    * improvement for `POLL_INTERVAL_MIN` from PR #797 was buggy [#2007]
+   * fix to clean obsoleted readings (if any) AFTER getting new info from an
+     `apcupsd` daemon, to avoid the gap when NUT driver knows nothing [#2007]
 
  - powercom driver: implement `nobt` config parameter to skip battery check
    on initialization/startup [PR #1256]

--- a/NEWS
+++ b/NEWS
@@ -89,6 +89,11 @@ as part of https://github.com/networkupstools/nut/issues/1410 solution.
    of recent codebase solves their practical issues. For "quick tests", a
    shortcut operation `./ci_build.sh inplace` was added [#1714]
 
+ - State tree structure and methods (including "dstate" wrapper for common
+   driver internals) was enhanced with time-stamping of last modification
+   (setting, changing, deleting the value or some fields in an entry):
+   this allows to detect stale information in a centralized fashion [#2010]
+
  - We lacked log information about changes of chroot jail (uncommon) and
    of UID/GID (everywhere), which makes troubleshooting harder (e.g. lack
    of access to config files or USB device nodes). Now we have it [#1694]

--- a/common/common.c
+++ b/common/common.c
@@ -735,6 +735,35 @@ static nsec_t timespec_load_nsec(const struct timespec *ts) {
 
 	return (nsec_t) ts->tv_sec * NSEC_PER_SEC + (nsec_t) ts->tv_nsec;
 }
+
+double difftimespec(struct timespec x, struct timespec y)
+{
+	struct timespec	result;
+	double	d;
+
+	/* Code below assumes that tv_sec is signed (time_t),
+	 * but tv_nsec is not necessarily */
+	/* Perform the carry for the later subtraction by updating y. */
+	if (x.tv_nsec < y.tv_nsec) {
+		intmax_t numsec = (y.tv_nsec - x.tv_nsec) / 1000000000L + 1;
+		y.tv_nsec -= 1000000000L * numsec;
+		y.tv_sec += numsec;
+	}
+
+	if (x.tv_nsec - y.tv_nsec > 1000000) {
+		intmax_t numsec = (x.tv_nsec - y.tv_nsec) / 1000000000L;
+		y.tv_nsec += 1000000000L * numsec;
+		y.tv_sec -= numsec;
+	}
+
+	/* Compute the time remaining to wait.
+	 * tv_nsec is certainly positive. */
+	result.tv_sec = x.tv_sec - y.tv_sec;
+	result.tv_nsec = x.tv_nsec - y.tv_nsec;
+
+	d = 0.000000001 * result.tv_nsec + result.tv_sec;
+	return d;
+}
 #endif	/* HAVE_CLOCK_GETTIME && HAVE_CLOCK_MONOTONIC */
 
 /* Send (daemon) state-change notifications to an

--- a/common/common.c
+++ b/common/common.c
@@ -667,17 +667,19 @@ double difftimeval(struct timeval x, struct timeval y)
 	struct timeval	result;
 	double	d;
 
+	/* Code below assumes that tv_sec is signed (time_t),
+	 * but tv_usec is not necessarily */
 	/* Perform the carry for the later subtraction by updating y. */
 	if (x.tv_usec < y.tv_usec) {
-		intmax_t nsec = (y.tv_usec - x.tv_usec) / 1000000 + 1;
-		y.tv_usec -= 1000000 * nsec;
-		y.tv_sec += nsec;
+		intmax_t numsec = (y.tv_usec - x.tv_usec) / 1000000 + 1;
+		y.tv_usec -= 1000000 * numsec;
+		y.tv_sec += numsec;
 	}
 
 	if (x.tv_usec - y.tv_usec > 1000000) {
-		intmax_t nsec = (x.tv_usec - y.tv_usec) / 1000000;
-		y.tv_usec += 1000000 * nsec;
-		y.tv_sec -= nsec;
+		intmax_t numsec = (x.tv_usec - y.tv_usec) / 1000000;
+		y.tv_usec += 1000000 * numsec;
+		y.tv_sec -= numsec;
 	}
 
 	/* Compute the time remaining to wait.

--- a/common/state.c
+++ b/common/state.c
@@ -311,6 +311,7 @@ int state_setinfo(st_tree_t **nptr, const char *var, const char *val)
 	(*nptr)->var = xstrdup(var);
 	(*nptr)->raw = xstrdup(val);
 	(*nptr)->rawsize = strlen(val) + 1;
+	st_tree_node_refresh_timestamp(*nptr);
 
 	val_escape(*nptr);
 

--- a/common/state.c
+++ b/common/state.c
@@ -253,6 +253,7 @@ int state_delinfo_olderthan(st_tree_t **nptr, const char *var, const st_tree_tim
 			upsdebugx(6, "%s: not deleting recently updated variable [%s]", __func__, var);
 			return 0;
 		}
+		upsdebugx(6, "%s: deleting variable [%s] last updated too long ago", __func__, var);
 
 		/* whatever is on the left, hang it off current right */
 		st_tree_node_add(&node->right, node->left);

--- a/common/state.c
+++ b/common/state.c
@@ -171,6 +171,11 @@ int st_tree_node_compare_timestamp(
 	if (!cutoff)
 		return -3;
 
+	/* Like in difftime(), the first arg is "finish" and
+	 * the second arg is "start" of a time range (below),
+	 * so if the diff is negative, then "lastset" happened
+	 * before "cutoff":
+	 */
 #if defined(HAVE_CLOCK_GETTIME) && defined(HAVE_CLOCK_MONOTONIC) && HAVE_CLOCK_GETTIME && HAVE_CLOCK_MONOTONIC
 	d = difftimespec(node->lastset, *cutoff);
 #else

--- a/configure.ac
+++ b/configure.ac
@@ -861,7 +861,7 @@ AC_CACHE_CHECK([for clock_gettime(CLOCK_MONOTONIC,ts)],
 ],
             [struct timespec monoclock_ts;
 int got_monoclock = clock_gettime(CLOCK_MONOTONIC, &monoclock_ts);
-if (ts.tv_sec < 0 || ts.tv_nsec < 0) return 1])],
+if (monoclock_ts.tv_sec < 0 || monoclock_ts.tv_nsec < 0) return 1])],
         [ac_cv_func_clock_gettime=yes], [ac_cv_func_clock_gettime=no]
     )])
 AS_IF([test x"${ac_cv_func_clock_gettime}" = xyes],

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -274,7 +274,7 @@ if HAVE_ASPELL
 SPELLCHECK_SRC = $(ALL_TXT_SRC) ../README ../INSTALL.nut ../UPGRADING  ../NEWS \
 	../TODO ../scripts/ufw/README ../scripts/augeas/README ../lib/README \
 	../tools/nut-scanner/README \
-	../AUTHORS ../COPYING ../LICENSE-GPL2 ../LICENSE-GPL3
+	../AUTHORS ../COPYING ../LICENSE-GPL2 ../LICENSE-GPL3 ../LICENSE-DCO
 
 # Directory SPELLCHECK_SRC files are relative to. Overriden by other Makefiles.
 SPELLCHECK_DIR = $(srcdir)

--- a/drivers/apcupsd-ups.c
+++ b/drivers/apcupsd-ups.c
@@ -174,6 +174,7 @@ static int getdata(void)
 	char *data;
 	struct pollfd p;
 	char bfr[1024];
+	int ret = -1;
 #ifndef WIN32
 	int fd_flags;
 #else
@@ -192,14 +193,18 @@ static int getdata(void)
 	if (INVALID_FD_SOCK( p.fd = socket(AF_INET, SOCK_STREAM, 0) ))
 	{
 		upsdebugx(1,"socket error");
-		return -1;
+		/* return -1; */
+		ret = -1;
+		goto getdata_return;
 	}
 
 	if(connect(p.fd,(struct sockaddr *)&host,sizeof(host)))
 	{
 		upsdebugx(1,"can't connect to apcupsd");
-		close(p.fd);
-		return -1;
+		/* close(p.fd);
+		return -1; */
+		ret = -1;
+		goto getdata_return;
 	}
 
 #ifndef WIN32
@@ -207,15 +212,19 @@ static int getdata(void)
 	fd_flags = fcntl(p.fd, F_GETFL);
 	if (fd_flags == -1) {
 		upsdebugx(1,"unexpected fcntl(fd, F_GETFL) failure");
-		close(p.fd);
-		return -1;
+		/* close(p.fd);
+		return -1; */
+		ret = -1;
+		goto getdata_return;
 	}
 	fd_flags |= O_NONBLOCK;
 	if(fcntl(p.fd, F_SETFL, fd_flags) == -1)
 	{
 		upsdebugx(1,"unexpected fcntl(fd, F_SETFL, fd_flags|O_NONBLOCK) failure");
-		close(p.fd);
-		return -1;
+		/* close(p.fd);
+		return -1; */
+		ret = -1;
+		goto getdata_return;
 	}
 #else
 	event = CreateEvent(
@@ -244,20 +253,14 @@ static int getdata(void)
 		if(read(p.fd,&n,2)!=2)
 		{
 			upsdebugx(1,"apcupsd communication error");
-			close(p.fd);
-#ifdef WIN32
-			CloseHandle(event);
-#endif
-			return -1;
+			ret = -1;
+			goto getdata_return;
 		}
 
 		if(!(x=ntohs(n)))
 		{
-			close(p.fd);
-#ifdef WIN32
-			CloseHandle(event);
-#endif
-			return 0;
+			ret = 0;
+			goto getdata_return;
 		}
 		else if(x<0||x>=(int)sizeof(bfr))
 		/* Note: LGTM.com suggests "Comparison is always false because x >= 0"
@@ -268,11 +271,8 @@ static int getdata(void)
 		 */
 		{
 			upsdebugx(1,"apcupsd communication error");
-			close(p.fd);
-#ifdef WIN32
-			CloseHandle(event);
-#endif
-			return -1;
+			ret = -1;
+			goto getdata_return;
 		}
 
 #ifndef WIN32
@@ -284,11 +284,8 @@ static int getdata(void)
 		if(read(p.fd,bfr,(size_t)x)!=x)
 		{
 			upsdebugx(1,"apcupsd communication error");
-			close(p.fd);
-#ifdef WIN32
-			CloseHandle(event);
-#endif
-			return -1;
+			ret = -1;
+			goto getdata_return;
 		}
 
 		bfr[x]=0;
@@ -296,21 +293,15 @@ static int getdata(void)
 		if(!(item=strtok(bfr," \t:\r\n")))
 		{
 			upsdebugx(1,"apcupsd communication error");
-			close(p.fd);
-#ifdef WIN32
-			CloseHandle(event);
-#endif
-			return -1;
+			ret = -1;
+			goto getdata_return;
 		}
 
 		if(!(data=strtok(NULL,"\r\n")))
 		{
 			upsdebugx(1,"apcupsd communication error");
-			close(p.fd);
-#ifdef WIN32
-			CloseHandle(event);
-#endif
-			return -1;
+			ret = -1;
+			goto getdata_return;
 		}
 		while(*data==' '||*data=='\t'||*data==':')data++;
 
@@ -318,11 +309,16 @@ static int getdata(void)
 	}
 
 	upsdebugx(1,"unexpected connection close by apcupsd");
-	close(p.fd);
+	ret = -1;
+
+getdata_return:
+	if (VALID_FD_SOCK(p.fd))
+		close(p.fd);
 #ifdef WIN32
-	CloseHandle(event);
+	if (event != NULL)
+		CloseHandle(event);
 #endif
-	return -1;
+	return ret;
 }
 
 void upsdrv_initinfo(void)

--- a/drivers/apcupsd-ups.c
+++ b/drivers/apcupsd-ups.c
@@ -39,7 +39,7 @@ typedef unsigned long int nfds_t;
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"apcupsd network client UPS driver"
-#define DRIVER_VERSION	"0.70"
+#define DRIVER_VERSION	"0.71"
 
 #define POLL_INTERVAL_MIN 10
 
@@ -331,7 +331,7 @@ void upsdrv_initinfo(void)
 	if(getdata())fatalx(EXIT_FAILURE,"can't communicate with apcupsd!");
 	else dstate_dataok();
 
-	poll_interval = (poll_interval > POLL_INTERVAL_MIN) ? POLL_INTERVAL_MIN : poll_interval;
+	poll_interval = (poll_interval < POLL_INTERVAL_MIN) ? POLL_INTERVAL_MIN : poll_interval;
 }
 
 void upsdrv_updateinfo(void)
@@ -339,7 +339,7 @@ void upsdrv_updateinfo(void)
 	if(getdata())upslogx(LOG_ERR,"can't communicate with apcupsd!");
 	else dstate_dataok();
 
-	poll_interval = (poll_interval > POLL_INTERVAL_MIN) ? POLL_INTERVAL_MIN : poll_interval;
+	poll_interval = (poll_interval < POLL_INTERVAL_MIN) ? POLL_INTERVAL_MIN : poll_interval;
 }
 
 void upsdrv_shutdown(void)

--- a/drivers/apcupsd-ups.c
+++ b/drivers/apcupsd-ups.c
@@ -189,7 +189,7 @@ static int getdata(void)
 
 	state_get_timestamp((st_tree_timespec_t *)&start);
 
-	if (INVALID_FD_SOCK( p.fd = socket(AF_INET, SOCK_STREAM, 0) ))
+	if (INVALID_FD_SOCK( (p.fd = socket(AF_INET, SOCK_STREAM, 0)) ))
 	{
 		upsdebugx(1,"socket error");
 		/* return -1; */

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -1400,6 +1400,20 @@ int dstate_delinfo(const char *var)
 	return ret;
 }
 
+int dstate_delinfo_olderthan(const char *var, const st_tree_timespec_t *cutoff)
+{
+	int	ret;
+
+	ret = state_delinfo_olderthan(&dtree_root, var, cutoff);
+
+	/* update listeners */
+	if (ret == 1) {
+		send_to_all("DELINFO %s\n", var);
+	}
+
+	return ret;
+}
+
 int dstate_delenum(const char *var, const char *val)
 {
 	int	ret;

--- a/drivers/dstate.h
+++ b/drivers/dstate.h
@@ -75,6 +75,7 @@ void dstate_delflags(const char *var, const int delflags);
 void dstate_setaux(const char *var, long aux);
 const char *dstate_getinfo(const char *var);
 void dstate_addcmd(const char *cmdname);
+int dstate_delinfo_olderthan(const char *var, const st_tree_timespec_t *cutoff);
 int dstate_delinfo(const char *var);
 int dstate_delenum(const char *var, const char *val);
 int dstate_delrange(const char *var, const int min, const int max);

--- a/include/common.h
+++ b/include/common.h
@@ -409,6 +409,9 @@ char * getfullpath(char * relative_path);
 
 /* Return a difference of two timevals as a floating-point number */
 double difftimeval(struct timeval x, struct timeval y);
+#if defined(HAVE_CLOCK_GETTIME) && defined(HAVE_CLOCK_MONOTONIC) && HAVE_CLOCK_GETTIME && HAVE_CLOCK_MONOTONIC
+double difftimespec(struct timespec x, struct timespec y);
+#endif
 
 #ifndef HAVE_USLEEP
 /* int __cdecl usleep(unsigned int useconds); */

--- a/include/state.h
+++ b/include/state.h
@@ -81,6 +81,7 @@ void state_infofree(st_tree_t *node);
 void state_cmdfree(cmdlist_t *list);
 int state_delcmd(cmdlist_t **list, const char *cmd);
 int state_delinfo(st_tree_t **root, const char *var);
+int state_delinfo_olderthan(st_tree_t **root, const char *var, const st_tree_timespec_t *cutoff);
 int state_delenum(st_tree_t *root, const char *var, const char *val);
 int state_delrange(st_tree_t *root, const char *var, const int min, const int max);
 st_tree_t *state_tree_find(st_tree_t *node, const char *var);

--- a/include/state.h
+++ b/include/state.h
@@ -32,6 +32,12 @@ extern "C" {
 
 #define ST_SOCK_BUF_LEN 512
 
+#if defined(HAVE_CLOCK_GETTIME) && defined(HAVE_CLOCK_MONOTONIC) && HAVE_CLOCK_GETTIME && HAVE_CLOCK_MONOTONIC
+typedef struct timespec	st_tree_timespec_t;
+#else
+typedef struct timeval	st_tree_timespec_t;
+#endif
+
 typedef struct st_tree_s {
 	char	*var;
 	char	*val;			/* points to raw or safe */
@@ -45,6 +51,12 @@ typedef struct st_tree_s {
 	int	flags;
 	long	aux;
 
+	/* When was this entry last written (meaning that
+	 * val/raw/safe, flags, aux, enum or range value
+	 * was added, changed or deleted)?
+	 */
+	st_tree_timespec_t	lastset;
+
 	struct enum_s		*enum_list;
 	struct range_s		*range_list;
 
@@ -52,6 +64,8 @@ typedef struct st_tree_s {
 	struct st_tree_s	*right;
 } st_tree_t;
 
+int state_get_timestamp(st_tree_timespec_t *now);
+int st_tree_node_compare_timestamp(const st_tree_t *node, const st_tree_timespec_t *cutoff);
 int state_setinfo(st_tree_t **nptr, const char *var, const char *val);
 int state_addenum(st_tree_t *root, const char *var, const char *val);
 int state_addrange(st_tree_t *root, const char *var, const int min, const int max);

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -13,6 +13,9 @@
 /nutlogtest
 /nutlogtest.log
 /nutlogtest.trs
+/nuttimetest
+/nuttimetest.log
+/nuttimetest.trs
 /getvaluetest
 /getvaluetest.log
 /getvaluetest.trs

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -40,6 +40,10 @@ else
 TESTS += nutlogtest
 endif
 
+TESTS += nuttimetest
+nuttimetest_SOURCES = nuttimetest.c
+nuttimetest_LDADD = $(top_builddir)/common/libcommon.la
+
 # Separate the .deps of other dirs from this one
 LINKED_SOURCE_FILES = hidparser.c
 

--- a/tests/nuttimetest.c
+++ b/tests/nuttimetest.c
@@ -1,0 +1,154 @@
+/*  nuttimetest.c - test custom NUT routines for time comparison and manipulation
+ *
+ *  Copyright (C)
+ *      2023            Jim Klimov <jimklimov+nut@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ */
+
+#include "config.h"
+#include "common.h"
+#include "nut_stdint.h"
+#include "nut_float.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+static int check_difftime()
+{
+	time_t tv1, tv2;
+	double d1, d2;
+	int res = 0;
+
+	printf("=== %s(time_t):\t", __func__);
+
+	/* Often time_t is a long int, maybe signed */
+	tv1 = 5;
+	printf(" tv1=%" PRIiMAX, (intmax_t)tv1);
+
+	tv2 = 8;
+	printf(" tv2=%" PRIiMAX, (intmax_t)tv2);
+
+	/* like in difftime(): (double)seconds elapsed time between older tv2 and newer tv1 */
+	d1 = difftime(tv1, tv2);
+	if (!d_equal(d1, -3))
+		res++;
+	printf(" => diff1(tv1, tv2)=%f (%s)", d1, d_equal(d1, -3) ? "OK" : "FAIL");
+
+	d2 = difftime(tv2, tv1);
+	if (!d_equal(d2, 3))
+		res++;
+	printf(" => diff2(tv2, tv1)=%f (%s)", d2, d_equal(d2, 3) ? "OK" : "FAIL");
+
+	if (!d_equal(d1, -d2)) {
+		printf(" => diff1 != -diff2 (FAIL)\n");
+		res++;
+	} else {
+		printf(" => diff1 == -diff2 (OK)\n");
+	}
+
+	return res;
+}
+
+static int check_difftimeval()
+{
+	struct timeval tv1, tv2;
+	double d1, d2;
+	int res = 0;
+
+	printf("=== %s(struct timeval):\t", __func__);
+
+	tv1.tv_sec = 5;
+	tv1.tv_usec = 900000;
+	printf(" tv1=%" PRIiMAX ".%06" PRIiMAX, (intmax_t)tv1.tv_sec, (intmax_t)tv1.tv_usec);
+
+	tv2.tv_sec = 8;
+	tv2.tv_usec = 230000;
+	printf(" tv2=%" PRIiMAX ".%06" PRIiMAX, (intmax_t)tv2.tv_sec, (intmax_t)tv2.tv_usec);
+
+	/* like in difftime(): (double)seconds elapsed time between older tv2 and newer tv1 */
+	d1 = difftimeval(tv1, tv2);
+	if (!d_equal(d1, -2.33))
+		res++;
+	printf(" => diff1(tv1, tv2)=%f (%s)", d1, d_equal(d1, -2.33) ? "OK" : "FAIL");
+
+	d2 = difftimeval(tv2, tv1);
+	if (!d_equal(d2, 2.33))
+		res++;
+	printf(" => diff2(tv2, tv1)=%f (%s)", d2, d_equal(d2, 2.33) ? "OK" : "FAIL");
+
+	if (!d_equal(d1, -d2)) {
+		printf(" => diff1 != -diff2 (FAIL)\n");
+		res++;
+	} else {
+		printf(" => diff1 == -diff2 (OK)\n");
+	}
+
+	return res;
+}
+
+static int check_difftimespec()
+{
+	int res = 0;
+#if defined(HAVE_CLOCK_GETTIME) && defined(HAVE_CLOCK_MONOTONIC) && HAVE_CLOCK_GETTIME && HAVE_CLOCK_MONOTONIC
+	struct timespec tv1, tv2;
+	double d1, d2;
+
+	printf("=== %s(struct timespec):\t", __func__);
+
+	tv1.tv_sec = 5;
+	tv1.tv_nsec = 900000000;
+	printf(" tv1=%" PRIiMAX ".%09" PRIiMAX, (intmax_t)tv1.tv_sec, (intmax_t)tv1.tv_nsec);
+
+	tv2.tv_sec = 8;
+	tv2.tv_nsec =    230000;
+	printf(" tv2=%" PRIiMAX ".%09" PRIiMAX, (intmax_t)tv2.tv_sec, (intmax_t)tv2.tv_nsec);
+
+	/* like in difftime(): (double)seconds elapsed time between older tv2 and newer tv1 */
+	d1 = difftimespec(tv1, tv2);
+	if (!d_equal(d1, -2.10023))
+		res++;
+	printf(" => diff1(tv1, tv2)=%f (%s)", d1, d_equal(d1, -2.10023) ? "OK" : "FAIL");
+
+	d2 = difftimespec(tv2, tv1);
+	if (!d_equal(d2, 2.10023))
+		res++;
+	printf(" => diff2(tv2, tv1)=%f (%s)", d2, d_equal(d2, 2.10023) ? "OK" : "FAIL");
+
+	if (!d_equal(d1, -d2)) {
+		printf(" => diff1 != -diff2 (FAIL)\n");
+		res++;
+	} else {
+		printf(" => diff1 == -diff2 (OK)\n");
+	}
+#else
+	printf("=== %s(struct timespec):\tSKIP: NOT IMPLEMENTED for this build (not HAVE_CLOCK_GETTIME or not HAVE_CLOCK_MONOTONIC)\n", __func__);
+#endif
+
+	return res;
+}
+
+int main(void)
+{
+	int ret = 0;
+
+	ret += check_difftime();
+	ret += check_difftimeval();
+	ret += check_difftimespec();
+
+	return (ret != 0);
+}


### PR DESCRIPTION
CC @aquette @clepple : This is a fairly noticeable change to the deep internals, state info trees are at the core of everything in NUT. Would welcome another set of eyeballs that I got this conceptually right :)

Should I be concerned about computational overheads to keep reading and comparing time values? Should this behavior become a toggle (e.g. for programs that know they intend to use this feature at all)?

In context of issue #2007 there is a need to somehow avoid the current behavior with deletion of nearly all info about the device and then re-querying `apcupsd` to populate the dstate again. With this change we hopefully (un-tested so far) have a way to determine if any entries were not updated in the last read, and so should be cleaned away AFTER talking to the device (apcupsd server in this case).

While this is a first use for such tech, I can see it proliferating into other drivers to support "Data stale" decisions (e.g. attempt to re-initialize the hardware connection), etc.

Closes: #2007
Fixes: #797 fallout