### PR TITLE
upsmon: fix discrepancies between linestate & status flags resulting in critical UPS

### DIFF
--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -1221,7 +1221,10 @@ static void ups_fsd(utype_t *ups)
 /* cleanly close the connection to a given UPS */
 static void drop_connection(utype_t *ups)
 {
-	upsdebugx(2, "Dropping connection to UPS [%s], last seen in linestate %d", ups->sys, ups->linestate);
+	if (ups->linestate == 1 && flag_isset(ups->status, ST_ONLINE))
+		upsdebugx(2, "Dropping connection to UPS [%s], last seen as fully online.", ups->sys);
+	else
+		upsdebugx(2, "Dropping connection to UPS [%s], last seen as not fully online.", ups->sys);
 
 	ups->commstate = 0;
 

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -1224,7 +1224,16 @@ static void drop_connection(utype_t *ups)
 	if (ups->linestate == 1 && flag_isset(ups->status, ST_ONLINE))
 		upsdebugx(2, "Dropping connection to UPS [%s], last seen as fully online.", ups->sys);
 	else
-		upsdebugx(2, "Dropping connection to UPS [%s], last seen as not fully online.", ups->sys);
+		upsdebugx(2, "Dropping connection to UPS [%s], last seen as not fully online (might be considered critical later).", ups->sys);
+
+	if(ups->offstate == 1 || flag_isset(ups->status, ST_OFF))
+		upsdebugx(2, "Disconnected UPS [%s] was last seen in status OFF, this UPS might be considered critical later.", ups->sys);
+
+	if(ups->bypassstate == 1 || flag_isset(ups->status, ST_BYPASS))
+		upsdebugx(2, "Disconnected UPS [%s] was last seen in status BYPASS, this UPS might be considered critical later.", ups->sys);
+
+	if(flag_isset(ups->status, ST_CAL))
+		upsdebugx(2, "Disconnected UPS [%s] was last seen in status CAL, this UPS might be considered critical later.", ups->sys);
 
 	ups->commstate = 0;
 

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -1224,7 +1224,6 @@ static void drop_connection(utype_t *ups)
 	upsdebugx(2, "Dropping connection to UPS [%s]", ups->sys);
 
 	ups->commstate = 0;
-	ups->linestate = 0;
 
 	/* forget poll-failure logging throttling */
 	ups->pollfail_log_throttle_count = -1;

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -1221,7 +1221,7 @@ static void ups_fsd(utype_t *ups)
 /* cleanly close the connection to a given UPS */
 static void drop_connection(utype_t *ups)
 {
-	upsdebugx(2, "Dropping connection to UPS [%s]", ups->sys);
+	upsdebugx(2, "Dropping connection to UPS [%s], last seen in linestate %d", ups->sys, ups->linestate);
 
 	ups->commstate = 0;
 


### PR DESCRIPTION
fixes #2126 

previously OL devices now no longer go critical in nocomms situations (as intended)
previously not-OL devices still go critical in nocomms situations (as intended)

tested the following situations:
- NUT as master with SNMP driver, UPS last seen as OL => not critical on comm-loss (as intended, works)
- NUT as master with SNMP driver, UPS last seen as OB => critical on comm-loss (as intended, works)
- NUT as slave with NUT master last seen as OL => not critical on comm-loss (as intended, works)
- NUT as slave with NUT master last seen as OB => critical on comm-loss (as intended, works)

input welcome (first code-wise contribution to the project)