### PR TITLE
clients/upsmon.c: fix offstate not being a requirement for a critical UPS on OFF

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -55,6 +55,9 @@ https://github.com/networkupstools/nut/milestone/10
      activity was completed by the hardware, which led to mis-processing of
      shutdown triggers. Also, notification was added to report "finished
      calibration". [issue #2168, PR #2169]
+   * `upsmon` recognition of `OFF` state as a trigger for FSD (forced shut
+     down) criticality considered also the input line state, which may be
+     an independently evolving circumstance. [issue #2278, PR #2279]
    * `upsmon` support for `POLLFAIL_LOG_THROTTLE_MAX` did not neuter the
      applied setting when live-reloading configuration, so commenting it
      away in `upsmon.conf` did not have the effect of resetting the logging

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -1100,7 +1100,7 @@ static int is_ups_critical(utype_t *ups)
 
 	/* administratively OFF (long enough, see OFFDURATION) */
 	if (flag_isset(ups->status, ST_OFF) && offdurationtime >= 0
-	&& (ups->linestate == 0 || ups->offstate == 1)) {
+	&& ups->offstate == 1) {
 		upslogx(LOG_WARNING,
 			"UPS [%s] is reported as (administratively) OFF",
 			ups->sys);

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -1104,6 +1104,7 @@ static int is_ups_critical(utype_t *ups)
 		upslogx(LOG_WARNING,
 			"UPS [%s] is reported as (administratively) OFF",
 			ups->sys);
+		upsdebugx(1, "UPS [%s] is now critical being OFF for too long. In case of persisting unwanted shutdowns, consider disabling the upsmon 'OFFDURATION' option.", ups->sys);
 		return 1;
 	}
 

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3439 utf-8
+personal_ws-1.1 en 3440 utf-8
 AAC
 AAS
 ABI
@@ -1856,6 +1856,7 @@ cpqpower
 cpsups
 cr
 crestfactor
+criticality
 crlf
 cron
 crontab


### PR DESCRIPTION
I was able to replicate the issue #2278, it seems to be as suspected in #2278: Due to `offstate == 1` not being a required condition at present (rather an optional condition) when evaluating UPS criticality, instant FSD is triggered despite `offdurationtime` not being exceeded yet (and `offstate` still being 0) when the UPS is seen both `OB` and `OFF`. This happens due to disregarding `offstate` when `linestate == 0` in combination with the `ST_OFF` flag and `offdurationtime >= 0` is met.

However `offstate` must always be a required condition for `offdurationtime` to have an effect as `ST_OFF` flag is instantly set upon encountering an `OFF` state, regardless of how long the UPS has been in this state.

Testing the proposed change FSD is only happening when `offdurationtime` is reached, the `linestate` itself is no longer considered for OFF-induced UPS criticality as both an `OL` and `OB` device can no longer give power to the load due to being administratively `OFF`, regardless of the mains power situation. Hence it makes sense to disregard the linestate (mains power situation) and only look at - most importantly - `offstate == 1` in combination with `offdurationtime >= 0` and `ST_OFF` flag.

The current code results in the following behaviour when `OB` + `OFF` is encountered:
```
Jan 26 13:14:32 Tower upsmon[8689]: UPS ups@127.0.0.1 on battery
Jan 26 13:14:32 Tower upsmon[8689]: UPS ups@127.0.0.1: administratively OFF or asleep
***instant shutdown due to FSD***
```

The proposed change results in the following behaviour when `OB` + `OFF` is encountered (as expected):
```
Jan 26 13:18:56 Tower upsmon[8689]: UPS ups@127.0.0.1 on battery
Jan 26 13:18:56 Tower upsmon[8689]: UPS ups@127.0.0.1: administratively OFF or asleep
Jan 26 13:19:31 Tower upsmon[8689]: ups_is_off: ups@127.0.0.1 is in state OFF for 35 sec, assuming the line is not fed (if it is calibrating etc., check the upsmon 'OFFDURATION' option)
***delayed shutdown due to FSD***
```

fixes #2278 