### PR TITLE
Enhance USB device and subdriver matching in `usbhid-ups` to be on par with `nutdrv_qx`

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -152,6 +152,11 @@ as part of https://github.com/networkupstools/nut/issues/1410 solution.
    * extended default ranges for max battery voltage when guessing [#1279]
 
  - usbhid-ups updates:
+   * added support for `subdriver` configuration option, to select the
+     USB HID subdriver for the device manually where automatic match
+     does not suffice (e.g. new devices for which no `vendorid`/`productid`
+     pair was built into any driver, or for different-capability devices
+     with same interface chips, notably "phoenixtec/liebert" and "mge") [#1369]
    * cps-hid subdriver now applies same report descriptor fixing logic to
      devices with ProductID 0x0601 as done earlier for 0x0501, to get the
      correct output voltage data [#1497]

--- a/clients/Makefile.am
+++ b/clients/Makefile.am
@@ -12,8 +12,9 @@ $(top_builddir)/common/libcommonclient.la \
 $(top_builddir)/common/libparseconf.la: dummy
 	@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
-# by default, link programs in this directory with libcommon.a
-LDADD = $(top_builddir)/common/libcommon.la libupsclient.la $(NETLIBS)
+# by default, link programs in this directory with
+# the more compact libcommonclient.a bundle
+LDADD = $(top_builddir)/common/libcommonclient.la libupsclient.la $(NETLIBS)
 if WITH_SSL
   LDADD += $(LIBSSL_LIBS)
 endif

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -76,6 +76,14 @@ libcommonclient_la_LIBADD = libparseconf.la @LTLIBOBJS@ @NETLIBS@
 libcommon_la_CFLAGS = $(AM_CFLAGS)
 libcommonclient_la_CFLAGS = $(AM_CFLAGS)
 
+if HAVE_LIBREGEX
+  libcommon_la_CFLAGS += $(LIBREGEX_CFLAGS)
+  libcommon_la_LIBADD += $(LIBREGEX_LIBS)
+
+  libcommonclient_la_CFLAGS += $(LIBREGEX_CFLAGS)
+  libcommonclient_la_LIBADD += $(LIBREGEX_LIBS)
+endif
+
 # Did the user request, and build env support, tighter integration with
 # libsystemd methods such as sd_notify()?
 if WITH_LIBSYSTEMD

--- a/configure.ac
+++ b/configure.ac
@@ -4073,6 +4073,14 @@ dnl # -Wno-padded -- NSPR and NSS headers get to issue lots of that
 dnl # -Wno-c++98-compat-pedantic -Wno-c++98-compat -- our C++ code uses nullptr
 dnl #    as requested by newer linters, and C++98 does not. We require C++11
 dnl #    or newer anyway, and skip building C++ library and test otherwise.
+dnl # -Wno-fuse-ld-path -- not much in our control what recipes the autotools
+dnl #    on the build host generate... this tries to avoid failures due to:
+dnl #      clang-13: error: '-fuse-ld=' taking a path is deprecated.
+dnl #      Use '--ld-path=' instead [-Werror,-Wfuse-ld-path]
+dnl # -Wno-unsafe-buffer-usage -- clang-16 introduced a check too smart for
+dnl #    its own good. It detects use of pointer aritmetics as arrays are
+dnl #    walked, which is indeed potentially dangerous. And also is nearly
+dnl #    unavoidable in C (at least not without major rewrites of the world).
 dnl ### Special exclusion picks for clang-medium (same as hard, plus...):
 dnl # -Wno-float-conversion -Wno-double-promotion -Wno-implicit-float-conversion
 dnl #    -- reduce noise due to floating-point literals like "3.14" being a C
@@ -4103,12 +4111,12 @@ AS_CASE(["${nut_enable_warnings}"],
         CXXFLAGS="${CXXFLAGS} -Wall"
         ],
     [clang-hard], [
-        CFLAGS="${CFLAGS} -ferror-limit=0 -Wno-system-headers -Wall -Wextra -Weverything -Wno-disabled-macro-expansion -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -Wno-documentation -Wno-cast-qual -pedantic"
-        CXXFLAGS="${CXXFLAGS} -ferror-limit=0 -Wno-system-headers -Wall -Wextra -Weverything -Wno-disabled-macro-expansion -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -Wno-documentation -Wno-cast-qual -Wno-c++98-compat-pedantic -Wno-c++98-compat"
+        CFLAGS="${CFLAGS} -ferror-limit=0 -Wno-system-headers -Wall -Wextra -Weverything -Wno-disabled-macro-expansion -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -Wno-documentation -Wno-cast-qual -pedantic -Wno-fuse-ld-path -Wno-unsafe-buffer-usage"
+        CXXFLAGS="${CXXFLAGS} -ferror-limit=0 -Wno-system-headers -Wall -Wextra -Weverything -Wno-disabled-macro-expansion -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -Wno-documentation -Wno-cast-qual -Wno-c++98-compat-pedantic -Wno-c++98-compat -Wno-fuse-ld-path -Wno-unsafe-buffer-usage"
         ],
     [clang-medium], [
-        CFLAGS="${CFLAGS} -ferror-limit=0 -Wno-system-headers -Wall -Wextra -Weverything -Wno-disabled-macro-expansion -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -Wno-documentation -Wno-cast-qual -pedantic -Wno-float-conversion -Wno-double-promotion -Wno-implicit-float-conversion -Wno-conversion -Wno-incompatible-pointer-types-discards-qualifiers"
-        CXXFLAGS="${CXXFLAGS} -ferror-limit=0 -Wno-system-headers -Wall -Wextra -Weverything -Wno-disabled-macro-expansion -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -Wno-documentation -Wno-cast-qual -Wno-c++98-compat-pedantic -Wno-c++98-compat"
+        CFLAGS="${CFLAGS} -ferror-limit=0 -Wno-system-headers -Wall -Wextra -Weverything -Wno-disabled-macro-expansion -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -Wno-documentation -Wno-cast-qual -pedantic -Wno-fuse-ld-path -Wno-unsafe-buffer-usage -Wno-float-conversion -Wno-double-promotion -Wno-implicit-float-conversion -Wno-conversion -Wno-incompatible-pointer-types-discards-qualifiers"
+        CXXFLAGS="${CXXFLAGS} -ferror-limit=0 -Wno-system-headers -Wall -Wextra -Weverything -Wno-disabled-macro-expansion -Wno-unused-macros -Wno-reserved-id-macro -Wno-padded -Wno-documentation -Wno-cast-qual -Wno-c++98-compat-pedantic -Wno-c++98-compat -Wno-fuse-ld-path -Wno-unsafe-buffer-usage"
         ],
     [clang-minimal], [
         CFLAGS="${CFLAGS} -ferror-limit=0 -Wall -Wextra -Wno-documentation"

--- a/configure.ac
+++ b/configure.ac
@@ -193,13 +193,17 @@ if test ! -d "${auglensdir}"; then
    fi
 fi
 
-LIBREGEX_LIBS=''
+dnl ### NUT_CHECK_LIBREGEX ### Detect below as part of libusb etc.
+dnl ### LIBREGEX_LIBS=''
 dnl Disable Hotplug, DevD and udev support on Windows
 dnl (useful when cross-compiling)
 case "${target_os}" in
     *mingw* )
-        dnl TODO: Actually detect it? See also nut_check_libusb.m4 for same.
-        LIBREGEX_LIBS='-lregex'
+        dnl TODO: Actually detect it? See also nut_check_libregex.m4 for same.
+        dnl Here we assumed from practice that it is available...
+        dnl ### if test x"${LIBREGEX_LIBS}" = x ; then
+        dnl ###     LIBREGEX_LIBS='-lregex'
+        dnl ### fi
         hotplugdir=''
         udevdir=''
         devddir=''
@@ -1522,6 +1526,7 @@ dnl These checks are performed unconditionally, even if the corresponding
 dnl --with-* options are not given. This is because we cannot predict
 dnl what will be in the --with-drivers argument.
 
+NUT_CHECK_LIBREGEX
 NUT_ARG_WITH([usb], [build and install USB drivers, optionally require build with specified version of libusb library and API: (auto|libusb-0.1|libusb-1.0)], [auto])
 nut_usb_lib=""
 NUT_CHECK_LIBUSB

--- a/docs/man/nutdrv_qx.txt
+++ b/docs/man/nutdrv_qx.txt
@@ -348,7 +348,12 @@ include::nut_usb_addvars.txt[]
 *subdriver =* 'string'::
 Select a serial-over-USB subdriver to use.
 You have a choice between *cypress*, *fabula*, *fuji*, *hunnox*, *ippon*, *krauler*, *phoenix*, *phoenixtec*, *sgs*, *snr*,  *armac* and *ablerex*.
-When using this option, it is mandatory to also specify the *vendorid* and *productid*.
++
+Run the driver program with the `--help` option to see the exact list of
+`subdriver` values it would currently recognize.
++
+NOTE: When using this option, it is mandatory to also specify the *vendorid*
+and *productid* matching parameters.
 
 *langid_fix =* 'value'::
 Apply the language ID workaround to the *krauler* subdriver.

--- a/docs/man/nutdrv_qx.txt
+++ b/docs/man/nutdrv_qx.txt
@@ -64,6 +64,9 @@ If you set stayoff in linkman:ups.conf[5] when FSD arises the UPS will call a *s
 Skip autodetection of the protocol to use and only use the one specified.
 Supported values: 'bestups', 'hunnox', 'masterguard', 'mecer', 'megatec', 'megatec/old', 'mustek', 'q1', 'voltronic', 'voltronic-qs', 'voltronic-qs-hex' and 'zinto'.
 +
+Run the driver program with the `--help` option to see the exact list of
+`protocol` values it would currently recognize.
++
 Note that if you end up using the 'q1' protocol, you may want to give a try to the 'mecer', 'megatec' and 'zinto' ones setting the <<old-blazer-protocols-options,*novendor*/*norating* flags>> (only one, or both).
 
 *pollfreq =* 'num'::

--- a/docs/man/usbhid-ups.txt
+++ b/docs/man/usbhid-ups.txt
@@ -61,6 +61,9 @@ by device attributes alone does not suffice (e.g. new devices for which no
 support is anticipated, or for different-capability devices with same
 interface chips, notably "phoenixtec/liebert" and "mge").
 +
+Run the driver program with the `--help` option to see the exact list of
+`subdriver` values it would currently recognize.
++
 NOTE: this option first checks for exact matches to subdriver identification
 strings, such as `"TrippLite HID 0.85"` (which are prone to bit-rot), and if
 there was no exact match -- retries with a case-insensitive extended regular

--- a/docs/man/usbhid-ups.txt
+++ b/docs/man/usbhid-ups.txt
@@ -54,6 +54,18 @@ This driver also supports the following optional settings:
 
 include::nut_usb_addvars.txt[]
 
+*subdriver*='regex'::
+Select the USB HID subdriver for the device manually, where automatic match
+by device attributes alone does not suffice (e.g. new devices for which no
+`vendorid`/`productid` pair was built into any driver -- but common USB HID
+support is anticipated, or for different-capability devices with same
+interface chips, notably "phoenixtec/liebert" and "mge").
++
+NOTE: this option first checks for exact matches to subdriver identification
+strings, such as `"TrippLite HID 0.85"` (which are prone to bit-rot), and if
+there was no exact match -- retries with a case-insensitive extended regular
+expression.
+
 *offdelay*='num'::
 Set the timer before the UPS is turned off after the kill power command is
 sent (via the *-k* switch).

--- a/docs/man/usbhid-ups.txt
+++ b/docs/man/usbhid-ups.txt
@@ -65,6 +65,9 @@ NOTE: this option first checks for exact matches to subdriver identification
 strings, such as `"TrippLite HID 0.85"` (which are prone to bit-rot), and if
 there was no exact match -- retries with a case-insensitive extended regular
 expression.
++
+NOTE: When using this option, it is mandatory to also specify the *vendorid*
+and *productid* matching parameters.
 
 *offdelay*='num'::
 Set the timer before the UPS is turned off after the kill power command is

--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -124,6 +124,7 @@ upsdrvctl_LDADD = $(LDADD_COMMON) libdummy_upsdrvquery.la
 # serial drivers: all of them use standard LDADD and CFLAGS
 al175_SOURCES = al175.c
 apcsmart_SOURCES = apcsmart.c apcsmart_tabs.c
+apcsmart_CFLAGS = $(LIBREGEX_CFLAGS)
 apcsmart_LDADD = $(LDADD) $(LIBREGEX_LIBS)
 apcsmart_old_SOURCES = apcsmart-old.c
 bcmxcp_SOURCES = bcmxcp.c bcmxcp_ser.c

--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -38,6 +38,9 @@ endif
 if WITH_MODBUS
   AM_CFLAGS += $(LIBMODBUS_CFLAGS)
 endif
+if HAVE_LIBREGEX
+  AM_CFLAGS += $(LIBREGEX_CFLAGS)
+endif
 
 NUTSW_DRIVERLIST = dummy-ups clone clone-outlet apcupsd-ups skel
 SERIAL_DRIVERLIST = al175 bcmxcp belkin belkinunv bestfcom	\
@@ -124,7 +127,6 @@ upsdrvctl_LDADD = $(LDADD_COMMON) libdummy_upsdrvquery.la
 # serial drivers: all of them use standard LDADD and CFLAGS
 al175_SOURCES = al175.c
 apcsmart_SOURCES = apcsmart.c apcsmart_tabs.c
-apcsmart_CFLAGS = $(LIBREGEX_CFLAGS)
 apcsmart_LDADD = $(LDADD) $(LIBREGEX_LIBS)
 apcsmart_old_SOURCES = apcsmart-old.c
 bcmxcp_SOURCES = bcmxcp.c bcmxcp_ser.c

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -39,6 +39,7 @@
  */
 
 #include "config.h"
+#include <ctype.h>
 #include "main.h"
 #include "attribute.h"
 #include "nut_float.h"
@@ -2771,20 +2772,45 @@ void	upsdrv_shutdown(void)
 
 void	upsdrv_help(void)
 {
-#ifdef QX_USB
-	#ifndef TESTING
+#ifndef TESTING
 	size_t i;
 
+# ifdef QX_USB
+	/* Subdrivers have special SOMETHING_command() handling and
+	 * are listed in usbsubdriver[] array (just above in this
+	 * source file).
+	 */
 	printf("\nAcceptable values for 'subdriver' via -x or ups.conf in this driver: ");
-
 	for (i = 0; usbsubdriver[i].name != NULL; i++) {
 		if (i>0)
 			printf(", ");
 		printf("%s", usbsubdriver[i].name);
 	}
 	printf("\n\n");
-	#endif
-#endif
+# endif	/* QX_USB*/
+
+	/* Protocols are the first token from "name" field in
+	 * subdriver_t instances in files like nutdrv_qx_mecer.c
+	 */
+	printf("\nAcceptable values for 'protocol' via -x or ups.conf in this driver: ");
+	for (i = 0; subdriver_list[i] != NULL; i++) {
+		char	subdrv_name[SMALLBUF], *p;
+
+		/* Get rid of subdriver version */
+		snprintf(subdrv_name, sizeof(subdrv_name), "%.*s",
+			(int)strcspn(subdriver_list[i]->name, " "),
+			subdriver_list[i]->name);
+
+		/* lowercase the (ASCII) string */
+		for (p = subdrv_name; *p; ++p)
+			*p = tolower(*p);
+
+		if (i>0)
+			printf(", ");
+		printf("%s", subdrv_name);
+	}
+	printf("\n\n");
+#endif	/* TESTING */
 
 	printf("Read The Fine Manual ('man 8 nutdrv_qx')\n");
 }

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -893,7 +893,19 @@ void upsdrv_shutdown(void)
 
 void upsdrv_help(void)
 {
-	/* FIXME: to be completed */
+	size_t i;
+	printf("\nAcceptable values for 'subdriver' via -x or ups.conf "
+		"in this driver (exact names here, case-insensitive "
+		"sub-strings may be used, as well as regular expressions): ");
+
+	for (i = 0; subdriver_list[i] != NULL; i++) {
+		if (i>0)
+			printf(", ");
+		printf("\"%s\"", subdriver_list[i]->name);
+	}
+	printf("\n\n");
+
+	printf("Read The Fine Manual ('man 8 usbhid-ups')\n");
 }
 
 void upsdrv_makevartable(void)

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -534,6 +534,7 @@ info_lkp_t kelvin_celsius_conversion[] = {
 
 static subdriver_t *match_function_subdriver_name(int fatal_mismatch) {
 	char	*subdrv = getval("subdriver");
+	subdriver_t	*info = NULL;
 
 	/* Pick up the subdriver name if set explicitly */
 	if (subdrv) {
@@ -556,7 +557,8 @@ static subdriver_t *match_function_subdriver_name(int fatal_mismatch) {
 		 */
 		for (i=0; subdriver_list[i] != NULL; i++) {
 			if (strcmp_null(subdrv, subdriver_list[i]->name) == 0) {
-				return subdriver_list[i];
+				info = subdriver_list[i];
+				goto found;
 			}
 		}
 
@@ -570,7 +572,8 @@ static subdriver_t *match_function_subdriver_name(int fatal_mismatch) {
 				res = match_regex(regex_ptr, subdriver_list[i]->name);
 				if (res == 1) {
 					free(regex_ptr);
-					return subdriver_list[i];
+					info = subdriver_list[i];
+					goto found;
 				}
 			}
 		}
@@ -596,7 +599,8 @@ static subdriver_t *match_function_subdriver_name(int fatal_mismatch) {
 					res = match_regex(regex_ptr, subdriver_list[i]->name);
 					if (res == 1) {
 						free(regex_ptr);
-						return subdriver_list[i];
+						info = subdriver_list[i];
+						goto found;
 					}
 				}
 			}
@@ -624,6 +628,10 @@ static subdriver_t *match_function_subdriver_name(int fatal_mismatch) {
 	/* No match (and non-fatal mismatch mode), or no
 	 * "subdriver" was specified in configuration */
 	return NULL;
+
+found:
+	upsdebugx(2, "%s: found a match: %s", __func__, info->name);
+	return info;
 }
 
 /*!

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -631,6 +631,20 @@ static subdriver_t *match_function_subdriver_name(int fatal_mismatch) {
 
 found:
 	upsdebugx(2, "%s: found a match: %s", __func__, info->name);
+	if (!getval("vendorid") || !getval("productid")) {
+		if (fatal_mismatch) {
+			fatalx(EXIT_FAILURE,
+				"When specifying a subdriver, "
+				"'vendorid' and 'productid' "
+				"are mandatory.");
+		} else {
+			upslogx(LOG_WARNING,
+				"When specifying a subdriver, "
+				"'vendorid' and 'productid' "
+				"are highly recommended.");
+		}
+	}
+
 	return info;
 }
 

--- a/include/common.h
+++ b/include/common.h
@@ -85,6 +85,10 @@
 #include "proto.h"
 #include "str.h"
 
+#if (defined HAVE_LIBREGEX && HAVE_LIBREGEX)
+# include <regex.h>
+#endif
+
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 extern "C" {
@@ -337,6 +341,42 @@ void *xmalloc(size_t size);
 void *xcalloc(size_t number, size_t size);
 void *xrealloc(void *ptr, size_t size);
 char *xstrdup(const char *string);
+
+/**** REGEX helper methods ****/
+
+/* helper function: version of strcmp that tolerates NULL
+ * pointers. NULL is considered to come before all other strings
+ * alphabetically.
+ */
+int strcmp_null(const char *s1, const char *s2);
+
+#if (defined HAVE_LIBREGEX && HAVE_LIBREGEX)
+/* Helper function for compiling a regular expression. On success,
+ * store the compiled regular expression (or NULL) in *compiled, and
+ * return 0. On error with errno set, return -1. If the supplied
+ * regular expression is unparseable, return -2 (an error message can
+ * then be retrieved with regerror(3)). Note that *compiled will be an
+ * allocated value, and must be freed with regfree(), then free(), see
+ * regex(3). As a special case, if regex==NULL, then set
+ * *compiled=NULL (regular expression NULL is intended to match
+ * anything).
+ */
+int compile_regex(regex_t **compiled, const char *regex, const int cflags);
+
+/* Helper function for regular expression matching. Check if the
+ * entire string str (minus any initial and trailing whitespace)
+ * matches the compiled regular expression preg. Return 1 if it
+ * matches, 0 if not. Return -1 on error with errno set. Special
+ * cases: if preg==NULL, it matches everything (no contraint).  If
+ * str==NULL, then it is treated as "".
+ */
+int match_regex(const regex_t *preg, const char *str);
+
+/* Helper function, similar to match_regex, but the argument being
+ * matched is a (hexadecimal) number, rather than a string. It is
+ * converted to a 4-digit hexadecimal string. */
+int match_regex_hex(const regex_t *preg, const int n);
+#endif	/* HAVE_LIBREGEX */
 
 /* Note: different method signatures instead of TYPE_FD_SER due to "const" */
 #ifndef WIN32

--- a/m4/nut_check_libregex.m4
+++ b/m4/nut_check_libregex.m4
@@ -71,6 +71,8 @@ if test -z "${nut_have_libregex_seen}"; then
 
 	AC_SEARCH_LIBS([regcomp, regexec], [], [nut_have_regex=yes], [
 		AS_IF([test x"$LIBS" = x], [
+			dnl Avoid using cached reply for the absent library name
+			unset ac_cv_search_regcomp__regexec || true
 			AC_SEARCH_LIBS([regcomp, regexec], [regex], [
 				LIBS="-lregex"
 				nut_have_regex=yes

--- a/m4/nut_check_libregex.m4
+++ b/m4/nut_check_libregex.m4
@@ -1,0 +1,100 @@
+dnl Check for LIBREGEX (and, if found, fill 'nut_usb_lib' with its
+dnl approximate version) and its compiler flags. On success, set
+dnl nut_have_libusb="yes" and set LIBREGEX_CFLAGS and LIBREGEX_LIBS. On failure, set
+dnl nut_have_libusb="no". This macro can be run multiple times, but will
+dnl do the checking only once.
+
+AC_DEFUN([NUT_CHECK_LIBREGEX],
+[
+if test -z "${nut_have_libregex_seen}"; then
+	nut_have_libregex_seen=yes
+	NUT_CHECK_PKGCONFIG
+
+	dnl save CFLAGS and LIBS
+	CFLAGS_ORIG="${CFLAGS}"
+	LIBS_ORIG="${LIBS}"
+	CFLAGS=""
+	LIBS=""
+
+	dnl Actually did not see it in any systems' pkg-config info...
+	dnl Part of standard footprint?
+	LIBREGEX_MODULE=""
+	AS_IF([test x"$have_PKG_CONFIG" = xyes],
+		[AC_MSG_CHECKING(for libregex version via pkg-config)
+		 LIBREGEX_VERSION="`$PKG_CONFIG --silence-errors --modversion regex 2>/dev/null`"
+		 if test "$?" != "0" -o -z "${LIBREGEX_VERSION}"; then
+		    LIBREGEX_VERSION="`$PKG_CONFIG --silence-errors --modversion libregex 2>/dev/null`"
+		    if test "$?" != "0" -o -z "${LIBREGEX_VERSION}"; then
+		        LIBREGEX_VERSION="none"
+		    else
+		        LIBREGEX_MODULE="libregex"
+		    fi
+		 else
+		    LIBREGEX_MODULE="regex"
+		 fi
+		 AC_MSG_RESULT(${LIBREGEX_VERSION} found)
+		],
+		[LIBREGEX_VERSION="none"
+			 AC_MSG_NOTICE([can not check libregex settings via pkg-config])
+		]
+	)
+
+	AS_IF([test x"$LIBREGEX_VERSION" != xnone && test x"$LIBREGEX_MODULE" != x],
+		[CFLAGS="`$PKG_CONFIG --silence-errors --cflags "${LIBREGEX_MODULE}" 2>/dev/null`"
+		 LIBS="`$PKG_CONFIG --silence-errors --libs "${LIBREGEX_MODULE}" 2>/dev/null`"
+		 REQUIRES="${LIBREGEX_MODULE}"
+		],
+		[CFLAGS=""
+		 LIBS=""
+		 REQUIRES=""
+		]
+	)
+
+	dnl Check if libregex is usable
+	AC_LANG_PUSH([C])
+	dnl # With USB we can match desired devices by regex
+	dnl # (and currently have no other use for the library);
+	dnl # however we may have some general regex helper
+	dnl # methods built into libcommon (may become useful
+	dnl # elsewhere) - so need to know if we may and should.
+	dnl # Maybe already involved in NUT for Windows builds...
+	nut_have_regex=no
+	AC_CHECK_HEADER([regex.h],
+		[nut_have_regex=yes
+		 AC_DEFINE([HAVE_REGEX_H], [1],
+			[Define to 1 if you have <regex.h>.])])
+	AC_CHECK_DECLS([regexec, regcomp], [nut_have_regex=yes], [],
+[#ifdef HAVE_REGEX_H
+# include <regex.h>
+#endif
+])
+
+	AC_SEARCH_LIBS([regcomp, regexec], [], [nut_have_regex=yes], [
+		AS_IF([test x"$LIBS" = x], [
+			AC_SEARCH_LIBS([regcomp, regexec], [regex], [
+				LIBS="-lregex"
+				nut_have_regex=yes
+			])
+		])
+	])
+
+	AS_IF([test x"${nut_have_regex}" = xyes], [
+		LIBREGEX_CFLAGS="${CFLAGS}"
+		LIBREGEX_LIBS="${LIBS}"
+		AC_DEFINE(HAVE_LIBREGEX, 1,
+			[Define to 1 for build where we can support general regex matching.])
+		], [
+		LIBREGEX_CFLAGS=""
+		LIBREGEX_LIBS=""
+		AC_DEFINE(HAVE_LIBREGEX, 0,
+			[Define to 1 for build where we can support general regex matching.])
+		])
+	AM_CONDITIONAL(HAVE_LIBREGEX, test x"${nut_have_regex}" = xyes)
+
+	AC_LANG_POP([C])
+
+	dnl restore original CFLAGS and LIBS
+	CFLAGS="${CFLAGS_ORIG}"
+	LIBS="${LIBS_ORIG}"
+fi
+])

--- a/m4/nut_check_libusb.m4
+++ b/m4/nut_check_libusb.m4
@@ -14,6 +14,9 @@ if test -z "${nut_have_libusb_seen}"; then
 	nut_have_libusb_seen=yes
 	NUT_CHECK_PKGCONFIG
 
+	dnl Our USB matching relies on regex abilities
+	NUT_CHECK_LIBREGEX
+
 	dnl save CFLAGS and LIBS
 	CFLAGS_ORIG="${CFLAGS}"
 	LIBS_ORIG="${LIBS}"
@@ -325,10 +328,6 @@ if test -z "${nut_have_libusb_seen}"; then
 		dnl DEFINE WITH_USB_BUSPORT
 		dnl #endif
 		AC_CHECK_FUNCS(libusb_get_port_number, [nut_with_usb_busport=yes])
-
-		dnl # With USB we can match desired devices by regex;
-		dnl # and currently have no other use for the library:
-		AC_SEARCH_LIBS(regcomp, regex)
 	])
 	AC_LANG_POP([C])
 

--- a/tools/nut-scanner/nutscan-display.c
+++ b/tools/nut-scanner/nutscan-display.c
@@ -324,9 +324,9 @@ next:
 				j, entry->key[0], entry->key[0], entry->val);
 		}
 
-		/* Duplicates (maybe same device, maybe not) */
+		/* Duplicates (maybe same device, maybe not) - see if val has a ',' */
 		for (j = 0; entry->val[j] != '\0' && entry->val[j] != ','; j++);
-		if (j > 0 && entry->key[j] != '\0') {
+		if (j > 0 && entry->val[j] != '\0') {
 			printf("\n# WARNING: same \"serial\" value \"%s\" "
 				"reported in several device configurations "
 				"(maybe okay if multiple drivers for same device, "

--- a/tools/nut-scanner/nutscan-display.c
+++ b/tools/nut-scanner/nutscan-display.c
@@ -294,7 +294,7 @@ next:
 		goto exit;
 	}
 
-	/* Now look for red flags in the map */
+	/* Now look for red flags in the map (key=sernum, val=device(s)) */
 	/* FIXME: Weed out special chars to avoid breaking comment-line markup?
 	 * Thinking of ASCII control codes < 32 including CR/LF, and codes 128+... */
 	for (i = 0; i < count; i++) {
@@ -306,6 +306,13 @@ next:
 			printf("\n# WARNING: %s \"serial\" reported in some devices: %s\n",
 				entry->key, entry->val);
 			continue;
+		}
+
+		j = strlen(entry->key);
+		if (j > 0 && (entry->key[j-1] == '\t' || entry->key[j-1] == ' ')) {
+			printf("\n# WARNING: trailing blank space in \"serial\" "
+				"value \"%s\" reported in device configuration(s): %s",
+				entry->key, entry->val);
 		}
 
 		/* All chars in "serial" are same (zero, space, etc.) */

--- a/tools/nut-scanner/nutscan-display.c
+++ b/tools/nut-scanner/nutscan-display.c
@@ -322,7 +322,6 @@ next:
 				"with %" PRIuSIZE " copies of '%c' (0x%02X) "
 				"reported in some devices: %s\n",
 				j, entry->key[0], entry->key[0], entry->val);
-			continue;
 		}
 
 		/* Duplicates (maybe same device, maybe not) */
@@ -334,7 +333,6 @@ next:
 				"likely a vendor bug if reported by same driver "
 				"for many devices): %s\n",
 				entry->key, entry->val);
-			continue;
 		}
 	}
 


### PR DESCRIPTION
Closes: #1369

By side effect, moves detection of libregex build parameters (if any are needed) into a separate m4 script, and creates automake and C macros to shield about their presence. Generic regex helper methods (not intimate to USB) moved to common.c/h. Also, found that `clients/*` were built by default with `libcommon.la` (not `libcommonclient.la`) and pulled extra dependencies like `-lsystemd` that (most of) the clients should not care about - also addressed.

Example testing outcome: this change allows poking an Eaton device with a "not-its" (Tripplite) subdriver, even getting a bit of info as seen below.

Unlike `nutdrv_qx`, for the iteration shown below I did not constrain this feature to require at least a specified `vendorid` and `productid` in configuration, but makes sense to add it. As seen in the "screenshot", the driver opened the first device it had FS-level permission to access.

````
# Full built-in name:
:; ./drivers/usbhid-ups -DD -s test -x port=auto -x subdriver='TrippLite HID 0.85' -d1
...
   0.002171     [D2] Checking device 4 of 9 (1D6B/0003)
   0.002175     [D1] Failed to open device (1D6B/0003), skipping: Access denied (insufficient permissions)
   0.002177     [D2] Checking device 5 of 9 (0463/FFFF)
   0.424708     [D2] - VendorID: 0463
   0.424724     [D2] - ProductID: ffff
   0.424730     [D2] - Manufacturer: EATON
   0.424734     [D2] - Product: Ellipse ECO
   0.424739     [D2] - Serial Number: 000000000
   0.424750     [D2] - Bus: 003
   0.424756     [D2] - Bus Port: 002
   0.424761     [D2] - Device: 007
   0.424764     [D2] - Device release number: 0100
   0.424768     [D2] Trying to match device
   0.424773     [D2] match_function_subdriver_name: matching a subdriver by explicit name/regex: 'TrippLite HID 0.85'...
   0.424779     [D2] match_function_subdriver_name: found a match: TrippLite HID 0.85
   0.424783     [D2] Device matches
   0.424787     [D2] Reading first configuration descriptor
   0.424810     [D2] Claimed interface 0 successfully
...
````

Similarly by substring regex which is a more likely use-case:
````
:; ./drivers/usbhid-ups -DD -s test -x port=auto -x subdriver='tripplite' -d1
...
   0.003256     [D2] Checking device 4 of 9 (1D6B/0003)
   0.003261     [D1] Failed to open device (1D6B/0003), skipping: Access denied (insufficient permissions)
   0.003264     [D2] Checking device 5 of 9 (0463/FFFF)
   0.424078     [D2] - VendorID: 0463
   0.424092     [D2] - ProductID: ffff
   0.424097     [D2] - Manufacturer: EATON
   0.424100     [D2] - Product: Ellipse ECO
   0.424103     [D2] - Serial Number: 000000000
   0.424107     [D2] - Bus: 003
   0.424111     [D2] - Bus Port: 002
   0.424115     [D2] - Device: 007
   0.424119     [D2] - Device release number: 0100
   0.424122     [D2] Trying to match device
   0.424127     [D2] match_function_subdriver_name: matching a subdriver by explicit name/regex: 'tripplite'...
   0.424138     [D2] match_function_subdriver_name: retry matching by regex 'as is'
   0.424228     [D2] match_function_subdriver_name: retry matching by regex with added '.*'
   0.424259     [D2] match_function_subdriver_name: found a match: TrippLite HID 0.85
   0.424263     [D2] Device matches
   0.424266     [D2] Reading first configuration descriptor
   0.424302     [D2] Claimed interface 0 successfully
   0.491079     [D2] Retrieved HID descriptor (expected 9, got 9)
   0.491091     [D2] HID descriptor length 909
   3.661073     [D2] Report Descriptor size = 909
   3.661117     [D2] match_function_subdriver_name: matching a subdriver by explicit name/regex: 'tripplite'...
   3.661122     [D2] match_function_subdriver_name: retry matching by regex 'as is'
   3.661156     [D2] match_function_subdriver_name: retry matching by regex with added '.*'
   3.661170     [D2] match_function_subdriver_name: found a match: TrippLite HID 0.85
   3.661172     Using subdriver: TrippLite HID 0.85
   3.661175     [D1] 94 HID objects found
   3.703060     [D1] Path: UPS.BatterySystem.Battery.AudibleAlarmControl, Type: Feature, ReportID: 0x20, Offset: 0, Size: 8, Value: 1
...
   6.551087     [D1] upsdrv_updateinfo...
   7.301215     [D2] nut_libusb_get_interrupt: Connection timed out
   7.301236     [D1] Got 0 HID objects...
   7.301245     [D1] Quick update...
   7.301255     [D2] Path: UPS.PowerSummary.PresentStatus.ACPresent, Type: Feature, ReportID: 0x01, Offset: 0, Size: 1, Value: 1
   7.301262     [D2] Path: UPS.PowerSummary.PresentStatus.BelowRemainingCapacityLimit, Type: Feature, ReportID: 0x01, Offset: 1, Size: 1, Value: 0
   7.301270     [D2] Path: UPS.PowerSummary.PresentStatus.Charging, Type: Feature, ReportID: 0x01, Offset: 2, Size: 1, Value: 1
   7.301279     [D2] Path: UPS.PowerSummary.PresentStatus.Discharging, Type: Feature, ReportID: 0x01, Offset: 4, Size: 1, Value: 0
battery.charge: 100
battery.charge.low: 20
battery.runtime: 1312
battery.type: PbAc
device.mfr: EATON
device.model: Ellipse ECO
device.serial: 000000000
device.type: ups
driver.debug: 2
driver.flag.allow_killpower: 0
driver.name: usbhid-ups
driver.parameter.pollfreq: 30
driver.parameter.pollinterval: 2
driver.parameter.port: auto
driver.parameter.subdriver: tripplite
driver.parameter.synchronous: auto
driver.state: dumping
driver.version: 2.8.0-2497-gc83ad2e3f
driver.version.data: TrippLite HID 0.85
driver.version.internal: 0.52
driver.version.usb: libusb-1.0.24 (API: 0x1000108)
input.transfer.high: 264.0
input.transfer.low: 161.0
output.voltage: 230.0
ups.beeper.status: enabled
ups.mfr: EATON
ups.model: Ellipse ECO
ups.productid: ffff
ups.serial: 000000000
ups.status: OL CHRG
ups.vendorid: 0463
   7.301370     [D1] upsdrv_cleanup...
````

Example of standard matching options still being honoured (using locally-absent `vendorid`):
````
# ./drivers/usbhid-ups -DDD -s test -x port=auto -x subdriver='tripplite' -d1 -x vendorid=1234
Network UPS Tools - Generic HID driver 0.52 (2.8.0-2497-gc83ad2e3f)
USB communication driver (libusb 1.0) 0.46
   0.000000     [D3] main_arg: var='port' val='auto'
   0.000012     [D3] main_arg: var='subdriver' val='tripplite'
   0.000020     [D3] main_arg: var='vendorid' val='1234'
   0.000027     [D1] Network UPS Tools version 2.8.0-2497-gc83ad2e3f (release/snapshot of 2.8.0.1) built with gcc (Debian 10.2.1-6) 10.2.1 20210110 and configured with flags: --with-user=nut --with-group=nut --with-all --with-docs=man --sysconfdir=/etc/nut --enable-silent-rules
   0.000033     [D1] debug level is '3'
   0.000618     [D1] Succeeded to become_user(nut): now UID=77 GID=77
   0.000631     [D1] upsdrv_initups (non-SHUT)...
   0.000635     [D2] Initializing an USB-connected UPS with library libusb-1.0.24 (API: 0x1000108) (NUT subdriver name='USB communication driver (libusb 1.0)' ver='0.46')
   0.004118     [D2] Checking device 1 of 9 (1D6B/0003)
   0.004140     [D1] Failed to open device (1D6B/0003), skipping: Access denied (insufficient permissions)
   0.004145     [D2] Checking device 2 of 9 (03F0/0D4A)
   0.004152     [D1] Failed to open device (03F0/0D4A), skipping: Access denied (insufficient permissions)
   0.004156     [D2] Checking device 3 of 9 (1D6B/0002)
   0.004162     [D1] Failed to open device (1D6B/0002), skipping: Access denied (insufficient permissions)
   0.004165     [D2] Checking device 4 of 9 (1D6B/0003)
   0.004171     [D1] Failed to open device (1D6B/0003), skipping: Access denied (insufficient permissions)
   0.004174     [D2] Checking device 5 of 9 (0463/FFFF)
   0.428129     [D2] - VendorID: 0463
   0.428143     [D2] - ProductID: ffff
   0.428148     [D2] - Manufacturer: EATON
   0.428154     [D2] - Product: Ellipse ECO
   0.428161     [D2] - Serial Number: 000000000
   0.428165     [D2] - Bus: 003
   0.428168     [D2] - Bus Port: 002
   0.428171     [D2] - Device: 007
   0.428175     [D2] - Device release number: 0100
   0.428178     [D2] Trying to match device
   0.428183     [D2] match_function_subdriver_name: matching a subdriver by explicit name/regex: 'tripplite'...
   0.428194     [D2] match_function_subdriver_name: retry matching by regex 'as is'
   0.428253     [D2] match_function_subdriver_name: retry matching by regex with added '.*'
   0.428285     [D2] match_function_subdriver_name: found a match: TrippLite HID 0.85
   0.428289     [D3] match_function_regex: matching a device...
   0.428293     [D2] match_function_regex: failed match of VendorID:  463
   0.428297     [D2] Device does not match - skipping
   0.428308     [D2] Checking device 6 of 9 (1D6B/0002)
   0.428322     [D1] Failed to open device (1D6B/0002), skipping: Access denied (insufficient permissions)
   0.428325     [D2] Checking device 7 of 9 (1D6B/0003)
   0.428332     [D1] Failed to open device (1D6B/0003), skipping: Access denied (insufficient permissions)
   0.428336     [D2] Checking device 8 of 9 (048D/5702)
   0.428342     [D1] Failed to open device (048D/5702), skipping: Access denied (insufficient permissions)
   0.428345     [D2] Checking device 9 of 9 (1D6B/0002)
   0.428351     [D1] Failed to open device (1D6B/0002), skipping: Access denied (insufficient permissions)
   0.428356     [D2] libusb1: No appropriate HID device found
   0.428361     libusb1: Could not open any HID devices: insufficient permissions on everything
   0.428365     No matching HID UPS found
````

Also fixes some issues with `nut-scanner` reporting of suspect serial numbers, and quiesces some warnings for new clang versions (which we can't do much about in practice => CC #823 "fightwarn" effort).