### PR TITLE
tripplite_usb.c Enhanced Device Identification in the tripplite_usb Driver for Tripp Lite USB UPSes

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -178,6 +178,9 @@ as part of https://github.com/networkupstools/nut/issues/1410 solution.
 
  - powercom driver should now try harder to refresh data from device [#356]
 
+ - tripplite_usb driver now supports configuration of `upsid` to match the
+   specific device (not all firmware/hardware models support this) [#2075]
+
  - apcupsd-ups:
    * improvement for `POLL_INTERVAL_MIN` from PR #797 was buggy [#2007]
    * fix to clean obsoleted readings (if any) AFTER getting new info from an

--- a/docs/man/tripplite_usb.txt
+++ b/docs/man/tripplite_usb.txt
@@ -63,6 +63,14 @@ file (or with '-x' on the command line):
 
 include::nut_usb_addvars.txt[]
 
+- `-x upsid="12345"`
+
+Select a specific UPS by its unique UPS ID. The argument is a regular expression 
+that must match the UPS ID string. This allows for precise identification of UPS 
+devices when multiple devices of the same make and model are connected.
+See below regarding how to read and write the ups id (unit id) using linkman:upsrw[8].
+
+
 [NOTE]
 .Notes for `tripplite_usb` driver handling of common USB matching settings:
 ======
@@ -110,7 +118,7 @@ changed at runtime by linkman:upsrw[8].
 
 *ups.id*::
 
-Some SMARTPRO models feature an ID that can be set and retrieved.
+Some SMARTPRO models feature an Unit ID (ups.id) that can be set and retrieved.
 If your UPS supports this feature, this variable will be listed in
 the output of linkman:upsrw[8].
 
@@ -143,10 +151,10 @@ same time, since they have different USB Product ID strings. If you have two
 SMART1500RM2U units, you would have to find which USB bus and device number
 each unit is on (via lsusb(8)).
 
-Some of the SMART*2U models have an ID number, but because this ID is not
-exposed as a USB string descriptor, there is no easy way to use this ID to
-distinguish between multiple UPS units on a single machine. The UPS would need
-to be claimed by the driver in order to read this ID.
+Some of the SMART*2U models have a configurable Unit ID number, and you can now use the `upsid` 
+config argument to uniquely specify which UPS a given driver instance should control. 
+This allows for precise identification of UPS devices when multiple devices are connected.
+To retrieve or set the upsid use the linkman:upsrw[8] utility.
 
 AUTHORS
 -------

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1319,6 +1319,7 @@ UPS's
 UPSCONN
 UPSDESC
 UPSHOST
+upsid
 UPSIMAGEPATH
 UPSLC
 UPSOutletSystemOutletDelayBeforeReboot

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -326,8 +326,8 @@ static int send_cmd(const unsigned char *msg, size_t msg_len, unsigned char *rep
    Default Unit Id is 65535. May be set with upsrw, and it persists after powerloss as well.
    To match by ups id, (upsid='your ups id') must be defined inside the ups.conf
 */ 
-int match_by_unitid(usb_dev_handle *udev, USBDevice_t *hd, usb_ctrl_charbuf rdbuf, usb_ctrl_charbufsize rdlen);
-int match_by_unitid(usb_dev_handle *udev, USBDevice_t *hd, usb_ctrl_charbuf rdbuf, usb_ctrl_charbufsize rdlen)
+int match_by_unitid(usb_dev_handle *argudev, USBDevice_t *arghd, usb_ctrl_charbuf rdbuf, usb_ctrl_charbufsize rdlen);
+int match_by_unitid(usb_dev_handle *argudev, USBDevice_t *arghd, usb_ctrl_charbuf rdbuf, usb_ctrl_charbufsize rdlen)
 {
 	char *value = getval("upsid");
 	int config_unit_id = 0;
@@ -335,8 +335,8 @@ int match_by_unitid(usb_dev_handle *udev, USBDevice_t *hd, usb_ctrl_charbuf rdbu
 	unsigned char u_msg[] = "U";
 	unsigned char u_value[9];
 
-	NUT_UNUSED_VARIABLE(udev);
-	NUT_UNUSED_VARIABLE(hd);
+	NUT_UNUSED_VARIABLE(argudev);
+	NUT_UNUSED_VARIABLE(arghd);
 	NUT_UNUSED_VARIABLE(rdbuf);
 	NUT_UNUSED_VARIABLE(rdlen);
 

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -146,7 +146,7 @@ upsdrv_info_t	upsdrv_info = {
 	"Charles Lepple <clepple+nut@gmail.com>\n" \
 	"Russell Kroll <rkroll@exploits.org>\n" \
 	"Rickard E. (Rik) Faith <faith@alephnull.com>\n" \
-	"Nicholas J. Kain <nicholas@kain.us>\n", \
+	"Nicholas J. Kain <nicholas@kain.us>\n" \
 	"Eliran Sapir <e@vcboy.com>",
 	DRV_EXPERIMENTAL,
 	{ NULL }

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -318,7 +318,7 @@ static long battery_voltage_nominal = 12,
 static unsigned int offdelay = DEFAULT_OFFDELAY;
 /* static unsigned int bootdelay = DEFAULT_BOOTDELAY; */
 
-// Function declaration for send_cmd
+/* Function declaration for send_cmd */
 static int send_cmd(const unsigned char *msg, size_t msg_len, unsigned char *reply, size_t reply_len);
 
 /* Driver matching by ups.id since serial number isn't exposed on some Tripplite models.
@@ -329,36 +329,39 @@ static int send_cmd(const unsigned char *msg, size_t msg_len, unsigned char *rep
 int match_by_unitid(usb_dev_handle *udev, USBDevice_t *hd, usb_ctrl_charbuf rdbuf, usb_ctrl_charbufsize rdlen);
 int match_by_unitid(usb_dev_handle *udev, USBDevice_t *hd, usb_ctrl_charbuf rdbuf, usb_ctrl_charbufsize rdlen)
 {
-    NUT_UNUSED_VARIABLE(udev);
-    NUT_UNUSED_VARIABLE(hd);
-    NUT_UNUSED_VARIABLE(rdbuf);
-    NUT_UNUSED_VARIABLE(rdlen);
 	char *value = getval("upsid");
 	int config_unit_id = 0;
-    ssize_t ret;
-    unsigned char u_msg[] = "U";
-    unsigned char u_value[9];
-	// Read ups id from the ups.conf
+	ssize_t ret;
+	unsigned char u_msg[] = "U";
+	unsigned char u_value[9];
+
+	NUT_UNUSED_VARIABLE(udev);
+	NUT_UNUSED_VARIABLE(hd);
+	NUT_UNUSED_VARIABLE(rdbuf);
+	NUT_UNUSED_VARIABLE(rdlen);
+
+	/* Read ups id from the ups.conf */
     if (value != NULL) {
         config_unit_id = atoi(value);
     }
-    // Read ups id from the device
-    if (tl_model != TRIPP_LITE_OMNIVS && tl_model != TRIPP_LITE_SMART_0004) {
-        /* Unit ID might not be supported by all models: */
-        ret = send_cmd(u_msg, sizeof(u_msg), u_value, sizeof(u_value) - 1);
-        if (ret <= 0) {
-            upslogx(LOG_INFO, "Unit ID not retrieved (not available on all models)");
-        } else {
-            unit_id = (int)((unsigned)(u_value[1]) << 8) | (unsigned)(u_value[2]);
-        }
-    }
 
-    // Check if the ups ids match
-    if (config_unit_id == unit_id) {
-        return 1;
-    } else {
-        return 0;
-    }
+	/* Read ups id from the device */
+	if (tl_model != TRIPP_LITE_OMNIVS && tl_model != TRIPP_LITE_SMART_0004) {
+		/* Unit ID might not be supported by all models: */
+		ret = send_cmd(u_msg, sizeof(u_msg), u_value, sizeof(u_value) - 1);
+		if (ret <= 0) {
+			upslogx(LOG_INFO, "Unit ID not retrieved (not available on all models)");
+		} else {
+			unit_id = (int)((unsigned)(u_value[1]) << 8) | (unsigned)(u_value[2]);
+		}
+	}
+
+    /* Check if the ups ids match */
+	if (config_unit_id == unit_id) {
+		return 1;
+	} else {
+		return 0;
+	}
 }
 
 /*!@brief Try to reconnect once.


### PR DESCRIPTION
@jimklimov My apologies, I screwed up the pull request with a rebase. I just started a new pull request to have a clean slate scenario. Added the NUT_UNUSED_VARIABLE  per your recommendation.

background:
tripplite_usb.c Added UPS ID (upsid) Support: The code now includes support for matching and uniquely identifying UPS devices using the UPS ID (upsid). The upsid configuration option has been added, which accepts a regular expression to match the UPS ID string. This was done by adding a new function called match_by_unitid, that reads the upsid from the config file, then reads the upsid from the device, and checks if they match. This function is now passed to the comm_driver matcher on first connect and reconnects.

Added the upsid to the upsdrv_makevartable function so it is read and stored from the config file.

tripplite_usb.txt Updated Documentation: The driver documentation was updated to reflect the new functionality. The "EXTRA ARGUMENTS" section now includes information about the upsid configuration option, and how to set it.

thank you to @jimklimov for pointing me in the right direction and hand holding.
closes #2075 