### PR TITLE
Revise `upsmon` reaction to UPS calibrations vs. critical state

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -404,7 +404,12 @@ as part of https://github.com/networkupstools/nut/issues/1410 solution.
    `MONITOR`'ed amount of power sources are considered not being "fed" for
    the power value calculation purposes. The `BYPASS` state is now treated
    similarly to `ONBATT`: currently this UPS "feeds" its load, but if later
-   communications fail, it is considered dead. [#2044]
+   communications fail, it is considered dead. This may have unintended
+   consequences for devices (or NUT drivers) that do not report these modes
+   correctly, e.g. an APC calibration routine seems to start with a few
+   seconds of "OFF" state, so the reported status is only considered as a
+   loss of feed if it persists for more than `OFFDURATION` seconds. [#2044,
+   #2104]
 
  - Extended Linux systemd support with optional notifications about daemon
    state (READY, RELOADING, STOPPING) and watchdog keep-alive messages [#1590]

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -1070,8 +1070,9 @@ static int is_ups_critical(utype_t *ups)
 
 	/* give the primary up to HOSTSYNC seconds before shutting down */
 	if ((now - ups->lastnoncrit) > hostsync) {
-		upslogx(LOG_WARNING, "Giving up on the primary for UPS [%s]",
-			ups->sys);
+		upslogx(LOG_WARNING, "Giving up on the primary for UPS [%s] "
+			"after %d sec since last comms",
+			ups->sys, (int)(now - ups->lastnoncrit));
 		return 1;
 	}
 

--- a/clients/upsmon.h
+++ b/clients/upsmon.h
@@ -73,6 +73,9 @@ typedef struct {
 	time_t  lastnoncrit;		/* time of last non-crit poll	*/
 	time_t	lastrbwarn;		/* time of last REPLBATT warning*/
 	time_t	lastncwarn;		/* time of last NOCOMM warning	*/
+
+	time_t	offsince;		/* time of recent entry into OFF state	*/
+
 	void	*next;
 }	utype_t;
 

--- a/conf/upsmon.conf.sample.in
+++ b/conf/upsmon.conf.sample.in
@@ -332,6 +332,25 @@ POWERDOWNFLAG "@POWERDOWNFLAG@"
 # If you use IGNORE, don't use any other flags on the same line.
 
 # --------------------------------------------------------------------------
+# OFFDURATION - put "OFF" state into effect if it persists for this many seconds
+#
+# NUT supports an "administrative OFF" for power devices which can be managed to
+# turn off their application workload, while the UPS or ePDU remains accessible
+# for monitoring and management. This toggle allows to delay propagation of such
+# state into a known loss of a feed (possibly triggering FSD on `upsmon` clients
+# which `MONITOR` the device and are in fact still alive -- e.g. with multiple
+# power sources or because they as the load are not really turned off), because
+# when some devices begin battery calibration, they report "OFF" for a few seconds
+# and only then they might report "CAL" after switching all the power relays --
+# thus causing false-positives for `upsmon` FSD trigger.
+#
+# A negative value means to disable decreasing the counter of working power
+# supplies in such cases, and a zero makes the effect of detected "OFF" state
+# immediate. Built-in default value is 30 (seconds).
+
+OFFDURATION 30
+
+# --------------------------------------------------------------------------
 # RBWARNTIME - replace battery warning time in seconds
 #
 # upsmon will normally warn you about a battery that needs to be replaced

--- a/docs/man/upsmon.conf.txt
+++ b/docs/man/upsmon.conf.txt
@@ -318,6 +318,27 @@ Refer to the section:
 [[UPS_shutdown]] "Configuring automatic shutdowns for low battery events",
 or refer to the online version.
 
+*OFFDURATION* 'seconds'::
+
+NUT supports an "administrative OFF" for power devices which can be managed to
+turn off their application workload, while the UPS or ePDU remains accessible
+for monitoring and management. This toggle allows to delay propagation of such
+state into a known loss of a feed (possibly triggering FSD on `upsmon` clients
+which `MONITOR` the device and are in fact still alive -- e.g. with multiple
+power sources or because they as the load are not really turned off), because
+when some devices begin battery calibration, they report "OFF" for a few seconds
+and only then they might report "CAL" after switching all the power relays --
+thus causing false-positives for `upsmon` FSD trigger.
++
+A negative value means to disable decreasing the counter of working power
+supplies in such cases, and a zero makes the effect of detected "OFF" state
+immediate. Built-in default value is 30 (seconds), to put an "OFF" state into
+effect (decrease known-fed supplies count) if it persists for this many seconds.
++
+NOTE: so far we support the device reporting an "OFF" state which usually
+means completely un-powering the load; a bug-tracker issue was logged to
+design similar support for just some manageable outlets or outlet groups.
+
 *RBWARNTIME* 'seconds'::
 
 When a UPS says that it needs to have its battery replaced, upsmon will

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3246 utf-8
+personal_ws-1.1 en 3247 utf-8
 AAS
 ABI
 ACFAIL
@@ -818,6 +818,7 @@ OC
 ODH
 OEM
 OEM'ed
+OFFDURATION
 OID
 OIDs
 OLHVT

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -1856,6 +1856,15 @@ static void ups_status_set(void)
 		dstate_delinfo("input.transfer.reason");
 	}
 
+	/* Report calibration mode first, because it looks like OFF or OB
+	 * for many implementations (literally, it is a temporary OB state
+	 * managed by the UPS hardware to become OL later... if it guesses
+	 * correctly when to do so), and may cause false alarms for us to
+	 * raise FSD urgently. So we first let upsmon know it is just a drill.
+	 */
+	if (ups_status & STATUS(CALIB)) {
+		status_set("CAL");		/* calibration */
+	}
 
 	if (!(ups_status & STATUS(ONLINE))) {
 		status_set("OB");		/* on battery */
@@ -1906,9 +1915,6 @@ static void ups_status_set(void)
 	}
 	if (ups_status & STATUS(OFF)) {
 		status_set("OFF");		/* ups is off */
-	}
-	if (ups_status & STATUS(CALIB)) {
-		status_set("CAL");		/* calibration */
 	}
 }
 


### PR DESCRIPTION
Addresses part of #2104

This PR revisits the changes from PR #2055 for issue #2044, which added handling of (presumed administrative) "OFF" and "BYPASS" states in `upsmon`, to report that while the power device remains manageable, its load is no longer fed (thus `upsmon` must decrease the counter of healthy power supplies).

Practice has shown that some devices begin their calibration rituals indistinguishably (at least in existing NUT drivers) from an "OFF" state, and only after a few seconds they switch to "OL+DISCHRG" (in the example case at #2104). This time gap sufficed for NUT to initiate system shutdown whenever the UPS started its regular calibration.

This PR introduces an `OFFDURATION` option to take into account the reported "OFF" state only if it has persisted long enough, and revises the triggers we use in `upsmon` to proclaim a device as being in critical state (hence to decrease the supplies counter, which can lead to initiating a shutdown).