### PR TITLE
Retouch nut-scanner docs and NEWS

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -88,10 +88,15 @@ https://github.com/networkupstools/nut/milestone/10
    * Added generation of FreeBSD/pfSense quirks for USB devices supported
      by NUT (may get installed to `$datadir` e.g. `/usr/local/share/nut`
      and need to be pasted into your `/boot/loader.conf.local`). [#2159]
-   * nut-scanner can now discover NUT simulated devices (.dev & .seq files)
-     located in your sysconfig directory
-   * nut-scanner now report 'dummy-ups' as driver when scanning NUT with
-     Old or Avahi method.
+   * nut-scanner now avoids creating ambiguous `nutdevN` device section names
+     when called separately to scan different media buses (one at a time).
+     Now the "bus" name would be embedded (e.g. non-colliding `nutdev-usb1`
+     and `nutdev-snmp1`). [#2247]
+   * nut-scanner can now discover NUT simulated devices (`.dev` and `.seq`
+     files) located in your sysconfig directory, and prepare configuration
+     sections with the simulation driver (currently `dummy-ups`). [#2246]
+   * nut-scanner now reports `dummy-ups` as driver when scanning NUT "bus"
+     with Old or Avahi method. [#2236, #2245]
 
  - upsd: Fixed conditions for "no listening interface available" diagnosis
    to check how many listeners we succeeded with, not whether the first one

--- a/docs/man/nut-scanner.txt
+++ b/docs/man/nut-scanner.txt
@@ -222,55 +222,65 @@ EXAMPLES
 
 To scan USB devices only:
 
-*nut-scanner -U*
-+
+----
+:; nut-scanner -U
+
 [nutdev-usb1]
         driver = "snmp-ups"
         port = "192.168.0.42"
-+
+----
 
 To scan SNMP v1 device with public community on address range 192.168.0.0
 to 192.168.0.255:
 
-*nut-scanner -S -s 192.168.0.0 -e 192.168.0.255*
-+
+----
+:; nut-scanner -S -s 192.168.0.0 -e 192.168.0.255
+
 [nutdev-snmp1]
         driver = "snmp-ups"
         port = "192.168.0.42"
-+
+----
 
 The same using CIDR notation:
 
-*nut-scanner -S -m 192.168.0.0/24*
-+
+----
+:; nut-scanner -S -m 192.168.0.0/24
+
 [nutdev-snmp1]
         driver = "snmp-ups"
         port = "192.168.0.42"
-+
+----
 
 To scan NUT servers with a timeout of 10 seconds on IP range 192.168.0.0
 to 192.168.0.127 using CIDR notation:
 
-*nut-scanner -O -t 10 -m 192.168.0.0/25*
-+
+----
+:; nut-scanner -O -t 10 -m 192.168.0.0/25
+
 [nutdev-nut1]
         driver = "dummy-ups"
         port = "dummy-test@192.168.1.28"
-+
+----
 
 To scan for power supplies, through IPMI (1.5 mode) over the network,
 on address range 192.168.0.0 to 192.168.0.255 using CIDR notation:
 
-*nut-scanner -I -m 192.168.0.0/24 -b username -B password*
+----
+:; nut-scanner -I -m 192.168.0.0/24 -b username -B password
+----
 
-To scan for Eaton serial devices on ports 0 and 1 (/dev/ttyS0,
-/dev/ttyUSB0, /dev/ttyS1 and /dev/ttyUSB1 on Linux):
+To scan for Eaton serial devices on ports 0 and 1 (`/dev/ttyS0`,
+`/dev/ttyUSB0`, `/dev/ttyS1` and `/dev/ttyUSB1` on Linux):
 
-*nut-scanner --eaton_serial 0-1*
+----
+:; nut-scanner --eaton_serial 0-1
+----
 
-To scan for Eaton serial devices on ports 1 and 2 (COM1 and COM2 on Windows):
+To scan for Eaton serial devices on ports 1 and 2 (`COM1` and `COM2` on Windows):
 
-*nut-scanner --eaton_serial 1-2*
+----
+:; nut-scanner --eaton_serial 1-2
+----
 
 SEE ALSO
 --------

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3423 utf-8
+personal_ws-1.1 en 3424 utf-8
 AAC
 AAS
 ABI
@@ -2637,6 +2637,7 @@ numq
 nutclient
 nutclientmem
 nutdev
+nutdevN
 nutdrv
 nutmon
 nutscan


### PR DESCRIPTION
Follow-up from #2245, #2246, #2247...

Should help avoid this:
````
make[2]: Entering directory '/home/jim/nut/docs/man'
  DOC-MAN  Generating nut-scanner.8
asciidoc: WARNING: nut-scanner.txt: line 227: missing style: [paradef-literal]: nutdev-usb1
asciidoc: WARNING: nut-scanner.txt: line 237: missing style: [paradef-literal]: nutdev-snmp1
asciidoc: WARNING: nut-scanner.txt: line 237: missing style: [paradef-literal]: nutdev-snmp1
asciidoc: WARNING: nut-scanner.txt: line 256: missing style: [paradef-literal]: nutdev-nut1
````