### PR TITLE
Fix docs generation of ChangeLog (in out-of-tree builds)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -323,8 +323,10 @@ GITLOG_START_POINT=v2.6.0
 dummy-stamp:
 # Be sure to not confuse with a DIST'ed file (and try to overwrite it):
 ChangeLog: $(abs_top_builddir)/ChangeLog
+	+@$(MAKE) $(AM_MAKEFLAGS) $(abs_top_builddir)/ChangeLog
+
 $(abs_top_builddir)/ChangeLog: tools/gitlog2changelog.py dummy-stamp
-	cd $(abs_top_srcdir) && \
+	@cd $(abs_top_srcdir) && \
 	    if test -e .git ; then \
 	        CHANGELOG_FILE="$@" $(abs_top_builddir)/tools/gitlog2changelog.py $(GITLOG_START_POINT) || \
 	        { printf "gitlog2changelog.py failed to generate the ChangeLog.\n\nNOTE: See https://github.com/networkupstools/nut/commits/master for change history.\n\n" > "$@" ; } ; \

--- a/Makefile.am
+++ b/Makefile.am
@@ -331,7 +331,7 @@ $(abs_top_builddir)/ChangeLog: tools/gitlog2changelog.py dummy-stamp
 	        CHANGELOG_FILE="$@" $(abs_top_builddir)/tools/gitlog2changelog.py $(GITLOG_START_POINT) || \
 	        { printf "gitlog2changelog.py failed to generate the ChangeLog.\n\nNOTE: See https://github.com/networkupstools/nut/commits/master for change history.\n\n" > "$@" ; } ; \
 	    else \
-	        if x"$(abs_top_srcdir)" != x"$(abs_top_builddir)" -a -s ./ChangeLog ; then \
+	        if test x"$(abs_top_srcdir)" != x"$(abs_top_builddir)" -a -s ./ChangeLog ; then \
 	            echo "Using distributed ChangeLog file from sources" >&2 ; \
 	            rm -f "$@" || true ; \
 	            cat ./ChangeLog > "$@" ; \

--- a/Makefile.am
+++ b/Makefile.am
@@ -321,10 +321,10 @@ GITLOG_START_POINT=v2.6.0
 # the current dir, and defaults to generate a "ChangeLog" in the current dir.
 # The script itself is generated from a template, so resides in builddir.
 dummy-stamp:
-# Be sure to not confuse with a DIST'ed file (and try to overwrite it):
-ChangeLog: $(abs_top_builddir)/ChangeLog
+ChangeLog: dummy-stamp
 	+@$(MAKE) $(AM_MAKEFLAGS) $(abs_top_builddir)/ChangeLog
 
+# Be sure to not confuse with a DIST'ed file (and so try to overwrite it):
 $(abs_top_builddir)/ChangeLog: tools/gitlog2changelog.py dummy-stamp
 	@cd $(abs_top_srcdir) && \
 	    if test -e .git ; then \

--- a/Makefile.am
+++ b/Makefile.am
@@ -321,14 +321,22 @@ GITLOG_START_POINT=v2.6.0
 # the current dir, and defaults to generate a "ChangeLog" in the current dir.
 # The script itself is generated from a template, so resides in builddir.
 dummy-stamp:
-ChangeLog: tools/gitlog2changelog.py dummy-stamp
+# Be sure to not confuse with a DIST'ed file (and try to overwrite it):
+ChangeLog: $(abs_top_builddir)/ChangeLog
+$(abs_top_builddir)/ChangeLog: tools/gitlog2changelog.py dummy-stamp
 	cd $(abs_top_srcdir) && \
 	    if test -e .git ; then \
 	        CHANGELOG_FILE="$@" $(abs_top_builddir)/tools/gitlog2changelog.py $(GITLOG_START_POINT) || \
 	        { printf "gitlog2changelog.py failed to generate the ChangeLog.\n\nNOTE: See https://github.com/networkupstools/nut/commits/master for change history.\n\n" > "$@" ; } ; \
 	    else \
-	        if ! test -s "$@" ; then \
-	            printf "Failed to generate the ChangeLog.\n\nNOTE: See https://github.com/networkupstools/nut/commits/master for change history.\n\n" > "$@" ; \
+	        if x"$(abs_top_srcdir)" != x"$(abs_top_builddir)" -a -s ./ChangeLog ; then \
+	            echo "Using distributed ChangeLog file from sources" >&2 ; \
+	            rm -f "$@" || true ; \
+	            cat ./ChangeLog > "$@" ; \
+	        else \
+	            if ! test -s "$@" ; then \
+	                printf "Failed to generate the ChangeLog.\n\nNOTE: See https://github.com/networkupstools/nut/commits/master for change history.\n\n" > "$@" ; \
+	            fi ; \
 	        fi ; \
 	    fi
 

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -240,7 +240,7 @@ $(top_builddir)/ChangeLog.adoc: $(top_builddir)/ChangeLog
 	 || { \
 	     MSG="FAILED to resolve input or output filename with this make implementation, or input was not generated!"; \
 	     echo "  DOC-CHANGELOG-ASCIIDOC	SKIP: $${MSG}" >&2; \
-	     test -n "$@" && echo "$${MSG}" > "$@" ; \
+	     test -n "$@" && { printf '=== Failed to generate the ChangeLog\n\n%s\n\nNOTE: See https://github.com/networkupstools/nut/commits/master for change history.\n\n' "$${MSG}" > "$@" ; } ; \
 	     exit ; \
 	 } ; \
 	 echo "  DOC-CHANGELOG-ASCIIDOC	$${INPUT} => $@" \


### PR DESCRIPTION
Follow up from #2318 work: on at least OpenBSD, the existing recipe was all but skipped, so no `ChangeLog` appeared in the builddir and ultimately no `adoc` and `html` products from it.