### PR TITLE
Fix docs makefiles

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -403,16 +403,26 @@ ASPELL_OUT_NOTERRORS = (^[ \t]*[\*\@]|^$$)
 
 # WARNING: The percent wildcard is a GNU extension; otherwise we need
 # a ".txt.txt-spellchecked" type of rule and files like "README" all
-# renamed to *.txt, or lots of rules for files without the extensions
+# renamed to *.txt, or lots of rules for files without the extensions.
+# Maybe this will get simplified with renaming to *.adoc though ;)
+#
 # Other Makefiles have a relatively simple life, dealing with just a
 # few texts and name/extension patterns in their directories.
 #?#.txt.txt-spellchecked: Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
 #%-spellchecked: % Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
 #*-spellchecked */*-spellchecked: $(@:-spellchecked=) $(top_srcdir)/docs/Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
-# NOTE: This portable  rule RELIES on just one SPELLCHECK_SRC defined
+#
+# NOTE: For some reason, at least GNU make insists on bogus calls:
+#   update target 'asciidoc-vars.conf' due to: asciidoc-vars.conf-spellchecked
+# when we e.g. `make dist` after a `make spellcheck` and ended up
+# with removed and touched (emptied) file, only this one so far.
+#
+# NOTE: This portable rule RELIES on just one SPELLCHECK_SRC defined
 # at a time, with an outer Makefile caller ensuring the looping:
 $(SPELLCHECK_BUILDDIR)/$(SPELLCHECK_SRC_ONE)-spellchecked: $(SPELLCHECK_SRCDIR)/$(SPELLCHECK_SRC_ONE) $(abs_top_srcdir)/docs/Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
 	@LANG=C; LC_ALL=C; export LANG; export LC_ALL; \
+	 if test x"$(SPELLCHECK_SRC_ONE)" = x ; then echo "SKIP: Bogus spellcheck call for empty target filename (with make target $@)" >&2 ; exit 0; fi; \
+	 case "$@" in *-spellchecked) ;; *) echo "SKIP: Bogus spellcheck call for non '*-spellchecked' target filename (with make target $@)" >&2 ; exit 0;; esac; \
 	 rm -f "$@" || true ; \
 	 echo "  ASPELL   Spell checking on $(SPELLCHECK_SRCDIR)/$(SPELLCHECK_SRC_ONE)"; \
 	 OUT="`(sed 's,^\(.*\)$$, \1,' | $(ASPELL) -a $(ASPELL_NUT_TEXMODE_ARGS) $(ASPELL_NUT_COMMON_ARGS) 2>&1) < "$(SPELLCHECK_SRCDIR)/$(SPELLCHECK_SRC_ONE)"`" \

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -37,7 +37,7 @@ MAN_CONF_PAGES = \
 	upsd.users.5 \
 	upsmon.conf.5 \
 	upssched.conf.5
-endif
+endif WITH_MANS
 
 man5_MANS = $(MAN_CONF_PAGES)
 
@@ -81,7 +81,7 @@ MAN_CLIENT_PAGES = \
 	upsmon.8 \
 	upsrw.8 \
 	upssched.8
-endif
+endif WITH_MANS
 
 man8_MANS = $(MAN_CLIENT_PAGES)
 
@@ -102,7 +102,7 @@ SRC_TOOL_PAGES = nut-scanner.txt nut-recorder.txt
 
 if WITH_MANS
 MAN_TOOL_PAGES = nut-scanner.8 nut-recorder.8
-endif
+endif WITH_MANS
 
 man8_MANS += $(MAN_TOOL_PAGES)
 
@@ -127,12 +127,12 @@ MAN8_CGI_PAGES = \
 	upsset.cgi.8 \
 	upsstats.cgi.8 \
 	upsimage.cgi.8
-endif
+endif WITH_MANS
 
 if WITH_CGI
 man5_MANS += $(MAN5_CGI_PAGES)
 man8_MANS += $(MAN8_CGI_PAGES)
-endif
+endif WITH_CGI
 
 HTML_CGI_MANS = \
 	hosts.conf.html \
@@ -318,7 +318,7 @@ MAN1_DEV_PAGES = \
 
 MAN8_DEV_PAGES = \
 	sockdebug.8
-endif
+endif WITH_MANS
 
 if WITH_DEV
 man3_MANS = $(MAN3_DEV_PAGES)
@@ -326,9 +326,9 @@ man8_MANS += $(MAN8_DEV_PAGES)
 
 if !WITH_PKG_CONFIG
 man1_MANS = $(MAN1_DEV_PAGES)
-endif
-# WITH_DEV
-endif
+endif !WITH_PKG_CONFIG
+
+endif WITH_DEV
 
 HTML_DEV_MANS = \
 	upsclient.html \
@@ -382,11 +382,11 @@ HTML_DEV_MANS = \
 
 # Drivers related manpages
 
-# (--with-drivers=...)
+# If (--with-drivers=...) then we only build specific documents, however
+# still do track (and EXTRA_DIST, and spellcheck) all available sources.
 if SOME_DRIVERS
 man8_MANS += $(DRIVER_MAN_LIST)
-
-else
+endif
 
 # (--with-serial)
 SRC_SERIAL_PAGES = \
@@ -433,6 +433,7 @@ SRC_SERIAL_PAGES = \
 	victronups.txt	\
 	apcupsd-ups.txt
 
+if ! SOME_DRIVERS
 if WITH_MANS
 MAN_SERIAL_PAGES = \
 	al175.8	\
@@ -476,11 +477,11 @@ MAN_SERIAL_PAGES = \
 	upscode2.8	\
 	victronups.8	\
 	apcupsd-ups.8
-endif
+endif WITH_MANS
 
 if WITH_SERIAL
 man8_MANS +=  $(MAN_SERIAL_PAGES)
-endif
+endif WITH_SERIAL
 
 HTML_SERIAL_MANS = \
 	al175.html	\
@@ -524,18 +525,21 @@ HTML_SERIAL_MANS = \
 	upscode2.html	\
 	victronups.html	\
 	apcupsd-ups.html
+endif ! SOME_DRIVERS
 
 # (--with-snmp)
 SRC_SNMP_PAGES = snmp-ups.txt
+if ! SOME_DRIVERS
 if WITH_MANS
 MAN_SNMP_PAGES = snmp-ups.8
-endif
+endif WITH_MANS
 
 if WITH_SNMP
 man8_MANS += $(MAN_SNMP_PAGES)
-endif
+endif WITH_SNMP
 
 HTML_SNMP_MANS = snmp-ups.html
+endif ! SOME_DRIVERS
 
 # (--with-usb)
 SRC_USB_LIBUSB_PAGES = \
@@ -549,6 +553,7 @@ SRC_USB_LIBUSB_PAGES = \
 	tripplite_usb.txt \
 	usbhid-ups.txt
 
+if ! SOME_DRIVERS
 # NOTE: nut_usb_addvars and blazer-common are not standalone man pages
 if WITH_MANS
 MAN_USB_LIBUSB_PAGES = \
@@ -559,11 +564,11 @@ MAN_USB_LIBUSB_PAGES = \
 	riello_usb.8	\
 	tripplite_usb.8 \
 	usbhid-ups.8
-endif
+endif WITH_MANS
 
 if WITH_USB
 man8_MANS += $(MAN_USB_LIBUSB_PAGES)
-endif
+endif WITH_USB
 
 HTML_USB_LIBUSB_MANS = \
 	bcmxcp_usb.html \
@@ -573,121 +578,140 @@ HTML_USB_LIBUSB_MANS = \
 	riello_usb.html	\
 	tripplite_usb.html \
 	usbhid-ups.html
+endif ! SOME_DRIVERS
 
 # (--with-serial / --with-usb)
 SRC_SERIAL_USB_PAGES = \
 	nutdrv_qx.txt
 
+if ! SOME_DRIVERS
 if WITH_MANS
 MAN_SERIAL_USB_PAGES = \
 	nutdrv_qx.8
-endif
+endif WITH_MANS
 
 if WITH_SERIAL
 man8_MANS += $(MAN_SERIAL_USB_PAGES)
-else
+else !WITH_SERIAL
 if WITH_USB
 man8_MANS += $(MAN_SERIAL_USB_PAGES)
-endif
-endif
+endif WITH_USB
+endif !WITH_SERIAL
 
 HTML_SERIAL_USB_MANS = \
 	nutdrv_qx.html
+endif ! SOME_DRIVERS
 
 # (--with-neon)
 SRC_NETXML_PAGES = netxml-ups.txt
+if ! SOME_DRIVERS
 if WITH_MANS
 MAN_NETXML_PAGES = netxml-ups.8
-endif
+endif WITH_MANS
 
 if WITH_NEON
 man8_MANS += $(MAN_NETXML_PAGES)
-endif
+endif WITH_NEON
 
 HTML_NETXML_MANS = netxml-ups.html
+endif ! SOME_DRIVERS
 
 # (--with-powerman)
 SRC_POWERMAN_PAGES = powerman-pdu.txt
+if ! SOME_DRIVERS
 if WITH_MANS
 MAN_POWERMAN_PAGES = powerman-pdu.8
-endif
+endif WITH_MANS
 
 if WITH_LIBPOWERMAN
 man8_MANS += $(MAN_POWERMAN_PAGES)
-endif
+endif WITH_LIBPOWERMAN
 
 HTML_POWERMAN_MANS = powerman-pdu.html
+endif ! SOME_DRIVERS
 
 # (--with-ipmi)
 SRC_IPMIPSU_PAGES = nut-ipmipsu.txt
+if ! SOME_DRIVERS
 if WITH_MANS
 MAN_IPMIPSU_PAGES = nut-ipmipsu.8
-endif
+endif WITH_MANS
 
 if WITH_IPMI
 man8_MANS += $(MAN_IPMIPSU_PAGES)
-endif
+endif WITH_IPMI
 
 HTML_IPMIPSU_MANS = nut-ipmipsu.html
+endif ! SOME_DRIVERS
 
+# (--with-macosx_ups)
 SRC_MACOSX_PAGES = macosx-ups.txt
+if ! SOME_DRIVERS
 if WITH_MANS
 MAN_MACOSX_PAGES = macosx-ups.8
-endif
+endif WITH_MANS
 
 if WITH_MACOSX
 man8_MANS += $(MAN_MACOSX_PAGES)
-endif
+endif WITH_MACOSX
 
 HTML_MACOSX_MANS = macosx-ups.html
+endif ! SOME_DRIVERS
 
+# (--with-modbus)
 SRC_MODBUS_PAGES = phoenixcontact_modbus.txt \
 	generic_modbus.txt \
 	huawei-ups2000.txt \
 	socomec_jbus.txt   \
 	adelsystem_cbi.txt
+
+if ! SOME_DRIVERS
 if WITH_MANS
 MAN_MODBUS_PAGES = phoenixcontact_modbus.8 \
 	generic_modbus.8 \
 	huawei-ups2000.8 \
 	socomec_jbus.8   \
 	adelsystem_cbi.8
-endif
+endif WITH_MANS
 
 if WITH_MODBUS
 man8_MANS += $(MAN_MODBUS_PAGES)
-endif
+endif WITH_MODBUS
 
 HTML_MODBUS_MANS = phoenixcontact_modbus.html \
 	generic_modbus.html \
 	huawei-ups2000.html \
 	socomec_jbus.html   \
 	adelsystem_cbi.html
+endif ! SOME_DRIVERS
 
+# (--with-linux_i2c)
 SRC_LINUX_I2C_PAGES = asem.txt pijuice.txt
+if ! SOME_DRIVERS
 if WITH_MANS
 MAN_LINUX_I2C_PAGES = asem.8 pijuice.8
-endif
+endif WITH_MANS
 
 if WITH_LINUX_I2C
 man8_MANS += $(MAN_LINUX_I2C_PAGES)
-endif
+endif WITH_LINUX_I2C
 
 HTML_LINUX_I2C_MANS = asem.html pijuice.html
+endif ! SOME_DRIVERS
 
+# (--with-gpio)
 SRC_GPIO_PAGES = generic_gpio.txt
+if ! SOME_DRIVERS
 if WITH_MANS
 MAN_GPIO_PAGES = generic_gpio.8
-endif
+endif WITH_MANS
 
 if WITH_GPIO
 man8_MANS += $(MAN_GPIO_PAGES)
-endif
+endif WITH_GPIO
 
 HTML_GPIO_MANS = generic_gpio.html
-
-# SOME_DRIVERS
-endif
+endif ! SOME_DRIVERS
 
 MAN_MANS =
 if WITH_MANS
@@ -711,7 +735,7 @@ MAN_MANS += \
 	$(MAN_MODBUS_PAGES) \
 	$(MAN_LINUX_I2C_PAGES) \
 	$(MAN_GPIO_PAGES)
-endif
+endif WITH_MANS
 
 SRC_DRIVERS_PAGES = \
 	$(SRC_SERIAL_PAGES) \
@@ -727,8 +751,8 @@ SRC_DRIVERS_PAGES = \
 	$(SRC_GPIO_PAGES)
 
 if SOME_DRIVERS
-# The list above probably came up empty in this case, so make sure that
-# the drivers requested by configure script are documented in the build;
+# (Legacy note) The list above probably came up empty in this case, so make sure
+# that the drivers requested by configure script are documented in the build;
 # notably in the linkman-driver-names.txt file.
 SRC_DRIVERS_PAGES += \
 	$(DRIVER_MAN_LIST_PAGES)
@@ -756,8 +780,8 @@ if ! SKIP_MANS
 EXTRA_DIST += dist
 dist:
 	@echo "ERROR: Manpage building was disabled by configure script, and these pages are required for our proper 'make dist'" >&2 ; false
-endif
-endif
+endif ! SKIP_MANS
+endif ! WITH_MANS
 
 # For builds done from dist'ed sources, there may be a conflict of timestamps
 # between original *.txt files and pre-built manpages etc. leading to skipping


### PR DESCRIPTION
Closes: #2081 (to always distribute all man page sources - even if the build was configured only for a few drivers)

Note: thinking about it, this might still falter in contrived use-cases... The dist tarball is supposed to include pre-built man pages (from the distributor's system), so the building systems have an option to not re-generate the pages or even to not have tools for that, and yet to produce packages convenient for end-users. A `configure --with-drivers=usbhid-ups` sort of build config would only pre-generate and dist-tarball that driver's man page. TLDR: "real" dist tarballs should be made on systems capable of (and configured to) building all driver types.

TODO: In fact, no system is able to build all driver types nowadays - e.g. some are specific to MacOS or Linux. A recipe toggle is needed, perhaps to `configure` a build for dist purposes and force building all man pages (and/or other doc formats) regardless of being able to build the drivers.

Other than that, with this PR I've also caught an annoying problem that sometimes `docs/asciidoc-vars.conf` just disappeared. This was tracked down to strange mis-behavior of (GNU?) make: if I `make spellcheck` and then e.g. `make dist`, it tries to:
````
Makefile:1224: update target 'asciidoc-vars.conf' due to: asciidoc-vars.conf-spellchecked
````
and passes an empty `"$(SPELLCHECK_SRC_ONE)"` into it, however the target `"$@"` is set to `asciidoc-vars.conf` (for a rule targeting explicitly `$(SPELLCHECK_BUILDDIR)/$(SPELLCHECK_SRC_ONE)-spellchecked: ...`!) As a result, it deletes the target file and then fails to process the empty input. Strange case (only for this file) got strange workarounds with this PR...

Just to clarify: it should never have got to update the documentation source due to touch-file at all, it should be the other way around!