### PR TITLE
drivers/libusb1.c: Remove unnecessary validation for bus_num

### DIFF
--- a/drivers/libusb1.c
+++ b/drivers/libusb1.c
@@ -263,14 +263,7 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 			libusb_free_device_list(devlist, 1);
 			fatal_with_errno(EXIT_FAILURE, "Out of memory");
 		}
-		if (bus_num > 0) {
-			sprintf(curDevice->Bus, "%03d", bus_num);
-		} else {
-			upsdebugx(1, "%s: invalid libusb bus number %i",
-				__func__, bus_num);
-			free(curDevice->Bus);
-			curDevice->Bus = NULL;
-		}
+		sprintf(curDevice->Bus, "%03d", bus_num);
 
 		device_addr = libusb_get_device_address(device);
 		curDevice->Device = (char *)malloc(4);


### PR DESCRIPTION
The libusb_get_bus_number() function serves as a simple accessor for the bus number of the opaque device struct. Unlike libusb_get_port_number(), it does not have the ability to convey errors back to the caller, and a bus number of 0 is a valid value. Therefore, any validation around bus_num is redundant.

This commit removes the unnecessary validation code related to bus_num.

Signed-Off-By:	Xin LI <delphij@FreeBSD.org>