### PR TITLE
Correct voltage and battery capacity for Opti-UPS 230VAC and/or 24VDC models

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -228,6 +228,14 @@ as part of https://github.com/networkupstools/nut/issues/1410 solution.
  - The `bestfortress` driver shutdown handling was fixed to use a non-trivial
    default timeout [#1820]
 
+ - The `optiups` driver only gave accurate voltage information with 120VAC
+   models and assumed a 12V battery when calculating capacity. There is
+   a protocol command that gives a (fixed) voltage which correlates with
+   the voltage selection DIP switches on the back of the UPS, taking into
+   account whether it is a 120 or 240VAC model. Likewise, now the battery
+   capacity fix is applied globally, based on whether or not the battery
+   voltage is greater than 20V. [#2089]
+
  - GPIO drivers [#1855]:
    * Added a new category of drivers, using GPIO interface to locally connected
      devices (currently limited to 2018+ Linux libgpiod, but its architecture

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -925,6 +925,7 @@
 "Opti-UPS"	"ups"	"1"	"PowerES"	"420E"	"optiups"
 "Opti-UPS"	"ups"	"1"	"VS 575C"	"type=OPTI"	"powercom"
 "Opti-UPS"	"ups"	"1"	"Power Series"	"PS1500E"	"blazer_usb"
+"Opti-UPS"	"ups"	"1"	"Power Series"	"PS1440RM"	"optiups"
 
 "Orvaldi Power Protection"	"ups"	"2"	"various"	"not 400 or 600"	"blazer_ser"
 "Orvaldi Power Protection"	"ups"	"2"	"750 / 900SP"	"USB"	"blazer_usb"

--- a/drivers/optiups.c
+++ b/drivers/optiups.c
@@ -488,22 +488,22 @@ void upsdrv_updateinfo(void)
 		optifill( _pollv_ps, sizeof(_pollv_ps)/sizeof(_pollv_ps[0]) );
 
 		r = optiquery( "NV" );
-		float inV = strtol ( _buf, NULL, 10);
+		short inV = atoi ( _buf );
 		r = optiquery( "OV" );
-		float outV = strtol ( _buf, NULL, 10);
+		short outV = atoi ( _buf );
 
 		r = optiquery( "FV" );
 		if ( r >= 1 )
 		{
-			float f = strtol ( _buf, NULL, 10 );
+			short f = atoi ( _buf );
 			if ( f > 180 )
 			{
 				inV = inV * 2;
 				outV = outV * 2;
 			}
 		}
-		dstate_setinfo( "input.voltage", "%.1f", inV );
-		dstate_setinfo( "output.voltage", "%.1f", outV );
+		dstate_setinfo( "input.voltage", "%d", inV );
+		dstate_setinfo( "output.voltage", "%d", outV );
 	}
 	else
 		optifill( _pollv, sizeof(_pollv)/sizeof(_pollv[0]) );

--- a/drivers/optiups.c
+++ b/drivers/optiups.c
@@ -485,9 +485,9 @@ void upsdrv_updateinfo(void)
 	if ( optimodel == OPTIMODEL_ZINTO )
 		optifill( _pollv_zinto, sizeof(_pollv_zinto)/sizeof(_pollv_zinto[0]) );
 	else if ( optimodel == OPTIMODEL_PS ) {
-		optifill( _pollv_ps, sizeof(_pollv_ps)/sizeof(_pollv_ps[0]) );
-
 		short inV, outV, fV;
+
+		optifill( _pollv_ps, sizeof(_pollv_ps)/sizeof(_pollv_ps[0]) );
 
 		r = optiquery( "NV" );
 		str_to_short ( _buf, &inV, 10 );

--- a/drivers/optiups.c
+++ b/drivers/optiups.c
@@ -487,16 +487,18 @@ void upsdrv_updateinfo(void)
 	else if ( optimodel == OPTIMODEL_PS ) {
 		optifill( _pollv_ps, sizeof(_pollv_ps)/sizeof(_pollv_ps[0]) );
 
+		short inV, outV, fV;
+
 		r = optiquery( "NV" );
-		short inV = atoi ( _buf );
+		str_to_short ( _buf, &inV, 10 );
 		r = optiquery( "OV" );
-		short outV = atoi ( _buf );
+		str_to_short ( _buf, &outV, 10 );
 
 		r = optiquery( "FV" );
 		if ( r >= 1 )
 		{
-			short f = atoi ( _buf );
-			if ( f > 180 )
+			str_to_short ( _buf, &fV, 10 );
+			if ( fV > 180 )
 			{
 				inV = inV * 2;
 				outV = outV * 2;

--- a/drivers/optiups.c
+++ b/drivers/optiups.c
@@ -28,7 +28,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"Opti-UPS driver"
-#define DRIVER_VERSION "1.03"
+#define DRIVER_VERSION "1.04"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -83,7 +83,8 @@ static char _buf[256];
 static int optimodel = 0;
 enum {
 	OPTIMODEL_DEFAULT = 0,
-	OPTIMODEL_ZINTO = 1
+	OPTIMODEL_ZINTO = 1,
+	OPTIMODEL_PS = 2
 };
 
 
@@ -120,6 +121,19 @@ static ezfill_t _pollv_zinto[] = {
 	{ "OV", "output.voltage", 2.0 },
 	{ "OF", "output.frequency", 0.1 },
 	{ "NF", "input.frequency", 0.1 },
+	{ "BT", "ups.temperature", 0 },
+};
+
+/* When on a 220-2400V mains supply, the NV and OV commands return 115V values. FV
+ * returns a value that matches the DIP switch settings for 120/240V models, so
+ * it can be used to scale the valus from NV and OV.
+ *
+ * I suspect this will be the case for other Opti-UPS models, but as I can only
+ * test with a PS-1440RM at 230V the change is only applied to PowerSeries models.
+ */
+static ezfill_t _pollv_ps[] = {
+ 	{ "OL", "ups.load", 1.0 },
+ 	{ "FF", "input.frequency", 0.1 },
 	{ "BT", "ups.temperature", 0 },
 };
 
@@ -347,6 +361,13 @@ void upsdrv_initinfo(void)
 		optiquery( "ON" );
 	}
 
+	/* Autodetect an Opti-UPS PS series */
+	r = optiquery( "IO" );
+	if ( r > 0 && !strncasecmp(_buf, "PS-", 3) )
+	{
+		optimodel = OPTIMODEL_PS;
+	}
+
 	optifill( _initv, sizeof(_initv)/sizeof(_initv[0]) );
 
 	/* Parse out model into longer string -- is this really USEFUL??? */
@@ -463,6 +484,27 @@ void upsdrv_updateinfo(void)
 	/* read some easy settings */
 	if ( optimodel == OPTIMODEL_ZINTO )
 		optifill( _pollv_zinto, sizeof(_pollv_zinto)/sizeof(_pollv_zinto[0]) );
+	else if ( optimodel == OPTIMODEL_PS ) {
+		optifill( _pollv_ps, sizeof(_pollv_ps)/sizeof(_pollv_ps[0]) );
+
+		r = optiquery( "NV" );
+		float inV = strtol ( _buf, NULL, 10);
+		r = optiquery( "OV" );
+		float outV = strtol ( _buf, NULL, 10);
+
+		r = optiquery( "FV" );
+		if ( r >= 1 )
+		{
+			float f = strtol ( _buf, NULL, 10 );
+			if ( f > 180 )
+			{
+				inV = inV * 2;
+				outV = outV * 2;
+			}
+		}
+		dstate_setinfo( "input.voltage", "%.1f", inV );
+		dstate_setinfo( "output.voltage", "%.1f", outV );
+	}
 	else
 		optifill( _pollv, sizeof(_pollv)/sizeof(_pollv[0]) );
 
@@ -475,8 +517,16 @@ void upsdrv_updateinfo(void)
 		float p, v = strtol( _buf, NULL, 10 ) / 10.0;
 		dstate_setinfo("battery.voltage", "%.1f", v );
 
-		/* battery voltage range: 10.4 - 13.0 VDC */
-		p = ((v  - 10.4) / 2.6) * 100.0;
+		if (v > 20)
+		{
+			/* battery voltage range: 20.8 - 26.0 VDC */
+			p = ((v  - 20.8) / 5.2) * 100.0;
+		}
+		else
+		{
+			/* battery voltage range: 10.4 - 13.0 VDC */
+			p = ((v  - 10.4) / 2.6) * 100.0;
+		}
 		if ( p > 100.0 )
 			p = 100.0;
 		dstate_setinfo("battery.charge", "%.1f", p );


### PR DESCRIPTION
The _optiups_ driver only gave accurate voltage information with 120VAC models and assumed a 12V battery when calculating capacity.

There's an `FV` command that gives a (fixed) voltage that correlates with the voltage selection DIP switches on the back of the UPS, taking into account whether ti's a 120 or 240VAC model. So it's easy enough to do `if (FV > 180) then voltage = voltage * 2`, still using the `NV` and `OV` commands to pull the live in/out voltage data.

I suspect this would apply to all UPS using this protocol, under the assumption that the driver was developed on 120VAC devices where the scaling issue wasn't apparent.  However, as I can only test on a PS-1440RM at 230VAC, I've only applied the change to "PS-*" series UPS through a new `_pollv_ps[]` struct.

It would make sense to apply the change by default via the `_pollv[]` struct, if it can be confirmed it doesn't break things for other models at 120VAC.

The battery capacity fix _is_ applied globally., based on whether or not the battery voltage is greater than 20V.

I don't work with C very often, and due to my lack of familiarity there's some inefficiency with how the `FV` command is handled. It really should only need to be run once, during init. I have it being run on every update because I wasn't sure how best to set it during init and then get it for the updates. So that's not ideal, but it works and a few extra bytes each update doesn't seem like the end of  the world.  :) I'd be happy to fix the inefficiency if someone wants to point me in the right direction though.