### PR TITLE
`upsdrvctl`: separate `exec_timeout` from `exec_error`

### DIFF
--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -1125,6 +1125,8 @@ static void exit_cleanup(void)
 	}
 
 	free(driverpath);
+
+	upsdebugx(1, "Completed the job of upsdrvctl tool, clean-up finished, exiting now");
 }
 
 int main(int argc, char **argv)
@@ -1325,6 +1327,9 @@ int main(int argc, char **argv)
 	if (exec_timeout) {
 #ifndef WIN32
 		ups_t	*tmp = upstable;
+#endif
+		upsdebugx(1, "upsdrvctl: got some timeouts with preceding operations, revising them now");
+#ifndef WIN32
 		while (tmp) {
 			if (tmp->exceeded_timeout && tmp->pid) {
 				/* reap zombie if this child died, and
@@ -1402,8 +1407,10 @@ int main(int argc, char **argv)
 #endif	/* WIN32 */
 	}
 
-	if (exec_error)
+	if (exec_error) {
+		upsdebugx(1, "upsdrvctl: got some errors with preceding operations, exiting with failure now");
 		exit(EXIT_FAILURE);
+	}
 
 	if (command == &start_driver
 	&&  upscount > 0
@@ -1412,7 +1419,7 @@ int main(int argc, char **argv)
 		/* Note: for a single started driver, we just
 		 * exec() it and should not even get here
 		 */
-		upsdebugx(1, "upsdrvctl was asked for explicit foregrounding - "
+		upsdebugx(1, "upsdrvctl: was asked for explicit foregrounding - "
 			"not exiting now (driver startup was completed)");
 
 		/* raise exit_flag upon SIGTERM, Ctrl+C, etc. */
@@ -1500,5 +1507,6 @@ int main(int argc, char **argv)
 		}
 	}
 
+	upsdebugx(1, "upsdrvctl: successfully finished");
 	exit(EXIT_SUCCESS);
 }

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -606,7 +606,7 @@ static void forkexec(char *const argv[], const ups_t *ups)
 		upsdebugx(1, "Starting the only driver with explicitly "
 			"requested foregrounding mode, not forking");
 	} else {
-		pid_t	pid;
+		pid_t	pid, waitret;
 
 		pid = fork();
 
@@ -665,11 +665,11 @@ static void forkexec(char *const argv[], const ups_t *ups)
 					alarm((unsigned int)maxstartdelay);
 			}
 
-			ret = waitpid(pid, &wstat, 0);
+			waitret = waitpid(pid, &wstat, 0);
 
 			alarm(0);
 
-			if (ret == -1) {
+			if (waitret == -1) {
 				upslogx(LOG_WARNING, "Startup timer elapsed, continuing...");
 				exec_timeout++;
 				*puexectimeout = 1;

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -1347,7 +1347,8 @@ int main(int argc, char **argv)
 						tmp->upsname, (intmax_t)tmp->pid);
 					tmp->exceeded_timeout = 0;
 				} else
-				if (waitret == -1) {
+				if (waitret == 0) {
+					/* Special behavior for WNOHANG */
 					upslogx(LOG_WARNING,
 						"Driver [%s] PID %" PRIdMAX " initially exceeded "
 						"maxstartdelay and is still starting",
@@ -1359,6 +1360,13 @@ int main(int argc, char **argv)
 					 *     if (argc != (lastarg + 1)) ...
 					 * or  if (upscount == 1) ...
 					 */
+					exec_error++;
+				} else
+				if (waitret == -1) {
+					upslog_with_errno(LOG_WARNING,
+						"Driver [%s] PID %" PRIdMAX " initially exceeded "
+						"maxstartdelay and we got an error asking it again",
+						tmp->upsname, (intmax_t)tmp->pid);
 					exec_error++;
 				} else
 				if (WIFEXITED(wstat) == 0) {

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -682,14 +682,14 @@ static void forkexec(char *const argv[], const ups_t *ups)
 				return;
 			}
 
+			/* the rest only work when WIFEXITED is nonzero */
+
 			if (WEXITSTATUS(wstat) != 0) {
 				upslogx(LOG_WARNING, "Driver failed to start"
 				" (exit status=%d)", WEXITSTATUS(wstat));
 				exec_error++;
 				return;
 			}
-
-			/* the rest only work when WIFEXITED is nonzero */
 
 			if (WIFSIGNALED(wstat)) {
 				upslog_with_errno(LOG_WARNING, "Driver died after signal %d",
@@ -716,10 +716,10 @@ static void forkexec(char *const argv[], const ups_t *ups)
 	PROCESS_INFORMATION	ProcessInformation;
 	int	i = 1;
 
-	memset(&StartupInfo,0,sizeof(STARTUPINFO));
+	memset(&StartupInfo, 0, sizeof(STARTUPINFO));
 
 	/* the command line is made of the driver name followed by args */
-	snprintf(commandline,sizeof(commandline),"%s", ups->driver);
+	snprintf(commandline, sizeof(commandline), "%s", ups->driver);
 	while (argv[i] != NULL) {
 		snprintfcat(commandline, sizeof(commandline), " %s", argv[i]);
 		i++;
@@ -743,8 +743,8 @@ static void forkexec(char *const argv[], const ups_t *ups)
 	}
 
 	/* Wait a bit then look at driver process.
-	 Unlike under Linux, Windows spwan drivers directly. If the driver is alive, all is OK.
-	 An optimization can probably be implemented to prevent waiting so much time when all is OK.
+	 * Unlike under Linux, Windows spawn drivers directly. If the driver is alive, all is OK.
+	 * An optimization can probably be implemented to prevent waiting so much time when all is OK.
 	 */
 	res = WaitForSingleObject(ProcessInformation.hProcess,
 			(ups->maxstartdelay!=-1?ups->maxstartdelay:maxstartdelay)*1000);

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -1332,6 +1332,13 @@ int main(int argc, char **argv)
 				int wstat;
 				pid_t waitret = waitpid(tmp->pid, &wstat, WNOHANG);
 
+				upsdebugx(1,
+					"Driver [%s] PID %" PRIdMAX " initially exceeded "
+					"maxstartdelay but now waitpid() returns %" PRIdMAX
+					" and status bits %Xd",
+					tmp->upsname, (intmax_t)tmp->pid,
+					(intmax_t)waitret, wstat);
+
 				if (waitret == tmp->pid) {
 					upsdebugx(1,
 						"Driver [%s] PID %" PRIdMAX " initially exceeded "

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -705,7 +705,8 @@ static void forkexec(char *const argv[], const ups_t *ups)
 
 	ret = execv(argv[0], argv);
 
-	/* shouldn't get here */
+	/* shouldn't get here normally */
+	upsdebugx(1, "%s: execv returned %d", __func__, ret);
 	fatal_with_errno(EXIT_FAILURE, "execv");
 #else
 	BOOL	ret;


### PR DESCRIPTION
Follows up from #2134 discussion; also addresses a few minor issues in the tool.

The current behavior for `upsdrvctl` is to treat timeout (over `maxstartdelay`) immediately as a bump of `exit_error` counter, which leads to `exit(EXIT_FAILURE)` after all the drivers (if many) have been processed. This gives time for some long-initializing driver to have in fact completed the start-up (or definitely fail it).

The PR changes the behavior to separately track timeouts vs. known errors, and only later revise how those PIDs ended up.

CC @desertwitch : would you like to test if this behaves differently for your case (even if just logging the situation more clearly)?

So far the default behavior remains the same - if the driver is still initializing, the tool bumps the error counter and exits with an error. But with these changes in place, it may be easier to amend (e.g. only bump `exec_error` for timeouts unless some envvar or config option is set).

NOTE: looking at `exit_cleanup()` method I saw it may after all actively try to stop the processes it had started, though only does so if `nut_foreground_passthrough` is set for explicitly foregrounded mode - there it makes sense (e.g. a single Ctrl+C to kill all tested drivers, as it was originally introduced). In that case it does not care about timeouts (does not call `waitpid()`).