### PR TITLE
tripplite_usb.c add device matching based on ups.id

### DIFF
--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -331,7 +331,7 @@ static int reconnect_ups(void)
 	upsdebugx(2, "= device has been disconnected, try to reconnect =");
 	upsdebugx(2, "==================================================");
 
-	ret = comm_driver->open_dev(&udev, &curDevice, reopen_matcher, NULL);
+	ret = comm_driver->open_dev(&udev, &curDevice, reopen_matcher, match_ups_id);
 	if (ret < 1) {
 		upslogx(LOG_INFO, "Reconnecting to UPS failed; will retry later...");
 		dstate_datastale();
@@ -1582,8 +1582,9 @@ void upsdrv_initups(void)
 	regex_array[4] = getval("serial"); /* probably won't see this */
 	regex_array[5] = getval("bus");
 	regex_array[6] = getval("device");
+	regex_array[7] = getval("upsid");  /* this is a unique number that is settable with upsrw */
 #if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
-	regex_array[7] = getval("busport");
+	regex_array[8] = getval("busport");
 #endif
 
 	r = USBNewRegexMatcher(&regex_matcher, regex_array, REG_ICASE | REG_EXTENDED);
@@ -1598,7 +1599,7 @@ void upsdrv_initups(void)
 
 	/* Search for the first supported UPS matching the regular
 	 * expression */
-	r = comm_driver->open_dev(&udev, &curDevice, regex_matcher, NULL);
+	r = comm_driver->open_dev(&udev, &curDevice, regex_matcher, match_ups_id);
 	if (r < 1) {
 		fatalx(EXIT_FAILURE, "No matching USB/HID UPS found");
 	}
@@ -1647,6 +1648,31 @@ void upsdrv_initups(void)
 	if (getval("rebootdelay"))
 		bootdelay = atoi(getval("rebootdelay"));
 #endif
+}
+
+int match_ups_id(USBDevice_t *hd) {
+    char u_msg[] = "U";
+    unsigned char u_value[9];
+    long unit_id = -1;
+    ssize_t ret;
+    char *config_ups_id = getval("upsid");
+
+    ret = send_cmd(u_msg, sizeof(u_msg), u_value, sizeof(u_value)-1);
+    if (ret <= 0) {
+        upslogx(LOG_INFO, "Unit ID not retrieved (not available on all models)");
+    } else {
+        unit_id = (long)((unsigned)(u_value[1]) << 8) | (unsigned)(u_value[2]);
+    }
+
+    if (unit_id >= 0 && strcmp(config_ups_id, unit_id) == 0) {
+        dstate_setinfo("ups.id", "%ld", unit_id);
+        dstate_setflags("ups.id", ST_FLAG_RW | ST_FLAG_STRING);
+        dstate_setaux("ups.id", 5);
+        upslogx(LOG_DEBUG, "Unit ID: %ld", unit_id);
+        return 1; // Match found
+    } else {
+        return 0; // No match
+    }
 }
 
 void upsdrv_cleanup(void)


### PR DESCRIPTION
Implemented a function: match_ups_id to read the upsid from config file, read the ups.id from the device and compare them such that the driver can match based on the ups.id (unit id) which is user configureable using upsrw. 

We need to add this to driver documentation.
Probably bump driver version.

Not sure if this code actually works. I didn't compile... theoretically though it should.