### PR TITLE
CI: Fix C/C++ standard customization

### DIFF
--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -30,6 +30,13 @@ import org.nut.dynamatrix.*;
     dynacfgPipeline.disableSlowBuildCIBuild = false
     dynacfgPipeline.disableSlowBuildCIBuildExperimental = false
 
+    // NOTE: Disabled by default because with -std=c* the compiler and linker
+    // (at least on environments NUT CI farm has) do not "see" many things,
+    // and do not even define WIN32, and this is unrelated to NUT codebase.
+    // This toggle aims to only disable 'c' builds in the scenario; but the
+    //'gnu' ones should still happen if it is enabled overall.
+    dynacfgPipeline.disableStrictCIBuild_CrossWindows = true
+
     // At this time, GCC succeeds building C89/GNU89 mode for NUT
     // while CLANG complains about things we can't fix easily.
     dynacfgPipeline.axisCombos_COMPILER_GCC = [~/COMPILER=GCC/]
@@ -1221,7 +1228,7 @@ set | sort -n """
                 dynamatrixAxesVirtualLabelsMap: [
                     'BITS': [64, 32],
                     'CSTDVERSION_${KEY}': [ ['c': '99', 'cxx': '11'] ],
-                    'CSTDVARIANT': ['c', 'gnu'],
+                    'CSTDVARIANT': ['gnu'] + (dynacfgPipeline.disableStrictCIBuild_CrossWindows ? [] : ['c']),
                     ],
                 dynamatrixAxesCommonEnv: [
                     ['LANG=C','LC_ALL=C','TZ=UTC',

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -80,6 +80,8 @@ https://github.com/networkupstools/nut/milestone/10
      application name. [#2205]
    * Original recipe for `apc_modbus` strictly required USB support even if
      building NUT without it. [#2262]
+   * Builds requested with a specific C/C++ language standard revision via
+     `CFLAGS` and `CXXFLAGS` should again be honoured. [PR #2306]
 
  - nut-usbinfo.pl, nut-scanner and libnutscan:
    * Library API version for `libnutscan` was bumped from 2.2.0 to 2.5.0

--- a/UPGRADING.adoc
+++ b/UPGRADING.adoc
@@ -30,6 +30,11 @@ Changes from 2.8.2 to 2.8.3
 Changes from 2.8.1 to 2.8.2
 ---------------------------
 
+- Builds requested with a specific C/C++ language standard revision via
+  `CFLAGS` and `CXXFLAGS` should again be honoured. There was a mishap
+  with the `m4` scripting for `autoconf` which could have caused use of
+  C11/C++11 if compiler supported it, regardless of a request. [PR #2306]
+
 - Added generation of FreeBSD/pfSense quirks for USB devices supported
   by NUT (may get installed to `$datadir` e.g. `/usr/local/share/nut`
   and need to be pasted into your `/boot/loader.conf.local`). [#2159]

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -1895,7 +1895,7 @@ bindings)
 ""|inplace)
     echo "ERROR: No BUILD_TYPE was specified, doing a minimal default ritual without any required options" >&2
     if [ -n "${BUILD_WARNOPT}${BUILD_WARNFATAL}" ]; then
-        echo "WARNING: BUILD_WARNOPT and BUILD_WARNFATAL settings are ignored in this mode" >&2
+        echo "WARNING: BUILD_WARNOPT and BUILD_WARNFATAL settings are ignored in this mode (warnings are always enabled and fatal for these developer-oriented builds)" >&2
         sleep 5
     fi
     echo ""

--- a/clients/cgilib.c
+++ b/clients/cgilib.c
@@ -17,9 +17,11 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
-#include <ctype.h>
-
 #include "common.h"
+
+#include <ctype.h>
+#include <stdio.h>
+
 #include "cgilib.h"
 #include "parseconf.h"
 

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -1780,7 +1780,7 @@ static int parse_conf_arg(size_t numargs, char **arg)
 	/* DEBUG_MIN (NUM) */
 	/* debug_min (NUM) also acceptable, to be on par with ups.conf */
 	if (!strcasecmp(arg[0], "DEBUG_MIN")) {
-		int lvl = -1; // typeof common/common.c: int nut_debug_level
+		int lvl = -1; /* typeof common/common.c: int nut_debug_level */
 		if ( str_to_int (arg[1], &lvl, 10) && lvl >= 0 ) {
 			nut_debug_level_global = lvl;
 		} else {

--- a/clients/upssched.c
+++ b/clients/upssched.c
@@ -683,6 +683,7 @@ static int sock_read(conn_t *conn)
 		 * fit in the US_MAX_READ length limit - at worst we would
 		 * "return 0", and continue with pconf_char() next round.
 		 */
+		size_t numarg;
 #ifndef WIN32
 		errno = 0;
 		ret = read(conn->fd, &ch, 1);
@@ -768,7 +769,7 @@ static int sock_read(conn_t *conn)
 
 		/* try to use it, and complain about unknown commands */
 		upsdebugx(3, "Ending sock_read() on a good note: try to use command:");
-		for (size_t numarg = 0; numarg < conn->ctx.numargs; numarg++)
+		for (numarg = 0; numarg < conn->ctx.numargs; numarg++)
 			upsdebugx(3, "\targ %" PRIuSIZE ": %s", numarg, conn->ctx.arglist[numarg]);
 		if (!sock_arg(conn)) {
 			log_unknown(conn->ctx.numargs, conn->ctx.arglist);

--- a/common/common.c
+++ b/common/common.c
@@ -2295,7 +2295,8 @@ static char * get_libname_in_dir(const char* base_libname, size_t base_libname_l
 
 # ifdef WIN32
 			if (!libname_path) {
-				for (char *p = current_test_path; *p != '\0' && (p - current_test_path) < LARGEBUF; p++) {
+				char *p;
+				for (p = current_test_path; *p != '\0' && (p - current_test_path) < LARGEBUF; p++) {
 					if (*p == '/') *p = '\\';
 				}
 				upsdebugx(3, "%s: WIN32: re-checking with %s", __func__, current_test_path);

--- a/common/strptime.c
+++ b/common/strptime.c
@@ -32,6 +32,10 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
+/* Use NUT build configuration */
+#include "config.h"
+
 /*
 #include <sys/cdefs.h>
 #if defined(LIBC_SCCS) && !defined(lint)

--- a/common/strptime.c
+++ b/common/strptime.c
@@ -81,13 +81,13 @@ static char gmt[] = { "GMT" };
 static char utc[] = { "UTC" };
 /* RFC-822/RFC-2822 */
 static const char * const nast[5] = {
-       "EST",    "CST",    "MST",    "PST",    "\0\0\0"
+	"EST",	"CST",	"MST",	"PST",	"\0\0\0"
 };
 static const char * const nadt[5] = {
-       "EDT",    "CDT",    "MDT",    "PDT",    "\0\0\0"
+	"EDT",	"CDT",	"MDT",	"PDT",	"\0\0\0"
 };
 static const char * const am_pm[2] = {
-       "am", "pm"
+	"am", "pm"
 };
 static const char * const day[7] = {
 	"sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"
@@ -111,7 +111,7 @@ static const u_char *find_string(const u_char *, int *, const char * const *,
 static int
 strncasecmp(const char *a, const char *b, size_t c)
 {
-    return _strnicmp(a, b, c);
+	return _strnicmp(a, b, c);
 }
 #endif
 */
@@ -167,11 +167,11 @@ literal:
 		/*
 		 * "Complex" conversion rules, implemented through recursion.
 		 */
-		/* we do not need 'c'
-      case 'c': Date and time, using the locale's format. 
+/* // we do not need 'c':
+		case 'c': Date and time, using the locale's format.
 			new_fmt = _ctloc(d_t_fmt);
 			goto recurse;
-      */
+*/
 
 		case 'D':	/* The date as "%m/%d/%y". */
 			new_fmt = "%m/%d/%y";
@@ -189,7 +189,7 @@ literal:
 			goto recurse;
 
 		case 'r':	/* The time in 12-hour clock representation. */
-			new_fmt = "%I:%M:S %p";//_ctloc(t_fmt_ampm);
+			new_fmt = "%I:%M:S %p";/*_ctloc(t_fmt_ampm); */
 			LEGAL_ALT(0);
 			goto recurse;
 
@@ -198,18 +198,20 @@ literal:
 			LEGAL_ALT(0);
 			goto recurse;
 
-		/* we don't use 'X'
-      case 'X': The time, using the locale's format.
+/* // we don't use 'X'
+		case 'X': The time, using the locale's format.
 			new_fmt =_ctloc(t_fmt);
 			goto recurse;
-      */
+*/
 
-		/* we do not need 'x'
-      case 'x': The date, using the locale's format.
-			new_fmt =_ctloc(d_fmt);*/
+/* // we do not need 'x'
+		case 'x': The date, using the locale's format.
+			new_fmt =_ctloc(d_fmt);
+*/
+
 recurse:
 			bp = (const u_char *)strptime((const char *)bp,
-							    new_fmt, tm);
+							new_fmt, tm);
 			LEGAL_ALT(ALT_E);
 			continue;
 
@@ -323,7 +325,7 @@ recurse:
 				}
 
 				tm = localtime(&sse);
-            if (tm == NULL)
+				if (tm == NULL)
 					bp = NULL;
 			}
 			continue;
@@ -360,9 +362,9 @@ recurse:
 		case 'G':	/* The year corresponding to the ISO week
 				 * number with century.
 				 */
-			do
+			do {
 				bp++;
-			while (isdigit(*bp));
+			} while (isdigit(*bp));
 			continue;
 
 		case 'V':	/* The ISO 8601:1988 week number as decimal */
@@ -396,7 +398,8 @@ recurse:
 		case 'Z':
 			_tzset();
 			if (strncasecmp((const char *)bp, gmt, 3) == 0
-          || strncasecmp((const char *)bp, utc, 3) == 0) {
+			 || strncasecmp((const char *)bp, utc, 3) == 0
+			) {
 				tm->tm_isdst = 0;
 #ifdef TM_GMTOFF
 				tm->TM_GMTOFF = 0;
@@ -407,8 +410,8 @@ recurse:
 				bp += 3;
 			} else {
 				ep = find_string(bp, &i,
-					       	 (const char * const *)tzname,
-					       	  NULL, 2);
+					(const char * const *)tzname,
+					NULL, 2);
 				if (ep != NULL) {
 					tm->tm_isdst = i;
 #ifdef TM_GMTOFF
@@ -494,12 +497,13 @@ recurse:
 				}
 
 				if ((*bp >= 'A' && *bp <= 'I') ||
-				    (*bp >= 'L' && *bp <= 'Y')) {
+				    (*bp >= 'L' && *bp <= 'Y')
+				) {
 #ifdef TM_GMTOFF
 					/* Argh! No 'J'! */
 					if (*bp >= 'A' && *bp <= 'I')
 						tm->TM_GMTOFF =
-						    ('A' - 1) - (int)*bp;
+							('A' - 1) - (int)*bp;
 					else if (*bp >= 'L' && *bp <= 'M')
 						tm->TM_GMTOFF = 'A' - (int)*bp;
 					else if (*bp >= 'N' && *bp <= 'Y')

--- a/configure.ac
+++ b/configure.ac
@@ -3535,7 +3535,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[${CPLUSPLUS_DECL}]], [[${CPLUSPLUS_MAIN}]])
     [AC_MSG_RESULT([yes, out of the box])
      have_cxx11=yes],
     [AS_CASE(["${CXXFLAGS}"],
-        [*"-std="*], [
+        [*"-std="*|*"-ansi"*], [
             AC_MSG_RESULT([no, not with the standard already set in CXXFLAGS='${CXXFLAGS}'])
             have_cxx11=no
         ],[

--- a/configure.ac
+++ b/configure.ac
@@ -89,6 +89,20 @@ AC_CONFIG_HEADERS([include/config.h])
 AC_PREFIX_DEFAULT(/usr/local/ups)
 AM_INIT_AUTOMAKE([subdir-objects])
 
+AS_CASE([${target_os}],
+	[*mingw*], [AS_CASE([${CFLAGS-}${CXXFLAGS-}],
+		[*"-std=c"*|*-ansi*], [
+			AC_MSG_NOTICE(
+[-----------------------------------------------------------------------
+WARNING: It seems you are building with MinGW and requested a strict C/C++
+language mode. Per https://stackoverflow.com/a/76780217/4715872 MinGW may
+not define WIN32 and other options needed for proper building and linking.
+If this happens, please retry with GNU C/C++ language mode options instead.
+-----------------------------------------------------------------------])
+			sleep 5
+		])]
+)
+
 dnl Default to `configure --enable-silent-rules` or `make V=1` for details?
 dnl This feature seems to require automake-1.13 or newer (1.11+ by other info)
 dnl On very old systems can comment it away with little loss (then automake-1.10
@@ -2831,6 +2845,7 @@ AS_IF([test "x$nut_cv_header_windows_h" = xyes],
 	[AM_CONDITIONAL([HAVE_WINDOWS], [test "${nut_have_mingw_resgen}" = "yes"])],
 	[AM_CONDITIONAL([HAVE_WINDOWS], [false])]
 	)
+
 
 dnl ----------------------------------------------------------------------
 

--- a/docs/developers.txt
+++ b/docs/developers.txt
@@ -170,7 +170,7 @@ Other hints
 ~~~~~~~~~~~
 
 TIP: At this point NUT is expected to work correctly when built with a
-C99 (or rather GNU99 on many systems) or newer standard.
+"strict" C99 (or rather GNU99 on many systems) or newer standard.
 
 The NUT codebase may build in a mode without warnings made fatal on C89
 (GNU89), but the emitted warnings indicate that those binaries may crash.
@@ -178,8 +178,18 @@ By the end of 2021, NUT codebase has been revised to pass GNU and strict-C
 mode builds with C89 standard with the GCC toolkit (and on systems that do
 have the newer features in libraries, just hide them in standard headers);
 however CLANG toolkit is more restrictive about the C99+ syntax used.
-If somebody in the community requires to build and run NUT on systems
-that old, pull requests to fix the offending coding issues are welcome.
+That said, some systems refuse to expose methods or types available in
+their system headers and binary libraries if strict-C mode is used alone,
+without extra system-specific defines to enable more than the baseline.
+
+It was also seen that cross-builds (e.g. NUT for Windows using mingw on
+Linux) may be unable to define `WIN32` and/or find symbols for linking
+when using a strict-C language standard.
+
+The C++ support expects C++11 or newer (not really configured or tested
+for older C++98 or C++03), modulo features that were deprecated in later
+language revisions (C++14 onwards) as highlighted by warnings from newer
+compilers.
 
 Note also that the NUT codebase currently relies on certain features,
 such as the printf format modifiers for `(s)size_t`, use of `long long`,
@@ -190,8 +200,16 @@ revisions). Many of the "offences" against the older standard actually
 come from system and third-party header files.
 
 That said, the NUT CI farm does run non-regression builds with GNU C89
-and strict C89 standard revisions and minimal passing warnings level,
+and "strict" C89 standard revisions and minimal passing warnings level,
 to ensure that codebase is and remains at least basically compliant.
+We try to cover a few distributions from early 2000's for this, either
+in regular CI builds or one-off local builds for community members with
+a zoo of old systems.
+
+If somebody in the community actually requires to build and run NUT on
+systems that old, where newer compilers are not available, pull requests
+to fix the offending coding issues in some way that does not break other
+use-cases are welcome.
 
 Continuous Integration and Automated Builds
 -------------------------------------------

--- a/docs/developers.txt
+++ b/docs/developers.txt
@@ -317,7 +317,8 @@ Jenkins CI
 ^^^^^^^^^^
 
 Since mid-2021, the NUT CI farm is implemented by several virtual servers
-courteously provided by http://fosshost.org
+courteously provided by link:http://fosshost.org[Fosshost] and later by
+link:https://www.digitalocean.com/?refcode=d2fbf2b9e082&utm_campaign=Referral_Invite&utm_medium=Referral_Program&utm_source=badge[DigitalOcean].
 
 These run various operating systems as build agents, and a Jenkins instance
 to orchestrate the builds of NUT branches and pull requests on those agents.

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3443 utf-8
+personal_ws-1.1 en 3444 utf-8
 AAC
 AAS
 ABI
@@ -2686,6 +2686,7 @@ ont
 ontd
 ontimedays
 ontiniedays
+onwards
 ooce
 openSUSE
 opencollective

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -165,17 +165,17 @@ static TYPE_FD sock_open(const char *fn)
 #else /* WIN32 */
 
 	fd = CreateNamedPipe(
-			fn,			// pipe name
-			PIPE_ACCESS_DUPLEX |  // read/write access
-			FILE_FLAG_OVERLAPPED, // async IO
+			fn,			/* pipe name */
+			PIPE_ACCESS_DUPLEX |	/* read/write access */
+			FILE_FLAG_OVERLAPPED,	/* async IO */
 			PIPE_TYPE_BYTE |
 			PIPE_READMODE_BYTE |
 			PIPE_WAIT,
-			PIPE_UNLIMITED_INSTANCES, // max. instances
-			ST_SOCK_BUF_LEN,	// output buffer size
-			ST_SOCK_BUF_LEN,	// input buffer size
-			0,			// client time-out
-			NULL);			// FIXME: default security attribute
+			PIPE_UNLIMITED_INSTANCES,	/* max. instances */
+			ST_SOCK_BUF_LEN,	/* output buffer size */
+			ST_SOCK_BUF_LEN,	/* input buffer size */
+			0,			/* client time-out */
+			NULL);			/* FIXME: default security attribute */
 
 	if (INVALID_FD(fd)) {
 		fatal_with_errno(EXIT_FAILURE,
@@ -520,17 +520,17 @@ static void sock_connect(TYPE_FD sock)
 
 	/* sockfd is the handle of the connection pending pipe */
 	sockfd = CreateNamedPipe(
-			pipename,			// pipe name
-			PIPE_ACCESS_DUPLEX |  // read/write access
-			FILE_FLAG_OVERLAPPED, // async IO
+			pipename,		/* pipe name */
+			PIPE_ACCESS_DUPLEX |	/* read/write access */
+			FILE_FLAG_OVERLAPPED,	/* async IO */
 			PIPE_TYPE_BYTE |
 			PIPE_READMODE_BYTE |
 			PIPE_WAIT,
-			PIPE_UNLIMITED_INSTANCES, // max. instances
-			ST_SOCK_BUF_LEN,	// output buffer size
-			ST_SOCK_BUF_LEN,	// input buffer size
-			0,			// client time-out
-			NULL);			// FIXME: default security attribute
+			PIPE_UNLIMITED_INSTANCES,	/* max. instances */
+			ST_SOCK_BUF_LEN,	/* output buffer size */
+			ST_SOCK_BUF_LEN,	/* input buffer size */
+			0,			/* client time-out */
+			NULL);			/* FIXME: default security attribute */
 
 	if (INVALID_FD(sockfd)) {
 		fatal_with_errno(EXIT_FAILURE,

--- a/drivers/eaton-pdu-marlin-mib.c
+++ b/drivers/eaton-pdu-marlin-mib.c
@@ -232,7 +232,7 @@ const char *su_temperature_read_fun(void *raw_snmp_value) {
 	NUT_UNUSED_VARIABLE(raw_snmp_value);
 	return "dummy";
 }
-#endif // WITH_SNMP_LKP_FUN_DUMMY
+#endif /* WITH_SNMP_LKP_FUN_DUMMY */
 
 static info_lkp_t eaton_sensor_temperature_unit_info[] = {
 	{ 0, "dummy", eaton_sensor_temperature_unit_fun, NULL },
@@ -244,7 +244,7 @@ static info_lkp_t eaton_sensor_temperature_read_info[] = {
 	{ 0, NULL, NULL, NULL }
 };
 
-#else // if not WITH_SNMP_LKP_FUN:
+#else /* if not WITH_SNMP_LKP_FUN: */
 
 /* FIXME: For now, DMF codebase falls back to old implementation with static
  * lookup/mapping tables for this, which can easily go into the DMF XML file.
@@ -256,7 +256,7 @@ static info_lkp_t eaton_sensor_temperature_unit_info[] = {
 	{ 0, NULL, NULL, NULL }
 };
 
-#endif // WITH_SNMP_LKP_FUN
+#endif /* WITH_SNMP_LKP_FUN */
 
 /* Extracted from powerware-mib.c ; try to commonalize */
 static info_lkp_t marlin_ambient_drycontacts_polarity_info[] = {

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -1029,7 +1029,7 @@ static int main_arg(char *var, char *val)
 	 * catch commented-away settings, so not checking previous value.
 	 */
 	if (!strcmp(var, "debug_min")) {
-		int lvl = -1; // typeof common/common.c: int nut_debug_level
+		int lvl = -1; /* typeof common/common.c: int nut_debug_level */
 		if ( str_to_int (val, &lvl, 10) && lvl >= 0 ) {
 			nut_debug_level_driver = lvl;
 		} else {
@@ -1154,7 +1154,7 @@ static void do_global_args(const char *var, const char *val)
 	 * catch commented-away settings, so not checking previous value.
 	 */
 	if (!strcmp(var, "debug_min")) {
-		int lvl = -1; // typeof common/common.c: int nut_debug_level
+		int lvl = -1; /* typeof common/common.c: int nut_debug_level */
 		if ( str_to_int (val, &lvl, 10) && lvl >= 0 ) {
 			nut_debug_level_global = lvl;
 		} else {

--- a/drivers/mge-hid.c
+++ b/drivers/mge-hid.c
@@ -39,6 +39,17 @@
 #include "nut_float.h"
 #include "timehead.h"
 
+#ifdef WIN32
+# include "wincompat.h"
+# ifndef LDOUBLE
+#  ifdef HAVE_LONG_DOUBLE
+#   define LDOUBLE long double
+#  else
+#   define LDOUBLE double
+#  endif
+# endif
+#endif
+
 #define MGE_HID_VERSION		"MGE HID 1.46"
 
 /* (prev. MGE Office Protection Systems, prev. MGE UPS SYSTEMS) */

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -2002,7 +2002,7 @@ static int	armac_command(const char *cmd, char *buf, size_t buflen)
 			ret = usb_interrupt_read(udev, 0x81,
 				(usb_ctrl_charbuf)tmpbuf, ARMAC_READ_SIZE_FOR_CONTROL, 100);
 			if (ret != ARMAC_READ_SIZE_FOR_CONTROL) {
-				// Timeout - buffer is clean.
+				/* Timeout - buffer is clean. */
 				break;
 			}
 			upsdebugx(4, "armac cleanup ret i=%" PRIuSIZE " ret=%d ctrl=%02hhx", i, ret, tmpbuf[0]);

--- a/drivers/nutdrv_qx_ablerex.c
+++ b/drivers/nutdrv_qx_ablerex.c
@@ -33,15 +33,18 @@ static int ablerexQ5Vb = -1;
 
 static int ablerex_Q5(item_t *item, char *value, const size_t valuelen) {
 	int	Q5_Fout, Q5_Vb, Q5_O_Cur, Q5_Err;
-/*
-	//int	Q5_InvW;
-	int	RawValue = 0;
+#ifdef ABLEREX_WITH_Q5_InvW
+	int	Q5_InvW;
+#endif
+#ifdef ABLEREX_WITH_RawValue
+	int	RawValue = ((int)(unsigned char)item->value[0]) * 256 + (unsigned char)item->value[1];
+#endif
 
-	RawValue  = (unsigned char)item->value[0] * 256 + (unsigned char)item->value[1];
+/* // real code below, this is for dev-testing
+	ablerexQ5Vb = ((int)(unsigned char)buf[7]) * 256 + (unsigned char)buf[8];
+	Q5_Vbc = ((int)(unsigned char)buf[9]) * 256 + (unsigned char)buf[10];
 */
 
-	//ablerexQ5Vb = (unsigned char)buf[7] * 256 + (unsigned char)buf[8];
-	//Q5_Vbc = (unsigned char)buf[9] * 256 + (unsigned char)buf[10];
 	upsdebugx(2, "Q51: %d %d %d %d %d %d", item->answer[0], item->answer[1], item->answer[2], item->answer[3], item->answer[4], item->answer[5]);
 	upsdebugx(2, "Q52: %d %d %d %d %d %d", item->answer[6], item->answer[7], item->answer[8], item->answer[9], item->answer[10], item->answer[11]);
 	upsdebugx(2, "Q53: %d %d %d %d", item->answer[12], item->answer[13], item->answer[14], item->answer[15]);
@@ -49,20 +52,25 @@ static int ablerex_Q5(item_t *item, char *value, const size_t valuelen) {
 	Q5_Fout = (unsigned char)item->answer[1] * 256 + (unsigned char)item->answer[2];
 	Q5_Vb = (unsigned char)item->answer[7] * 256 + (unsigned char)item->answer[8];
 	Q5_Vbc = (unsigned char)item->answer[9] * 256 + (unsigned char)item->answer[10];
-	//int Q5_InvW = (unsigned char)item->answer[11] * 256 + (unsigned char)item->answer[12];
+#ifdef ABLEREX_WITH_Q5_InvW
+	Q5_InvW = (unsigned char)item->answer[11] * 256 + (unsigned char)item->answer[12];
+#endif
 	Q5_Err = (unsigned char)item->answer[13] * 256 + (unsigned char)item->answer[14];
 	Q5_O_Cur = (unsigned char)item->answer[15] * 256 + (unsigned char)item->answer[16];
 
 	ablerexQ5Vb = Q5_Vb;
 	upsdebugx(2, "Q5: %.1f %d %.1f", 0.1 * Q5_Fout, Q5_Err, 0.1 * Q5_O_Cur);
 	upsdebugx(2, "Q5Vb: %d Vbc %d", Q5_Vb, Q5_Vbc);
+#ifdef ABLEREX_WITH_Q5_InvW
+	upsdebugx(2, "Q5_InvW: %d", Q5_InvW);
+#endif
 	dstate_setinfo("output.frequency", "%.1f", 0.1 * Q5_Fout);
 	dstate_setinfo("ups.alarm", "%d", Q5_Err);
 	dstate_setinfo("output.current", "%.1f", 0.1 * Q5_O_Cur);
 
 	snprintf(value, valuelen, "%.1f", Q5_Fout * 0.1);
 
-/*
+#ifdef ABLEREX_WITH_RawValue
 	switch (item->from)
 	{
 	case 1:
@@ -79,10 +87,10 @@ static int ablerex_Q5(item_t *item, char *value, const size_t valuelen) {
 		break;
 
 	default:
-		//Don't know what happened
+		/* Don't know what happened */
 		return -1;
 	}
-*/
+#endif
 
 	return 0;
 }
@@ -102,7 +110,9 @@ static int ablerex_battery(item_t *item, char *value, const size_t valuelen) {
 
 	nomBattV = strtod(dstate_getinfo("battery.voltage.nominal"),  NULL);
 	upsdebugx(2, "battvoltact1: %.2f", nomBattV);
-	//return 0;
+/*
+ *	//return 0;
+ */
 
 	if (ablerexQ5Vb > 0) {
 		battvoltact = ablerexQ5Vb * nomBattV / 1200;
@@ -162,8 +172,10 @@ static int ablerex_battery_charge(double BattIn)
 			}
 		}
 	} else {
-		//double nomBattV = strtod(dstate_getinfo("battery.voltage.nominal"),  NULL);
-		//double battV = BattIn / (nomBattV / 12);
+/*
+ *		//double nomBattV = strtod(dstate_getinfo("battery.voltage.nominal"),  NULL);
+ *		//double battV = BattIn / (nomBattV / 12);
+ */
 
 		for (i = 0; offlineC[i] > 0; i++) {
 			if (BattIn >= offlineP[i]) {
@@ -190,13 +202,17 @@ static int ablerex_batterycharge(item_t *item, char *value, const size_t valuele
 
 	nomBattV = strtod(dstate_getinfo("battery.voltage.nominal"),  NULL);
 	upsdebugx(2, "battvv1: %.2f", nomBattV);
-	//return 0;
+/*
+ *	//return 0;
+ */
 
 	if (BattV > 3.0) {
 		BattV = BattV / (nomBattV / 12);
 	}
 	BattP = ablerex_battery_charge(BattV);
-	//dstate_setinfo("battery.charge", "%.0f", BattP);
+/*
+ *	//dstate_setinfo("battery.charge", "%.0f", BattP);
+ */
 
 	snprintf(value, valuelen, "%d", BattP);
 	upsdebugx(2, "battcharge: %d", BattP);
@@ -370,9 +386,13 @@ static item_t	ablerex_qx2nut[] = {
 	/* Ablerex */
 	{ "output.frequency",	0,	NULL,	"Q5\r",	"",	22,	'(',	"",	1,	18,	"%.1f",	0,	NULL,	NULL,	ablerex_Q5 },
 	{ "battery.runtime",	0,	NULL,	"At\r",	"",	0,	'(',	"",	0,	0,	"%d",	0,	NULL,	NULL,	ablerex_At },
-	//{ "ups.alarm",		0,	NULL,	"Q5\r",	"",	22,	'(',	"",	1,	14,	"%.0f",	0,	QX_FLAG_QUICK_POLL,	NULL,	ablerex_Q5 },
+/*
+ *	//{ "ups.alarm",		0,	NULL,	"Q5\r",	"",	22,	'(',	"",	1,	14,	"%.0f",	0,	QX_FLAG_QUICK_POLL,	NULL,	ablerex_Q5 },
+ */
 	{ "ups.test.result",	0,	NULL,	"TR\r",	"",	0,	'#',	"",	0,	0,	"%s",	0,	NULL,	NULL,	ablerex_TR },
-	//{ "output.current",		0,	NULL,	"Q5\r",	"",	22,	'(',	"",	1,	16,	"%.1f",	0,	QX_FLAG_QUICK_POLL,	NULL,	ablerex_Q5 },
+/*
+ *	//{ "output.current",		0,	NULL,	"Q5\r",	"",	22,	'(',	"",	1,	16,	"%.1f",	0,	QX_FLAG_QUICK_POLL,	NULL,	ablerex_Q5 },
+ */
 
 	/*
 	 * > [I\r]

--- a/drivers/pijuice.c
+++ b/drivers/pijuice.c
@@ -53,7 +53,7 @@
  * situation.
  */
 #if WITH_LINUX_I2C
-#if !HAVE_DECL_I2C_SMBUS_ACCESS
+# if !HAVE_DECL_I2C_SMBUS_ACCESS
 static inline __s32 i2c_smbus_access(int file, char read_write, __u8 command,
                                      int size, union i2c_smbus_data *data)
 {
@@ -70,9 +70,9 @@ static inline __s32 i2c_smbus_access(int file, char read_write, __u8 command,
 		err = -errno;
 	return err;
 }
-#endif
+# endif
 
-#if !HAVE_DECL_I2C_SMBUS_READ_BYTE_DATA
+# if !HAVE_DECL_I2C_SMBUS_READ_BYTE_DATA
 static inline __s32 i2c_smbus_read_byte_data(int file, __u8 command)
 {
 	union i2c_smbus_data data;
@@ -84,9 +84,9 @@ static inline __s32 i2c_smbus_read_byte_data(int file, __u8 command)
 	else
 		return 0x0FF & data.byte;
 }
-#endif
+# endif
 
-#if !HAVE_DECL_I2C_SMBUS_WRITE_BYTE_DATA
+# if !HAVE_DECL_I2C_SMBUS_WRITE_BYTE_DATA
 static inline __s32 i2c_smbus_write_byte_data(int file, __u8 command, __u8 value)
 {
 	union i2c_smbus_data data;
@@ -99,9 +99,9 @@ static inline __s32 i2c_smbus_write_byte_data(int file, __u8 command, __u8 value
 	else
 		return 0x0FF & data.byte;
 }
-#endif
+# endif
 
-#if !HAVE_DECL_I2C_SMBUS_READ_WORD_DATA
+# if !HAVE_DECL_I2C_SMBUS_READ_WORD_DATA
 static inline __s32 i2c_smbus_read_word_data(int file, __u8 command)
 {
 	union i2c_smbus_data data;
@@ -113,9 +113,9 @@ static inline __s32 i2c_smbus_read_word_data(int file, __u8 command)
 	else
 		return 0x0FFFF & data.word;
 }
-#endif
+# endif
 
-#if !HAVE_DECL_I2C_SMBUS_WRITE_WORD_DATA
+# if !HAVE_DECL_I2C_SMBUS_WRITE_WORD_DATA
 static inline __s32 i2c_smbus_write_word_data(int file, __u8 command, __u16 value)
 {
 	union i2c_smbus_data data;
@@ -128,9 +128,9 @@ static inline __s32 i2c_smbus_write_word_data(int file, __u8 command, __u16 valu
 	else
 		return 0x0FFFF & data.word;
 }
-#endif
+# endif
 
-#if !HAVE_DECL_I2C_SMBUS_READ_BLOCK_DATA
+# if !HAVE_DECL_I2C_SMBUS_READ_BLOCK_DATA
 static inline __u8* i2c_smbus_read_i2c_block_data(int file, __u8 command, __u8 length, __u8 *values)
 {
 	union i2c_smbus_data data;
@@ -152,8 +152,8 @@ static inline __u8* i2c_smbus_read_i2c_block_data(int file, __u8 command, __u8 l
 
 	return values;
 }
-#endif
-#endif // if WITH_LINUX_I2C
+# endif
+#endif /* if WITH_LINUX_I2C */
 
 #define STATUS_CMD                          0x40
 #define CHARGE_LEVEL_CMD                    0x41

--- a/drivers/riello.c
+++ b/drivers/riello.c
@@ -26,6 +26,9 @@
  * Reference of the derivative work: blazer driver
  */
 
+#include "config.h" /* must be the first header */
+#include "common.h" /* for upsdebugx() etc */
+
 #include <string.h>
 
 #include "main.h"

--- a/drivers/riello_ser.c
+++ b/drivers/riello_ser.c
@@ -35,13 +35,15 @@
 #include "main.h"
 #include "serial.h"
 #include "timehead.h"
+
 /*
-// The serial driver has no need for HID structures/code currently
-// (maybe there is/was a plan for sharing something between siblings).
-// Note that HID is tied to libusb or libshut definitions at the moment.
+ * // The serial driver has no need for HID structures/code currently
+ * // (maybe there is/was a plan for sharing something between siblings).
+ * // Note that HID is tied to libusb or libshut definitions at the moment.
 #include "hidparser.h"
 #include "hidtypes.h"
-*/
+ */
+
 #include "common.h" /* for upsdebugx() etc */
 #include "riello.h"
 

--- a/drivers/riello_ser.c
+++ b/drivers/riello_ser.c
@@ -25,6 +25,7 @@
  */
 
 #include "config.h" /* must be the first header */
+#include "common.h" /* for upsdebugx() etc */
 
 #include <string.h>
 
@@ -44,7 +45,6 @@
 #include "hidtypes.h"
  */
 
-#include "common.h" /* for upsdebugx() etc */
 #include "riello.h"
 
 #define DRIVER_NAME	"Riello serial driver"

--- a/drivers/sms_ser.c
+++ b/drivers/sms_ser.c
@@ -54,13 +54,14 @@ upsdrv_info_t upsdrv_info = {
 void sms_parse_features(uint8_t *rawvalues, SmsData *results) {
     char tbattery[6];
     char frequency[4];
+    int i;
 
     memset(results->voltageRange, 0, sizeof(results->voltageRange));
     memset(results->currentRange, 0, sizeof(results->currentRange));
     memset(tbattery, 0, sizeof(tbattery));
     memset(frequency, 0, sizeof(frequency));
 
-    for (int i = 1; i < BUFFER_SIZE - 2; i++) {
+    for (i = 1; i < BUFFER_SIZE - 2; i++) {
         if (i <= 7) {
             snprintfcat(results->voltageRange, 14, "%c", rawvalues[i]);
         } else if (i <= 10) {
@@ -79,10 +80,12 @@ void sms_parse_features(uint8_t *rawvalues, SmsData *results) {
 void sms_parse_information(uint8_t *rawvalues, SmsData *results) {
     /* Count from 1 to ignore first char and remove 2 from BUFFER_SIZE
      *  to compensate the start and ignore '\r' from end. */
+    int i;
+
     memset(results->model, 0, sizeof(results->model));
     memset(results->version, 0, sizeof(results->version));
 
-    for (int i = 1; i < BUFFER_SIZE - 2; i++) {
+    for (i = 1; i < BUFFER_SIZE - 2; i++) {
         if (i <= 12) {
             snprintfcat(results->model, 24, "%c", rawvalues[i]);
         } else {

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -2174,7 +2174,7 @@ const char *su_find_strval(info_lkp_t *oid2info, void *value)
 #else
 	NUT_UNUSED_VARIABLE(oid2info);
 	upsdebugx(1, "%s: no mapping function for this OID string value (%s)", __func__, (char*)value);
-#endif // WITH_SNMP_LKP_FUN
+#endif /* WITH_SNMP_LKP_FUN */
 	return NULL;
 }
 
@@ -2194,7 +2194,7 @@ const char *su_find_infoval(info_lkp_t *oid2info, void *raw_value)
 		upsdebugx(2, "%s: got value '%s'", __func__, retvalue);
 		return retvalue;
 	}
-#endif // WITH_SNMP_LKP_FUN
+#endif /* WITH_SNMP_LKP_FUN */
 
 	/* Otherwise, use the simple values mapping */
 	for (info_lkp = oid2info; (info_lkp != NULL) &&

--- a/drivers/snmp-ups.h
+++ b/drivers/snmp-ups.h
@@ -275,8 +275,8 @@ typedef struct {
 #define SU_AMBIENT_TEMPLATE	(1UL << 26)	/* ambient template definition */
 
 /* Reserved slot -- to import from DMF branch codebase:
-//#define SU_FLAG_FUNCTION	(1UL << 27)
-*/
+ * //#define SU_FLAG_FUNCTION	(1UL << 27)
+ */
 
 /* status string components
  * FIXME: these should be removed, since there is no added value.

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -1601,9 +1601,9 @@ void upsdrv_makevartable(void)
 		MAX_VOLT);
 	addvar(VAR_VALUE, "battery_max", msg);
 
-	// allow -x upsid=X
+	/* allow -x upsid=X */
 	snprintf(msg, sizeof msg, "UPS ID (Unit ID) (default=%d)", DEFAULT_UPSID);
-    addvar(VAR_VALUE, "upsid", msg);
+	addvar(VAR_VALUE, "upsid", msg);
 
 #if 0
 	snprintf(msg, sizeof msg, "Set start delay, in seconds (default=%d).",

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -443,8 +443,9 @@ static void stop_driver(const ups_t *ups)
 #endif
 			if (ret != 0) {
 				upsdebugx(2, "Sending signal to %s failed, driver is finally down or wrongly owned", pidfn);
-				// While a TERMinated driver cleans up,
-				// a stuck and KILLed one does not, so:
+				/* While a TERMinated driver cleans up,
+				 * a stuck and KILLed one does not, so:
+				 */
 				if (ups->pid == -1) {
 					unlink(pidfn);
 				}

--- a/drivers/upsdrvquery.c
+++ b/drivers/upsdrvquery.c
@@ -89,14 +89,14 @@ udq_pipe_conn_t *upsdrvquery_connect(const char *sockfn) {
 	}
 
 	conn->sockfd = CreateFile(
-			sockfn,         // pipe name
-			GENERIC_READ |  // read and write access
+			sockfn,         /* pipe name */
+			GENERIC_READ |  /* read and write access */
 			GENERIC_WRITE,
-			0,              // no sharing
-			NULL,           // default security attributes FIXME
-			OPEN_EXISTING,  // opens existing pipe
-			FILE_FLAG_OVERLAPPED, //  enable async IO
-			NULL);          // no template file
+			0,              /* no sharing */
+			NULL,           /* default security attributes FIXME */
+			OPEN_EXISTING,  /* opens existing pipe */
+			FILE_FLAG_OVERLAPPED, /*  enable async IO */
+			NULL);          /* no template file */
 
 	if (conn->sockfd == INVALID_HANDLE_VALUE) {
 		upslog_with_errno(LOG_ERR, "CreateFile : %d\n", GetLastError());
@@ -417,7 +417,7 @@ ssize_t upsdrvquery_prepare(udq_pipe_conn_t *conn, struct timeval tv) {
 		tv.tv_usec -= (suseconds_t)(difftimeval(now, start));
 		while (tv.tv_usec < 0) {
 			tv.tv_sec--;
-			tv.tv_usec = 1000000 + tv.tv_usec;	// Note it is negative
+			tv.tv_usec = 1000000 + tv.tv_usec;	/* Note it is negative */
 		}
 		if (tv.tv_sec <= 0 && tv.tv_usec <= 0) {
 			upsdebugx(5, "%s: requested timeout expired", __func__);

--- a/m4/nut_compiler_family.m4
+++ b/m4/nut_compiler_family.m4
@@ -207,7 +207,7 @@ dnl # Some distributions and platforms also have problems
 dnl # building in "strict C" mode, so for the GNU-compatible
 dnl # compilers we default to the GNU C/C++ dialects.
     AS_IF([test "x$GCC" = xyes -o "x$CLANGCC" = xyes],
-        [AS_CASE(["${CFLAGS}"], [-std=*], [],
+        [AS_CASE(["${CFLAGS}"], [*"-std="*], [],
             [AC_LANG_PUSH([C])
              AX_CHECK_COMPILE_FLAG([-std=gnu99],
                 [AC_MSG_NOTICE([Defaulting C standard support to GNU C99 on a GCC or CLANG compatible compiler])
@@ -220,7 +220,7 @@ dnl # compilers we default to the GNU C/C++ dialects.
 dnl # Note: this might upset some very old compilers
 dnl # but then by default we wouldn't build C++ parts
     AS_IF([test "x$GCC" = xyes -o "x$CLANGCC" = xyes],
-        [AS_CASE(["${CXXFLAGS}"], [-std=*], [],
+        [AS_CASE(["${CXXFLAGS}"], [*"-std="*], [],
             [AC_LANG_PUSH([C++])
              AX_CHECK_COMPILE_FLAG([-std=gnu++11],
                 [AC_MSG_NOTICE([Defaulting C++ standard support to GNU C++11 on a GCC or CLANG compatible compiler])
@@ -246,7 +246,7 @@ dnl # Some distributions and platforms also have problems
 dnl # building in "strict C" mode, so for the GNU-compatible
 dnl # compilers we default to the GNU C/C++ dialects.
     AS_IF([test "x$GCC" = xyes -o "x$CLANGCC" = xyes],
-        [AS_CASE(["${CFLAGS}"], [*-std=*], [],
+        [AS_CASE(["${CFLAGS}"], [*"-std="*], [],
             [AC_LANG_PUSH([C])
              AX_CHECK_COMPILE_FLAG([-std=gnu99],
                 [AC_MSG_NOTICE([Defaulting C standard support to GNU C99 on a GCC or CLANG compatible compiler])
@@ -259,7 +259,7 @@ dnl # compilers we default to the GNU C/C++ dialects.
 dnl # Note: this might upset some very old compilers
 dnl # but then by default we wouldn't build C++ parts
     AS_IF([test "x$GCC" = xyes -o "x$CLANGCC" = xyes],
-        [AS_CASE(["${CXXFLAGS}"], [*-std=*], [],
+        [AS_CASE(["${CXXFLAGS}"], [*"-std="*], [],
             [AC_LANG_PUSH([C++])
              AX_CHECK_COMPILE_FLAG([-std=gnu++11],
                 [AC_MSG_NOTICE([Defaulting C++ standard support to GNU C++11 on a GCC or CLANG compatible compiler])

--- a/m4/nut_compiler_family.m4
+++ b/m4/nut_compiler_family.m4
@@ -207,7 +207,7 @@ dnl # Some distributions and platforms also have problems
 dnl # building in "strict C" mode, so for the GNU-compatible
 dnl # compilers we default to the GNU C/C++ dialects.
     AS_IF([test "x$GCC" = xyes -o "x$CLANGCC" = xyes],
-        [AS_CASE(["${CFLAGS}"], [*"-std="*], [],
+        [AS_CASE(["${CFLAGS}"], [*"-std="*|*"-ansi"*], [],
             [AC_LANG_PUSH([C])
              AX_CHECK_COMPILE_FLAG([-std=gnu99],
                 [AC_MSG_NOTICE([Defaulting C standard support to GNU C99 on a GCC or CLANG compatible compiler])
@@ -220,7 +220,7 @@ dnl # compilers we default to the GNU C/C++ dialects.
 dnl # Note: this might upset some very old compilers
 dnl # but then by default we wouldn't build C++ parts
     AS_IF([test "x$GCC" = xyes -o "x$CLANGCC" = xyes],
-        [AS_CASE(["${CXXFLAGS}"], [*"-std="*], [],
+        [AS_CASE(["${CXXFLAGS}"], [*"-std="*|*"-ansi"*], [],
             [AC_LANG_PUSH([C++])
              AX_CHECK_COMPILE_FLAG([-std=gnu++11],
                 [AC_MSG_NOTICE([Defaulting C++ standard support to GNU C++11 on a GCC or CLANG compatible compiler])
@@ -246,7 +246,7 @@ dnl # Some distributions and platforms also have problems
 dnl # building in "strict C" mode, so for the GNU-compatible
 dnl # compilers we default to the GNU C/C++ dialects.
     AS_IF([test "x$GCC" = xyes -o "x$CLANGCC" = xyes],
-        [AS_CASE(["${CFLAGS}"], [*"-std="*], [],
+        [AS_CASE(["${CFLAGS}"], [*"-std="*|*"-ansi"*], [],
             [AC_LANG_PUSH([C])
              AX_CHECK_COMPILE_FLAG([-std=gnu99],
                 [AC_MSG_NOTICE([Defaulting C standard support to GNU C99 on a GCC or CLANG compatible compiler])
@@ -259,7 +259,7 @@ dnl # compilers we default to the GNU C/C++ dialects.
 dnl # Note: this might upset some very old compilers
 dnl # but then by default we wouldn't build C++ parts
     AS_IF([test "x$GCC" = xyes -o "x$CLANGCC" = xyes],
-        [AS_CASE(["${CXXFLAGS}"], [*"-std="*], [],
+        [AS_CASE(["${CXXFLAGS}"], [*"-std="*|*"-ansi"*], [],
             [AC_LANG_PUSH([C++])
              AX_CHECK_COMPILE_FLAG([-std=gnu++11],
                 [AC_MSG_NOTICE([Defaulting C++ standard support to GNU C++11 on a GCC or CLANG compatible compiler])

--- a/scripts/Windows/DriverInstaller/wdi-simple.c
+++ b/scripts/Windows/DriverInstaller/wdi-simple.c
@@ -45,7 +45,9 @@ int __cdecl main(int argc, char** argv)
 	struct wdi_options_install_driver oid = { 0 };
 	int c, r;
 	int opt_silent = 0, opt_extract = 0, log_level = WDI_LOG_LEVEL_WARNING;
-//	int opt_silent = 0, opt_extract = 0, log_level = WDI_LOG_LEVEL_DEBUG;
+/*
+	int opt_silent = 0, opt_extract = 0, log_level = WDI_LOG_LEVEL_DEBUG;
+*/
 	char *inf_name = INF_NAME;
 	char *ext_dir = DEFAULT_DIR;
 	bool matching_device_found;
@@ -55,7 +57,9 @@ int __cdecl main(int argc, char** argv)
 	ocl.list_hubs = true;
 	ocl.trim_whitespaces = true;
 	opd.driver_type = WDI_LIBUSB0;
-//	opd.driver_type = WDI_WINUSB;
+/*
+	opd.driver_type = WDI_WINUSB;
+*/
 
 	wdi_set_log_level(log_level);
 
@@ -63,7 +67,7 @@ int __cdecl main(int argc, char** argv)
 	oprintf("-------------------------\n\n");
 	oprintf("Searching for known UPS...\n");
 
-	// Try to match against a plugged device
+	/* Try to match against a plugged device */
 	matching_device_found = false;
 	if (wdi_create_list(&ldev, &ocl) == WDI_SUCCESS) {
 		r = WDI_SUCCESS;
@@ -78,10 +82,14 @@ int __cdecl main(int argc, char** argv)
 			dev.driver = NULL;
 			dev.device_id = NULL;
 			dev.hardware_id = NULL;
-//			oprintf("NUT device : vid :  %0X - pid : %0X\n",dev.vid, dev.pid);
+/*
+			oprintf("NUT device : vid :  %0X - pid : %0X\n",dev.vid, dev.pid);
+*/
 
 			for (ldev = ldev_start; (ldev != NULL) && (r == WDI_SUCCESS); ldev = ldev->next) {
-//				oprintf("trying vid :  %0X - pid : %0X\n",ldev->vid, ldev->pid);
+/*
+				oprintf("trying vid :  %0X - pid : %0X\n",ldev->vid, ldev->pid);
+*/
 				if ( (ldev->vid == dev.vid) && (ldev->pid == dev.pid) && (ldev->mi == dev.mi) ) {
 					oprintf("Found UPS : vendor ID = %0X - Product ID = %0X\n",ldev->vid, ldev->pid, ldev->mi);
 					dev.hardware_id = ldev->hardware_id;
@@ -112,7 +120,7 @@ int __cdecl main(int argc, char** argv)
 		}
 	}
 
-	// No plugged USB device matches
+	/* No plugged USB device matches */
 	if (!matching_device_found) {
 		oprintf("No known UPS device found.\nTry installing libUSB manually.\nHit enter to continue\n");
 		getc(stdin);

--- a/server/conf.c
+++ b/server/conf.c
@@ -169,7 +169,7 @@ static int parse_upsd_conf_args(size_t numargs, char **arg)
 	/* DEBUG_MIN (NUM) */
 	/* debug_min (NUM) also acceptable, to be on par with ups.conf */
 	if (!strcasecmp(arg[0], "DEBUG_MIN")) {
-		int lvl = -1; // typeof common/common.c: int nut_debug_level
+		int lvl = -1; /* typeof common/common.c: int nut_debug_level */
 		if ( str_to_int (arg[1], &lvl, 10) && lvl >= 0 ) {
 			nut_debug_level_global = lvl;
 		} else {

--- a/server/netssl.c
+++ b/server/netssl.c
@@ -23,6 +23,9 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
+#include "config.h" /* must be the first header */
+#include "common.h" /* for upsdebugx() etc */
+
 #include <sys/types.h>
 #ifndef WIN32
 #include <netinet/in.h>

--- a/server/pipedebug.c
+++ b/server/pipedebug.c
@@ -53,14 +53,14 @@ static HANDLE pipe_connect(const char *pipefn)
 	}
 
 	fd = CreateFile(
-			pipename,       // pipe name
-			GENERIC_READ |  // read and write access
+			pipename,       /* pipe name */
+			GENERIC_READ |  /* read and write access */
 			GENERIC_WRITE,
-			0,              // no sharing
-			NULL,           // default security attributes FIXME
-			OPEN_EXISTING,  // opens existing pipe
-			FILE_FLAG_OVERLAPPED, //  enable async IO
-			NULL);          // no template file
+			0,              /* no sharing */
+			NULL,           /* default security attributes FIXME */
+			OPEN_EXISTING,  /* opens existing pipe */
+			FILE_FLAG_OVERLAPPED, /*  enable async IO */
+			NULL);          /* no template file */
 
 	if (fd == INVALID_HANDLE_VALUE) {
 		printf("CreateFile : %d\n",GetLastError());

--- a/server/sockdebug.c
+++ b/server/sockdebug.c
@@ -19,6 +19,7 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
+#include "common.h"
 
 #include <fcntl.h>
 #include <stdio.h>
@@ -28,7 +29,6 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 
-#include "common.h"
 #include "parseconf.h"
 #include "nut_stdint.h"
 

--- a/server/sstate.c
+++ b/server/sstate.c
@@ -278,14 +278,14 @@ TYPE_FD sstate_connect(upstype_t *ups)
 	}
 
 	fd = CreateFile(
-			pipename,   // pipe name
-			GENERIC_READ |  // read and write access
+			pipename,       /* pipe name */
+			GENERIC_READ |  /* read and write access */
 			GENERIC_WRITE,
-			0,              // no sharing
-			NULL,           // default security attributes FIXME
-			OPEN_EXISTING,  // opens existing pipe
-			FILE_FLAG_OVERLAPPED, //  enable async IO
-			NULL);          // no template file
+			0,              /* no sharing */
+			NULL,           /* default security attributes FIXME */
+			OPEN_EXISTING,  /* opens existing pipe */
+			FILE_FLAG_OVERLAPPED, /*  enable async IO */
+			NULL);          /* no template file */
 
 	if (fd == INVALID_HANDLE_VALUE) {
 		upslog_with_errno(LOG_ERR, "Can't connect to UPS [%s] (%s)", ups->name, ups->fn);

--- a/tests/generic_gpio_liblocal.c
+++ b/tests/generic_gpio_liblocal.c
@@ -75,6 +75,7 @@ void setNextLinesReadToFail(void) {
 int gpiod_line_get_value_bulk(struct gpiod_line_bulk *bulk,
 			      int *values)
 {
+	unsigned int	i;
 	int	pinPos = 1;
 	NUT_UNUSED_VARIABLE(bulk);
 
@@ -83,7 +84,7 @@ int gpiod_line_get_value_bulk(struct gpiod_line_bulk *bulk,
 		errno = EPERM;
 		return -1;
 	}
-	for(unsigned int i=0; i<num_lines; i++) {
+	for(i=0; i<num_lines; i++) {
 		values[i]=(gStatus&pinPos)!=0;
 		pinPos=pinPos<<1;
 	}

--- a/tests/generic_gpio_utest.c
+++ b/tests/generic_gpio_utest.c
@@ -389,4 +389,10 @@ int main(int argc, char **argv) {
 		cases_passed+cases_failed, cases_passed, cases_failed);
 	fclose(testData);
 	done = 1;
+
+	/* Return 0 (exit-code OK, boolean false) if no tests failed and some ran */
+	if ( (cases_failed == 0) && (cases_passed > 0) )
+		return 0;
+
+	return 1;
 }

--- a/tests/generic_gpio_utest.c
+++ b/tests/generic_gpio_utest.c
@@ -44,9 +44,11 @@ static int cases_failed;
 static char * pass_fail[2] = {"pass", "fail"};
 
 void getWithoutUnderscores(char *var) {
+	int i;
+
 	fEof=fscanf(testData, "%s", var);
-	for(int i=0; var[i]; i++) {
-		if(var[i]=='_') var[i]=' ';
+	for (i=0; var[i]; i++) {
+		if (var[i]=='_') var[i]=' ';
 	}
 }
 
@@ -237,8 +239,9 @@ int main(int argc, char **argv) {
 						printf("%s %s test rule %u [%s]\n", pass_fail[0], testType, i, rules);
 						cases_passed++;
 					} else {
+						int k;
 						printf("%s %s test rule %u [%s] %s", pass_fail[1], testType, i, rules, upsfdtest->rules[j]->stateName);
-						for(int k=0; k<upsfdtest->upsLinesCount; k++) {
+						for(k=0; k<upsfdtest->upsLinesCount; k++) {
 							printf(" %d", upsfdtest->upsLinesStates[k]);
 						}
 						printf("\n");


### PR DESCRIPTION
While our NUT CI matrix code allows to pick `-std=...` settings for `CFLAGS` and `CXXFLAGS`, it was found that builds launched allegedly in `c99`/`c++98` mode (or `gnu` equivalents) did not actually use that, and added flags for C11/C++11 (if supported by compiler) regardless.

This PR fixes the detection we have for caller-specified `-std=...` or `-ansi` to avoid slapping on another value, and some fallout of this change per CI findings.

NOTE: Builds in strict-C `-ansi` mode (aka `c89` and `c++98`) do not pass - unable to find many standard library methods and types in system headers (`snprintf`, `timespec` etc.) and complain about `//` comments that remain abundant in our codebase. So they are not a practical immediate goal. However, builds requested with `gnu89` and `gnu++98` modes (to whatever extent C++ would be or not be enabled in practice) should pass.