### PR TITLE
dummy-ups: relax error handling to prevent premature driver termination

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -217,6 +217,12 @@ as part of https://github.com/networkupstools/nut/issues/1410 solution.
      commits to apcupsd sources were in 2017 (with last release 3.14.14 in
      May 2016): https://sourceforge.net/p/apcupsd/svn/HEAD/tree/
 
+  - dummy-ups:
+    * added an `repeater_disable_strict_start` option to disable the driver
+      exiting upon encountering any kind of error at startup (as repeater).
+      This option should allow for collective `upsdrvctl` startup despite
+      individual target UPS to be repeated or `upsd` not having come up yet.
+
  - NUT for Windows:
    * Ability to build NUT for Windows, last tackled with a branch based on
      NUT v2.6.5 a decade ago, has been revived with the 2.8.x era codebase [#5].

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -221,7 +221,7 @@ as part of https://github.com/networkupstools/nut/issues/1410 solution.
     * added an `repeater_disable_strict_start` option to disable the driver
       exiting upon encountering any kind of error at startup (as repeater).
       This option should allow for collective `upsdrvctl` startup despite
-      individual target UPS to be repeated or `upsd` not having come up yet.
+      individual target UPS to be repeated or `upsd` not having come up yet. [#2132]
 
  - NUT for Windows:
    * Ability to build NUT for Windows, last tackled with a branch based on

--- a/docs/man/dummy-ups.txt
+++ b/docs/man/dummy-ups.txt
@@ -174,7 +174,7 @@ second), independently of (and/or in addition to) any `TIMER` keywords.
 Repeater Mode
 ~~~~~~~~~~~~~
 
-In this context, `port` in the `ups.conf` block is the name of a remote UPS,
+In this context, `port` in the `ups.conf` block is the name of the target UPS,
 using the NUT format, i.e.:
 
 	<upsname>@<hostname>[:<port>]
@@ -194,6 +194,11 @@ Note that to avoid CPU overload with an infinite loop, the driver "sleeps" a
 bit between data-requesting cycles (currently this delay is hardcoded to one
 second), so propagation of data updates available to a remote `upsd` may lag
 by this much.
+
+Beware that any error encountered at repeater mode startup (e.g. when not all
+target UPS to be repeated or `upsd` instances are connectable yet) will cause
+*dummy-ups* driver to terminate prematurely. This behaviour can be changed by
+setting the `repeater_disable_strict_start` flag, making such errors non-fatal.
 
 INTERACTION
 -----------

--- a/drivers/dummy-ups.c
+++ b/drivers/dummy-ups.c
@@ -156,7 +156,7 @@ void upsdrv_initinfo(void)
 			ups = xmalloc(sizeof(*ups));
 			if (upscli_connect(ups, hostname, port, UPSCLI_CONN_TRYSSL) < 0)
 			{
-				fatalx(EXIT_FAILURE, "Error: %s", upscli_strerror(ups));
+				upslogx(LOG_ERR, "Error: %s", upscli_strerror(ups));
 			}
 			else
 			{
@@ -169,7 +169,7 @@ void upsdrv_initinfo(void)
 				{
 					fatalx(EXIT_FAILURE, "Error: upsd is too old to support this query");
 				}
-				fatalx(EXIT_FAILURE, "Error: %s", upscli_strerror(ups));
+				upslogx(LOG_ERR, "Error: %s", upscli_strerror(ups));
 			}
 			/* FIXME: commands and settable variable! */
 			break;


### PR DESCRIPTION
This presents a possible follow up for the useful revisions of #2118.

It is currently not possible to utilize the `dummy-ups` driver's repeater function within a local multi-UPS `ups.conf` file, particularly having `upsdrvctl` collectively start all drivers via e.g. `/usr/sbin/upsdrvctl -u root start` or within a systemd environment.

The reason for this is that the `dummy-ups` driver at present terminates prematurely upon encountering any kind of error at repeater mode startup, in particular a connectivity one due to the driver it should repeat not being 100% up yet or `upsd` not being up yet - as encountered during collective `upsdrvctl` startup. This proceeds to raise an erroneous return code from `upsdrvctl` (`Driver failed to start (exit status=1)`) possibly breaking the user's entire NUT startup depending on their service scripts.

```
[ups]
driver = usbhid-ups
port = auto

[qnapups]
driver = dummy-ups
port = ups@127.0.0.1
```

Such a configuration would - at present - require to first start `ups`  and afterwards `qnapups` via individual command.
It is a configuration commonly used by users with QNAP, Synology etc. devices which require certain UPS names to function.

The current error handling in `dummy-ups` complicates such a setup and could also pose a theoretical problem in a networked NUT environment when e.g. a NUT installation is restarted after a reboot (due to a power loss situation). When the server comes back up and starts NUT, but individual network devices (switches, ...) have not recovered yet, a `dummy-ups` driver will terminate encountering the temporary (but later recovered from) connectivity problem.

I therefore propose the following changes, as I believe that we could allow `dummy-ups` to attempt to recover from any such not-necessarily fatal errors (_with the fatal ones already specifically defined and causing driver termination - such as too old upsd, bad configuration etc._). While the user would still be notified of the errors occurring, the driver would not terminate in such a situation.

In general I assume most users utilizing `dummy-ups` to have to a degree RTFM and also bring enough technical proficiency to read and understand the error messages in the log if they see their `dummy-ups` setup not working as expected.

Here's such an example configuration and respective log from my testing system with a SNMP driver and a `dummy-ups` repeater configured locally and invoked via `/usr/sbin/upsdrvctl -u root start`: 

```
[ups]
driver = snmp-ups
port = 192.168.0.100
pollfreq = 15
community = public
snmp_version = v2c

[qnapups]
driver = dummy-ups
port = ups@127.0.0.1
```

```
Oct 25 06:24:36 Tower snmp-ups[17731]: Startup successful
Oct 25 06:24:36 Tower root: Error: Connection failure: Connection refused
Oct 25 06:24:36 Tower dummy-ups[17732]: Error: Connection failure: Connection refused
Oct 25 06:24:36 Tower root: Error: Driver not connected
Oct 25 06:24:36 Tower dummy-ups[17732]: Error: Driver not connected

== THE DUMMY-UPS DRIVER WOULD TERMINATE HERE IN CURRENT MASTER ==
== BELOW LOG MESSAGES DUE TO CHANGES INTRODUCED IN PULL REQUEST ==

Oct 25 06:24:37 Tower dummy-ups[17739]: Startup successful
Oct 25 06:24:37 Tower root: Network UPS Tools - UPS driver controller 2.8.0.1
Oct 25 06:24:38 Tower upsd[17745]: listening on 0.0.0.0 port 3493
Oct 25 06:24:38 Tower upsd[17745]: Connected to UPS [qnapups]: dummy-ups-qnapups
Oct 25 06:24:38 Tower dummy-ups[17739]: sock_connect: enabling asynchronous mode (auto)
Oct 25 06:24:38 Tower snmp-ups[17731]: sock_connect: enabling asynchronous mode (auto)
Oct 25 06:24:38 Tower upsd[17745]: Connected to UPS [ups]: snmp-ups-ups
Oct 25 06:24:38 Tower upsd[17745]: Found 2 UPS defined in ups.conf
Oct 25 06:24:38 Tower upsd[17746]: Startup successful
Oct 25 06:24:38 Tower upsd[17746]: Data for UPS [qnapups] is stale - check driver
Oct 25 06:24:38 Tower upsmon[17749]: Startup successful
Oct 25 06:24:38 Tower upsd[17746]: User masteruser@127.0.0.1 logged into UPS [ups]
Oct 25 06:24:42 Tower upsd[17746]: UPS [qnapups] data is no longer stale

== THE DRIVER RECOVERS TO NORMAL OPERATION FROM THE INITIAL CONNECTIVITY PROBLEM ==

```


