### PR TITLE
Add usb_config_index to usb_communication_subdriver_s, default to 0.

### DIFF
--- a/drivers/libusb0.c
+++ b/drivers/libusb0.c
@@ -435,8 +435,9 @@ static int libusb_open(usb_dev_handle **udevp,
 				}
 
 				fatalx(EXIT_FAILURE,
-					"Can't claim USB device [%04x:%04x]@%d/%d: %s",
+					"Can't claim USB device [%04x:%04x]@%d/%d/%d: %s",
 					curDevice->VendorID, curDevice->ProductID,
+					usb_subdriver.usb_config_index,
 					usb_subdriver.hid_rep_index,
 					usb_subdriver.hid_desc_index,
 					usb_strerror());
@@ -449,8 +450,9 @@ static int libusb_open(usb_dev_handle **udevp,
 				}
 
 				fatalx(EXIT_FAILURE,
-					"Can't claim USB device [%04x:%04x]@%d/%d: %s",
+					"Can't claim USB device [%04x:%04x]@%d/%d/%d: %s",
 					curDevice->VendorID, curDevice->ProductID,
+					usb_subdriver.usb_config_index,
 					usb_subdriver.hid_rep_index,
 					usb_subdriver.hid_desc_index,
 					usb_strerror());
@@ -508,10 +510,7 @@ static int libusb_open(usb_dev_handle **udevp,
 
 			/* Note: on some broken UPS's (e.g. Tripp Lite Smart1000LCD),
 				only this second method gives the correct result */
-
-			/* for now, we always assume configuration 0, interface 0,
-			   altsetting 0, as above. */
-			iface = &dev->config[0].interface[usb_subdriver.hid_rep_index].altsetting[0];
+			iface = &dev->config[usb_subdriver.usb_config_index].interface[usb_subdriver.hid_rep_index].altsetting[0];
 			for (i=0; i<iface->extralen; i+=iface->extra[i]) {
 				upsdebugx(4, "i=%d, extra[i]=%02x, extra[i+1]=%02x", i,
 					iface->extra[i], iface->extra[i+1]);
@@ -904,6 +903,7 @@ usb_communication_subdriver_t usb_subdriver = {
 	libusb_set_report,
 	libusb_get_string,
 	libusb_get_interrupt,
+	LIBUSB_DEFAULT_CONF_INDEX,
 	LIBUSB_DEFAULT_INTERFACE,
 	LIBUSB_DEFAULT_DESC_INDEX,
 	LIBUSB_DEFAULT_HID_EP_IN,

--- a/drivers/libusb1.c
+++ b/drivers/libusb1.c
@@ -418,9 +418,10 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 		 * that the device is not what we want. */
 		upsdebugx(2, "Device matches");
 
-		upsdebugx(2, "Reading first configuration descriptor");
+		upsdebugx(2, "Reading configuration descriptor %d of %d",
+			usb_subdriver.usb_config_index+1, dev_desc.bNumConfigurations);
 		ret = libusb_get_config_descriptor(device,
-			(uint8_t)usb_subdriver.hid_rep_index,
+			(uint8_t)usb_subdriver.usb_config_index,
 			&conf_desc);
 		/*ret = libusb_get_active_config_descriptor(device, &conf_desc);*/
 		if (ret < 0)
@@ -497,8 +498,9 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 			libusb_free_config_descriptor(conf_desc);
 			libusb_free_device_list(devlist, 1);
 			fatalx(EXIT_FAILURE,
-				"Can't claim USB device [%04x:%04x]@%d/%d: %s",
+				"Can't claim USB device [%04x:%04x]@%d/%d/%d: %s",
 				curDevice->VendorID, curDevice->ProductID,
+				usb_subdriver.usb_config_index,
 				usb_subdriver.hid_rep_index,
 				usb_subdriver.hid_desc_index,
 				libusb_strerror((enum libusb_error)ret));
@@ -513,8 +515,9 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 			libusb_free_config_descriptor(conf_desc);
 			libusb_free_device_list(devlist, 1);
 			fatalx(EXIT_FAILURE,
-				"Can't claim USB device [%04x:%04x]@%d/%d: %s",
+				"Can't claim USB device [%04x:%04x]@%d/%d/%d: %s",
 				curDevice->VendorID, curDevice->ProductID,
+				usb_subdriver.usb_config_index,
 				usb_subdriver.hid_rep_index,
 				usb_subdriver.hid_desc_index,
 				libusb_strerror((enum libusb_error)ret));
@@ -533,7 +536,10 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 		}
 
 		if (!conf_desc) { /* ?? this should never happen */
-			upsdebugx(2, "  Couldn't retrieve descriptors");
+			upsdebugx(2, "  Couldn't retrieve config descriptor [%04x:%04x]@%d",
+				curDevice->VendorID, curDevice->ProductID,
+				usb_subdriver.usb_config_index
+			);
 			goto next_device;
 		}
 
@@ -1025,6 +1031,7 @@ usb_communication_subdriver_t usb_subdriver = {
 	nut_libusb_set_report,
 	nut_libusb_get_string,
 	nut_libusb_get_interrupt,
+	LIBUSB_DEFAULT_CONF_INDEX,
 	LIBUSB_DEFAULT_INTERFACE,
 	LIBUSB_DEFAULT_DESC_INDEX,
 	LIBUSB_DEFAULT_HID_EP_IN,

--- a/drivers/nut_libusb.h
+++ b/drivers/nut_libusb.h
@@ -37,6 +37,7 @@
                          * and for libusb headers and 0.1/1.0 mapping */
 
 /* Used in drivers/libusb*.c sources: */
+#define LIBUSB_DEFAULT_CONF_INDEX       0
 #define LIBUSB_DEFAULT_INTERFACE        0
 #define LIBUSB_DEFAULT_DESC_INDEX       0
 #define LIBUSB_DEFAULT_HID_EP_IN        1
@@ -72,6 +73,15 @@ typedef struct usb_communication_subdriver_s {
 	int (*get_interrupt)(usb_dev_handle *sdev,
 		usb_ctrl_charbuf buf, usb_ctrl_charbufsize bufsize,
 		usb_ctrl_timeout_msec timeout);
+
+	/* Nearly all devices use a single configuration descriptor, index 0.
+	 * But, it is possible for a device have more than one, check bNumConfigration
+	 * on the device descriptor for the total.
+	 *
+	 * In USB, the descriptor heirarchy is
+	 * device -> configuration(s) -> interface(s) -> endpoint(s)
+	 */
+	usb_ctrl_cfgindex usb_config_index;		/* index of the device config we use. Almost always 0; see comments above */
 
 	/* Used for Powervar UPS or similar cases to make sure
 	 * we use the right interface in the Composite device.

--- a/drivers/usb-common.h
+++ b/drivers/usb-common.h
@@ -122,6 +122,10 @@
  #define USB_CTRL_MSGVALUE_MIN	0
  #define USB_CTRL_MSGVALUE_MAX	UINT16_MAX
 
+ typedef uint8_t usb_ctrl_cfgindex;
+ #define USB_CTRL_CFGINDEX_MIN	0
+ #define USB_CTRL_CFGINDEX_MAX	UINT8_MAX
+
  typedef uint16_t usb_ctrl_repindex;
  #define USB_CTRL_REPINDEX_MIN	0
  #define USB_CTRL_REPINDEX_MAX	UINT16_MAX
@@ -410,6 +414,10 @@
  typedef int usb_ctrl_msgvalue;
  #define USB_CTRL_MSGVALUE_MIN	INT_MIN
  #define USB_CTRL_MSGVALUE_MAX	INT_MAX
+
+ typedef uint8_t usb_ctrl_cfgindex;
+ #define USB_CTRL_CFGINDEX_MIN	0
+ #define USB_CTRL_CFGINDEX_MAX	UINT8_MAX
 
  typedef int usb_ctrl_repindex;
  #define USB_CTRL_REPINDEX_MIN	INT_MIN


### PR DESCRIPTION
The tactical goal of this change is to change
                ret = libusb_get_config_descriptor(device,
                        (uint8_t)usb_subdriver.hid_rep_index,
                        &conf_desc);
to
                ret = libusb_get_config_descriptor(device,
                        (uint8_t)usb_subdriver.usb_config_index,
                        &conf_desc);

Before this change, libusb1.c did libusb_get_config_descriptor() with a config index equal to the interface number. For composite devices using an interface index > 0, this is usally the wrong choice. Concretely, I'm using an Arduino for a DIY UPS project and these are composite devices with multiple interfaces under the first (and only) config descriptor.

In the USB descriptor heirarchy, deivce descriptors have config descriptors which have interface descriptors. Also, nearly all USB devices have a single configuration (index 0).

In order to do this, I added a new member alongside the existing hid_rep_idex and hid_desc_index. I chose to do this instead of using the add_var method because this member is used in places in very similar ways to how hid_rep_index and hid_desc_index is used. This new member defaults to 0 which covers the majority of USB devices. Any future subdriver is able to use this if a device requires it. For existing subdrives, we'll just use an index of 0.

I also changed some debug logging to print out the config index where the code was already printing the interface index.

<!-- Comment:
* Please revise the docs/developers.txt for coding style suggestions and
  other considerations applicable to NUT codebase contributions, as well
  as for which text documents to update. See also docs/developer-guide.txt
  for general points on NUT architecture and design.

* Please note that we require "Signed-Off-By" tags in each Git Commit
  message, to conform to the common DCO (Developer Certificate of Origin)
  as posted in LICENSE-DCO at root of NUT codebase as well as published
  at https://developercertificate.org/

* The checklist below is more of a reminder of steps to take and "dangers"
  to look out for. PRs to update this template are also welcome :)

* Local build iterations can be augmented with the ci_build.sh script.
-->

## General points

- [ ] Described the changes in the PR submission or a separate issue, e.g.
  known published or discovered protocols, applicable hardware (expected
  compatible and actually tested/developed against), limitations, etc.

- [ ] There may be multiple commits in the PR, aligned and commented with
  a functional change. Notably, coding style changes better belong in a
  separate PR, but certainly in a dedicated commit to simplify reviews
  of "real" changes in the other commits. Similarly for typo fixes in
  comments or text documents.

## Frequent "underwater rocks" for driver addition/update PRs

- [ ] Revised existing driver families and added a sub-driver if applicable
  (`nutdrv_qx`, `usbhid-ups`...) or added a brand new driver in the other
  case.

- [ ] Did not extend obsoleted drivers with new hardware support features
  (notably `blazer` and other single-device family drivers for Qx protocols,
  except the new `nutdrv_qx` which should cover them all).

- [ ] For updated existing device drivers, bumped the `DRIVER_VERSION` macro
  or its equivalent.

<!-- Comment:
  Some sub-drivers have `SUBDRIVER_VERSION` or customized names like
  e.g. `MEGATEC_VERSION` in `drivers/nutdrv_qx_megatec.c`
-->

- [ ] For USB devices (HID or not), revised that the driver uses unique
  VID/PID combinations, or raised discussions when this is not the case
  (several vendors do use same interface chips for unrelated protocols).

- [ ] For new USB devices, built and committed the changes for the
  `scripts/upower/95-upower-hid.hwdb` file

- [ ] Proposed NUT data mapping is aligned with existing `docs/nut-names.txt`
  file. If the device exposes useful data points not listed in the file, the
  `experimental.*` namespace can be used as documented there, and discussion
  should be raised on the NUT Developers mailing list to standardize the new
  concept.

- [ ] Updated `data/driver.list.in` if applicable (new tested device info)
<!-- Comment:
Also note below, a point about PR posting for NUT DDL
-->

## Frequent "underwater rocks" for general C code PRs

- [ ] Did not "blindly assume" default integer type sizes and value ranges,
  structure layout and alignment in memory, endianness (layout of bytes and
  bits in memory for multi-byte numeric types), or use of generic `int` where
  language or libraries dictate the use of `size_t` (or `ssize_t` sometimes).

<!-- Comment:
* NOTE: Casting and/or pragmas (support detected at compile time,
  see `m4/ax_c_pragmas.m4`) to silence warnings may be acceptable,
  but only if coupled with range checks or similar actions.
-->

- [ ] Progress and errors are handled with `upsdebugx()`, `upslogx()`,
  `fatalx()` and related methods, not with direct `printf()` or `exit()`.
  Similarly, NUT helpers are used for error-checked memory allocation and
  string operations (except where customized error handling is needed,
  such as unlocking device ports, etc.)

- [ ] Coding style (including whitespace for indentations) follows precedent
  in the code of the file, and examples/guide in `docs/developers.txt` file.

- [ ] For newly added files, the `Makefile.am` recipes were updated and the
  `make distcheck` target passes.

## General documentation updates

- [ ] Updated `docs/acknowledgements.txt` (for vendor-backed device support)

- [ ] Added or updated manual page information in `docs/man/*.txt` files
  and corresponding recipe lists in `docs/man/Makefile.am` for new pages

- [ ] Passed `make spellcheck`, updated spell-checking dictionary in the
  `docs/nut.dict` file if needed (did not remove any words -- the `make`
  rule printout in case of changes suggests how to maintain it).

## Additional work may be needed after posting this PR

- [ ] Propose a PR for NUT DDL with detailed device data dumps from tests
  against real hardware (the more models, the better).

- [ ] Address NUT CI farm build failures for the PR: testing on numerous
  platforms and toolkits can expose issues not seen on just one system.

<!-- Comment:
* One frequent "offence" is the appearance of unexpected (not git-ignored)
  or modification during build of files tracked in Git.

* Another frequent issue is not tracking newly introduced file names in
  `EXTRA_DIST` of the `Makefile.am` (and for `*.in` templates -- of rules
  in the `configure.ac` script) so the `make distcheck` fails.

* Avoid using GNU-specific constructs in the `Makefile.am`, even if that
  means cumbersome ways to build a target. This should not happen in mere
  driver updates, however.

* Also some third-party libraries or OS headers and method argument types
  and counts can differ -- necessitating m4 code for `configure` script
  probing, and `ifdef`, `typedef`, etc. in C code to adapt to the build
  environment (precedents available in NUT codebase). In extreme cases,
  you may need to spin up a VM or container to reproduce those issues
  and iterate on a fix locally; see `docs/config-prereqs.txt` and
  `docs/ci-farm-lxc-setup.txt` for notes taken during preparation of
  the multi-platform NUT CI farm.
-->

- [ ] Revise suggestions from LGTM.COM analysis about "new issues" with
  the changed codebase.

<!-- Comment:
  Take them with a grain of salt, especially with regard to things like
  architecture-dependent range checks, but many of the complaints from
  the tool are indeed useful.
-->
