### PR TITLE
Help users about `nutdrv_qx` and similar drivers built for serial-only support but used for USB devices

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -104,6 +104,12 @@ https://github.com/networkupstools/nut/milestone/10
      up in the link:https://pypi.org/project/PyNUTClient[PyPI repository].
      [#2158]
 
+ - main driver core codebase:
+   * Help users of drivers that can be built to support optionally USB and
+     other media (like `nutdrv_qx` built for serial-only support), and built
+     in fact without USB support but used for USB devices, with some more
+     information to make troubleshooting easier. [#2259]
+
  - powerpanel text driver now handles status responses in any format and should
    support most devices [#2156]
 

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -109,6 +109,9 @@ https://github.com/networkupstools/nut/milestone/10
      other media (like `nutdrv_qx` built for serial-only support), and built
      in fact without USB support but used for USB devices, with some more
      information to make troubleshooting easier. [#2259]
+   * Driver programs with debug tracing support via `-D` CLI option and/or
+     the `NUT_DEBUG_LEVEL` environment variable now check those earlier in
+     their life-time, so that initialization routine can be debugged. [#2259]
 
  - powerpanel text driver now handles status responses in any format and should
    support most devices [#2156]

--- a/drivers/libusb0.c
+++ b/drivers/libusb0.c
@@ -95,6 +95,8 @@ void nut_usb_addvars(void)
 	addvar(VAR_VALUE, "usb_set_altinterface", "Force redundant call to usb_set_altinterface() (value=bAlternateSetting; default=0)");
 
 	dstate_setinfo("driver.version.usb", "libusb-0.1 (or compat)");
+
+	upsdebugx(1, "Using USB implementation: %s", dstate_getinfo("driver.version.usb"));
 }
 
 /* From usbutils: workaround libusb (0.1) API goofs:

--- a/drivers/libusb1.c
+++ b/drivers/libusb1.c
@@ -93,6 +93,8 @@ void nut_usb_addvars(void)
 #else  /* no LIBUSB_API_VERSION */
 	dstate_setinfo("driver.version.usb", "libusb-%u.%u.%u", v->major, v->minor, v->micro);
 #endif /* LIBUSB_API_VERSION */
+
+	upsdebugx(1, "Using USB implementation: %s", dstate_getinfo("driver.version.usb"));
 }
 
 /* invoke matcher against device */

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -351,6 +351,31 @@ void storeval(const char *var, char *val)
 	printf("Look in the man page or call this driver with -h for a list of\n");
 	printf("valid variable names and flags.\n");
 
+	if (!strcmp(progname, "nutdrv_qx")) {
+		/* First many entries are from nut_usb_addvars() implementations;
+		 * the latter two (about langid) are from nutdrv_qx.c
+		 */
+		if (!strcmp(var, "vendor")
+		||  !strcmp(var, "product")
+		||  !strcmp(var, "serial")
+		||  !strcmp(var, "vendorid")
+		||  !strcmp(var, "productid")
+		||  !strcmp(var, "bus")
+		||  !strcmp(var, "device")
+		||  !strcmp(var, "busport")
+		||  !strcmp(var, "usb_set_altinterface")
+		||  !strcmp(var, "allow_duplicates")
+		||  !strcmp(var, "langid_fix")
+		||  !strcmp(var, "noscanlangid")
+		) {
+			printf("\nNOTE: for driver '%s', options like '%s' are only available\n"
+				"if it was built with USB support. If you are running a custom build of NUT,\n"
+				"please check results of the `configure` checks, and consider an explicit\n"
+				"`--with-usb` option. Also make sure that both libusb library and headers\n"
+				"are installed in your build environment.\n\n", progname, var);
+		}
+	}
+
 	exit(EXIT_SUCCESS);
 }
 


### PR DESCRIPTION
Closes: #2259

Currently emitted messages in this case require some sleuthing. This PR hopefully makes troubleshooting easier:
````
./nutdrv_qx -s test -x productid=1234
Network UPS Tools - Generic Q* Serial driver 0.36 (2.8.1-285-ge2bfdbbd4)

Fatal error: 'productid' is not a valid variable name for this driver.

Look in the man page or call this driver with -h for a list of
valid variable names and flags.

NOTE: for driver 'nutdrv_qx', options like 'productid' are only available
if it was built with USB support. If you are running a custom build of NUT,
please check results of the `configure` checks, and consider an explicit
`--with-usb` option. Also make sure that both libusb library and headers
are installed in your build environment.

upsnotify: notify about state 4 with libsystemd: was requested, but not running as a service unit now, will not spam more about it
upsnotify: failed to notify about state 4: no notification tech defined, will not spam more about it
````