### PR TITLE
Correct access method used for flag battery_voltage_reports_one_pack

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -187,6 +187,11 @@ https://github.com/networkupstools/nut/milestone/10
        is not reported by the device (should be frequent by default, in case
        the UPS-reported state combination does reflect a bad power condition).
 
+ - nutdrv_qx driver:
+   * Fixed handling of `battery_voltage_reports_one_pack` configuration flag
+     introduced in NUT v2.8.1. [originally by PR #1279; fixed by PR #2324,
+     issue #2325]
+
  - Various code and documentation fixes for NSS crypto support. [#2274, #2268]
 
  - Laid foundations for the SmartNUT effort (aiming to integrate drivers with

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -370,8 +370,7 @@ static void	qx_initbattery(void)
 		batt_packs_known = 1;
 	}
 
-	val = getval("battery_voltage_reports_one_pack");
-	if (val) {
+	if (testvar("battery_voltage_reports_one_pack")) {
 		battery_voltage_reports_one_pack = 1;
 		/* If we already have a battery.voltage reading from the device,
 		 * it is not yet "adjusted" to consider the multiplication for


### PR DESCRIPTION
The current code uses getval() to examine the setting of `battery_voltage_reports_one_pack`. However, since `battery_voltage_reports_one_pack` is a flag rather than a variable, getval() will always return null. Function testvar() must be used instead.

Closes: #2325