### PR TITLE
nut-scanner: detect and configure NUT simulation devices

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -88,6 +88,8 @@ https://github.com/networkupstools/nut/milestone/10
    * Added generation of FreeBSD/pfSense quirks for USB devices supported
      by NUT (may get installed to `$datadir` e.g. `/usr/local/share/nut`
      and need to be pasted into your `/boot/loader.conf.local`). [#2159]
+   * nut-scanner can now discover NUT simulated devices (.dev & .seq files)
+     located in your sysconfig directory
 
  - upsd: Fixed conditions for "no listening interface available" diagnosis
    to check how many listeners we succeeded with, not whether the first one

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -906,6 +906,7 @@
 "Numeric"	"ups"	"2"	"Digital 800 plus"	"USB"	"nutdrv_qx or blazer_usb"
 
 "NUT"	"ups"	"5"	"all supported NUT devices, through remote upsd"	""	"dummy-ups"
+"NUT"	"ups"	"5"	"Simulated devices"	""	"dummy-ups"
 
 "Oneac"	"ups"	"1"	"ON400"	"advanced interface"	"oneac"
 "Oneac"	"ups"	"1"	"ON600"	"advanced interface"	"oneac"

--- a/docs/developer-guide.txt
+++ b/docs/developer-guide.txt
@@ -113,6 +113,17 @@ Here is an example to setup a device simulation:
 
 For more information, refer to linkman:dummy-ups[8] manual page.
 
+[[dev-simu-disco]]
+
+Simulated devices discovery
+---------------------------
+
+Any simulation file that is saved in the sysconfig directory can be
+automatically discovered and configured using nut-scanner:
++
+	$ nut-scanner -n
+	$ nut-scanner --nut_simulation_scan
++
 
 [[dev-recording]]
 

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -174,6 +174,7 @@ SRC_DEV_PAGES = \
 	nutscan_scan_usb.txt \
 	nutscan_scan_xml_http_range.txt \
 	nutscan_scan_nut.txt \
+	nutscan_scan_nut_simulation.txt \
 	nutscan_scan_avahi.txt \
 	nutscan_scan_ipmi.txt \
 	nutscan_scan_eaton_serial.txt \
@@ -291,6 +292,7 @@ MAN3_DEV_PAGES = \
 	nutscan_scan_usb.3 \
 	nutscan_scan_xml_http_range.3 \
 	nutscan_scan_nut.3 \
+	nutscan_scan_nut_simulation.3 \
 	nutscan_scan_avahi.3 \
 	nutscan_scan_ipmi.3 \
 	nutscan_scan_eaton_serial.3 \
@@ -360,6 +362,7 @@ HTML_DEV_MANS = \
 	nutscan_scan_usb.html \
 	nutscan_scan_xml_http_range.html \
 	nutscan_scan_nut.html \
+	nutscan_scan_nut_simulation.html \
 	nutscan_scan_avahi.html \
 	nutscan_scan_ipmi.html \
 	nutscan_scan_eaton_serial.html \

--- a/docs/man/nut-scanner.txt
+++ b/docs/man/nut-scanner.txt
@@ -67,6 +67,9 @@ interfaces to retrieve XML/HTTP capable devices. No IP required in this mode.
 *-O* | *--oldnut_scan*::
 Scan NUT devices (i.e. upsd daemon) on IP ranging from 'start IP' to 'end IP'.
 
+*-n* | *--nut_simulation_scan*::
+Scan NUT simulated devices (.dev files in $CONFPATH).
+
 *-A* | *--avahi_scan*::
 Scan NUT servers using Avahi request on the current network interfaces.
 No IP required.

--- a/docs/man/nutscan_init.txt
+++ b/docs/man/nutscan_init.txt
@@ -27,6 +27,7 @@ This depends on the libraries installed on the system:
 	nutscan_avail_avahi = 1 : AVAHI scan is available
 	nutscan_avail_ipmi = 1 : IPMI scan is available
 	nutscan_avail_nut = 1 : Old NUT method is available
+	nutscan_avail_nut_simulation = 1 : NUT simulation devices method is available
 	nutscan_avail_snmp = 1 : SNMP method is available
 	nutscan_avail_usb = 1 : USB method is available
 	nutscan_avail_xml_http = 1 : XML HTTP method is available
@@ -44,9 +45,9 @@ SEE ALSO
 
 linkman:nutscan_init[3], linkman:nutscan_scan_usb[3],
 linkman:nutscan_scan_snmp[3], linkman:nutscan_scan_xml_http_range[3],
-linkman:nutscan_scan_nut[3], linkman:nutscan_scan_avahi[3],
-linkman:nutscan_scan_ipmi[3], linkman:nutscan_display_ups_conf[3],
-linkman:nutscan_display_sanity_check[3],
+linkman:nutscan_scan_nut[3], linkman:nutscan_scan_nut_simulation[3],
+linkman:nutscan_scan_avahi[3], linkman:nutscan_scan_ipmi[3],
+linkman:nutscan_display_ups_conf[3], linkman:nutscan_display_sanity_check[3],
 linkman:nutscan_display_sanity_check_serial[3],
 linkman:nutscan_display_ups_conf_with_sanity_check[3],
 linkman:nutscan_display_parsable[3], linkman:nutscan_new_device[3],

--- a/docs/man/nutscan_scan_nut_simulation.txt
+++ b/docs/man/nutscan_scan_nut_simulation.txt
@@ -1,0 +1,52 @@
+NUTSCAN_SCAN_NUT_SIMULATION(3)
+==============================
+
+NAME
+----
+
+nutscan_scan_nut_simulation - Scan your sysconfig directory for NUT simulation devices.
+
+SYNOPSIS
+--------
+
+ #include <nut-scan.h>
+ #include <unistd.h> /* useconds_t */
+
+ nutscan_device_t * nutscan_scan_nut_simulation();
+
+DESCRIPTION
+-----------
+
+The *nutscan_scan_nut_simulation()* function try to detect available NUT
+simulation devices, by finding .dev and .seq files in your sysconfig
+directory.
+
+You MUST call linkman:nutscan_init[3] before using this function.
+
+A specific 'port' number may be passed, or NULL to use the default NUT port.
+
+This function waits up to 'usec_timeout' microseconds before considering
+an IP address does not respond to NUT queries.
+
+RETURN VALUE
+------------
+
+The *nutscan_scan_nut_simulation()* function returns a pointer to a
+`nutscan_device_t` structure containing all found devices or NULL if an
+error occurs or no device is found.
+
+SEE ALSO
+--------
+
+linkman:nutscan_init[3],
+linkman:nutscan_scan_usb[3], linkman:nutscan_scan_xml_http_range[3],
+linkman:nutscan_scan_snmp[3], linkman:nutscan_scan_avahi[3],
+linkman:nutscan_scan_ipmi[3], linkman:nutscan_scan_nut[3], 
+linkman:nutscan_display_sanity_check[3],
+linkman:nutscan_display_sanity_check_serial[3],
+linkman:nutscan_display_ups_conf_with_sanity_check[3],
+linkman:nutscan_display_ups_conf[3],
+linkman:nutscan_display_parsable[3], linkman:nutscan_new_device[3],
+linkman:nutscan_free_device[3], linkman:nutscan_add_option_to_device[3],
+linkman:nutscan_add_device_to_device[3], linkman:nutscan_scan_eaton_serial[3],
+linkman:nutscan_cidr_to_ip[3]

--- a/docs/man/nutscan_scan_nut_simulation.txt
+++ b/docs/man/nutscan_scan_nut_simulation.txt
@@ -23,11 +23,6 @@ directory.
 
 You MUST call linkman:nutscan_init[3] before using this function.
 
-A specific 'port' number may be passed, or NULL to use the default NUT port.
-
-This function waits up to 'usec_timeout' microseconds before considering
-an IP address does not respond to NUT queries.
-
 RETURN VALUE
 ------------
 

--- a/tools/nut-scanner/Makefile.am
+++ b/tools/nut-scanner/Makefile.am
@@ -50,7 +50,7 @@ if WITH_NUT_SCANNER
  bin_PROGRAMS = nut-scanner
  lib_LTLIBRARIES = libnutscan.la
 endif
-libnutscan_la_SOURCES = scan_nut.c scan_ipmi.c \
+libnutscan_la_SOURCES = scan_nut.c  scan_nut_simulation.c scan_ipmi.c \
 			nutscan-device.c nutscan-ip.c nutscan-display.c \
 			nutscan-init.c scan_usb.c scan_snmp.c scan_xml_http.c \
 			scan_avahi.c scan_eaton_serial.c nutscan-serial.c

--- a/tools/nut-scanner/nut-scan.h
+++ b/tools/nut-scanner/nut-scan.h
@@ -1,9 +1,9 @@
 /*
  *  Copyright (C)
  *    2011 - EATON
- *    2012 - Arnaud Quette <arnaud.quette@free.fr>
+ *    2012 - 2024 Arnaud Quette <arnaud.quette@free.fr>
  *    2016 - EATON - IP addressed XML scan
- *    2016-2021 - EATON - Various threads-related improvements
+ *    2016 - 2021 - EATON - Various threads-related improvements
  *    2023 - Jim Klimov <jimklimov+nut@gmail.com>
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -154,6 +154,8 @@ nutscan_device_t * nutscan_scan_usb(void);
 nutscan_device_t * nutscan_scan_xml_http_range(const char *start_ip, const char *end_ip, useconds_t usec_timeout, nutscan_xml_t * sec);
 
 nutscan_device_t * nutscan_scan_nut(const char * startIP, const char * stopIP, const char * port, useconds_t usec_timeout);
+
+nutscan_device_t * nutscan_scan_nut_simulation();
 
 nutscan_device_t * nutscan_scan_avahi(useconds_t usec_timeout);
 

--- a/tools/nut-scanner/nutscan-device.c
+++ b/tools/nut-scanner/nutscan-device.c
@@ -1,4 +1,5 @@
 /*
+ *  Copyright (C) 2011 - 2024 Arnaud Quette (Design and part of implementation)
  *  Copyright (C) 2011 - EATON
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -19,6 +20,7 @@
 /*! \file nutscan-device.c
     \brief manipulation of a container describing a NUT device
     \author Frederic Bohe <fredericbohe@eaton.com>
+	\author Arnaud Quette <arnaudquette@free.fr>
 */
 #include "config.h"	/* must be the first header */
 
@@ -32,6 +34,7 @@ const char * nutscan_device_type_strings[TYPE_END - 1] = {
 	"SNMP",
 	"XML",
 	"NUT",
+	"NUT_SIMULATION",
 	"IPMI",
 	"Avahi",
 	"serial",

--- a/tools/nut-scanner/nutscan-device.h
+++ b/tools/nut-scanner/nutscan-device.h
@@ -1,4 +1,5 @@
 /*
+ *  Copyright (C) 2011 - 2024 Arnaud Quette (Design and part of implementation)
  *  Copyright (C) 2011 - EATON
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -19,6 +20,7 @@
 /*! \file nutscan-device.h
     \brief definition of a container describing a NUT discovered device
     \author Frederic Bohe <fredericbohe@eaton.com>
+	\author Arnaud Quette <arnaudquette@free.fr>
 */
 
 #ifndef SCAN_DEVICE
@@ -46,6 +48,7 @@ typedef enum nutscan_device_type {
 	TYPE_SNMP,
 	TYPE_XML,
 	TYPE_NUT,
+	TYPE_NUT_SIMULATION,
 	TYPE_IPMI,
 	TYPE_AVAHI,
 	TYPE_EATON_SERIAL,

--- a/tools/nut-scanner/nutscan-init.c
+++ b/tools/nut-scanner/nutscan-init.c
@@ -1,4 +1,5 @@
 /*
+ *  Copyright (C) 2011 - 2024 Arnaud Quette (Design and part of implementation)
  *  Copyright (C) 2011-2021 - EATON
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -20,6 +21,7 @@
     \brief init functions for nut scanner library
     \author Frederic Bohe <fredericbohe@eaton.com>
     \author Arnaud Quette <ArnaudQuette@Eaton.com>
+	\author Arnaud Quette <arnaudquette@free.fr>
 */
 
 #include "common.h"
@@ -39,6 +41,7 @@
 int nutscan_avail_avahi = 0;
 int nutscan_avail_ipmi = 0;
 int nutscan_avail_nut = 0;
+int nutscan_avail_nut_simulation = 1;
 #ifdef WITH_SNMP_STATIC
 int nutscan_avail_snmp = 1;
 #else
@@ -356,6 +359,11 @@ void nutscan_init(void)
 	upsdebugx(1, "%s: %s to load the library for %s",
 		__func__, nutscan_avail_nut ? "succeeded" : "failed", "NUT Client library");
 /* end of libupsclient for "old NUT" (vs. Avahi) protocol */
+
+
+/* start of "NUT Simulation" - unconditional */
+/* no need for additional library */
+	nutscan_avail_nut = 1;
 
 }
 

--- a/tools/nut-scanner/nutscan-init.h
+++ b/tools/nut-scanner/nutscan-init.h
@@ -1,4 +1,5 @@
 /*
+ *  Copyright (C) 2011 - 2024 Arnaud Quette (Design and part of implementation)
  *  Copyright (C) 2011 - EATON
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -19,6 +20,7 @@
 /*! \file nutscan-init.h
     \brief initialisation data
     \author Frederic Bohe <fredericbohe@eaton.com>
+	\author Arnaud Quette <arnaudquette@free.fr>
 */
 
 #ifndef SCAN_INIT
@@ -33,6 +35,7 @@ extern "C" {
 extern int nutscan_avail_avahi;
 extern int nutscan_avail_ipmi;
 extern int nutscan_avail_nut;
+extern int nutscan_avail_nut_simulation;
 extern int nutscan_avail_snmp;
 extern int nutscan_avail_usb;
 extern int nutscan_avail_xml_http;

--- a/tools/nut-scanner/scan_avahi.c
+++ b/tools/nut-scanner/scan_avahi.c
@@ -1,4 +1,5 @@
 /*
+ *  Copyright (C) 2011 - 2024 Arnaud Quette (Design and part of implementation)
  *  Copyright (C) 2011 - EATON
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -19,6 +20,7 @@
 /*! \file scan_avahi.c
     \brief detect NUT through Avahi mDNS / DNS-SD services
     \author Frederic Bohe <fredericbohe@eaton.com>
+	\author Arnaud Quette <arnaudquette@free.fr>
 */
 
 #include "common.h"

--- a/tools/nut-scanner/scan_nut_simulation.c
+++ b/tools/nut-scanner/scan_nut_simulation.c
@@ -1,0 +1,103 @@
+/*
+ *  Copyright (C) 2024 Arnaud Quette
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+/*! \file scan_nut_simulation.c
+    \brief detect local NUT simulation devices (.dev & .seq)
+    \author Arnaud Quette <arnaud.quette@free.fr>
+*/
+
+#include "common.h"
+#include "nut-scan.h"
+#include "nut_stdint.h"
+#include <dirent.h>
+#if !HAVE_DECL_REALPATH
+# include <sys/stat.h>
+#endif
+
+#define SCAN_NUT_SIMULATION_DRIVERNAME "dummy-ups"
+
+/* dynamic link library stuff */
+static nutscan_device_t * dev_ret = NULL;
+
+#ifdef HAVE_PTHREAD
+static pthread_mutex_t dev_mutex;
+#endif
+
+/* return 1 when filter is ok (.dev or .seq) */
+static int filter_ext(const struct dirent *dir)
+{
+	if(!dir)
+		return 0;
+
+	if(dir->d_type == DT_REG) { /* only deal with regular file */
+		const char *ext = strrchr(dir->d_name,'.');
+		if((!ext) || (ext == dir->d_name))
+			return 0;
+		else {
+			if ((strcmp(ext, ".dev") == 0) || (strcmp(ext, ".seq") == 0)) {
+				return 1;
+			}
+		}
+	}
+	return 0;
+}
+
+nutscan_device_t * nutscan_scan_nut_simulation()
+{
+	nutscan_device_t * dev = NULL;
+	struct dirent **namelist;
+	int n;
+
+#if HAVE_PTHREAD
+	pthread_mutex_init(&dev_mutex, NULL);
+#endif /* HAVE_PTHREAD */
+
+	upsdebugx(1,"Scanning: %s", CONFPATH);
+
+	n = scandir(CONFPATH, &namelist, filter_ext, alphasort);
+	if (n < 0) {
+		fatal_with_errno(EXIT_FAILURE, "Failed to scandir");
+		return NULL;
+	}
+	else {
+		while (n--) {
+			upsdebugx(1,"Found simulation file: %s", namelist[n]->d_name);
+
+			dev = nutscan_new_device();
+			dev->type = TYPE_NUT_SIMULATION;
+			dev->driver = strdup(SCAN_NUT_SIMULATION_DRIVERNAME);
+			dev->port = strdup(namelist[n]->d_name);
+
+#ifdef HAVE_PTHREAD
+			pthread_mutex_lock(&dev_mutex);
+#endif
+			dev_ret = nutscan_add_device_to_device(dev_ret, dev);
+#ifdef HAVE_PTHREAD
+			pthread_mutex_unlock(&dev_mutex);
+#endif
+			free(namelist[n]);
+		}
+		free(namelist);
+	}
+
+#if HAVE_PTHREAD
+	pthread_mutex_destroy(&dev_mutex);
+#endif /* HAVE_PTHREAD */
+
+	return nutscan_rewind_device(dev_ret);
+}


### PR DESCRIPTION
Provide an additional nut-scanner "-n | --nut_simulation_scan" option to detect and configure dummy simulation (.dev & .seq) from the default $sysconfdir.

This should standardize and streamline the use of nut-scanner as an automatic detection and configuration tool.

Closes: #networkupstools/nut/issues/2242