### PR TITLE
drivers/libusb1.c: nut_libusb_open(): do not keep Bus/Device/BusPort…

### DIFF
--- a/drivers/libusb1.c
+++ b/drivers/libusb1.c
@@ -268,6 +268,8 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 		} else {
 			upsdebugx(1, "%s: invalid libusb bus number %i",
 				__func__, bus_num);
+			free(curDevice->Bus);
+			curDevice->Bus = NULL;
 		}
 
 		device_addr = libusb_get_device_address(device);
@@ -290,6 +292,8 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 			} else {
 				upsdebugx(1, "%s: invalid libusb device address %" PRIu8,
 					__func__, device_addr);
+				free(curDevice->Device);
+				curDevice->Device = NULL;
 			}
 		}
 
@@ -305,6 +309,8 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 		} else {
 			upsdebugx(1, "%s: invalid libusb bus number %i",
 				__func__, bus_port);
+			free(curDevice->BusPort);
+			curDevice->BusPort = NULL;
 		}
 #endif
 


### PR DESCRIPTION
…pointers to random malloc() block if we did not get a number to print there from libusb(-1.0)

Avoid (un-)pretty prints like:
````
   0.031364     [D2] - Bus: 006
   0.031366     [D2] - Bus Port: ▒UV▒▒U
   0.031368     [D2] - Device: 001
````

The problem seems to be introduced only with `libusb1.c`, not with `libusb0.c` nor `tools/nut-scanner/scan_usb.c` (where such reports are collected differently), so can be considered a fallout of #300.

It happens when the platform can not report a useful number (so was not noticed until introduction of `busport` handling with #2054, but the same pattern related to earlier Bus and Device number handling too).