### PR TITLE
nut_usbinfo.pl: Lowercase the USB ids before inserting

### DIFF
--- a/tools/nut-usbinfo.pl
+++ b/tools/nut-usbinfo.pl
@@ -304,6 +304,9 @@ sub find_usbdevs
 				}
 			}
 
+			$VendorID=lc($VendorID);
+			$ProductID=lc($ProductID);
+
 			# store data (to be optimized)
 			# and don't overwrite actual vendor names with empty values
 			if( (!$vendorName{$VendorID}) or (($vendorName{$VendorID} eq "") and ($VendorName ne "")) )


### PR DESCRIPTION
If we don't normalize the case before inserting VID/PID/Driver into `$vendor` we can have duplicate entries.