### PR TITLE
.github/workflows/PyNUTClient.yml: limit auto-runs to NUT upstream [#2158]

### DIFF
--- a/.github/workflows/PyNUTClient.yml
+++ b/.github/workflows/PyNUTClient.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   build-n-publish:
+    if: github.repository_owner == 'networkupstools'
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Other repos lack needed pypi credentials anyway.

@gdt: I think this is the issue you reported. 