### PR TITLE
CI: Fix NIT `isBusy_NUT_PORT()` method

### DIFF
--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -87,7 +87,7 @@ isBusy_NUT_PORT() {
     [ -n "${NUT_PORT}" ] || return
 
     log_debug "isBusy_NUT_PORT() Trying to report if NUT_PORT=${NUT_PORT} is used"
-    if [ -s /proc/net/tcp ] || [ -s /proc/net/tcp6 ]; then
+    if [ -e /proc/net/tcp ] || [ -e /proc/net/tcp6 ]; then
         # Assume Linux - hex-encoded
         # IPv4:
         #   sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -1344,6 +1344,7 @@ testgroup_sandbox_nutscanner() {
 ################################################################
 
 case "${NIT_CASE}" in
+    isBusy_NUT_PORT) DEBUG=yes isBusy_NUT_PORT ;;
     cppnit) testgroup_sandbox_cppnit ;;
     python) testgroup_sandbox_python ;;
     nutscanner|nut-scanner) testgroup_sandbox_nutscanner ;;

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -53,6 +53,7 @@ log_debug() {
     if shouldDebug ; then
         echo "`TZ=UTC LANG=C date` [DEBUG] $@" >&2
     fi
+    return 0
 }
 
 log_info() {

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -107,8 +107,8 @@ isBusy_NUT_PORT() {
         return 1
     fi
 
-    (netstat -an || sockstat -l) 2>/dev/null | grep -E "[:.]${NUT_PORT}(\t| |\$)" > /dev/null && return
-    && log_debug "isBusy_NUT_PORT() found that NUT_PORT=${NUT_PORT} is busy per netstat or sockstat" \
+    (netstat -an || sockstat -l || ss -tn || ss -n) 2>/dev/null | grep -E "[:.]${NUT_PORT}(\t| |\$)" > /dev/null \
+    && log_debug "isBusy_NUT_PORT() found that NUT_PORT=${NUT_PORT} is busy per netstat, sockstat or ss" \
     && return
 
     (lsof -i :"${NUT_PORT}") 2>/dev/null \
@@ -116,9 +116,9 @@ isBusy_NUT_PORT() {
     && return
 
     # Not busy... or no tools to confirm?
-    if (command -v netstat || command -v sockstat || command -v lsof) 2>/dev/null >/dev/null ; then
+    if (command -v netstat || command -v sockstat || command -v ss || command -v lsof) 2>/dev/null >/dev/null ; then
         # at least one tool is present, so not busy
-        log_debug "isBusy_NUT_PORT() found that NUT_PORT=${NUT_PORT} is not busy per netstat, sockstat or lsof"
+        log_debug "isBusy_NUT_PORT() found that NUT_PORT=${NUT_PORT} is not busy per netstat, sockstat, ss or lsof"
         return 1
     fi
 


### PR DESCRIPTION
On some systems NIT did not find many tools or data sources needed to check the busy/free port state, and used BASH `echo ... > /dev/tcp/...` for active probing. It is suspected that at least on older distros this could lead to the previously available port remaining in `WAITING` state, so `upsd` could not bind to it for the first minute or so.

This PR revises the "passive" probing methods to try avoiding this situation.