### PR TITLE
`usbhid-ups`: allow to throttle or suppress logged messages about `OL+DISCHRG` situation

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -110,6 +110,15 @@ https://github.com/networkupstools/nut/milestone/10
    * The `onlinedischarge` configuration flag name was too ambiguous and got
      deprecated (will be supported but no longer promoted by documentation),
      introducing `onlinedischarge_onbattery` as the meaningful alias. [#2213]
+   * Logged notifications about `OL+DISCHRG` state should now be throttled
+     (see the driver manual page for more details) [#2214]:
+     - If `battery.charge` is available, make the message when entering the
+       state and then only if the charge differs from that when we posted
+       the earlier message (e.g. really discharging);
+     - Also can throttle to a time frequency configurable by a new option
+       `onlinedischarge_log_throttle_sec`, by default 30 sec if `battery.charge`
+       is not reported by the device (should be frequent by default, in case
+       the UPS-reported state combination does reflect a bad power condition).
 
 Release notes for NUT 2.8.1 - what's new since 2.8.0
 ----------------------------------------------------

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -107,6 +107,9 @@ https://github.com/networkupstools/nut/milestone/10
    * `arduino-hid` subdriver was enhanced from "initial bare bones" experimental
      set of mapped data points to support some 20 more mappings to make it more
      useful as an UPS driver, not just a controller developer sandbox. [#2188]
+   * The `onlinedischarge` configuration flag name was too ambiguous and got
+     deprecated (will be supported but no longer promoted by documentation),
+     introducing `onlinedischarge_onbattery` as the meaningful alias. [#2213]
 
 Release notes for NUT 2.8.1 - what's new since 2.8.0
 ----------------------------------------------------

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -111,10 +111,11 @@ https://github.com/networkupstools/nut/milestone/10
      deprecated (will be supported but no longer promoted by documentation),
      introducing `onlinedischarge_onbattery` as the meaningful alias. [#2213]
    * Logged notifications about `OL+DISCHRG` state should now be throttled
-     (see the driver manual page for more details) [#2214]:
+     (see the driver manual page for more details) [#2214, #2215]:
      - If `battery.charge` is available, make the message when entering the
        state and then only if the charge differs from that when we posted
-       the earlier message (e.g. really discharging);
+       the earlier message (e.g. really discharging) and is under
+       `onlinedischarge_log_throttle_hovercharge` value (defaults to 100%);
      - Also can throttle to a time frequency configurable by a new option
        `onlinedischarge_log_throttle_sec`, by default 30 sec if `battery.charge`
        is not reported by the device (should be frequent by default, in case

--- a/docs/man/usbhid-ups.txt
+++ b/docs/man/usbhid-ups.txt
@@ -135,6 +135,23 @@ NOTE: If it takes so long on your device that a shutdown gets issued, you may
 want to look at `upsmon` option `OFFDURATION` used to filter out temporary
 values of "administrative OFF" as not a loss of a feed for the powered load.
 
+*onlinedischarge_log_throttle_sec*='num'::
+Set the minimum frequency (in seconds) at which warnings would be emitted
+for an otherwise not handled `OL+DISCHRG` device status combination.
+Negative values disable sequentially repeated messages (when this state
+appears and persists).
++
+If the device does not report `battery.charge`, the default value is 30 seconds
+(fairly frequent, in case the UPS-reported state combination does reflect a
+bad power condition and so the situation is urgent).
++
+If it does report `battery.charge`, by default the repeated notifications
+would only be logged if this charge is different from when the message was
+emitted previously (e.g. when the battery is really discharging).
++
+If both this option is set, and `battery.charge` is correctly reported,
+either of these rules allow the notification to be logged.
+
 *disable_fix_report_desc*::
 Set to disable fix-ups for broken USB encoding, etc. which we apply by default
 on certain models (vendors/products) which were reported as not following the

--- a/docs/man/usbhid-ups.txt
+++ b/docs/man/usbhid-ups.txt
@@ -114,11 +114,16 @@ If this flag is set, the driver will not use Interrupt In transfers during the
 shorter "pollinterval" cycles (not recommended, but needed if these reports
 are broken on your UPS).
 
-*onlinedischarge*::
-If this flag is set, the driver will treat `OL+DISCHRG` status as offline.
+*onlinedischarge_battery*::
+If this flag is set, the driver will treat `OL+DISCHRG` status as
+offline/on-battery.
++
 For most devices this combination means calibration or similar maintenance;
 however some UPS models (e.g. CyberPower UT series) emit `OL+DISCHRG` when
 wall power is lost -- and need this option to handle shutdowns.
+
+*onlinedischarge*::
+DEPRECATED, old name for `onlinedischarge_battery` described above.
 
 *onlinedischarge_calibration*::
 If this flag is set, the driver will treat `OL+DISCHRG` status as calibration.

--- a/docs/man/usbhid-ups.txt
+++ b/docs/man/usbhid-ups.txt
@@ -152,6 +152,14 @@ emitted previously (e.g. when the battery is really discharging).
 If both this option is set, and `battery.charge` is correctly reported,
 either of these rules allow the notification to be logged.
 
+*onlinedischarge_log_throttle_hovercharge*='num'::
+See details in `onlinedischarge_log_throttle_sec` and `battery.charge` based
+log message throttling description above.  This option adds a concept of UPS
+"hovering" a battery charge at some level deemed safe for its chemistry, and
+not forcing it to be fully charged all the time.  As long as the current value
+of `battery.charge` remains at or above this threshold percentage (default 100),
+the `OL+DISCHRG` message logging is not triggered by variations of the charge.
+
 *disable_fix_report_desc*::
 Set to disable fix-ups for broken USB encoding, etc. which we apply by default
 on certain models (vendors/products) which were reported as not following the

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3421 utf-8
+personal_ws-1.1 en 3422 utf-8
 AAC
 AAS
 ABI
@@ -2661,6 +2661,7 @@ oldmge
 oldnut
 omnios
 onbatt
+onbattery
 onbattwarn
 onclick
 ondelay

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3422 utf-8
+personal_ws-1.1 en 3423 utf-8
 AAC
 AAS
 ABI
@@ -2173,6 +2173,7 @@ hostnames
 hostsfile
 hotplug
 hotplugging
+hovercharge
 hpe
 href
 htaccess


### PR DESCRIPTION
Closes: #1970
Closes: #2212
Closes: #2213
Closes: #2214
Closes: #2215

Introduces a number of new configurable toggles with hopefully reasonable defaults, which should help to reduce log noise on systems where an UPS reports "online" and "discharging" simultaneously (so far some CyberPower and APC models were reported to behave so, with different physical situations).