### PR TITLE
Fix: tripplite_usb: if upsid is not specified, make any unit ID match

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -151,6 +151,9 @@ https://github.com/networkupstools/nut/milestone/10
  - powerpanel text driver now handles status responses in any format and should
    support most devices. [#2156]
 
+ - tripplite_usb driver now allows any device to match if a particular Unit ID
+   was not specified in `ups.conf`. [PR #2297, issues #2282 and #2258]
+
  - snmp-ups driver:
    * added support for Eaton EMP002 sensor for ATS16 NM2 sub-driver. [#2286]
    * mapping table updates for apc-mib sub-driver. [#2264]

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -340,8 +340,10 @@ int match_by_unitid(usb_dev_handle *argudev, USBDevice_t *arghd, usb_ctrl_charbu
 	NUT_UNUSED_VARIABLE(rdbuf);
 	NUT_UNUSED_VARIABLE(rdlen);
 
-	/* Read ups id from the ups.conf */
-    if (value != NULL) {
+    // If upsid is not defined in the config, return 1 (null behavior), otherwise read it from ups.conf
+    if (value == NULL) {
+        return 1;
+    } else {
         config_unit_id = atoi(value);
     }
 

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -363,11 +363,11 @@ int match_by_unitid(usb_dev_handle *argudev, USBDevice_t *arghd, usb_ctrl_charbu
 
 	/* Check if the ups ids match */
 	if (config_unit_id == unit_id) {
-		upsdebugx(1, "Retrieved Unit ID (%ld) matches the configured one (%d)",
+		upsdebugx(1, "Retrieved Unit ID (%ld) matches the configured one (%ld)",
 			unit_id, config_unit_id);
 		return 1;
 	} else {
-		upsdebugx(1, "Retrieved Unit ID (%ld) does not match the configured one (%d). "
+		upsdebugx(1, "Retrieved Unit ID (%ld) does not match the configured one (%ld). "
 			"Do you have several compatible UPSes? Otherwise, please check if the ID "
 			"was set in the previous life of your device (can use upsrw to set another"
 			"value).", unit_id, config_unit_id);

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -340,7 +340,8 @@ int match_by_unitid(usb_dev_handle *argudev, USBDevice_t *arghd, usb_ctrl_charbu
 	NUT_UNUSED_VARIABLE(rdbuf);
 	NUT_UNUSED_VARIABLE(rdlen);
 
-    // If upsid is not defined in the config, return 1 (null behavior), otherwise read it from ups.conf
+    /* If upsid is not defined in the config, return 1 (null behavior - match any device),
+	 * otherwise read it from the device and match against what was asked in ups.conf */
     if (value == NULL) {
         return 1;
     } else {
@@ -355,13 +356,20 @@ int match_by_unitid(usb_dev_handle *argudev, USBDevice_t *arghd, usb_ctrl_charbu
 			upslogx(LOG_INFO, "Unit ID not retrieved (not available on all models)");
 		} else {
 			unit_id = (int)((unsigned)(u_value[1]) << 8) | (unsigned)(u_value[2]);
+			upsdebugx(1, "Retrieved Unit ID: %d", unit_id);
 		}
 	}
 
     /* Check if the ups ids match */
 	if (config_unit_id == unit_id) {
+		upsdebugx(1, "Retrieved Unit ID (%d) matches the configured one (%d)",
+			unit_id, config_unit_id);
 		return 1;
 	} else {
+		upsdebugx(1, "Retrieved Unit ID (%d) does not match the configured one (%d). "
+			"Do you have several compatible UPSes? Otherwise, please check if the ID "
+			"was set in the previous life of your device (can use upsrw to set another"
+			"value).", unit_id, config_unit_id);
 		return 0;
 	}
 }


### PR DESCRIPTION
small fix restoring matching when upsid is undefined in the ups.conf file closes #2282 as per the thread
cc @clepple 