### PR TITLE
Fix recipes for openbsd

### DIFF
--- a/docs/config-prereqs.txt
+++ b/docs/config-prereqs.txt
@@ -798,9 +798,9 @@ default site.
 
 # NOTE: For python, you may eventually have to specify a variant like this
 # (numbers depending on default or additional packages of your distro):
-#   :; pkg_add python-2.7.15p0
+#   :; pkg_add python-2.7.15p0 py-pip
 # and/or:
-#   :; pkg_add python-3.6.6p1
+#   :; pkg_add python-3.6.6p1 py3-pip
 # although you might succeed specifying shorter names and the packager
 # will offer a list of matching variants (as it does for "python" above).
 # NOTE: "perl" is not currently a package, but seemingly part of base OS.

--- a/m4/nut_check_libltdl.m4
+++ b/m4/nut_check_libltdl.m4
@@ -50,12 +50,19 @@ if test -z "${nut_have_libltdl_seen}"; then
 	], [])dnl No fallback here - we probe suitable libs below
 	AC_MSG_RESULT([${LIBS}])
 
-	AC_CHECK_HEADERS(ltdl.h, [nut_have_libltdl=yes], [nut_have_libltdl=no], [AC_INCLUDES_DEFAULT])
+	AC_CHECK_HEADERS(ltdl.h, [nut_have_libltdl=yes], [
+		dnl Double-check if we stashed include paths to try above
+		AS_IF([test -n "$myCFLAGS"], [
+			CFLAGS="$myCFLAGS"
+			AS_UNSET([ac_cv_header_ltdl_h])
+			AC_CHECK_HEADERS(ltdl.h, [nut_have_libltdl=yes], [nut_have_libltdl=no], [AC_INCLUDES_DEFAULT])
+			],[nut_have_libltdl=no]
+		)], [AC_INCLUDES_DEFAULT])
 	AS_IF([test x"$nut_have_libltdl" = xyes], [
 		dnl ltdl-number may help find it for MingW DLLs naming
 		AC_SEARCH_LIBS(lt_dlinit, ltdl ltdl-7, [], [
 			nut_have_libltdl=no
-			AS_IF([test -n "$myCFLAGS"], [
+			AS_IF([test -n "$myCFLAGS" -a x"$myCFLAGS" != x"$CFLAGS"], [
 				CFLAGS="$myCFLAGS"
 				dnl No ltdl-7 here, this codepath is unlikely on Windows where that matters:
 				AC_SEARCH_LIBS(lt_dlinit, ltdl, [nut_have_libltdl=yes], [])


### PR DESCRIPTION
NUT failed to detect `libltdl` and so build `nut-scanner` on OpenBSD; now it should.