### PR TITLE
Fix loss of configure-phase detection due to recent enhancements

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1205,8 +1205,8 @@ AC_CACHE_CHECK([for inet_pton() with IPv4 and IPv6 support],
             [[/* int inet_pton(int af, const char *src, char *dst); */
 struct in_addr  ipv4;
 struct in6_addr ipv6;
-printf("%i", inet_pton(AF_INET, "1.2.3.4", &ipv4));
-printf("%i", inet_pton(AF_INET6, "::1", &ipv6))
+printf("%i ", inet_pton(AF_INET, "1.2.3.4", &ipv4));
+printf("%i ", inet_pton(AF_INET6, "::1", &ipv6))
 /* autoconf adds ";return 0;" */
 ]])],
         [ac_cv_func_inet_pton=yes], [ac_cv_func_inet_pton=no]

--- a/configure.ac
+++ b/configure.ac
@@ -1024,28 +1024,6 @@ AC_CHECK_FUNCS(vsnprintf snprintf, [], [
 	AC_TYPE_LONG_LONG_INT
 ])
 
-AC_MSG_CHECKING([whether printf allows null string args])
-AC_LANG_PUSH([C])
-dnl The following code crashes on some libc implementations (e.g. Solaris 8)
-dnl TODO: We may need to update NUT codebase to use NUT_STRARG() macro more
-dnl often and consistently, or find a way to tweak upsdebugx() etc. varargs
-AX_RUN_OR_LINK_IFELSE([AC_LANG_PROGRAM(
-    [#include <stdlib.h>],
-    [printf("%s", NULL)]
-)],
-    [
-     AC_MSG_RESULT([ok])
-     AM_CONDITIONAL([REQUIRE_NUT_STRARG], [false])
-    ],
-    [AC_MSG_RESULT([no])
-     AC_DEFINE([REQUIRE_NUT_STRARG], [1],
-        [Define to 1 if your libc requires workarounds to print NULL values.])
-     AC_MSG_WARN([Your C library requires workarounds to print NULL values; if something crashes with a segmentation fault (especially with verbose debug) - that may be why])
-     AM_CONDITIONAL([REQUIRE_NUT_STRARG], [true])
-    ]
-)
-AC_LANG_POP([C])
-
 
 AC_REPLACE_FUNCS(setenv strerror atexit)
 

--- a/include/str.h
+++ b/include/str.h
@@ -31,9 +31,10 @@ extern "C" {
 
 /* Some compilers and/or C libraries do not handle printf("%s", NULL) correctly */
 #ifndef NUT_STRARG
-# ifdef HAVE_PRINTF_STRING_NULL
+# if (defined REQUIRE_NUT_STRARG) && (REQUIRE_NUT_STRARG == 0)
 #  define NUT_STRARG(x) x
 # else
+/* Is required, or not defined => err on safe side */
 #  define NUT_STRARG(x) (x?x:"(null)")
 # endif
 #endif

--- a/m4/ax_c_pragmas.m4
+++ b/m4/ax_c_pragmas.m4
@@ -1017,13 +1017,8 @@ if (res < 0) {
 return 0;
             ]])],
         [ax_cv__printf_string_null=yes
-         AM_CONDITIONAL([REQUIRE_NUT_STRARG], [false])
         ],
         [ax_cv__printf_string_null=no
-         AC_DEFINE([REQUIRE_NUT_STRARG], [1],
-            [Define to 1 if your libc requires workarounds to print NULL values.])
-         AC_MSG_WARN([Your C library requires workarounds to print NULL values; if something crashes with a segmentation fault (especially during verbose debug) - that may be why])
-         AM_CONDITIONAL([REQUIRE_NUT_STRARG], [true])
         ],
         [${myWARN_CFLAGS}]
     )]
@@ -1031,7 +1026,14 @@ return 0;
   unset myWARN_CFLAGS
 
   AS_IF([test "$ax_cv__printf_string_null" = "yes"],[
-    AC_DEFINE([HAVE_PRINTF_STRING_NULL], 1, [define if your libc can printf("%s", NULL) sanely])
+    AM_CONDITIONAL([REQUIRE_NUT_STRARG], [false])
+    AC_DEFINE([REQUIRE_NUT_STRARG], [0],
+      [Define to 0 if your libc can printf("%s", NULL) sanely, or to 1 if your libc requires workarounds to print NULL values.])
+  ],[
+    AM_CONDITIONAL([REQUIRE_NUT_STRARG], [true])
+    AC_DEFINE([REQUIRE_NUT_STRARG], [1],
+      [Define to 0 if your libc can printf("%s", NULL) sanely, or to 1 if your libc requires workarounds to print NULL values.])
+    AC_MSG_WARN([Your C library requires workarounds to print NULL values; if something crashes with a segmentation fault (especially during verbose debug) - that may be why])
   ])
 
   AC_LANG_POP([C])

--- a/m4/ax_run_or_link_ifelse.m4
+++ b/m4/ax_run_or_link_ifelse.m4
@@ -19,7 +19,8 @@ AC_DEFUN([AX_RUN_OR_LINK_IFELSE],
 	myCFLAGS="$CFLAGS"
 	myCXXFLAGS="$CXXFLAGS"
 	CFLAGS="$myCFLAGS -Werror -Werror=implicit-function-declaration $4"
-	CXXFLAGS="$myCXXFLAGS -Werror -Werror=implicit-function-declaration $5"
+	dnl # cc1plus: error: '-Werror=' argument '-Werror=implicit-function-declaration' is not valid for C++ [-Werror]
+	CXXFLAGS="$myCXXFLAGS -Werror $5"
 	AC_RUN_IFELSE([$1], [$2], [$3],
 		[
 		AC_MSG_WARN([Current build is a cross-build, so not running test binaries, just linking them])

--- a/m4/ax_run_or_link_ifelse.m4
+++ b/m4/ax_run_or_link_ifelse.m4
@@ -3,6 +3,10 @@ dnl but it provides the fourth argument to customize the handling.
 dnl In our case, we would fall back to trying just to link then -
 dnl the result would not be as relevant regarding run-time behavior
 dnl of the code, but at least we would know that API and ABI are ok.
+dnl Here the fourth and fifth arguments can be used to pass custom
+dnl CFLAGS and CXXFLAGS options (e.g. warnings to cover or ignore),
+dnl respectively. For the test to succeed, the build/link must pass
+dnl without warnings.
 
 dnl Per original /usr/share/autoconf/autoconf/general.m4 which makes
 dnl a similar wrapper:
@@ -14,8 +18,8 @@ AC_DEFUN([AX_RUN_OR_LINK_IFELSE],
 [
 	myCFLAGS="$CFLAGS"
 	myCXXFLAGS="$CXXFLAGS"
-	CFLAGS="$myCFLAGS -Werror -Werror=implicit-function-declaration"
-	CXXFLAGS="$myCXXFLAGS -Werror -Werror=implicit-function-declaration"
+	CFLAGS="$myCFLAGS -Werror -Werror=implicit-function-declaration $4"
+	CXXFLAGS="$myCXXFLAGS -Werror -Werror=implicit-function-declaration $5"
 	AC_RUN_IFELSE([$1], [$2], [$3],
 		[
 		AC_MSG_WARN([Current build is a cross-build, so not running test binaries, just linking them])

--- a/m4/ax_run_or_link_ifelse.m4
+++ b/m4/ax_run_or_link_ifelse.m4
@@ -18,9 +18,16 @@ AC_DEFUN([AX_RUN_OR_LINK_IFELSE],
 [
 	myCFLAGS="$CFLAGS"
 	myCXXFLAGS="$CXXFLAGS"
-	CFLAGS="$myCFLAGS -Werror -Werror=implicit-function-declaration $4"
-	dnl # cc1plus: error: '-Werror=' argument '-Werror=implicit-function-declaration' is not valid for C++ [-Werror]
-	CXXFLAGS="$myCXXFLAGS -Werror $5"
+	AS_IF([test "${GCC}" = "yes" || test "${CLANGCC}" = "yes"], [
+		CFLAGS="$myCFLAGS -Werror -Werror=implicit-function-declaration $4"
+		dnl # cc1plus: error: '-Werror=' argument '-Werror=implicit-function-declaration' is not valid for C++ [-Werror]
+		CXXFLAGS="$myCXXFLAGS -Werror $5"
+	], [
+		dnl # Don't know what to complain about for unknown compilers
+		dnl # FIXME: Presume here they have at least a "-Werror" option
+		CFLAGS="$myCFLAGS -Werror $4"
+		CXXFLAGS="$myCXXFLAGS -Werror $5"
+	])
 	AC_RUN_IFELSE([$1], [$2], [$3],
 		[
 		AC_MSG_WARN([Current build is a cross-build, so not running test binaries, just linking them])

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -30,7 +30,7 @@ nutlogtest-nofail.sh: nutlogtest$(EXEEXT)
 	@echo '#!/bin/sh' > $@
 	@echo 'echo "WARNING: Your C library requires workarounds to print NULL values!" >&2' >> $@
 	@echo 'echo "If nutlogtest below, or generally some NUT program, crashes with" >&2' >> $@
-	@echo 'echo "a segmentation fault (especially with verbose debug) - that may be why" >&2' >> $@
+	@echo 'echo "a segmentation fault (especially during verbose debug) - that may be why" >&2' >> $@
 	@echo 'SCRIPT_DIR="`dirname "$$0"`"' >> $@
 	@echo '"$${SCRIPT_DIR}/nutlogtest" "$$@" || echo "nutlogtest FAILED but it was expected"' >> $@
 	@chmod +x $@


### PR DESCRIPTION
Closes: #2109
Follows up from: #2096, #823

As now posted, the PR should allow configure script to gauge practical support of `printf("%s", NULL)` again, and refactors the two detections of this ability, that have evolved over time, into one.

Also includes a little fix to same feature that broke detection of C++ CPPUNIT testability support.