### PR TITLE
`nut-scanner`: additional multiarch libraries search path; general: fixes to (debug) logging

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -281,8 +281,9 @@ as part of https://github.com/networkupstools/nut/issues/1410 solution.
    and receivers such as logging systems, may still impose limits of their own.
 
  - The `nut-scanner` usage and debug printouts now include the loadable library
-   search paths, to help troubleshooting especially in multi-platform builds
-   [#317]
+   search paths, to help troubleshooting especially in multi-platform builds;
+   pre-filtering of the built-in paths was introduced (to walk only existing
+   and unique directory names) [#317]
 
  - The nut-scanner program was updated to fall back to loading unresolved
    library filenames, hoping that `lt_dlopen()` implementation on the current

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -275,6 +275,10 @@ as part of https://github.com/networkupstools/nut/issues/1410 solution.
    this variable unless troubleshooting, although other systems rely on it)
    [#805]
 
+ - The `nut-scanner` usage and debug printouts now include the loadable library
+   search paths, to help troubleshooting especially in multi-platform builds
+   [#317]
+
  - The nut-scanner program was updated to fall back to loading unresolved
    library filenames, hoping that `lt_dlopen()` implementation on the current
    platform would find library files better [#805]

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -275,6 +275,11 @@ as part of https://github.com/networkupstools/nut/issues/1410 solution.
    this variable unless troubleshooting, although other systems rely on it)
    [#805]
 
+ - Debug information tracing methods like `upsdebugx()` should now be less
+   limited in the sizes of messages that they can print, such as path names
+   that may be quite long. Note that the OS methods manipulating the strings,
+   and receivers such as logging systems, may still impose limits of their own.
+
  - The `nut-scanner` usage and debug printouts now include the loadable library
    search paths, to help troubleshooting especially in multi-platform builds
    [#317]

--- a/UPGRADING.adoc
+++ b/UPGRADING.adoc
@@ -124,6 +124,10 @@ Changes from 2.8.0 to 2.8.1
   or explicitly forfeit building the tool (some distro packages missed it
   quietly in the past) [#1560]
 
+- An `upsdebugx_report_search_paths()` method in NUT common code was added,
+  and exposed in `libnutscan.so` builds in particular - API version for the
+  public library was bumped [#317]
+
 - `configure` script, reference init-script and packaging templates updated
   to eradicate `@PIDPATH@/nut` ambiguity in favor of `@ALTPIDPATH@` for the
   unprivileged processes vs. `@PIDPATH@` for those running as root [#1719]

--- a/common/common.c
+++ b/common/common.c
@@ -1912,6 +1912,20 @@ static const char * search_paths[] = {
 	NULL
 };
 
+void upsdebugx_report_search_paths(int level) {
+	size_t	index;
+
+	if (nut_debug_level < level)
+		return;
+
+
+	upsdebugx(level, "Run-time loadable library search paths used by this build of NUT:");
+	for (index = 0; search_paths[index] != NULL; index++)
+	{
+		upsdebugx(level, "\t%s", search_paths[index]);
+	}
+}
+
 static char * get_libname_in_dir(const char* base_libname, size_t base_libname_length, const char* dirname, int index) {
 	/* Implementation detail for get_libname() below.
 	 * Returns pointer to allocated copy of the buffer

--- a/common/common.c
+++ b/common/common.c
@@ -1861,6 +1861,19 @@ static const char * search_paths[] = {
 	LIBDIR,
 	"/usr"LIBDIR,		/* Note: this can lead to bogus strings like */
 	"/usr/local"LIBDIR,	/* "/usr/usr/lib" which would be ignored quickly */
+/* TOTHINK: Should AUTOTOOLS_* specs also be highly preferred?
+ * Currently they are listed after the "legacy" hard-coded paths...
+ */
+#ifdef MULTIARCH_TARGET_ALIAS
+# ifdef BUILD_64
+	"/usr/lib/64/" MULTIARCH_TARGET_ALIAS,
+	"/usr/lib64/" MULTIARCH_TARGET_ALIAS,
+	"/lib/64/" MULTIARCH_TARGET_ALIAS,
+	"/lib64/" MULTIARCH_TARGET_ALIAS,
+# endif	/* MULTIARCH_TARGET_ALIAS && BUILD_64 */
+	"/usr/lib/" MULTIARCH_TARGET_ALIAS,
+	"/lib/" MULTIARCH_TARGET_ALIAS,
+#endif	/* MULTIARCH_TARGET_ALIAS */
 #ifdef BUILD_64
 	/* Fall back to explicit preference of 64-bit paths as named on some OSes */
 	"/usr/lib/64",

--- a/common/common.c
+++ b/common/common.c
@@ -2096,7 +2096,7 @@ static char * get_libname_in_pathset(const char* base_libname, size_t base_libna
 	/* First call to tokenization passes the string, others pass NULL */
 	pathset_tmp = xstrdup(pathset);
 	while (NULL != (onedir = strtok( (onedir ? NULL : pathset_tmp), ":" ))) {
-		libname_path = get_libname_in_dir(base_libname, base_libname_length, onedir, *counter++);
+		libname_path = get_libname_in_dir(base_libname, base_libname_length, onedir, (*counter)++);
 		if (libname_path != NULL)
 			break;
 	}
@@ -2108,7 +2108,7 @@ static char * get_libname_in_pathset(const char* base_libname, size_t base_libna
 	if (!libname_path) {
 		onedir = NULL; /* probably is NULL already, but better ensure this */
 		while (NULL != (onedir = strtok( (onedir ? NULL : pathset_tmp), ";" ))) {
-			libname_path = get_libname_in_dir(base_libname, base_libname_length, onedir, *counter++);
+			libname_path = get_libname_in_dir(base_libname, base_libname_length, onedir, (*counter)++);
 			if (libname_path != NULL)
 				break;
 		}

--- a/common/common.c
+++ b/common/common.c
@@ -1855,8 +1855,8 @@ ssize_t select_write(serial_handler_t *fd, const void *buf, const size_t buflen,
 static const char * search_paths[] = {
 	/* Use the library path (and bitness) provided during ./configure first */
 	LIBDIR,
-	"/usr"LIBDIR,
-	"/usr/local"LIBDIR,
+	"/usr"LIBDIR,		/* Note: this can lead to bogus strings like */
+	"/usr/local"LIBDIR,	/* "/usr/usr/lib" which would be ignored quickly */
 #ifdef BUILD_64
 	/* Fall back to explicit preference of 64-bit paths as named on some OSes */
 	"/usr/lib/64",

--- a/common/common.c
+++ b/common/common.c
@@ -2083,30 +2083,37 @@ static char * get_libname_in_dir(const char* base_libname, size_t base_libname_l
 static char * get_libname_in_pathset(const char* base_libname, size_t base_libname_length, char* pathset, int *counter)
 {
 	/* Note: this method iterates specified pathset,
-	 * so increments the counter by reference */
+	 * so it increments the counter by reference.
+	 * A copy of original pathset is used, because
+	 * strtok() tends to modify its input! */
 	char *libname_path = NULL;
 	char *onedir = NULL;
+	char* pathset_tmp;
 
 	if (!pathset || *pathset == '\0')
 		return NULL;
 
 	/* First call to tokenization passes the string, others pass NULL */
-	while (NULL != (onedir = strtok( (onedir ? NULL : pathset), ":" ))) {
+	pathset_tmp = xstrdup(pathset);
+	while (NULL != (onedir = strtok( (onedir ? NULL : pathset_tmp), ":" ))) {
 		libname_path = get_libname_in_dir(base_libname, base_libname_length, onedir, *counter++);
 		if (libname_path != NULL)
 			break;
 	}
+	free(pathset_tmp);
 
 #ifdef WIN32
 	/* Note: with mingw, the ":" separator above might have been resolvable */
+	pathset_tmp = xstrdup(pathset);
 	if (!libname_path) {
 		onedir = NULL; /* probably is NULL already, but better ensure this */
-		while (NULL != (onedir = strtok( (onedir ? NULL : pathset), ";" ))) {
+		while (NULL != (onedir = strtok( (onedir ? NULL : pathset_tmp), ";" ))) {
 			libname_path = get_libname_in_dir(base_libname, base_libname_length, onedir, *counter++);
 			if (libname_path != NULL)
 				break;
 		}
 	}
+	free(pathset_tmp);
 #endif  /* WIN32 */
 
 	return libname_path;

--- a/common/common.c
+++ b/common/common.c
@@ -1287,11 +1287,15 @@ static void vupslog(int priority, const char *fmt, va_list va, int use_strerror)
 				now.tv_sec -= 1;
 			}
 
-			fprintf(stderr, "%4.0f.%06ld\t",
+			/* Print all in one shot, to better avoid
+			 * mixed lines in parallel threads */
+			fprintf(stderr, "%4.0f.%06ld\t%s\n",
 				difftime(now.tv_sec, upslog_start.tv_sec),
-				(long)(now.tv_usec - upslog_start.tv_usec));
+				(long)(now.tv_usec - upslog_start.tv_usec),
+				buf);
+		} else {
+			fprintf(stderr, "%s\n", buf);
 		}
-		fprintf(stderr, "%s\n", buf);
 #ifdef WIN32
 		fflush(stderr);
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -3860,6 +3860,14 @@ if test -n "${target_cpu}" -a -n "${target_os}" ; then
 	NUT_REPORT_TARGET(AUTOTOOLS_TARGET_SHORT_ALIAS, "${target_cpu}-${target_os}", [host OS short spec we built for])
 fi
 
+AC_MSG_CHECKING([whether compiler suggests a MULTIARCH value])
+dnl Recent GCC generally supports this call, although it often returns empty
+dnl Some versions of CLANG also have it, others reject the unknown CLI switch
+compiler_multiarch="`${CC} -print-multiarch 2>/dev/null`" || compiler_multiarch=""
+if test -n "${compiler_multiarch}" ; then
+	NUT_REPORT_TARGET(MULTIARCH_TARGET_ALIAS, "${compiler_multiarch}", [host multiarch spec we build for (as suggested by compiler being used)])
+fi
+
 dnl ----------------------------------------------------------------------
 dnl Check the user and group to run as last, so we can use the paths configured
 dnl above as data sources for default values if building an in-place replacement

--- a/include/common.h
+++ b/include/common.h
@@ -336,7 +336,8 @@ void nut_report_config_flags(void);
 
 /* Report search paths used by ltdl-augmented code to discover and
  * load shared binary object files at run-time (nut-scanner, DMF...) */
-void upsdebugx_report_search_paths(int level);
+void upsdebugx_report_search_paths(int level, int report_search_paths_builtin);
+void nut_prepare_search_paths(void);
 
 extern int nut_debug_level;
 extern int nut_log_level;

--- a/include/common.h
+++ b/include/common.h
@@ -334,6 +334,10 @@ void fatalx(int status, const char *fmt, ...)
  */
 void nut_report_config_flags(void);
 
+/* Report search paths used by ltdl-augmented code to discover and
+ * load shared binary object files at run-time (nut-scanner, DMF...) */
+void upsdebugx_report_search_paths(int level);
+
 extern int nut_debug_level;
 extern int nut_log_level;
 

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -1150,6 +1150,7 @@ testcase_sandbox_nutscanner_list() {
 
     # NOTE: Currently mask mode is IPv4 only
     runcmd "${TOP_BUILDDIR}/tools/nut-scanner/nut-scanner" -m 127.0.0.1/32 -O -p "${NUT_PORT}" \
+    && test -n "$CMDOUT" \
     || runcmd "${TOP_BUILDDIR}/tools/nut-scanner/nut-scanner" -s localhost -O -p "${NUT_PORT}"
 
     LD_LIBRARY_PATH="${LD_LIBRARY_PATH_ORIG}"

--- a/tools/nut-scanner/Makefile.am
+++ b/tools/nut-scanner/Makefile.am
@@ -16,6 +16,7 @@ $(NUT_SCANNER_DEPS): dummy
 	@cd .. && $(MAKE) $(AM_MAKEFLAGS) nut-scanner-deps
 
 # Make sure out-of-dir dependencies exist (especially when dev-building parts):
+$(top_builddir)/common/libcommonclient.la \
 $(top_builddir)/common/libcommon.la: dummy
 	@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
@@ -79,7 +80,7 @@ endif
 # object .so names would differ)
 #
 # libnutscan version information
-libnutscan_la_LDFLAGS += -version-info 2:1:0
+libnutscan_la_LDFLAGS += -version-info 2:2:0
 
 # libnutscan exported symbols regex
 # WARNING: Since the library includes parts of libcommon (as much as needed
@@ -90,7 +91,7 @@ libnutscan_la_LDFLAGS += -version-info 2:1:0
 # copies of "nut_debug_level" making fun of our debug-logging attempts.
 # One solution to tackle if needed for those cases would be to make some
 # dynamic/shared libnutcommon (etc.)
-libnutscan_la_LDFLAGS += -export-symbols-regex '^(nutscan_|nut_debug_level|s_upsdebugx|max_threads|curr_threads|nut_report_config_flags)'
+libnutscan_la_LDFLAGS += -export-symbols-regex '^(nutscan_|nut_debug_level|s_upsdebugx|max_threads|curr_threads|nut_report_config_flags|upsdebugx_report_search_paths)'
 libnutscan_la_CFLAGS = -I$(top_srcdir)/clients -I$(top_srcdir)/include \
 			$(LIBLTDL_CFLAGS) -I$(top_srcdir)/drivers
 

--- a/tools/nut-scanner/Makefile.am
+++ b/tools/nut-scanner/Makefile.am
@@ -91,7 +91,7 @@ libnutscan_la_LDFLAGS += -version-info 2:2:0
 # copies of "nut_debug_level" making fun of our debug-logging attempts.
 # One solution to tackle if needed for those cases would be to make some
 # dynamic/shared libnutcommon (etc.)
-libnutscan_la_LDFLAGS += -export-symbols-regex '^(nutscan_|nut_debug_level|s_upsdebugx|max_threads|curr_threads|nut_report_config_flags|upsdebugx_report_search_paths)'
+libnutscan_la_LDFLAGS += -export-symbols-regex '^(nutscan_|nut_debug_level|s_upsdebugx|max_threads|curr_threads|nut_report_config_flags|upsdebugx_report_search_paths|nut_prepare_search_paths)'
 libnutscan_la_CFLAGS = -I$(top_srcdir)/clients -I$(top_srcdir)/include \
 			$(LIBLTDL_CFLAGS) -I$(top_srcdir)/drivers
 

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -219,7 +219,7 @@ static void show_usage(void)
 
 	printf("\nNote: many scanning options depend on further loadable libraries.\n");
 	/* Note: if debug is enabled, this is prefixed with timestamps */
-	upsdebugx_report_search_paths(0);
+	upsdebugx_report_search_paths(0, 0);
 
 	printf("\nNetwork specific options:\n");
 	printf("  -t, --timeout <timeout in seconds>: network operation timeout (default %d).\n", DEFAULT_NETWORK_TIMEOUT);

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -217,6 +217,10 @@ static void show_usage(void)
 	printf("  -T, --thread <max number of threads>: Limit the amount of scanning threads running simultaneously (not implemented in this build: no pthread support)");
 #endif
 
+	printf("\nNote: many scanning options depend on further loadable libraries.\n");
+	/* Note: if debug is enabled, this is prefixed with timestamps */
+	upsdebugx_report_search_paths(0);
+
 	printf("\nNetwork specific options:\n");
 	printf("  -t, --timeout <timeout in seconds>: network operation timeout (default %d).\n", DEFAULT_NETWORK_TIMEOUT);
 	printf("  -s, --start_ip <IP address>: First IP address to scan.\n");

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -214,7 +214,7 @@ static void show_usage(void)
 #if (defined HAVE_PTHREAD) && (defined HAVE_PTHREAD_TRYJOIN)
 	printf("  -T, --thread <max number of threads>: Limit the amount of scanning threads running simultaneously (default: %" PRIuSIZE ").\n", max_threads);
 #else
-	printf("  -T, --thread <max number of threads>: Limit the amount of scanning threads running simultaneously (not implemented in this build: no pthread support)");
+	printf("  -T, --thread <max number of threads>: Limit the amount of scanning threads running simultaneously (not implemented in this build: no pthread support)\n");
 #endif
 
 	printf("\nNote: many scanning options depend on further loadable libraries.\n");

--- a/tools/nut-scanner/nutscan-init.c
+++ b/tools/nut-scanner/nutscan-init.c
@@ -110,8 +110,11 @@ void nutscan_init(void)
 {
 	char *libname = NULL;
 
+	/* Optional filter to not walk things twice */
+	nut_prepare_search_paths();
+
 	/* Report library paths we would search, at given debug verbosity level */
-	upsdebugx_report_search_paths(1);
+	upsdebugx_report_search_paths(1, 1);
 
 #ifdef HAVE_PTHREAD
 /* TOTHINK: Should semaphores to limit thread count

--- a/tools/nut-scanner/nutscan-init.c
+++ b/tools/nut-scanner/nutscan-init.c
@@ -110,6 +110,9 @@ void nutscan_init(void)
 {
 	char *libname = NULL;
 
+	/* Report library paths we would search, at given debug verbosity level */
+	upsdebugx_report_search_paths(1);
+
 #ifdef HAVE_PTHREAD
 /* TOTHINK: Should semaphores to limit thread count
  * and the more naive but portable methods be an

--- a/tools/nut-scanner/nutscan-ip.c
+++ b/tools/nut-scanner/nutscan-ip.c
@@ -279,6 +279,9 @@ int nutscan_cidr_to_ip(const char * cidr, char ** start_ip, char ** stop_ip)
 
 	*start_ip = NULL;
 	*stop_ip = NULL;
+#ifdef WIN32
+        WSADATA WSAdata;
+#endif
 
 	cidr_tok = strdup(cidr);
 	first_ip = strdup(strtok_r(cidr_tok, "/", &saveptr));
@@ -320,6 +323,12 @@ int nutscan_cidr_to_ip(const char * cidr, char ** start_ip, char ** stop_ip)
 	hints.ai_family = AF_INET;
 
 	ip.type = IPv4;
+
+#ifdef WIN32
+        WSAStartup(2,&WSAdata);
+        atexit((void(*)(void))WSACleanup);
+#endif
+
 	if ((ret = getaddrinfo(first_ip, NULL, &hints, &res)) != 0) {
 		/* EAI_ADDRFAMILY? */
 		upsdebugx(5, "%s: getaddrinfo() failed for AF_INET (IPv4): %d",


### PR DESCRIPTION
Closes: #317

On one hand, this PR does what issue #317 asked for, to consider "multiarch" path components (if suggested by compiler) when we consider dynamic library loading at run-time (`nut-scanner`, eventually DMF, etc.) Resulting paths are constructed per https://wiki.debian.org/Multiarch/LibraryPathOverview (prefixing `(/usr)/lib(bits)` essentially).

On another, it uncovered and addressed some earlier issues (bugs and annoyances):
* the `get_libname_in_pathset()` method (added after 2.8.0 release, largely as part of NUT for Windows effort) had some issues both with accounting the number of directories checked, and with looking at them in the reentrant fashion (`strtok()` involved in parsing mangled the original string, such as `getenv("PATH")` original, adding `0x00` chars where it found separators).
* the `upsdebugx()` => `vupslog()` methods limited the printable reports to `LARGEBUF` (`1024` bytes currently) as compiled into the program. This truncated reports of `PATH` (quite long on Windows) for example, and was not hard to replace by a dynamically growing buffer to fit the conversions. Default behavior should be same as before, and it should fit the majority of practical cases, but there should be fewer truncations now. Note that receivers like syslog may do their own truncations of very long lines.
* nut-scanner also failed to parse CIDR on Windows (needs special init, missed here)

Something not addressed here was a lingering idea to check if the initially successfully prepared `buf` string length is comparable with `bufsize` (minus... how much?) and if it is - also extend, so that our later suffixes (errno details, etc.) would fit.