### PR TITLE
Fix `ever-hid` mapping for `powerfactor`

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -154,6 +154,8 @@ as part of https://github.com/networkupstools/nut/issues/1410 solution.
      devices with ProductID 0x0601 as done earlier for 0x0501, to get the
      correct output voltage data [#1497]
    * apc-hid subdriver now also supports ProductID 0x0004 [#1429]
+   * ever-hid subdriver reported a `powerfactor` without a namespace (bug
+     in 2.8.0 release), fixed to `outlet.powerfactor`
    * the `usbhid-ups` driver should now reconnect if `libusb` returned a
      memory allocation error [#1422] (seen as "Can't retrieve Report 0a:
      Resource temporarily unavailable"), which can cause practical problems

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3225 utf-8
+personal_ws-1.1 en 3230 utf-8
 AAS
 ABI
 ACFAIL
@@ -292,6 +292,7 @@ Dharm
 DiSplay
 Diehl
 Dietze
+Disassembly
 Digitus
 Digys
 Dimitris
@@ -1727,6 +1728,7 @@ collectd
 colspan
 command's
 commandlen
+committer
 compat
 compilerPath
 conf
@@ -1828,6 +1830,7 @@ dialout
 difftool
 dipsw
 dir
+disassembly
 discardable
 disp
 distcheck
@@ -1847,6 +1850,7 @@ dockapp
 docs
 dod
 domxml
+downloadable
 dpkg
 dq
 driverexec
@@ -3135,6 +3139,7 @@ ver
 verifySourceSig
 versa
 versioned
+versioning
 victron
 victronups
 vid

--- a/drivers/ever-hid.c
+++ b/drivers/ever-hid.c
@@ -33,7 +33,7 @@
 #include "main.h"	/* for getval() */
 #include "usb-common.h"
 
-#define EVER_HID_VERSION	"Ever HID 0.1"
+#define EVER_HID_VERSION	"Ever HID 0.10"
 /* FIXME: experimental flag to be put in upsdrv_info */
 
 /* Ever */
@@ -533,7 +533,7 @@ static hid_info_t ever_hid2nut[] = {
   /* WAS: "experimental.inverter_info.battery_temperature" */
   { "battery.temperature", 0, 0, "UPS.EVER1.EVER43", NULL, "%s", 0, kelvin_celsius_conversion },
   /* WAS: "experimental.ups_info.output_powerfactor" */
-  { "powerfactor", 0, 0, "UPS.EVER1.EVER44", NULL, "%.0f", 0, NULL },
+  { "output.powerfactor", 0, 0, "UPS.EVER1.EVER44", NULL, "%.0f", 0, NULL },
 
   /* experimental: Should these be HU_TYPE_CMD entries?
    * Or are they really settings? */


### PR DESCRIPTION
Casually a small bug was found in 2.8.0 release, while processing DDL contributions, with a report value not namespaced.