### PR TITLE
m4/nut_compiler_family.m4: fix cross-compilation

### DIFF
--- a/m4/nut_compiler_family.m4
+++ b/m4/nut_compiler_family.m4
@@ -178,19 +178,21 @@ dnl # confuse the compiler assumptions - along with its provided headers)...
 dnl # ideally; in practice however cppunit, net-snmp and some system include
 dnl # files do cause grief to picky compiler settings (more so from third
 dnl # party packages shipped via /usr/local/... namespace):
-    AS_IF([test "x$CLANGCC" = xyes -o "x$GCC" = xyes], [
-dnl #        CFLAGS="-isystem /usr/include $CFLAGS"
-        AS_IF([test -d /usr/local/include],
-            [CFLAGS="-isystem /usr/local/include $CFLAGS"])
-        AS_IF([test -d /usr/pkg/include],
-            [CFLAGS="-isystem /usr/pkg/include $CFLAGS"])
-    ])
-    AS_IF([test "x$CLANGXX" = xyes -o "x$GXX" = xyes], [
-dnl #        CXXFLAGS="-isystem /usr/include $CXXFLAGS"
-        AS_IF([test -d /usr/local/include],
-            [CXXFLAGS="-isystem /usr/local/include $CXXFLAGS"])
-        AS_IF([test -d /usr/pkg/include],
-            [CXXFLAGS="-isystem /usr/pkg/include $CXXFLAGS"])
+    AS_IF([test "x$cross_compiling" != xyes], [
+        AS_IF([test "x$CLANGCC" = xyes -o "x$GCC" = xyes], [
+dnl #            CFLAGS="-isystem /usr/include $CFLAGS"
+            AS_IF([test -d /usr/local/include],
+                [CFLAGS="-isystem /usr/local/include $CFLAGS"])
+            AS_IF([test -d /usr/pkg/include],
+                [CFLAGS="-isystem /usr/pkg/include $CFLAGS"])
+        ])
+        AS_IF([test "x$CLANGXX" = xyes -o "x$GXX" = xyes], [
+dnl #           CXXFLAGS="-isystem /usr/include $CXXFLAGS"
+            AS_IF([test -d /usr/local/include],
+                [CXXFLAGS="-isystem /usr/local/include $CXXFLAGS"])
+            AS_IF([test -d /usr/pkg/include],
+                [CXXFLAGS="-isystem /usr/pkg/include $CXXFLAGS"])
+        ])
     ])
 
 dnl # Default to avoid noisy warnings on older compilers


### PR DESCRIPTION
Do not use isystem with host paths when cross-compiling