### PR TITLE
CI: Optimize `ci_build.sh` initial clean-up

### DIFF
--- a/ci_build.sh
+++ b/ci_build.sh
@@ -1297,6 +1297,19 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
     # This matches the use-case of distro-building from release tarballs that
     # include all needed pre-generated files to rely less on OS facilities.
     if [ -s Makefile ]; then
+        if [ -n "`find "${SCRIPTDIR}" -name configure.ac -newer "${CI_BUILDDIR}"/configure`" ] \
+        || [ -n "`find "${SCRIPTDIR}" -name '*.m4' -newer "${CI_BUILDDIR}"/configure`" ] \
+        || [ -n "`find "${SCRIPTDIR}" -name Makefile.am -newer "${CI_BUILDDIR}"/Makefile`" ] \
+        || [ -n "`find "${SCRIPTDIR}" -name Makefile.in -newer "${CI_BUILDDIR}"/Makefile`" ] \
+        || [ -n "`find "${SCRIPTDIR}" -name Makefile.am -newer "${CI_BUILDDIR}"/Makefile.in`" ] \
+        ; then
+            # Avoid reconfiguring for the sake of distclean
+            echo "=== Starting initial clean-up (from old build products): TAKING SHORTCUT because recipes changed"
+            rm -f "${CI_BUILDDIR}"/Makefile "${CI_BUILDDIR}"/configure
+        fi
+    fi
+
+    if [ -s Makefile ]; then
         # Let initial clean-up be at default verbosity
 
         # Handle Ctrl+C with helpful suggestions:
@@ -1891,6 +1904,19 @@ bindings)
     fi
 
     cd "${SCRIPTDIR}"
+    if [ -s Makefile ]; then
+        if [ -n "`find "${SCRIPTDIR}" -name configure.ac -newer "${CI_BUILDDIR}"/configure`" ] \
+        || [ -n "`find "${SCRIPTDIR}" -name '*.m4' -newer "${CI_BUILDDIR}"/configure`" ] \
+        || [ -n "`find "${SCRIPTDIR}" -name Makefile.am -newer "${CI_BUILDDIR}"/Makefile`" ] \
+        || [ -n "`find "${SCRIPTDIR}" -name Makefile.in -newer "${CI_BUILDDIR}"/Makefile`" ] \
+        || [ -n "`find "${SCRIPTDIR}" -name Makefile.am -newer "${CI_BUILDDIR}"/Makefile.in`" ] \
+        ; then
+            # Avoid reconfiguring for the sake of distclean
+            echo "=== Starting initial clean-up (from old build products): TAKING SHORTCUT because recipes changed"
+            rm -f "${CI_BUILDDIR}"/Makefile "${CI_BUILDDIR}"/configure
+        fi
+    fi
+
     if [ -s Makefile ]; then
         # Help developers debug:
         # Let initial clean-up be at default verbosity


### PR DESCRIPTION
Currently the `ci_build.sh` script starts many of its build scenarios with `make distclean` or `make realclean`. 

However in case of local development workflows, when some `Makefile.am` file(s) or the `configure.ac` script are edited, this call to `make` causes re-generation of Makefiles by a re-run of `configure` script (refreshed for the purpose) just to discover how to delete the previous build area and follow up with a new generation and configuration. Plain waste of several minutes (on slower platforms).

This PR allows the script to take a shortcut, with proper cleanup happening if recipes did not change since the last time, but a quick deletion of `Makefile` and `configure` products to cause re-generation for the new build right away if recipe files were edited or touched otherwise.