### PR TITLE
drivers/apcsmart-old.c: do_capabilities(): revert to behavior like in…

### DIFF
--- a/drivers/apcsmart-old.c
+++ b/drivers/apcsmart-old.c
@@ -24,7 +24,7 @@
 #include "apcsmart-old.h"
 #include "nut_stdint.h"
 
-#define DRIVER_NAME	"APC Smart protocol driver"
+#define DRIVER_NAME	"APC Smart protocol driver (old)"
 #define DRIVER_VERSION	"2.32"
 
 static upsdrv_info_t table_info = {

--- a/drivers/apcsmart-old.c
+++ b/drivers/apcsmart-old.c
@@ -25,7 +25,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"APC Smart protocol driver"
-#define DRIVER_VERSION	"2.31"
+#define DRIVER_VERSION	"2.32"
 
 static upsdrv_info_t table_info = {
 	"APC command table",
@@ -395,15 +395,20 @@ static void do_capabilities(void)
 				__func__, (ptr[2] - 48), (ptr[3] - 48),
 				cmd, loc);
 
-			/* just ignore it as we did for ages (the
-			 * rest of loop cycle would be no-op anyway)
+			/* just ignore it as we did for ages see e.g. v2.7.4
+			 * (note the next loop cycle was and still would be
+			 * no-op anyway, if "nument <= 0").
 			 */
-			ptr = entptr;
-			continue;
-		}
+			nument = 0;
+			entlen = 0;
 
-		nument = (size_t)ptr[2] - 48;
-		entlen = (size_t)ptr[3] - 48;
+			/* NOT a full skip: Gotta handle "vt" to act like before */
+			/*ptr = entptr;*/
+			/*continue;*/
+		} else {
+			nument = (size_t)ptr[2] - 48;
+			entlen = (size_t)ptr[3] - 48;
+		}
 
 		vt = vartab_lookup_char(cmd);
 		valid = vt && ((loc == upsloc) || (loc == '4'));

--- a/drivers/apcsmart.c
+++ b/drivers/apcsmart.c
@@ -36,7 +36,7 @@
 #include "apcsmart_tabs.h"
 
 #define DRIVER_NAME	"APC Smart protocol driver"
-#define DRIVER_VERSION	"3.31"
+#define DRIVER_VERSION	"3.32"
 
 #ifdef WIN32
 # ifndef ECANCELED
@@ -1040,15 +1040,20 @@ static void apc_getcaps(int qco)
 				__func__, (ptr[2] - 48), (ptr[3] - 48),
 				cmd, loc);
 
-			/* just ignore it as we did for ages (the
-			 * rest of loop cycle would be no-op anyway)
+			/* just ignore it as we did for ages see e.g. v2.7.4
+			 * (note the next loop cycle was and still would be
+			 * no-op anyway, if "nument <= 0").
 			 */
-			ptr = entptr;
-			continue;
-		}
+			nument = 0;
+			entlen = 0;
 
-		nument = (size_t)ptr[2] - 48;
-		entlen = (size_t)ptr[3] - 48;
+			/* NOT a full skip: Gotta handle "vt" to act like before */
+			/*ptr = entptr;*/
+			/*continue;*/
+		} else {
+			nument = (size_t)ptr[2] - 48;
+			entlen = (size_t)ptr[3] - 48;
+		}
 
 		vt = vt_lookup_char(cmd);
 		valid = vt && ((loc == upsloc) || (loc == '4')) && !(vt->flags & APC_PACK);


### PR DESCRIPTION
… NUT v2.7.4 about invalid nument/entlen value(s)

Closes: #1941

As discussed in the issue linked above, the driver misbehaved due to changes in 2.8.0 release compared to 2.7.4, which were supposed to make the code sturdier against invalid inputs. In practice it seems they went a bit too far, so this PR reverts the effective behavior to what was in 2.7.4 - to cleanly skip a processing loop if `nument` is invalid, but to do process other directives as it did before.