### PR TITLE
nut-scanner: fix device-name collisions in generated conf

### DIFF
--- a/docs/man/nut-scanner.txt
+++ b/docs/man/nut-scanner.txt
@@ -19,6 +19,9 @@ DESCRIPTION
 *nut-scanner* scans available communication buses and displays any
 NUT-compatible devices it has found.
 
+*nut-scanner* can also display the detected devices in various formats,
+including ups.cconf, and ensures generated devices name unicity across buses.
+
 INSTALLATION
 ------------
 
@@ -90,7 +93,6 @@ This option must be requested explicitly, even for a complete scan.
 ports using 'X-Y', where X and Y are characters referring to the port number.
 - a single port name.
 - a list of ports name, coma separated, like '/dev/ttyS1,/dev/ttyS4'.
-
 
 NETWORK OPTIONS
 ---------------
@@ -220,20 +222,40 @@ EXAMPLES
 To scan USB devices only:
 
 *nut-scanner -U*
++
+[nutdev-usb1]
+        driver = "snmp-ups"
+        port = "192.168.0.42"
++
 
 To scan SNMP v1 device with public community on address range 192.168.0.0
 to 192.168.0.255:
 
 *nut-scanner -S -s 192.168.0.0 -e 192.168.0.255*
++
+[nutdev-snmp1]
+        driver = "snmp-ups"
+        port = "192.168.0.42"
++
 
 The same using CIDR notation:
 
 *nut-scanner -S -m 192.168.0.0/24*
++
+[nutdev-snmp1]
+        driver = "snmp-ups"
+        port = "192.168.0.42"
++
 
 To scan NUT servers with a timeout of 10 seconds on IP range 192.168.0.0
 to 192.168.0.127 using CIDR notation:
 
 *nut-scanner -O -t 10 -m 192.168.0.0/25*
++
+[nutdev-nut1]
+        driver = "dummy-ups"
+        port = "dummy-test@192.168.1.28"
++
 
 To scan for power supplies, through IPMI (1.5 mode) over the network,
 on address range 192.168.0.0 to 192.168.0.255 using CIDR notation:

--- a/docs/man/nut-scanner.txt
+++ b/docs/man/nut-scanner.txt
@@ -20,7 +20,8 @@ DESCRIPTION
 NUT-compatible devices it has found.
 
 *nut-scanner* can also display the detected devices in various formats,
-including ups.cconf, and ensures generated devices name unicity across buses.
+including ups.conf, and ensures that the generated devices name are unique
+across buses.
 
 INSTALLATION
 ------------

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -1215,9 +1215,12 @@ testcase_sandbox_nutscanner_list() {
     # Note: the reported "driver" string is not too helpful as a "nutclient".
     # In practice this could be a "dummy-ups" repeater or "clone" driver,
     # or some of the config elements needed for upsmon (lacking creds/role)
+    # Also note that before PR #2247 nut-scanner returned "nutdev<NUM>"
+    # section names, but now it returns "nutdev-<BUS><NUM>" to differentiate
+    # the scanned buses (serial, snmp, usb, etc.)
     if (
         test -n "$CMDOUT" \
-        && echo "$CMDOUT" | grep -E '^\[nutdev1\]$' \
+        && echo "$CMDOUT" | grep -E '^\[nutdev-nut1\]$' \
         && echo "$CMDOUT" | grep 'port = "dummy@' \
         || return
 
@@ -1234,9 +1237,9 @@ testcase_sandbox_nutscanner_list() {
         if [ x"${TOP_SRCDIR}" = x ]; then
             log_info "[testcase_sandbox_nutscanner_list] Note: only testing one dummy device" >&2
         else
-            echo "$CMDOUT" | grep -E '^\[nutdev2\]$' \
+            echo "$CMDOUT" | grep -E '^\[nutdev-nut2\]$' \
             && echo "$CMDOUT" | grep 'port = "UPS1@' \
-            && echo "$CMDOUT" | grep -E '^\[nutdev3\]$' \
+            && echo "$CMDOUT" | grep -E '^\[nutdev-nut3\]$' \
             && echo "$CMDOUT" | grep 'port = "UPS2@' \
             || {
                 log_error "[testcase_sandbox_nutscanner_list] something about UPS1/UPS2 not found" >&2

--- a/tools/nut-scanner/nutscan-device.c
+++ b/tools/nut-scanner/nutscan-device.c
@@ -29,7 +29,8 @@
 #include <string.h>
 #include <assert.h>
 
-const char * nutscan_device_type_strings[TYPE_END - 1] = {
+const char * nutscan_device_type_strings[TYPE_END] = {
+	"NONE", /* 0 */
 	"USB",
 	"SNMP",
 	"XML",
@@ -37,6 +38,19 @@ const char * nutscan_device_type_strings[TYPE_END - 1] = {
 	"NUT_SIMULATION",
 	"IPMI",
 	"Avahi",
+	"serial",
+};
+
+/* lower strings, used for device names */
+const char * nutscan_device_type_lstrings[TYPE_END] = {
+	"none", /* 0 */
+	"usb",
+	"snmp",
+	"xml",
+	"nut",
+	"simulation",
+	"ipmi",
+	"avahi",
 	"serial",
 };
 

--- a/tools/nut-scanner/nutscan-device.h
+++ b/tools/nut-scanner/nutscan-device.h
@@ -41,6 +41,8 @@ extern "C" {
  */
 #define nutscan_device_type_string(type) \
 	(assert(0 < (type) && (type) < TYPE_END), nutscan_device_type_strings[type - 1])
+#define nutscan_device_type_lstring(type) \
+	(assert(0 < (type) && (type) < TYPE_END), nutscan_device_type_lstrings[type - 1])
 
 typedef enum nutscan_device_type {
 	TYPE_NONE = 0,
@@ -56,7 +58,8 @@ typedef enum nutscan_device_type {
 } nutscan_device_type_t;
 
 /** Device type -> string mapping */
-extern const char * nutscan_device_type_strings[TYPE_END - 1];
+extern const char * nutscan_device_type_strings[TYPE_END];
+extern const char * nutscan_device_type_lstrings[TYPE_END];
 
 typedef struct nutscan_options {
 	char *		option;

--- a/tools/nut-scanner/nutscan-display.c
+++ b/tools/nut-scanner/nutscan-display.c
@@ -71,7 +71,8 @@ void nutscan_display_ups_conf(nutscan_device_t * device)
 
 	/* Display each device */
 	do {
-		printf("[nutdev%i]\n\tdriver = \"%s\"",
+		printf("[nutdev-%s%i]\n\tdriver = \"%s\"",
+			nutscan_device_type_lstrings[current_dev->type],
 			nutdev_num, current_dev->driver);
 
 		if (current_dev->alt_driver_names) {
@@ -214,7 +215,7 @@ void nutscan_display_sanity_check_serial(nutscan_device_t * device)
 	}
 
 	/* Process each device:
-	 * Build a map of "serial"=>"nutdevX[,...,nutdevZ]"
+	 * Build a map of "serial"=>"nutdev-serialX[,...,nutdev-serialZ]"
 	 * and warn if there are bogus "serial" keys or if
 	 * there are several nutdev's (a comma in value).
 	 */
@@ -256,7 +257,7 @@ void nutscan_display_sanity_check_serial(nutscan_device_t * device)
 					 * dynamic allocation, malloc data for larger "val".
 					 */
 					snprintfcat(entry->val, sizeof(entry->val),
-						",nutdev%i", nutdev_num);
+						",nutdev-serial%i", nutdev_num);
 				} else {
 					/* No hit => new key */
 					upsdebugx(3, "%s: new entry for serial '%s'",
@@ -280,7 +281,7 @@ void nutscan_display_sanity_check_serial(nutscan_device_t * device)
 					snprintf(entry->key, sizeof(entry->key),
 						"%s", keytmp);
 					snprintf(entry->val, sizeof(entry->val),
-						"nutdev%i", nutdev_num);
+						"nutdev-serial%i", nutdev_num);
 				}
 
 				/* Abort the opt-searching loop for this device */


### PR DESCRIPTION
When nut-scanner is called separately, to scan different buses, it will generate similar names for each of these:
* USB scan
> [nutdev1]
> ...
* NUT scan
> [nutdev1]
> ...
* ... As a result, one can't just redirect nut-scanner outputs directly to ups.conf, without a 'sed' hack workaround.

Solution: simply refine the device names, like "nutdev-<method><id>".
Ex: nutdev-usb1, nutdev-usb2, nutdev-nut1, nutdev-snmp1, nutdev-simulation1, ...