### PR TITLE
.gitattributes: make sure docs/nut.dict is always LF (no CR)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,14 @@
 *.am text eol=lf
 *.hwdb text eol=lf
 
+# Aspell claims issues finding `utf-8\r` sometimes (from heading line of
+# the dictionary file), with messages like this:
+#   .cset" could not be opened for reading or does not exist.lib/aspell/utf-8
+# which tends to happen in mixed-OS development environments. Tracer shows it:
+#   read(3, "personal_ws-1.1 en 3225 utf-8\r\nA"..., 4096) = 4096
+#   access("/usr/lib/aspell/utf-8\r.cset", F_OK) = -1 ENOENT (No such file or directory)
+/docs/nut.dict text eol=lf
+
 # Some files are binary always:
 *.png bin
 *.ico bin


### PR DESCRIPTION
In a mixed environment with Windows IDEs chiseling Linux codebase and back, I got `make spellcheck` broken.

Investigation boiled down to CRLF ends of lines used in `docs/nut.dict` at that time, with the `\r` character confusing the Linux build of `aspell`. So far it never worked for me on MSYS2/MinGW x64 workspaces (no aspell builds working there so far), so there is no loss bolting it to be LF always.