### PR TITLE
drivers/riello*.c: fix back bit maths changed with #1106

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -114,6 +114,7 @@ as part of https://github.com/networkupstools/nut/issues/1410 solution.
      (without specifying the single device) [#1759, #1806, #1875]
    * The `apcsmart` and `apcsmart-old` handled invalid data too zealously
      and aborted instead of skipping over it, like they did before [#2015]
+   * A bit maths optimization in `riello_ser` and `riello_usb` misfired [#2137]
    * Something about compile-time macros or other warnings-related refactoring
      seems to have confused the MGE SHUT (Serial HID UPS Transfer) driver
      support [#2022]

--- a/drivers/riello.c
+++ b/drivers/riello.c
@@ -67,14 +67,12 @@ uint16_t riello_calc_CRC(uint8_t type, uint8_t *buff, uint16_t size, uint8_t che
 				size--;
 				CRC_Word = 0x554D;
 				while(size--) {
-					pom  = (CRC_Word ^ *buff) & 0x00ff;
-					pom  = (pom ^ (pom << 4)) & 0x00ff;
-					/* Thanks to &0xff above, pom is at most 255 --
-					 * so shifted by 8 bits is still uint16_t range
+					pom = (CRC_Word ^ *buff) & 0x00ff;
+					pom = (pom ^ (pom << 4)) & 0x00ff;
+					/* Thanks to &0x00ff above, pom is at most 255 --
+					 * so shifted by 8 bits is still uint16_t range:
 					 */
-					pom  = (uint16_t)(pom << 8);
-					pom ^= (pom << 3);
-					pom ^= (pom >> 4);
+					pom = (pom << 8) ^ (pom << 3) ^ (pom >> 4);
 					CRC_Word = (CRC_Word >> 8) ^ pom;
 					buff++;
 				}

--- a/drivers/riello_ser.c
+++ b/drivers/riello_ser.c
@@ -46,7 +46,7 @@
 #include "riello.h"
 
 #define DRIVER_NAME	"Riello serial driver"
-#define DRIVER_VERSION	"0.08"
+#define DRIVER_VERSION	"0.09"
 
 #define DEFAULT_OFFDELAY   5
 #define DEFAULT_BOOTDELAY  5

--- a/drivers/riello_usb.c
+++ b/drivers/riello_usb.c
@@ -34,7 +34,7 @@
 #include "riello.h"
 
 #define DRIVER_NAME	"Riello USB driver"
-#define DRIVER_VERSION	"0.10"
+#define DRIVER_VERSION	"0.11"
 
 #define DEFAULT_OFFDELAY   5  /*!< seconds (max 0xFF) */
 #define DEFAULT_BOOTDELAY  5  /*!< seconds (max 0xFF) */


### PR DESCRIPTION
Closes: #2137

Follows up from [#1106 int-type changes to riello.c (among many others)](https://github.com/networkupstools/nut/pull/1106/files#diff-547696e27242b307a42b56fef3bc671cdeb0266794d735e2bb40a16f6a32db7f)