### PR TITLE
Revert "cyberpower-mib: fix instant command declarations"

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -66,8 +66,9 @@ as part of https://github.com/networkupstools/nut/issues/1410 solution.
      fixed for NUT v2.8.1.
    * A table in `cyberpower-mib` (for `snmp-ups` driver) sources was
      arranged in NUT v2.8.0 release in a way that precluded the driver
-     logic from looking at all of its entries. Regression fixed for NUT
-     v2.8.1 [#1432]
+     logic from looking at all of its entries. Also a fix for instant
+     command definitions had in fact broken them due to other development.
+     Regressions fixed for NUT v2.8.1 [#1432, #2029]
    * A change for file-change detection in `dummy-ups` driver for NUT
      v2.8.0 release misfired on some platforms. Regression fixed for NUT
      v2.8.1 [#1420]

--- a/drivers/cyberpower-mib.c
+++ b/drivers/cyberpower-mib.c
@@ -195,22 +195,22 @@ static snmp_info_t cyberpower_mib[] = {
 		SU_FLAG_OK | SU_TYPE_TIME, NULL },
 	/* instant commands. */
 	/* upsAdvanceControlUpsOff */
-	{ "load.off", 0, 2, ".1.3.6.1.4.1.3808.1.1.1.6.2.1.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "load.off", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.6.2.1.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
 	/* upsAdvanceControlTurnOnUPS */
-	{ "load.on", 0, 2, ".1.3.6.1.4.1.3808.1.1.1.6.2.6.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "load.on", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.6.2.6.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
 	/* upsAdvanceControlUpsOff */
-	{ "shutdown.stayoff", 0, 3, ".1.3.6.1.4.1.3808.1.1.1.6.2.6.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
-	/* upsAdvanceControlUpsSleep */
-	{ "shutdown.return", 0, 3, ".1.3.6.1.4.1.3808.1.1.1.6.2.3.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "shutdown.stayoff", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.6.2.6.0", "3", SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	/* upsBaseControlConserveBattery */
+	{ "shutdown.return", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.6.1.1.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
 	/* upsAdvanceControlSimulatePowerFail */
-	{ "test.failure.start", 0, 2, ".1.3.6.1.4.1.3808.1.1.1.6.2.4.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "test.failure.start", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.6.2.4.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
 	/* upsAdvanceTestIndicators */
-	{ "test.panel.start", 0, 2, ".1.3.6.1.4.1.3808.1.1.1.7.2.5.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "test.panel.start", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.7.2.5.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
 	/* upsAdvanceTestDiagnostics */
-	{ "test.battery.start", 0, 2, ".1.3.6.1.4.1.3808.1.1.1.7.2.2.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "test.battery.start", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.7.2.2.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
 	/* upsAdvanceTestRuntimeCalibration */
-	{ "calibrate.start", 0, 2, ".1.3.6.1.4.1.3808.1.1.1.7.2.6.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
-	{ "calibrate.stop", 0, 3, ".1.3.6.1.4.1.3808.1.1.1.7.2.6.0", NULL, SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "calibrate.start", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.7.2.6.0", "2", SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	{ "calibrate.stop", 0, 1, ".1.3.6.1.4.1.3808.1.1.1.7.2.6.0", "3", SU_TYPE_CMD | SU_FLAG_OK, NULL },
 
 	/* upsAdvanceTestLastDiagnosticsDate */
 	{ "ups.test.date", ST_FLAG_STRING, 8, ".1.3.6.1.4.1.3808.1.1.1.7.2.4.0", "",


### PR DESCRIPTION
This reverts commit 8bcf255b624e6ba6c89a2a3eeab37658d9cb8cb4 from PR #686.

Cyberpower `snmp_info_t` got updated to conform with pre 5d97d07 instant
commands layout, but got merged after it. Reverting 8bcf255 so that command
values are correctly in `su_info_t->dfl`.

Fixes #2028.
