### PR TITLE
Report config parsing errors ("invalid directive")

### DIFF
--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -1847,6 +1847,7 @@ static void upsmon_err(const char *errmsg)
 static void loadconfig(void)
 {
 	PCONF_CTX_t	ctx;
+	int	numerrors = 0;
 
 	pconf_init(&ctx, upsmon_err);
 
@@ -1872,6 +1873,7 @@ static void loadconfig(void)
 		if (pconf_parse_error(&ctx)) {
 			upslogx(LOG_ERR, "Parse error: %s:%d: %s",
 				configfile, ctx.linenum, ctx.errmsg);
+			numerrors++;
 			continue;
 		}
 
@@ -1890,6 +1892,7 @@ static void loadconfig(void)
 				snprintfcat(errmsg, sizeof(errmsg), " %s",
 					ctx.arglist[i]);
 
+			numerrors++;
 			upslogx(LOG_WARNING, "%s", errmsg);
 		}
 	}
@@ -1914,6 +1917,13 @@ static void loadconfig(void)
 				"Applying pollfail_log_throttle_max=%d from upsmon.conf",
 				pollfail_log_throttle_max);
 		}
+	}
+
+	/* FIXME: Per legacy behavior, we silently went on.
+	 * Maybe should abort on unusable configs?
+	 */
+	if (numerrors) {
+		upslogx(LOG_ERR, "Encountered %d config errors, those entries were ignored", numerrors);
 	}
 
 	pconf_finish(&ctx);

--- a/clients/upssched.c
+++ b/clients/upssched.c
@@ -1440,6 +1440,7 @@ static void checkconf(void)
 {
 	char	fn[SMALLBUF];
 	PCONF_CTX_t	ctx;
+	int	numerrors = 0;
 
 	snprintf(fn, sizeof(fn), "%s/upssched.conf", confpath());
 
@@ -1454,6 +1455,7 @@ static void checkconf(void)
 		if (pconf_parse_error(&ctx)) {
 			upslogx(LOG_ERR, "Parse error: %s:%d: %s",
 				fn, ctx.linenum, ctx.errmsg);
+			numerrors++;
 			continue;
 		}
 
@@ -1471,8 +1473,17 @@ static void checkconf(void)
 				snprintfcat(errmsg, sizeof(errmsg), " %s",
 					ctx.arglist[i]);
 
+			numerrors++;
 			upslogx(LOG_WARNING, "%s", errmsg);
 		}
+	}
+
+
+	/* FIXME: Per legacy behavior, we silently went on.
+	 * Maybe should abort on unusable configs?
+	 */
+	if (numerrors) {
+		upslogx(LOG_ERR, "Encountered %d config errors, those entries were ignored", numerrors);
 	}
 
 	pconf_finish(&ctx);

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -4176,6 +4176,7 @@ void read_mibconf(char *mib)
 {
 	char	fn[SMALLBUF];
 	PCONF_CTX_t	ctx;
+	int	numerrors = 0;
 
 	upsdebugx(2, "SNMP UPS driver: entering %s(%s)", __func__, mib);
 
@@ -4190,6 +4191,7 @@ void read_mibconf(char *mib)
 		if (pconf_parse_error(&ctx)) {
 			upslogx(LOG_ERR, "Parse error: %s:%d: %s",
 				fn, ctx.linenum, ctx.errmsg);
+			numerrors++;
 			continue;
 		}
 
@@ -4207,8 +4209,17 @@ void read_mibconf(char *mib)
 				snprintfcat(errmsg, sizeof(errmsg), " %s",
 					ctx.arglist[i]);
 
+			numerrors++;
 			upslogx(LOG_WARNING, "%s", errmsg);
 		}
 	}
+
+	/* FIXME: Per legacy behavior, we silently went on.
+	 * Maybe should abort on unusable configs?
+	 */
+	if (numerrors) {
+		upslogx(LOG_ERR, "Encountered %d MIB config errors, those entries were ignored", numerrors);
+	}
+
 	pconf_finish(&ctx);
 }


### PR DESCRIPTION
When certain NUT daemons (upsd, upsmon, upssched; also snmp-ups with mib.conf files) initialize and parse their configuration, they used to just report seeing a certain parse error and it was not clear if the problem was considered fatal, or if the service proceeded to start.

With this PR, we report and count all such errors, and if the count was non-zero - issue a message to stress that some config entries were ignored but the program proceeds.

It feels reasonable to not start the mis-configured service as well, so the admins would fix it... But that may be a task for some other PR (e.g. consider an older daemon running against newer-syntax config files).