### PR TITLE
2249 nut master branch builds broken after recent prs andor infra changes

### DIFF
--- a/tools/nut-scanner/nut-scan.h
+++ b/tools/nut-scanner/nut-scan.h
@@ -155,7 +155,7 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char *start_ip, const char 
 
 nutscan_device_t * nutscan_scan_nut(const char * startIP, const char * stopIP, const char * port, useconds_t usec_timeout);
 
-nutscan_device_t * nutscan_scan_nut_simulation();
+nutscan_device_t * nutscan_scan_nut_simulation(void);
 
 nutscan_device_t * nutscan_scan_avahi(useconds_t usec_timeout);
 

--- a/tools/nut-scanner/scan_nut_simulation.c
+++ b/tools/nut-scanner/scan_nut_simulation.c
@@ -44,14 +44,12 @@ static int filter_ext(const struct dirent *dir)
 	if(!dir)
 		return 0;
 
-	if(dir->d_type == DT_REG) { /* only deal with regular file */
-		const char *ext = strrchr(dir->d_name,'.');
-		if((!ext) || (ext == dir->d_name))
-			return 0;
-		else {
-			if ((strcmp(ext, ".dev") == 0) || (strcmp(ext, ".seq") == 0)) {
-				return 1;
-			}
+	const char *ext = strrchr(dir->d_name,'.');
+	if((!ext) || (ext == dir->d_name))
+		return 0;
+	else {
+		if ((strcmp(ext, ".dev") == 0) || (strcmp(ext, ".seq") == 0)) {
+			return 1;
 		}
 	}
 	return 0;

--- a/tools/nut-scanner/scan_nut_simulation.c
+++ b/tools/nut-scanner/scan_nut_simulation.c
@@ -54,8 +54,10 @@ nutscan_device_t * nutscan_scan_nut_simulation(void)
 
 	while ((dirp = readdir(dp)) != NULL)
 	{
-		upsdebugx(5,"Comparing file %s with simulation file extensions", dirp->d_name);
-		const char *ext = strrchr(dirp->d_name,'.');
+		const char *ext;
+
+		upsdebugx(5, "Comparing file %s with simulation file extensions", dirp->d_name);
+		ext = strrchr(dirp->d_name, '.');
 		if((!ext) || (ext == dirp->d_name))
 			continue;
 

--- a/tools/nut-scanner/scan_nut_simulation.c
+++ b/tools/nut-scanner/scan_nut_simulation.c
@@ -69,7 +69,7 @@ nutscan_device_t * nutscan_scan_nut_simulation(void)
 
 	upsdebugx(1,"Scanning: %s", CONFPATH);
 
-	n = scandir(CONFPATH, &namelist, filter_ext, alphasort);
+	n = scandir(CONFPATH, &namelist, filter_ext, NULL);
 	if (n < 0) {
 		fatal_with_errno(EXIT_FAILURE, "Failed to scandir");
 		return NULL;

--- a/tools/nut-scanner/scan_nut_simulation.c
+++ b/tools/nut-scanner/scan_nut_simulation.c
@@ -57,7 +57,7 @@ static int filter_ext(const struct dirent *dir)
 	return 0;
 }
 
-nutscan_device_t * nutscan_scan_nut_simulation()
+nutscan_device_t * nutscan_scan_nut_simulation(void)
 {
 	nutscan_device_t * dev = NULL;
 	struct dirent **namelist;


### PR DESCRIPTION
nut-scanner: simplify and fix simulation scan code

Remove non-portable directory and alphasort filtering code, since there is no
actual need for it, and cause system portability issues.
Also fix the simulation scan function prototype.

Closes: #2249