### PR TITLE
Clean up `dummy-ups` code, behavior and logs; added `NUT_DEBUG_PID` option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ Makefile.in
 *.adoc*.tmp
 *.txt*.tmp
 /cppcheck*.xml
+/.ci*.txt*
 /.ci*.log
 /.ci*.log.*
 .dirstamp

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -139,6 +139,10 @@ as part of https://github.com/networkupstools/nut/issues/1410 solution.
    of UID/GID (everywhere), which makes troubleshooting harder (e.g. lack
    of access to config files or USB device nodes). Now we have it [#1694]
 
+ - A `NUT_DEBUG_PID` envvar (presence) support was added to add current
+   process ID to tags with debug-level identifiers. This may be useful
+   when many NUT daemons write to the same console or log file. [#2118]
+
  - huawei-ups2000 is now known to support more devices, noted in docs and
    for auto-detection [#1448, #1684]
 

--- a/UPGRADING.adoc
+++ b/UPGRADING.adoc
@@ -128,6 +128,11 @@ Changes from 2.8.0 to 2.8.1
   and exposed in `libnutscan.so` builds in particular - API version for the
   public library was bumped [#317]
 
+- A `NUT_DEBUG_PID` envvar (presence) support was added to add current
+  process ID to tags with debug-level identifiers. This may be useful
+  when many NUT daemons write to the same console or log file, such as
+  in containers/plugins for Home Assistant, storage appliances, etc. [#2118]
+
 - `configure` script, reference init-script and packaging templates updated
   to eradicate `@PIDPATH@/nut` ambiguity in favor of `@ALTPIDPATH@` for the
   unprivileged processes vs. `@PIDPATH@` for those running as root [#1719]

--- a/common/common.c
+++ b/common/common.c
@@ -1519,6 +1519,7 @@ void s_upsdebug_with_errno(int level, const char *fmt, ...)
 {
 	va_list va;
 	char fmt2[LARGEBUF];
+	static int NUT_DEBUG_PID = -1;
 
 	/* Note: Thanks to macro wrapping, we do not quite need this
 	 * test now, but we still need the "level" value to report
@@ -1534,7 +1535,18 @@ void s_upsdebug_with_errno(int level, const char *fmt, ...)
  * can help limit this debug stream quicker, than experimentally picking ;) */
 	if (level > 0) {
 		int ret;
-		ret = snprintf(fmt2, sizeof(fmt2), "[D%d] %s", level, fmt);
+
+		if (NUT_DEBUG_PID < 0) {
+			NUT_DEBUG_PID = (getenv("NUT_DEBUG_PID") != NULL);
+		}
+
+		if (NUT_DEBUG_PID) {
+			/* Note that we re-request PID every time as it can
+			 * change during the run-time (forking etc.) */
+			ret = snprintf(fmt2, sizeof(fmt2), "[D%d:%" PRIiMAX "] %s", level, (intmax_t)getpid(), fmt);
+		} else {
+			ret = snprintf(fmt2, sizeof(fmt2), "[D%d] %s", level, fmt);
+		}
 		if ((ret < 0) || (ret >= (int) sizeof(fmt2))) {
 			syslog(LOG_WARNING, "upsdebug_with_errno: snprintf needed more than %d bytes",
 				LARGEBUF);
@@ -1564,6 +1576,7 @@ void s_upsdebugx(int level, const char *fmt, ...)
 {
 	va_list va;
 	char fmt2[LARGEBUF];
+	static int NUT_DEBUG_PID = -1;
 
 	if (nut_debug_level < level)
 		return;
@@ -1571,7 +1584,19 @@ void s_upsdebugx(int level, const char *fmt, ...)
 /* See comments above in upsdebug_with_errno() - they apply here too. */
 	if (level > 0) {
 		int ret;
-		ret = snprintf(fmt2, sizeof(fmt2), "[D%d] %s", level, fmt);
+
+		if (NUT_DEBUG_PID < 0) {
+			NUT_DEBUG_PID = (getenv("NUT_DEBUG_PID") != NULL);
+		}
+
+		if (NUT_DEBUG_PID) {
+			/* Note that we re-request PID every time as it can
+			 * change during the run-time (forking etc.) */
+			ret = snprintf(fmt2, sizeof(fmt2), "[D%d:%" PRIiMAX "] %s", level, (intmax_t)getpid(), fmt);
+		} else {
+			ret = snprintf(fmt2, sizeof(fmt2), "[D%d] %s", level, fmt);
+		}
+
 		if ((ret < 0) || (ret >= (int) sizeof(fmt2))) {
 			syslog(LOG_WARNING, "upsdebugx: snprintf needed more than %d bytes",
 				LARGEBUF);

--- a/drivers/dummy-ups.c
+++ b/drivers/dummy-ups.c
@@ -245,8 +245,13 @@ void upsdrv_updateinfo(void)
 				/* Determine if file modification timestamp has changed
 				 * since last use (so we would want to re-read it) */
 #ifndef WIN32
-				/* Either successful stat is OK to fill the "fs" struct */
-				if (0 != fstat (upsfd, &fs) && 0 != stat (fn, &fs))
+				/* Either successful stat (zero return) is OK to
+				 * fill the "fs" struct. Note that currently
+				 * "upsfd" is a no-op for files, they are re-opened
+				 * and re-parsed every time so callers can modify
+				 * the data without complications.
+				 */
+				if ( (INVALID_FD(upsfd) || 0 != fstat (upsfd, &fs)) && 0 != stat (fn, &fs))
 #else
 				/* Consider GetFileAttributesEx() for WIN32_FILE_ATTRIBUTE_DATA?
 				 *   https://stackoverflow.com/questions/8991192/check-the-file-size-without-opening-file-in-c/8991228#8991228
@@ -494,8 +499,13 @@ void upsdrv_initups(void)
 
 		/* Update file modification timestamp (and other data) */
 #ifndef WIN32
-		/* Either successful stat is OK to fill the "datafile_stat" struct */
-		if (0 != fstat (upsfd, &datafile_stat) && 0 != stat (device_path, &datafile_stat))
+		/* Either successful stat (zero return) is OK to fill the
+		 * "datafile_stat" struct. Note that currently "upsfd" is
+		 * a no-op for files, they are re-opened and re-parsed
+		 * every time so callers can modify the data without
+		 * complications.
+		 */
+		if ( (INVALID_FD(upsfd) || 0 != fstat (upsfd, &datafile_stat)) && 0 != stat (device_path, &datafile_stat))
 #else
 		/* Consider GetFileAttributesEx() for WIN32_FILE_ATTRIBUTE_DATA?
 		 *   https://stackoverflow.com/questions/8991192/check-the-file-size-without-opening-file-in-c/8991228#8991228

--- a/drivers/dummy-ups.c
+++ b/drivers/dummy-ups.c
@@ -2,6 +2,7 @@
 
    Copyright (C)
        2005 - 2015  Arnaud Quette <http://arnaud.quette.free.fr/contact.html>
+       2014 - 2023  Jim Klimov <jimklimov+nut@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -47,7 +48,7 @@
 #include "dummy-ups.h"
 
 #define DRIVER_NAME	"Device simulation and repeater driver"
-#define DRIVER_VERSION	"0.16"
+#define DRIVER_VERSION	"0.17"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info =

--- a/drivers/dummy-ups.c
+++ b/drivers/dummy-ups.c
@@ -505,12 +505,12 @@ void upsdrv_initups(void)
 		 * every time so callers can modify the data without
 		 * complications.
 		 */
-		if ( (INVALID_FD(upsfd) || 0 != fstat (upsfd, &datafile_stat)) && 0 != stat (device_path, &datafile_stat))
+		if ( (INVALID_FD(upsfd) || 0 != fstat (upsfd, &datafile_stat)) && 0 != stat (fn, &datafile_stat))
 #else
 		/* Consider GetFileAttributesEx() for WIN32_FILE_ATTRIBUTE_DATA?
 		 *   https://stackoverflow.com/questions/8991192/check-the-file-size-without-opening-file-in-c/8991228#8991228
 		 */
-		if (0 != stat (device_path, &datafile_stat))
+		if (0 != stat (fn, &datafile_stat))
 #endif
 		{
 			upsdebugx(2, "%s: Can't stat %s (%s) currently", __func__, device_path, fn);

--- a/drivers/dummy-ups.c
+++ b/drivers/dummy-ups.c
@@ -98,7 +98,7 @@ static struct stat	datafile_stat;
 
 static int setvar(const char *varname, const char *val);
 static int instcmd(const char *cmdname, const char *extra);
-static int parse_data_file(TYPE_FD upsfd);
+static int parse_data_file(TYPE_FD arg_upsfd);
 static dummy_info_t *find_info(const char *varname);
 static int is_valid_data(const char* varname);
 static int is_valid_value(const char* varname, const char *value);

--- a/drivers/dummy-ups.c
+++ b/drivers/dummy-ups.c
@@ -657,7 +657,7 @@ static dummy_info_t *find_info(const char *varname)
 			return item;
 	}
 
-	upsdebugx(2, "find_info: unknown variable: %s\n", varname);
+	upsdebugx(2, "find_info: unknown variable: %s", varname);
 
 	return NULL;
 }

--- a/drivers/dummy-ups.c
+++ b/drivers/dummy-ups.c
@@ -479,16 +479,18 @@ void upsdrv_initups(void)
 #ifdef WIN32
 		||  device_path[1] == ':'	/* "C:\..." */
 #endif
-		)
+		) {
 			snprintf(fn, sizeof(fn), "%s", device_path);
-		else if (device_path[0] == '.')	{
+		} else if (device_path[0] == '.')	{
 			/* "./" or "../" e.g. via CLI */
 			if (getcwd(fn, sizeof(fn))) {
 				snprintf(fn + strlen(fn), sizeof(fn) - strlen(fn), "/%s", device_path);
-			} else
+			} else {
 				snprintf(fn, sizeof(fn), "%s", device_path);
-		} else
+			}
+		} else {
 			snprintf(fn, sizeof(fn), "%s/%s", confpath(), device_path);
+		}
 
 		/* Update file modification timestamp (and other data) */
 #ifndef WIN32

--- a/drivers/dummy-ups.c
+++ b/drivers/dummy-ups.c
@@ -254,15 +254,16 @@ void upsdrv_updateinfo(void)
 				if (0 != stat (fn, &fs))
 #endif
 				{
-					upsdebugx(2, "Can't open %s currently", fn);
+					upsdebugx(2, "%s: MODE_DUMMY_ONCE: Can't stat %s currently", __func__, fn);
 					/* retry ASAP until we get a file */
 					memset(&datafile_stat, 0, sizeof(struct stat));
 					next_update = 1;
 				} else {
 					if (datafile_stat.st_mtime != fs.st_mtime) {
 						upsdebugx(2,
-							"upsdrv_updateinfo: input file was already read once "
-							"to the end, but changed later - re-reading: %s", fn);
+							"%s: MODE_DUMMY_ONCE: input file was already read once "
+							"to the end, but changed later - re-reading: %s",
+							__func__, fn);
 						/* updated file => retry ASAP */
 						next_update = 1;
 						datafile_stat = fs;
@@ -271,7 +272,7 @@ void upsdrv_updateinfo(void)
 			}
 
 			if (ctx == NULL && next_update == -1) {
-				upsdebugx(2, "upsdrv_updateinfo: NO-OP: input file was already read once to the end");
+				upsdebugx(2, "%s: MODE_DUMMY_ONCE: NO-OP: input file was already read once to the end", __func__);
 				dstate_dataok();
 			} else {
 				/* initial parsing interrupted by e.g. TIMER line */
@@ -500,7 +501,7 @@ void upsdrv_initups(void)
 		if (0 != stat (device_path, &datafile_stat))
 #endif
 		{
-			upsdebugx(2, "Can't open %s (%s) currently", device_path, fn);
+			upsdebugx(2, "%s: Can't stat %s (%s) currently", __func__, device_path, fn);
 		} else {
 			upsdebugx(2, "Located %s for device simulation data: %s", device_path, fn);
 		}

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -744,7 +744,18 @@ sandbox_start_drivers() {
     if shouldDebug ; then
         (ps -ef || ps -xawwu) 2>/dev/null | grep -E '(ups|nut|dummy|'"`basename "$0"`"')' | grep -vE '(ssh|startups|grep)' || true
     fi
-    log_info "Starting dummy-ups driver(s) for sandbox - finished"
+
+    if isPidAlive "$PID_DUMMYUPS" \
+    && { [ x"${TOP_SRCDIR}" != x ] && isPidAlive "$PID_DUMMYUPS1" && isPidAlive "$PID_DUMMYUPS2" \
+         || [ x"${TOP_SRCDIR}" = x ] ; } \
+    ; then
+        # All drivers expected for this environment are already running
+        log_info "Starting dummy-ups driver(s) for sandbox - all expected processes are running"
+        return 0
+    else
+        log_error "Starting dummy-ups driver(s) for sandbox - finished, but something seems to not be running"
+        return 1
+    fi
 }
 
 testcase_sandbox_start_upsd_alone() {

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -34,6 +34,9 @@ export TZ LANG LC_ALL
 NUT_QUIET_INIT_SSL="true"
 export NUT_QUIET_INIT_SSL
 
+NUT_DEBUG_PID="true"
+export NUT_DEBUG_PID
+
 log_separator() {
     echo "" >&2
     echo "================================" >&2

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -1256,6 +1256,7 @@ testgroup_sandbox() {
     testcases_sandbox_cppnit
     testcases_sandbox_nutscanner
 
+    log_separator
     sandbox_forget_configs
 }
 
@@ -1263,6 +1264,8 @@ testgroup_sandbox_python() {
     # Arrange for quick test iterations
     testcase_sandbox_start_drivers_after_upsd
     testcases_sandbox_python
+
+    log_separator
     sandbox_forget_configs
 }
 
@@ -1270,6 +1273,8 @@ testgroup_sandbox_cppnit() {
     # Arrange for quick test iterations
     testcase_sandbox_start_drivers_after_upsd
     testcases_sandbox_cppnit
+
+    log_separator
     sandbox_forget_configs
 }
 
@@ -1277,6 +1282,8 @@ testgroup_sandbox_cppnit_simple_admin() {
     # Arrange for quick test iterations
     testcase_sandbox_start_drivers_after_upsd
     testcase_sandbox_cppnit_simple_admin
+
+    log_separator
     sandbox_forget_configs
 }
 
@@ -1284,6 +1291,8 @@ testgroup_sandbox_nutscanner() {
     # Arrange for quick test iterations
     testcase_sandbox_start_drivers_after_upsd
     testcases_sandbox_nutscanner
+
+    log_separator
     sandbox_forget_configs
 }
 

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -830,7 +830,12 @@ testcase_sandbox_start_drivers_after_upsd() {
     sandbox_start_drivers
 
     log_info "[testcase_sandbox_start_drivers_after_upsd] Query driver state from UPSD by UPSC after driver startup"
-    COUNTDOWN=60
+    # Timing issues: upsd starts, we wait 10 sec, drivers start and init,
+    # at 20 sec upsd does not see them yet, at 30 sec the sockets connect
+    # but info does not come yet => may be "driver stale", finally at
+    # 40+(drv)/50+(upsd) sec a DUMPALL is processed (regular 30-sec loop?) -
+    # so tightly near a minute until we have sturdy replies.
+    COUNTDOWN=90
     while [ "$COUNTDOWN" -gt 0 ]; do
         # For query errors or known wait, keep looping
         runcmd upsc dummy@localhost:$NUT_PORT \

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -945,9 +945,9 @@ testcase_sandbox_upsc_query_bogus() {
     # Note: avoid exact matching for stderr, because it can have Init SSL messages etc.
     if echo "$CMDERR" | grep 'Error: Variable not supported by UPS' >/dev/null ; then
         PASSED="`expr $PASSED + 1`"
-        log_info "[testcase_sandbox_upsc_query_bogus] PASSED: got expected reply to bogus query: '$CMDERR'"
+        log_info "[testcase_sandbox_upsc_query_bogus] PASSED: got expected reply to bogus query"
     else
-        log_error "[testcase_sandbox_upsc_query_bogus] got some other reply for upsc query when 'Error: Variable not supported by UPS' was expected on stderr: '$CMDERR'"
+        log_error "[testcase_sandbox_upsc_query_bogus] got some other reply for upsc query when 'Error: Variable not supported by UPS' was expected on stderr: stderr:'$CMDERR' / stdout:'$CMDOUT'"
         FAILED="`expr $FAILED + 1`"
         FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_upsc_query_bogus"
     fi

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -837,10 +837,12 @@ testcase_sandbox_start_drivers_after_upsd() {
     # so tightly near a minute until we have sturdy replies.
     COUNTDOWN=90
     while [ "$COUNTDOWN" -gt 0 ]; do
-        # For query errors or known wait, keep looping
+        # For query errors or known wait, keep looping. May get:
+        #   driver.state: updateinfo
+        #   ups.status: WAIT
         runcmd upsc dummy@localhost:$NUT_PORT \
         && case "$CMDOUT" in
-            "ups.status: WAIT") ;;
+            *"ups.status: WAIT"*) ;;
             *) log_info "Got output:" ; echo "$CMDOUT" ; break ;;
         esac
         sleep 1

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -727,13 +727,16 @@ sandbox_start_drivers() {
     #upsdrvctl -F start dummy &
     dummy-ups -a dummy -F &
     PID_DUMMYUPS="$!"
+    log_debug "Tried to start dummy-ups driver for 'dummy' as PID $PID_DUMMYUPS"
 
     if [ x"${TOP_SRCDIR}" != x ]; then
         dummy-ups -a UPS1 -F &
         PID_DUMMYUPS1="$!"
+        log_debug "Tried to start dummy-ups driver for 'UPS1' as PID $PID_DUMMYUPS1"
 
         dummy-ups -a UPS2 -F &
         PID_DUMMYUPS2="$!"
+        log_debug "Tried to start dummy-ups driver for 'UPS2' as PID $PID_DUMMYUPS2"
     fi
 
     sleep 5

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -739,7 +739,7 @@ sandbox_start_drivers() {
     sleep 5
 
     if shouldDebug ; then
-        (ps -ef || ps -xawwu) 2>/dev/null | grep -E '(ups|nut|dummy)' || true
+        (ps -ef || ps -xawwu) 2>/dev/null | grep -E '(ups|nut|dummy|'"`basename "$0"`"')' | grep -vE '(ssh|startups|grep)' || true
     fi
 }
 


### PR DESCRIPTION
This PR started as an investigation into occasional NIT (NUT Integration Test) script failures, and so far stumbled on a number of imperfections in the dummy-ups driver - so started with those.

Updated with NIT test-script fixes as well.

NOTE: Strange behavior noted on WSL2 Ubuntu builds (maybe the VM is just slow now) that both `upsd` and `dummy-ups` daemons logged stuff in bursts separated by roughly 10 sec, and those logs took a while to appear on display. There seemed to be a considerable delay between driver start, and readiness, and socket creation, and upsd connection to that socket, and DUMPALL request, and lots of info streaming until DUMPDONE marker - took about a minute overall for that test case initialization, and almost 3 min for the script. On other systems it goes at 1 sec cadence and all test cases complete in 20 sec.

UPDATE: Yeah, a laggy VM, huge load average with no real CPU load - nothing a `wsl --shutdown` could not fix.

To make sense of that wall of text, added `NUT_DEBUG_PID` optional envvar support to OPTIONALLY log with non-zero debug level and PIDs, like:
````
[D5:21086] send_to_all: SETINFO driver.state "cleanup.exit"
````
instead of plain
````
[D5] send_to_all: SETINFO driver.state "cleanup.exit"
````

This allows NIT mixed log from 4 daemons to be better understandable (adding a name might be better?) and I suppose can help systems that run all NUT programs as one logged bundle - e.g. containers like HA plugins - without a syslog/journal that would add identifiers to each line.