### PR TITLE
2236 nut scanner reports non existent driver for nut discovery

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -88,6 +88,8 @@ https://github.com/networkupstools/nut/milestone/10
    * Added generation of FreeBSD/pfSense quirks for USB devices supported
      by NUT (may get installed to `$datadir` e.g. `/usr/local/share/nut`
      and need to be pasted into your `/boot/loader.conf.local`). [#2159]
+   * nut-scanner now report 'dummy-ups' as driver when scanning NUT with
+     Old or Avahi method.
 
  - upsd: Fixed conditions for "no listening interface available" diagnosis
    to check how many listeners we succeeded with, not whether the first one

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -905,6 +905,8 @@
 "Numeric"	"ups"	"2"	"3000 SW"	""	"blazer_ser"
 "Numeric"	"ups"	"2"	"Digital 800 plus"	"USB"	"nutdrv_qx or blazer_usb"
 
+"NUT"	"ups"	"5"	"all supported NUT devices, through remote upsd"	""	"dummy-ups"
+
 "Oneac"	"ups"	"1"	"ON400"	"advanced interface"	"oneac"
 "Oneac"	"ups"	"1"	"ON600"	"advanced interface"	"oneac"
 "Oneac"	"ups"	"1"	"ON900"	"advanced interface"	"oneac"

--- a/tools/nut-scanner/scan_avahi.c
+++ b/tools/nut-scanner/scan_avahi.c
@@ -1,4 +1,5 @@
 /*
+ *  Copyright (C) 2011 - 2023 Arnaud Quette (Design and part of implementation)
  *  Copyright (C) 2011 - EATON
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -19,6 +20,7 @@
 /*! \file scan_avahi.c
     \brief detect NUT through Avahi mDNS / DNS-SD services
     \author Frederic Bohe <fredericbohe@eaton.com>
+    \author Arnaud Quette <arnaudquette@free.fr>
 */
 
 #include "common.h"
@@ -39,6 +41,8 @@
 #include <avahi-common/error.h>
 
 #include <ltdl.h>
+
+#define SCAN_AVAHI_DRIVERNAME "dummy-ups"
 
 /* dynamic link library stuff */
 static lt_dlhandle dl_handle = NULL;
@@ -266,7 +270,7 @@ static void update_device(const char * host_name, const char *ip, uint16_t port,
 			dev->type = TYPE_NUT;
 			/* NOTE: There is no driver by such name, in practice it could
 			 * be a dummy-ups relay, a clone driver, or part of upsmon config */
-			dev->driver = strdup("nutclient");
+			dev->driver = strdup(SCAN_AVAHI_DRIVERNAME);
 			if (proto == AVAHI_PROTO_INET) {
 				nutscan_add_option_to_device(dev, "desc", "IPv4");
 			}
@@ -322,7 +326,7 @@ static void update_device(const char * host_name, const char *ip, uint16_t port,
 		else {
 			dev = nutscan_new_device();
 			dev->type = TYPE_NUT;
-			dev->driver = strdup("nutclient");
+			dev->driver = strdup(SCAN_AVAHI_DRIVERNAME);
 			if (proto == AVAHI_PROTO_INET) {
 				nutscan_add_option_to_device(dev, "desc", "IPv4");
 			}

--- a/tools/nut-scanner/scan_nut.c
+++ b/tools/nut-scanner/scan_nut.c
@@ -1,4 +1,5 @@
 /*
+ *  Copyright (C) 2011 - 2023 Arnaud Quette (Design and part of implementation)
  *  Copyright (C) 2011 - EATON
  *  Copyright (C) 2016-2021 - EATON - Various threads-related improvements
  *
@@ -21,6 +22,7 @@
     \brief detect remote NUT services
     \author Frederic Bohe <fredericbohe@eaton.com>
     \author Jim Klimov <EvgenyKlimov@eaton.com>
+    \author Arnaud Quette <arnaudquette@free.fr>
 */
 
 #include "common.h"
@@ -28,6 +30,8 @@
 #include "nut-scan.h"
 #include "nut_stdint.h"
 #include <ltdl.h>
+
+#define SCAN_NUT_DRIVERNAME "dummy-ups"
 
 /* dynamic link library stuff */
 static lt_dlhandle dl_handle = NULL;
@@ -192,7 +196,7 @@ static void * list_nut_devices(void * arg)
 		dev->type = TYPE_NUT;
 		/* NOTE: There is no driver by such name, in practice it could
 		 * be a dummy-ups relay, a clone driver, or part of upsmon config */
-		dev->driver = strdup("nutclient");
+		dev->driver = strdup(SCAN_NUT_DRIVERNAME);
 		/* +1+1 is for '@' character and terminating 0 */
 		buf_size = strlen(answer[1]) + strlen(hostname) + 1 + 1;
 		if (port != PORT) {


### PR DESCRIPTION
When discovering NUT, either with Avahi or old method, the reported driver is "nutclient", which doesn't (yet) exists.
This should be fixed to dummy-ups, which will use the repeater mode, while waiting for #2232 

the short term fix is to symlink nutclient to dummy-ups (example on Debian):

> cd /lib/nut && ln -s dummy-ups nutclient