### PR TITLE
Fix possible buffer overrun calls to PR_GetErrorText

### DIFF
--- a/server/netssl.c
+++ b/server/netssl.c
@@ -193,9 +193,15 @@ static char *nss_password_callback(PK11SlotInfo *slot, PRBool retry,
 static void nss_error(const char* text)
 {
 	char buffer[SMALLBUF];
-	PRInt32 length = PR_GetErrorText(buffer);
-	if (length > 0 && length < SMALLBUF) {
-		upsdebugx(1, "nss_error %ld in %s : %s", (long)PR_GetError(), text, buffer);
+	PRErrorCode err_num = PR_GetError();
+	PRInt32 err_len = PR_GetErrorTextLength();
+	if (err_len > 0) {
+		if (err_len < SMALLBUF) {
+			PR_GetErrorText(buffer);
+			upsdebugx(1, "nss_error %ld in %s : %s", (long)err_num, text, buffer);
+		}else{
+			upsdebugx(1, "nss_error %ld in %s : Internal error buffer too small, needs %ld bytes", (long)err_num, text, (long)err_len);
+		}
 	}else{
 		upsdebugx(1, "nss_error %ld in %s", (long)PR_GetError(), text);
 	}
@@ -204,17 +210,20 @@ static void nss_error(const char* text)
 static int ssl_error(PRFileDesc *ssl, ssize_t ret)
 {
 	char buffer[256];
-	PRInt32 length;
-	PRErrorCode e;
 	NUT_UNUSED_VARIABLE(ssl);
 	NUT_UNUSED_VARIABLE(ret);
-
-	e = PR_GetError();
-	length = PR_GetErrorText(buffer);
-	if (length > 0 && length < 256) {
-		upsdebugx(1, "ssl_error() ret=%d %*s", e, length, buffer);
-	} else {
-		upsdebugx(1, "ssl_error() ret=%d", e);
+	PRErrorCode err_num = PR_GetError();
+	PRInt32 err_len = PR_GetErrorTextLength();
+	PRInt32 length;
+	if (err_len > 0) {
+		if (err_len < SMALLBUF) {
+			length = PR_GetErrorText(buffer);
+			upsdebugx(1, "ssl_error %ld : %*s", (long)err_num, length, buffer);
+		}else{
+			upsdebugx(1, "ssl_error %ld : Internal error buffer too small, needs %ld bytes", (long)err_num, (long)err_len);
+		}
+	}else{
+		upsdebugx(1, "ssl_error %ld", (long)err_num);
 	}
 
 	return -1;
@@ -506,24 +515,21 @@ void ssl_init(void)
 
 	PK11_SetPasswordFunc(nss_password_callback);
 
-	if (certfile)
-		/* Note: this call can generate memory leaks not resolvable
-		 * by any release function.
-		 * Probably NSS key module object allocation and
-		 * probably NSS key db object allocation too. */
-		status = NSS_Init(certfile);
-	else
-		status = NSS_NoDB_Init(NULL);
+	/* Note: this call can generate memory leaks not resolvable
+	 * by any release function.
+	 * Probably NSS key module object allocation and
+	 * probably NSS key db object allocation too. */
+	status = NSS_Init(certfile);
 	if (status != SECSuccess) {
 		upslogx(LOG_ERR, "Can not initialize SSL context");
-		nss_error("upscli_init / NSS_[NoDB]_Init");
+		nss_error("ssl_init / NSS_Init");
 		return;
 	}
 
 	status = NSS_SetDomesticPolicy();
 	if (status != SECSuccess) {
 		upslogx(LOG_ERR, "Can not initialize SSL policy");
-		nss_error("upscli_init / NSS_SetDomesticPolicy");
+		nss_error("ssl_init / NSS_SetDomesticPolicy");
 		return;
 	}
 
@@ -531,7 +537,7 @@ void ssl_init(void)
 	status = SSL_ConfigServerSessionIDCache(0, 0, 0, NULL);
 	if (status != SECSuccess) {
 		upslogx(LOG_ERR, "Can not initialize SSL server cache");
-		nss_error("upscli_init / SSL_ConfigServerSessionIDCache");
+		nss_error("ssl_init / SSL_ConfigServerSessionIDCache");
 		return;
 	}
 
@@ -539,13 +545,13 @@ void ssl_init(void)
 		status = SSL_OptionSetDefault(SSL_ENABLE_SSL3, PR_TRUE);
 		if (status != SECSuccess) {
 			upslogx(LOG_ERR, "Can not enable SSLv3");
-			nss_error("upscli_init / SSL_OptionSetDefault(SSL_ENABLE_SSL3)");
+			nss_error("ssl_init / SSL_OptionSetDefault(SSL_ENABLE_SSL3)");
 			return;
 		}
 		status = SSL_OptionSetDefault(SSL_ENABLE_TLS, PR_TRUE);
 		if (status != SECSuccess) {
 			upslogx(LOG_ERR, "Can not enable TLSv1");
-			nss_error("upscli_init / SSL_OptionSetDefault(SSL_ENABLE_TLS)");
+			nss_error("ssl_init / SSL_OptionSetDefault(SSL_ENABLE_TLS)");
 			return;
 		}
 	} else {
@@ -553,7 +559,7 @@ void ssl_init(void)
 		status = SSL_VersionRangeGetSupported(ssl_variant_stream, &range);
 		if (status != SECSuccess) {
 			upslogx(LOG_ERR, "Can not get versions supported");
-			nss_error("upscli_init / SSL_VersionRangeGetSupported");
+			nss_error("ssl_init / SSL_VersionRangeGetSupported");
 			return;
 		}
 		range.min = SSL_LIBRARY_VERSION_TLS_1_1;
@@ -563,7 +569,7 @@ void ssl_init(void)
 		status = SSL_VersionRangeSetDefault(ssl_variant_stream, &range);
 		if (status != SECSuccess) {
 			upslogx(LOG_ERR, "Can not set versions supported");
-			nss_error("upscli_init / SSL_VersionRangeSetDefault");
+			nss_error("ssl_init / SSL_VersionRangeSetDefault");
 			return;
 		}
 		/* Disable old/weak ciphers */
@@ -575,13 +581,13 @@ void ssl_init(void)
 		status = SSL_OptionSetDefault(SSL_ENABLE_SSL3, PR_FALSE);
 		if (status != SECSuccess) {
 			upslogx(LOG_ERR, "Can not disable SSLv3");
-			nss_error("upscli_init / SSL_OptionSetDefault(SSL_DISABLE_SSL3)");
+			nss_error("ssl_init / SSL_OptionSetDefault(SSL_DISABLE_SSL3)");
 			return;
 		}
 		status = SSL_OptionSetDefault(SSL_ENABLE_TLS, PR_TRUE);
 		if (status != SECSuccess) {
 			upslogx(LOG_ERR, "Can not enable TLSv1");
-			nss_error("upscli_init / SSL_OptionSetDefault(SSL_ENABLE_TLS)");
+			nss_error("ssl_init / SSL_OptionSetDefault(SSL_ENABLE_TLS)");
 			return;
 		}
 #endif
@@ -599,7 +605,7 @@ void ssl_init(void)
 		status = SSL_OptionSetDefault(SSL_REQUEST_CERTIFICATE, PR_TRUE);
 		if (status != SECSuccess) {
 			upslogx(LOG_ERR, "Can not enable certificate request");
-			nss_error("upscli_init / SSL_OptionSetDefault(SSL_REQUEST_CERTIFICATE)");
+			nss_error("ssl_init / SSL_OptionSetDefault(SSL_REQUEST_CERTIFICATE)");
 			return;
 		}
 	}
@@ -608,7 +614,7 @@ void ssl_init(void)
 		status = SSL_OptionSetDefault(SSL_REQUIRE_CERTIFICATE, PR_TRUE);
 		if (status != SECSuccess) {
 			upslogx(LOG_ERR, "Can not enable certificate requirement");
-			nss_error("upscli_init / SSL_OptionSetDefault(SSL_REQUIRE_CERTIFICATE)");
+			nss_error("ssl_init / SSL_OptionSetDefault(SSL_REQUIRE_CERTIFICATE)");
 			return;
 		}
 	}
@@ -617,14 +623,14 @@ void ssl_init(void)
 	cert = PK11_FindCertFromNickname(certname, NULL);
 	if(cert==NULL)	{
 		upslogx(LOG_ERR, "Can not find server certificate");
-		nss_error("upscli_init / PK11_FindCertFromNickname");
+		nss_error("ssl_init / PK11_FindCertFromNickname");
 		return;
 	}
 
 	privKey = PK11_FindKeyByAnyCert(cert, NULL);
 	if(privKey==NULL){
 		upslogx(LOG_ERR, "Can not find private key associate to server certificate");
-		nss_error("upscli_init / PK11_FindKeyByAnyCert");
+		nss_error("ssl_init / PK11_FindKeyByAnyCert");
 		return;
 	}
 


### PR DESCRIPTION
Removed call to NSS_NoDB_Init as certfile is already set. If certfile is not set, then ssl_init exits at the start.
Changed messages about upscli to ssl_init.

<!-- Comment:
* Please revise the docs/developers.txt for coding style suggestions and
  other considerations applicable to NUT codebase contributions, as well
  as for which text documents to update. See also docs/developer-guide.txt
  for general points on NUT architecture and design.

* Please note that we require "Signed-Off-By" tags in each Git Commit
  message, to conform to the common DCO (Developer Certificate of Origin)
  as posted in LICENSE-DCO at root of NUT codebase as well as published
  at https://developercertificate.org/

* The checklist below is more of a reminder of steps to take and "dangers"
  to look out for. PRs to update this template are also welcome :)

* Local build iterations can be augmented with the ci_build.sh script.
-->

## General points

- [ ] Described the changes in the PR submission or a separate issue, e.g.
  known published or discovered protocols, applicable hardware (expected
  compatible and actually tested/developed against), limitations, etc.

- [ ] There may be multiple commits in the PR, aligned and commented with
  a functional change. Notably, coding style changes better belong in a
  separate PR, but certainly in a dedicated commit to simplify reviews
  of "real" changes in the other commits. Similarly for typo fixes in
  comments or text documents.

- [ ] Please star NUT on GitHub, this helps with sponsorships! ;)

## Frequent "underwater rocks" for driver addition/update PRs

- [ ] Revised existing driver families and added a sub-driver if applicable
  (`nutdrv_qx`, `usbhid-ups`...) or added a brand new driver in the other
  case.

- [ ] Did not extend obsoleted drivers with new hardware support features
  (notably `blazer` and other single-device family drivers for Qx protocols,
  except the new `nutdrv_qx` which should cover them all).

- [ ] For updated existing device drivers, bumped the `DRIVER_VERSION` macro
  or its equivalent.

<!-- Comment:
  Some sub-drivers have `SUBDRIVER_VERSION` or customized names like
  e.g. `MEGATEC_VERSION` in `drivers/nutdrv_qx_megatec.c`
-->

- [ ] For USB devices (HID or not), revised that the driver uses unique
  VID/PID combinations, or raised discussions when this is not the case
  (several vendors do use same interface chips for unrelated protocols).

- [ ] For new USB devices, built and committed the changes for the
  `scripts/upower/95-upower-hid.hwdb` file

- [ ] Proposed NUT data mapping is aligned with existing `docs/nut-names.txt`
  file. If the device exposes useful data points not listed in the file, the
  `experimental.*` namespace can be used as documented there, and discussion
  should be raised on the NUT Developers mailing list to standardize the new
  concept.

- [ ] Updated `data/driver.list.in` if applicable (new tested device info)
<!-- Comment:
Also note below, a point about PR posting for NUT DDL
-->

## Frequent "underwater rocks" for general C code PRs

- [ ] Did not "blindly assume" default integer type sizes and value ranges,
  structure layout and alignment in memory, endianness (layout of bytes and
  bits in memory for multi-byte numeric types), or use of generic `int` where
  language or libraries dictate the use of `size_t` (or `ssize_t` sometimes).

<!-- Comment:
* NOTE: Casting and/or pragmas (support detected at compile time,
  see `m4/ax_c_pragmas.m4`) to silence warnings may be acceptable,
  but only if coupled with range checks or similar actions.
-->

- [ ] Progress and errors are handled with `upsdebugx()`, `upslogx()`,
  `fatalx()` and related methods, not with direct `printf()` or `exit()`.
  Similarly, NUT helpers are used for error-checked memory allocation and
  string operations (except where customized error handling is needed,
  such as unlocking device ports, etc.)

- [ ] Coding style (including whitespace for indentations) follows precedent
  in the code of the file, and examples/guide in `docs/developers.txt` file.

- [ ] For newly added files, the `Makefile.am` recipes were updated and the
  `make distcheck` target passes.

## General documentation updates

- [ ] Updated `docs/acknowledgements.txt` (for vendor-backed device support)

- [ ] Added or updated manual page information in `docs/man/*.txt` files
  and corresponding recipe lists in `docs/man/Makefile.am` for new pages

- [ ] Passed `make spellcheck`, updated spell-checking dictionary in the
  `docs/nut.dict` file if needed (did not remove any words -- the `make`
  rule printout in case of changes suggests how to maintain it).

## Additional work may be needed after posting this PR

- [ ] Propose a PR for NUT DDL with detailed device data dumps from tests
  against real hardware (the more models, the better).

- [ ] Address NUT CI farm build failures for the PR: testing on numerous
  platforms and toolkits can expose issues not seen on just one system.

<!-- Comment:
* One frequent "offence" is the appearance of unexpected (not git-ignored)
  or modification during build of files tracked in Git.

* Another frequent issue is not tracking newly introduced file names in
  `EXTRA_DIST` of the `Makefile.am` (and for `*.in` templates -- of rules
  in the `configure.ac` script) so the `make distcheck` fails.

* Avoid using GNU-specific constructs in the `Makefile.am`, even if that
  means cumbersome ways to build a target. This should not happen in mere
  driver updates, however.

* Also some third-party libraries or OS headers and method argument types
  and counts can differ -- necessitating m4 code for `configure` script
  probing, and `ifdef`, `typedef`, etc. in C code to adapt to the build
  environment (precedents available in NUT codebase). In extreme cases,
  you may need to spin up a VM or container to reproduce those issues
  and iterate on a fix locally; see `docs/config-prereqs.txt` and
  `docs/ci-farm-lxc-setup.txt` for notes taken during preparation of
  the multi-platform NUT CI farm.
-->

- [ ] Revise suggestions from LGTM.COM analysis about "new issues" with
  the changed codebase.

<!-- Comment:
  Take them with a grain of salt, especially with regard to things like
  architecture-dependent range checks, but many of the complaints from
  the tool are indeed useful.
-->
