### PR TITLE
Define `upsd` option to `LISTEN *` as specifically handling both IPv4 and IPv6 "ANY" address

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -287,6 +287,12 @@ as part of https://github.com/networkupstools/nut/issues/1410 solution.
    would warn if a hostname resolves to several addresses (and would only
    listen on the first hit, as before in such cases) [#2012]
 
+ - A definitive behavior for `LISTEN *` directives became specified, to try
+   handling both IPv4 and IPv6 "any" address (subject to `upsd` CLI options
+   to only choose one, and to OS abilities); this use-case may be practically
+   implemented as a single IPv6 socket on systems with enabled "dual-stack"
+   support or as two separate listening sockets [#2012]
+
  - sstate (server state, e.g. upsd) should now "PING" drivers also if they
    last reported themselves as "stale" (and might later crash) so their
    connections would be terminated if really no longer active [#1626]

--- a/NEWS
+++ b/NEWS
@@ -282,6 +282,11 @@ as part of https://github.com/networkupstools/nut/issues/1410 solution.
    (the last listed address was applied first), which was counter-intuitive
    and fixed for this release [#2012]
 
+ - The `upsd` configured to listen on IPv6 addresses should handle only
+   IPv6 (and not IPv4-mappings) to avoid surprises and insecurity; it
+   would warn if a hostname resolves to several addresses (and would only
+   listen on the first hit, as before in such cases) [#2012]
+
  - sstate (server state, e.g. upsd) should now "PING" drivers also if they
    last reported themselves as "stale" (and might later crash) so their
    connections would be terminated if really no longer active [#1626]

--- a/NEWS
+++ b/NEWS
@@ -294,7 +294,7 @@ as part of https://github.com/networkupstools/nut/issues/1410 solution.
    asking for disabled IPv4-mapped IPv6 address support (if the OS honors
    that), and then an IPv4 socket (which may fail if the IPv6 socket already
    covers it anyway); in other words, you can end up with one or two separate
-   listening sockets [#2012]
+   listening sockets. [#2012]
 
  - sstate (server state, e.g. upsd) should now "PING" drivers also if they
    last reported themselves as "stale" (and might later crash) so their

--- a/NEWS
+++ b/NEWS
@@ -278,6 +278,10 @@ as part of https://github.com/networkupstools/nut/issues/1410 solution.
    * added support for `NUT_QUIET_INIT_SSL` environment variable to hide
      the infamous "Init SSL without certificate database" warning [#1662]
 
+ - The `upsd.conf` listing of `LISTEN` addresses was previously inverted
+   (the last listed address was applied first), which was counter-intuitive
+   and fixed for this release [#2012]
+
  - sstate (server state, e.g. upsd) should now "PING" drivers also if they
    last reported themselves as "stale" (and might later crash) so their
    connections would be terminated if really no longer active [#1626]

--- a/NEWS
+++ b/NEWS
@@ -62,7 +62,7 @@ as part of https://github.com/networkupstools/nut/issues/1410 solution.
      too low. As issue #1455 and PR #1495 found, in two cases the called
      commands did "meaningfully" modify data -- so without debug logs the
      program misbehaved. A known regression for `upscode2` driver; might
-     be or not be a problem with `upsd` driver in NUT v2.8.0 release,
+     be or not be a problem with `upsd` server in NUT v2.8.0 release,
      fixed for NUT v2.8.1.
    * A table in `cyberpower-mib` (for `snmp-ups` driver) sources was
      arranged in NUT v2.8.0 release in a way that precluded the driver

--- a/NEWS
+++ b/NEWS
@@ -284,14 +284,17 @@ as part of https://github.com/networkupstools/nut/issues/1410 solution.
 
  - The `upsd` configured to listen on IPv6 addresses should handle only
    IPv6 (and not IPv4-mappings) to avoid surprises and insecurity; it
-   would warn if a hostname resolves to several addresses (and would only
+   will now warn if a host name resolves to several addresses (and will only
    listen on the first hit, as before in such cases) [#2012]
 
  - A definitive behavior for `LISTEN *` directives became specified, to try
    handling both IPv4 and IPv6 "any" address (subject to `upsd` CLI options
-   to only choose one, and to OS abilities); this use-case may be practically
-   implemented as a single IPv6 socket on systems with enabled "dual-stack"
-   support or as two separate listening sockets [#2012]
+   to only choose one, and to OS abilities). When both address families are
+   enabled, the `upsd` data server will first try to open an IPv6 socket
+   asking for disabled IPv4-mapped IPv6 address support (if the OS honors
+   that), and then an IPv4 socket (which may fail if the IPv6 socket already
+   covers it anyway); in other words, you can end up with one or two separate
+   listening sockets [#2012]
 
  - sstate (server state, e.g. upsd) should now "PING" drivers also if they
    last reported themselves as "stale" (and might later crash) so their

--- a/UPGRADING
+++ b/UPGRADING
@@ -71,6 +71,14 @@ Changes from 2.8.0 to 2.8.1
   order (e.g. to prioritize IPv6 vs IPv4 listeners), configuration changes
   may be needed. [#2012]
 
+- The `upsd` configured to listen on IPv6 addresses should handle only
+  IPv6 (and not IPv4-mappings like it might have done before) to avoid
+  surprises and insecurity -- if user configurations somehow relied on
+  this dual support, configuration changes may be needed to specify both
+  desired IP addresses. Note that the daemon logs would warn if a hostname
+  resolves to several addresses (and would only listen on the first hit,
+  as it did before in such cases) [#2012]
+
 - Added support for `make sockdebug` for easier developer access to the tool;
   also if `configure --with-dev` is in effect, it would now be installed to
   the configured `libexec` location. A man page was also added. [#1936]

--- a/UPGRADING
+++ b/UPGRADING
@@ -77,7 +77,7 @@ Changes from 2.8.0 to 2.8.1
   this dual support, configuration changes may be needed to specify both
   desired IP addresses. Note that the daemon logs will now warn if a
   host name resolves to several addresses (and will only listen on the
-  first hit, as it did before in such cases) [#2012]
+  first hit, as it did before in such cases). [#2012]
 
 - A definitive behavior for `LISTEN *` directives became specified, to try
   handling both IPv4 and IPv6 "any" address (subject to `upsd` CLI options

--- a/UPGRADING
+++ b/UPGRADING
@@ -65,6 +65,12 @@ Changes from 2.8.0 to 2.8.1
   the packaging recipes may use NUT source-code facilities and package just
   symlinks as relevant for each distro separately [#1462, #1504]
 
+- The `upsd.conf` listing of `LISTEN` addresses was previously inverted
+  (the last listed address was applied first), which was counter-intuitive
+  and fixed for this release. If user configurations somehow relied on this
+  order (e.g. to prioritize IPv6 vs IPv4 listeners), configuration changes
+  may be needed. [#2012]
+
 - Added support for `make sockdebug` for easier developer access to the tool;
   also if `configure --with-dev` is in effect, it would now be installed to
   the configured `libexec` location. A man page was also added. [#1936]

--- a/UPGRADING
+++ b/UPGRADING
@@ -79,6 +79,12 @@ Changes from 2.8.0 to 2.8.1
   resolves to several addresses (and would only listen on the first hit,
   as it did before in such cases) [#2012]
 
+- A definitive behavior for `LISTEN *` directives became specified, to try
+  handling both IPv4 and IPv6 "any" address (subject to `upsd` CLI options
+  to only choose one, and to OS abilities); this use-case may be practically
+  implemented as a single IPv6 socket on systems with enabled "dual-stack"
+  support or as two separate listening sockets [#2012]
+
 - Added support for `make sockdebug` for easier developer access to the tool;
   also if `configure --with-dev` is in effect, it would now be installed to
   the configured `libexec` location. A man page was also added. [#1936]

--- a/UPGRADING
+++ b/UPGRADING
@@ -75,15 +75,19 @@ Changes from 2.8.0 to 2.8.1
   IPv6 (and not IPv4-mappings like it might have done before) to avoid
   surprises and insecurity -- if user configurations somehow relied on
   this dual support, configuration changes may be needed to specify both
-  desired IP addresses. Note that the daemon logs would warn if a hostname
-  resolves to several addresses (and would only listen on the first hit,
-  as it did before in such cases) [#2012]
+  desired IP addresses. Note that the daemon logs will now warn if a
+  host name resolves to several addresses (and will only listen on the
+  first hit, as it did before in such cases) [#2012]
 
 - A definitive behavior for `LISTEN *` directives became specified, to try
   handling both IPv4 and IPv6 "any" address (subject to `upsd` CLI options
-  to only choose one, and to OS abilities); this use-case may be practically
-  implemented as a single IPv6 socket on systems with enabled "dual-stack"
-  support or as two separate listening sockets [#2012]
+  to only choose one, and to OS abilities). This use-case may be practically
+  implemented as a single IPv6 socket on systems with enabled and required
+  IPv4-mapped IPv6 address support, or as two separate listening sockets -
+  logged messages to this effect (e.g. inability to listen on IPv4 after
+  opening IPv6) are expected on some platforms. End-users may also want to
+  reconfigure their `upsd.conf` files to remove some now-redundant `LISTEN`
+  lines. [#2012]
 
 - Added support for `make sockdebug` for easier developer access to the tool;
   also if `configure --with-dev` is in effect, it would now be installed to

--- a/conf/upsd.conf.sample
+++ b/conf/upsd.conf.sample
@@ -64,6 +64,12 @@
 # Note that it is not true for Windows platforms. You shouldn't use IPv6 in
 # your configuration files unless you have IPv6 installed.
 #
+# As a special case, `LISTEN * <port>` (with an asterisk) would try
+# to listen on "ANY" IP address for both IPv4 (0.0.0.0) and IPv6 (::0),
+# subject to `upsd` command-line arguments or OS/kernel configuration.
+# If the system supports "dual-stack" mode (IPv4-mapped IPv6) per RFC-3493
+# then there would be one listening socket for both address types.
+#
 # One or more LISTEN statements give the IP address (or name that
 # resolves to such an address) for upsd to listen on, optionally with
 # a port number.
@@ -74,6 +80,12 @@
 #
 # This will only be read at startup of upsd.  If you make changes here,
 # you'll need to restart upsd, as reload will have no effect.
+#
+# Please note that older NUT releases could have been using the "dual-stack"
+# mode, if provided by the system. Current versions (since NUT v2.8.1 release)
+# try to restrict their listening sockets to only support IPv6 addresses and
+# so avoid IPv4-mapped mode, except when handling the special `LISTEN * <port>`
+# directive.
 
 # =======================================================================
 # MAXCONN <connections>

--- a/conf/upsd.conf.sample
+++ b/conf/upsd.conf.sample
@@ -64,11 +64,12 @@
 # Note that it is not true for Windows platforms. You shouldn't use IPv6 in
 # your configuration files unless you have IPv6 installed.
 #
-# As a special case, `LISTEN * <port>` (with an asterisk) would try
-# to listen on "ANY" IP address for both IPv4 (0.0.0.0) and IPv6 (::0),
-# subject to `upsd` command-line arguments or OS/kernel configuration.
-# If the system supports "dual-stack" mode (IPv4-mapped IPv6) per RFC-3493
-# then there would be one listening socket for both address types.
+# As a special case, `LISTEN * <port>` (with an asterisk) will try
+# to listen on "ANY" IP address for both IPv6 (::0) and IPv4 (0.0.0.0),
+# subject to `upsd` command-line arguments, or system configuration.
+# Note that if the system supports IPv4-mapped IPv6 addressing per RFC-3493,
+# and does not allow to disable this mode, then there may be one listening
+# socket to handle both address families.
 #
 # One or more LISTEN statements give the IP address (or name that
 # resolves to such an address) for upsd to listen on, optionally with
@@ -81,11 +82,11 @@
 # This will only be read at startup of upsd.  If you make changes here,
 # you'll need to restart upsd, as reload will have no effect.
 #
-# Please note that older NUT releases could have been using the "dual-stack"
-# mode, if provided by the system. Current versions (since NUT v2.8.1 release)
-# try to restrict their listening sockets to only support IPv6 addresses and
-# so avoid IPv4-mapped mode, except when handling the special `LISTEN * <port>`
-# directive.
+# Please note that older NUT releases could have been using the IPv4-mapped
+# IPv6 addressing (sometimes also known as "dual-stack") mode, if provided
+# by the system. Current versions (since NUT v2.8.1 release) explicitly try
+# to restrict their listening sockets to only support one address family on
+# each socket, and so avoid IPv4-mapped mode where possible.
 
 # =======================================================================
 # MAXCONN <connections>

--- a/configure.ac
+++ b/configure.ac
@@ -1120,7 +1120,7 @@ NUT_TYPE_SOCKLEN_T
 NUT_CHECK_SOCKETLIB
 NUT_FUNC_GETNAMEINFO_ARGTYPES
 
-AC_CACHE_CHECK([for inet_ntop()],
+AC_CACHE_CHECK([for inet_ntop() with IPv4 and IPv6 support],
     [ac_cv_func_inet_ntop],
     [AC_LANG_PUSH([C])
     dnl e.g. add "-lws2_32" for mingw builds
@@ -1148,7 +1148,8 @@ AC_CACHE_CHECK([for inet_ntop()],
 ]],
             [[/* const char* inet_ntop(int af, const void* src, char* dst, size_t cnt); */
 char buf[128];
-printf("%s", inet_ntop(AF_INET, "1.2.3.4", buf, 10))
+printf("%s", inet_ntop(AF_INET, "1.2.3.4", buf, 10));
+printf("%s", inet_ntop(AF_INET6, "::1", buf, 10))
 /* autoconf adds ";return 0;" */
 ]])],
         [ac_cv_func_inet_ntop=yes], [ac_cv_func_inet_ntop=no]

--- a/docs/config-notes.txt
+++ b/docs/config-notes.txt
@@ -295,11 +295,12 @@ want `upsd` to listen on for connections, optionally with a port number.
 	LISTEN 127.0.0.1 3493
 	LISTEN ::1 3493
 
-As a special case, `LISTEN * <port>` (with an asterisk) would try
-to listen on "ANY" IP address for both IPv4 (`0.0.0.0`) and IPv6 (`::0`),
-subject to `upsd` command-line arguments or OS/kernel configuration.
-If the system supports "dual-stack" mode (IPv4-mapped IPv6) per RFC-3493
-then there would be one listening socket for both address types.
+As a special case, `LISTEN * <port>` (with an asterisk) will try to
+listen on "ANY" IP address for both and IPv6 (`::0`) and IPv4 (`0.0.0.0`),
+subject to `upsd` command-line arguments, or system configuration or support.
+Note that if the system supports IPv4-mapped IPv6 addressing per RFC-3493,
+and does not allow to disable this mode, then there may be one listening
+socket to handle both address families.
 
 NOTE: Refer to the NUT user manual <<NUT_Security,security chapter>> for
 information on how to access and secure upsd clients connections.

--- a/docs/config-notes.txt
+++ b/docs/config-notes.txt
@@ -295,6 +295,12 @@ want `upsd` to listen on for connections, optionally with a port number.
 	LISTEN 127.0.0.1 3493
 	LISTEN ::1 3493
 
+As a special case, `LISTEN * <port>` (with an asterisk) would try
+to listen on "ANY" IP address for both IPv4 (`0.0.0.0`) and IPv6 (`::0`),
+subject to `upsd` command-line arguments or OS/kernel configuration.
+If the system supports "dual-stack" mode (IPv4-mapped IPv6) per RFC-3493
+then there would be one listening socket for both address types.
+
 NOTE: Refer to the NUT user manual <<NUT_Security,security chapter>> for
 information on how to access and secure upsd clients connections.
 

--- a/docs/man/upsd.conf.txt
+++ b/docs/man/upsd.conf.txt
@@ -70,8 +70,12 @@ Multiple LISTEN addresses may be specified.  The default is to bind to
 compiled in).
 +
 To listen on all available interfaces, you may also use '0.0.0.0' for IPv4 and
-and '::' for IPv6.
-
+and '::' for IPv6. As a special case, `LISTEN * <port>` (with an asterisk)
+would try to listen on both IPv4 (`0.0.0.0`) and IPv6 (`::0`) wild-card IP
+addresses, subject to `upsd` command-line arguments or OS/kernel configuration.
+If the system supports "dual-stack" mode (IPv4-mapped IPv6) per RFC-3493
+then there would be one listening socket for both address types.
++
 	LISTEN 127.0.0.1
 	LISTEN 192.168.50.1
 	LISTEN myhostname.mydomain
@@ -80,6 +84,12 @@ and '::' for IPv6.
 +
 This parameter will only be read at startup.  You'll need to restart
 (rather than reload) upsd to apply any changes made here.
++
+Please note that older NUT releases could have been using the "dual-stack"
+mode, if provided by the system. Current versions (since NUT v2.8.1 release)
+try to restrict their listening sockets to only support IPv6 addresses and
+so avoid IPv4-mapped mode, except when handling the special `LISTEN * <port>`
+directive.
 
 "MAXCONN 'connections'"::
 

--- a/docs/man/upsd.conf.txt
+++ b/docs/man/upsd.conf.txt
@@ -66,15 +66,17 @@ compiled into the code.  This overrides any value you may have set with
 upsd will listen on port 3493 for this interface.
 +
 Multiple LISTEN addresses may be specified.  The default is to bind to
-127.0.0.1 if no LISTEN addresses are specified (and ::1 if IPv6 support is
-compiled in).
+`127.0.0.1` if no LISTEN addresses are specified (and also `::1` if IPv6
+support is compiled in).
 +
-To listen on all available interfaces, you may also use '0.0.0.0' for IPv4 and
-and '::' for IPv6. As a special case, `LISTEN * <port>` (with an asterisk)
-would try to listen on both IPv4 (`0.0.0.0`) and IPv6 (`::0`) wild-card IP
-addresses, subject to `upsd` command-line arguments or OS/kernel configuration.
-If the system supports "dual-stack" mode (IPv4-mapped IPv6) per RFC-3493
-then there would be one listening socket for both address types.
+To listen on all available interfaces and configured IP addresses of your
+system, you may also use `::` for IPv6 and `0.0.0.0` for IPv4, respectively.
+As a special case, a single `LISTEN * <port>` directive (with an asterisk) will
+try to listen on both IPv6 (`::0`) and IPv4 (`0.0.0.0`) wild-card IP addresses,
+subject to `upsd` command-line arguments or system configuration.
+Note that if the system supports IPv4-mapped IPv6 addressing per RFC-3493,
+and does not allow to disable this mode, then there may be one listening
+socket to handle both address families.
 +
 	LISTEN 127.0.0.1
 	LISTEN 192.168.50.1
@@ -85,11 +87,11 @@ then there would be one listening socket for both address types.
 This parameter will only be read at startup.  You'll need to restart
 (rather than reload) upsd to apply any changes made here.
 +
-Please note that older NUT releases could have been using the "dual-stack"
-mode, if provided by the system. Current versions (since NUT v2.8.1 release)
-try to restrict their listening sockets to only support IPv6 addresses and
-so avoid IPv4-mapped mode, except when handling the special `LISTEN * <port>`
-directive.
+Please note that older NUT releases could have been using the IPv4-mapped
+IPv6 addressing (sometimes also known as "dual-stack") mode, if provided
+by the system. Current versions (since NUT v2.8.1 release) explicitly try
+to restrict their listening sockets to only support one address family on
+each socket, and so avoid IPv4-mapped mode where possible.
 
 "MAXCONN 'connections'"::
 

--- a/docs/security.txt
+++ b/docs/security.txt
@@ -234,6 +234,12 @@ compiled in).
 	   LISTEN ::1
 	   LISTEN 2001:0db8:1234:08d3:1319:8a2e:0370:7344
 
+As a special case, `LISTEN * <port>` (with an asterisk) would try
+to listen on "ANY" IP address for both IPv4 (`0.0.0.0`) and IPv6 (`::0`),
+subject to `upsd` command-line arguments or OS/kernel configuration.
+If the system supports "dual-stack" mode (IPv4-mapped IPv6) per RFC-3493
+then there would be one listening socket for both address types.
+
 This parameter will only be read at startup.  You'll need to restart (rather
 than reload) `upsd` to apply any changes made here.
 

--- a/docs/security.txt
+++ b/docs/security.txt
@@ -234,11 +234,12 @@ compiled in).
 	   LISTEN ::1
 	   LISTEN 2001:0db8:1234:08d3:1319:8a2e:0370:7344
 
-As a special case, `LISTEN * <port>` (with an asterisk) would try
-to listen on "ANY" IP address for both IPv4 (`0.0.0.0`) and IPv6 (`::0`),
-subject to `upsd` command-line arguments or OS/kernel configuration.
-If the system supports "dual-stack" mode (IPv4-mapped IPv6) per RFC-3493
-then there would be one listening socket for both address types.
+As a special case, `LISTEN * <port>` (with an asterisk) will try to
+listen on "ANY" IP address for both IPv6 (`::0`) and IPv4 (`0.0.0.0`),
+subject to `upsd` command-line arguments, or system configuration or support.
+Note that if the system supports IPv4-mapped IPv6 addressing per RFC-3493,
+and does not allow to disable this mode, then there may be one listening
+socket to handle both address families.
 
 This parameter will only be read at startup.  You'll need to restart (rather
 than reload) `upsd` to apply any changes made here.

--- a/scripts/augeas/nutupsdconf.aug.in
+++ b/scripts/augeas/nutupsdconf.aug.in
@@ -57,8 +57,8 @@ let upsd_certfile = [ opt_spc . key "CERTFILE" . sep_spc . store path . eol ]
  * LISTEN interface port
  *    Multiple lines each with one LISTEN address (or host name) and an optional
  *    port may be specified. The default is to bind to IPv4 and IPv6 "localhost"
- *    addresses (subject to CLI options `-4` or `-6` constraining IP version or
- *    OS kernel/configuration support), if no LISTEN addresses are specified.
+ *    addresses (subject to CLI options `-4` or `-6` constraining IP version,
+ *    or system configuration or support), if no LISTEN addresses are specified.
  *    LISTEN 127.0.0.1
  *    LISTEN 192.168.50.1
  *    LISTEN ::1

--- a/scripts/augeas/nutupsdconf.aug.in
+++ b/scripts/augeas/nutupsdconf.aug.in
@@ -55,8 +55,14 @@ let upsd_certfile = [ opt_spc . key "CERTFILE" . sep_spc . store path . eol ]
  * ALLOW_NO_DEVICE Boolean
  * STATEPATH path
  * LISTEN interface port
- *    Multiple LISTEN addresses may be specified. The default is to bind to 0.0.0.0 if no LISTEN addresses are specified.
- *    LISTEN 127.0.0.1 LISTEN 192.168.50.1 LISTEN ::1 LISTEN 2001:0db8:1234:08d3:1319:8a2e:0370:7344
+ *    Multiple lines each with one LISTEN address (or host name) and an optional
+ *    port may be specified. The default is to bind to IPv4 and IPv6 "localhost"
+ *    addresses (subject to CLI options `-4` or `-6` constraining IP version or
+ *    OS kernel/configuration support), if no LISTEN addresses are specified.
+ *    LISTEN 127.0.0.1
+ *    LISTEN 192.168.50.1
+ *    LISTEN ::1
+ *    LISTEN 2001:0db8:1234:08d3:1319:8a2e:0370:7344
  *
  *************************************************************************)
 let upsd_other  =  upsd_maxage | upsd_trackingdelay | upsd_allow_no_device | upsd_statepath | upsd_listen_list | upsd_maxconn | upsd_certfile

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -237,9 +237,15 @@ void listen_add(const char *addr, const char *port)
 	server->addr = xstrdup(addr);
 	server->port = xstrdup(port);
 	server->sock_fd = ERROR_FD_SOCK;
-	server->next = firstaddr;
+	server->next = NULL;
 
-	firstaddr = server;
+	if (firstaddr) {
+		stype_t	*tmp;
+		for (tmp = firstaddr; tmp->next; tmp = tmp->next);
+		tmp->next = server;
+	} else {
+		firstaddr = server;
+	}
 
 	upsdebugx(3, "listen_add: added %s:%s", server->addr, server->port);
 }

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -694,13 +694,16 @@ void server_load(void)
 {
 	stype_t	*server;
 
-	/* default behaviour if no LISTEN addres has been specified */
+	/* default behaviour if no LISTEN address has been specified */
 	if (!firstaddr) {
+		/* Note: default opt_af==AF_UNSPEC so not constrained to only one protocol */
 		if (opt_af != AF_INET) {
+			upsdebugx(1, "%s: No LISTEN configuration provided, will try IPv6 localhost", __func__);
 			listen_add("::1", string_const(PORT));
 		}
 
 		if (opt_af != AF_INET6) {
+			upsdebugx(1, "%s: No LISTEN configuration provided, will try IPv4 localhost", __func__);
 			listen_add("127.0.0.1", string_const(PORT));
 		}
 	}

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -312,6 +312,20 @@ static void setuptcp(stype_t *server)
 			continue;
 		}
 
+		if (ai->ai_next) {
+			char ipaddrbuf[SMALLBUF];
+			const char *ipaddr;
+			snprintf(ipaddrbuf, sizeof(ipaddrbuf), " as ");
+			ipaddr = inet_ntop(ai->ai_family, ai->ai_addr,
+				ipaddrbuf + strlen(ipaddrbuf),
+				sizeof(ipaddrbuf));
+			upslogx(LOG_WARNING,
+				"setuptcp: bound to %s%s but there seem to be "
+				"further (ignored) addresses resolved for this name",
+				server->addr,
+				ipaddr == NULL ? "" : ipaddrbuf);
+		}
+
 		server->sock_fd = sock_fd;
 		break;
 	}

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -339,8 +339,6 @@ static void setuptcp(stype_t *server)
 					canhaveAnyV4 = 1;
 					close(serverAnyV4->sock_fd);
 					serverAnyV4->sock_fd = ERROR_FD_SOCK;
-					/* Let the system know about the change: */
-					/* usleep(100); */
 				} else {
 					upsdebugx(3,
 						"%s: Could not bind to %s:%s trying to handle a 'LISTEN *' directive",

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -349,7 +349,7 @@ static void setuptcp(stype_t *server)
 			 */
 			upsdebugx(3, "%s: try taking IPv4 'ANY'%s",
 				__func__,
-				serverAnyV6 ? " (if dual-stack IPv6 'ANY' did not grab it)" : "");
+				canhaveAnyV6 ? " (if dual-stack IPv6 'ANY' did not grab it)" : "");
 			setuptcp(serverAnyV4);
 			if (VALID_FD_SOCK(serverAnyV4->sock_fd)) {
 				canhaveAnyV4 = 1;
@@ -357,7 +357,7 @@ static void setuptcp(stype_t *server)
 				upsdebugx(3,
 					"%s: Could not bind to IPv4 %s:%s%s",
 					__func__, serverAnyV4->addr, serverAnyV4->port,
-					serverAnyV6 ? (" after trying to bind to IPv6: "
+					canhaveAnyV6 ? (" after trying to bind to IPv6: "
 						"assuming dual-stack support on this "
 						"system could not be disabled") : "");
 			}

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -303,6 +303,17 @@ static void setuptcp(stype_t *server)
 			fatal_with_errno(EXIT_FAILURE, "setuptcp: setsockopt");
 		}
 
+		/* Ordinarily we request that IPv6 listeners handle only IPv6.
+		 * TOTHINK: Does any platform need `#ifdef IPV6_V6ONLY` given
+		 * that we apparently already have AF_INET6 OS support everywhere?
+		 */
+		if (ai->ai_family == AF_INET6) {
+			if (setsockopt(sock_fd, IPPROTO_IPV6, IPV6_V6ONLY, (void *)&one, sizeof(one)) != 0) {
+				upsdebug_with_errno(3, "setuptcp: setsockopt IPV6_V6ONLY");
+				/* ack, ignore */
+			}
+		}
+
 		if (bind(sock_fd, ai->ai_addr, ai->ai_addrlen) < 0) {
 			upsdebug_with_errno(3, "setuptcp: bind");
 			close(sock_fd);


### PR DESCRIPTION
...and fix some related issues

Closes: #2012

Testing:
* allowing "IPv4-mapped IPv6" mode, expected to be default for most OSes now, getting one socket for both IP versions:
````
...
Aug 05 22:56:41 pve nut-server[1767496]:    0.000240        [D3] setuptcp: try to bind to * port 3493
Aug 05 22:56:41 pve nut-server[1767496]:    0.000245        [D1] setuptcp: handling 'LISTEN * 3493' with IPv4 any-address support
Aug 05 22:56:41 pve nut-server[1767496]:    0.000250        [D1] setuptcp: handling 'LISTEN * 3493' with IPv6 any-address support
Aug 05 22:56:41 pve nut-server[1767496]:    0.000254        [D3] setuptcp: try to bind to 0.0.0.0 port 3493
Aug 05 22:56:41 pve nut-server[1767496]:    0.000273        listening on 0.0.0.0 port 3493
Aug 05 22:56:41 pve nut-server[1767496]:    0.000278        [D3] setuptcp: Could bind to 0.0.0.0:3493 trying to handle a 'LISTEN *' directive; will release it for now to try IPv6
Aug 05 22:56:41 pve nut-server[1767496]:    0.000287        [D3] setuptcp: try to bind to ::0 port 3493
Aug 05 22:56:41 pve nut-server[1767496]:    0.000299        listening on ::0 port 3493
Aug 05 22:56:41 pve nut-server[1767496]:    0.000303        [D3] setuptcp: try taking IPv4 'ANY' again (if dual-stack IPv6 'ANY' did not grab it)
Aug 05 22:56:41 pve nut-server[1767496]:    0.000307        [D3] setuptcp: try to bind to 0.0.0.0 port 3493
Aug 05 22:56:41 pve nut-server[1767496]:    0.000316        [D3] setuptcp: bind: Address already in use
Aug 05 22:56:41 pve nut-server[1767496]:    0.000322        not listening on 0.0.0.0 port 3493
Aug 05 22:56:41 pve nut-server[1767496]:    0.000327        [D3] setuptcp: Could not bind to IPv4 0.0.0.0:3493 after trying to bind to IPv6: assuming dual-stack support on this system
Aug 05 22:56:41 pve nut-server[1767496]:    0.000331        [D3] setuptcp: remembering IPv6 'ANY' instead of 'LISTEN *'
...

:; netstat -anp | grep 3493
tcp        0      0 127.0.0.1:36442         127.0.0.1:3493          ESTABLISHED 1767499/upsmon
tcp6       0      0 :::3493                 :::*                    LISTEN      1767496/upsd
tcp6       0      0 127.0.0.1:3493          127.0.0.1:36442         ESTABLISHED 1767496/upsd
````

* custom build with required "IPv6-only" mode, getting two sockets:
````
...
Aug 05 22:51:49 pve nut-server[1751573]:    0.000160        [D3] setuptcp: try to bind to * port 3493
Aug 05 22:51:49 pve nut-server[1751573]:    0.000164        [D1] setuptcp: handling 'LISTEN * 3493' with IPv4 any-address support
Aug 05 22:51:49 pve nut-server[1751573]:    0.000167        [D1] setuptcp: handling 'LISTEN * 3493' with IPv6 any-address support
Aug 05 22:51:49 pve nut-server[1751573]:    0.000169        [D3] setuptcp: try to bind to 0.0.0.0 port 3493
Aug 05 22:51:49 pve nut-server[1751573]:    0.000181        listening on 0.0.0.0 port 3493
Aug 05 22:51:49 pve nut-server[1751573]:    0.000184        [D3] setuptcp: Could bind to 0.0.0.0:3493 trying to handle a 'LISTEN *' directive; will release it for now to try IPv6
Aug 05 22:51:49 pve nut-server[1751573]:    0.000190        [D3] setuptcp: try to bind to ::0 port 3493
Aug 05 22:51:49 pve nut-server[1751573]:    0.000197        listening on ::0 port 3493
Aug 05 22:51:49 pve nut-server[1751573]:    0.000200        [D3] setuptcp: try taking IPv4 'ANY' again (if dual-stack IPv6 'ANY' did not grab it)
Aug 05 22:51:49 pve nut-server[1751573]:    0.000202        [D3] setuptcp: try to bind to 0.0.0.0 port 3493
Aug 05 22:51:49 pve nut-server[1751573]:    0.000208        listening on 0.0.0.0 port 3493
Aug 05 22:51:49 pve nut-server[1751573]:    0.000211        [D3] setuptcp: remembering IPv4 'ANY' instead of 'LISTEN *'
Aug 05 22:51:49 pve nut-server[1751573]:    0.000213        [D3] setuptcp: also remembering IPv6 'ANY' instead of 'LISTEN *'
Aug 05 22:51:49 pve nut-server[1751573]:    0.000218        [D6] setuptcp: SKIP bind to ::0 port 3493: entry already initialized
...

:; netstat -anp | grep 3493
tcp        0      0 0.0.0.0:3493            0.0.0.0:*               LISTEN      1751573/upsd
tcp        0      0 127.0.0.1:3493          127.0.0.1:50286         ESTABLISHED 1751573/upsd
tcp        0      0 127.0.0.1:50286         127.0.0.1:3493          ESTABLISHED 1749655/upsmon
tcp6       0      0 :::3493                 :::*                    LISTEN      1751573/upsd
````

CC @gdt @svarshavchik @clepple @aquette 