### PR TITLE
`configure.ac`: revise detection of `LN_S_R` method applicable for the build (out-of-tree concerns)

### DIFF
--- a/ci_build.sh
+++ b/ci_build.sh
@@ -585,7 +585,12 @@ build_to_only_catch_errors_target() {
         default)
           $CI_TIME $MAKE -k $PARMAKE_FLAGS "$@" ;;
       esac ) && echo "`date`: SUCCESS" ; ) || \
-    ( echo "`date`: Starting the sequential build attempt (to list remaining files with errors considered fatal for this build configuration) for '$@'..."; \
+    ( RET=$?
+      if [ "$CI_FAILFAST" = true ]; then
+        echo "===== Aborting after parallel build attempt failure for '$*' because CI_FAILFAST=$CI_FAILFAST" >&2
+        exit $RET
+      fi
+      echo "`date`: Starting the sequential build attempt (to list remaining files with errors considered fatal for this build configuration) for '$@'..."; \
       $CI_TIME $MAKE $MAKE_FLAGS_VERBOSE "$@" -k ) || return $?
     return 0
 }

--- a/configure.ac
+++ b/configure.ac
@@ -1108,13 +1108,32 @@ AC_MSG_CHECKING([whether ln -sr works])
 dnl We need to relative-symlink some files. Or hardlink. Or copy...
 LN_S_R="cp -pR"
 if test "$as_ln_s" = "ln -s" ; then
-    LN_S_R="ln"
+    _abs_srcdir="`cd "${srcdir}" && pwd`" || _abs_srcdir=""
+    _abs_builddir="`pwd`"
+    dnl AC_MSG_NOTICE([srcdir='${srcdir}' _abs_srcdir='${_abs_srcdir}' _abs_builddir='${_abs_builddir}'])
+    if test x"${_abs_srcdir}" = x"${_abs_builddir}" ; then
+        LN_S_R="ln"
+    else
+        _fs_srcdir="`df "${_abs_srcdir}" | tail -1 | awk '{print $1}'`" || fs_srcdir="XXXs"
+        _fs_builddir="`df "${_abs_builddir}" | tail -1 | awk '{print $1}'`" || fs_builddir="XXXb"
+        dnl AC_MSG_NOTICE([_fs_srcdir='${_fs_srcdir}' _fs_builddir='${_fs_builddir}'])
+        if test x"${_fs_srcdir}" = x"${_fs_builddir}" ; then
+            LN_S_R="ln"
+        fi
+        dnl ELSE Source and build areas are in different filesystems,
+        dnl can not hardlink - keep copying approach in place
+        unset _fs_srcdir _fs_builddir
+    fi
+    unset _abs_srcdir _abs_builddir
+
+    dnl Explore GNU ln (or compatible) with relative symlink support
     DIR1="$(mktemp -d "dir1.XXXXXXX")" && \
     DIR2="$(mktemp -d "dir2.XXXXXXX")" && \
     touch "${DIR1}/a" && \
     $as_ln_s -r "${DIR1}/a" "${DIR2}/b" && \
     ls -la "${DIR2}/b" | grep '\.\./' > /dev/null && \
     LN_S_R="$as_ln_s -r"
+
     rm -rf "${DIR1}" "${DIR2}"
 fi
 AC_SUBST([LN_S_R], [${LN_S_R}])

--- a/configure.ac
+++ b/configure.ac
@@ -1119,9 +1119,11 @@ if test "$as_ln_s" = "ln -s" ; then
         dnl AC_MSG_NOTICE([_fs_srcdir='${_fs_srcdir}' _fs_builddir='${_fs_builddir}'])
         if test x"${_fs_srcdir}" = x"${_fs_builddir}" ; then
             LN_S_R="ln"
+        else
+            dnl Source and build areas are in different filesystems,
+            dnl can not hardlink - keep copying approach in place
+            AC_MSG_NOTICE([Source and build areas are in different filesystems, or we could not detect this for sure - avoiding hardlinks])
         fi
-        dnl ELSE Source and build areas are in different filesystems,
-        dnl can not hardlink - keep copying approach in place
         unset _fs_srcdir _fs_builddir
     fi
     unset _abs_srcdir _abs_builddir


### PR DESCRIPTION
In some build recipes we use symbolic- or hard-linking of files (e.g. DIST'ed resources) and originally had a fallback to `ln` if relative `ln -s -r` was not available. This fallback did not work when source and build areas (the most typical use-cases) are on different filesystems (e.g. under `/home` and `/tmp`) - with this PR, fall back to full copy would be used instead.

Follows up from #2318 work.

NOTES:
* This macro is not actually used in current Makefiles of the `master` branch so far, but perhaps should be (especially for other out-of-tree concerns, like that with text sources for docs per #2318). It is used in DMF/FTY branches that slowly converge towards getting upstreamed, however. And now that a deficiency in the macro already present in the main codebase is known, fixing it is prudent anyway.
* TODO: Consider `install-sh` like autotools does for some cases?

UPDATE: Also added `CI_FAILFAST` support for `ci_build.sh` part about building in parallel and retrying sequentially upon failures. Unrelated, but won't hurt to pass through CI in one shot :)