### PR TITLE
python: Do not install setup.py

### DIFF
--- a/scripts/python/Makefile.am
+++ b/scripts/python/Makefile.am
@@ -86,7 +86,6 @@ PYNUT_TEMPLATE = \
 	module/test_nutclient.py.in
 
 PYNUT_GENERATED_NOEXEC = \
-	module/setup.py \
 	module/PyNUT.py
 
 PYNUT_GENERATED_SCRIPT = \


### PR DESCRIPTION
The code as is installs the python module's setup.py in the site-packages directory; this is incorrect.

This commit removes setup.py from an automake variable, which resolves the issue.  I do not know if it impacts any other kind of module publicaition process.  We may need a more complicated fix.