### PR TITLE
Fix parts of issue 2249

### DIFF
--- a/tools/nut-scanner/nut-scan.h
+++ b/tools/nut-scanner/nut-scan.h
@@ -155,7 +155,7 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char *start_ip, const char 
 
 nutscan_device_t * nutscan_scan_nut(const char * startIP, const char * stopIP, const char * port, useconds_t usec_timeout);
 
-nutscan_device_t * nutscan_scan_nut_simulation();
+nutscan_device_t * nutscan_scan_nut_simulation(void);
 
 nutscan_device_t * nutscan_scan_avahi(useconds_t usec_timeout);
 

--- a/tools/nut-scanner/scan_nut_simulation.c
+++ b/tools/nut-scanner/scan_nut_simulation.c
@@ -44,7 +44,18 @@ static int filter_ext(const struct dirent *dir)
 	if(!dir)
 		return 0;
 
+#if defined(DT_REG)
+	/* NOTE: dirent->d_type is not ubiquitous; here we take
+	 * existence of its standard values as presence of the
+	 * struct field too, rather than adding a configure test.
+	 * TODO: Else check with fopen()+fstat()...
+	 */
 	if(dir->d_type == DT_REG) { /* only deal with regular file */
+#else
+	upsdebugx(0,
+		"WARNING: checking all types of directory entries on this platform,\n"
+		"not constrained to regular files for NUT simulation data!");
+#endif
 		const char *ext = strrchr(dir->d_name,'.');
 		if((!ext) || (ext == dir->d_name))
 			return 0;
@@ -53,7 +64,9 @@ static int filter_ext(const struct dirent *dir)
 				return 1;
 			}
 		}
+#if defined(DT_REG)
 	}
+#endif
 	return 0;
 }
 

--- a/tools/nut-scanner/scan_nut_simulation.c
+++ b/tools/nut-scanner/scan_nut_simulation.c
@@ -57,7 +57,7 @@ static int filter_ext(const struct dirent *dir)
 	return 0;
 }
 
-nutscan_device_t * nutscan_scan_nut_simulation()
+nutscan_device_t * nutscan_scan_nut_simulation(void)
 {
 	nutscan_device_t * dev = NULL;
 	struct dirent **namelist;


### PR DESCRIPTION
See #2249 

* Could not reproduce the autoconf problem on any of the workers, will look out for it more later.
* Fixed method declarations.
* Hacked around lack of `dirent->d_type` on some platforms (any non-GNU land I suppose). A better fix is desirable for fallback equivalent logic via `fstat()`, see e.g.
  * https://mingw-users.narkive.com/JpEGojiV/linux-dirent-d-type-windows-equivalent
  * https://stackoverflow.com/questions/35215109/struct-dirent-does-not-have-de-type-in-header-file/35215258#35215258
* Did not address the methods missing on mingw at this time.