### PR TITLE
Add `SIZEOF_ARRAY` macro and use where applicable

### DIFF
--- a/drivers/apc_modbus.c
+++ b/drivers/apc_modbus.c
@@ -1218,7 +1218,7 @@ void upsdrv_initups(void)
 #  endif
 
 		has_nonzero_regex = 0;
-		for (i = 0; i < sizeof(regex_array) / sizeof(regex_array[0]); i++) {
+		for (i = 0; i < SIZEOF_ARRAY(regex_array); i++) {
 			if (regex_array[i] != NULL) {
 				has_nonzero_regex = 1;
 			}

--- a/drivers/apcsmart.c
+++ b/drivers/apcsmart.c
@@ -260,7 +260,7 @@ static void apc_ser_diff(struct termios *tioset, struct termios *tioget)
 
 	/* clear status flags so that they don't affect our binary compare */
 #if defined(PENDIN) || defined(FLUSHO)
-	for (i = 0; i < sizeof(tio)/sizeof(tio[0]); i++) {
+	for (i = 0; i < SIZEOF_ARRAY(tio); i++) {
 #ifdef PENDIN
 		tio[i]->c_lflag &= ~(unsigned int)PENDIN;
 #endif
@@ -283,7 +283,7 @@ static void apc_ser_diff(struct termios *tioset, struct termios *tioget)
 	 * rate of 2400.
 	 */
 
-	for (i = 0; i < sizeof(tio)/sizeof(tio[0]); i++) {
+	for (i = 0; i < SIZEOF_ARRAY(tio); i++) {
 		upsdebugx(1, "tc%cetattr(): gfmt1:cflag=%x:iflag=%x:lflag=%x:oflag=%x:", dir[i],
 				(unsigned int) tio[i]->c_cflag, (unsigned int) tio[i]->c_iflag,
 				(unsigned int) tio[i]->c_lflag, (unsigned int) tio[i]->c_oflag);

--- a/drivers/belkinunv.c
+++ b/drivers/belkinunv.c
@@ -159,7 +159,7 @@ upsdrv_info_t upsdrv_info = {
 #define BS_REPLACE   0x80
 
 /* size of an array */
-#define asize(x) ((int)(sizeof(x)/sizeof(x[0])))
+#define asize(x) ((int)(SIZEOF_ARRAY(x)))
 
 static const char *upstype[3] = {
 	"ONLINE",

--- a/drivers/openups-hid.c
+++ b/drivers/openups-hid.c
@@ -121,7 +121,7 @@ static const unsigned int therm_tbl[] =
 	(unsigned int)0x3CC
 };
 
-static const unsigned int therm_tbl_size = sizeof(therm_tbl)/sizeof(therm_tbl[0]);
+static const unsigned int therm_tbl_size = SIZEOF_ARRAY(therm_tbl);
 
 static const char *openups_charging_fun(double value);
 static const char *openups_discharging_fun(double value);

--- a/drivers/optiups.c
+++ b/drivers/optiups.c
@@ -368,7 +368,7 @@ void upsdrv_initinfo(void)
 		optimodel = OPTIMODEL_PS;
 	}
 
-	optifill( _initv, sizeof(_initv)/sizeof(_initv[0]) );
+	optifill( _initv, SIZEOF_ARRAY(_initv) );
 
 	/* Parse out model into longer string -- is this really USEFUL??? */
 	r = optiquery( "IO" );
@@ -483,11 +483,11 @@ void upsdrv_updateinfo(void)
 
 	/* read some easy settings */
 	if ( optimodel == OPTIMODEL_ZINTO )
-		optifill( _pollv_zinto, sizeof(_pollv_zinto)/sizeof(_pollv_zinto[0]) );
+		optifill( _pollv_zinto, SIZEOF_ARRAY(_pollv_zinto) );
 	else if ( optimodel == OPTIMODEL_PS ) {
 		short inV, outV, fV;
 
-		optifill( _pollv_ps, sizeof(_pollv_ps)/sizeof(_pollv_ps[0]) );
+		optifill( _pollv_ps, SIZEOF_ARRAY(_pollv_ps) );
 
 		r = optiquery( "NV" );
 		str_to_short ( _buf, &inV, 10 );
@@ -508,7 +508,7 @@ void upsdrv_updateinfo(void)
 		dstate_setinfo( "output.voltage", "%d", outV );
 	}
 	else
-		optifill( _pollv, sizeof(_pollv)/sizeof(_pollv[0]) );
+		optifill( _pollv, SIZEOF_ARRAY(_pollv) );
 
 	/* Battery voltage is harder */
 	r = optiquery( "BV" );

--- a/drivers/tripplitesu.c
+++ b/drivers/tripplitesu.c
@@ -424,7 +424,7 @@ static int get_sensitivity(void) {
 
 	if (do_command(POLL, VOLTAGE_SENSITIVITY, "", response) <= 0)
 		return 0;
-	for (i = 0; i < sizeof(sensitivity) / sizeof(sensitivity[0]); i++) {
+	for (i = 0; i < SIZEOF_ARRAY(sensitivity); i++) {
 		if (sensitivity[i].code == atoi(response)) {
 			dstate_setinfo("input.sensitivity", "%s",
 			               sensitivity[i].name);
@@ -439,7 +439,7 @@ static void set_sensitivity(const char *val) {
 	char parm[20];
 	unsigned int i;
 
-	for (i = 0; i < sizeof(sensitivity) / sizeof(sensitivity[0]); i++) {
+	for (i = 0; i < SIZEOF_ARRAY(sensitivity); i++) {
 		if (!strcasecmp(val, sensitivity[i].name)) {
 			snprintf(parm, sizeof(parm), "%u", i);
 			do_command(SET, VOLTAGE_SENSITIVITY, parm, NULL);
@@ -660,8 +660,7 @@ void upsdrv_initinfo(void)
 	}
 	if (get_sensitivity()) {
 		dstate_setflags("input.sensitivity", ST_FLAG_RW);
-		for (i = 0; i < sizeof(sensitivity) / sizeof(sensitivity[0]);
-		     i++)
+		for (i = 0; i < SIZEOF_ARRAY(sensitivity); i++)
 			dstate_addenum("input.sensitivity", "%s",
 			               sensitivity[i].name);
 	}
@@ -811,8 +810,7 @@ void upsdrv_updateinfo(void)
 		size_t	trsize;
 
 		r = atoi(response);
-		trsize = sizeof(test_result_names) /
-			sizeof(test_result_names[0]);
+		trsize = SIZEOF_ARRAY(test_result_names);
 
 		if ((r < 0) || (r >= (int) trsize))
 			r = 0;

--- a/include/common.h
+++ b/include/common.h
@@ -171,6 +171,8 @@ typedef struct serial_handler_s {
 #define INVALID_FD_SOCK(a) (!VALID_FD_SOCK(a))
 #define INVALID_FD(a) (!VALID_FD(a))
 
+#define SIZEOF_ARRAY(a) (sizeof(a) / sizeof(a[0]))
+
 extern const char *UPS_VERSION;
 
 /* Use in code to notify the developers and quiesce the compiler that

--- a/tests/getvaluetest.c
+++ b/tests/getvaluetest.c
@@ -110,7 +110,7 @@ static int RunBuiltInTests(char *argv[]) {
 
 	NUT_UNUSED_VARIABLE(argv);
 
-	for (i = 0; i < sizeof(testData)/sizeof(testData[0]); i++) {
+	for (i = 0; i < SIZEOF_ARRAY(testData); i++) {
 		next = testData[i].buf;
 		for (bufSize = 0; *next != 0; bufSize++) {
 			reportBuf[bufSize] = (uint8_t) strtol(next, (char **)&next, 16);


### PR DESCRIPTION
This adds a new `SIZEOF_ARRAY` to `common.h` and changes some code to use it.

<!-- Comment:
* Please revise the docs/developers.txt for coding style suggestions and
  other considerations applicable to NUT codebase contributions, as well
  as for which text documents to update. See also docs/developer-guide.txt
  for general points on NUT architecture and design.

* Please note that we require "Signed-Off-By" tags in each Git Commit
  message, to conform to the common DCO (Developer Certificate of Origin)
  as posted in LICENSE-DCO at root of NUT codebase as well as published
  at https://developercertificate.org/

* The checklist below is more of a reminder of steps to take and "dangers"
  to look out for. PRs to update this template are also welcome :)

* Local build iterations can be augmented with the ci_build.sh script.
-->

## General points

- [x] Described the changes in the PR submission or a separate issue, e.g.
  known published or discovered protocols, applicable hardware (expected
  compatible and actually tested/developed against), limitations, etc.

- [x] There may be multiple commits in the PR, aligned and commented with
  a functional change. Notably, coding style changes better belong in a
  separate PR, but certainly in a dedicated commit to simplify reviews
  of "real" changes in the other commits. Similarly for typo fixes in
  comments or text documents.

## Frequent "underwater rocks" for driver addition/update PRs

- [x] Revised existing driver families and added a sub-driver if applicable
  (`nutdrv_qx`, `usbhid-ups`...) or added a brand new driver in the other
  case.

- [x] Did not extend obsoleted drivers with new hardware support features
  (notably `blazer` and other single-device family drivers for Qx protocols,
  except the new `nutdrv_qx` which should cover them all).

- [x] For updated existing device drivers, bumped the `DRIVER_VERSION` macro
  or its equivalent.

<!-- Comment:
  Some sub-drivers have `SUBDRIVER_VERSION` or customized names like
  e.g. `MEGATEC_VERSION` in `drivers/nutdrv_qx_megatec.c`
-->

- [x] For USB devices (HID or not), revised that the driver uses unique
  VID/PID combinations, or raised discussions when this is not the case
  (several vendors do use same interface chips for unrelated protocols).

- [x] For new USB devices, built and committed the changes for the
  `scripts/upower/95-upower-hid.hwdb` file

- [x] Proposed NUT data mapping is aligned with existing `docs/nut-names.txt`
  file. If the device exposes useful data points not listed in the file, the
  `experimental.*` namespace can be used as documented there, and discussion
  should be raised on the NUT Developers mailing list to standardize the new
  concept.

- [x] Updated `data/driver.list.in` if applicable (new tested device info)
<!-- Comment:
Also note below, a point about PR posting for NUT DDL
-->

## Frequent "underwater rocks" for general C code PRs

- [x] Did not "blindly assume" default integer type sizes and value ranges,
  structure layout and alignment in memory, endianness (layout of bytes and
  bits in memory for multi-byte numeric types), or use of generic `int` where
  language or libraries dictate the use of `size_t` (or `ssize_t` sometimes).

<!-- Comment:
* NOTE: Casting and/or pragmas (support detected at compile time,
  see `m4/ax_c_pragmas.m4`) to silence warnings may be acceptable,
  but only if coupled with range checks or similar actions.
-->

- [x] Progress and errors are handled with `upsdebugx()`, `upslogx()`,
  `fatalx()` and related methods, not with direct `printf()` or `exit()`.
  Similarly, NUT helpers are used for error-checked memory allocation and
  string operations (except where customized error handling is needed,
  such as unlocking device ports, etc.)

- [x] Coding style (including whitespace for indentations) follows precedent
  in the code of the file, and examples/guide in `docs/developers.txt` file.

- [x] For newly added files, the `Makefile.am` recipes were updated and the
  `make distcheck` target passes.

## General documentation updates

- [x] Updated `docs/acknowledgements.txt` (for vendor-backed device support)

- [x] Added or updated manual page information in `docs/man/*.txt` files
  and corresponding recipe lists in `docs/man/Makefile.am` for new pages

- [x] Passed `make spellcheck`, updated spell-checking dictionary in the
  `docs/nut.dict` file if needed (did not remove any words -- the `make`
  rule printout in case of changes suggests how to maintain it).

## Additional work may be needed after posting this PR

- [ ] Propose a PR for NUT DDL with detailed device data dumps from tests
  against real hardware (the more models, the better).

- [ ] Address NUT CI farm build failures for the PR: testing on numerous
  platforms and toolkits can expose issues not seen on just one system.

<!-- Comment:
* One frequent "offence" is the appearance of unexpected (not git-ignored)
  or modification during build of files tracked in Git.

* Another frequent issue is not tracking newly introduced file names in
  `EXTRA_DIST` of the `Makefile.am` (and for `*.in` templates -- of rules
  in the `configure.ac` script) so the `make distcheck` fails.

* Avoid using GNU-specific constructs in the `Makefile.am`, even if that
  means cumbersome ways to build a target. This should not happen in mere
  driver updates, however.

* Also some third-party libraries or OS headers and method argument types
  and counts can differ -- necessitating m4 code for `configure` script
  probing, and `ifdef`, `typedef`, etc. in C code to adapt to the build
  environment (precedents available in NUT codebase). In extreme cases,
  you may need to spin up a VM or container to reproduce those issues
  and iterate on a fix locally; see `docs/config-prereqs.txt` and
  `docs/ci-farm-lxc-setup.txt` for notes taken during preparation of
  the multi-platform NUT CI farm.
-->

- [ ] Revise suggestions from LGTM.COM analysis about "new issues" with
  the changed codebase.

<!-- Comment:
  Take them with a grain of salt, especially with regard to things like
  architecture-dependent range checks, but many of the complaints from
  the tool are indeed useful.
-->
