### PR TITLE
Allow USB device matching by `busport` value

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -233,6 +233,11 @@ as part of https://github.com/networkupstools/nut/issues/1410 solution.
    of all USB drivers using these options to include the same description
    [#1766]
 
+ - Added a "busport" USB matching option (if supported by the hardware, OS and
+   libusb on the particular deployment, it should allow to specify physical
+   port numbers on an USB hub, rather than logical "device" enumeration values,
+   and in turn -- this should be less volatile across reboots etc.) [#2043]
+
  - Added an `allow_duplicates` flag for common USB matching options which
    may help monitor several related no-name devices (although without knowing
    reliably which one is which... better than nothing) [#1756]

--- a/docs/man/nut_usb_addvars.txt
+++ b/docs/man/nut_usb_addvars.txt
@@ -65,7 +65,8 @@ Select a UPS on a specific USB device or group of devices. The argument is
 a regular expression that must match the device name where the UPS is
 connected (e.g. `device="001"` or `device="00[1-2]"`) as seen on Linux
 in `/sys/bus/usb/devices` or *lsusb(8)*; including leading zeroes.
-Note that device numbers are not guaranteed by the OS to be stable across
++
+NOTE: device numbers are not guaranteed by the OS to be stable across
 re-boots or device re-plugging.
 
 *busport =* 'regex'::

--- a/docs/man/nut_usb_addvars.txt
+++ b/docs/man/nut_usb_addvars.txt
@@ -56,15 +56,15 @@ Examples:
 
 Select a UPS on a specific USB bus or group of buses. The argument is
 a regular expression that must match the bus name where the UPS is
-connected (e.g. `bus="002"` or `bus="00[2-3]"`) as seen in
-`/proc/bus/usb/devices` or *lsusb(8)*; including leading zeroes.
+connected (e.g. `bus="002"` or `bus="00[2-3]"`) as seen on Linux in
+`/sys/bus/usb/devices` or *lsusb(8)*; including leading zeroes.
 
 *device =* 'regex'::
 
 Select a UPS on a specific USB device or group of devices. The argument is
 a regular expression that must match the device name where the UPS is
-connected (e.g. `device="001"` or `device="00[1-2]"`) as seen in
-`/proc/bus/usb/devices` or *lsusb(8)*; including leading zeroes.
+connected (e.g. `device="001"` or `device="00[1-2]"`) as seen on Linux
+in `/sys/bus/usb/devices` or *lsusb(8)*; including leading zeroes.
 Note that device numbers are not guaranteed by the OS to be stable across
 re-boots or device re-plugging.
 

--- a/docs/man/nut_usb_addvars.txt
+++ b/docs/man/nut_usb_addvars.txt
@@ -68,6 +68,17 @@ in `/sys/bus/usb/devices` or *lsusb(8)*; including leading zeroes.
 Note that device numbers are not guaranteed by the OS to be stable across
 re-boots or device re-plugging.
 
+*busport =* 'regex'::
+
+If supported by the hardware, OS and libusb on the particular deployment,
+this option should allow to specify physical port numbers on an USB hub,
+rather than logical `device` enumeration values, and in turn -- this should
+be less volatile across reboots or re-plugging.
++
+NOTE: this option is not practically supported by some NUT builds
+(it should be ignored with a warning then), and not by all systems
+that NUT can run on.
+
 *allow_duplicates*::
 
 If you have several UPS devices which may not be uniquely identified by

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3222 utf-8
+personal_ws-1.1 en 3223 utf-8
 AAS
 ABI
 ACFAIL
@@ -1639,6 +1639,7 @@ bugfixes
 buildbots
 builddir
 bullseye
+busport
 busybox
 bv
 bypassvolts

--- a/drivers/blazer_usb.c
+++ b/drivers/blazer_usb.c
@@ -609,9 +609,9 @@ void upsdrv_initups(void)
 	regex_array[4] = getval("serial");
 	regex_array[5] = getval("bus");
 	regex_array[6] = getval("device");
-#ifdef WITH_USB_BUSPORT
+# ifdef WITH_USB_BUSPORT
 	regex_array[7] = getval("busport");
-#endif
+# endif
 
 	/* check for language ID workaround (#1) */
 	if (getval("langid_fix")) {
@@ -727,9 +727,9 @@ void upsdrv_cleanup(void)
 	free(usbdevice.Product);
 	free(usbdevice.Serial);
 	free(usbdevice.Bus);
-#ifdef WITH_USB_BUSPORT
-	free(usbdevice.BusPort);
-#endif
 	free(usbdevice.Device);
+# ifdef WITH_USB_BUSPORT
+	free(usbdevice.BusPort);
+# endif
 #endif	/* TESTING */
 }

--- a/drivers/blazer_usb.c
+++ b/drivers/blazer_usb.c
@@ -611,6 +611,10 @@ void upsdrv_initups(void)
 	regex_array[6] = getval("device");
 # ifdef WITH_USB_BUSPORT
 	regex_array[7] = getval("busport");
+# else
+	if (getval("busport")) {
+		upslogx(LOG_WARNING, "\"busport\" is configured for the device, but is not actually handled by current build combination of NUT and libusb (ignored)");
+	}
 # endif
 
 	/* check for language ID workaround (#1) */

--- a/drivers/blazer_usb.c
+++ b/drivers/blazer_usb.c
@@ -609,7 +609,7 @@ void upsdrv_initups(void)
 	regex_array[4] = getval("serial");
 	regex_array[5] = getval("bus");
 	regex_array[6] = getval("device");
-# ifdef WITH_USB_BUSPORT
+#if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
 	regex_array[7] = getval("busport");
 # else
 	if (getval("busport")) {
@@ -732,7 +732,7 @@ void upsdrv_cleanup(void)
 	free(usbdevice.Serial);
 	free(usbdevice.Bus);
 	free(usbdevice.Device);
-# ifdef WITH_USB_BUSPORT
+#if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
 	free(usbdevice.BusPort);
 # endif
 #endif	/* TESTING */

--- a/drivers/blazer_usb.c
+++ b/drivers/blazer_usb.c
@@ -37,7 +37,7 @@
 #endif
 
 #define DRIVER_NAME	"Megatec/Q1 protocol USB driver"
-#define DRIVER_VERSION	"0.16"
+#define DRIVER_VERSION	"0.17"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/blazer_usb.c
+++ b/drivers/blazer_usb.c
@@ -597,7 +597,7 @@ void upsdrv_initups(void)
 #ifndef TESTING
 	int	ret, langid;
 	char	tbuf[255]; /* Some devices choke on size > 255 */
-	char	*regex_array[7];
+	char	*regex_array[REGEXP_ARRAY_LIMIT];
 	char	*subdrv = getval("subdriver");
 
 	warn_if_bad_usb_port_filename(device_path);
@@ -609,6 +609,9 @@ void upsdrv_initups(void)
 	regex_array[4] = getval("serial");
 	regex_array[5] = getval("bus");
 	regex_array[6] = getval("device");
+#ifdef WITH_USB_BUSPORT
+	regex_array[7] = getval("busport");
+#endif
 
 	/* check for language ID workaround (#1) */
 	if (getval("langid_fix")) {
@@ -724,6 +727,9 @@ void upsdrv_cleanup(void)
 	free(usbdevice.Product);
 	free(usbdevice.Serial);
 	free(usbdevice.Bus);
+#ifdef WITH_USB_BUSPORT
+	free(usbdevice.BusPort);
+#endif
 	free(usbdevice.Device);
 #endif	/* TESTING */
 }

--- a/drivers/blazer_usb.c
+++ b/drivers/blazer_usb.c
@@ -597,7 +597,7 @@ void upsdrv_initups(void)
 #ifndef TESTING
 	int	ret, langid;
 	char	tbuf[255]; /* Some devices choke on size > 255 */
-	char	*regex_array[REGEXP_ARRAY_LIMIT];
+	char	*regex_array[USBMATCHER_REGEXP_ARRAY_LIMIT];
 	char	*subdrv = getval("subdriver");
 
 	warn_if_bad_usb_port_filename(device_path);

--- a/drivers/libshut.c
+++ b/drivers/libshut.c
@@ -43,7 +43,7 @@
 #include "common.h" /* for xmalloc, upsdebugx prototypes */
 
 #define SHUT_DRIVER_NAME	"SHUT communication driver"
-#define SHUT_DRIVER_VERSION	"0.87"
+#define SHUT_DRIVER_VERSION	"0.88"
 
 /* communication driver description structure */
 upsdrv_info_t comm_upsdrv_info = {
@@ -487,13 +487,16 @@ static int libshut_open(
 #endif
 
 	curDevice->bcdDevice = dev_descriptor->bcdDevice;
-	curDevice->Vendor = strdup("Eaton");
+	curDevice->Vendor = NULL;
 	if (dev_descriptor->iManufacturer) {
 		ret = shut_get_string_simple(*arg_upsfd, dev_descriptor->iManufacturer,
 			string, MAX_STRING_SIZE);
 		if (ret > 0) {
 			curDevice->Vendor = strdup(string);
 		}
+	}
+	if (curDevice->Vendor == NULL) {
+		curDevice->Vendor = strdup("Eaton");
 	}
 
 	/* ensure iProduct retrieval */

--- a/drivers/libshut.c
+++ b/drivers/libshut.c
@@ -468,7 +468,7 @@ static int libshut_open(
 	free(curDevice->Serial);
 	free(curDevice->Bus);
 	free(curDevice->Device);
-#ifdef WITH_USB_BUSPORT
+#if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
 	free(curDevice->BusPort);
 #endif
 	memset(curDevice, '\0', sizeof(*curDevice));
@@ -477,7 +477,7 @@ static int libshut_open(
 	curDevice->ProductID = dev_descriptor->idProduct;
 	curDevice->Bus = strdup("serial");
 	curDevice->Device = strdup(arg_device_path);
-#ifdef WITH_USB_BUSPORT
+#if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
 	curDevice->BusPort = (char *)malloc(4);
 	if (curDevice->BusPort == NULL) {
 		fatal_with_errno(EXIT_FAILURE, "Out of memory");
@@ -529,7 +529,7 @@ static int libshut_open(
 	upsdebugx(2, "- Product: %s", curDevice->Product);
 	upsdebugx(2, "- Serial Number: %s", curDevice->Serial);
 	upsdebugx(2, "- Bus: %s", curDevice->Bus);
-#ifdef WITH_USB_BUSPORT
+#if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
 	upsdebugx(2, "- Bus Port: %s", curDevice->BusPort ? curDevice->BusPort : "unknown");
 #endif
 	upsdebugx(2, "- Device: %s", curDevice->Device ? curDevice->Device : "unknown");

--- a/drivers/libshut.c
+++ b/drivers/libshut.c
@@ -468,12 +468,24 @@ static int libshut_open(
 	free(curDevice->Serial);
 	free(curDevice->Bus);
 	free(curDevice->Device);
+#ifdef WITH_USB_BUSPORT
+	free(curDevice->BusPort);
+#endif
 	memset(curDevice, '\0', sizeof(*curDevice));
 
 	curDevice->VendorID = dev_descriptor->idVendor;
 	curDevice->ProductID = dev_descriptor->idProduct;
 	curDevice->Bus = strdup("serial");
 	curDevice->Device = strdup(arg_device_path);
+#ifdef WITH_USB_BUSPORT
+	curDevice->BusPort = (char *)malloc(4);
+	if (curDevice->BusPort == NULL) {
+		fatal_with_errno(EXIT_FAILURE, "Out of memory");
+	}
+	upsdebugx(2, "%s: NOTE: BusPort is always zero with libshut", __func__);
+	sprintf(curDevice->BusPort, "%03d", 0);
+#endif
+
 	curDevice->bcdDevice = dev_descriptor->bcdDevice;
 	curDevice->Vendor = strdup("Eaton");
 	if (dev_descriptor->iManufacturer) {
@@ -514,6 +526,9 @@ static int libshut_open(
 	upsdebugx(2, "- Product: %s", curDevice->Product);
 	upsdebugx(2, "- Serial Number: %s", curDevice->Serial);
 	upsdebugx(2, "- Bus: %s", curDevice->Bus);
+#ifdef WITH_USB_BUSPORT
+	upsdebugx(2, "- Bus Port: %s", curDevice->BusPort ? curDevice->BusPort : "unknown");
+#endif
 	upsdebugx(2, "- Device: %s", curDevice->Device ? curDevice->Device : "unknown");
 	upsdebugx(2, "- Device release number: %04x", curDevice->bcdDevice);
 	upsdebugx(2, "Device matches");

--- a/drivers/libshut.h
+++ b/drivers/libshut.h
@@ -116,7 +116,7 @@ typedef int usb_ctrl_timeout_msec;	/* in milliseconds */
 
 /*!
  * SHUTDevice_t: Describe a SHUT device. This structure contains exactly
- * the 5 pieces of information by which a SHUT device identifies
+ * the 5 or more pieces of information by which a SHUT device identifies
  * itself, so it serves as a kind of "fingerprint" of the device. This
  * information must be matched exactly when reopening a device, and
  * therefore must not be "improved" or updated by a client
@@ -132,6 +132,9 @@ typedef struct SHUTDevice_s {
 	char*		Bus;       /*!< Bus name, e.g. "003"  */
 	uint16_t	bcdDevice; /*!< Device release number */
 	char		*Device;   /*!< Device name on the bus, e.g. "001"  */
+#if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
+	char		*BusPort;  /*!< Port name, e.g. "001"  */
+#endif
 } SHUTDevice_t;
 
 /*!

--- a/drivers/libusb0.c
+++ b/drivers/libusb0.c
@@ -306,9 +306,6 @@ static int libusb_open(usb_dev_handle **udevp,
 			curDevice->Device = xstrdup(dev->filename);
 			curDevice->bcdDevice = dev->descriptor.bcdDevice;
 
-			upsdebugx(2, "dev->filename: %s", dev->filename);
-			upsdebugx(2, "bus->dirname: %s", bus->dirname);
-
 #ifdef WITH_USB_BUSPORT
 			curDevice->BusPort = (char *)malloc(4);
 			if (curDevice->BusPort == NULL) {
@@ -368,7 +365,7 @@ static int libusb_open(usb_dev_handle **udevp,
 			upsdebugx(2, "- Bus: %s", curDevice->Bus ? curDevice->Bus : "unknown");
 			upsdebugx(2, "- Device: %s", curDevice->Device ? curDevice->Device : "unknown");
 #ifdef WITH_USB_BUSPORT
-			upsdebugx(2, "- Port: %s", curDevice->BusPort ? curDevice->BusPort : "unknown");
+			upsdebugx(2, "- Bus Port: %s", curDevice->BusPort ? curDevice->BusPort : "unknown");
 #endif
 			upsdebugx(2, "- Device release number: %04x", curDevice->bcdDevice);
 

--- a/drivers/libusb0.c
+++ b/drivers/libusb0.c
@@ -287,6 +287,9 @@ static int libusb_open(usb_dev_handle **udevp,
 			free(curDevice->Serial);
 			free(curDevice->Bus);
 			free(curDevice->Device);
+#ifdef WITH_USB_BUSPORT
+			free(curDevice->BusPort);
+#endif
 			memset(curDevice, '\0', sizeof(*curDevice));
 
 			/* Keep the list of items in sync with those matched by
@@ -297,6 +300,18 @@ static int libusb_open(usb_dev_handle **udevp,
 			curDevice->Bus = xstrdup(bus->dirname);
 			curDevice->Device = xstrdup(dev->filename);
 			curDevice->bcdDevice = dev->descriptor.bcdDevice;
+
+			upsdebugx(2, "dev->filename: %s", dev->filename);
+			upsdebugx(2, "bus->dirname: %s", bus->dirname);
+
+#ifdef WITH_USB_BUSPORT
+			curDevice->BusPort = (char *)malloc(4);
+			if (curDevice->BusPort == NULL) {
+				fatal_with_errno(EXIT_FAILURE, "Out of memory");
+			}
+			// always zero
+			sprintf(curDevice->BusPort, "%03d", 0);
+#endif
 
 			if (dev->descriptor.iManufacturer) {
 				retries = MAX_RETRY;
@@ -347,6 +362,9 @@ static int libusb_open(usb_dev_handle **udevp,
 			upsdebugx(2, "- Serial Number: %s", curDevice->Serial ? curDevice->Serial : "unknown");
 			upsdebugx(2, "- Bus: %s", curDevice->Bus ? curDevice->Bus : "unknown");
 			upsdebugx(2, "- Device: %s", curDevice->Device ? curDevice->Device : "unknown");
+#ifdef WITH_USB_BUSPORT
+			upsdebugx(2, "- Port: %s", curDevice->BusPort ? curDevice->BusPort : "unknown");
+#endif
 			upsdebugx(2, "- Device release number: %04x", curDevice->bcdDevice);
 
 			/* FIXME: extend to Eaton OEMs (HP, IBM, ...) */

--- a/drivers/libusb0.c
+++ b/drivers/libusb0.c
@@ -76,6 +76,11 @@ void nut_usb_addvars(void)
 
 	addvar(VAR_VALUE, "bus", "Regular expression to match USB bus name");
 	addvar(VAR_VALUE, "device", "Regular expression to match USB device name");
+	/* Not supported by libusb0, but let's not crash config
+	 * parsing on unknown keywords due to such nuances! :) */
+	addvar(VAR_VALUE, "busport", "Regular expression to match USB bus port name"
+		" (tolerated but ignored in this build)"
+	);
 
 	/* Warning: this feature is inherently non-deterministic!
 	 * If you only care to know that at least one of your no-name UPSes is online,

--- a/drivers/libusb0.c
+++ b/drivers/libusb0.c
@@ -292,7 +292,7 @@ static int libusb_open(usb_dev_handle **udevp,
 			free(curDevice->Serial);
 			free(curDevice->Bus);
 			free(curDevice->Device);
-#ifdef WITH_USB_BUSPORT
+#if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
 			free(curDevice->BusPort);
 #endif
 			memset(curDevice, '\0', sizeof(*curDevice));
@@ -306,7 +306,7 @@ static int libusb_open(usb_dev_handle **udevp,
 			curDevice->Device = xstrdup(dev->filename);
 			curDevice->bcdDevice = dev->descriptor.bcdDevice;
 
-#ifdef WITH_USB_BUSPORT
+#if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
 			curDevice->BusPort = (char *)malloc(4);
 			if (curDevice->BusPort == NULL) {
 				fatal_with_errno(EXIT_FAILURE, "Out of memory");
@@ -364,7 +364,7 @@ static int libusb_open(usb_dev_handle **udevp,
 			upsdebugx(2, "- Serial Number: %s", curDevice->Serial ? curDevice->Serial : "unknown");
 			upsdebugx(2, "- Bus: %s", curDevice->Bus ? curDevice->Bus : "unknown");
 			upsdebugx(2, "- Device: %s", curDevice->Device ? curDevice->Device : "unknown");
-#ifdef WITH_USB_BUSPORT
+#if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
 			upsdebugx(2, "- Bus Port: %s", curDevice->BusPort ? curDevice->BusPort : "unknown");
 #endif
 			upsdebugx(2, "- Device release number: %04x", curDevice->bcdDevice);

--- a/drivers/libusb0.c
+++ b/drivers/libusb0.c
@@ -309,7 +309,7 @@ static int libusb_open(usb_dev_handle **udevp,
 			if (curDevice->BusPort == NULL) {
 				fatal_with_errno(EXIT_FAILURE, "Out of memory");
 			}
-			// always zero
+			upsdebugx(2, "%s: NOTE: BusPort is always zero with libusb0", __func__);
 			sprintf(curDevice->BusPort, "%03d", 0);
 #endif
 

--- a/drivers/libusb0.c
+++ b/drivers/libusb0.c
@@ -37,7 +37,7 @@
 #endif
 
 #define USB_DRIVER_NAME		"USB communication driver (libusb 0.1)"
-#define USB_DRIVER_VERSION	"0.44"
+#define USB_DRIVER_VERSION	"0.45"
 
 /* driver description structure */
 upsdrv_info_t comm_upsdrv_info = {

--- a/drivers/libusb1.c
+++ b/drivers/libusb1.c
@@ -288,7 +288,6 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 		}
 
 #ifdef WITH_USB_BUSPORT
-
 		bus_port = libusb_get_port_number(device);
 		curDevice->BusPort = (char *)malloc(4);
 		if (curDevice->BusPort == NULL) {

--- a/drivers/libusb1.c
+++ b/drivers/libusb1.c
@@ -66,9 +66,11 @@ void nut_usb_addvars(void)
 
 	addvar(VAR_VALUE, "bus", "Regular expression to match USB bus name");
 	addvar(VAR_VALUE, "device", "Regular expression to match USB device name");
-#ifdef WITH_USB_BUSPORT
-	addvar(VAR_VALUE, "busport", "Regular expression to match USB bus port name");
+	addvar(VAR_VALUE, "busport", "Regular expression to match USB bus port name"
+#ifndef WITH_USB_BUSPORT
+		" (tolerated but ignored in this build)"
 #endif
+	);
 
 	/* Warning: this feature is inherently non-deterministic!
 	 * If you only care to know that at least one of your no-name UPSes is online,

--- a/drivers/libusb1.c
+++ b/drivers/libusb1.c
@@ -67,7 +67,7 @@ void nut_usb_addvars(void)
 	addvar(VAR_VALUE, "bus", "Regular expression to match USB bus name");
 	addvar(VAR_VALUE, "device", "Regular expression to match USB device name");
 	addvar(VAR_VALUE, "busport", "Regular expression to match USB bus port name"
-#ifndef WITH_USB_BUSPORT
+#if (!defined WITH_USB_BUSPORT) || (!WITH_USB_BUSPORT)
 		/* Not supported by this version of libusb1,
 		 * but let's not crash config parsing on
 		 * unknown keywords due to such nuances! :)
@@ -172,7 +172,7 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 	const struct libusb_interface_descriptor *if_desc;
 	libusb_device_handle *udev;
 	uint8_t bus_num, device_addr;
-#ifdef WITH_USB_BUSPORT
+#if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
 	uint8_t bus_port;
 #endif
 	int ret, res;
@@ -249,7 +249,7 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 		free(curDevice->Serial);
 		free(curDevice->Bus);
 		free(curDevice->Device);
-#ifdef WITH_USB_BUSPORT
+#if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
 		free(curDevice->BusPort);
 #endif
 		memset(curDevice, '\0', sizeof(*curDevice));
@@ -293,7 +293,7 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 			}
 		}
 
-#ifdef WITH_USB_BUSPORT
+#if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
 		bus_port = libusb_get_port_number(device);
 		curDevice->BusPort = (char *)malloc(4);
 		if (curDevice->BusPort == NULL) {
@@ -372,7 +372,7 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 		upsdebugx(2, "- Product: %s", curDevice->Product ? curDevice->Product : "unknown");
 		upsdebugx(2, "- Serial Number: %s", curDevice->Serial ? curDevice->Serial : "unknown");
 		upsdebugx(2, "- Bus: %s", curDevice->Bus ? curDevice->Bus : "unknown");
-#ifdef WITH_USB_BUSPORT
+#if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
 		upsdebugx(2, "- Bus Port: %s", curDevice->BusPort ? curDevice->BusPort : "unknown");
 #endif
 		upsdebugx(2, "- Device: %s", curDevice->Device ? curDevice->Device : "unknown");

--- a/drivers/libusb1.c
+++ b/drivers/libusb1.c
@@ -33,7 +33,7 @@
 #include "nut_stdint.h"
 
 #define USB_DRIVER_NAME		"USB communication driver (libusb 1.0)"
-#define USB_DRIVER_VERSION	"0.45"
+#define USB_DRIVER_VERSION	"0.46"
 
 /* driver description structure */
 upsdrv_info_t comm_upsdrv_info = {

--- a/drivers/libusb1.c
+++ b/drivers/libusb1.c
@@ -68,6 +68,10 @@ void nut_usb_addvars(void)
 	addvar(VAR_VALUE, "device", "Regular expression to match USB device name");
 	addvar(VAR_VALUE, "busport", "Regular expression to match USB bus port name"
 #ifndef WITH_USB_BUSPORT
+		/* Not supported by this version of libusb1,
+		 * but let's not crash config parsing on
+		 * unknown keywords due to such nuances! :)
+		 */
 		" (tolerated but ignored in this build)"
 #endif
 	);

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -3016,7 +3016,7 @@ void	upsdrv_initups(void)
 		getval("serial") ||
 		getval("bus") ||
 		getval("langid_fix")
-#ifdef WITH_USB_BUSPORT
+#if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
 		|| getval("busport")
 #endif
 	) {
@@ -3124,7 +3124,7 @@ void	upsdrv_initups(void)
 		regex_array[4] = getval("serial");
 		regex_array[5] = getval("bus");
 		regex_array[6] = getval("device");
-#  ifdef WITH_USB_BUSPORT
+#  if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
 		regex_array[7] = getval("busport");
 #  else
 		if (getval("busport")) {
@@ -3294,7 +3294,7 @@ void	upsdrv_cleanup(void)
 		free(usbdevice.Serial);
 		free(usbdevice.Bus);
 		free(usbdevice.Device);
-#  ifdef WITH_USB_BUSPORT
+#  if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
 		free(usbdevice.BusPort);
 #  endif
 

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -3110,7 +3110,7 @@ void	upsdrv_initups(void)
 
 	warn_if_bad_usb_port_filename(device_path);
 
-	#ifndef TESTING
+# ifndef TESTING
 		int	ret, langid;
 		char	tbuf[255];	/* Some devices choke on size > 255 */
 		char	*regex_array[USBMATCHER_REGEXP_ARRAY_LIMIT];
@@ -3124,9 +3124,9 @@ void	upsdrv_initups(void)
 		regex_array[4] = getval("serial");
 		regex_array[5] = getval("bus");
 		regex_array[6] = getval("device");
-#ifdef WITH_USB_BUSPORT
+#  ifdef WITH_USB_BUSPORT
 		regex_array[7] = getval("busport");
-#endif
+#  endif
 
 		/* Check for language ID workaround (#1) */
 		if (getval("langid_fix")) {
@@ -3242,11 +3242,11 @@ void	upsdrv_initups(void)
 			}
 		}
 
-	#endif	/* TESTING */
+# endif	/* TESTING */
 
-	#ifdef QX_SERIAL
+# ifdef QX_SERIAL
 	}	/* is_usb */
-	#endif	/* QX_SERIAL */
+# endif	/* QX_SERIAL */
 
 #endif	/* QX_USB */
 
@@ -3266,23 +3266,22 @@ void	upsdrv_cleanup(void)
 
 #ifndef TESTING
 
-#ifdef QX_SERIAL
+# ifdef QX_SERIAL
 
-	#ifdef QX_USB
+#  ifdef QX_USB
 	if (!is_usb) {
-	#endif	/* QX_USB */
+#  endif	/* QX_USB */
 
 		ser_set_dtr(upsfd, 0);
 		ser_close(upsfd, device_path);
 
-	#ifdef QX_USB
+#  ifdef QX_USB
 	} else {	/* is_usb */
-	#endif	/* QX_USB */
+#  endif	/* QX_USB */
 
-#endif	/* QX_SERIAL */
+# endif	/* QX_SERIAL */
 
-#ifdef QX_USB
-
+# ifdef QX_USB
 		usb->close_dev(udev);
 		USBFreeExactMatcher(reopen_matcher);
 		USBFreeRegexMatcher(regex_matcher);
@@ -3295,11 +3294,11 @@ void	upsdrv_cleanup(void)
 #endif
 		free(usbdevice.Device);
 
-	#ifdef QX_SERIAL
+#  ifdef QX_SERIAL
 	}	/* is_usb */
-	#endif	/* QX_SERIAL */
+#  endif	/* QX_SERIAL */
 
-#endif	/* QX_USB */
+# endif	/* QX_USB */
 
 #endif	/* TESTING */
 

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -3113,7 +3113,7 @@ void	upsdrv_initups(void)
 	#ifndef TESTING
 		int	ret, langid;
 		char	tbuf[255];	/* Some devices choke on size > 255 */
-		char	*regex_array[REGEXP_ARRAY_LIMIT];
+		char	*regex_array[USBMATCHER_REGEXP_ARRAY_LIMIT];
 
 		char	*subdrv = getval("subdriver");
 

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -3126,6 +3126,10 @@ void	upsdrv_initups(void)
 		regex_array[6] = getval("device");
 #  ifdef WITH_USB_BUSPORT
 		regex_array[7] = getval("busport");
+#  else
+		if (getval("busport")) {
+			upslogx(LOG_WARNING, "\"busport\" is configured for the device, but is not actually handled by current build combination of NUT and libusb (ignored)");
+		}
 #  endif
 
 		/* Check for language ID workaround (#1) */

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -57,7 +57,7 @@
 	#define DRIVER_NAME	"Generic Q* Serial driver"
 #endif	/* QX_USB */
 
-#define DRIVER_VERSION	"0.35"
+#define DRIVER_VERSION	"0.36"
 
 #ifdef QX_SERIAL
 	#include "serial.h"
@@ -3293,10 +3293,10 @@ void	upsdrv_cleanup(void)
 		free(usbdevice.Product);
 		free(usbdevice.Serial);
 		free(usbdevice.Bus);
-#ifdef WITH_USB_BUSPORT
-		free(usbdevice.BusPort);
-#endif
 		free(usbdevice.Device);
+#  ifdef WITH_USB_BUSPORT
+		free(usbdevice.BusPort);
+#  endif
 
 #  ifdef QX_SERIAL
 	}	/* is_usb */

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -3016,6 +3016,9 @@ void	upsdrv_initups(void)
 		getval("serial") ||
 		getval("bus") ||
 		getval("langid_fix")
+#ifdef WITH_USB_BUSPORT
+		|| getval("busport")
+#endif
 	) {
 		/* USB */
 		is_usb = 1;
@@ -3110,7 +3113,7 @@ void	upsdrv_initups(void)
 	#ifndef TESTING
 		int	ret, langid;
 		char	tbuf[255];	/* Some devices choke on size > 255 */
-		char	*regex_array[7];
+		char	*regex_array[REGEXP_ARRAY_LIMIT];
 
 		char	*subdrv = getval("subdriver");
 
@@ -3121,6 +3124,9 @@ void	upsdrv_initups(void)
 		regex_array[4] = getval("serial");
 		regex_array[5] = getval("bus");
 		regex_array[6] = getval("device");
+#ifdef WITH_USB_BUSPORT
+		regex_array[7] = getval("busport");
+#endif
 
 		/* Check for language ID workaround (#1) */
 		if (getval("langid_fix")) {
@@ -3284,6 +3290,9 @@ void	upsdrv_cleanup(void)
 		free(usbdevice.Product);
 		free(usbdevice.Serial);
 		free(usbdevice.Bus);
+#ifdef WITH_USB_BUSPORT
+		free(usbdevice.BusPort);
+#endif
 		free(usbdevice.Device);
 
 	#ifdef QX_SERIAL

--- a/drivers/riello_usb.c
+++ b/drivers/riello_usb.c
@@ -851,7 +851,7 @@ void upsdrv_initups(void)
 	};
 
 	int	ret;
-	char	*regex_array[REGEXP_ARRAY_LIMIT];
+	char	*regex_array[USBMATCHER_REGEXP_ARRAY_LIMIT];
 
 	char	*subdrv = getval("subdriver");
 

--- a/drivers/riello_usb.c
+++ b/drivers/riello_usb.c
@@ -864,7 +864,7 @@ void upsdrv_initups(void)
 	regex_array[4] = getval("serial");
 	regex_array[5] = getval("bus");
 	regex_array[6] = getval("device");
-#ifdef WITH_USB_BUSPORT
+#if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
 	regex_array[7] = getval("busport");
 #else
 	if (getval("busport")) {
@@ -1240,7 +1240,7 @@ void upsdrv_cleanup(void)
 	free(usbdevice.Serial);
 	free(usbdevice.Bus);
 	free(usbdevice.Device);
-#ifdef WITH_USB_BUSPORT
+#if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
 	free(usbdevice.BusPort);
 #endif
 }

--- a/drivers/riello_usb.c
+++ b/drivers/riello_usb.c
@@ -851,7 +851,7 @@ void upsdrv_initups(void)
 	};
 
 	int	ret;
-	char	*regex_array[7];
+	char	*regex_array[REGEXP_ARRAY_LIMIT];
 
 	char	*subdrv = getval("subdriver");
 
@@ -864,6 +864,9 @@ void upsdrv_initups(void)
 	regex_array[4] = getval("serial");
 	regex_array[5] = getval("bus");
 	regex_array[6] = getval("device");
+#ifdef WITH_USB_BUSPORT
+	regex_array[7] = getval("busport");
+#endif
 
 	/* pick up the subdriver name if set explicitly */
 	if (subdrv) {
@@ -1232,5 +1235,8 @@ void upsdrv_cleanup(void)
 	free(usbdevice.Product);
 	free(usbdevice.Serial);
 	free(usbdevice.Bus);
+#ifdef WITH_USB_BUSPORT
+	free(usbdevice.BusPort);
+#endif
 	free(usbdevice.Device);
 }

--- a/drivers/riello_usb.c
+++ b/drivers/riello_usb.c
@@ -34,7 +34,7 @@
 #include "riello.h"
 
 #define DRIVER_NAME	"Riello USB driver"
-#define DRIVER_VERSION	"0.09"
+#define DRIVER_VERSION	"0.10"
 
 #define DEFAULT_OFFDELAY   5  /*!< seconds (max 0xFF) */
 #define DEFAULT_BOOTDELAY  5  /*!< seconds (max 0xFF) */
@@ -1239,8 +1239,8 @@ void upsdrv_cleanup(void)
 	free(usbdevice.Product);
 	free(usbdevice.Serial);
 	free(usbdevice.Bus);
+	free(usbdevice.Device);
 #ifdef WITH_USB_BUSPORT
 	free(usbdevice.BusPort);
 #endif
-	free(usbdevice.Device);
 }

--- a/drivers/riello_usb.c
+++ b/drivers/riello_usb.c
@@ -866,6 +866,10 @@ void upsdrv_initups(void)
 	regex_array[6] = getval("device");
 #ifdef WITH_USB_BUSPORT
 	regex_array[7] = getval("busport");
+#else
+	if (getval("busport")) {
+		upslogx(LOG_WARNING, "\"busport\" is configured for the device, but is not actually handled by current build combination of NUT and libusb (ignored)");
+	}
 #endif
 
 	/* pick up the subdriver name if set explicitly */

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -1568,7 +1568,7 @@ void upsdrv_makevartable(void)
  */
 void upsdrv_initups(void)
 {
-	char *regex_array[REGEXP_ARRAY_LIMIT];
+	char *regex_array[USBMATCHER_REGEXP_ARRAY_LIMIT];
 	char *value;
 	int r;
 

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -1568,7 +1568,7 @@ void upsdrv_makevartable(void)
  */
 void upsdrv_initups(void)
 {
-	char *regex_array[7];
+	char *regex_array[REGEXP_ARRAY_LIMIT];
 	char *value;
 	int r;
 
@@ -1582,6 +1582,9 @@ void upsdrv_initups(void)
 	regex_array[4] = getval("serial"); /* probably won't see this */
 	regex_array[5] = getval("bus");
 	regex_array[6] = getval("device");
+#ifdef WITH_USB_BUSPORT
+	regex_array[7] = getval("busport");
+#endif
 
 	r = USBNewRegexMatcher(&regex_matcher, regex_array, REG_ICASE | REG_EXTENDED);
 	if (r==-1) {
@@ -1655,5 +1658,8 @@ void upsdrv_cleanup(void)
 	free(curDevice.Product);
 	free(curDevice.Serial);
 	free(curDevice.Bus);
+#ifdef WITH_USB_BUSPORT
+	free(curDevice.BusPort);
+#endif
 	free(curDevice.Device);
 }

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -1658,8 +1658,8 @@ void upsdrv_cleanup(void)
 	free(curDevice.Product);
 	free(curDevice.Serial);
 	free(curDevice.Bus);
+	free(curDevice.Device);
 #ifdef WITH_USB_BUSPORT
 	free(curDevice.BusPort);
 #endif
-	free(curDevice.Device);
 }

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -1582,7 +1582,7 @@ void upsdrv_initups(void)
 	regex_array[4] = getval("serial"); /* probably won't see this */
 	regex_array[5] = getval("bus");
 	regex_array[6] = getval("device");
-#ifdef WITH_USB_BUSPORT
+#if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
 	regex_array[7] = getval("busport");
 #endif
 
@@ -1659,7 +1659,7 @@ void upsdrv_cleanup(void)
 	free(curDevice.Serial);
 	free(curDevice.Bus);
 	free(curDevice.Device);
-#ifdef WITH_USB_BUSPORT
+#if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
 	free(curDevice.BusPort);
 #endif
 }

--- a/drivers/usb-common.c
+++ b/drivers/usb-common.c
@@ -448,7 +448,7 @@ int USBNewRegexMatcher(USBDeviceMatcher_t **matcher, char **regex, int cflags)
 	m->privdata = (void *)data;
 	m->next = NULL;
 
-	for (i=0; i<REGEXP_ARRAY_LIMIT; i++) {
+	for (i=0; i < USBMATCHER_REGEXP_ARRAY_LIMIT; i++) {
 		r = compile_regex(&data->regex[i], regex[i], cflags);
 		if (r == -2) {
 			r = i+1;

--- a/drivers/usb-common.c
+++ b/drivers/usb-common.c
@@ -309,7 +309,7 @@ static int match_regex_hex(regex_t *preg, int n)
 
 /* private data type: hold a set of compiled regular expressions. */
 typedef struct regex_matcher_data_s {
-	regex_t	*regex[8];
+	regex_t	*regex[USBMATCHER_REGEXP_ARRAY_LIMIT];
 } regex_matcher_data_t;
 
 /* private callback function for regex matches */
@@ -475,7 +475,7 @@ void USBFreeRegexMatcher(USBDeviceMatcher_t *matcher)
 
 	data = (regex_matcher_data_t *)matcher->privdata;
 
-	for (i = 0; i < 8; i++) {
+	for (i = 0; i < USBMATCHER_REGEXP_ARRAY_LIMIT; i++) {
 		if (!data->regex[i]) {
 			continue;
 		}

--- a/drivers/usb-common.c
+++ b/drivers/usb-common.c
@@ -119,7 +119,7 @@ static int match_function_exact(USBDevice_t *hd, void *privdata)
 		return 0;
 	}
 #endif
-#ifdef WITH_USB_BUSPORT
+#if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
   #ifdef DEBUG_EXACT_MATCH_BUSPORT
 	if (strcmp_null(hd->BusPort, data->BusPort) != 0) {
 		upsdebugx(2, "%s: failed match of %s: %s != %s",
@@ -400,7 +400,7 @@ static int match_function_regex(USBDevice_t *hd, void *privdata)
 		return r;
 	}
 
-#ifdef WITH_USB_BUSPORT
+#if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
 	r = match_regex(data->regex[7], hd->BusPort);
 	if (r != 1) {
 /*

--- a/drivers/usb-common.c
+++ b/drivers/usb-common.c
@@ -119,6 +119,15 @@ static int match_function_exact(USBDevice_t *hd, void *privdata)
 		return 0;
 	}
 #endif
+#ifdef WITH_USB_BUSPORT
+  #ifdef DEBUG_EXACT_MATCH_BUSPORT
+	if (strcmp_null(hd->BusPort, data->BusPort) != 0) {
+		upsdebugx(2, "%s: failed match of %s: %s != %s",
+		    __func__, "BusPort", hd->BusPort, data->BusPort);
+		return 0;
+	}
+  #endif
+#endif
 #ifdef DEBUG_EXACT_MATCH_DEVICE
 	if (strcmp_null(hd->Device, data->Device) != 0) {
 		upsdebugx(2, "%s: failed match of %s: %s != %s",
@@ -300,7 +309,7 @@ static int match_regex_hex(regex_t *preg, int n)
 
 /* private data type: hold a set of compiled regular expressions. */
 typedef struct regex_matcher_data_s {
-	regex_t	*regex[7];
+	regex_t	*regex[8];
 } regex_matcher_data_t;
 
 /* private callback function for regex matches */
@@ -390,6 +399,19 @@ static int match_function_regex(USBDevice_t *hd, void *privdata)
 		    __func__, "Device", hd->Device);
 		return r;
 	}
+
+#ifdef WITH_USB_BUSPORT
+	r = match_regex(data->regex[7], hd->BusPort);
+	if (r != 1) {
+/*
+		upsdebugx(2, "%s: failed match of %s: %s !~ %s",
+		    __func__, "Device", hd->Device, data->regex[6]);
+*/
+		upsdebugx(2, "%s: failed match of %s: %s",
+		    __func__, "Bus Port", hd->BusPort);
+		return r;
+	}
+#endif
 	return 1;
 }
 
@@ -426,7 +448,7 @@ int USBNewRegexMatcher(USBDeviceMatcher_t **matcher, char **regex, int cflags)
 	m->privdata = (void *)data;
 	m->next = NULL;
 
-	for (i=0; i<7; i++) {
+	for (i=0; i<REGEXP_ARRAY_LIMIT; i++) {
 		r = compile_regex(&data->regex[i], regex[i], cflags);
 		if (r == -2) {
 			r = i+1;
@@ -453,7 +475,7 @@ void USBFreeRegexMatcher(USBDeviceMatcher_t *matcher)
 
 	data = (regex_matcher_data_t *)matcher->privdata;
 
-	for (i = 0; i < 7; i++) {
+	for (i = 0; i < 8; i++) {
 		if (!data->regex[i]) {
 			continue;
 		}

--- a/drivers/usb-common.h
+++ b/drivers/usb-common.h
@@ -461,9 +461,9 @@
 /* USB standard timeout [ms] */
 #define USB_TIMEOUT 5000
 #ifdef WITH_USB_BUSPORT
-#define REGEXP_ARRAY_LIMIT	8
+# define USBMATCHER_REGEXP_ARRAY_LIMIT	8
 #else
-#define REGEXP_ARRAY_LIMIT	7
+# define USBMATCHER_REGEXP_ARRAY_LIMIT	7
 #endif
 
 /*!

--- a/drivers/usb-common.h
+++ b/drivers/usb-common.h
@@ -460,7 +460,7 @@
 
 /* USB standard timeout [ms] */
 #define USB_TIMEOUT 5000
-#ifdef WITH_USB_BUSPORT
+#if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
 # define USBMATCHER_REGEXP_ARRAY_LIMIT	8
 #else
 # define USBMATCHER_REGEXP_ARRAY_LIMIT	7
@@ -487,7 +487,7 @@ typedef struct USBDevice_s {
 	char		*Bus;      /*!< Bus name, e.g. "003"  */
 	uint16_t	bcdDevice; /*!< Device release number */
 	char		*Device;   /*!< Device name on the bus, e.g. "001"  */
-#ifdef WITH_USB_BUSPORT
+#if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
 	char		*BusPort;  /*!< Port name, e.g. "001"  */
 #endif
 } USBDevice_t;

--- a/drivers/usb-common.h
+++ b/drivers/usb-common.h
@@ -460,6 +460,11 @@
 
 /* USB standard timeout [ms] */
 #define USB_TIMEOUT 5000
+#ifdef WITH_USB_BUSPORT
+#define REGEXP_ARRAY_LIMIT	8
+#else
+#define REGEXP_ARRAY_LIMIT	7
+#endif
 
 /*!
  * USBDevice_t: Describe a USB device. This structure contains exactly
@@ -482,6 +487,9 @@ typedef struct USBDevice_s {
 	char		*Bus;      /*!< Bus name, e.g. "003"  */
 	uint16_t	bcdDevice; /*!< Device release number */
 	char		*Device;   /*!< Device name on the bus, e.g. "001"  */
+#ifdef WITH_USB_BUSPORT
+	char		*BusPort;  /*!< Port name, e.g. "001"  */
+#endif
 } USBDevice_t;
 
 /*!

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -1054,7 +1054,7 @@ void upsdrv_initups(void)
 	regex_array[4] = getval("serial");
 	regex_array[5] = getval("bus");
 	regex_array[6] = getval("device");
-#ifdef WITH_USB_BUSPORT
+#if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
 	regex_array[7] = getval("busport");
 #else
 	if (getval("busport")) {
@@ -1184,7 +1184,7 @@ void upsdrv_cleanup(void)
 	free(curDevice.Serial);
 	free(curDevice.Bus);
 	free(curDevice.Device);
-# ifdef WITH_USB_BUSPORT
+# if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
 	free(curDevice.BusPort);
 # endif
 #endif	/* !SHUT_MODE => USB */

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -1023,7 +1023,7 @@ void upsdrv_initups(void)
 
 	subdriver_matcher = device_path;
 #else	/* !SHUT_MODE => USB */
-	char *regex_array[7];
+	char *regex_array[REGEXP_ARRAY_LIMIT];
 
 	upsdebugx(1, "upsdrv_initups (non-SHUT)...");
 
@@ -1054,6 +1054,9 @@ void upsdrv_initups(void)
 	regex_array[4] = getval("serial");
 	regex_array[5] = getval("bus");
 	regex_array[6] = getval("device");
+#ifdef WITH_USB_BUSPORT
+	regex_array[7] = getval("busport");
+#endif
 
 	ret = USBNewRegexMatcher(&regex_matcher, regex_array, REG_ICASE | REG_EXTENDED);
 	switch(ret)
@@ -1176,6 +1179,9 @@ void upsdrv_cleanup(void)
 	free(curDevice.Product);
 	free(curDevice.Serial);
 	free(curDevice.Bus);
+#ifdef WITH_USB_BUSPORT
+	free(curDevice.BusPort);
+#endif
 	free(curDevice.Device);
 #endif	/* !SHUT_MODE => USB */
 }

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -1056,6 +1056,10 @@ void upsdrv_initups(void)
 	regex_array[6] = getval("device");
 #ifdef WITH_USB_BUSPORT
 	regex_array[7] = getval("busport");
+#else
+	if (getval("busport")) {
+		upslogx(LOG_WARNING, "\"busport\" is configured for the device, but is not actually handled by current build combination of NUT and libusb (ignored)");
+	}
 #endif
 
 	ret = USBNewRegexMatcher(&regex_matcher, regex_array, REG_ICASE | REG_EXTENDED);

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -1023,7 +1023,7 @@ void upsdrv_initups(void)
 
 	subdriver_matcher = device_path;
 #else	/* !SHUT_MODE => USB */
-	char *regex_array[REGEXP_ARRAY_LIMIT];
+	char *regex_array[USBMATCHER_REGEXP_ARRAY_LIMIT];
 
 	upsdebugx(1, "upsdrv_initups (non-SHUT)...");
 

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -28,7 +28,7 @@
  */
 
 #define DRIVER_NAME	"Generic HID driver"
-#define DRIVER_VERSION	"0.50"
+#define DRIVER_VERSION	"0.51"
 
 #define HU_VAR_WAITBEFORERECONNECT "waitbeforereconnect"
 
@@ -1183,10 +1183,10 @@ void upsdrv_cleanup(void)
 	free(curDevice.Product);
 	free(curDevice.Serial);
 	free(curDevice.Bus);
-#ifdef WITH_USB_BUSPORT
-	free(curDevice.BusPort);
-#endif
 	free(curDevice.Device);
+# ifdef WITH_USB_BUSPORT
+	free(curDevice.BusPort);
+# endif
 #endif	/* !SHUT_MODE => USB */
 }
 

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -118,7 +118,11 @@ static subdriver_t *subdriver = NULL;
 
 /* Global vars */
 static HIDDevice_t *hd = NULL;
-static HIDDevice_t curDevice = { 0x0000, 0x0000, NULL, NULL, NULL, NULL, 0, NULL };
+static HIDDevice_t curDevice = { 0x0000, 0x0000, NULL, NULL, NULL, NULL, 0, NULL
+#if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
+	, NULL
+#endif
+};
 static HIDDeviceMatcher_t *subdriver_matcher = NULL;
 #if !((defined SHUT_MODE) && SHUT_MODE)
 static HIDDeviceMatcher_t *exact_matcher = NULL;

--- a/m4/nut_check_libusb.m4
+++ b/m4/nut_check_libusb.m4
@@ -286,6 +286,7 @@ if test -z "${nut_have_libusb_seen}"; then
 		nut_have_libusb=no
 	fi
 
+	nut_with_usb_busport=no
 	AS_IF([test "${nut_have_libusb}" = "yes"], [
 		dnl ----------------------------------------------------------------------
 		dnl additional USB-related checks
@@ -318,11 +319,26 @@ if test -z "${nut_have_libusb_seen}"; then
 				]
 		)
 
+		dnl AC_MSG_CHECKING([for libusb bus port support])
+		dnl Per https://github.com/networkupstools/nut/issues/2043#issuecomment-1721856494 :
+		dnl #if defined(LIBUSB_API_VERSION) && (LIBUSB_API_VERSION >= 0x01000102)
+		dnl DEFINE WITH_USB_BUSPORT
+		dnl #endif
+		AC_CHECK_FUNCS(libusb_get_port_number, [nut_with_usb_busport=yes])
+
 		dnl # With USB we can match desired devices by regex;
 		dnl # and currently have no other use for the library:
 		AC_SEARCH_LIBS(regcomp, regex)
 	])
 	AC_LANG_POP([C])
+
+	AS_IF([test x"${nut_with_usb_busport}" = xyes], [
+		AC_DEFINE(WITH_USB_BUSPORT, 1,
+			[Define to 1 for libusb versions where we can support "busport" USB matching value.])
+	], [
+		AC_DEFINE(WITH_USB_BUSPORT, 0,
+			[Define to 1 for libusb versions where we can support "busport" USB matching value.])
+	])
 
 	AS_IF([test "${nut_have_libusb}" = "yes"], [
 		LIBUSB_CFLAGS="${CFLAGS}"

--- a/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
+++ b/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
@@ -490,7 +490,7 @@ upsconf_getDriverMedia() {
                     printf '%s\n%s\n' "$CURR_DRV" "usb" ; return ;;
                 /dev/*)
                     # See drivers/nutdrv_qx.c :: upsdrv_initups() for a list
-                    if [ -n "`upsconf_getValue "$1" 'subdriver' 'vendorid' 'productid' 'vendor' 'product' 'serial' 'bus' 'langid_fix'`" ] \
+                    if [ -n "`upsconf_getValue "$1" 'subdriver' 'vendorid' 'productid' 'vendor' 'product' 'serial' 'bus' 'busport' 'langid_fix'`" ] \
                     ; then
                         printf '%s\n%s\n' "$CURR_DRV" "usb" ; return
                     else


### PR DESCRIPTION
Closes: #2043 (thanks @wavebvg for initial impulse!)
Related to: #1763 and like its outcome - does not impact the too-different old USB drivers like richcomm, bcmxcp, nutdrv_atcl

Note this is limited to systems that actually support the feature on hardware, OS and libusb version sides.