### PR TITLE
Fightwarn: numerous complaints from clang-15 [#823]

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -113,6 +113,8 @@ as part of https://github.com/networkupstools/nut/issues/1410 solution.
    * Something about compile-time macros or other warnings-related refactoring
      seems to have confused the MGE SHUT (Serial HID UPS Transfer) driver
      support [#2022]
+   * Some warnings were not detected by the tools or build scenarios used
+     earlier, and only got addressed now
 
  - An issue was identified which could cause `libupsclient` parser of device
    and host names to crash upon bad inputs (e.g. poorly resolved environment

--- a/clients/cgilib.c
+++ b/clients/cgilib.c
@@ -40,6 +40,7 @@ static char *unescape(char *buf)
 			ch = ' ';
 
 		if (ch == '%') {
+			long l;
 			if (i + 2 > buflen)
 				fatalx(EXIT_FAILURE, "string too short for escaped char");
 			hex[0] = buf[++i];
@@ -48,7 +49,7 @@ static char *unescape(char *buf)
 			if (!isxdigit((unsigned char) hex[0])
 				|| !isxdigit((unsigned char) hex[1]))
 				fatalx(EXIT_FAILURE, "bad escape char");
-			long l = strtol(hex, NULL, 16);
+			l = strtol(hex, NULL, 16);
 			assert(l>=0);
 			assert(l<=255);
 			ch = (char)l;	/* FIXME: Loophole about non-ASCII symbols in top 128 values, or negatives for signed char... */

--- a/clients/upsclient.c
+++ b/clients/upsclient.c
@@ -329,6 +329,7 @@ static void HandshakeCallback(PRFileDesc *fd, UPSCONN_t *client_data)
 int upscli_init(int certverify, const char *certpath,
 					const char *certname, const char *certpasswd)
 {
+	const char *quiet_init_ssl;
 #ifdef WITH_OPENSSL
 	long ret;
 	int ssl_mode = SSL_VERIFY_NONE;
@@ -343,7 +344,7 @@ int upscli_init(int certverify, const char *certpath,
 	NUT_UNUSED_VARIABLE(certpasswd);
 #endif /* WITH_OPENSSL | WITH_NSS */
 
-	const char *quiet_init_ssl = getenv("NUT_QUIET_INIT_SSL");
+	quiet_init_ssl = getenv("NUT_QUIET_INIT_SSL");
 	if (quiet_init_ssl != NULL) {
 		if (*quiet_init_ssl == '\0'
 			|| (strncmp(quiet_init_ssl, "true", 4)
@@ -678,8 +679,9 @@ static ssize_t net_read(UPSCONN_t *ups, char *buf, size_t buflen, const time_t t
 		 * 32-bit builds)... Not likely to exceed in 64-bit builds,
 		 * but smaller systems with 16-bits might be endangered :)
 		 */
+		int iret;
 		assert(buflen <= INT_MAX);
-		int iret = SSL_read(ups->ssl, buf, (int)buflen);
+		iret = SSL_read(ups->ssl, buf, (int)buflen);
 		assert(iret <= SSIZE_MAX);
 		ret = (ssize_t)iret;
 #elif defined(WITH_NSS) /* WITH_OPENSSL */
@@ -762,8 +764,9 @@ static ssize_t net_write(UPSCONN_t *ups, const char *buf, size_t buflen, const t
 		 * 32-bit builds)... Not likely to exceed in 64-bit builds,
 		 * but smaller systems with 16-bits might be endangered :)
 		 */
+		int iret;
 		assert(buflen <= INT_MAX);
-		int iret = SSL_write(ups->ssl, buf, (int)buflen);
+		iret = SSL_write(ups->ssl, buf, (int)buflen);
 		assert(iret <= SSIZE_MAX);
 		ret = (ssize_t)iret;
 #elif defined(WITH_NSS) /* WITH_OPENSSL */

--- a/clients/upslog.c
+++ b/clients/upslog.c
@@ -559,9 +559,9 @@ int main(int argc, char **argv)
 			monhost_ups_anchor = monhost_ups_current;
 			monhost_ups_current->next = NULL;
 			monhost_ups_current->monhost = monhost;
-			monhost_len=1;
+			monhost_len = 1;
 		} else {
-			fatalx(EXIT_FAILURE, "No UPS defined for monitoring - use -s <system>");
+			fatalx(EXIT_FAILURE, "No UPS defined for monitoring - use -s <system> or -m <ups,logfile>");
 		}
 
 		if (logfn)
@@ -573,6 +573,10 @@ int main(int argc, char **argv)
 	/* shouldn't happen */
 	if (!logformat)
 		fatalx(EXIT_FAILURE, "No format defined - but this should be impossible");
+
+	/* shouldn't happen */
+	if (!monhost_len)
+		fatalx(EXIT_FAILURE, "No UPS defined for monitoring - use -s <system> or -m <ups,logfile>");
 
 	for (monhost_ups_current = monhost_ups_anchor;
 	     monhost_ups_current != NULL;

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -1182,6 +1182,7 @@ static void addups(int reloading, const char *sys, const char *pvs,
 {
 	unsigned int	pv;
 	utype_t	*tmp, *last;
+	long	lpv;
 
 	/* the username is now required - no more host-based auth */
 
@@ -1191,7 +1192,7 @@ static void addups(int reloading, const char *sys, const char *pvs,
 		return;
 	}
 
-	long lpv = strtol(pvs, (char **) NULL, 10);
+	lpv = strtol(pvs, (char **) NULL, 10);
 
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
 # pragma GCC diagnostic push

--- a/clients/upsset.c
+++ b/clients/upsset.c
@@ -751,11 +751,12 @@ static void do_type(const char *varname)
 
 		if (!strncasecmp(answer[i], "STRING:", 7)) {
 			char	*ptr, len;
+			long	l;
 
 			/* split out the :<len> data */
 			ptr = strchr(answer[i], ':');
 			*ptr++ = '\0';
-			long l = strtol(ptr, (char **) NULL, 10);
+			l = strtol(ptr, (char **) NULL, 10);
 			assert(l <= 127);	/* FIXME: Loophole about longer numbers? Why are we limited to char at all here? */
 			len = (char)l;
 

--- a/common/common.c
+++ b/common/common.c
@@ -78,7 +78,7 @@ const char *UPS_VERSION = NUT_VERSION_MACRO;
 #include <sys/types.h>
 #include <limits.h>
 #include <stdlib.h>
-pid_t get_max_pid_t()
+pid_t get_max_pid_t(void)
 {
 #ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
 #pragma GCC diagnostic push
@@ -1948,9 +1948,10 @@ static char * get_libname_in_dir(const char* base_libname, size_t base_libname_l
 #if !HAVE_DECL_REALPATH
 		struct stat	st;
 #endif
+		int compres;
 
 		upsdebugx(5,"Comparing lib %s with dirpath entry %s", base_libname, dirp->d_name);
-		int compres = strncmp(dirp->d_name, base_libname, base_libname_length);
+		compres = strncmp(dirp->d_name, base_libname, base_libname_length);
 		if (compres == 0
 		&&  dirp->d_name[base_libname_length] == '\0' /* avoid "*.dll.a" etc. */
 		) {

--- a/drivers/adelsystem_cbi.c
+++ b/drivers/adelsystem_cbi.c
@@ -900,13 +900,16 @@ int get_dev_state(devreg_t regindx, devstate_t **dvstat)
 		case LVDC:					/* "output.voltage" */
 		case LCUR:					/* "output.current" */
 			if (reg_val != 0) {
+				char	*fval_s;
+				double	fval;
+
 				state->reg.val.ui16 = reg_val;
-				double fval = reg_val / 1000.00; /* convert mV to V, mA to A */
+				fval = reg_val / 1000.00; /* convert mV to V, mA to A */
 				n = snprintf(NULL, 0, "%.2f", fval);
 				if (ptr != NULL) {
 					free(ptr);
 				}
-				char *fval_s = (char *)xmalloc(sizeof(char) * (n + 1));
+				fval_s = (char *)xmalloc(sizeof(char) * (n + 1));
 				ptr = fval_s;
 				sprintf(fval_s, "%.2f", fval);
 				state->reg.strval = fval_s;
@@ -921,12 +924,14 @@ int get_dev_state(devreg_t regindx, devstate_t **dvstat)
 		case BCEF:
 		case VAC:					/* "input.voltage" */
 			if (reg_val != 0) {
+				char	*reg_val_s;
+
 				state->reg.val.ui16 = reg_val;
 				n = snprintf(NULL, 0, "%d", reg_val);
 				if (ptr != NULL) {
 					free(ptr);
 				}
-				char *reg_val_s = (char *)xmalloc(sizeof(char) * (n + 1));
+				reg_val_s = (char *)xmalloc(sizeof(char) * (n + 1));
 				ptr = reg_val_s;
 				sprintf(reg_val_s, "%d", reg_val);
 				state->reg.strval = reg_val_s;
@@ -938,13 +943,16 @@ int get_dev_state(devreg_t regindx, devstate_t **dvstat)
 			break;
 		case BSOC:					/* "battery.charge" */
 			if (reg_val != 0) {
+				double	fval;
+				char	*fval_s;
+
 				state->reg.val.ui16 = reg_val;
-				double fval = (double )reg_val * regs[BSOC].scale;
+				fval = (double )reg_val * regs[BSOC].scale;
 				n = snprintf(NULL, 0, "%.2f", fval);
 				if (ptr != NULL) {
 					free(ptr);
 				}
-				char *fval_s = (char *)xmalloc(sizeof(char) * (n + 1));
+				fval_s = (char *)xmalloc(sizeof(char) * (n + 1));
 				ptr = fval_s;
 				sprintf(fval_s, "%.2f", fval);
 				state->reg.strval = fval_s;
@@ -956,16 +964,21 @@ int get_dev_state(devreg_t regindx, devstate_t **dvstat)
 			break;
 		case BTMP:					/* "battery.temperature" */
 		case OTMP:					/* "ups.temperature" */
-			state->reg.val.ui16 = reg_val;
-			double fval = reg_val - 273.15;
-			n = snprintf(NULL, 0, "%.2f", fval);
-			char *fval_s = (char *)xmalloc(sizeof(char) * (n + 1));
-			if (ptr != NULL) {
-				free(ptr);
+			{ /* scoping */
+				double	fval;
+				char	*fval_s;
+
+				state->reg.val.ui16 = reg_val;
+				fval = reg_val - 273.15;
+				n = snprintf(NULL, 0, "%.2f", fval);
+				fval_s = (char *)xmalloc(sizeof(char) * (n + 1));
+				if (ptr != NULL) {
+					free(ptr);
+				}
+				ptr = fval_s;
+				sprintf(fval_s, "%.2f", fval);
+				state->reg.strval = fval_s;
 			}
-			ptr = fval_s;
-			sprintf(fval_s, "%.2f", fval);
-			state->reg.strval = fval_s;
 			upsdebugx(3, "get_dev_state: variable: %s", state->reg.strval);
 			break;
 		case PMNG:					/* "ups.status" & "battery.charge" */
@@ -1155,15 +1168,18 @@ int get_dev_state(devreg_t regindx, devstate_t **dvstat)
 		 * memory corruptions and buggy inputs below...
 		 */
 		default:
-			state->reg.val.ui16 = reg_val;
-			n = snprintf(NULL, 0, "%d", reg_val);
-			if (ptr != NULL) {
-				free(ptr);
+			{ /* scoping */
+				char	*reg_val_s;
+				state->reg.val.ui16 = reg_val;
+				n = snprintf(NULL, 0, "%d", reg_val);
+				if (ptr != NULL) {
+					free(ptr);
+				}
+				reg_val_s = (char *)xmalloc(sizeof(char) * (n + 1));
+				ptr = reg_val_s;
+				sprintf(reg_val_s, "%d", reg_val);
+				state->reg.strval = reg_val_s;
 			}
-			char *reg_val_s = (char *)xmalloc(sizeof(char) * (n + 1));
-			ptr = reg_val_s;
-			sprintf(reg_val_s, "%d", reg_val);
-			state->reg.strval = reg_val_s;
 			break;
 #ifdef __clang__
 # pragma clang diagnostic pop

--- a/drivers/al175.c
+++ b/drivers/al175.c
@@ -553,9 +553,9 @@ static int al_parse_reply(io_head_t *io_head, raw_data_t *io_buf, /*const*/ raw_
  *     begin                                                                        end
  */
 
-	int err;
-	size_t i;
-	const byte_t *reply = NULL;
+	int	err;
+	size_t	i, io_buf_len;
+	const byte_t	*reply = NULL;
 
 	/* 1: extract header and parse it */
 	/*const*/ raw_data_t raw_reply_head = raw_reply;
@@ -578,7 +578,7 @@ static int al_parse_reply(io_head_t *io_head, raw_data_t *io_buf, /*const*/ raw_
 	}
 
 
-	/* extract the data */
+	/* 3: extract the data */
 	if (io_buf->buf_size < io_head->len)	{
 		upsdebugx(3, "%s: too much data to fit in io_buf\t(%" PRIuSIZE " > %" PRIuSIZE ")",
 				__func__, io_head->len, io_buf->buf_size);
@@ -592,7 +592,7 @@ static int al_parse_reply(io_head_t *io_head, raw_data_t *io_buf, /*const*/ raw_
 		*(io_buf->end++) = reply[11+i];
 
 	assert(io_buf->end - io_buf->begin >= 0);
-	size_t io_buf_len = (size_t)(io_buf->end - io_buf->begin);
+	io_buf_len = (size_t)(io_buf->end - io_buf->begin);
 	reverse_bits(io_buf->begin, io_buf_len );
 
 	upsdebug_hex(3, "\t\t--> payload", io_buf->begin, io_buf_len);
@@ -670,14 +670,15 @@ static int al_check_ack(/*const*/ raw_data_t raw_ack)
 /* clear any flow control (copy from powercom.c) */
 static void ser_disable_flow_control (void)
 {
-	struct termios tio;
+	struct termios	tio;
+	tcflag_t	x;
 
 	tcgetattr (upsfd, &tio);
 
 	/* Clumsy rewrite of a one-liner
 	 *   tio.c_iflag &= ~ (IXON | IXOFF);
 	 * to avoid type conversion warnings */
-	tcflag_t x = (IXON | IXOFF);
+	x = (IXON | IXOFF);
 	tio.c_iflag &= ~ x;
 	tio.c_cc[VSTART] = _POSIX_VDISABLE;
 	tio.c_cc[VSTOP] = _POSIX_VDISABLE;
@@ -688,7 +689,7 @@ static void ser_disable_flow_control (void)
 	tcsetattr(upsfd, TCSANOW, &tio);
 }
 
-static void flush_rx_queue()
+static void flush_rx_queue(void)
 {
 	ser_flush_in(upsfd, "", /*verbose=*/nut_debug_level);
 }
@@ -702,10 +703,11 @@ static void flush_rx_queue()
  */
 static int tx(const char *dmsg, /*const*/ raw_data_t frame)
 {
-	ssize_t err;
+	ssize_t	err;
+	size_t	frame_len;
 
 	assert(frame.end - frame.begin >= 0);
-	size_t frame_len = (size_t)(frame.end - frame.begin);
+	frame_len = (size_t)(frame.end - frame.begin);
 
 	upsdebug_ascii(3, dmsg, frame.begin, frame_len);
 
@@ -807,9 +809,9 @@ static int scan_for(char c)
  *
  * @return 0 (ok) -1 (error)
  */
-static int recv_command_ack()
+static int recv_command_ack(void)
 {
-	ssize_t err;
+	ssize_t	err;
 	raw_data_t ack;
 	byte_t     ack_buf[8];
 
@@ -855,12 +857,12 @@ static int recv_command_ack()
  */
 static int recv_register_data(io_head_t *io, raw_data_t *io_buf)
 {
-	ssize_t err;
-	int ret;
-	raw_data_t reply_head;
-	raw_data_t reply;
-
-	byte_t     reply_head_buf[11];
+	ssize_t	err;
+	int	ret;
+	size_t	reply_head_len;
+	raw_data_t	reply_head;
+	raw_data_t	reply;
+	byte_t	reply_head_buf[11];
 
 	/* 1:  STX  */
 	err = scan_for(STX);
@@ -897,7 +899,7 @@ static int recv_register_data(io_head_t *io, raw_data_t *io_buf)
 	reply = raw_xmalloc(11/*head*/ + io->len/*data*/ + 2/*ETX BCC*/);
 
 	assert (reply_head.end - reply_head.begin >= 0);
-	size_t reply_head_len = (size_t)(reply_head.end - reply_head.begin);
+	reply_head_len = (size_t)(reply_head.end - reply_head.begin);
 
 	memcpy(reply.end, reply_head.begin, reply_head_len);
 	reply.end += reply_head_len;
@@ -1053,9 +1055,9 @@ ACT	SWITCH_TEMP_COMP	(uint16_t on);
 ACT	SWITCH_SYM_ALARM	(void);
 
 /* Implement */
-ACT	TOGGLE_PRS_ONOFF	()		{ return al175_do(0x81, 0x80			Z3);	}
-ACT	CANCEL_BOOST		()		{ return al175_do(0x82, 0x80			Z3);	}
-ACT	STOP_BATTERY_TEST	()		{ return al175_do(0x83, 0x80			Z3);	}
+ACT	TOGGLE_PRS_ONOFF	(void)		{ return al175_do(0x81, 0x80			Z3);	}
+ACT	CANCEL_BOOST		(void)		{ return al175_do(0x82, 0x80			Z3);	}
+ACT	STOP_BATTERY_TEST	(void)		{ return al175_do(0x83, 0x80			Z3);	}
 ACT	START_BATTERY_TEST	(VV_t EndVolt, mm_t Minutes)
 						{ return al175_do(0x83, 0x81, EndVolt, Minutes	Z1);	}
 
@@ -1068,8 +1070,8 @@ ACT	SET_DISCONNECT_LEVEL_AND_DELAY
 				(VV_t level, mm_t delay)
 						{ return al175_do(0x87, 0x84, level, delay	Z1);	}
 
-ACT	RESET_ALARMS		()		{ return al175_do(0x88, 0x80			Z3);	}
-ACT	CHANGE_COMM_PROTOCOL	()		{ return al175_do(0x89, 0x80			Z3);	}
+ACT	RESET_ALARMS		(void)		{ return al175_do(0x88, 0x80			Z3);	}
+ACT	CHANGE_COMM_PROTOCOL	(void)		{ return al175_do(0x89, 0x80			Z3);	}
 ACT	SET_VOLTAGE_AT_ZERO_T	(VV_t v)	{ return al175_do(0x8a, 0x80, v			Z2);	}
 ACT	SET_SLOPE_AT_ZERO_T	(VV_t mv_per_degree)
 						{ return al175_do(0x8a, 0x81, mv_per_degree	Z2);	}
@@ -1078,7 +1080,7 @@ ACT	SET_MAX_TCOMP_VOLTAGE	(VV_t v)	{ return al175_do(0x8a, 0x82, v			Z2);	}
 ACT	SET_MIN_TCOMP_VOLTAGE	(VV_t v)	{ return al175_do(0x8a, 0x83, v			Z2);	}
 ACT	SWITCH_TEMP_COMP	(uint16_t on)	{ return al175_do(0x8b, 0x80, on		Z2);	}
 
-ACT	SWITCH_SYM_ALARM	()		{ return al175_do(0x8c, 0x80			Z3);	}
+ACT	SWITCH_SYM_ALARM	(void)		{ return al175_do(0x8c, 0x80			Z3);	}
 
 
 /**

--- a/drivers/bcmxcp.c
+++ b/drivers/bcmxcp.c
@@ -389,7 +389,7 @@ unsigned char calc_checksum(const unsigned char *buf)
 	return c;
 }
 
-void init_command_map()
+void init_command_map(void)
 {
 	int i = 0;
 
@@ -442,7 +442,7 @@ void init_command_map()
 	}
 }
 
-void init_meter_map()
+void init_meter_map(void)
 {
 	/* Clean entire map */
 	memset(&bcmxcp_meter_map, 0, sizeof(BCMXCP_METER_MAP_ENTRY_t) * BCMXCP_METER_MAP_MAX);
@@ -519,7 +519,7 @@ void init_meter_map()
 	bcmxcp_meter_map[BCMXCP_METER_MAP_LINE_EVENT_COUNTER].nut_entity = "input.quality";
 }
 
-void init_alarm_map()
+void init_alarm_map(void)
 {
 	/* Clean entire map */
 	memset(&bcmxcp_alarm_map, 0, sizeof(BCMXCP_ALARM_MAP_ENTRY_t) * BCMXCP_ALARM_MAP_MAX);

--- a/drivers/bcmxcp_ser.c
+++ b/drivers/bcmxcp_ser.c
@@ -270,7 +270,7 @@ ssize_t command_write_sequence(unsigned char *command, size_t command_length, un
 	return bytes_read;
 }
 
-void upsdrv_comm_good()
+void upsdrv_comm_good(void)
 {
 	ser_comm_good();
 }

--- a/drivers/bestuferrups.c
+++ b/drivers/bestuferrups.c
@@ -420,7 +420,7 @@ static void setup_serial(void)
 }
 
 
-void upsdrv_initups ()
+void upsdrv_initups (void)
 {
 	char	temp[256], fcstring[512];
 

--- a/drivers/blazer_usb.c
+++ b/drivers/blazer_usb.c
@@ -300,6 +300,7 @@ static int krauler_command(const char *cmd, char *buf, size_t buflen)
 			upsdebugx(1, "received %d (%d)", ret, buf[0]);
 
 			if (langid_fix != -1) {
+				size_t	di, si, size;
 				/* Limit this check, at least for now */
 				/* Invalid receive size - message corrupted */
 				if (ret != buf[0])
@@ -311,7 +312,7 @@ static int krauler_command(const char *cmd, char *buf, size_t buflen)
 				/* Simple unicode -> ASCII inplace conversion
 				 * FIXME: this code is at least shared with mge-shut/libshut
 				 * Create a common function? */
-				size_t di, si, size = (size_t)buf[0];
+				size = (size_t)buf[0];
 				for (di = 0, si = 2; si < size; si += 2) {
 					if (di >= (buflen - 1))
 						break;
@@ -564,8 +565,9 @@ static const struct subdriver_t {
 void upsdrv_help(void)
 {
 #ifndef TESTING
-	printf("\nAcceptable values for 'subdriver' via -x or ups.conf in this driver: ");
 	size_t i;
+
+	printf("\nAcceptable values for 'subdriver' via -x or ups.conf in this driver: ");
 
 	for (i = 0; subdriver[i].name != NULL; i++) {
 		if (i>0)

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -1592,11 +1592,13 @@ void alarm_set(const char *buf)
 		 * Note: LARGEBUF was the original limit mismatched vs alarm_buf
 		 * size before PR #986.
 		 */
-		char alarm_tmp[LARGEBUF];
+		char	alarm_tmp[LARGEBUF];
+		int	ibuflen;
+		size_t	buflen;
+
 		memset(alarm_tmp, 0, sizeof(alarm_tmp));
 		/* A bit of complexity to keep both (int)snprintf(...) and (size_t)sizeof(...) happy */
-		int ibuflen = snprintf(alarm_tmp, sizeof(alarm_tmp), "%s", buf);
-		size_t buflen;
+		ibuflen = snprintf(alarm_tmp, sizeof(alarm_tmp), "%s", buf);
 		if (ibuflen < 0) {
 			alarm_tmp[0] = 'N';
 			alarm_tmp[1] = '/';
@@ -1632,10 +1634,12 @@ void alarm_set(const char *buf)
 		upslogx(LOG_ERR, "%s: error setting alarm_buf to: %s%s",
 			__func__, alarm_tmp, ( (buflen < sizeof(alarm_tmp)) ? "" : "...<truncated>" ) );
 	} else if ((size_t)ret > sizeof(alarm_buf)) {
-		char alarm_tmp[LARGEBUF];
+		char	alarm_tmp[LARGEBUF];
+		int	ibuflen;
+		size_t	buflen;
+
 		memset(alarm_tmp, 0, sizeof(alarm_tmp));
-		int ibuflen = snprintf(alarm_tmp, sizeof(alarm_tmp), "%s", buf);
-		size_t buflen;
+		ibuflen = snprintf(alarm_tmp, sizeof(alarm_tmp), "%s", buf);
 		if (ibuflen < 0) {
 			alarm_tmp[0] = 'N';
 			alarm_tmp[1] = '/';
@@ -1932,9 +1936,11 @@ static int dstate_tree_dump(const st_tree_t *node)
 /* Public interface */
 void dstate_dump(void)
 {
+	const st_tree_t *node;
+
 	upsdebugx(3, "Entering %s", __func__);
 
-	const st_tree_t *node = (const st_tree_t *)dstate_getroot();
+	node = (const st_tree_t *)dstate_getroot();
 
 	dstate_tree_dump(node);
 }

--- a/drivers/eaton-pdu-marlin-mib.c
+++ b/drivers/eaton-pdu-marlin-mib.c
@@ -380,7 +380,7 @@ static snmp_info_t eaton_marlin_mib[] = {
 	{ "ups.type", ST_FLAG_STRING, SU_INFOSIZE,
 		NULL,
 		"pdu", SU_FLAG_STATIC | SU_FLAG_ABSENT | SU_FLAG_OK, NULL },
-	 /* FIXME: needs a date reformating callback
+	 /* FIXME: needs a date reformatting callback
 	 *   2011-8-29,16:27:25.0,+1:0
 	 *   Hex-STRING: 07 DB 08 1D 10 0C 36 00 2B 01 00 00
 	 * { "ups.date", ST_FLAG_STRING, SU_INFOSIZE,

--- a/drivers/ever-hid.c
+++ b/drivers/ever-hid.c
@@ -59,7 +59,7 @@ static usb_device_id_t ever_usb_device_table[] = {
 
 static const char *ever_format_hardware_fun(double value)
 {
-	/*TODO - add exception handling for v1.0b0B */
+	/* TODO - add exception handling for v1.0b0B */
 	const char* hard_rev[27] = {"0", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"};
 	static char model[10];
 	snprintf(model, sizeof(model), "rev.%sv%02u",
@@ -70,8 +70,9 @@ static const char *ever_format_hardware_fun(double value)
 
 static const char *ever_format_version_fun(double value)
 {
-	/*upsdebugx(1, "UPS ups_firmware_conversion_fun VALUE: %d", (long)value  ); */
 	static char model[10];
+
+	/*upsdebugx(1, "UPS ups_firmware_conversion_fun VALUE: %d", (long)value);*/
 	snprintf(model, sizeof(model), "v%X.%Xb%02d",
 		((unsigned int)value & 0xF000)>>12,
 		((unsigned int)value & 0xF00)>>8,
@@ -81,18 +82,17 @@ static const char *ever_format_version_fun(double value)
 
 static const char *ever_mac_address_fun(double value)
 {
+	int	mac_adress_report_id = 210;
+	int	len = reportbuf->len[mac_adress_report_id];
+	int	n = 0;	/* number of characters currently in line */
+	int	i;	/* number of bytes output from buffer */
+	const void	*buf = reportbuf->data[mac_adress_report_id];
+	static char	line[100];
 	NUT_UNUSED_VARIABLE(value);
 
-	int mac_adress_report_id = 210;
-	int len = reportbuf->len[mac_adress_report_id];
-	const void *buf = reportbuf->data[mac_adress_report_id];
-
-	static char line[100];
 	line[0] = '\0';
-	int n = 0;	/* number of characters currently in line */
-	int i;	/* number of bytes output from buffer */
 
-	/* skip first elemnt which is a report id */
+	/* skip first element which is a report id */
 	for (i = 1; i < len; i++) {
 		n = snprintfcat(line, sizeof(line), n ? ":%02x" : "%02x",
 			((unsigned char *)buf)[i]);
@@ -103,10 +103,13 @@ static const char *ever_mac_address_fun(double value)
 
 static const char *ever_ip_address_fun(double value)
 {
+	static int	report_counter = 1;
+	int	report_id = 211, len;
+	int	n = 0;	/* number of characters currently in line */
+	int	i;	/* number of bytes output from buffer */
+	const void	*buf;
+	static char	line[100];
 	NUT_UNUSED_VARIABLE(value);
-
-	static int report_counter = 1;
-	int report_id = 211;
 
 	if(report_counter == 1)
 		report_id = 211; /* notification dest ip */
@@ -119,15 +122,12 @@ static const char *ever_ip_address_fun(double value)
 
 	report_counter== 4 ? report_counter=1 : report_counter++;
 
-	int len = reportbuf->len[report_id];
-	const void *buf = reportbuf->data[report_id];
+	len = reportbuf->len[report_id];
+	buf = reportbuf->data[report_id];
 
-	static char line[100];
 	line[0] = '\0';
-	int n = 0;	/* number of characters currently in line */
-	int i;	/* number of bytes output from buffer */
 
-	/*skip first element which is a report id */
+	/* skip first element which is a report id */
 	for (i = 1; i < len; i++)
 	{
 		n = snprintfcat(line, sizeof(line), n ? ".%d" : "%d",
@@ -139,10 +139,11 @@ static const char *ever_ip_address_fun(double value)
 
 static const char *ever_packets_fun(double value)
 {
+	static int	report_counter = 1;
+	int	report_id = 215, len, res;
+	const unsigned char	*buf;
+	static char	line[200];
 	NUT_UNUSED_VARIABLE(value);
-
-	static int report_counter = 1;
-	int report_id = 215;
 
 	if(report_counter == 1 )
 		report_id = 215;
@@ -155,18 +156,17 @@ static const char *ever_packets_fun(double value)
 
 	report_counter== 4 ? report_counter=1 : report_counter++;
 
-	int len = reportbuf->len[report_id];
-	const unsigned char *buf = reportbuf->data[report_id];
+	len = reportbuf->len[report_id];
+	buf = reportbuf->data[report_id];
 
-	static char line[100];
 	line[0] = '\0';
 
-	/*skip first elemnt which is a report id */
+	/* skip first element which is a report id */
 
 	if(len < 5)
 		return "";
 
-	int res = (int)buf[1];
+	res  = (int)buf[1];
 	res |= (int)buf[2] << 8;
 	res |= (int)buf[3] << 16;
 	res |= (int)buf[4] << 24;
@@ -178,16 +178,15 @@ static const char *ever_packets_fun(double value)
 
 static const char* ever_workmode_fun(double value)
 {
+	int	workmode_report_id = 74;
+	int	workmode = -1;
+	const unsigned char	*buf = reportbuf->data[workmode_report_id];
+	static char	line[200];
 	NUT_UNUSED_VARIABLE(value);
 
-	int workmode_report_id = 74;
-	int workmode = -1;
-	const unsigned char *buf = reportbuf->data[workmode_report_id];
-
-	static char line[100];
 	line[0] = '\0';
 
-	/*skip first element which is a report id */
+	/* skip first element which is a report id */
 	snprintfcat(line, sizeof(line), "%d", buf[1]);
 
 	workmode = atoi(line);
@@ -223,19 +222,17 @@ static const char* ever_workmode_fun(double value)
 
 static const char* ever_messages_fun(double value)
 {
+	int	messages_report_id = 75, messages;
+	int	n = 0;	/* number of characters currently in line */
+	const unsigned char	*buf = reportbuf->data[messages_report_id];
+	static char	line[200];
 	NUT_UNUSED_VARIABLE(value);
 
-	int messages_report_id = 75;
-	const unsigned char *buf = reportbuf->data[messages_report_id];
-
-	static char line[200];
 	line[0] = '\0';
 
-	/*skip first element which is a report id */
-	int messages = (int)buf[1];
+	/* skip first element which is a report id */
+	messages  = (int)buf[1];
 	messages |= (int)buf[2] << 8;
-
-	int n = 0;	/* number of characters currently in line */
 
 	/* duplicate of ups.status: OB LB */
 	/*
@@ -271,20 +268,17 @@ static const char* ever_messages_fun(double value)
 
 static const char* ever_alarms_fun(double value)
 {
+	int	alarms_report_id = 76, alarms;
+	int	n = 0;	/* number of characters currently in line */
+	const unsigned char	*buf = reportbuf->data[alarms_report_id];
+	static char	line[200];
 	NUT_UNUSED_VARIABLE(value);
 
-	int alarms_report_id = 76;
-
-	const unsigned char *buf = reportbuf->data[alarms_report_id];
-
-	static char line[200];
 	line[0] = '\0';
 
-	/*skip first element which is a report id */
-	int alarms = (int)buf[1];
+	/* skip first element which is a report id */
+	alarms  = (int)buf[1];
 	alarms |= (int)buf[2] << 8;
-
-	int n = 0;	/* number of characters currently in line */
 
 	if(alarms & 0x01)
 		n = snprintfcat(line, sizeof(line), n ? " %s" : "%s", "OVERLOAD");
@@ -308,16 +302,15 @@ static const char* ever_alarms_fun(double value)
 
 static const char* ever_on_off_fun(double value)
 {
+	int	workmode_report_id = 74;
+	int	workmode = -1;
+	const unsigned char	*buf = reportbuf->data[workmode_report_id];
+	static char	line[200];
 	NUT_UNUSED_VARIABLE(value);
 
-	int workmode_report_id = 74;
-	int workmode = -1;
-	const unsigned char *buf = reportbuf->data[workmode_report_id];
-
-	static char line[100];
 	line[0] = '\0';
 
-	/*skip first element which is a report id */
+	/* skip first element which is a report id */
 	snprintfcat(line, sizeof(line), "%d", buf[1]);
 
 	workmode = atoi(line);

--- a/drivers/generic_modbus.c
+++ b/drivers/generic_modbus.c
@@ -707,7 +707,7 @@ int get_signal_state(devstate_t state)
 }
 
 /* get driver configuration parameters */
-void get_config_vars()
+void get_config_vars(void)
 {
 	int i; /* local index */
 

--- a/drivers/hidparser.c
+++ b/drivers/hidparser.c
@@ -451,14 +451,16 @@ HIDData_t *FindObject_with_ID_Node(HIDDesc_t *pDesc_arg, uint8_t ReportID, HIDNo
 	size_t	i;
 
 	for (i = 0; i < pDesc_arg->nitems; i++) {
-		HIDData_t *pData = &pDesc_arg->item[i];
+		HIDData_t	*pData = &pDesc_arg->item[i];
+		HIDPath_t	*pPath;
+		uint8_t	size;
 
 		if (pData->ReportID != ReportID) {
 			continue;
 		}
 
-		HIDPath_t * pPath = &pData->Path;
-		uint8_t size = pPath->Size;
+		pPath = &pData->Path;
+		size = pPath->Size;
 		if (size == 0 || pPath->Node[size-1] != Node) {
 			continue;
 		}

--- a/drivers/hpe-pdu-mib.c
+++ b/drivers/hpe-pdu-mib.c
@@ -231,7 +231,7 @@ static snmp_info_t hpe_pdu_mib[] = {
 	{ "ups.type", ST_FLAG_STRING, SU_INFOSIZE, NULL, "pdu",
 		SU_FLAG_STATIC | SU_FLAG_ABSENT | SU_FLAG_OK, NULL },
 
-	 /* FIXME: needs a date reformating callback
+	 /* FIXME: needs a date reformatting callback
 	 *   2011-8-29,16:27:25.0,+1:0
 	 *   Hex-STRING: 07 DB 08 1D 10 0C 36 00 2B 01 00 00
 	 * { "ups.date", ST_FLAG_STRING, SU_INFOSIZE,

--- a/drivers/libusb0.c
+++ b/drivers/libusb0.c
@@ -215,12 +215,13 @@ static int libusb_open(usb_dev_handle **udevp,
 	usb_ctrl_char	rdbuf[MAX_REPORT_SIZE];
 	usb_ctrl_charbufsize		rdlen;
 
+	struct usb_bus *busses;
+
 	/* libusb base init */
 	usb_init();
 	usb_find_busses();
 	usb_find_devices();
 
-	struct usb_bus *busses;
 #ifdef WIN32
 	busses = usb_get_busses();
 #else

--- a/drivers/mge-hid.c
+++ b/drivers/mge-hid.c
@@ -695,7 +695,6 @@ static info_lkp_t eaton_check_country_info[] = {
  * compute a realpower approximation using available data */
 static const char *eaton_compute_realpower_fun(double value)
 {
-	NUT_UNUSED_VARIABLE(value);
 	const char *str_ups_load = dstate_getinfo("ups.load");
 	const char *str_power_nominal = dstate_getinfo("ups.power.nominal");
 	const char *str_powerfactor = dstate_getinfo("output.powerfactor");
@@ -703,6 +702,8 @@ static const char *eaton_compute_realpower_fun(double value)
 	int power_nominal = 0;
 	int ups_load = 0;
 	double realpower = 0;
+	NUT_UNUSED_VARIABLE(value);
+
 	if (str_power_nominal && str_ups_load) {
 		/* Extract needed values */
 		ups_load = atoi(str_ups_load);

--- a/drivers/mge-utalk.c
+++ b/drivers/mge-utalk.c
@@ -956,7 +956,9 @@ static ssize_t mge_command(char *reply, size_t replylen, const char *fmt, ...)
 	bytes_rcvd = ser_get_line(upsfd, reply, replylen,
 		MGE_REPLY_ENDCHAR, MGE_REPLY_IGNCHAR, 3, 0);
 
-	upsdebugx(4, "mge_command: received %" PRIiSIZE " byte(s)", bytes_rcvd);
+	upsdebugx(4, "mge_command: sent %" PRIiSIZE
+		", received %" PRIiSIZE " byte(s)",
+		bytes_sent, bytes_rcvd);
 
 	return bytes_rcvd;
 }

--- a/drivers/mge-xml.c
+++ b/drivers/mge-xml.c
@@ -1537,9 +1537,9 @@ subdriver_t mge_xml_subdriver = {
 };
 
 const char *vname_nut2mge_xml(const char *name) {
-	assert(NULL != name);
-
 	size_t i = 0;
+
+	assert(NULL != name);
 
 	for (; i < sizeof(mge_xml2nut) / sizeof(xml_info_t); ++i) {
 		xml_info_t *info = mge_xml2nut + i;
@@ -1553,9 +1553,9 @@ const char *vname_nut2mge_xml(const char *name) {
 }
 
 const char *vname_mge_xml2nut(const char *name) {
-	assert(NULL != name);
-
 	size_t i = 0;
+
+	assert(NULL != name);
 
 	for (; i < sizeof(mge_xml2nut) / sizeof(xml_info_t); ++i) {
 		xml_info_t *info = mge_xml2nut + i;
@@ -1569,9 +1569,9 @@ const char *vname_mge_xml2nut(const char *name) {
 }
 
 char *vvalue_mge_xml2nut(const char *name, const char *value, size_t len) {
-	assert(NULL != name);
-
 	size_t i = 0;
+
+	assert(NULL != name);
 
 	for (; i < sizeof(mge_xml2nut) / sizeof(xml_info_t); ++i) {
 		xml_info_t *info = mge_xml2nut + i;

--- a/drivers/netxml-ups.c
+++ b/drivers/netxml-ups.c
@@ -932,9 +932,8 @@ static int netxml_dispatch_request(ne_request *request, ne_xml_parser *parser)
 /* Supply the 'login' and 'password' when authentication is required */
 static int netxml_authenticate(void *userdata, const char *realm, int attempt, char *username, char *password)
 {
-	NUT_UNUSED_VARIABLE(userdata);
-
 	char	*val;
+	NUT_UNUSED_VARIABLE(userdata);
 
 	upsdebugx(2, "%s: realm = [%s], attempt = %d", __func__, realm, attempt);
 
@@ -1216,13 +1215,14 @@ static object_entry_t *set_object_add(
 	const char     *name,
 	const char     *value)
 {
-	char *name_cpy;
-	char *value_cpy;
+	char	*name_cpy;
+	char	*value_cpy;
+	object_entry_t	*entry;
 
 	assert(NULL != name);
 	assert(NULL != value);
 
-	object_entry_t *entry = (object_entry_t *)calloc(1,
+	entry = (object_entry_t *)calloc(1,
 		sizeof(object_entry_t));
 
 	if (NULL == entry)
@@ -1297,13 +1297,15 @@ static object_query_status_t set_object_serialise_entries(ne_buffer *buff, objec
 
 
 static ne_buffer *set_object_serialise_raw(object_query_t *handle) {
+	ne_buffer	*buff;
+
 	assert(NULL != handle);
 
 	/* Sanity checks */
 	assert(SET_OBJECT_REQUEST == handle->type);
 
 	/* Create buffer */
-	ne_buffer *buff = ne_buffer_create();
+	buff = ne_buffer_create();
 
 	/* neon API ref. states that the function always succeeds */
 	assert(NULL != buff);
@@ -1316,7 +1318,8 @@ static ne_buffer *set_object_serialise_raw(object_query_t *handle) {
 
 
 static ne_buffer *set_object_serialise_form(object_query_t *handle) {
-	const char *vname = NULL;
+	const char	*vname = NULL;
+	ne_buffer	*buff;
 
 	assert(NULL != handle);
 
@@ -1324,7 +1327,7 @@ static ne_buffer *set_object_serialise_form(object_query_t *handle) {
 	assert(SET_OBJECT_REQUEST == handle->type);
 
 	/* Create buffer */
-	ne_buffer *buff = ne_buffer_create();
+	buff = ne_buffer_create();
 
 	/* neon API ref. states that the function always succeeds */
 	assert(NULL != buff);
@@ -1562,18 +1565,20 @@ static int set_object_raw_resp_end_element(
 
 
 static object_query_t *set_object_deserialise_raw(ne_buffer *buff) {
-	int ne_status;
+	int	ne_status;
+	object_query_t	*handle;
+	ne_xml_parser	*parser;
 
 	assert(NULL != buff);
 
 	/* Create SET_OBJECT query response */
-	object_query_t *handle = object_query_create(SET_OBJECT_RESPONSE, RAW_POST);
+	handle = object_query_create(SET_OBJECT_RESPONSE, RAW_POST);
 
 	if (NULL == handle)
 		return NULL;
 
 	/* Create XML parser */
-	ne_xml_parser *parser = ne_xml_create();
+	parser = ne_xml_create();
 
 	/* neon API ref. states that the function always succeeds */
 	assert(NULL != parser);
@@ -1632,7 +1637,8 @@ static int send_http_request(
 	assert(NULL != req);
 
 	do {  /* Pragmatic do ... while (0) loop allowing breaks on error */
-		const ne_status *req_st;
+		const ne_status	*req_st;
+		int	status;
 
 		/* Set Content-Type */
 		if (NULL != ct)
@@ -1645,7 +1651,7 @@ static int send_http_request(
 				req_body->data, req_body->used - 1);
 
 		/* Send request */
-		int status = ne_begin_request(req);
+		status = ne_begin_request(req);
 
 		if (NE_OK != status) {
 			break;

--- a/drivers/nut-libfreeipmi.c
+++ b/drivers/nut-libfreeipmi.c
@@ -329,7 +329,7 @@ static float libfreeipmi_get_voltage (uint8_t voltage_code)
 }
 
 /* Cleanup IPMI contexts */
-static void libfreeipmi_cleanup()
+static void libfreeipmi_cleanup(void)
 {
 	/* cleanup */
 	if (fru_ctx) {
@@ -842,7 +842,7 @@ Record ID, Sensor Name, Sensor Number, Sensor Type, Sensor State, Sensor Reading
 
 */
 
-int nut_ipmi_monitoring_init()
+int nut_ipmi_monitoring_init(void)
 {
 	int errnum;
 

--- a/drivers/nutdrv_atcl_usb.c
+++ b/drivers/nutdrv_atcl_usb.c
@@ -258,6 +258,17 @@ static int usb_device_open(usb_dev_handle **handlep, USBDevice_t *device, USBDev
 {
 	int ret = 0;
 	uint8_t iManufacturer = 0, iProduct = 0, iSerialNumber = 0;
+#if WITH_LIBUSB_1_0
+	libusb_device **devlist;
+	ssize_t devcount = 0;
+	libusb_device_handle *handle;
+	struct libusb_device_descriptor dev_desc;
+	uint8_t bus_num;
+	/* TODO: consider device_addr */
+	int i;
+#else  /* => WITH_LIBUSB_0_1 */
+	struct usb_bus	*bus;
+#endif
 
 	/* libusb base init */
 #if WITH_LIBUSB_1_0
@@ -279,14 +290,6 @@ static int usb_device_open(usb_dev_handle **handlep, USBDevice_t *device, USBDev
 #endif
 
 #if WITH_LIBUSB_1_0
-	libusb_device **devlist;
-	ssize_t devcount = 0;
-	libusb_device_handle *handle;
-	struct libusb_device_descriptor dev_desc;
-	uint8_t bus_num;
-	/* TODO: consider device_addr */
-	int i;
-
 	devcount = libusb_get_device_list(NULL, &devlist);
 	if (devcount <= 0)
 		fatal_with_errno(EXIT_FAILURE, "No USB device found");
@@ -299,7 +302,6 @@ static int usb_device_open(usb_dev_handle **handlep, USBDevice_t *device, USBDev
 		ret = libusb_open(dev, &handle);
 		*handlep = handle;
 #else  /* => WITH_LIBUSB_0_1 */
-	struct usb_bus	*bus;
 	for (bus = usb_busses; bus; bus = bus->next) {
 
 		struct usb_device	*dev;

--- a/drivers/nutdrv_qx_ablerex.c
+++ b/drivers/nutdrv_qx_ablerex.c
@@ -32,8 +32,10 @@ static int Q5_Vbc = -1;
 static int ablerexQ5Vb = -1;
 
 static int ablerex_Q5(item_t *item, char *value, const size_t valuelen) {
+	int	Q5_Fout, Q5_Vb, Q5_O_Cur, Q5_Err;
 /*
-	int RawValue = 0;
+	//int	Q5_InvW;
+	int	RawValue = 0;
 
 	RawValue  = (unsigned char)item->value[0] * 256 + (unsigned char)item->value[1];
 */
@@ -44,12 +46,12 @@ static int ablerex_Q5(item_t *item, char *value, const size_t valuelen) {
 	upsdebugx(2, "Q52: %d %d %d %d %d %d", item->answer[6], item->answer[7], item->answer[8], item->answer[9], item->answer[10], item->answer[11]);
 	upsdebugx(2, "Q53: %d %d %d %d", item->answer[12], item->answer[13], item->answer[14], item->answer[15]);
 
-	int Q5_Fout = (unsigned char)item->answer[1] * 256 + (unsigned char)item->answer[2];
-	int Q5_Vb = (unsigned char)item->answer[7] * 256 + (unsigned char)item->answer[8];
+	Q5_Fout = (unsigned char)item->answer[1] * 256 + (unsigned char)item->answer[2];
+	Q5_Vb = (unsigned char)item->answer[7] * 256 + (unsigned char)item->answer[8];
 	Q5_Vbc = (unsigned char)item->answer[9] * 256 + (unsigned char)item->answer[10];
 	//int Q5_InvW = (unsigned char)item->answer[11] * 256 + (unsigned char)item->answer[12];
-	int Q5_Err = (unsigned char)item->answer[13] * 256 + (unsigned char)item->answer[14];
-	int Q5_O_Cur = (unsigned char)item->answer[15] * 256 + (unsigned char)item->answer[16];
+	Q5_Err = (unsigned char)item->answer[13] * 256 + (unsigned char)item->answer[14];
+	Q5_O_Cur = (unsigned char)item->answer[15] * 256 + (unsigned char)item->answer[16];
 
 	ablerexQ5Vb = Q5_Vb;
 	upsdebugx(2, "Q5: %.1f %d %.1f", 0.1 * Q5_Fout, Q5_Err, 0.1 * Q5_O_Cur);
@@ -86,7 +88,10 @@ static int ablerex_Q5(item_t *item, char *value, const size_t valuelen) {
 }
 
 static int ablerex_battery(item_t *item, char *value, const size_t valuelen) {
-	double BattV = 0.0;
+	double	BattV = 0.0;
+	double	nomBattV = 0.0;
+	double	battvoltact = 0.0;
+
 	BattV = strtod(item->value, NULL);
 	upsdebugx(2, "battvoltact2: %.2f", BattV);
 	if (!dstate_getinfo("battery.voltage.nominal"))
@@ -95,12 +100,9 @@ static int ablerex_battery(item_t *item, char *value, const size_t valuelen) {
 		return 0;
 	}
 
-	double nomBattV = 0.0;
 	nomBattV = strtod(dstate_getinfo("battery.voltage.nominal"),  NULL);
 	upsdebugx(2, "battvoltact1: %.2f", nomBattV);
 	//return 0;
-
-	double battvoltact = 0.0;
 
 	if (ablerexQ5Vb > 0) {
 		battvoltact = ablerexQ5Vb * nomBattV / 1200;
@@ -174,7 +176,10 @@ static int ablerex_battery_charge(double BattIn)
 }
 
 static int ablerex_batterycharge(item_t *item, char *value, const size_t valuelen) {
-	double BattV = 0.0;
+	double	BattV = 0.0;
+	double	nomBattV = 0.0;
+	int	BattP;
+
 	BattV = strtod(item->value, NULL);
 	upsdebugx(2, "battvoltc2: %.2f", BattV);
 	if (!dstate_getinfo("battery.voltage.nominal"))
@@ -183,7 +188,6 @@ static int ablerex_batterycharge(item_t *item, char *value, const size_t valuele
 		return 0;
 	}
 
-	double nomBattV = 0.0;
 	nomBattV = strtod(dstate_getinfo("battery.voltage.nominal"),  NULL);
 	upsdebugx(2, "battvv1: %.2f", nomBattV);
 	//return 0;
@@ -191,7 +195,7 @@ static int ablerex_batterycharge(item_t *item, char *value, const size_t valuele
 	if (BattV > 3.0) {
 		BattV = BattV / (nomBattV / 12);
 	}
-	int BattP = ablerex_battery_charge(BattV);
+	BattP = ablerex_battery_charge(BattV);
 	//dstate_setinfo("battery.charge", "%.0f", BattP);
 
 	snprintf(value, valuelen, "%d", BattP);
@@ -301,10 +305,12 @@ static int	ablerex_process_status_bits(item_t *item, char *value, const size_t v
 			status_set("RB");
 		}
 
-		double vout = strtod(dstate_getinfo("output.voltage"), NULL);
+		{ /* scope */
+			double vout = strtod(dstate_getinfo("output.voltage"), NULL);
 
-		if (vout < 50.0) {
-			status_set("OFF");
+			if (vout < 50.0) {
+				status_set("OFF");
+			}
 		}
 		break;
 

--- a/drivers/nutdrv_qx_bestups.c
+++ b/drivers/nutdrv_qx_bestups.c
@@ -357,12 +357,14 @@ static int	bestups_preprocess_id_answer(item_t *item, const int len)
 /* *SETVAR(/NONUT)* Preprocess setvars */
 static int	bestups_process_setvar(item_t *item, char *value, const size_t valuelen)
 {
+	double	val;
+
 	if (!strlen(value)) {
 		upsdebugx(2, "%s: value not given for %s", __func__, item->info_type);
 		return -1;
 	}
 
-	double	val = strtod(value, NULL);
+	val = strtod(value, NULL);
 
 	if (!strcasecmp(item->info_type, "pins_shutdown_mode")) {
 

--- a/drivers/nutdrv_qx_masterguard.c
+++ b/drivers/nutdrv_qx_masterguard.c
@@ -444,10 +444,10 @@ static int masterguard_fault(item_t *item, char *value, const size_t valuelen) {
 
 /* add slave address (from masterguard_my_slaveaddr) to commands that require it */
 static int masterguard_add_slaveaddr(item_t *item, char *command, const size_t commandlen) {
+	size_t l;
+
 	NUT_UNUSED_VARIABLE(item);
 	NUT_UNUSED_VARIABLE(commandlen);
-
-	size_t l;
 
 	l = strlen(command);
 	if (strncmp(command + l - 4, ",XX\r", 4) != 0) {
@@ -465,12 +465,12 @@ static int masterguard_add_slaveaddr(item_t *item, char *command, const size_t c
 /* helper, not to be called directly from table */
 /*!! use parameter from the value field instead of ups.delay.{shutdown,return}?? */
 static int masterguard_shutdown(item_t *item, char *value, const size_t valuelen, const int stayoff) {
-	NUT_UNUSED_VARIABLE(item);
-
 	long offdelay;
 	char *p;
 	const char *val, *name;
 	char offstr[3];
+
+	NUT_UNUSED_VARIABLE(item);
 
 	offdelay = strtol((val = dstate_getinfo(name = "ups.delay.shutdown")), &p, 10);
 	if (*p != '\0') goto ill;
@@ -511,15 +511,16 @@ static int masterguard_shutdown_stayoff(item_t *item, char *value, const size_t 
 }
 
 static int masterguard_test_battery(item_t *item, char *value, const size_t valuelen) {
-	NUT_UNUSED_VARIABLE(item);
-
 	long duration;
 	char *p;
+
+	NUT_UNUSED_VARIABLE(item);
 
 	if (value[0] == '\0') {
 		upsdebugx(2, "battery test: no duration");
 		return -1;
 	}
+
 	duration = strtol(value, &p, 10);
 	if (*p != '\0') goto ill;
 	if (duration == 10) {

--- a/drivers/nutdrv_siemens_sitop.c
+++ b/drivers/nutdrv_siemens_sitop.c
@@ -98,7 +98,7 @@ static void rm_buffer_head(unsigned int n) {
 /* parse incoming data from the UPS.
  * return true if something new was received.
  */
-static int check_for_new_data() {
+static int check_for_new_data(void) {
 	int new_data_received = 0;
 	int done = 0;
 	ssize_t num_received;

--- a/drivers/phoenixcontact_modbus.c
+++ b/drivers/phoenixcontact_modbus.c
@@ -57,11 +57,11 @@ void upsdrv_initinfo(void)
 
 void upsdrv_updateinfo(void)
 {
+	uint16_t tab_reg[64];
+
 	errcount = 0;
 
 	upsdebugx(2, "upsdrv_updateinfo");
-
-	uint16_t tab_reg[64];
 
 	mrir(modbus_ctx, 29697, 3, tab_reg);
 

--- a/drivers/pijuice.c
+++ b/drivers/pijuice.c
@@ -305,7 +305,7 @@ static inline int open_i2c_bus(char *path, uint8_t addr)
 	return file;
 }
 
-static void get_charge_level_hi_res()
+static void get_charge_level_hi_res(void)
 {
 	uint8_t cmd = CHARGE_LEVEL_HI_RES_CMD;
 	uint16_t data;
@@ -334,11 +334,10 @@ static void get_charge_level_hi_res()
 	dstate_setinfo( "battery.charge", "%02.1f", battery_charge_level );
 }
 
-static void get_status()
+static void get_status(void)
 {
-	uint8_t cmd = STATUS_CMD;
-	uint8_t data;
-	char status_buf[ST_MAX_VALUE_LEN];
+	uint8_t	cmd = STATUS_CMD, data, batteryStatus, powerInput, powerInput5vIo;
+	char	status_buf[ST_MAX_VALUE_LEN];
 
 	upsdebugx( 3, __func__ );
 
@@ -346,7 +345,7 @@ static void get_status()
 
 	I2C_READ_BYTE( upsfd, cmd, __func__ )
 
-	uint8_t batteryStatus = data >> 2 & 0x03;
+	batteryStatus = data >> 2 & 0x03;
 	switch( batteryStatus )
 	{
 		case BATT_NORMAL:
@@ -373,7 +372,7 @@ static void get_status()
 			upsdebugx( 1, "battery.status: UNKNOWN" );
 	}
 
-	uint8_t powerInput = data >> 4 & 0x03;
+	powerInput = data >> 4 & 0x03;
 	switch( powerInput )
 	{
 		case POWER_NOT_PRESENT:
@@ -392,7 +391,7 @@ static void get_status()
 			upsdebugx( 1, "Power Input: UNKNOWN" );
 	}
 
-	uint8_t powerInput5vIo = data >> 6 & 0x03;
+	powerInput5vIo = data >> 6 & 0x03;
 	switch( powerInput5vIo )
 	{
 		case POWER_NOT_PRESENT :
@@ -535,7 +534,7 @@ static void get_status()
 	}
 }
 
-static void get_battery_temperature()
+static void get_battery_temperature(void)
 {
 	uint8_t cmd = BATTERY_TEMPERATURE_CMD;
 	int16_t data;
@@ -548,7 +547,7 @@ static void get_battery_temperature()
 	dstate_setinfo( "battery.temperature", "%d", data );
 }
 
-static void get_battery_voltage()
+static void get_battery_voltage(void)
 {
 	uint8_t cmd = BATTERY_VOLTAGE_CMD;
 	int16_t data;
@@ -561,7 +560,7 @@ static void get_battery_voltage()
 	dstate_setinfo( "battery.voltage", "%0.3f", data / 1000.0 );
 }
 
-static void get_battery_current()
+static void get_battery_current(void)
 {
 	uint8_t cmd = BATTERY_CURRENT_CMD;
 	int16_t data;
@@ -583,7 +582,7 @@ static void get_battery_current()
 	dstate_setinfo( "battery.current", "%0.3f", data / 1000.0 );
 }
 
-static void get_io_voltage()
+static void get_io_voltage(void)
 {
 	uint8_t cmd = IO_VOLTAGE_CMD;
 	int16_t data;
@@ -596,7 +595,7 @@ static void get_io_voltage()
 	dstate_setinfo( "input.voltage", "%.3f", data / 1000.0 );
 }
 
-static void get_io_current()
+static void get_io_current(void)
 {
 	uint8_t cmd = IO_CURRENT_CMD;
 	int16_t data;
@@ -618,7 +617,7 @@ static void get_io_current()
 	dstate_setinfo( "input.current", "%.3f", data / 1000.0 );
 }
 
-static void get_firmware_version()
+static void get_firmware_version(void)
 {
 	uint8_t cmd = FIRMWARE_VERSION_CMD;
 	uint16_t data;
@@ -640,7 +639,7 @@ static void get_firmware_version()
 	dstate_setinfo( "ups.firmware", "%d.%d", major, minor );
 }
 
-static void get_battery_profile()
+static void get_battery_profile(void)
 {
 	uint8_t cmd = BATTERY_PROFILE_CMD;
 	__u8 block[I2C_SMBUS_BLOCK_MAX];
@@ -653,7 +652,7 @@ static void get_battery_profile()
 	dstate_setinfo( "battery.capacity", "%0.3f", ( block[1] << 8 | block[0] ) / 1000.0 );
 }
 
-static void get_battery_profile_ext()
+static void get_battery_profile_ext(void)
 {
 	uint8_t cmd = BATTERY_EXT_PROFILE_CMD;
 	__u8 block[I2C_SMBUS_BLOCK_MAX];
@@ -678,7 +677,7 @@ static void get_battery_profile_ext()
 	}
 }
 
-static void get_power_off()
+static void get_power_off(void)
 {
 	uint8_t cmd = POWER_OFF_CMD;
 	uint8_t data;
@@ -697,7 +696,7 @@ static void get_power_off()
 	}
 }
 
-static void set_power_off()
+static void set_power_off(void)
 {
 	uint8_t cmd = POWER_OFF_CMD;
 
@@ -729,7 +728,7 @@ static void set_power_off()
 	I2C_WRITE_BYTE( upsfd, cmd, shutdown_delay, __func__ )
 }
 
-static void get_time()
+static void get_time(void)
 {
 	uint8_t cmd = RTC_TIME_CMD;
 	__u8 block[I2C_SMBUS_BLOCK_MAX];
@@ -755,7 +754,7 @@ static void get_time()
 	dstate_setinfo( "ups.date", "%04d-%02d-%02d", year, month, day );
 }
 
-static void get_i2c_address()
+static void get_i2c_address(void)
 {
 	uint8_t cmd = I2C_ADDRESS_CMD;
 	uint8_t data;

--- a/drivers/richcomm_usb.c
+++ b/drivers/richcomm_usb.c
@@ -242,6 +242,9 @@ static void usb_comm_good(void)
  */
 static int driver_callback(usb_dev_handle *handle, USBDevice_t *device)
 {
+#if WITH_LIBUSB_1_0
+	int ret = 0;
+#endif
 	NUT_UNUSED_VARIABLE(device);
 
 	if (usb_set_configuration(handle, 1) < 0) {
@@ -263,8 +266,6 @@ static int driver_callback(usb_dev_handle *handle, USBDevice_t *device)
 		return -1;
 	}
 #elif WITH_LIBUSB_1_0
-	int ret = 0;
-
 	if ((ret = libusb_set_interface_alt_setting(handle, 0, 0)) < 0) {
 		upsdebugx(5, "Can't set USB alternate interface: %s", nut_usb_strerror(ret));
 		return -1;
@@ -307,6 +308,17 @@ static int usb_device_open(usb_dev_handle **handlep, USBDevice_t *device, USBDev
 {
 	int ret = 0;
 	uint8_t iManufacturer = 0, iProduct = 0, iSerialNumber = 0;
+#if WITH_LIBUSB_1_0
+	libusb_device **devlist;
+	ssize_t devcount = 0;
+	libusb_device_handle *handle;
+	struct libusb_device_descriptor dev_desc;
+	uint8_t bus_num;
+	/* TODO: consider device_addr */
+	int i;
+#else  /* => WITH_LIBUSB_0_1 */
+	struct usb_bus	*bus;
+#endif
 
 	/* libusb base init */
 #if WITH_LIBUSB_1_0
@@ -328,14 +340,6 @@ static int usb_device_open(usb_dev_handle **handlep, USBDevice_t *device, USBDev
 #endif
 
 #if WITH_LIBUSB_1_0
-	libusb_device **devlist;
-	ssize_t devcount = 0;
-	libusb_device_handle *handle;
-	struct libusb_device_descriptor dev_desc;
-	uint8_t bus_num;
-	/* TODO: consider device_addr */
-	int i;
-
 	devcount = libusb_get_device_list(NULL, &devlist);
 	if (devcount <= 0)
 		fatal_with_errno(EXIT_FAILURE, "No USB device found");
@@ -348,8 +352,6 @@ static int usb_device_open(usb_dev_handle **handlep, USBDevice_t *device, USBDev
 		ret = libusb_open(dev, &handle);
 		*handlep = handle;
 #else  /* => WITH_LIBUSB_0_1 */
-	struct usb_bus	*bus;
-
 	for (bus = usb_busses; bus; bus = bus->next) {
 
 		struct usb_device	*dev;

--- a/drivers/riello.c
+++ b/drivers/riello.c
@@ -914,7 +914,7 @@ void riello_parse_sentr(uint8_t* buffer, TRielloData* data)
 		data->StatusCode[2] |= 0x01;
 }
 
-void riello_init_serial()
+void riello_init_serial(void)
 {
 	wait_packet = 1;
 	buf_ptr_length = 0;

--- a/drivers/riello_ser.c
+++ b/drivers/riello_ser.c
@@ -207,7 +207,7 @@ static void riello_serialcomm(uint8_t* arg_bufIn, uint8_t typedev)
 	}
 }
 
-static int get_ups_nominal()
+static int get_ups_nominal(void)
 {
 	uint8_t length;
 
@@ -240,7 +240,7 @@ static int get_ups_nominal()
 	return 0;
 }
 
-static int get_ups_status()
+static int get_ups_status(void)
 {
 	uint8_t numread, length;
 
@@ -280,7 +280,7 @@ static int get_ups_status()
 	return 0;
 }
 
-static int get_ups_extended()
+static int get_ups_extended(void)
 {
 	uint8_t length;
 
@@ -314,7 +314,7 @@ static int get_ups_extended()
 }
 
 /* Not static, exposed via header. Not used though, currently... */
-int get_ups_statuscode()
+int get_ups_statuscode(void)
 {
 	uint8_t length;
 
@@ -347,7 +347,7 @@ int get_ups_statuscode()
 	return 0;
 }
 
-static int get_ups_sentr()
+static int get_ups_sentr(void)
 {
 	uint8_t length;
 
@@ -679,7 +679,7 @@ static int riello_instcmd(const char *cmdname, const char *extra)
 	return STAT_INSTCMD_UNKNOWN;
 }
 
-static int start_ups_comm()
+static int start_ups_comm(void)
 {
 	uint8_t length;
 

--- a/drivers/riello_usb.c
+++ b/drivers/riello_usb.c
@@ -81,7 +81,7 @@ static void ussleep(useconds_t usec)
 	usleep(usec);
 }
 
-static int cypress_setfeatures()
+static int cypress_setfeatures(void)
 {
 	int ret;
 
@@ -434,7 +434,7 @@ static int riello_command(uint8_t *cmd, uint8_t *buf, uint16_t length, uint16_t 
 	return ret;
 }
 
-static int get_ups_nominal()
+static int get_ups_nominal(void)
 {
 
 	uint8_t length;
@@ -467,7 +467,7 @@ static int get_ups_nominal()
 	return 0;
 }
 
-static int get_ups_status()
+static int get_ups_status(void)
 {
 	uint8_t numread, length;
 	int recv;
@@ -506,7 +506,7 @@ static int get_ups_status()
 	return 0;
 }
 
-static int get_ups_extended()
+static int get_ups_extended(void)
 {
 	uint8_t length;
 	int recv;
@@ -539,7 +539,7 @@ static int get_ups_extended()
 }
 
 /* Not static, exposed via header. Not used though, currently... */
-int get_ups_statuscode()
+int get_ups_statuscode(void)
 {
 	uint8_t length;
 	int recv;
@@ -795,7 +795,7 @@ static int riello_instcmd(const char *cmdname, const char *extra)
 	return STAT_INSTCMD_UNKNOWN;
 }
 
-static int start_ups_comm()
+static int start_ups_comm(void)
 {
 	uint16_t length;
 	int recv;

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -593,10 +593,11 @@ void upsdrv_initups(void)
 	/* Retrieve user's parameters */
 	mibs = testvar(SU_VAR_MIBS) ? getval(SU_VAR_MIBS) : "auto";
 	if (!strcmp(mibs, "--list")) {
+		int i;
+
 		printf("The 'mibs' argument is '%s', so just listing the mappings this driver knows,\n"
 		       "and for 'mibs=auto' these mappings will be tried in the following order until\n"
 		       "the first one matches your device\n\n", mibs);
-		int i;
 		printf("%7s\t%-23s\t%-7s\t%-31s\t%-s\n",
 			"NUMBER", "MAPPING NAME", "VERSION",
 			"ENTRY POINT OID", "AUTO CHECK OID");
@@ -1122,6 +1123,8 @@ static struct snmp_pdu **nut_snmp_walk(const char *OID, int max_iteration)
 	current_name_len = name_len;
 
 	while( nb_iteration < max_iteration ) {
+		struct snmp_pdu	**new_ret_array;
+
 		/* Going to a shorter OID means we are outside our sub-tree */
 		if( current_name_len < name_len ) {
 			break;
@@ -1204,7 +1207,7 @@ static struct snmp_pdu **nut_snmp_walk(const char *OID, int max_iteration)
 
 		nb_iteration++;
 		/* +1 is for the terminating NULL */
-		struct snmp_pdu ** new_ret_array = realloc(
+		new_ret_array = realloc(
 			ret_array,
 			sizeof(struct snmp_pdu*) * ((size_t)nb_iteration+1)
 			);
@@ -1261,21 +1264,24 @@ static bool_t decode_str(struct snmp_pdu *pdu, char *buf, size_t buf_len, info_l
 	switch (pdu->variables->type) {
 	case ASN_OCTET_STR:
 	case ASN_OPAQUE:
-		len = pdu->variables->val_len > buf_len - 1 ?
-			buf_len - 1 : pdu->variables->val_len;
-		/* Test for hexadecimal values */
-		int hex = 0, x;
-		unsigned char *cp;
-		for(cp = pdu->variables->val.string, x = 0; x < (int)pdu->variables->val_len; x++, cp++) {
-			if (!(isprint((size_t)*cp) || isspace((size_t)*cp))) {
-				hex = 1;
+		{ /* scoping */
+			/* Test for hexadecimal values */
+			int hex = 0, x;
+			unsigned char *cp;
+
+			len = pdu->variables->val_len > buf_len - 1 ?
+				buf_len - 1 : pdu->variables->val_len;
+			for(cp = pdu->variables->val.string, x = 0; x < (int)pdu->variables->val_len; x++, cp++) {
+				if (!(isprint((size_t)*cp) || isspace((size_t)*cp))) {
+					hex = 1;
+				}
 			}
-		}
-		if (hex)
-			snprint_hexstring(buf, buf_len, pdu->variables->val.string, pdu->variables->val_len);
-		else {
-			memcpy(buf, pdu->variables->val.string, len);
-			buf[len] = '\0';
+			if (hex)
+				snprint_hexstring(buf, buf_len, pdu->variables->val.string, pdu->variables->val_len);
+			else {
+				memcpy(buf, pdu->variables->val.string, len);
+				buf[len] = '\0';
+			}
 		}
 		break;
 	case ASN_INTEGER:
@@ -1320,9 +1326,10 @@ static bool_t decode_str(struct snmp_pdu *pdu, char *buf, size_t buf_len, info_l
 		upsdebugx(2, "Received an OID value: %s", tmp_buf);
 		/* Try to get the value of the pointed OID */
 		if (nut_snmp_get_str(tmp_buf, buf, buf_len, oid2info) == FALSE) {
+			char	*oid_leaf;
 			upsdebugx(3, "Failed to retrieve OID value, using fallback");
 			/* Otherwise return the last part of the returned OID (ex: 1.2.3 => 3) */
-			char *oid_leaf = strrchr(tmp_buf, '.');
+			oid_leaf = strrchr(tmp_buf, '.');
 			snprintf(buf, buf_len, "%s", oid_leaf+1);
 			upsdebugx(3, "Fallback value: %s", buf);
 		}
@@ -1441,9 +1448,10 @@ bool_t nut_snmp_get_int(const char *OID, long *pval)
 		upsdebugx(2, "Received an OID value: %s", tmp_buf);
 		/* Try to get the value of the pointed OID */
 		if (nut_snmp_get_int(tmp_buf, &value) == FALSE) {
+			char	*oid_leaf;
 			upsdebugx(3, "Failed to retrieve OID value, using fallback");
 			/* Otherwise return the last part of the returned OID (ex: 1.2.3 => 3) */
-			char *oid_leaf = strrchr(tmp_buf, '.');
+			oid_leaf = strrchr(tmp_buf, '.');
 			value = strtol(oid_leaf+1, NULL, 0);
 			upsdebugx(3, "Fallback value: %ld", value);
 		}
@@ -1795,8 +1803,9 @@ void su_alarm_set(snmp_info_t *su_info_p, long value)
 		 * start of path */
 		if (info_type[0] == 'L') {
 			/* Extract phase number */
-			item_number = atoi(info_type+1);
 			char alarm_info_value_more[SU_LARGEBUF + 32]; /* can sprintf() SU_LARGEBUF plus markup into here */
+
+			item_number = atoi(info_type+1);
 
 			upsdebugx(2, "%s: appending phase L%i", __func__, item_number);
 
@@ -1837,7 +1846,7 @@ snmp_info_t *su_find_info(const char *type)
 
 /* Counter match the sysOID using {device,ups}.model OID
  * Return TRUE if this OID can be retrieved, FALSE otherwise */
-static bool_t match_model_OID()
+static bool_t match_model_OID(void)
 {
 	bool_t retCode = FALSE;
 	snmp_info_t *su_info_p, *cur_info_p;
@@ -1899,7 +1908,7 @@ static bool_t match_model_OID()
 
 /* Try to find the MIB using sysOID matching.
  * Return a pointer to a mib2nut definition if found, NULL otherwise */
-static mib2nut_info_t *match_sysoid()
+static mib2nut_info_t *match_sysoid(void)
 {
 	char sysOID_buf[LARGEBUF];
 	oid device_sysOID[MAX_OID_LEN];
@@ -2147,14 +2156,16 @@ long su_find_valinfo(info_lkp_t *oid2info, const char* value)
 	return -1;
 }
 
-/* String reformating function */
+/* String reformatting function */
 const char *su_find_strval(info_lkp_t *oid2info, void *value)
 {
 #if WITH_SNMP_LKP_FUN
 	/* First test if we have a generic lookup function */
 	if ( (oid2info != NULL) && (oid2info->fun_vp2s != NULL) ) {
+		const char	*retvalue;
+
 		upsdebugx(2, "%s: using generic lookup function (string reformatting)", __func__);
-		const char * retvalue = oid2info->fun_vp2s(value);
+		retvalue = oid2info->fun_vp2s(value);
 		upsdebugx(2, "%s: got value '%s'", __func__, retvalue);
 		return retvalue;
 	}
@@ -2175,8 +2186,10 @@ const char *su_find_infoval(info_lkp_t *oid2info, void *raw_value)
 #if WITH_SNMP_LKP_FUN
 	/* First test if we have a generic lookup function */
 	if ( (oid2info != NULL) && (oid2info->fun_vp2s != NULL) ) {
+		const char	*retvalue;
+
 		upsdebugx(2, "%s: using generic lookup function", __func__);
-		const char * retvalue = oid2info->fun_vp2s(raw_value);
+		retvalue = oid2info->fun_vp2s(raw_value);
 		upsdebugx(2, "%s: got value '%s'", __func__, retvalue);
 		return retvalue;
 	}
@@ -2338,12 +2351,14 @@ static void free_info(snmp_info_t *su_info_p)
  * the MIB, based on a test using a template OID */
 static int base_snmp_template_index(const snmp_info_t *su_info_p)
 {
+	int	base_index = -1;
+	char	test_OID[SU_INFOSIZE];
+	snmp_info_flags_t	template_type;
+
 	if (!su_info_p)
 		return -1;
 
-	int base_index = -1;
-	char test_OID[SU_INFOSIZE];
-	snmp_info_flags_t template_type = get_template_type(su_info_p->info_type);
+	template_type = get_template_type(su_info_p->info_type);
 
 	upsdebugx(3, "%s: OID template = %s", __func__,
 		(su_info_p->OID ? su_info_p->OID : "<null>") );
@@ -2863,7 +2878,7 @@ bool_t get_and_process_data(int mode, snmp_info_t *su_info_p)
  * Determine the number of device(s) and if daisychain support has to be enabled
  * Set the values of devices_count (internal) and "device.count" (public)
  * Return TRUE if daisychain support is enabled, FALSE otherwise */
-bool_t daisychain_init()
+bool_t daisychain_init(void)
 {
 	snmp_info_t *su_info_p = NULL;
 
@@ -3132,7 +3147,10 @@ static int process_phase_data(const char* type, long *nb_phases, snmp_info_t *su
 bool_t snmp_ups_walk(int mode)
 {
 	long *walked_input_phases, *walked_output_phases, *walked_bypass_phases;
-	static unsigned long iterations = 0;
+#ifdef COUNT_ITERATIONS
+	/* Experimental workaround for stale info */
+	static unsigned long	iterations = 0;
+#endif
 	snmp_info_t *su_info_p;
 	bool_t status = FALSE;
 
@@ -3291,11 +3309,13 @@ bool_t snmp_ups_walk(int mode)
 				continue;
 			}
 
+#ifdef COUNT_ITERATIONS
 			/* check stale elements only on each PN_STALE_RETRY iteration. */
-	/*		if ((su_info_p->flags & SU_FLAG_STALE) &&
+	 		if ((su_info_p->flags & SU_FLAG_STALE) &&
 					(iterations % SU_STALE_RETRY) != 0)
 				continue;
-	*/
+#endif
+
 			/* Filter 1-phase Vs 3-phase according to {input,output,bypass}.phase.
 			 * Non matching items are disabled, and flags are cleared at init
 			 * time */
@@ -3366,7 +3386,11 @@ bool_t snmp_ups_walk(int mode)
 			device_alarm_init();
 		}
 	}
+
+#ifdef COUNT_ITERATIONS
 	iterations++;
+#endif
+
 	return status;
 }
 
@@ -3640,6 +3664,7 @@ bool_t su_ups_get(snmp_info_t *su_info_p)
 		status = nut_snmp_get_str(su_info_p->OID, buf,
 			sizeof(buf), su_info_p->oid2info);
 		if (status == TRUE) {
+			const char *fmt_buf;
 			if (quirk_symmetra_threephase) {
 				if (!strcasecmp(su_info_p->info_type, "input.transfer.low")
 				 || !strcasecmp(su_info_p->info_type, "input.transfer.high")) {
@@ -3649,8 +3674,8 @@ bool_t su_ups_get(snmp_info_t *su_info_p)
 					snprintf(buf, sizeof(buf), "%.2f", tmp_dvalue);
 				}
 			}
-			/* Check if there is a string reformating function */
-			const char *fmt_buf = NULL;
+			/* Check if there is a string reformatting function */
+			fmt_buf = NULL;
 			if ((fmt_buf = su_find_strval(su_info_p->oid2info, buf)) != NULL) {
 				snprintf(buf, sizeof(buf), "%s", fmt_buf);
 			}
@@ -3724,7 +3749,7 @@ static int su_setOID(int mode, const char *varname, const char *val)
 	snmp_info_t *su_info_p = NULL;
 	bool_t status;
 	int retval = STAT_SET_FAILED;
-	int cmd_offset = 0;
+	int cmd_offset = 0;	/* FIXME: Does not seem to be actually used! */
 	long value = -1;
 	/* normal (default), outlet, or outlet group variable */
 	snmp_info_flags_t vartype = 0;
@@ -3846,13 +3871,14 @@ static int su_setOID(int mode, const char *varname, const char *val)
 		}
 	} else {
 		/* is indeed an outlet.* or device.x.outlet.* */
-		snmp_info_t *tmp_info_p;
+		snmp_info_t	*tmp_info_p;
 		/* Point the outlet or outlet group number in the string */
-		const char *item_number_ptr = NULL;
+		const char	*item_number_ptr = NULL;
+		char	*item_varname;
 		/* Store the target outlet or group number */
-		int item_number = extract_template_number_from_snmp_info_t(tmp_varname);
+		int	item_number = extract_template_number_from_snmp_info_t(tmp_varname);
 		/* Store the total number of outlets or outlet groups */
-		int total_items = -1;
+		int	total_items = -1;
 
 		/* Check if it is outlet / outlet.group */
 		vartype = get_template_type(tmp_varname);
@@ -3878,7 +3904,7 @@ static int su_setOID(int mode, const char *varname, const char *val)
 			return STAT_SET_INVALID;
 		}
 		/* find back the item template */
-		char *item_varname = (char *)xmalloc(SU_INFOSIZE);
+		item_varname = (char *)xmalloc(SU_INFOSIZE);
 		snprintf(item_varname, SU_INFOSIZE, "%s.%s%s",
 				(vartype == SU_OUTLET)?"outlet":"outlet.group",
 				"%i", strchr(item_number_ptr++, '.'));
@@ -3916,8 +3942,8 @@ static int su_setOID(int mode, const char *varname, const char *val)
 				/* Workaround buggy Eaton Pulizzi implementation
 				 * which have different offsets index for data & commands! */
 				if (su_info_p->flags & SU_CMD_OFFSET) {
-					upsdebugx(3, "Adding command offset");
 					cmd_offset++;
+					upsdebugx(3, "Adding command offset, now: %i", cmd_offset);
 				}
 			}
 

--- a/drivers/socomec_jbus.c
+++ b/drivers/socomec_jbus.c
@@ -53,11 +53,11 @@ upsdrv_info_t upsdrv_info = {
 
 void upsdrv_initinfo(void)
 {
-	upsdebugx(2, "upsdrv_initinfo");
-
 	uint16_t tab_reg[12];
 	int r;
 	
+	upsdebugx(2, "upsdrv_initinfo");
+
 	dstate_setinfo("device.mfr", "socomec jbus");
 	dstate_setinfo("device.model", "Socomec Generic");
 
@@ -117,11 +117,11 @@ void upsdrv_initinfo(void)
 
 void upsdrv_updateinfo(void)
 {
-	upsdebugx(2, "upsdrv_updateinfo");
-
 	uint16_t tab_reg[64];
 	int r;
 	
+	upsdebugx(2, "upsdrv_updateinfo");
+
 	status_init();
 
 	/* ups configuration */

--- a/drivers/solis.c
+++ b/drivers/solis.c
@@ -413,16 +413,18 @@ static void scan_received_pack(void) {
 				OutVoltage = RecPack[1] * a *  TENSAO_SAIDA_F1_MI[configRelay] + TENSAO_SAIDA_F2_MI[configRelay];
 			}
 		} else {
+			double	RealPower, potVA1, potVA2, potLin, potRe;
+
 			OutCurrent = (float)(corrente_saida_F1_MR * RecPack[5] + corrente_saida_F2_MR);
 			OutVoltage = RecPack[1] * TENSAO_SAIDA_F1_MR[configRelay] + TENSAO_SAIDA_F2_MR[configRelay];
 			AppPower = OutCurrent * OutVoltage;
 
-			double RealPower = (RecPack[7] + RecPack[8] * 256);
+			RealPower = (RecPack[7] + RecPack[8] * 256);
 
-			double potVA1 = 5.968 * AppPower - 284.36;
-			double potVA2 = 7.149 * AppPower - 567.18;
-			double potLin = 0.1664 * RealPower + 49.182;
-			double potRe = 0.1519 * RealPower + 32.644;
+			potVA1 = 5.968 * AppPower - 284.36;
+			potVA2 = 7.149 * AppPower - 567.18;
+			potLin = 0.1664 * RealPower + 49.182;
+			potRe = 0.1519 * RealPower + 32.644;
 			if (fabs(potVA1 - RealPower) < fabs(potVA2 - RealPower))
 				RealPower = potLin;
 			else

--- a/drivers/tripplite.c
+++ b/drivers/tripplite.c
@@ -612,9 +612,10 @@ void upsdrv_makevartable(void)
 
 void upsdrv_initups(void)
 {
+	char	*val;
+
 	upsfd = ser_open(device_path);
 	ser_set_speed(upsfd, device_path, B2400);
-	char *val;
 
 	if ((val = getval("offdelay"))) {
 		int ipv = atoi(val);

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -173,19 +173,19 @@ static int subdriver_match_func(USBDevice_t *arghd, void *privdata)
 
 	switch (is_usb_device_supported(tripplite_usb_device_table, arghd))
 	{
-	case SUPPORTED:
-		return 1;
-
-	case POSSIBLY_SUPPORTED:
-		/* by default, reject, unless the productid option is given */
-		if (getval("productid")) {
+		case SUPPORTED:
 			return 1;
-		}
-		return 0;
 
-	case NOT_SUPPORTED:
-	default:
-		return 0;
+		case POSSIBLY_SUPPORTED:
+			/* by default, reject, unless the productid option is given */
+			if (getval("productid")) {
+				return 1;
+			}
+			return 0;
+
+		case NOT_SUPPORTED:
+		default:
+			return 0;
 	}
 }
 
@@ -207,58 +207,58 @@ static enum tl_model_t {
 /*! Are the values encoded in ASCII or binary?
  * TODO: Add 3004?
  */
-static int is_binary_protocol()
+static int is_binary_protocol(void)
 {
 	switch(tl_model) {
-	case TRIPP_LITE_SMART_3005:
-		return 1;
-	case TRIPP_LITE_SMARTPRO:
-	case TRIPP_LITE_SMART_0004:
-	case TRIPP_LITE_OMNIVS:
-	case TRIPP_LITE_OMNIVS_2001:
-	case TRIPP_LITE_UNKNOWN:
+		case TRIPP_LITE_SMART_3005:
+			return 1;
+		case TRIPP_LITE_SMARTPRO:
+		case TRIPP_LITE_SMART_0004:
+		case TRIPP_LITE_OMNIVS:
+		case TRIPP_LITE_OMNIVS_2001:
+		case TRIPP_LITE_UNKNOWN:
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT)
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wcovered-switch-default"
 #endif
-	/* All enum cases defined as of the time of coding
-	 * have been covered above. Handle later definitions,
-	 * memory corruptions and buggy inputs below...
-	 */
-	default:
+		/* All enum cases defined as of the time of coding
+		 * have been covered above. Handle later definitions,
+		 * memory corruptions and buggy inputs below...
+		 */
+		default:
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT)
 # pragma GCC diagnostic pop
 #endif
-		return 0;
+			return 0;
 	}
 }
 
 /*! Is this the "SMART" family of protocols?
  * TODO: Add 3004?
  */
-static int is_smart_protocol()
+static int is_smart_protocol(void)
 {
 	switch(tl_model) {
-	case TRIPP_LITE_SMARTPRO:
-	case TRIPP_LITE_SMART_0004:
-	case TRIPP_LITE_SMART_3005:
-		return 1;
-	case TRIPP_LITE_OMNIVS:
-	case TRIPP_LITE_OMNIVS_2001:
-	case TRIPP_LITE_UNKNOWN:
+		case TRIPP_LITE_SMARTPRO:
+		case TRIPP_LITE_SMART_0004:
+		case TRIPP_LITE_SMART_3005:
+			return 1;
+		case TRIPP_LITE_OMNIVS:
+		case TRIPP_LITE_OMNIVS_2001:
+		case TRIPP_LITE_UNKNOWN:
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT)
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wcovered-switch-default"
 #endif
-	/* All enum cases defined as of the time of coding
-	 * have been covered above. Handle later definitions,
-	 * memory corruptions and buggy inputs below...
-	 */
-	default:
+		/* All enum cases defined as of the time of coding
+		 * have been covered above. Handle later definitions,
+		 * memory corruptions and buggy inputs below...
+		 */
+		default:
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT)
 # pragma GCC diagnostic pop
 #endif
-		return 0;
+			return 0;
 	}
 }
 
@@ -595,11 +595,11 @@ static void usb_comm_fail(int res, const char *msg)
  */
 static int send_cmd(const unsigned char *msg, size_t msg_len, unsigned char *reply, size_t reply_len)
 {
-	NUT_UNUSED_VARIABLE(reply_len);
 	unsigned char buffer_out[8];
 	unsigned char csum = 0;
 	int ret = 0, send_try, recv_try=0, done = 0;
 	size_t i = 0;
+	NUT_UNUSED_VARIABLE(reply_len);
 
 	upsdebugx(3, "send_cmd(msg_len=%u, type='%c')", (unsigned)msg_len, msg[0]);
 

--- a/drivers/tripplitesu.c
+++ b/drivers/tripplitesu.c
@@ -252,6 +252,7 @@ static ssize_t do_command(char type, const char *command, const char *parameters
 	upsdebugx(3, "do_command: %" PRIiSIZE " byted read [%s]", ret, buffer);
 
 	if (!strcmp(buffer, "~00D")) {
+		int	c;
 
 		ret = ser_get_buf_len(upsfd, (unsigned char *)buffer, 3, 3, 0);
 		if (ret < 0) {
@@ -266,7 +267,7 @@ static ssize_t do_command(char type, const char *command, const char *parameters
 		buffer[ret] = '\0';
 		upsdebugx(3, "do_command: %" PRIiSIZE " bytes read [%s]", ret, buffer);
 
-		int c = atoi(buffer);
+		c = atoi(buffer);
 		if (c < 0) {
 			upsdebugx(3, "do_command: response not expected to be a negative count!");
 			return -1;

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -527,13 +527,15 @@ static void set_reload_flag(const
 
 static void setup_signals(void)
 {
+#ifndef WIN32
+	struct sigaction	sa;
+#endif
+
 	set_exit_flag(0);
 	reset_signal_flag();
 
 #ifndef WIN32
 	/* Keep in sync with signal handling in drivers/main.c */
-	struct sigaction	sa;
-
 	sigemptyset(&sa.sa_mask);
 	sa.sa_flags = 0;
 	sa.sa_handler = set_exit_flag;

--- a/drivers/upsdrvquery.c
+++ b/drivers/upsdrvquery.c
@@ -187,6 +187,13 @@ void upsdrvquery_close(udq_pipe_conn_t *conn) {
 
 ssize_t upsdrvquery_read_timeout(udq_pipe_conn_t *conn, struct timeval tv) {
 	ssize_t	ret;
+#ifndef WIN32
+	fd_set	rfds;
+#else
+	DWORD	bytesRead = 0;
+	BOOL	res = FALSE;
+	struct timeval	start, now, presleep;
+#endif
 
 	if (!conn || INVALID_FD(conn->sockfd)) {
 		upslog_with_errno(LOG_ERR, "socket not initialized");
@@ -194,8 +201,6 @@ ssize_t upsdrvquery_read_timeout(udq_pipe_conn_t *conn, struct timeval tv) {
 	}
 
 #ifndef WIN32
-	fd_set	rfds;
-
 	FD_ZERO(&rfds);
 	FD_SET(conn->sockfd, &rfds);
 
@@ -217,9 +222,6 @@ ssize_t upsdrvquery_read_timeout(udq_pipe_conn_t *conn, struct timeval tv) {
 	upslog_with_errno(LOG_ERR, "Support for this platform is not currently implemented");
 	return -1;
 */
-	DWORD	bytesRead = 0;
-	BOOL	res = FALSE;
-	struct timeval	start, now, presleep;
 
 	/* Is GetLastError() required to move on if pipe has more data?
 	 *   if (GetLastError() == ERROR_IO_PENDING) {
@@ -321,6 +323,12 @@ ssize_t upsdrvquery_read_timeout(udq_pipe_conn_t *conn, struct timeval tv) {
 
 ssize_t upsdrvquery_write(udq_pipe_conn_t *conn, const char *buf) {
 	size_t	buflen = strlen(buf);
+#ifndef WIN32
+	int	ret;
+#else
+	DWORD	bytesWritten = 0;
+	BOOL	result = FALSE;
+#endif  /* WIN32 */
 
 	upsdebugx(5, "%s: write to driver socket: %s", __func__, buf);
 
@@ -330,7 +338,7 @@ ssize_t upsdrvquery_write(udq_pipe_conn_t *conn, const char *buf) {
 	}
 
 #ifndef WIN32
-	int ret = write(conn->sockfd, buf, buflen);
+	ret = write(conn->sockfd, buf, buflen);
 
 	if (ret < 0 || ret != (int)buflen) {
 		upslog_with_errno(LOG_ERR, "Write to socket %d failed", conn->sockfd);
@@ -339,9 +347,6 @@ ssize_t upsdrvquery_write(udq_pipe_conn_t *conn, const char *buf) {
 
 	return ret;
 #else
-	DWORD	bytesWritten = 0;
-	BOOL	result = FALSE;
-
 	result = WriteFile(conn->sockfd, buf, buflen, &bytesWritten, NULL);
 	if (result == 0 || bytesWritten != (DWORD)buflen) {
 		upslog_with_errno(LOG_ERR, "Write to handle %p failed", conn->sockfd);

--- a/server/netssl.c
+++ b/server/netssl.c
@@ -639,6 +639,9 @@ void ssl_init(void)
 ssize_t ssl_read(nut_ctype_t *client, char *buf, size_t buflen)
 {
 	ssize_t	ret = -1;
+#ifdef WITH_OPENSSL
+	int	iret;
+#endif
 
 	if (!client->ssl_connected) {
 		return -1;
@@ -651,7 +654,7 @@ ssize_t ssl_read(nut_ctype_t *client, char *buf, size_t buflen)
 	 * but smaller systems with 16-bits might be endangered :)
 	 */
 	assert(buflen <= INT_MAX);
-	int iret = SSL_read(client->ssl, buf, (int)buflen);
+	iret = SSL_read(client->ssl, buf, (int)buflen);
 	assert(iret <= SSIZE_MAX);
 	ret = (ssize_t)iret;
 #elif defined(WITH_NSS) /* WITH_OPENSSL */
@@ -672,6 +675,9 @@ ssize_t ssl_read(nut_ctype_t *client, char *buf, size_t buflen)
 ssize_t ssl_write(nut_ctype_t *client, const char *buf, size_t buflen)
 {
 	ssize_t	ret = -1;
+#ifdef WITH_OPENSSL
+	int	iret;
+#endif
 
 	if (!client->ssl_connected) {
 		return -1;
@@ -684,7 +690,7 @@ ssize_t ssl_write(nut_ctype_t *client, const char *buf, size_t buflen)
 	 * but smaller systems with 16-bits might be endangered :)
 	 */
 	assert(buflen <= INT_MAX);
-	int iret = SSL_write(client->ssl, buf, (int)buflen);
+	iret = SSL_write(client->ssl, buf, (int)buflen);
 	assert(iret <= SSIZE_MAX);
 	ret = (ssize_t)iret;
 #elif defined(WITH_NSS) /* WITH_OPENSSL */

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -995,6 +995,7 @@ static void poll_reload(void)
 {
 #ifndef WIN32
 	long	ret;
+	size_t	maxalloc;
 
 	ret = sysconf(_SC_OPEN_MAX);
 
@@ -1012,7 +1013,7 @@ static void poll_reload(void)
 	}
 
 	/* How many items can we stuff into the array? */
-	size_t maxalloc = SIZE_MAX / sizeof(void *);
+	maxalloc = SIZE_MAX / sizeof(void *);
 	if ((uintmax_t)maxalloc < (uintmax_t)maxconn) {
 		fatalx(EXIT_FAILURE,
 			"You requested %" PRIdMAX " as maximum number of connections, but we can only allocate %" PRIuSIZE ".\n"

--- a/tests/getvaluetest.c
+++ b/tests/getvaluetest.c
@@ -65,8 +65,6 @@ static void PrintBufAndData(uint8_t *buf, size_t bufSize, HIDData_t *pData) {
 }
 
 static int RunBuiltInTests(char *argv[]) {
-	NUT_UNUSED_VARIABLE(argv);
-
 	int exitStatus = 0;
 	size_t i;
 	char *next;
@@ -104,6 +102,14 @@ static int RunBuiltInTests(char *argv[]) {
 		{.buf = "16 0c 00 00 00", .Offset = 10, .Size = 1, .LogMin = 0, .LogMax = 1, .expectedValue =  0}
 	};
 
+	/* See comments below about rdlen calculation emulation for tests */
+	usb_ctrl_char	bufC[2];
+	signed char	bufS[2];
+	unsigned char	bufU[2];
+	int rdlen;
+
+	NUT_UNUSED_VARIABLE(argv);
+
 	for (i = 0; i < sizeof(testData)/sizeof(testData[0]); i++) {
 		next = testData[i].buf;
 		for (bufSize = 0; *next != 0; bufSize++) {
@@ -134,10 +140,6 @@ static int RunBuiltInTests(char *argv[]) {
 	 * from the protocol buffer, and build a platform
 	 * dependent representation of a two-byte word.
 	 */
-	usb_ctrl_char	bufC[2];
-	signed char	bufS[2];
-	unsigned char	bufU[2];
-	int rdlen;
 
 	/* Example from issue https://github.com/networkupstools/nut/issues/1261
 	 * where resulting length 0x01a9 should be "425" but ended up "-87" */

--- a/tests/nuttimetest.c
+++ b/tests/nuttimetest.c
@@ -28,7 +28,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-static int check_difftime()
+static int check_difftime(void)
 {
 	time_t tv1, tv2;
 	double d1, d2;
@@ -64,7 +64,7 @@ static int check_difftime()
 	return res;
 }
 
-static int check_difftimeval()
+static int check_difftimeval(void)
 {
 	struct timeval tv1, tv2;
 	double d1, d2;
@@ -101,7 +101,7 @@ static int check_difftimeval()
 	return res;
 }
 
-static int check_difftimespec()
+static int check_difftimespec(void)
 {
 	int res = 0;
 #if defined(HAVE_CLOCK_GETTIME) && defined(HAVE_CLOCK_MONOTONIC) && HAVE_CLOCK_GETTIME && HAVE_CLOCK_MONOTONIC

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -173,7 +173,7 @@ static void * run_eaton_serial(void *arg)
 
 #endif /* HAVE_PTHREAD */
 
-static void show_usage()
+static void show_usage(void)
 {
 /* NOTE: This code uses `nutscan_avail_*` global vars from nutscan-init.c */
 	puts("nut-scanner : utility for detection of available power devices.\n");
@@ -362,6 +362,11 @@ int main(int argc, char *argv[])
 	int quiet = 0; /* The debugging level for certain upsdebugx() progress messages; 0 = print always, quiet==1 is to require at least one -D */
 	void (*display_func)(nutscan_device_t * device);
 	int ret_code = EXIT_SUCCESS;
+#ifdef HAVE_PTHREAD
+# ifdef HAVE_SEMAPHORE
+	sem_t	*current_sem;
+# endif
+#endif
 #if (defined HAVE_PTHREAD) && ( (defined HAVE_PTHREAD_TRYJOIN) || (defined HAVE_SEMAPHORE) ) && (defined HAVE_SYS_RESOURCE_H)
 	struct rlimit nofile_limit;
 
@@ -694,7 +699,7 @@ display_help:
 	/* FIXME: Currently sem_init already done on nutscan-init for lib need.
 	   We need to destroy it before re-init. We currently can't change "sem value"
 	   on lib (need to be thread safe). */
-	sem_t *current_sem = nutscan_semaphore();
+	current_sem = nutscan_semaphore();
 	sem_destroy(current_sem);
 #ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
 #pragma GCC diagnostic push

--- a/tools/nut-scanner/nutscan-device.c
+++ b/tools/nut-scanner/nutscan-device.c
@@ -37,7 +37,7 @@ const char * nutscan_device_type_strings[TYPE_END - 1] = {
 	"serial",
 };
 
-nutscan_device_t * nutscan_new_device()
+nutscan_device_t * nutscan_new_device(void)
 {
 	nutscan_device_t * device;
 

--- a/tools/nut-scanner/nutscan-init.c
+++ b/tools/nut-scanner/nutscan-init.c
@@ -108,6 +108,8 @@ void do_upsconf_args(char *confupsname, char *var, char *val) {
 
 void nutscan_init(void)
 {
+	char *libname = NULL;
+
 #ifdef HAVE_PTHREAD
 /* TOTHINK: Should semaphores to limit thread count
  * and the more naive but portable methods be an
@@ -148,8 +150,6 @@ void nutscan_init(void)
 	pthread_mutex_init(&threadcount_mutex, NULL);
 # endif
 #endif	/* HAVE_PTHREAD */
-
-	char *libname = NULL;
 
 #ifdef WITH_USB
  #if WITH_LIBUSB_1_0

--- a/tools/nut-scanner/nutscan-ip.c
+++ b/tools/nut-scanner/nutscan-ip.c
@@ -322,9 +322,10 @@ int nutscan_cidr_to_ip(const char * cidr, char ** start_ip, char ** stop_ip)
 	/* Detecting IPv4 vs IPv6 */
 	if (getaddrinfo(first_ip, NULL, &hints, &res) != 0) {
 		/*Try IPv6 detection */
+		int ret;
+
 		ip.type = IPv6;
 		hints.ai_family = AF_INET6;
-		int ret;
 		if ((ret = getaddrinfo(first_ip, NULL, &hints, &res)) != 0) {
 			free(first_ip);
 			return 0;

--- a/tools/nut-scanner/scan_eaton_serial.c
+++ b/tools/nut-scanner/scan_eaton_serial.c
@@ -539,13 +539,14 @@ nutscan_device_t * nutscan_scan_eaton_serial(const char* ports_range)
 
 #ifdef HAVE_PTHREAD
 			if (pthread_create(&thread, NULL, nutscan_scan_eaton_serial_device, (void*)current_port_name) == 0) {
+				nutscan_thread_t	*new_thread_array;
 # ifdef HAVE_PTHREAD_TRYJOIN
 				pthread_mutex_lock(&threadcount_mutex);
 				curr_threads++;
 # endif /* HAVE_PTHREAD_TRYJOIN */
 
 				thread_count++;
-				nutscan_thread_t *new_thread_array = realloc(thread_array,
+				new_thread_array = realloc(thread_array,
 					thread_count * sizeof(nutscan_thread_t));
 				if (new_thread_array == NULL) {
 					upsdebugx(1, "%s: Failed to realloc thread array", __func__);

--- a/tools/nut-scanner/scan_nut.c
+++ b/tools/nut-scanner/scan_nut.c
@@ -440,13 +440,14 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 
 #ifdef HAVE_PTHREAD
 			if (pthread_create(&thread, NULL, list_nut_devices, (void*)nut_arg) == 0) {
+				nutscan_thread_t	*new_thread_array;
 # ifdef HAVE_PTHREAD_TRYJOIN
 				pthread_mutex_lock(&threadcount_mutex);
 				curr_threads++;
 # endif /* HAVE_PTHREAD_TRYJOIN */
 
 				thread_count++;
-				nutscan_thread_t *new_thread_array = realloc(thread_array,
+				new_thread_array = realloc(thread_array,
 					thread_count * sizeof(nutscan_thread_t));
 				if (new_thread_array == NULL) {
 					upsdebugx(1, "%s: Failed to realloc thread array", __func__);

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -567,6 +567,7 @@ static struct snmp_pdu * scan_snmp_get_oid(char* oid_str, void* handle)
 		return NULL;
 	}
 
+	upsdebugx(3, "%s: collected index: %i", __func__, index);
 	return response;
 }
 
@@ -1004,6 +1005,7 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
                                      useconds_t usec_timeout, nutscan_snmp_t * sec)
 {
 	bool_t pass = TRUE; /* Track that we may spawn a scanning thread */
+	nutscan_device_t * result;
 	nutscan_snmp_t * tmp_sec;
 	nutscan_ip_iter_t ip;
 	char * ip_str = NULL;
@@ -1166,13 +1168,14 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 
 #ifdef HAVE_PTHREAD
 			if (pthread_create(&thread, NULL, try_SysOID, (void*)tmp_sec) == 0) {
+				nutscan_thread_t	*new_thread_array;
 # ifdef HAVE_PTHREAD_TRYJOIN
 				pthread_mutex_lock(&threadcount_mutex);
 				curr_threads++;
 # endif /* HAVE_PTHREAD_TRYJOIN */
 
 				thread_count++;
-				nutscan_thread_t *new_thread_array = realloc(thread_array,
+				new_thread_array = realloc(thread_array,
 					thread_count * sizeof(nutscan_thread_t));
 				if (new_thread_array == NULL) {
 					upsdebugx(1, "%s: Failed to realloc thread array", __func__);
@@ -1281,7 +1284,7 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 # endif /* HAVE_SEMAPHORE */
 #endif /* HAVE_PTHREAD */
 
-	nutscan_device_t * result = nutscan_rewind_device(dev_ret);
+	result = nutscan_rewind_device(dev_ret);
 	dev_ret = NULL;
 	return result;
 }

--- a/tools/nut-scanner/scan_usb.c
+++ b/tools/nut-scanner/scan_usb.c
@@ -246,7 +246,7 @@ static char* is_usb_device_supported(usb_device_id_t *usb_device_id_list,
 }
 
 /* return NULL if error */
-nutscan_device_t * nutscan_scan_usb()
+nutscan_device_t * nutscan_scan_usb(void)
 {
 	int ret;
 	char string[256];
@@ -289,6 +289,9 @@ nutscan_device_t * nutscan_scan_usb()
 	 * available in libusb (and hoping the OS and HW honour it).
 	 */
 	char *bus_port = NULL;
+	ssize_t devcount = 0;
+	struct libusb_device_descriptor dev_desc;
+	int i;
 #else  /* => WITH_LIBUSB_0_1 */
 	struct usb_device *dev;
 	struct usb_bus *bus;
@@ -316,10 +319,6 @@ nutscan_device_t * nutscan_scan_usb()
 #endif /* WITH_LIBUSB_1_0 */
 
 #if WITH_LIBUSB_1_0
-	ssize_t devcount = 0;
-	struct libusb_device_descriptor dev_desc;
-	int i;
-
 	devcount = (*nut_usb_get_device_list)(NULL, &devlist);
 	if (devcount <= 0) {
 		(*nut_usb_exit)(NULL);
@@ -624,7 +623,7 @@ nutscan_device_t * nutscan_scan_usb()
 #else /* not WITH_USB */
 
 /* stub function */
-nutscan_device_t * nutscan_scan_usb()
+nutscan_device_t * nutscan_scan_usb(void)
 {
 	return NULL;
 }


### PR DESCRIPTION
Surprised that so many of these were not found sooner. Almost all fall into a few simple categories:
* method(void) declared without a "void"
* declarations after code
    * NUT_UNUSED_VARIABLE() is code
    * scoping in switch() cases
* a few smartly detected unused variables => added reasonable use-cases (logging or better)
