### PR TITLE
upsmon: `POLLFAIL_LOG_THROTTLE_MAX` had an off-by-one error

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -55,6 +55,10 @@ https://github.com/networkupstools/nut/milestone/10
      activity was completed by the hardware, which led to mis-processing of
      shutdown triggers. Also, notification was added to report "finished
      calibration". [issue #2168, PR #2169]
+   * `upsmon` support for `POLLFAIL_LOG_THROTTLE_MAX` did not neuter the
+     applied setting when live-reloading configuration, so commenting it
+     away in `upsmon.conf` did not have the effect of resetting the logging
+     frequency to default. [#2207]
    * Drivers running with non-default user account (e.g. with `user=root`
      in their configuration) failed to apply group ownership and permissions
      to their Unix socket file for interaction with the local data server.

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -59,6 +59,9 @@ https://github.com/networkupstools/nut/milestone/10
      applied setting when live-reloading configuration, so commenting it
      away in `upsmon.conf` did not have the effect of resetting the logging
      frequency to default. [#2207]
+   * `upsmon` support for `POLLFAIL_LOG_THROTTLE_MAX` had an off-by-one error
+     (e.g. reporting "Data stale" or "Driver not connected" every 30 sec with
+     `POLLFAIL_LOG_THROTTLE_MAX 5` and `POLLFREQ 5` settings). [#2207]
    * Drivers running with non-default user account (e.g. with `user=root`
      in their configuration) failed to apply group ownership and permissions
      to their Unix socket file for interaction with the local data server.

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -58,7 +58,8 @@ https://github.com/networkupstools/nut/milestone/10
    * `upsmon` support for `POLLFAIL_LOG_THROTTLE_MAX` did not neuter the
      applied setting when live-reloading configuration, so commenting it
      away in `upsmon.conf` did not have the effect of resetting the logging
-     frequency to default. [#2207]
+     frequency to default. It also did not reset the counters to certainly
+     follow the new configuration for existing faults. [#2207]
    * `upsmon` support for `POLLFAIL_LOG_THROTTLE_MAX` had an off-by-one error
      (e.g. reporting "Data stale" or "Driver not connected" every 30 sec with
      `POLLFAIL_LOG_THROTTLE_MAX 5` and `POLLFREQ 5` settings). [#2207]

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -1875,7 +1875,7 @@ static void loadconfig(void)
 			utype_t	*ups;
 
 			upslogx(LOG_INFO,
-				"Forgetting pollfail_log_throttle_max=%d and "
+				"Forgetting POLLFAIL_LOG_THROTTLE_MAX=%d and "
 				"resetting UPS error-state counters before "
 				"a configuration reload",
 				pollfail_log_throttle_max);
@@ -1938,7 +1938,7 @@ static void loadconfig(void)
 
 		if (pollfail_log_throttle_max >= 0) {
 			upslogx(LOG_INFO,
-				"Applying pollfail_log_throttle_max=%d from upsmon.conf",
+				"Applying POLLFAIL_LOG_THROTTLE_MAX %d from upsmon.conf",
 				pollfail_log_throttle_max);
 		}
 	}

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -1924,7 +1924,7 @@ static void loadconfig(void)
 	if (reload_flag == 1) {
 		if (nut_debug_level_global > -1) {
 			upslogx(LOG_INFO,
-				"Applying debug_min=%d from upsmon.conf",
+				"Applying DEBUG_MIN %d from upsmon.conf",
 				nut_debug_level_global);
 			nut_debug_level = nut_debug_level_global;
 		} else {

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -2308,9 +2308,10 @@ static void pollups(utype_t *ups)
 				upslogx(LOG_ERR, "Poll UPS [%s] failure state code "
 					"changed from %d to %d; "
 					"report below will only be repeated to syslog "
-					"every %d polling loop cycles:",
+					"every %d polling loop cycles (%d sec):",
 					ups->sys, ups->pollfail_log_throttle_state,
-					upserror, pollfail_log_throttle_max);
+					upserror, pollfail_log_throttle_max,
+					pollfail_log_throttle_max * pollfreq);
 			}
 
 			ups->pollfail_log_throttle_state = upserror;

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -3,6 +3,7 @@
    Copyright (C)
      1998  Russell Kroll <rkroll@exploits.org>
      2012  Arnaud Quette <arnaud.quette.free.fr>
+     2020-2023  Jim Klimov <jimklimov+nut@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -1867,6 +1868,13 @@ static void loadconfig(void)
 		 * (or commented away) the debug_min
 		 * setting, detect that */
 		nut_debug_level_global = -1;
+
+		if (pollfail_log_throttle_max >= 0) {
+			upslogx(LOG_INFO,
+				"Forgetting pollfail_log_throttle_max=%d before configuration reload",
+				pollfail_log_throttle_max);
+			pollfail_log_throttle_max = -1;
+		}
 	}
 
 	while (pconf_file_next(&ctx)) {

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -218,7 +218,8 @@ typedef struct async_notify_s {
 	int flags;
 	char *ntype;
 	char *upsname;
-	char *date; } async_notify_t;
+	char *date;
+} async_notify_t;
 
 static unsigned __stdcall async_notify(LPVOID param)
 {

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -1872,10 +1872,24 @@ static void loadconfig(void)
 		nut_debug_level_global = -1;
 
 		if (pollfail_log_throttle_max >= 0) {
+			utype_t	*ups;
+
 			upslogx(LOG_INFO,
-				"Forgetting pollfail_log_throttle_max=%d before configuration reload",
+				"Forgetting pollfail_log_throttle_max=%d and "
+				"resetting UPS error-state counters before "
+				"a configuration reload",
 				pollfail_log_throttle_max);
 			pollfail_log_throttle_max = -1;
+
+			/* forget poll-failure logging throttling, so that we
+			 * rediscover the error-states and the counts involved
+			 */
+			ups = firstups;
+			while (ups) {
+				ups->pollfail_log_throttle_count = -1;
+				ups->pollfail_log_throttle_state = UPSCLI_ERR_NONE;
+				ups = ups->next;
+			}
 		}
 	}
 

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -60,8 +60,8 @@ static	unsigned int	pollfreq = 5, pollfreqalert = 5;
 	 * will only be repeated every so many POLLFREQ loops.
 	 * If pollfail_log_throttle_max == 0, such error messages will
 	 * only be reported once when that situation starts, and ends.
-	 * By default it is logged every pollfreq (which can abuse syslog
-	 * and its storage).
+	 * By default (or for negative values) it is logged every pollfreq
+	 * loop cycle (which can abuse syslog and its storage).
 	 * To support this, each utype_t (UPS) structure tracks individual
 	 * pollfail_log_throttle_count and pollfail_log_throttle_state
 	 */

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -62,7 +62,8 @@ static	unsigned int	pollfreq = 5, pollfreqalert = 5;
 	 * If pollfail_log_throttle_max == 0, such error messages will
 	 * only be reported once when that situation starts, and ends.
 	 * By default (or for negative values) it is logged every pollfreq
-	 * loop cycle (which can abuse syslog and its storage).
+	 * loop cycle (which can abuse syslog and its storage), same as
+	 * if "max = 1".
 	 * To support this, each utype_t (UPS) structure tracks individual
 	 * pollfail_log_throttle_count and pollfail_log_throttle_state
 	 */
@@ -2267,9 +2268,11 @@ static void pollups(utype_t *ups)
 				 * failure state */
 				pollfail_log = 0;
 			} else {
-				/* Only log once for start, every MAX iterations,
-				 * and end of the same failure state */
-				if (ups->pollfail_log_throttle_count++ >= pollfail_log_throttle_max) {
+				/* here (pollfail_log_throttle_max > 0) :
+				 * only log once for start, every MAX iterations,
+				 * and end of the same failure state
+				 */
+				if (ups->pollfail_log_throttle_count++ >= (pollfail_log_throttle_max - 1)) {
 					/* ping... */
 					pollfail_log = 1;
 					ups->pollfail_log_throttle_count = 0;

--- a/conf/upsmon.conf.sample.in
+++ b/conf/upsmon.conf.sample.in
@@ -415,9 +415,11 @@ NOCOMMWARNTIME 300
 # extended timeframe, you can use this throttle to reduce the stress on
 # syslog traffic and storage, by posting these messages only once in every
 # several loop cycles, and when the error condition has changed or cleared.
-# A negative value means standard behavior (log on every loop), and a zero
-# value means to never repeat the message (log only on start and end/change
-# of the failure state).
+# A negative value means standard behavior (log on every loop, same as when
+# max=1), and a zero value means to never repeat the message (log only on
+# start and end/change of the failure state).
+# Note that this throttle only applies to one latest-active error state per
+# monitored device.
 #
 #POLLFAIL_LOG_THROTTLE_MAX 100
 

--- a/conf/upsmon.conf.sample.in
+++ b/conf/upsmon.conf.sample.in
@@ -415,8 +415,9 @@ NOCOMMWARNTIME 300
 # extended timeframe, you can use this throttle to reduce the stress on
 # syslog traffic and storage, by posting these messages only once in every
 # several loop cycles, and when the error condition has changed or cleared.
-# A negative value means standard behavior, and a zero value means to never
-# repeat the message (log only on start and end/change of the failure state).
+# A negative value means standard behavior (log on every loop), and a zero
+# value means to never repeat the message (log only on start and end/change
+# of the failure state).
 #
 #POLLFAIL_LOG_THROTTLE_MAX 100
 

--- a/docs/man/upsmon.conf.txt
+++ b/docs/man/upsmon.conf.txt
@@ -171,9 +171,10 @@ system log as configured.  If your devices are expected to be AWOL for an
 extended timeframe, you can use this throttle to reduce the stress on
 syslog traffic and storage, by posting these messages only once in every
 several loop cycles, and when the error condition has changed or cleared.
-
-A negative value means standard behavior, and a zero value means to never
-repeat the message (log only on start and end/change of the failure state).
++
+A negative value means standard behavior (log on every loop), and a zero
+value means to never repeat the message (log only on start and end/change
+of the failure state).
 
 *NOTIFYCMD* 'command'::
 

--- a/docs/man/upsmon.conf.txt
+++ b/docs/man/upsmon.conf.txt
@@ -172,9 +172,12 @@ extended timeframe, you can use this throttle to reduce the stress on
 syslog traffic and storage, by posting these messages only once in every
 several loop cycles, and when the error condition has changed or cleared.
 +
-A negative value means standard behavior (log on every loop), and a zero
-value means to never repeat the message (log only on start and end/change
-of the failure state).
+A negative value means standard behavior (log on every loop, effectively
+same as when `max=1`), and a zero value means to never repeat the message
+(log only on start and end/change of the failure state).
++
+Note that this throttle only applies to one latest-active error state per
+monitored device.
 
 *NOTIFYCMD* 'command'::
 

--- a/docs/man/upsmon.txt
+++ b/docs/man/upsmon.txt
@@ -475,9 +475,12 @@ system log as configured.  If your devices are expected to be AWOL for an
 extended timeframe, you can use POLLFAIL_LOG_THROTTLE_MAX to reduce the
 stress on syslog traffic and storage, by posting these messages only once
 in every several loop cycles, and when the error condition has changed or
-cleared.  A negative value means standard behavior (log on every loop),
-and a zero value means to never repeat the message (log only on start and
-end/change of the failure state).
+cleared.  A negative value means standard behavior (log on every loop,
+effectively same as when `max=1`), and a zero value means to never repeat
+the message (log only on start and end/change of the failure state).
+
+Note that this throttle only applies to one latest-active error state per
+monitored device.
 
 RELOADING NUANCES
 -----------------

--- a/docs/man/upsmon.txt
+++ b/docs/man/upsmon.txt
@@ -475,9 +475,9 @@ system log as configured.  If your devices are expected to be AWOL for an
 extended timeframe, you can use POLLFAIL_LOG_THROTTLE_MAX to reduce the
 stress on syslog traffic and storage, by posting these messages only once
 in every several loop cycles, and when the error condition has changed or
-cleared. A negative value means standard behavior, and a zero value means
-to never repeat the message (log only on start and end/change of the failure
-state).
+cleared.  A negative value means standard behavior (log on every loop),
+and a zero value means to never repeat the message (log only on start and
+end/change of the failure state).
 
 RELOADING NUANCES
 -----------------

--- a/server/conf.c
+++ b/server/conf.c
@@ -415,7 +415,7 @@ void load_upsdconf(int reloading)
 	if (reloading) {
 		if (nut_debug_level_global > -1) {
 			upslogx(LOG_INFO,
-				"Applying debug_min=%d from upsd.conf",
+				"Applying DEBUG_MIN %d from upsd.conf",
 				nut_debug_level_global);
 			nut_debug_level = nut_debug_level_global;
 		} else {


### PR DESCRIPTION
Closes: #2207
Follows up from #1784

Now `POLLFAIL_LOG_THROTTLE_MAX` is actually the "max" and not "skip N loops and report during the next one after N", so the default behavior of reporting the errors on every loop (also as the negative `POLLFAIL_LOG_THROTTLE_MAX` value) is same as setting `1` here. A `0` still goes for reporting only the start and end of a condition; still one tracked `upserror` condition per UPS.

With this PR in place, it also logs the expected report frequency more clearly (in seconds, not just loop counts):
````
Dec 01 12:25:44 pve nut-monitor[1521804]: Poll UPS [dummy] failure state code changed from -1 to 10; report below will only be repeated to syslog every 3 polling loop cycles (15 sec):
Dec 01 12:25:44 pve nut-monitor[1521804]: Poll UPS [dummy] failed - Data stale
Dec 01 12:25:44 pve nut-monitor[1521804]: Communications with UPS dummy lost
Dec 01 12:25:44 pve nut-monitor[1522577]: Network UPS Tools upsmon 2.8.1-247-gf5cdaf906
Dec 01 12:25:59 pve nut-monitor[1521804]: Poll UPS [dummy] failed - Data stale
Dec 01 12:26:14 pve nut-monitor[1521804]: Poll UPS [dummy] failed - Data stale
Dec 01 12:26:29 pve nut-monitor[1521804]: Poll UPS [dummy] failed - Data stale
Dec 01 12:26:44 pve nut-monitor[1521804]: Poll UPS [dummy] failed - Data stale
Dec 01 12:26:59 pve nut-monitor[1521804]: Poll UPS [dummy] failed - Data stale
...
````

Now it also supports commenting-away of the setting in `upsmon.conf` as a return to default (during a live-reload).

````
# systemctl reload upsmon
Dec 01 12:37:07 pve systemd[1]: Reloading Network UPS Tools - power device monitor and shutdown controller.
Dec 01 12:37:07 pve nut-monitor[1705171]: Network UPS Tools upsmon 2.8.1-247-gf5cdaf906
Dec 01 12:37:07 pve nut-monitor[1521804]: Reloading configuration
Dec 01 12:37:07 pve nut-monitor[1521804]: Forgetting POLLFAIL_LOG_THROTTLE_MAX=3 and resetting UPS error-state counters before a configuration reload
Dec 01 12:37:07 pve nut-monitor[1521804]: Applying debug level 0 from original command line arguments
Dec 01 12:37:07 pve systemd[1]: Reloaded Network UPS Tools - power device monitor and shutdown controller.
````

Docs were also updated here and there.