### PR TITLE
Shell shebang

### DIFF
--- a/indent.sh
+++ b/indent.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Filter NUT C source file style to conform to recommendations of
 # https://www.networkupstools.org/docs/developer-guide.chunked/ar01s03.html#_coding_style

--- a/scripts/HP-UX/makedepot.sh
+++ b/scripts/HP-UX/makedepot.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -x
 

--- a/scripts/HP-UX/makedepot.sh
+++ b/scripts/HP-UX/makedepot.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -x 
+set -x
 
 CUR_DIR=$(pwd)
 TOP_DIR=$CUR_DIR/../..
@@ -26,5 +26,4 @@ cd $CUR_DIR
 swpackage -s nut.psf -d $CUR_DIR/nut.depot; \
 #tar cvf nut.depot.tar nut.depot
 #gzip nut.depot.tar
-echo "Execution completed" 
-
+echo "Execution completed"

--- a/scripts/Windows/build-mingw-nut.sh
+++ b/scripts/Windows/build-mingw-nut.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # NOTE: bash syntax (non-POSIX script) is used below!
 #

--- a/scripts/installer/make_package.sh
+++ b/scripts/installer/make_package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #	make_package.sh
 #	Copyright (c) 2013-2015, by Eaton (R) Corporation. All rights reserved.

--- a/scripts/subdriver/gen-snmp-subdriver.sh
+++ b/scripts/subdriver/gen-snmp-subdriver.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # an auxiliary script to produce a "stub" snmp-ups subdriver from
 # SNMP data from a real agent or from dump files

--- a/scripts/subdriver/gen-usbhid-subdriver.sh
+++ b/scripts/subdriver/gen-usbhid-subdriver.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # an auxiliary script to produce a "stub" usbhid-ups subdriver from
 # the output of


### PR DESCRIPTION
Fix the way we refer to `bash` where it is needed.