### PR TITLE
Fix some fallout of NUT v2.8.0 release for `mge-shut` (serial HID) driver

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -84,6 +84,9 @@ as part of https://github.com/networkupstools/nut/issues/1410 solution.
      (without specifying the single device) [#1759, #1806, #1875]
    * The `apcsmart` and `apcsmart-old` handled invalid data too zealously
      and aborted instead of skipping over it, like they did before [#2015]
+   * Something about compile-time macros or other warnings-related refactoring
+     seems to have confused the MGE SHUT (Serial HID UPS Transfer) driver
+     support [#2022]
 
  - New `configure --enable-inplace-runtime` option should set default values
    for `--sysconfdir`, `--with-user` and `--with-group` options to match an

--- a/drivers/hidparser.c
+++ b/drivers/hidparser.c
@@ -202,7 +202,7 @@ static int HIDParse(HIDParser_t *pParser, HIDData_t *pData)
 
 				/* Remove Usage */
 				pParser->UsageSize--;
-		        }
+			}
 
 			/* Get Index if any */
 			if (pParser->Value >= 0x80) {
@@ -361,7 +361,7 @@ static int HIDParse(HIDParser_t *pParser, HIDData_t *pData)
 		upslogx(LOG_ERR, "%s: HID Usage too high", __func__);
 
 	/* FIXME: comparison is always false due to limited range of data type [-Werror=type-limits]
-	 * with ReportID beint uint8_t and MAX_REPORT being 500 currently */
+	 * with ReportID being uint8_t and MAX_REPORT being 500 currently */
 	/*
 	if(pParser->Data.ReportID >= MAX_REPORT)
 		upslogx(LOG_ERR, "%s: Too many HID reports", __func__);

--- a/drivers/hidparser.h
+++ b/drivers/hidparser.h
@@ -38,11 +38,11 @@ extern "C" {
 /* Include "usb-common.h" or "libshut.h" as appropriate, to define the 
  * usb_ctrl_* types used below according to the backend USB API version
  */
-#ifdef SHUT_MODE
+#if (defined SHUT_MODE) && SHUT_MODE
 # include "libshut.h"
-#else
+#else	/* !SHUT_MODE => USB */
 # include "usb-common.h"
-#endif
+#endif	/* SHUT_MODE / USB */
 
 /*
  * Parse_ReportDesc

--- a/drivers/libhid.c
+++ b/drivers/libhid.c
@@ -694,7 +694,9 @@ int HIDGetEvents(hid_dev_handle_t udev, HIDData_t **event, int eventsize)
 	HIDData_t	*pData;
 
 	/* needs libusb-0.1.8 to work => use ifdef and autoconf */
-	r = interrupt_size ? interrupt_size : sizeof(buf);
+	r = (interrupt_size > 0 && interrupt_size < sizeof(buf))
+		? interrupt_size : sizeof(buf);
+
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_TYPE_LIMIT_COMPARE) )
 # pragma GCC diagnostic push
 #endif

--- a/drivers/libhid.c
+++ b/drivers/libhid.c
@@ -46,13 +46,13 @@
 #include "nut_stdint.h"
 
 /* Communication layers and drivers (USB and MGE SHUT) */
-#ifdef SHUT_MODE
+#if (defined SHUT_MODE) && SHUT_MODE
 	#include "libshut.h"
 	communication_subdriver_t *comm_driver = &shut_subdriver;
-#else
+#else	/* !SHUT_MODE => USB */
 	#include "nut_libusb.h"
 	communication_subdriver_t *comm_driver = &usb_subdriver;
-#endif
+#endif	/* SHUT_MODE / USB */
 
 /* support functions */
 static double logical_to_physical(HIDData_t *Data, long logical);
@@ -405,13 +405,13 @@ static struct {
 void HIDDumpTree(hid_dev_handle_t udev, HIDDevice_t *hd, usage_tables_t *utab)
 {
 	size_t	i;
-#ifdef SHUT_MODE
+#if (defined SHUT_MODE) && SHUT_MODE
 	NUT_UNUSED_VARIABLE(hd);
-#else
+#else	/* !SHUT_MODE => USB */
 	/* extract the VendorId for further testing */
 	int vendorID = hd->VendorID;
 	int productID = hd->ProductID;
-#endif
+#endif	/* SHUT_MODE / USB */
 
 	/* Do not go further if we already know nothing will be displayed.
 	 * Some reports take a while before they timeout, so if these are
@@ -430,11 +430,11 @@ void HIDDumpTree(hid_dev_handle_t udev, HIDDevice_t *hd, usage_tables_t *utab)
 		HIDData_t	*pData = &pDesc->item[i];
 
 		/* skip reports 254/255 for Eaton / MGE / Dell due to special handling needs */
-#ifdef SHUT_MODE
+#if (defined SHUT_MODE) && SHUT_MODE
 		if ((pData->ReportID == 254) || (pData->ReportID == 255)) {
 			continue;
 		}
-#else
+#else	/* !SHUT_MODE => USB */
 		if ((vendorID == 0x0463) || (vendorID == 0x047c)) {
 			if ((pData->ReportID == 254) || (pData->ReportID == 255)) {
 				continue;
@@ -447,7 +447,7 @@ void HIDDumpTree(hid_dev_handle_t udev, HIDDevice_t *hd, usage_tables_t *utab)
 				continue;
 			}
 		}
-#endif
+#endif	/* SHUT_MODE / USB */
 
 		/* Get data value */
 		if (HIDGetDataValue(udev, pData, &value, MAX_TS) == 1) {

--- a/drivers/libhid.h
+++ b/drivers/libhid.h
@@ -37,21 +37,21 @@
 
 #include "timehead.h"
 
-#ifdef SHUT_MODE
+#if (defined SHUT_MODE) && SHUT_MODE
 	#include "libshut.h"
 	typedef SHUTDevice_t                   HIDDevice_t;
 	typedef char                           HIDDeviceMatcher_t;
 	typedef usb_dev_handle                 hid_dev_handle_t;
 	typedef shut_communication_subdriver_t communication_subdriver_t;
 	#define HID_DEV_HANDLE_CLOSED          (hid_dev_handle_t)(ERROR_FD_SER)
-#else
+#else	/* !SHUT_MODE => USB */
 	#include "nut_libusb.h" /* includes usb-common.h */
 	typedef USBDevice_t                   HIDDevice_t;
 	typedef USBDeviceMatcher_t            HIDDeviceMatcher_t;
 	typedef usb_dev_handle *              hid_dev_handle_t;
 	typedef usb_communication_subdriver_t communication_subdriver_t;
 	#define HID_DEV_HANDLE_CLOSED          (hid_dev_handle_t)(NULL)
-#endif
+#endif	/* SHUT_MODE / USB */
 
 /* use explicit booleans */
 #ifndef FALSE

--- a/drivers/libshut.c
+++ b/drivers/libshut.c
@@ -467,11 +467,13 @@ static int libshut_open(
 	free(curDevice->Product);
 	free(curDevice->Serial);
 	free(curDevice->Bus);
+	free(curDevice->Device);
 	memset(curDevice, '\0', sizeof(*curDevice));
 
 	curDevice->VendorID = dev_descriptor->idVendor;
 	curDevice->ProductID = dev_descriptor->idProduct;
 	curDevice->Bus = strdup("serial");
+	curDevice->Device = strdup(arg_device_path);
 	curDevice->bcdDevice = dev_descriptor->bcdDevice;
 	curDevice->Vendor = strdup("Eaton");
 	if (dev_descriptor->iManufacturer) {
@@ -512,6 +514,7 @@ static int libshut_open(
 	upsdebugx(2, "- Product: %s", curDevice->Product);
 	upsdebugx(2, "- Serial Number: %s", curDevice->Serial);
 	upsdebugx(2, "- Bus: %s", curDevice->Bus);
+	upsdebugx(2, "- Device: %s", curDevice->Device ? curDevice->Device : "unknown");
 	upsdebugx(2, "- Device release number: %04x", curDevice->bcdDevice);
 	upsdebugx(2, "Device matches");
 

--- a/drivers/libshut.c
+++ b/drivers/libshut.c
@@ -43,7 +43,7 @@
 #include "common.h" /* for xmalloc, upsdebugx prototypes */
 
 #define SHUT_DRIVER_NAME	"SHUT communication driver"
-#define SHUT_DRIVER_VERSION	"0.86"
+#define SHUT_DRIVER_VERSION	"0.87"
 
 /* communication driver description structure */
 upsdrv_info_t comm_upsdrv_info = {
@@ -556,8 +556,7 @@ static int libshut_open(
 	}
 
 	/* USB_LE16_TO_CPU(desc->wDescriptorLength); */
-	desc->wDescriptorLength = (uint16_t)(buf[7]);
-	desc->wDescriptorLength |= (((uint16_t)buf[8]) << 8);
+	desc->wDescriptorLength = (0x00FF & (uint8_t)buf[7]) | ((0x00FF & (uint8_t)buf[8]) << 8);
 	upsdebugx(2, "HID descriptor retrieved (Reportlen = %u)", desc->wDescriptorLength);
 
 /*

--- a/drivers/libshut.c
+++ b/drivers/libshut.c
@@ -394,6 +394,10 @@ static int libshut_open(
 	 * version is at index 1 (in which case, bcdDevice == 0x0202) */
 	usb_ctrl_descindex	hid_desc_index = 0;
 
+	if (!arg_device_path) {
+		fatalx(EXIT_FAILURE, "%s: arg_device_path=null", __func__);
+	}
+
 	upsdebugx(2, "libshut_open: using port %s", arg_device_path);
 
 	/* If device is still open, close it */

--- a/drivers/mge-hid.c
+++ b/drivers/mge-hid.c
@@ -169,12 +169,12 @@ static char		mge_scratch_buf[20];
  * float mode is not important from the software's perspective, it's there to
  * help determine if the charger is advancing correctly.
  * So in float mode, the charger is charging the battery, so by definition you
- * can assert the CHRG flag in NUT when in “float” mode or “charge” mode.
- * When in “rest” mode the charger is not delivering anything to the battery,
+ * can assert the CHRG flag in NUT when in "float" mode or "charge" mode.
+ * When in "rest" mode the charger is not delivering anything to the battery,
  * but it will when the ABM cycle(28 days) ends, or a battery discharge occurs
- * and utility returns.  This is when the ABM status should be “resting”.
+ * and utility returns.  This is when the ABM status should be "resting".
  * If a battery failure is detected that disables the charger, it should be
- * reporting “off” in the ABM charger status.
+ * reporting "off" in the ABM charger status.
  * Of course when delivering load power from the battery, the ABM status is
  * discharging.
  */
@@ -1271,6 +1271,7 @@ static hid_info_t mge_hid2nut[] =
 	{ "BOOL", 0, 0, "UPS.PowerSummary.PresentStatus.ACPresent", NULL, NULL, HU_FLAG_QUICK_POLL, online_info },
 	{ "BOOL", 0, 0, "UPS.PowerConverter.Input.[3].PresentStatus.Used", NULL, NULL, 0, mge_onbatt_info },
 #if 0
+	/* NOTE: see entry with eaton_converter_online_info below now */
 	{ "BOOL", 0, 0, "UPS.PowerConverter.Input.[1].PresentStatus.Used", NULL, NULL, 0, online_info },
 #endif
 	/* These 2 ones are used when ABM is disabled */
@@ -1298,6 +1299,7 @@ static hid_info_t mge_hid2nut[] =
 	 * and must hence be after "UPS.PowerSummary.PresentStatus.Good" */
 	{ "BOOL", 0, 0, "UPS.PowerConverter.Input.[1].PresentStatus.Used", NULL, NULL, 0, eaton_converter_online_info },
 	{ "BOOL", 0, 0, "UPS.PowerConverter.Input.[2].PresentStatus.Used", NULL, NULL, 0, bypass_auto_info }, /* Automatic bypass */
+	/* NOTE: entry [3] is above as mge_onbatt_info */
 	{ "BOOL", 0, 0, "UPS.PowerConverter.Input.[4].PresentStatus.Used", NULL, NULL, 0, bypass_manual_info }, /* Manual bypass */
 	{ "BOOL", 0, 0, "UPS.PowerSummary.PresentStatus.FanFailure", NULL, NULL, 0, fanfail_info },
 	{ "BOOL", 0, 0, "UPS.BatterySystem.Battery.PresentStatus.Present", NULL, NULL, 0, nobattery_info },

--- a/drivers/mge-hid.c
+++ b/drivers/mge-hid.c
@@ -65,7 +65,7 @@
 /* IBM */
 #define IBM_VENDORID 0x04b3
 
-#ifndef SHUT_MODE
+#if !((defined SHUT_MODE) && SHUT_MODE)
 #include "usb-common.h"
 
 /* USB IDs device table */
@@ -98,7 +98,7 @@ static usb_device_id_t mge_usb_device_table[] = {
 	/* Terminating entry */
 	{ 0, 0, NULL }
 };
-#endif
+#endif	/* !SHUT_MODE => USB */
 
 typedef enum {
 	MGE_DEFAULT_OFFLINE = 0,
@@ -1574,7 +1574,10 @@ static const char *mge_format_serial(HIDDevice_t *hd) {
  * the device is supported by this subdriver, else 0. */
 static int mge_claim(HIDDevice_t *hd) {
 
-#ifndef SHUT_MODE
+#if (defined SHUT_MODE) && SHUT_MODE
+	NUT_UNUSED_VARIABLE(hd);
+	return 1;
+#else	/* !SHUT_MODE => USB */
 	int status = is_usb_device_supported(mge_usb_device_table, hd);
 
 	switch (status) {
@@ -1641,10 +1644,7 @@ static int mge_claim(HIDDevice_t *hd) {
 	default:
 		return 0;
 	}
-#else
-	NUT_UNUSED_VARIABLE(hd);
-	return 1;
-#endif
+#endif	/* SHUT_MODE / USB */
 }
 
 subdriver_t mge_subdriver = {

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -1014,11 +1014,6 @@ void upsdrv_initups(void)
 	int ret;
 	char *val;
 
-	upsdebugx(2, "Initializing an USB-connected UPS with library %s " \
-		"(NUT subdriver name='%s' ver='%s')",
-		dstate_getinfo("driver.version.usb"),
-		comm_driver->name, comm_driver->version );
-
 #if (defined SHUT_MODE) && SHUT_MODE
 	/*!
 	 * SHUT is a serial protocol, so it needs
@@ -1031,6 +1026,12 @@ void upsdrv_initups(void)
 	char *regex_array[7];
 
 	upsdebugx(1, "upsdrv_initups (non-SHUT)...");
+
+	upsdebugx(2, "Initializing an USB-connected UPS with library %s " \
+		"(NUT subdriver name='%s' ver='%s')",
+		dstate_getinfo("driver.version.usb"),
+		comm_driver->name, comm_driver->version );
+
 	warn_if_bad_usb_port_filename(device_path);
 
 	subdriver_matcher = &subdriver_matcher_struct;

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -820,7 +820,7 @@ void upsdrv_makevartable(void)
 
 #else
 	addvar(VAR_VALUE, "notification",
-		"Set notification type, (ignored, only for backward compatibility)");
+		"Set notification type (ignored, only for backward compatibility)");
 #endif
 }
 

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -45,7 +45,7 @@
 /* include all known subdrivers */
 #include "mge-hid.h"
 
-#ifndef SHUT_MODE
+#if !((defined SHUT_MODE) && SHUT_MODE)
 	/* explore stub goes first, others alphabetically */
 	#include "explore-hid.h"
 	#include "apc-hid.h"
@@ -62,15 +62,16 @@
 	#include "powervar-hid.h"
 	#include "salicru-hid.h"
 	#include "tripplite-hid.h"
-#endif
+#endif	/* !SHUT_MODE => USB */
 
 /* Reference list of available subdrivers */
 static subdriver_t *subdriver_list[] = {
-#ifndef SHUT_MODE
+#if !((defined SHUT_MODE) && SHUT_MODE)
 	&explore_subdriver,
-#endif
+#endif	/* !SHUT_MODE => USB */
+	/* mge-hid.c supports both SHUT and USB */
 	&mge_subdriver,
-#ifndef SHUT_MODE
+#if !((defined SHUT_MODE) && SHUT_MODE)
 	&apc_subdriver,
 	&arduino_subdriver,
 	&belkin_subdriver,
@@ -85,7 +86,7 @@ static subdriver_t *subdriver_list[] = {
 	&powervar_subdriver,
 	&salicru_subdriver,
 	&tripplite_subdriver,
-#endif
+#endif	/* !SHUT_MODE => USB */
 	NULL
 };
 
@@ -97,11 +98,11 @@ upsdrv_info_t upsdrv_info = {
 	"Arjen de Korte <adkorte-guest@alioth.debian.org>\n" \
 	"John Stamp <kinsayder@hotmail.com>",
 	/*FIXME: link the subdrivers? do the same as for the mibs! */
-#ifndef SHUT_MODE
+#if !((defined SHUT_MODE) && SHUT_MODE)
 	DRV_STABLE,
-#else
+#else	/* SHUT_MODE */
 	DRV_EXPERIMENTAL,
-#endif
+#endif	/* SHUT_MODE / USB */
 	{ &comm_upsdrv_info, NULL }
 };
 
@@ -119,10 +120,10 @@ static subdriver_t *subdriver = NULL;
 static HIDDevice_t *hd = NULL;
 static HIDDevice_t curDevice = { 0x0000, 0x0000, NULL, NULL, NULL, NULL, 0, NULL };
 static HIDDeviceMatcher_t *subdriver_matcher = NULL;
-#ifndef SHUT_MODE
+#if !((defined SHUT_MODE) && SHUT_MODE)
 static HIDDeviceMatcher_t *exact_matcher = NULL;
 static HIDDeviceMatcher_t *regex_matcher = NULL;
-#endif
+#endif	/* !SHUT_MODE => USB */
 static int pollfreq = DEFAULT_POLLFREQ;
 static unsigned ups_status = 0;
 static bool_t data_has_changed = FALSE; /* for SEMI_STATIC data polling */
@@ -531,7 +532,7 @@ info_lkp_t kelvin_celsius_conversion[] = {
  * as SHUT is only supported by MGE UPS SYSTEMS units
  */
 
-#ifndef SHUT_MODE
+#if !((defined SHUT_MODE) && SHUT_MODE)
 static int match_function_subdriver(HIDDevice_t *d, void *privdata) {
 	int i;
 	NUT_UNUSED_VARIABLE(privdata);
@@ -555,7 +556,7 @@ static HIDDeviceMatcher_t subdriver_matcher_struct = {
 	NULL,
 	NULL
 };
-#endif
+#endif	/* !SHUT_MODE => USB */
 
 /* ---------------------------------------------
  * driver functions implementations
@@ -803,7 +804,7 @@ void upsdrv_makevartable(void)
 	addvar(VAR_FLAG, "disable_fix_report_desc",
 		"Set to disable fix-ups for broken USB encoding, etc. which we apply by default on certain vendors/products");
 
-#ifndef SHUT_MODE
+#if !((defined SHUT_MODE) && SHUT_MODE)
 	/* allow -x vendor=X, vendorid=X, product=X, productid=X, serial=X */
 	nut_usb_addvars();
 
@@ -818,10 +819,10 @@ void upsdrv_makevartable(void)
 	addvar(VAR_VALUE, HU_VAR_WAITBEFORERECONNECT,
 		"Seconds to wait before trying to reconnect");
 
-#else
+#else	/* SHUT_MODE */
 	addvar(VAR_VALUE, "notification",
 		"Set notification type (ignored, only for backward compatibility)");
-#endif
+#endif	/* SHUT_MODE / USB */
 }
 
 #define	MAX_EVENT_NUM	32
@@ -1018,7 +1019,7 @@ void upsdrv_initups(void)
 		dstate_getinfo("driver.version.usb"),
 		comm_driver->name, comm_driver->version );
 
-#ifdef SHUT_MODE
+#if (defined SHUT_MODE) && SHUT_MODE
 	/*!
 	 * SHUT is a serial protocol, so it needs
 	 * only the device path
@@ -1026,7 +1027,7 @@ void upsdrv_initups(void)
 	upsdebugx(1, "upsdrv_initups (SHUT)...");
 
 	subdriver_matcher = device_path;
-#else
+#else	/* !SHUT_MODE => USB */
 	char *regex_array[7];
 
 	upsdebugx(1, "upsdrv_initups (non-SHUT)...");
@@ -1076,7 +1077,7 @@ void upsdrv_initups(void)
 
 	/* link the matchers */
 	subdriver_matcher->next = regex_matcher;
-#endif /* SHUT_MODE */
+#endif /* SHUT_MODE / USB */
 
 	/* Search for the first supported UPS matching the
 	   regular expression (USB) or device_path (SHUT) */
@@ -1166,7 +1167,7 @@ void upsdrv_cleanup(void)
 	comm_driver->close_dev(udev);
 	Free_ReportDesc(pDesc);
 	free_report_buffer(reportbuf);
-#ifndef SHUT_MODE
+#if !((defined SHUT_MODE) && SHUT_MODE)
 	USBFreeExactMatcher(exact_matcher);
 	USBFreeRegexMatcher(regex_matcher);
 
@@ -1175,7 +1176,7 @@ void upsdrv_cleanup(void)
 	free(curDevice.Serial);
 	free(curDevice.Bus);
 	free(curDevice.Device);
-#endif
+#endif	/* !SHUT_MODE => USB */
 }
 
 /**********************************************************************
@@ -1232,9 +1233,9 @@ static int callback(
 {
 	int i;
 	const char *mfr = NULL, *model = NULL, *serial = NULL;
-#ifndef SHUT_MODE
+#if !((defined SHUT_MODE) && SHUT_MODE)
 	int ret;
-#endif
+#endif	/* !SHUT_MODE => USB */
 	upsdebugx(2, "Report Descriptor size = %" PRI_NUT_USB_CTRL_CHARBUFSIZE, rdlen);
 
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) )
@@ -1297,7 +1298,7 @@ static int callback(
 	}
 	HIDDumpTree(udev, arghd, subdriver->utab);
 
-#ifndef SHUT_MODE
+#if !((defined SHUT_MODE) && SHUT_MODE)
 	/* create a new matcher for later matching */
 	USBFreeExactMatcher(exact_matcher);
 	ret = USBNewExactMatcher(&exact_matcher, hd);
@@ -1307,7 +1308,7 @@ static int callback(
 	}
 
 	regex_matcher->next = exact_matcher;
-#endif /* SHUT_MODE */
+#endif	/* !SHUT_MODE => USB */
 
 	/* apply subdriver specific formatting */
 	mfr = subdriver->format_mfr(hd);
@@ -1373,11 +1374,11 @@ static bool_t hid_ups_walk(walkmode_t mode)
 	double		value;
 	int		retcode;
 
-#ifndef SHUT_MODE
+#if !((defined SHUT_MODE) && SHUT_MODE)
 	/* extract the VendorId for further testing */
 	int vendorID = curDevice.VendorID;
 	int productID = curDevice.ProductID;
-#endif
+#endif	/* !SHUT_MODE => USB */
 
 	/* 3 modes: HU_WALKMODE_INIT, HU_WALKMODE_QUICK_UPDATE
 	 * and HU_WALKMODE_FULL_UPDATE */
@@ -1385,13 +1386,14 @@ static bool_t hid_ups_walk(walkmode_t mode)
 	/* Device data walk ----------------------------- */
 	for (item = subdriver->hid2nut; item->info_type != NULL; item++) {
 
-#ifdef SHUT_MODE
+#if (defined SHUT_MODE) && SHUT_MODE
 		/* Check if we are asked to stop (reactivity++) in SHUT mode.
 		 * In USB mode, looping through this takes well under a second,
 		 * so any effort to improve reactivity here is wasted. */
 		if (exit_flag != 0)
 			return TRUE;
-#endif
+#endif	/* SHUT_MODE */
+
 		/* filter data according to mode */
 		switch (mode)
 		{
@@ -1485,14 +1487,14 @@ static bool_t hid_ups_walk(walkmode_t mode)
 # pragma GCC diagnostic pop
 #endif
 
-#ifndef SHUT_MODE
+#if !((defined SHUT_MODE) && SHUT_MODE)
 		/* skip report 0x54 for Tripplite SU3000LCD2UHV due to firmware bug */
 		if ((vendorID == 0x09ae) && (productID == 0x1330)) {
 			if (item->hiddata && (item->hiddata->ReportID == 0x54)) {
 				continue;
 			}
 		}
-#endif
+#endif	/* !SHUT_MODE => USB */
 
 		retcode = HIDGetDataValue(udev, item->hiddata, &value, poll_interval);
 


### PR DESCRIPTION
Closes: #2022

Also adds a notion of "Device" to SHUT drivers, primarily to have a definite value there (not a random pointer) and while there, a useful one (store a copy of serial port path), to be on par with USB drivers per #974.