### PR TITLE
Cherry-pick nonfunctional improvements from PR #1652 (issue #1279)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -840,8 +840,10 @@ if (p == NULL || *p != '\0') return 1])],
     )])
 AS_IF([test x"${ac_cv_func_strptime}" = xyes],
     [AC_DEFINE([HAVE_STRPTIME], 1, [defined if standard library has, and C standard allows, the strptime(s1,s2,tm) method])],
-    [AC_MSG_WARN([Optional C library routine strptime not found; a fallback implementation will be built in])]
+    [AC_MSG_WARN([Optional C library routine strptime not found; try adding _GNU_SOURCE; a fallback implementation will be built in])]
     )
+dnl Note: per Linux headers, this may need __USE_XOPEN (features.h)
+dnl which is enabled by _XOPEN_SOURCE via _GNU_SOURCE on the platform.
 AM_CONDITIONAL([HAVE_STRPTIME], [test x"${ac_cv_func_strptime}" = "xyes"])
 
 AC_CACHE_CHECK([for clock_gettime(CLOCK_MONOTONIC,ts)],

--- a/drivers/libhid.c
+++ b/drivers/libhid.c
@@ -821,6 +821,7 @@ static double logical_to_physical(HIDData_t *Data, long logical)
 	if ((Data->PhyMax <= Data->PhyMin) || (Data->LogMax <= Data->LogMin))
 	{
 		/* this should not really happen */
+		upsdebugx(5, "Max was not greater than Min, returning logical value as is");
 		return (double)logical;
 	}
 
@@ -859,6 +860,7 @@ static long physical_to_logical(HIDData_t *Data, double physical)
 	if ((Data->PhyMax <= Data->PhyMin) || (Data->LogMax <= Data->LogMin))
 	{
 		/* this should not really happen */
+		upsdebugx(5, "Max was not greater than Min, returning physical value as is");
 		return (long)physical;
 	}
 

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -291,13 +291,17 @@ void storeval(const char *var, char *val)
 	 * addvar() in a driver codebase.
 	 */
 	if (!strncasecmp(var, "override.", 9)) {
+		/* NOTE: No regard for VAR_SENSITIVE here */
 		dstate_setinfo(var+9, "%s", val);
 		dstate_setflags(var+9, ST_FLAG_IMMUTABLE);
+		dparam_setinfo(var, val);
 		return;
 	}
 
 	if (!strncasecmp(var, "default.", 8)) {
+		/* NOTE: No regard for VAR_SENSITIVE here */
 		dstate_setinfo(var+8, "%s", val);
+		dparam_setinfo(var, val);
 		return;
 	}
 


### PR DESCRIPTION
Cherry-pick a few small fixes that got bogged down along with PR #1652 - both to improve the main codebase, and to minimize comparison noise for that PR eventually.

Arguably, the change to remember `override.*` and `default.*` values into `driver.parameter.*` values and eventually into reported dstate information, this one is not that non-functional. But did not even feel substantial enough to warrant bumping all driver versions.