### PR TITLE
`drivers/cps-hid.c` et al: add support for Cyber Energy branded devices (by Cyber Power Systems)

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -169,6 +169,8 @@ https://github.com/networkupstools/nut/milestone/10
    * `arduino-hid` subdriver was enhanced from "initial bare bones" experimental
      set of mapped data points to support some 20 more mappings to make it more
      useful as an UPS driver, not just a controller developer sandbox. [#2188]
+   * `cps-hid` subdriver now supports devices branded as Cyber Energy and built
+     by cooperation with Cyber Power Systems. [#2312]
    * The `onlinedischarge` configuration flag name was too ambiguous and got
      deprecated (will be supported but no longer promoted by documentation),
      introducing `onlinedischarge_onbattery` as the meaningful alias. [#2213]

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -221,6 +221,8 @@
 
 "Crown"	"ups"	"2"	"CMU-SP1200IEC"	"USB"	"nutdrv_qx port=auto vendorid=0001 productid=0000 protocol=hunnox langid_fix=0x0409 novendor noscanlangid"	# https://github.com/networkupstools/nut/pull/638 caveats at https://github.com/networkupstools/nut/issues/1014
 
+"Cyber Energy"	"ups"	"3"	"Models with USB ID 0483:A430"	"USB"	"usbhid-ups"	# https://alioth-lists.debian.net/pipermail/nut-upsdev/2024-February/007966.html
+
 "Cyber Power Systems"	"ups"	"1"	"550SL"	""	"genericups upstype=7"
 "Cyber Power Systems"	"ups"	"1"	"725SL"	""	"genericups upstype=7"
 "Cyber Power Systems"	"ups"	"1"	"CPS1100AVR"	""	"powerpanel"

--- a/drivers/cps-hid.c
+++ b/drivers/cps-hid.c
@@ -3,7 +3,7 @@
  *  Copyright (C)
  *  2003 - 2008 Arnaud Quette <arnaud.quette@free.fr>
  *  2005 - 2006 Peter Selinger <selinger@users.sourceforge.net>
- *  2020 - 2022 Jim Klimov <jimklimov+nut@gmail.com>
+ *  2020 - 2024 Jim Klimov <jimklimov+nut@gmail.com>
  *
  *  Note: this subdriver was initially generated as a "stub" by the
  *  gen-usbhid-subdriver script. It must be customized.
@@ -31,10 +31,17 @@
 #include "cps-hid.h"
 #include "usb-common.h"
 
-#define CPS_HID_VERSION      "CyberPower HID 0.8"
+#define CPS_HID_VERSION      "CyberPower HID 0.80"
 
 /* Cyber Power Systems */
 #define CPS_VENDORID 0x0764
+
+/* ST Microelectronics */
+#define STMICRO_VENDORID	0x0483
+/* Please note that USB vendor ID 0x0483 is from ST Microelectronics -
+ * with actual product IDs delegated to different OEMs.
+ * Devices handled in this driver are marketed under Cyber Energy brand.
+ */
 
 /* Values for correcting the HID on some models
  * where LogMin and LogMax are set incorrectly in the HID.
@@ -72,6 +79,9 @@ static usb_device_id_t cps_usb_device_table[] = {
 	{ USB_DEVICE(CPS_VENDORID, 0x0501), &cps_battery_scale },
 	/* OR2200LCDRM2U, OR700LCDRM1U, PR6000LCDRTXL5U */
 	{ USB_DEVICE(CPS_VENDORID, 0x0601), NULL },
+
+	/* Cyber Energy branded devices by CPS */
+	{ USB_DEVICE(STMICRO_VENDORID, 0xa430), NULL },
 
 	/* Terminating entry */
 	{ 0, 0, NULL }

--- a/drivers/ever-hid.c
+++ b/drivers/ever-hid.c
@@ -41,6 +41,10 @@
 
 /* ST Microelectronics */
 #define STMICRO_VENDORID	0x0483
+/* Please note that USB vendor ID 0x0483 is from ST Microelectronics -
+ * with actual product IDs delegated to different OEMs.
+ * Devices handled in this driver are marketed under Ever brand.
+ */
 
 /* USB IDs device table */
 static usb_device_id_t ever_usb_device_table[] = {

--- a/scripts/upower/95-upower-hid.hwdb
+++ b/scripts/upower/95-upower-hid.hwdb
@@ -38,6 +38,7 @@ usb:v047CpFFFF*
 
 # ST Microelectronics
 usb:v0483pA113*
+usb:v0483pA430*
  UPOWER_BATTERY_TYPE=ups
  UPOWER_VENDOR=ST Microelectronics
 


### PR DESCRIPTION
Following up from https://alioth-lists.debian.net/pipermail/nut-upsdev/2024-February/007966.html - this PR adds support for VID:PID delegated to Cyber Energy:

> In the past, CyberPower UPS works well with NUT. Today, I want to use another VID/PID to fulfill ODM business rather than CyberPower brand UPS. My engineer will apply standard USB power device description like as CyberPower’s USB design. The only difference is VID/PID.

Note that the oficially registered vendor ID 0x0483 is for ST Microelectronics who then delegate certain product IDs to different OEMs.