### PR TITLE
nut-scanner: add support for Home Assistant config format

### DIFF
--- a/docs/man/nut-scanner.txt
+++ b/docs/man/nut-scanner.txt
@@ -44,6 +44,9 @@ as comments (default).
 *-N* | *--disp_nut_conf*::
 Display result in the 'ups.conf' format.
 
+*-H* | *--disp_home_assistant_conf*::
+Display result in the Home Assistant format.
+
 *-P* | *--disp_parsable*::
 Display result in a parsable format.
 

--- a/tools/nut-scanner/nut-scan.h
+++ b/tools/nut-scanner/nut-scan.h
@@ -171,6 +171,7 @@ sem_t * nutscan_semaphore(void);
 
 /* Display functions */
 void nutscan_display_ups_conf(nutscan_device_t * device);
+void nutscan_display_home_assistant_conf(nutscan_device_t * device);
 void nutscan_display_parsable(nutscan_device_t * device);
 
 /* Display sanity-check concerns for various fields etc. (if any) */

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -61,7 +61,7 @@
 
 #define ERR_BAD_OPTION	(-1)
 
-static const char optstring[] = "?ht:T:s:e:E:c:l:u:W:X:w:x:p:b:B:d:L:CUSMOAm:QNPqIVaD";
+static const char optstring[] = "?ht:T:s:e:E:c:l:u:W:X:w:x:p:b:B:d:L:CUSMOAm:QNHPqIVaD";
 
 #ifdef HAVE_GETOPT_LONG
 static const struct option longopts[] = {
@@ -92,6 +92,7 @@ static const struct option longopts[] = {
 	{ "ipmi_scan", no_argument, NULL, 'I' },
 	{ "disp_nut_conf_with_sanity_check", no_argument, NULL, 'Q' },
 	{ "disp_nut_conf", no_argument, NULL, 'N' },
+	{ "disp_home_assistant_conf", no_argument, NULL, 'H' },
 	{ "disp_parsable", no_argument, NULL, 'P' },
 	{ "quiet", no_argument, NULL, 'q' },
 	{ "help", no_argument, NULL, 'h' },
@@ -339,6 +340,7 @@ static void show_usage(void)
 	printf("\ndisplay specific options:\n");
 	printf("  -Q, --disp_nut_conf_with_sanity_check: Display result in the ups.conf format with sanity-check warnings as comments (default)\n");
 	printf("  -N, --disp_nut_conf: Display result in the ups.conf format\n");
+	printf("  -H, --disp_home_assistant_conf: Display result in the Home Assistant format\n");
 	printf("  -P, --disp_parsable: Display result in a parsable format\n");
 	printf("\nMiscellaneous options:\n");
 	printf("  -h, --help: display this help text\n");
@@ -652,6 +654,9 @@ int main(int argc, char *argv[])
 				break;
 			case 'N':
 				display_func = nutscan_display_ups_conf;
+				break;
+			case 'H':
+				display_func = nutscan_display_home_assistant_conf;
 				break;
 			case 'P':
 				display_func = nutscan_display_parsable;

--- a/tools/nut-scanner/nutscan-display.c
+++ b/tools/nut-scanner/nutscan-display.c
@@ -104,6 +104,66 @@ void nutscan_display_ups_conf(nutscan_device_t * device)
 	last_nutdev_num = nutdev_num;
 }
 
+void nutscan_display_home_assistant_conf(nutscan_device_t * device)
+{
+	nutscan_device_t * current_dev = device;
+	nutscan_options_t * opt;
+	static int nutdev_num = 1;
+
+	upsdebugx(2, "%s: %s", __func__, device
+		? (device->type < TYPE_END ? nutscan_device_type_string[device->type] : "<UNKNOWN>")
+		: "<NULL>");
+
+	if (device == NULL) {
+		return;
+	}
+
+	/* Find start of the list */
+	while (current_dev->prev != NULL) {
+		current_dev = current_dev->prev;
+	}
+
+	printf("devices:\n");
+
+	/* Display each device */
+	do {
+		printf("  - name: nutdev%i\n    driver: %s",
+			nutdev_num, current_dev->driver);
+
+		if (current_dev->alt_driver_names) {
+			printf("  # alternately: %s",
+				current_dev->alt_driver_names);
+		}
+
+		printf("\n    port: %s",
+			current_dev->port);
+
+		opt = current_dev->opt;
+
+		printf("\n    config:\n");
+		while (NULL != opt) {
+			if (opt->option != NULL) {
+				printf("    - %s", opt->option);
+				if (opt->value != NULL) {
+					printf(" = %s", opt->value);
+				}
+				printf("\n");
+			}
+			else {
+				printf(" []\n");
+			}
+			opt = opt->next;
+		}
+
+		nutdev_num++;
+
+		current_dev = current_dev->next;
+	}
+	while (current_dev != NULL);
+
+	last_nutdev_num = nutdev_num;
+}
+
 void nutscan_display_parsable(nutscan_device_t * device)
 {
 	nutscan_device_t * current_dev = device;

--- a/tools/nut-scanner/nutscan-display.c
+++ b/tools/nut-scanner/nutscan-display.c
@@ -145,7 +145,7 @@ void nutscan_display_home_assistant_conf(nutscan_device_t * device)
 			if (opt->option != NULL) {
 				printf("    - %s", opt->option);
 				if (opt->value != NULL) {
-					printf(" = %s", opt->value);
+					printf(" = \"%s\"", opt->value);
 				}
 				printf("\n");
 			}


### PR DESCRIPTION
Add "-H, --disp_home_assistant_conf" to display nut-scanner results in the Home Assistant format