### PR TITLE
CI: make use of `ccache` namespace support, where possible

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,6 +3,15 @@
 # include directory for aclocal
 ACLOCAL_AMFLAGS = -I m4
 
+# Export certain values for ccache which NUT ci_build.sh can customize,
+# to facilitate developer iteration re-runs of "make" later.
+# At least GNU and BSD make implementations are okay with this syntax.
+export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
+export CCACHE_BASEDIR=@CCACHE_BASEDIR@
+export CCACHE_DIR=@CCACHE_DIR@
+export CCACHE_PATH=@CCACHE_PATH@
+export PATH=@PATH_DURING_CONFIGURE@
+
 # subdirectories to build and distribute. The order matters, as
 # several subdirectories depend on stuff in "common" or tools being built first
 SUBDIRS = include common clients conf data docs drivers tools \

--- a/Makefile.am
+++ b/Makefile.am
@@ -6,11 +6,11 @@ ACLOCAL_AMFLAGS = -I m4
 # Export certain values for ccache which NUT ci_build.sh can customize,
 # to facilitate developer iteration re-runs of "make" later.
 # At least GNU and BSD make implementations are okay with this syntax.
-export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
-export CCACHE_BASEDIR=@CCACHE_BASEDIR@
-export CCACHE_DIR=@CCACHE_DIR@
-export CCACHE_PATH=@CCACHE_PATH@
-export PATH=@PATH_DURING_CONFIGURE@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_BASEDIR=@CCACHE_BASEDIR@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_DIR=@CCACHE_DIR@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_PATH=@CCACHE_PATH@
+@NUT_AM_MAKE_CAN_EXPORT@export PATH=@PATH_DURING_CONFIGURE@
 
 # subdirectories to build and distribute. The order matters, as
 # several subdirectories depend on stuff in "common" or tools being built first

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -774,7 +774,7 @@ fi
 echo "Processing BUILD_TYPE='${BUILD_TYPE}' ..."
 
 echo "Build host settings:"
-set | grep -E '^(PATH|.*CCACHE.*|CI_.*|OS_.*|CANBUILD_.*|NODE_LABELS|MAKE|C.*FLAGS|LDFLAGS|ARCH.*|BITS.*|CC|CXX|CPP|DO_.*|BUILD_.*)=' || true
+set | grep -E '^(PATH|[^ ]*CCACHE[^ ]*|CI_[^ ]*|OS_[^ ]*|CANBUILD_[^ ]*|NODE_LABELS|MAKE|C[^ ]*FLAGS|LDFLAGS|ARCH[^ ]*|BITS[^ ]*|CC|CXX|CPP|DO_[^ ]*|BUILD_[^ ]*)=' || true
 uname -a
 echo "LONG_BIT:`getconf LONG_BIT` WORD_BIT:`getconf WORD_BIT`" || true
 if command -v xxd >/dev/null ; then xxd -c 1 -l 6 | tail -1; else if command -v od >/dev/null; then od -N 1 -j 5 -b | head -1 ; else hexdump -s 5 -n 1 -C | head -1; fi; fi < /bin/ls 2>/dev/null | awk '($2 == 1){print "Endianness: LE"}; ($2 == 2){print "Endianness: BE"}' || true

--- a/clients/Makefile.am
+++ b/clients/Makefile.am
@@ -4,11 +4,11 @@ EXTRA_DIST =
 # Export certain values for ccache which NUT ci_build.sh can customize,
 # to facilitate developer iteration re-runs of "make" later.
 # At least GNU and BSD make implementations are okay with this syntax.
-export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
-export CCACHE_BASEDIR=@CCACHE_BASEDIR@
-export CCACHE_DIR=@CCACHE_DIR@
-export CCACHE_PATH=@CCACHE_PATH@
-export PATH=@PATH_DURING_CONFIGURE@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_BASEDIR=@CCACHE_BASEDIR@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_DIR=@CCACHE_DIR@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_PATH=@CCACHE_PATH@
+@NUT_AM_MAKE_CAN_EXPORT@export PATH=@PATH_DURING_CONFIGURE@
 
 # nutclient.cpp for some legacy reason (maybe initial detached development?)
 # optionally includes "common.h" with the NUT build setup - and this option

--- a/clients/Makefile.am
+++ b/clients/Makefile.am
@@ -1,6 +1,15 @@
 # Network UPS Tools: clients
 EXTRA_DIST =
 
+# Export certain values for ccache which NUT ci_build.sh can customize,
+# to facilitate developer iteration re-runs of "make" later.
+# At least GNU and BSD make implementations are okay with this syntax.
+export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
+export CCACHE_BASEDIR=@CCACHE_BASEDIR@
+export CCACHE_DIR=@CCACHE_DIR@
+export CCACHE_PATH=@CCACHE_PATH@
+export PATH=@PATH_DURING_CONFIGURE@
+
 # nutclient.cpp for some legacy reason (maybe initial detached development?)
 # optionally includes "common.h" with the NUT build setup - and this option
 # was never triggered in fact, not until pushed through command line like this:

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -10,11 +10,11 @@ libparseconf_la_SOURCES = parseconf.c
 # Export certain values for ccache which NUT ci_build.sh can customize,
 # to facilitate developer iteration re-runs of "make" later.
 # At least GNU and BSD make implementations are okay with this syntax.
-export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
-export CCACHE_BASEDIR=@CCACHE_BASEDIR@
-export CCACHE_DIR=@CCACHE_DIR@
-export CCACHE_PATH=@CCACHE_PATH@
-export PATH=@PATH_DURING_CONFIGURE@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_BASEDIR=@CCACHE_BASEDIR@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_DIR=@CCACHE_DIR@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_PATH=@CCACHE_PATH@
+@NUT_AM_MAKE_CAN_EXPORT@export PATH=@PATH_DURING_CONFIGURE@
 
 # do not hard depend on '../include/nut_version.h', since it blocks
 # 'dist', and is only required for actual build, in which case

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -7,6 +7,15 @@ EXTRA_DIST =
 noinst_LTLIBRARIES = libparseconf.la libcommon.la libcommonclient.la
 libparseconf_la_SOURCES = parseconf.c
 
+# Export certain values for ccache which NUT ci_build.sh can customize,
+# to facilitate developer iteration re-runs of "make" later.
+# At least GNU and BSD make implementations are okay with this syntax.
+export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
+export CCACHE_BASEDIR=@CCACHE_BASEDIR@
+export CCACHE_DIR=@CCACHE_DIR@
+export CCACHE_PATH=@CCACHE_PATH@
+export PATH=@PATH_DURING_CONFIGURE@
+
 # do not hard depend on '../include/nut_version.h', since it blocks
 # 'dist', and is only required for actual build, in which case
 # BUILT_SOURCES (in ../include) will ensure nut_version.h will

--- a/configure.ac
+++ b/configure.ac
@@ -4608,7 +4608,19 @@ AC_ARG_WITH(CCACHE_NAMESPACE,
 	esac
 ], [])
 NUT_REPORT_TARGET(CCACHE_NAMESPACE, "${CCACHE_NAMESPACE}", [ccache namespace tag (if ccache is used and new enough)])
-AC_SUBST(CCACHE_NAMESPACE)
+
+dnl # Mark it as a "precious variable", for more details see
+dnl # https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Setting-Output-Variables.html
+AC_ARG_VAR(CCACHE_NAMESPACE)
+
+dnl # Also list some other ccache options which ci_build.sh can fiddle with.
+dnl # While that script "exports" them so it can call both configuration and
+dnl # the build, their values may be unknown when a developer re-runs "make".
+dnl # Normally most of the options would persist under $CCACHE_DIR/ccache.conf
+dnl # and we would not pass them via envvars.
+AC_ARG_VAR(CCACHE_BASEDIR)
+AC_ARG_VAR(CCACHE_DIR)
+AC_ARG_VAR(CCACHE_PATH)
 
 AC_MSG_NOTICE([Generating "data" files from templates, see below for executable scripts])
 AC_CONFIG_FILES([

--- a/configure.ac
+++ b/configure.ac
@@ -4622,6 +4622,9 @@ AC_ARG_VAR(CCACHE_BASEDIR)
 AC_ARG_VAR(CCACHE_DIR)
 AC_ARG_VAR(CCACHE_PATH)
 
+PATH_DURING_CONFIGURE="$PATH"
+AC_SUBST(PATH_DURING_CONFIGURE)
+
 AC_MSG_NOTICE([Generating "data" files from templates, see below for executable scripts])
 AC_CONFIG_FILES([
  clients/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -115,6 +115,19 @@ dnl Use "./configure --enable-maintainer-mode" to keep Makefile.in and Makefile
 dnl in sync after Git updates.
 AM_MAINTAINER_MODE
 
+dnl GNU and BSD make are okay with the syntax, but Sun make/dmake are not:
+AC_MSG_CHECKING([whether this make implementation supports export VAR=VAL syntax])
+nut_am_output="`printf 'export VAR=VAL\ntest:\n\t@echo "VAR=\$(VAR)"\n' | ${MAKE-make} -f - test`"
+nut_am_result="$?"
+AS_IF([test x"${nut_am_result}" = x0 -a x"${nut_am_output}" = x"VAR=VAL"], [
+	NUT_AM_MAKE_CAN_EXPORT=""
+	AC_MSG_RESULT(yes)
+], [
+	NUT_AM_MAKE_CAN_EXPORT="#ThisMakeCanNotExport# "
+	AC_MSG_RESULT(no: got '${nut_am_output}')
+])
+AC_SUBST(NUT_AM_MAKE_CAN_EXPORT)
+
 dnl Some systems have older autotools without direct macro support for PKG_CONF*
 NUT_CHECK_PKGCONFIG
 
@@ -4582,6 +4595,7 @@ dnl # NUT as the project and CPU architecture for resulting binaries;
 dnl # maybe we might use distro as well but some overlaps may be possible
 dnl # that result in same objects for different-looking build roots.
 dnl # Note this is enabled by default (explicit --without-... disables it).
+dnl # Has practical effect if NUT_AM_MAKE_CAN_EXPORT test is successful.
 AS_IF([test x"${CCACHE_NAMESPACE}" = x], [
 	CCACHE_NAMESPACE="nut"
 	dnl # Variables in this list are defined earlier in the script
@@ -4608,6 +4622,9 @@ AC_ARG_WITH(CCACHE_NAMESPACE,
 	esac
 ], [])
 NUT_REPORT_TARGET(CCACHE_NAMESPACE, "${CCACHE_NAMESPACE}", [ccache namespace tag (if ccache is used and new enough)])
+AS_IF([test x"$CCACHE_NAMESPACE" != x -a x"$NUT_AM_MAKE_CAN_EXPORT" != x], [
+	AC_MSG_WARN([CCACHE_NAMESPACE setting may have no effect: this make implementation seems to not support "export VAR=VAL" syntax])
+])
 
 dnl # Mark it as a "precious variable", for more details see
 dnl # https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Setting-Output-Variables.html

--- a/configure.ac
+++ b/configure.ac
@@ -4575,6 +4575,41 @@ EOF])
 ])
 AC_MSG_RESULT([done])
 
+dnl # ccache versions 4.5 and newer support namespacing of the objects
+dnl # to facilitate more targeted eviction with --evict-namespace and
+dnl # perhaps --evict-older-than options. Here we bolt a namespace with
+dnl # NUT as the project and CPU architecture for resulting binaries;
+dnl # maybe we might use distro as well but some overlaps may be possible
+dnl # that result in same objects for different-looking build roots.
+dnl # Note this is enabled by default (explicit --without-... disables it).
+AS_IF([test x"${CCACHE_NAMESPACE}" = x], [
+	CCACHE_NAMESPACE="nut"
+	dnl # Variables in this list are defined earlier in the script
+	for T in "${compiler_multiarch}" "${target_alias}" "${target}" "${target_cpu}-${target_os}" ; do
+		if test x"$T" != x -a x"$T" != x- ; then
+			CCACHE_NAMESPACE="${CCACHE_NAMESPACE}:${T}"
+			break
+		fi
+	done
+	unset T
+])
+AC_ARG_WITH(CCACHE_NAMESPACE,
+	AS_HELP_STRING([--with-CCACHE_NAMESPACE=namespace], [which ccache namespace to use for built binaries; typically nut:${autotools_target})]),
+[
+	case "${withval}" in
+	no)
+		CCACHE_NAMESPACE=""
+		;;
+	yes)	# Use user envvar or calculation above
+		;;
+	*)
+		CCACHE_NAMESPACE="${withval}"
+		;;
+	esac
+], [])
+NUT_REPORT_TARGET(CCACHE_NAMESPACE, "${CCACHE_NAMESPACE}", [ccache namespace tag (if ccache is used and new enough)])
+AC_SUBST(CCACHE_NAMESPACE)
+
 AC_MSG_NOTICE([Generating "data" files from templates, see below for executable scripts])
 AC_CONFIG_FILES([
  clients/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -117,7 +117,8 @@ AM_MAINTAINER_MODE
 
 dnl GNU and BSD make are okay with the syntax, but Sun make/dmake are not:
 AC_MSG_CHECKING([whether this make implementation supports export VAR=VAL syntax])
-nut_am_output="`printf 'export VAR=VAL\ntest:\n\t@echo "VAR=\$(VAR)"\n' | ${MAKE-make} -f - test`"
+dnl # using printf formatting for some funniner shells out there
+nut_am_output="`printf 'export VAR=VAL\ntest:\n\t@echo "VAR=%s%sVAR%s"\n' '\$' '(' ')' | ${MAKE-make} -f - test`"
 nut_am_result="$?"
 AS_IF([test x"${nut_am_result}" = x0 -a x"${nut_am_output}" = x"VAR=VAL"], [
 	NUT_AM_MAKE_CAN_EXPORT=""

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -1,3 +1,5 @@
+# Network UPS Tools: main docs
+
 MAINTAINERCLEANFILES = Makefile.in .dirstamp
 EXTRA_DIST =
 

--- a/docs/cables/Makefile.am
+++ b/docs/cables/Makefile.am
@@ -1,2 +1,4 @@
+# Network UPS Tools: cable docs
+
 CLEANFILES = *-spellchecked
 MAINTAINERCLEANFILES = Makefile.in .dirstamp

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -1,4 +1,4 @@
-# Network UPS Tools: man
+# Network UPS Tools: man pages
 #
 
 # Notes:

--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -1,5 +1,14 @@
 # Network UPS Tools: drivers
 
+# Export certain values for ccache which NUT ci_build.sh can customize,
+# to facilitate developer iteration re-runs of "make" later.
+# At least GNU and BSD make implementations are okay with this syntax.
+export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
+export CCACHE_BASEDIR=@CCACHE_BASEDIR@
+export CCACHE_DIR=@CCACHE_DIR@
+export CCACHE_PATH=@CCACHE_PATH@
+export PATH=@PATH_DURING_CONFIGURE@
+
 # Make sure out-of-dir dependencies exist (especially when dev-building parts):
 $(top_builddir)/common/libcommon.la \
 $(top_builddir)/common/libparseconf.la \

--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -3,11 +3,11 @@
 # Export certain values for ccache which NUT ci_build.sh can customize,
 # to facilitate developer iteration re-runs of "make" later.
 # At least GNU and BSD make implementations are okay with this syntax.
-export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
-export CCACHE_BASEDIR=@CCACHE_BASEDIR@
-export CCACHE_DIR=@CCACHE_DIR@
-export CCACHE_PATH=@CCACHE_PATH@
-export PATH=@PATH_DURING_CONFIGURE@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_BASEDIR=@CCACHE_BASEDIR@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_DIR=@CCACHE_DIR@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_PATH=@CCACHE_PATH@
+@NUT_AM_MAKE_CAN_EXPORT@export PATH=@PATH_DURING_CONFIGURE@
 
 # Make sure out-of-dir dependencies exist (especially when dev-building parts):
 $(top_builddir)/common/libcommon.la \

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -1,3 +1,5 @@
+# Network UPS Tools: include
+
 dist_noinst_HEADERS = attribute.h common.h extstate.h proto.h			\
     state.h str.h timehead.h upsconf.h nut_float.h nut_stdint.h nut_platform.h	\
     wincompat.h

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -3,11 +3,11 @@
 # Export certain values for ccache which NUT ci_build.sh can customize,
 # to facilitate developer iteration re-runs of "make" later.
 # At least GNU and BSD make implementations are okay with this syntax.
-export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
-export CCACHE_BASEDIR=@CCACHE_BASEDIR@
-export CCACHE_DIR=@CCACHE_DIR@
-export CCACHE_PATH=@CCACHE_PATH@
-export PATH=@PATH_DURING_CONFIGURE@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_BASEDIR=@CCACHE_BASEDIR@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_DIR=@CCACHE_DIR@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_PATH=@CCACHE_PATH@
+@NUT_AM_MAKE_CAN_EXPORT@export PATH=@PATH_DURING_CONFIGURE@
 
 dist_noinst_HEADERS = attribute.h common.h extstate.h proto.h			\
     state.h str.h timehead.h upsconf.h nut_float.h nut_stdint.h nut_platform.h	\

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -1,5 +1,14 @@
 # Network UPS Tools: include
 
+# Export certain values for ccache which NUT ci_build.sh can customize,
+# to facilitate developer iteration re-runs of "make" later.
+# At least GNU and BSD make implementations are okay with this syntax.
+export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
+export CCACHE_BASEDIR=@CCACHE_BASEDIR@
+export CCACHE_DIR=@CCACHE_DIR@
+export CCACHE_PATH=@CCACHE_PATH@
+export PATH=@PATH_DURING_CONFIGURE@
+
 dist_noinst_HEADERS = attribute.h common.h extstate.h proto.h			\
     state.h str.h timehead.h upsconf.h nut_float.h nut_stdint.h nut_platform.h	\
     wincompat.h

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,4 +1,14 @@
 # Network UPS Tools: lib
+
+# Export certain values for ccache which NUT ci_build.sh can customize,
+# to facilitate developer iteration re-runs of "make" later.
+# At least GNU and BSD make implementations are okay with this syntax.
+export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
+export CCACHE_BASEDIR=@CCACHE_BASEDIR@
+export CCACHE_DIR=@CCACHE_DIR@
+export CCACHE_PATH=@CCACHE_PATH@
+export PATH=@PATH_DURING_CONFIGURE@
+
 EXTRA_DIST = README.adoc
 
 if WITH_DEV

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -3,11 +3,11 @@
 # Export certain values for ccache which NUT ci_build.sh can customize,
 # to facilitate developer iteration re-runs of "make" later.
 # At least GNU and BSD make implementations are okay with this syntax.
-export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
-export CCACHE_BASEDIR=@CCACHE_BASEDIR@
-export CCACHE_DIR=@CCACHE_DIR@
-export CCACHE_PATH=@CCACHE_PATH@
-export PATH=@PATH_DURING_CONFIGURE@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_BASEDIR=@CCACHE_BASEDIR@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_DIR=@CCACHE_DIR@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_PATH=@CCACHE_PATH@
+@NUT_AM_MAKE_CAN_EXPORT@export PATH=@PATH_DURING_CONFIGURE@
 
 EXTRA_DIST = README.adoc
 

--- a/scripts/python/module/Makefile.am
+++ b/scripts/python/module/Makefile.am
@@ -1,3 +1,5 @@
+# Network UPS Tools: scripts/python/module (PyNUTClient)
+
 # See also: .github/workflows/PyNUTClient.yml
 # Note: this Makefile is focused on PyPI publication
 # The usual autotools stuff including clean-up is in parent dir

--- a/server/Makefile.am
+++ b/server/Makefile.am
@@ -1,5 +1,14 @@
 # Network UPS Tools: server
 
+# Export certain values for ccache which NUT ci_build.sh can customize,
+# to facilitate developer iteration re-runs of "make" later.
+# At least GNU and BSD make implementations are okay with this syntax.
+export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
+export CCACHE_BASEDIR=@CCACHE_BASEDIR@
+export CCACHE_DIR=@CCACHE_DIR@
+export CCACHE_PATH=@CCACHE_PATH@
+export PATH=@PATH_DURING_CONFIGURE@
+
 # Make sure out-of-dir dependencies exist (especially when dev-building parts):
 $(top_builddir)/common/libcommon.la \
 $(top_builddir)/common/libparseconf.la: dummy

--- a/server/Makefile.am
+++ b/server/Makefile.am
@@ -3,11 +3,11 @@
 # Export certain values for ccache which NUT ci_build.sh can customize,
 # to facilitate developer iteration re-runs of "make" later.
 # At least GNU and BSD make implementations are okay with this syntax.
-export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
-export CCACHE_BASEDIR=@CCACHE_BASEDIR@
-export CCACHE_DIR=@CCACHE_DIR@
-export CCACHE_PATH=@CCACHE_PATH@
-export PATH=@PATH_DURING_CONFIGURE@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_BASEDIR=@CCACHE_BASEDIR@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_DIR=@CCACHE_DIR@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_PATH=@CCACHE_PATH@
+@NUT_AM_MAKE_CAN_EXPORT@export PATH=@PATH_DURING_CONFIGURE@
 
 # Make sure out-of-dir dependencies exist (especially when dev-building parts):
 $(top_builddir)/common/libcommon.la \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,5 +1,14 @@
 # Network UPS Tools: tests
 
+# Export certain values for ccache which NUT ci_build.sh can customize,
+# to facilitate developer iteration re-runs of "make" later.
+# At least GNU and BSD make implementations are okay with this syntax.
+export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
+export CCACHE_BASEDIR=@CCACHE_BASEDIR@
+export CCACHE_DIR=@CCACHE_DIR@
+export CCACHE_PATH=@CCACHE_PATH@
+export PATH=@PATH_DURING_CONFIGURE@
+
 SUBDIRS = . NIT
 
 all: $(TESTS)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -3,11 +3,11 @@
 # Export certain values for ccache which NUT ci_build.sh can customize,
 # to facilitate developer iteration re-runs of "make" later.
 # At least GNU and BSD make implementations are okay with this syntax.
-export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
-export CCACHE_BASEDIR=@CCACHE_BASEDIR@
-export CCACHE_DIR=@CCACHE_DIR@
-export CCACHE_PATH=@CCACHE_PATH@
-export PATH=@PATH_DURING_CONFIGURE@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_BASEDIR=@CCACHE_BASEDIR@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_DIR=@CCACHE_DIR@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_PATH=@CCACHE_PATH@
+@NUT_AM_MAKE_CAN_EXPORT@export PATH=@PATH_DURING_CONFIGURE@
 
 SUBDIRS = . NIT
 

--- a/tests/NIT/Makefile.am
+++ b/tests/NIT/Makefile.am
@@ -1,3 +1,5 @@
+# Network UPS Tools: NUT Integration Tests (NIT)
+
 EXTRA_DIST = nit.sh README.adoc
 
 if WITH_CHECK_NIT

--- a/tests/NIT/Makefile.am
+++ b/tests/NIT/Makefile.am
@@ -3,11 +3,11 @@
 # Export certain values for ccache which NUT ci_build.sh can customize,
 # to facilitate developer iteration re-runs of "make" later.
 # At least GNU and BSD make implementations are okay with this syntax.
-export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
-export CCACHE_BASEDIR=@CCACHE_BASEDIR@
-export CCACHE_DIR=@CCACHE_DIR@
-export CCACHE_PATH=@CCACHE_PATH@
-export PATH=@PATH_DURING_CONFIGURE@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_BASEDIR=@CCACHE_BASEDIR@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_DIR=@CCACHE_DIR@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_PATH=@CCACHE_PATH@
+@NUT_AM_MAKE_CAN_EXPORT@export PATH=@PATH_DURING_CONFIGURE@
 
 EXTRA_DIST = nit.sh README.adoc
 

--- a/tests/NIT/Makefile.am
+++ b/tests/NIT/Makefile.am
@@ -1,5 +1,14 @@
 # Network UPS Tools: NUT Integration Tests (NIT)
 
+# Export certain values for ccache which NUT ci_build.sh can customize,
+# to facilitate developer iteration re-runs of "make" later.
+# At least GNU and BSD make implementations are okay with this syntax.
+export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
+export CCACHE_BASEDIR=@CCACHE_BASEDIR@
+export CCACHE_DIR=@CCACHE_DIR@
+export CCACHE_PATH=@CCACHE_PATH@
+export PATH=@PATH_DURING_CONFIGURE@
+
 EXTRA_DIST = nit.sh README.adoc
 
 if WITH_CHECK_NIT

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,5 +1,14 @@
 # Network UPS Tools: generators and other tools
 
+# Export certain values for ccache which NUT ci_build.sh can customize,
+# to facilitate developer iteration re-runs of "make" later.
+# At least GNU and BSD make implementations are okay with this syntax.
+export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
+export CCACHE_BASEDIR=@CCACHE_BASEDIR@
+export CCACHE_DIR=@CCACHE_DIR@
+export CCACHE_PATH=@CCACHE_PATH@
+export PATH=@PATH_DURING_CONFIGURE@
+
 # SUBDIRS are explicitly a listing of all the directories that make
 # must recurse into BEFORE processing the current directory.
 #

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,3 +1,5 @@
+# Network UPS Tools: generators and other tools
+
 # SUBDIRS are explicitly a listing of all the directories that make
 # must recurse into BEFORE processing the current directory.
 #

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -3,11 +3,11 @@
 # Export certain values for ccache which NUT ci_build.sh can customize,
 # to facilitate developer iteration re-runs of "make" later.
 # At least GNU and BSD make implementations are okay with this syntax.
-export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
-export CCACHE_BASEDIR=@CCACHE_BASEDIR@
-export CCACHE_DIR=@CCACHE_DIR@
-export CCACHE_PATH=@CCACHE_PATH@
-export PATH=@PATH_DURING_CONFIGURE@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_BASEDIR=@CCACHE_BASEDIR@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_DIR=@CCACHE_DIR@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_PATH=@CCACHE_PATH@
+@NUT_AM_MAKE_CAN_EXPORT@export PATH=@PATH_DURING_CONFIGURE@
 
 # SUBDIRS are explicitly a listing of all the directories that make
 # must recurse into BEFORE processing the current directory.

--- a/tools/nut-scanner/Makefile.am
+++ b/tools/nut-scanner/Makefile.am
@@ -1,3 +1,5 @@
+# Network UPS Tools: nut-scanner
+
 # Generally, list headers and/or sources which are re-generated
 # for nut-scanner in the parent dir
 NUT_SCANNER_DEPS_H = nutscan-usb.h nutscan-snmp.h

--- a/tools/nut-scanner/Makefile.am
+++ b/tools/nut-scanner/Makefile.am
@@ -1,5 +1,14 @@
 # Network UPS Tools: nut-scanner
 
+# Export certain values for ccache which NUT ci_build.sh can customize,
+# to facilitate developer iteration re-runs of "make" later.
+# At least GNU and BSD make implementations are okay with this syntax.
+export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
+export CCACHE_BASEDIR=@CCACHE_BASEDIR@
+export CCACHE_DIR=@CCACHE_DIR@
+export CCACHE_PATH=@CCACHE_PATH@
+export PATH=@PATH_DURING_CONFIGURE@
+
 # Generally, list headers and/or sources which are re-generated
 # for nut-scanner in the parent dir
 NUT_SCANNER_DEPS_H = nutscan-usb.h nutscan-snmp.h

--- a/tools/nut-scanner/Makefile.am
+++ b/tools/nut-scanner/Makefile.am
@@ -3,11 +3,11 @@
 # Export certain values for ccache which NUT ci_build.sh can customize,
 # to facilitate developer iteration re-runs of "make" later.
 # At least GNU and BSD make implementations are okay with this syntax.
-export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
-export CCACHE_BASEDIR=@CCACHE_BASEDIR@
-export CCACHE_DIR=@CCACHE_DIR@
-export CCACHE_PATH=@CCACHE_PATH@
-export PATH=@PATH_DURING_CONFIGURE@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_NAMESPACE=@CCACHE_NAMESPACE@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_BASEDIR=@CCACHE_BASEDIR@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_DIR=@CCACHE_DIR@
+@NUT_AM_MAKE_CAN_EXPORT@export CCACHE_PATH=@CCACHE_PATH@
+@NUT_AM_MAKE_CAN_EXPORT@export PATH=@PATH_DURING_CONFIGURE@
 
 # Generally, list headers and/or sources which are re-generated
 # for nut-scanner in the parent dir


### PR DESCRIPTION
Allow configuring it (or have it guessed), and `export` it in the `Makefile`s so that developer workflow benefits from the customized setting when running `make`. Tested to work for GNU and BSD makes, and not work for Sun make/dmake implementation (recipe change is a no-op there).

The namespacing allows the CI farm (or multiplatform/qemu container devs) to use the same `~/.ccache` area in a home directory, with object files grouped by the target build platform, so they can be "evicted" independently (e.g. did not cross-build ARM for a year - nuke just its files), e.g. with: `ccache -sv && ccache --evict-namespace=nut:aarch64-linux-gnu && ccache -sv`