### PR TITLE
scripts/Solaris/nut.xml.in: revise "refresh" handling in umbrella SMF service

### DIFF
--- a/scripts/Solaris/nut-driver-enumerator.xml.in
+++ b/scripts/Solaris/nut-driver-enumerator.xml.in
@@ -70,13 +70,13 @@
 			<exec_method
 			type='method'
 			name='start'
-			exec='@NUT_LIBEXECDIR@/nut-driver-enumerator.sh'
+			exec='REPORT_RESTART_42=no @NUT_LIBEXECDIR@/nut-driver-enumerator.sh'
 			timeout_seconds='0'/>
 
 			<exec_method
 			type='method'
 			name='refresh'
-			exec='@NUT_LIBEXECDIR@/nut-driver-enumerator.sh'
+			exec='REPORT_RESTART_42=no @NUT_LIBEXECDIR@/nut-driver-enumerator.sh'
 			timeout_seconds='0'/>
 
 <!-- a :KILL does not really apply to a transient service... -->
@@ -128,7 +128,7 @@
 			<exec_method
 			type='method'
 			name='start'
-			exec='@NUT_LIBEXECDIR@/nut-driver-enumerator.sh --daemon'
+			exec='REPORT_RESTART_42=no @NUT_LIBEXECDIR@/nut-driver-enumerator.sh --daemon'
 			timeout_seconds='0'/>
 
 			<exec_method

--- a/scripts/Solaris/nut.xml.in
+++ b/scripts/Solaris/nut.xml.in
@@ -53,12 +53,14 @@
 		exec='/usr/sbin/svcadm disable -ts svc:/system/power/nut-monitor:default || /bin/true ; /usr/sbin/svcadm disable -ts svc:/system/power/nut-server:default || /bin/true ; @SBINDIR@/upsdrvsvcctl stop || /bin/true ; /bin/true'
 		timeout_seconds='120' />
 
-		<!-- When users "refresh nut" they are likely interested
-		     in a new config being applied... -->
+		<!-- When users "refresh nut" they are likely interested in a new
+		     config being applied (currently calls NDE for drivers, if they
+		     and the script/service are installed on the current system),
+		     and refreshing the other services... -->
 		<exec_method
 		type='method'
 		name='refresh'
-		exec='@NUT_LIBEXECDIR@/nut-driver-enumerator.sh'
+		exec='/usr/sbin/svcadm refresh svc:/system/power/nut-driver-enumerator:default || /usr/sbin/svcadm refresh svc:/system/power/nut-driver-enumerator:daemon || @NUT_LIBEXECDIR@/nut-driver-enumerator.sh || /bin/true; /usr/sbin/svcadm refresh svc:/system/power/nut-monitor:default || /bin/true ; /usr/sbin/svcadm refresh svc:/system/power/nut-server:default || /bin/true'
 		timeout_seconds='0'/>
 
 		<property_group name='startd' type='framework'>

--- a/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
+++ b/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
@@ -1008,8 +1008,8 @@ nut_driver_enumerator_main() {
     RESTART_ALL=no
     upssvcconf_checksum_unchanged "" || { echo "`date -u` : Detected changes in global section of '$UPSCONF', will restart all drivers"; RESTART_ALL=yes; }
 
-    # Quickly exit if there's nothing to do; note the lists are pre-sorted
-    # Otherwise a non-zero exit will be done below
+    # Quickly exit if there's nothing to do (both lists empty or equal); note
+    # the lists are pre-sorted. Otherwise a non-zero exit will be done below.
     # Note: We implement testing in detail whether section definitions were
     # changed since last run, as a first step before checking that name
     # lists are still equivalent, because we need to always have the result
@@ -1017,9 +1017,11 @@ nut_driver_enumerator_main() {
     # while the check for no new device section definitions is just boolean.
     # We can only exit quickly if both there are no changed sections and no
     # new or removed sections since last run.
-    NEW_CHECKSUM="`upslist_checksums_unchanged "$UPSLIST_FILE" "$UPSLIST_SVCS"`" \
-    && [ -z "$NEW_CHECKSUM" ] \
-    && upslist_equals "$UPSLIST_FILE" "$UPSLIST_SVCS" \
+    ( [ -z "$UPSLIST_FILE" -a -z "$UPSLIST_SVCS" ] || ( \
+        NEW_CHECKSUM="`upslist_checksums_unchanged "$UPSLIST_FILE" "$UPSLIST_SVCS"`" \
+        && [ -z "$NEW_CHECKSUM" ] \
+        && upslist_equals "$UPSLIST_FILE" "$UPSLIST_SVCS" \
+    ) ) \
     && if [ -z "$DAEMON_SLEEP" -o "${VERBOSE_LOOP}" = yes ] ; then \
         echo "`date -u` : OK: No changes to reconcile between ${SERVICE_FRAMEWORK} service instances and device configurations in '$UPSCONF'" ; \
        fi \

--- a/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
+++ b/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
@@ -406,7 +406,9 @@ $LINE"
 
 upsconf_getSection() {
     # Use the whole output of normalization parser
-    upslist_normalizeFile_once || return    # Propagate errors upwards
+    if [ x"${AVOID_REPARSE}" != xyes ] ; then
+        upslist_normalizeFile_once || return    # Propagate errors upwards
+    fi
     upsconf_getSection_content "$@" << EOF
 ${UPSCONF_DATA}
 EOF
@@ -418,7 +420,9 @@ upsconf_getSection_MD5() {
 
 upsconf_getSection_SDP() {
     # Use the section-driver-port subset
-    upslist_normalizeFile_once || return    # Propagate errors upwards
+    if [ x"${AVOID_REPARSE}" != xyes ] ; then
+        upslist_normalizeFile_once || return    # Propagate errors upwards
+    fi
     upsconf_getSection_content "$@" << EOF
 ${UPSCONF_DATA_SDP}
 EOF
@@ -1005,8 +1009,12 @@ nut_driver_enumerator_main() {
     upslist_readSvcs "before manipulations"
 
     # Test if global config has changed since last run
+    # Note that we have upslist_normalizeFile called from upslist_readFile
+    # just above, so even if it came empty (e.g. new NUT installation, no
+    # device sections yet) we do not want to spend time and log storage to
+    # parse again and complain again.
     RESTART_ALL=no
-    upssvcconf_checksum_unchanged "" || { echo "`date -u` : Detected changes in global section of '$UPSCONF', will restart all drivers"; RESTART_ALL=yes; }
+    AVOID_REPARSE=yes upssvcconf_checksum_unchanged "" || { echo "`date -u` : Detected changes in global section of '$UPSCONF', will restart all drivers"; RESTART_ALL=yes; }
 
     # Quickly exit if there's nothing to do (both lists empty or equal); note
     # the lists are pre-sorted. Otherwise a non-zero exit will be done below.


### PR DESCRIPTION
Rely less on NDE (among nut-driver package footprint) being generally installed, and avoid calling it directly if possible; rather try to `refresh` all the anticipated units which do the work.