### PR TITLE
PyNUT license and other setup.py metadata

### DIFF
--- a/.github/workflows/PyNUTClient.yml
+++ b/.github/workflows/PyNUTClient.yml
@@ -56,6 +56,7 @@ jobs:
         mkdir src ;
         for F in *.py.in ; do sed -e "s,@PYTHON@,$(command -v python)," < "$F" > "src/`basename "$F" .in`" ; done ;
         cp README.adoc README.txt ;
+        cp ../../../LICENSE-GPL3 . ;
         chmod +x src/test*.py ;
     - name: Build a binary wheel
       run: >-

--- a/scripts/python/module/.gitignore
+++ b/scripts/python/module/.gitignore
@@ -7,3 +7,4 @@
 /src
 /README.txt
 /.pypi-*
+/LICENSE-GPL3

--- a/scripts/python/module/Makefile.am
+++ b/scripts/python/module/Makefile.am
@@ -17,7 +17,7 @@ $(GENERATED_DIST): .pypi-dist
 
 clean-local:
 	rm -rf $(GENERATED_SRC) $(GENERATED_DIST)
-	rm -f .pypi-src .pypi-dist
+	rm -f .pypi-src .pypi-dist LICENSE-GPL3
 
 MAINTAINERCLEANFILES = Makefile.in .dirstamp .pypi-tools*
 
@@ -32,7 +32,7 @@ upload publish:
 	 esac
 
 # README.txt is also a part of module standard expectations
-.pypi-src: test_nutclient.py.in PyNUT.py.in setup.py.in README.adoc Makefile
+.pypi-src: test_nutclient.py.in PyNUT.py.in setup.py.in README.adoc Makefile $(top_srcdir)/LICENSE-GPL3
 	@echo "  PYPI  Generate PyPI module source"
 	@rm -rf $(GENERATED_SRC) "$@"
 	@mkdir src
@@ -52,6 +52,7 @@ upload publish:
 		if test -x "$(srcdir)/$${B}.in" ; then chmod +x "src/$${B}"; fi ; \
 	 done ; \
 	 cp -pf "$(srcdir)/README.adoc" README.txt || exit ; \
+	 cp -pf "$(top_srcdir)/LICENSE-GPL3" . || exit ; \
 	 echo "from . import PyNUT" > src/__init__.py || exit
 	@touch "$@"
 

--- a/scripts/python/module/setup.py.in
+++ b/scripts/python/module/setup.py.in
@@ -25,7 +25,7 @@ setup(
     long_description_content_type =	"text/plain",	# NOTE: No asciidoc so far, see https://packaging.python.org/en/latest/specifications/core-metadata/
     long_description =	long_description,
     packages =	find_packages(),
-    install_requires =	['telnetlib'],
+    # install_requires =	['telnetlib'],	# NOTE: telnetlib.py is part of Python core for tested 2.x and 3.x versions, not something 'pip' can download
     keywords =	['pypi', 'cicd', 'python'],
     classifiers = [
         "Development Status :: 5 - Production/Stable",

--- a/scripts/python/module/setup.py.in
+++ b/scripts/python/module/setup.py.in
@@ -18,6 +18,7 @@ setup(
     name =	"PyNUTClient",
     version =	'@NUT_SOURCE_GITREV_NUMERIC@',
     author =	"The Network UPS Tools project",
+    license_files = ('LICENSE-GPL3',),
     author_email =	"jimklimov+nut@gmail.com",
     description =	"Python client bindings for NUT",
     url =	"https://github.com/networkupstools/nut/tree/master/scripts/python/module",

--- a/scripts/python/module/setup.py.in
+++ b/scripts/python/module/setup.py.in
@@ -15,18 +15,18 @@ with codecs.open(os.path.join(here, "README.txt"), encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
 setup(
-    name="PyNUTClient",
-    version='@NUT_SOURCE_GITREV_NUMERIC@',
-    author="The Network UPS Tools project",
-    author_email="jimklimov+nut@gmail.com",
-    description="Python client bindings for NUT",
-    url = "https://github.com/networkupstools/nut/tree/master/scripts/python/module",
-    long_description_content_type="text/plain",	# NOTE: No asciidoc so far, see https://packaging.python.org/en/latest/specifications/core-metadata/
-    long_description=long_description,
-    packages=find_packages(),
-    install_requires=['telnetlib'],
-    keywords=['pypi', 'cicd', 'python'],
-    classifiers=[
+    name =	"PyNUTClient",
+    version =	'@NUT_SOURCE_GITREV_NUMERIC@',
+    author =	"The Network UPS Tools project",
+    author_email =	"jimklimov+nut@gmail.com",
+    description =	"Python client bindings for NUT",
+    url =	"https://github.com/networkupstools/nut/tree/master/scripts/python/module",
+    long_description_content_type =	"text/plain",	# NOTE: No asciidoc so far, see https://packaging.python.org/en/latest/specifications/core-metadata/
+    long_description =	long_description,
+    packages =	find_packages(),
+    install_requires =	['telnetlib'],
+    keywords =	['pypi', 'cicd', 'python'],
+    classifiers = [
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "Programming Language :: Python :: 2.6",


### PR DESCRIPTION
Closes: #2180
Closes: #2181 

Passes installation when built locally:
````
nut/scripts/python/module/dist$ pip install PyNUTClient-2.8.1.139-py3-none-any.whl
Defaulting to user installation because normal site-packages is not writeable
Processing ./PyNUTClient-2.8.1.139-py3-none-any.whl
Installing collected packages: PyNUTClient
Successfully installed PyNUTClient-2.8.1.139
````

The `LICENSE-GPL3` file is included in `PyNUTClient-2.8.1.139.dist-info` subdirectory inside the archive.

A one-off test upload: https://test.pypi.org/project/PyNUTClient/2.8.1.139.1/

CC @mtelka