### PR TITLE
Introduce `NUT_QUIET_INIT_UPSNOTIFY=true` support

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -459,6 +459,13 @@ as part of https://github.com/networkupstools/nut/issues/1410 solution.
 
  - Extended Linux systemd support with optional notifications about daemon
    state (READY, RELOADING, STOPPING) and watchdog keep-alive messages [#1590]
+   * Normally *inability* to send such notifications (e.g. lack of systemd
+     or similar framework on the particular platform) would be reported once
+     per daemon uptime on its console log, to help troubleshooting situations
+     where such lack of notifications can cause automated service restarts.
+     These messages can be hidden by setting `NUT_QUIET_INIT_UPSNOTIFY=true`
+     environment variable in init-scripts on platforms where such frameworks
+     are not expected. [#2136]
 
  - Extended Linux systemd units with aliases named after the daemons:
    `nut-server.service` as `upsd.service`, and `nut-monitor.service` as

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3257 utf-8
+personal_ws-1.1 en 3258 utf-8
 AAC
 AAS
 ABI
@@ -1327,6 +1327,7 @@ UPSDESC
 UPSHOST
 UPSIMAGEPATH
 UPSLC
+UPSNOTIFY
 UPSOutletSystemOutletDelayBeforeReboot
 UPSOutletSystemOutletDelayBeforeShutdown
 UPSOutletSystemOutletDelayBeforeStartup

--- a/scripts/Aix/nut.init.in
+++ b/scripts/Aix/nut.init.in
@@ -40,6 +40,9 @@ NUTUSER="@RUN_AS_USER@"
 NUTGROUP="@RUN_AS_GROUP@"
 NUT_VAR_LOCK="/var/locks/ups"
 
+NUT_QUIET_INIT_UPSNOTIFY=true
+export NUT_QUIET_INIT_UPSNOTIFY
+
 if [ -f "$CONFIG" ] ; then
 	. "$CONFIG"
 

--- a/scripts/HP-UX/nut-drvctl.sh
+++ b/scripts/HP-UX/nut-drvctl.sh
@@ -24,6 +24,9 @@ umask 022
 PATH=/usr/sbin:/usr/bin:/sbin
 export PATH
 
+NUT_QUIET_INIT_UPSNOTIFY=true
+export NUT_QUIET_INIT_UPSNOTIFY
+
 WHAT='NUT UPS driver (Network UPS Tools -- http://www.exploits.org/nut)'
 WHAT_PATH=/opt/nut/bin/upsdrvctl
 WHAT_CONFIG=/etc/rc.config.d/nut-drvctl

--- a/scripts/HP-UX/nut-upsd.sh
+++ b/scripts/HP-UX/nut-upsd.sh
@@ -24,6 +24,9 @@ umask 022
 PATH=/usr/sbin:/usr/bin:/sbin
 export PATH
 
+NUT_QUIET_INIT_UPSNOTIFY=true
+export NUT_QUIET_INIT_UPSNOTIFY
+
 WHAT='NUT UPS daemon (Network UPS Tools -- http://www.exploits.org/nut)'
 WHAT_PATH=/opt/nut/sbin/upsd
 WHAT_CONFIG=/etc/rc.config.d/nut-upsd

--- a/scripts/HP-UX/nut-upsmon.sh
+++ b/scripts/HP-UX/nut-upsmon.sh
@@ -24,6 +24,9 @@ umask 022
 PATH=/usr/sbin:/usr/bin:/sbin
 export PATH
 
+NUT_QUIET_INIT_UPSNOTIFY=true
+export NUT_QUIET_INIT_UPSNOTIFY
+
 WHAT='NUT UPS monitor (Network UPS Tools -- http://www.exploits.org/nut)'
 WHAT_PATH=/opt/nut/sbin/upsmon
 WHAT_CONFIG=/etc/rc.config.d/nut-upsmon

--- a/scripts/RedHat/upsd.in
+++ b/scripts/RedHat/upsd.in
@@ -53,6 +53,9 @@ fi
 # if there are no config file, bail out
 [ -f "$UPSDCONF" ] && [ -f "$UPSCONF" ] || exit 0
 
+NUT_QUIET_INIT_UPSNOTIFY=true
+export NUT_QUIET_INIT_UPSNOTIFY
+
 runcmd() {
    echo -n "$1 "
    shift

--- a/scripts/RedHat/upsmon.in
+++ b/scripts/RedHat/upsmon.in
@@ -32,6 +32,9 @@ if [ -n "$NUT_SBINDIR" -a -d "$NUT_SBINDIR" ]; then
   PATH="$NUT_SBINDIR:$PATH"
 fi
 
+NUT_QUIET_INIT_UPSNOTIFY=true
+export NUT_QUIET_INIT_UPSNOTIFY
+
 # See how we are called.
 case "$1" in
   start)

--- a/scripts/Solaris/nut.in
+++ b/scripts/Solaris/nut.in
@@ -7,6 +7,10 @@ NUT_SBIN_DIR="${NUT_DIR}/sbin"
 NUT_LIB_DIR="${NUT_DIR}/lib"
 CONFIG="@CONFPATH@/nut.conf"
 
+# We anticipate some tighter integration with SMF later:
+#NUT_QUIET_INIT_UPSNOTIFY=true
+#export NUT_QUIET_INIT_UPSNOTIFY
+
 if [ -f "$CONFIG" ] ; then
 	. "$CONFIG"
 fi

--- a/scripts/Solaris/svc-nut-monitor.in
+++ b/scripts/Solaris/svc-nut-monitor.in
@@ -21,6 +21,10 @@ CONFIG="@CONFPATH@/nut.conf"
 NUTUSER="@RUN_AS_USER@"
 NUTGROUP="@RUN_AS_GROUP@"
 
+# We anticipate some tighter integration with SMF later:
+#NUT_QUIET_INIT_UPSNOTIFY=true
+#export NUT_QUIET_INIT_UPSNOTIFY
+
 if [ -f "$CONFIG" ] ; then
 	. "$CONFIG"
 fi

--- a/scripts/Solaris/svc-nut-server.in
+++ b/scripts/Solaris/svc-nut-server.in
@@ -31,6 +31,10 @@ NUTGROUP="`svcprop -p nut/NUTGROUP $SMF_FMRI`" \
 && [ -n "$NUTGROUP" ] \
 || NUTGROUP="@RUN_AS_GROUP@"
 
+# We anticipate some tighter integration with SMF later:
+#NUT_QUIET_INIT_UPSNOTIFY=true
+#export NUT_QUIET_INIT_UPSNOTIFY
+
 if [ -f "$CONFIG" ] ; then
 	. "$CONFIG"
 fi

--- a/scripts/Solaris8/S99upsmon
+++ b/scripts/Solaris8/S99upsmon
@@ -11,6 +11,9 @@ export PATH
 
 UPSDPATH=/usr/local/ups/sbin
 
+NUT_QUIET_INIT_UPSNOTIFY=true
+export NUT_QUIET_INIT_UPSNOTIFY
+
 # See how we are called.
 case "$1" in
   'start')
@@ -19,7 +22,7 @@ case "$1" in
        $UPSDPATH/upsmon >/dev/console 2>&1
        touch /var/lock/subsys/upsmon
     fi
-    ;;        
+    ;;
   'stop')
     echo "NUT Stopping UPS monitor "
     /usr/bin/pkill -x upsmon


### PR DESCRIPTION
Issue raised in mailing list, follow-up to #1590 and related issues: messages about *inability* to notify a framework are considered noise on OSes without any framework to notify. They can be important troubleshooting aid on systems *with* frameworks however.

* https://alioth-lists.debian.net/pipermail/nut-upsuser/2023-October/013457.html