### PR TITLE
systemd integration update and nut.conf comments

### DIFF
--- a/clients/Makefile.am
+++ b/clients/Makefile.am
@@ -12,12 +12,19 @@ $(top_builddir)/common/libcommonclient.la \
 $(top_builddir)/common/libparseconf.la: dummy
 	@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
+LDADD_FULL = $(top_builddir)/common/libcommon.la libupsclient.la $(NETLIBS)
+if WITH_SSL
+  LDADD_FULL += $(LIBSSL_LIBS)
+endif
+
+LDADD_CLIENT = $(top_builddir)/common/libcommonclient.la libupsclient.la $(NETLIBS)
+if WITH_SSL
+  LDADD_CLIENT += $(LIBSSL_LIBS)
+endif
+
 # by default, link programs in this directory with
 # the more compact libcommonclient.a bundle
-LDADD = $(top_builddir)/common/libcommonclient.la libupsclient.la $(NETLIBS)
-if WITH_SSL
-  LDADD += $(LIBSSL_LIBS)
-endif
+LDADD = $(LDADD_CLIENT)
 
 # Avoid per-target CFLAGS, because this will prevent re-use of object
 # files. In any case, CFLAGS are only -I options, so there is no harm,
@@ -62,12 +69,13 @@ upscmd_SOURCES = upscmd.c upsclient.h
 upsrw_SOURCES = upsrw.c upsclient.h
 upslog_SOURCES = upslog.c upsclient.h upslog.h
 upsmon_SOURCES = upsmon.c upsmon.h upsclient.h
+upsmon_LDADD = $(LDADD_FULL)
 if HAVE_WINDOWS_SOCKETS
 message_SOURCES = message.c
 endif
 
 upssched_SOURCES = upssched.c upssched.h
-upssched_LDADD = $(top_builddir)/common/libcommon.la $(top_builddir)/common/libparseconf.la $(NETLIBS)
+upssched_LDADD = $(top_builddir)/common/libcommonclient.la $(top_builddir)/common/libparseconf.la $(NETLIBS)
 
 upsimage_cgi_SOURCES = upsimage.c upsclient.h upsimagearg.h cgilib.c cgilib.h
 upsimage_cgi_LDADD = $(LDADD) $(LIBGD_LDFLAGS)

--- a/common/common.c
+++ b/common/common.c
@@ -832,14 +832,14 @@ int upsnotify(upsnotify_state_t state, const char *fmt, ...)
 	NUT_UNUSED_VARIABLE(buf);
 	NUT_UNUSED_VARIABLE(msglen);
 	if (!upsnotify_reported_disabled_systemd)
-		upsdebugx(6, "%s: notify about state %i with libsystemd: "
+		upsdebugx(0, "%s: notify about state %i with libsystemd: "
 		"skipped for libcommonclient build, "
 		"will not spam more about it", __func__, state);
 	upsnotify_reported_disabled_systemd = 1;
 # else
 	if (!getenv("NOTIFY_SOCKET")) {
 		if (!upsnotify_reported_disabled_systemd)
-			upsdebugx(6, "%s: notify about state %i with libsystemd: "
+			upsdebugx(0, "%s: notify about state %i with libsystemd: "
 				"was requested, but not running as a service unit now, "
 				"will not spam more about it",
 				__func__, state);
@@ -1110,7 +1110,7 @@ int upsnotify(upsnotify_state_t state, const char *fmt, ...)
 	) {
 		if (ret == -127) {
 			if (!upsnotify_reported_disabled_notech)
-				upsdebugx(6, "%s: failed to notify about state %i: no notification tech defined, will not spam more about it", __func__, state);
+				upsdebugx(0, "%s: failed to notify about state %i: no notification tech defined, will not spam more about it", __func__, state);
 			upsnotify_reported_disabled_notech = 1;
 		} else {
 			upsdebugx(6, "%s: failed to notify about state %i", __func__, state);
@@ -1120,7 +1120,7 @@ int upsnotify(upsnotify_state_t state, const char *fmt, ...)
 #if defined(WITH_LIBSYSTEMD) && (WITH_LIBSYSTEMD)
 # if ! DEBUG_SYSTEMD_WATCHDOG
 	if (state == NOTIFY_STATE_WATCHDOG && !upsnotify_reported_watchdog_systemd) {
-		upsdebugx(6, "%s: logged the systemd watchdog situation once, will not spam more about it", __func__);
+		upsdebugx(0, "%s: logged the systemd watchdog situation once, will not spam more about it", __func__);
 		upsnotify_reported_watchdog_systemd = 1;
 	}
 # endif

--- a/conf/nut.conf.sample
+++ b/conf/nut.conf.sample
@@ -13,6 +13,9 @@
 #  by systemd on Linux (no guaranteed expansion of variables).
 #  You MUST NOT use spaces around the equal sign!
 #
+# See also: `man nut.conf` (usually in Manual pages Section 5,
+#           for Configuration files)
+#
 ##############################################################################
 # General section
 ##############################################################################

--- a/conf/nut.conf.sample
+++ b/conf/nut.conf.sample
@@ -1,19 +1,28 @@
 # Network UPS Tools: example nut.conf
 #
+# This file tries to standardize the various files being found in the field,
+# like /etc/default/nut on Debian based systems, /etc/sysconfig/ups on RedHat
+# based systems, ... Distribution's init script or service unit/method script
+# should source this file to see which component(s) has to be started.
+# Some scripts and units provided by NUT project itself may also look into
+# this file for optional configuration about OS integration.
+#
+# IMPORTANT NOTES:
+#  This file is intended to be sourced by standard POSIX shell scripts
+#  (so there is no guaranteed `export VAR=VAL` syntax) and additionally
+#  by systemd on Linux (no guaranteed expansion of variables).
+#  You MUST NOT use spaces around the equal sign!
+#
 ##############################################################################
 # General section
 ##############################################################################
 # The MODE determines which part of the NUT is to be started, and which
 # configuration files must be modified.
 #
-# This file try to standardize the various files being found in the field, like
-# /etc/default/nut on Debian based systems, /etc/sysconfig/ups on RedHat based
-# systems, ... Distribution's init script should source this file to see which
-# component(s) has to be started.
-#
 # The values of MODE can be:
 # - none: NUT is not configured, or use the Integrated Power Management, or use
-#   some external system to startup NUT components. So nothing is to be started.
+#   some external system to startup NUT components. So nothing is to be started
+#   by scripts or services bundled with NUT packages.
 # - standalone: This mode address a local only configuration, with 1 UPS
 #   protecting the local system. This implies to start the 3 NUT layers (driver,
 #   upsd and upsmon) and the matching configuration files. This mode can also
@@ -23,12 +32,9 @@
 #   specific LISTEN directive in upsd.conf.
 #   Since this MODE is opened to the network, a special care should be applied
 #   to security concerns.
-# - netclient: this mode only requires upsmon.
-#
-# IMPORTANT NOTE:
-#  This file is intended to be sourced by standard POSIX shell scripts (so
-#  there is no guaranteed `export VAR=VAL` syntax) and by systemd on Linux.
-#  You MUST NOT use spaces around the equal sign!
+# - netclient: this mode only requires upsmon (and tools it may be using, like
+#   upssched or custom scripts) to monitor a remote NUT server and possibly
+#   shut down this system (part of upsmon must run as root then).
 
 MODE=none
 

--- a/conf/nut.conf.sample
+++ b/conf/nut.conf.sample
@@ -43,8 +43,29 @@
 
 MODE=none
 
-# Uncomment this to allow starting the service even if ups.conf has no device
-# sections at the moment. This environment variable overrides the built-in
-# "false" and an optional same-named default flag that can be set in upsd.conf:
+# Uncomment this to allow starting the service even if `ups.conf` has no device
+# sections configured at the moment. This environment variable overrides the
+# built-in "false" flag in `upsd`, and an optional same-named default flag that
+# can be set in `upsd.conf`. If you want a data server always running, even if
+# it initially has nothing to serve (may be live-reloaded later, when devices
+# become configured), this option is for you.
 #ALLOW_NO_DEVICE=true
 #export ALLOW_NO_DEVICE
+
+# The optional 'UPSD_OPTIONS' allow to set upsd specific command-line options.
+# It is ignored when 'MODE' above indicates that no upsd should be running.
+# It may be redundant in comparison to options which can be set in `upsd.conf`.
+#UPSD_OPTIONS=
+
+# The optional 'UPSMON_OPTIONS' allow to set upsmon specific command-line options.
+# It is ignored when 'MODE' above indicates that no upsmon should be running.
+# It may be redundant in comparison to options which can be set in `upsmon.conf`.
+#UPSMON_OPTIONS=
+
+# If the optional 'POWEROFF_WAIT' is configured (to a value that can be handled
+# by `/bin/sleep` on the current system - typically an integer with the number
+# of seconds for a delay, but not always limited to that syntax), and the current
+# system which manages one or more UPS devices would not only command it to shut
+# down, but also try to avoid the "Power race". Caveats emptor, see NUT FAQ and
+# other docs for details.
+#POWEROFF_WAIT=3600

--- a/conf/nut.conf.sample
+++ b/conf/nut.conf.sample
@@ -69,3 +69,10 @@ MODE=none
 # down, but also try to avoid the "Power race". Caveats emptor, see NUT FAQ and
 # other docs for details.
 #POWEROFF_WAIT=3600
+
+# The optional 'POWEROFF_QUIET' setting controls if the NUT shutdown integration
+# scripts or service units would emit messages about their activity (or lack
+# thereof). By default they may be verbose, to aid post-mortem troubleshooting
+# via logs or console captures.
+# Set to `true` to avoid that trove of information, if you consider it noise.
+#POWEROFF_QUIET=true

--- a/conf/nut.conf.sample
+++ b/conf/nut.conf.sample
@@ -12,6 +12,8 @@
 #  (so there is no guaranteed `export VAR=VAL` syntax) and additionally
 #  by systemd on Linux (no guaranteed expansion of variables).
 #  You MUST NOT use spaces around the equal sign!
+#  Practical support for this file and its settings currently varies between
+#  various OS packages and NUT sample scripts, but should converge over time.
 #
 # See also: `man nut.conf` (usually in Manual pages Section 5,
 #           for Configuration files)

--- a/configure.ac
+++ b/configure.ac
@@ -4352,6 +4352,11 @@ dnl by "root:${RUN_AS_GROUP}" with 77x permissions. Is it safer?..
 AS_IF([test -n "$systemdtmpfilesdir"],
     [mkdir -p "${TOP_BUILDDIR}"/scripts/systemd
      cat > "${TOP_BUILDDIR}"/scripts/systemd/nut-common-tmpfiles.conf.in << EOF
+# Network UPS Tools (NUT) systemd integration
+# Distributed under the terms of GPLv2+
+# See https://networkupstools.org/
+# and https://github.com/networkupstools/nut/
+
 # See also: https://github.com/networkupstools/nut/wiki/Technicalities:-Work-with-PID-and-state-file-paths#pidpath-altpidpath-statepath
 # State file (e.g. upsd to driver pipes) and PID file location for NUT:
 d @STATEPATH@ 0770 @RUN_AS_USER@ @RUN_AS_GROUP@ - -

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -631,6 +631,17 @@ configuration, this can include the `libupsclient`, `libnutclient`,
 `libnutclientsub`, `libnutscan` and their pkg-config metadata (see
 `--with-pkgconfig-dir` option). The default is `<exec_prefix>/lib`.
 
+	--libexecdir=PATH
+
+Sets the installation path for "executable libraries" -- helper scripts
+or programs that are not intended for direct and regular use by people,
+and rather are implementation details of services.  Depending on the
+build configuration, this can include the `nut-driver-enumerator.sh`,
+`sockdebug`, and others. The default is `<exec_prefix>/libexec`.
+
+Package distributions may want to use this option to customize this path
+to include the package name, e.g. set it to `<exec_prefix>/libexec/nut`.
+
 	--with-pkgconfig-dir=PATH
 
 Where to install pkg-config `*.pc` files. This option only has an

--- a/docs/man/nut.conf.txt
+++ b/docs/man/nut.conf.txt
@@ -87,9 +87,16 @@ unavailable.  On the other hand, it should not be so long that the
 system remains offline for an unreasonable amount of time if line
 power has returned.  See sleep(1) for compatible time syntax.
 If you specify the time in seconds, use the "s" suffix.
-
++
 WARNING: this workaround might be dangerous under some circumstances.
 Please read http://bugs.debian.org/358696 for more details.
+
+*POWEROFF_QUIET*::
+Optional, defaults to `false`.  This setting controls if the NUT shutdown
+integration scripts or service units would emit messages about their activity
+(or lack thereof).  By default they may be verbose, to aid in post-mortem
+troubleshooting via logs or console captures.  Set to `true` to avoid that
+trove of information, if you consider it noise.
 
 EXAMPLE
 -------

--- a/docs/man/nut.conf.txt
+++ b/docs/man/nut.conf.txt
@@ -54,6 +54,17 @@ netclient;; When only upsmon is required, possibly because
 there are other hosts that are more closely attached to the UPS,
 the MODE should be set to netclient.
 
+*ALLOW_NO_DEVICE*::
+Optional, defaults to `false`.  Set this to `true` to allow starting the `upsd`
+NUT data server service even if `ups.conf` has no device sections configured
+at the moment. This environment variable overrides the built-in "false" flag
+value in the `upsd` program, and an optional same-named default flag that
+can be set in `upsd.conf`.
++
+If you want a data server always running and responding on the network, even
+if it initially has nothing to serve (may be live-reloaded later, when devices
+become configured), this option is for you.
+
 *UPSD_OPTIONS*::
 Optional.  Set upsd specific options. See linkman:upsd[8] for more
 details.  It is ignored when 'MODE' above indicates that no upsd

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3242 utf-8
+personal_ws-1.1 en 3243 utf-8
 AAS
 ABI
 ACFAIL
@@ -2224,6 +2224,7 @@ libcurl
 libdir
 libdummy
 libexec
+libexecdir
 libfreeipmi
 libgd
 libgpgme

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3238 utf-8
+personal_ws-1.1 en 3239 utf-8
 AAS
 ABI
 ACFAIL
@@ -2393,6 +2393,7 @@ monpasswd
 monslave
 monuser
 morbo
+mortem
 mozilla
 msec
 msg

--- a/scripts/systemd/nut-driver-enumerator.path.in
+++ b/scripts/systemd/nut-driver-enumerator.path.in
@@ -1,4 +1,9 @@
 # Trigger restart of nut-driver-enumerator.service whenever ups.conf is edited
+# Network UPS Tools (NUT) systemd integration
+# Copyright (C) 2011-2023 by NUT contirbutors
+# Distributed under the terms of GPLv2+
+# See https://networkupstools.org/
+# and https://github.com/networkupstools/nut/
 
 [Path]
 PathModified=@CONFPATH@/ups.conf

--- a/scripts/systemd/nut-driver-enumerator.service.in
+++ b/scripts/systemd/nut-driver-enumerator.service.in
@@ -1,3 +1,9 @@
+# Network UPS Tools (NUT) systemd integration
+# Copyright (C) 2011-2023 by NUT contirbutors
+# Distributed under the terms of GPLv2+
+# See https://networkupstools.org/
+# and https://github.com/networkupstools/nut/
+
 [Unit]
 # This unit starts early in system lifecycle to set up nut-driver instances.
 # End-user may also restart this unit after editing ups.conf to automatically

--- a/scripts/systemd/nut-driver.target
+++ b/scripts/systemd/nut-driver.target
@@ -1,3 +1,9 @@
+# Network UPS Tools (NUT) systemd integration
+# Copyright (C) 2011-2023 by NUT contirbutors
+# Distributed under the terms of GPLv2+
+# See https://networkupstools.org/
+# and https://github.com/networkupstools/nut/
+
 [Unit]
 Description=Network UPS Tools - target for power device drivers on this system
 After=local-fs.target

--- a/scripts/systemd/nut-driver@.service.in
+++ b/scripts/systemd/nut-driver@.service.in
@@ -1,3 +1,9 @@
+# Network UPS Tools (NUT) systemd integration
+# Copyright (C) 2011-2023 by NUT contirbutors
+# Distributed under the terms of GPLv2+
+# See https://networkupstools.org/
+# and https://github.com/networkupstools/nut/
+
 [Unit]
 Description=Network UPS Tools - device driver for %I
 After=local-fs.target

--- a/scripts/systemd/nut-monitor.service.in
+++ b/scripts/systemd/nut-monitor.service.in
@@ -1,3 +1,9 @@
+# Network UPS Tools (NUT) systemd integration
+# Copyright (C) 2011-2023 by NUT contirbutors
+# Distributed under the terms of GPLv2+
+# See https://networkupstools.org/
+# and https://github.com/networkupstools/nut/
+
 [Unit]
 Description=Network UPS Tools - power device monitor and shutdown controller
 # Note: do not mistake this historic misnomer for "NUT-Monitor" Python GUI client

--- a/scripts/systemd/nut-server.service.in
+++ b/scripts/systemd/nut-server.service.in
@@ -1,3 +1,9 @@
+# Network UPS Tools (NUT) systemd integration
+# Copyright (C) 2011-2023 by NUT contirbutors
+# Distributed under the terms of GPLv2+
+# See https://networkupstools.org/
+# and https://github.com/networkupstools/nut/
+
 [Unit]
 Description=Network UPS Tools - power devices information server
 After=local-fs.target network.target nut-driver.target

--- a/scripts/systemd/nut.target
+++ b/scripts/systemd/nut.target
@@ -1,3 +1,9 @@
+# Network UPS Tools (NUT) systemd integration
+# Copyright (C) 2011-2023 by NUT contirbutors
+# Distributed under the terms of GPLv2+
+# See https://networkupstools.org/
+# and https://github.com/networkupstools/nut/
+
 [Unit]
 Description=Network UPS Tools - target for power device drivers, data server and monitoring client (if enabled) on this system
 After=local-fs.target nut-driver.target nut-server.service nut-monitor.service

--- a/scripts/systemd/nutshutdown.in
+++ b/scripts/systemd/nutshutdown.in
@@ -9,7 +9,7 @@
 # filesystems (may be read-only).
 #
 # Copyright (C) 2011-2023 by NUT contirbutors
-# Michal Hlavinka, Arnaud Quette, Jim Klimov et al.
+# Michal Hlavinka, Laurent Bigonville, Arnaud Quette, Jim Klimov et al.
 #
 # See https://networkupstools.org/
 # and https://github.com/networkupstools/nut/

--- a/scripts/systemd/nutshutdown.in
+++ b/scripts/systemd/nutshutdown.in
@@ -31,18 +31,25 @@
 [ -x "@SBINDIR@/upsmon" ] && [ -x "@SBINDIR@/upsdrvctl" ] || exit
 
 if @SBINDIR@/upsmon -K >/dev/null 2>&1; then
-  # The argument may be anything compatible with sleep
-  # (not necessarily a non-negative integer)
-  wait_delay="`/bin/sed -ne 's#^ *POWEROFF_WAIT= *\(.*\)$#\1#p' @CONFPATH@/nut.conf`" || wait_delay=""
+    # The argument may be anything compatible with /bin/sleep
+    # (on OSes with systemd - assuming GNU coreutils or compatible,
+    # so not necessarily a non-negative integer)
+    wait_delay="`/bin/sed -ne 's#^ *POWEROFF_WAIT= *\(.*\)$#\1#p' @CONFPATH@/nut.conf`" || wait_delay=""
 
-  @SBINDIR@/upsdrvctl shutdown
+    @SBINDIR@/upsdrvctl shutdown
 
-  if [ -n "$wait_delay" ] ; then
-    /bin/sleep $wait_delay
-    # We need to pass --force twice here to bypass systemd and execute the
-    # reboot directly ourself.
-    /bin/systemctl reboot --force --force
-  fi
+    if [ -n "$wait_delay" ] ; then
+        # Avoid the power-race condition (if wall power returned
+        # while we were shutting down, so some UPSes would not
+        # shutdown and/or powercycle the load as commanded above).
+        # Sleep "long enough" to drain the battery if the UPS is
+        # in fact on battery, or reboot if it became alive, so
+        # this computer is not in limbo forever.
+        /bin/sleep $wait_delay
+        # We need to pass --force twice here to bypass systemd
+        # and execute the reboot directly ourself.
+        /bin/systemctl reboot --force --force
+    fi
 fi
 
 exit 0

--- a/scripts/systemd/nutshutdown.in
+++ b/scripts/systemd/nutshutdown.in
@@ -28,7 +28,14 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-[ -x "@SBINDIR@/upsmon" ] && [ -x "@SBINDIR@/upsdrvctl" ] || exit
+POWEROFF_QUIET="`/bin/sed -ne 's#^ *POWEROFF_QUIET= *\(.*\)$#\1#p' @CONFPATH@/nut.conf`" \
+&& [ x"${POWEROFF_QUIET-}" = xtrue ] \
+|| POWEROFF_QUIET="false"
+
+[ -x "@SBINDIR@/upsmon" ] && [ -x "@SBINDIR@/upsdrvctl" ] || {
+    $POWEROFF_QUIET || echo "$0: SKIP: could not locate '@SBINDIR@/upsmon' and/or '@SBINDIR@/upsdrvctl'" >&2
+    exit 1
+}
 
 if @SBINDIR@/upsmon -K >/dev/null 2>&1; then
     # The argument may be anything compatible with /bin/sleep
@@ -36,6 +43,7 @@ if @SBINDIR@/upsmon -K >/dev/null 2>&1; then
     # so not necessarily a non-negative integer)
     wait_delay="`/bin/sed -ne 's#^ *POWEROFF_WAIT= *\(.*\)$#\1#p' @CONFPATH@/nut.conf`" || wait_delay=""
 
+    $POWEROFF_QUIET || echo "$0: Commanding UPSes (if any) to shutdown" >&2
     @SBINDIR@/upsdrvctl shutdown
 
     if [ -n "$wait_delay" ] ; then
@@ -45,11 +53,20 @@ if @SBINDIR@/upsmon -K >/dev/null 2>&1; then
         # Sleep "long enough" to drain the battery if the UPS is
         # in fact on battery, or reboot if it became alive, so
         # this computer is not in limbo forever.
+        $POWEROFF_QUIET || echo "$0: Power-race avoidance: sleeping $wait_delay" >&2
+
         /bin/sleep $wait_delay
+
+        $POWEROFF_QUIET || echo "$0: Power-race avoidance: sleep finished, rebooting..." >&2
+
         # We need to pass --force twice here to bypass systemd
         # and execute the reboot directly ourself.
         /bin/systemctl reboot --force --force
+    else
+        $POWEROFF_QUIET || echo "$0: Power-race avoidance: POWEROFF_WAIT is not configured at this time, proceeding to shutdown" >&2
     fi
+else
+    $POWEROFF_QUIET || echo "$0: SKIP: Not in FSD (killpower) mode at this time" >&2
 fi
 
 exit 0

--- a/scripts/systemd/nutshutdown.in
+++ b/scripts/systemd/nutshutdown.in
@@ -1,8 +1,33 @@
 #!/bin/sh
 
-# This script requires both nut-server (drivers)
-# and nut-client (upsmon) to be present locally
-# and on mounted filesystems
+# Network UPS Tools (NUT) systemd-shutdown integration handler.
+#
+# NOTE: This script requires both nut-server package (or more specifically,
+# the drivers for your device, which may be in further packages grouped
+# by media/protocol and third-party dependencies), nut-client (upsmon),
+# and their configuration files to be present locally and on still-mounted
+# filesystems (may be read-only).
+#
+# Copyright (C) 2011-2023 by NUT contirbutors
+# Michal Hlavinka, Arnaud Quette, Jim Klimov et al.
+#
+# See https://networkupstools.org/
+# and https://github.com/networkupstools/nut/
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
 [ -x "@SBINDIR@/upsmon" ] && [ -x "@SBINDIR@/upsdrvctl" ] || exit
 
 if @SBINDIR@/upsmon -K >/dev/null 2>&1; then

--- a/scripts/systemd/nutshutdown.in
+++ b/scripts/systemd/nutshutdown.in
@@ -32,9 +32,14 @@ POWEROFF_QUIET="`/bin/sed -ne 's#^ *POWEROFF_QUIET= *\(.*\)$#\1#p' @CONFPATH@/nu
 && [ x"${POWEROFF_QUIET-}" = xtrue ] \
 || POWEROFF_QUIET="false"
 
-[ -x "@SBINDIR@/upsmon" ] && [ -x "@SBINDIR@/upsdrvctl" ] || {
-    $POWEROFF_QUIET || echo "$0: SKIP: could not locate '@SBINDIR@/upsmon' and/or '@SBINDIR@/upsdrvctl'" >&2
+[ -x "@SBINDIR@/upsmon" ] || {
+    $POWEROFF_QUIET || echo "$0: SKIP: could not locate '@SBINDIR@/upsmon''" >&2
     exit 1
+}
+
+# Will at most run the optional power-race avoidance sleep part
+[ -x "@SBINDIR@/upsdrvctl" ] || {
+    $POWEROFF_QUIET || echo "$0: WARNING: could not locate '@SBINDIR@/upsdrvctl' - will not command any UPS devices to shut down" >&2
 }
 
 if @SBINDIR@/upsmon -K >/dev/null 2>&1; then
@@ -43,8 +48,10 @@ if @SBINDIR@/upsmon -K >/dev/null 2>&1; then
     # so not necessarily a non-negative integer)
     wait_delay="`/bin/sed -ne 's#^ *POWEROFF_WAIT= *\(.*\)$#\1#p' @CONFPATH@/nut.conf`" || wait_delay=""
 
-    $POWEROFF_QUIET || echo "$0: Commanding UPSes (if any) to shutdown" >&2
-    @SBINDIR@/upsdrvctl shutdown
+    if [ -x "@SBINDIR@/upsdrvctl" ] ; then
+        $POWEROFF_QUIET || echo "$0: Commanding UPSes (if any) to shutdown" >&2
+        @SBINDIR@/upsdrvctl shutdown || echo "$0: Something failed about UPS shutdown commands" >&2
+    fi
 
     if [ -n "$wait_delay" ] ; then
         # Avoid the power-race condition (if wall power returned

--- a/scripts/systemd/nutshutdown.in
+++ b/scripts/systemd/nutshutdown.in
@@ -28,8 +28,11 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-POWEROFF_QUIET="`/bin/sed -ne 's#^ *POWEROFF_QUIET= *\(.*\)$#\1#p' @CONFPATH@/nut.conf`" \
-&& [ x"${POWEROFF_QUIET-}" = xtrue ] \
+if [ -s "@CONFPATH@/nut.conf" ]; then
+    . "@CONFPATH@/nut.conf" || true
+fi
+
+[ x"${POWEROFF_QUIET-}" = xtrue ] \
 || POWEROFF_QUIET="false"
 
 [ -x "@SBINDIR@/upsmon" ] || {
@@ -43,26 +46,24 @@ POWEROFF_QUIET="`/bin/sed -ne 's#^ *POWEROFF_QUIET= *\(.*\)$#\1#p' @CONFPATH@/nu
 }
 
 if @SBINDIR@/upsmon -K >/dev/null 2>&1; then
-    # The argument may be anything compatible with /bin/sleep
-    # (on OSes with systemd - assuming GNU coreutils or compatible,
-    # so not necessarily a non-negative integer)
-    wait_delay="`/bin/sed -ne 's#^ *POWEROFF_WAIT= *\(.*\)$#\1#p' @CONFPATH@/nut.conf`" || wait_delay=""
-
     if [ -x "@SBINDIR@/upsdrvctl" ] ; then
         $POWEROFF_QUIET || echo "$0: Commanding UPSes (if any) to shutdown" >&2
         @SBINDIR@/upsdrvctl shutdown || echo "$0: Something failed about UPS shutdown commands" >&2
     fi
 
-    if [ -n "$wait_delay" ] ; then
+    if [ -n "$POWEROFF_WAIT" ] ; then
         # Avoid the power-race condition (if wall power returned
         # while we were shutting down, so some UPSes would not
         # shutdown and/or powercycle the load as commanded above).
         # Sleep "long enough" to drain the battery if the UPS is
         # in fact on battery, or reboot if it became alive, so
         # this computer is not in limbo forever.
-        $POWEROFF_QUIET || echo "$0: Power-race avoidance: sleeping $wait_delay" >&2
+        $POWEROFF_QUIET || echo "$0: Power-race avoidance: sleeping $POWEROFF_WAIT" >&2
 
-        /bin/sleep $wait_delay
+        # The argument may be anything compatible with /bin/sleep
+        # (on OSes with systemd - assuming GNU coreutils or compatible,
+        # so not necessarily a non-negative integer)
+        /bin/sleep $POWEROFF_WAIT
 
         $POWEROFF_QUIET || echo "$0: Power-race avoidance: sleep finished, rebooting..." >&2
 

--- a/scripts/systemd/nutshutdown.in
+++ b/scripts/systemd/nutshutdown.in
@@ -47,7 +47,10 @@ fi
 
 if @SBINDIR@/upsmon -K >/dev/null 2>&1; then
     if [ -x "@SBINDIR@/upsdrvctl" ] ; then
-        $POWEROFF_QUIET || echo "$0: Commanding UPSes (if any) to shutdown" >&2
+        $POWEROFF_QUIET || {
+            echo "$0: Commanding UPSes (if any) to shutdown" >&2
+            [ -w /dev/console ] && echo "`TZ=UTC LANG=C date`: $0: Commanding UPSes (if any) to shutdown" >/dev/console || true
+        }
         @SBINDIR@/upsdrvctl shutdown || echo "$0: Something failed about UPS shutdown commands" >&2
     fi
 
@@ -58,14 +61,20 @@ if @SBINDIR@/upsmon -K >/dev/null 2>&1; then
         # Sleep "long enough" to drain the battery if the UPS is
         # in fact on battery, or reboot if it became alive, so
         # this computer is not in limbo forever.
-        $POWEROFF_QUIET || echo "$0: Power-race avoidance: sleeping $POWEROFF_WAIT" >&2
+        $POWEROFF_QUIET || {
+            echo "$0: Power-race avoidance: sleeping $POWEROFF_WAIT" >&2
+            [ -w /dev/console ] && echo "`TZ=UTC LANG=C date`: $0: Power-race avoidance: sleeping $POWEROFF_WAIT" >/dev/console || true
+        }
 
         # The argument may be anything compatible with /bin/sleep
         # (on OSes with systemd - assuming GNU coreutils or compatible,
         # so not necessarily a non-negative integer)
         /bin/sleep $POWEROFF_WAIT
 
-        $POWEROFF_QUIET || echo "$0: Power-race avoidance: sleep finished, rebooting..." >&2
+        $POWEROFF_QUIET || {
+            echo "$0: Power-race avoidance: sleep finished, rebooting..." >&2
+            [ -w /dev/console ] && echo "`TZ=UTC LANG=C date`: $0: Power-race avoidance: sleep finished, rebooting..." >/dev/console || true
+        }
 
         # We need to pass --force twice here to bypass systemd
         # and execute the reboot directly ourself.


### PR DESCRIPTION
CC @bigon @aquette @clepple : I intend to merge this soon'ish - no big pressure to hurry, but no big reason to wait. Let me know if you want to review this (experiment in practice?) and need more time... :)

In this PR I poked at (lack of) useful messages from `scripts/systemd/nutshutdown` (and I now think this script itself is more generally useful than just for systemd). In a recent power failure I know the server went down correctly with most events traceable per its journal, but I have no idea if this script was tried.

This led to revision in docs (man page and sample of `nut.conf`) as well as updating the shutdown integration script to be optionally verbose (true by default), and to facilitate power-race avoidance shutdowns on systems that are purely NUT clients (have `upsmon` to check for killpower flag, but do not care about UPSes directly).

Also added small copyright headers for unit files to point back to NUT project, if people have questions...