### PR TITLE
Fix segfault in NUT clients with empty host/device name components

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -114,6 +114,10 @@ as part of https://github.com/networkupstools/nut/issues/1410 solution.
      seems to have confused the MGE SHUT (Serial HID UPS Transfer) driver
      support [#2022]
 
+ - An issue was identified which could cause `libupsclient` parser of device
+   and host names to crash upon bad inputs (e.g. poorly resolved environment
+   variables in scripts). Now it should fail more gracefully [#2052]
+
  - New `configure --enable-inplace-runtime` option should set default values
    for `--sysconfdir`, `--with-user` and `--with-group` options to match an
    existing NUT deployment -- for users who are trying if a custom build

--- a/clients/upsclient.c
+++ b/clients/upsclient.c
@@ -1161,7 +1161,7 @@ int upscli_tryconnect(UPSCONN_t *ups, const char *host, uint16_t port, int flags
 
 	pconf_init(&ups->pc_ctx, NULL);
 
-	ups->host = strdup(host);
+	ups->host = xstrdup(host);
 
 	if (!ups->host) {
 		ups->upserror = UPSCLI_ERR_NOMEM;
@@ -1618,15 +1618,15 @@ int upscli_splitname(const char *buf, char **upsname, char **hostname, uint16_t 
 
 	s = strchr(tmp, '@');
 
-	if ((*upsname = strdup(strtok_r(tmp, "@", &last))) == NULL) {
-		fprintf(stderr, "upscli_splitname: strdup failed\n");
+	if ((*upsname = xstrdup(strtok_r(tmp, "@", &last))) == NULL) {
+		fprintf(stderr, "upscli_splitname: xstrdup failed\n");
 		return -1;
 	}
 
 	/* only a upsname is specified, fill in defaults */
 	if (s == NULL) {
-		if ((*hostname = strdup("localhost")) == NULL) {
-			fprintf(stderr, "upscli_splitname: strdup failed\n");
+		if ((*hostname = xstrdup("localhost")) == NULL) {
+			fprintf(stderr, "upscli_splitname: xstrdup failed\n");
 			return -1;
 		}
 
@@ -1659,8 +1659,8 @@ int upscli_splitaddr(const char *buf, char **hostname, uint16_t *port)
 			return -1;
 		}
 
-		if ((*hostname = strdup(strtok_r(tmp+1, "]", &last))) == NULL) {
-			fprintf(stderr, "upscli_splitaddr: strdup failed\n");
+		if ((*hostname = xstrdup(strtok_r(tmp+1, "]", &last))) == NULL) {
+			fprintf(stderr, "upscli_splitaddr: xstrdup failed\n");
 			return -1;
 		}
 
@@ -1672,8 +1672,8 @@ int upscli_splitaddr(const char *buf, char **hostname, uint16_t *port)
 	} else {
 		s = strchr(tmp, ':');
 
-		if ((*hostname = strdup(strtok_r(tmp, ":", &last))) == NULL) {
-			fprintf(stderr, "upscli_splitaddr: strdup failed\n");
+		if ((*hostname = xstrdup(strtok_r(tmp, ":", &last))) == NULL) {
+			fprintf(stderr, "upscli_splitaddr: xstrdup failed\n");
 			return -1;
 		}
 

--- a/clients/upsclient.c
+++ b/clients/upsclient.c
@@ -1618,10 +1618,27 @@ int upscli_splitname(const char *buf, char **upsname, char **hostname, uint16_t 
 
 	s = strchr(tmp, '@');
 
+	/* someone passed a "@hostname" string? */
+	if (s == tmp) {
+		fprintf(stderr, "upscli_splitname: got empty upsname string\n");
+		return -1;
+	}
+
 	if ((*upsname = xstrdup(strtok_r(tmp, "@", &last))) == NULL) {
 		fprintf(stderr, "upscli_splitname: xstrdup failed\n");
 		return -1;
 	}
+
+	/* someone passed a "@hostname" string (take two)? */
+	if (!**upsname) {
+		fprintf(stderr, "upscli_splitname: got empty upsname string\n");
+		return -1;
+	}
+
+	/*
+	fprintf(stderr, "upscli_splitname3: got buf='%s', tmp='%s', upsname='%s', possible hostname:port='%s'\n",
+		NUT_STRARG(buf), NUT_STRARG(tmp), NUT_STRARG(*upsname), NUT_STRARG((s ? s+1 : s)));
+	*/
 
 	/* only a upsname is specified, fill in defaults */
 	if (s == NULL) {
@@ -1632,6 +1649,12 @@ int upscli_splitname(const char *buf, char **upsname, char **hostname, uint16_t 
 
 		*port = PORT;
 		return 0;
+	}
+
+	/* someone passed a "upsname@" string? */
+	if (!(*(s+1))) {
+		fprintf(stderr, "upscli_splitname: got the @ separator and then an empty hostname[:port] string\n");
+		return -1;
 	}
 
 	return upscli_splitaddr(s+1, hostname, port);

--- a/common/common.c
+++ b/common/common.c
@@ -1738,7 +1738,14 @@ void *xrealloc(void *ptr, size_t size)
 
 char *xstrdup(const char *string)
 {
-	char *p = strdup(string);
+	char *p;
+
+	if (string == NULL) {
+		upsdebugx(1, "%s: got null input", __func__);
+		return NULL;
+	}
+
+	p = strdup(string);
 
 	if (p == NULL)
 		fatal_with_errno(EXIT_FAILURE, "%s", oom_msg);

--- a/common/common.c
+++ b/common/common.c
@@ -643,11 +643,21 @@ int sendsignal(const char *progname, const char * sig)
 
 const char *xbasename(const char *file)
 {
+	const char *p;
+#ifdef WIN32
+	const char *r;
+#endif
+
+	if (file == NULL) {
+		upsdebugx(1, "%s: got null input", __func__);
+		return NULL;
+	}
+
 #ifndef WIN32
-	const char *p = strrchr(file, '/');
+	p = strrchr(file, '/');
 #else
-	const char *p = strrchr(file, '\\');
-	const char *r = strrchr(file, '/');
+	p = strrchr(file, '\\');
+	r = strrchr(file, '/');
 	/* if not found, try '/' */
 	if( r > p ) {
 		p = r;
@@ -1729,7 +1739,14 @@ void *xcalloc(size_t number, size_t size)
 
 void *xrealloc(void *ptr, size_t size)
 {
-	void *p = realloc(ptr, size);
+	void *p;
+
+	if (ptr == NULL) {
+		upsdebugx(1, "%s: got null input", __func__);
+		return NULL;
+	}
+
+	p = realloc(ptr, size);
 
 	if (p == NULL)
 		fatal_with_errno(EXIT_FAILURE, "%s", oom_msg);
@@ -1738,7 +1755,14 @@ void *xrealloc(void *ptr, size_t size)
 
 char *xstrdup(const char *string)
 {
-	char *p = strdup(string);
+	char *p;
+
+	if (string == NULL) {
+		upsdebugx(1, "%s: got null input", __func__);
+		return NULL;
+	}
+
+	p = strdup(string);
 
 	if (p == NULL)
 		fatal_with_errno(EXIT_FAILURE, "%s", oom_msg);

--- a/common/common.c
+++ b/common/common.c
@@ -643,21 +643,11 @@ int sendsignal(const char *progname, const char * sig)
 
 const char *xbasename(const char *file)
 {
-	const char *p;
-#ifdef WIN32
-	const char *r;
-#endif
-
-	if (file == NULL) {
-		upsdebugx(1, "%s: got null input", __func__);
-		return NULL;
-	}
-
 #ifndef WIN32
-	p = strrchr(file, '/');
+	const char *p = strrchr(file, '/');
 #else
-	p = strrchr(file, '\\');
-	r = strrchr(file, '/');
+	const char *p = strrchr(file, '\\');
+	const char *r = strrchr(file, '/');
 	/* if not found, try '/' */
 	if( r > p ) {
 		p = r;
@@ -1739,14 +1729,7 @@ void *xcalloc(size_t number, size_t size)
 
 void *xrealloc(void *ptr, size_t size)
 {
-	void *p;
-
-	if (ptr == NULL) {
-		upsdebugx(1, "%s: got null input", __func__);
-		return NULL;
-	}
-
-	p = realloc(ptr, size);
+	void *p = realloc(ptr, size);
 
 	if (p == NULL)
 		fatal_with_errno(EXIT_FAILURE, "%s", oom_msg);
@@ -1755,14 +1738,7 @@ void *xrealloc(void *ptr, size_t size)
 
 char *xstrdup(const char *string)
 {
-	char *p;
-
-	if (string == NULL) {
-		upsdebugx(1, "%s: got null input", __func__);
-		return NULL;
-	}
-
-	p = strdup(string);
+	char *p = strdup(string);
 
 	if (p == NULL)
 		fatal_with_errno(EXIT_FAILURE, "%s", oom_msg);


### PR DESCRIPTION
Closes: #2052 

The culprit was that in some libc implementations, calling `strdup(NULL)` causes a segfault, where such `NULL` can be returned by `strtok()` if there were no hits. Using `xstrdup()` introduced across NUT codebase specifically for safety checks like these turns it into a graceful failure that calling code can handle meaningfully.

See also #677 for related concerns.