### PR TITLE
docs/Makefile.am: reminder about missing dictionary when aspell is unavailable

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -597,11 +597,11 @@ spellcheck-interactive:
 else !HAVE_ASPELL
 # This rule woulf probably just fail; normally with no ASPELL there are no callers for it
 */*-spellchecked *-spellchecked: Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
-	@echo "  SKIP-ASPELL   $@ : Documentation spell check not available since 'aspell' was not found." >&2
+	@echo "  SKIP-ASPELL   $@ : Documentation spell check not available since 'aspell' was not found (or missing its English dictionary)." >&2
 spellcheck:
-	@echo "Documentation spell check not available since 'aspell' was not found."
+	@echo "Documentation spell check not available since 'aspell' was not found (or missing its English dictionary)."
 spellcheck-interactive:
-	@echo "Documentation spell check not available since 'aspell' was not found."
+	@echo "Documentation spell check not available since 'aspell' was not found (or missing its English dictionary)."
 endif !HAVE_ASPELL
 
 

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -595,7 +595,7 @@ spellcheck-interactive:
 	 echo "------------------------------------------------------------------------"
 
 else !HAVE_ASPELL
-# This rule woulf probably just fail; normally with no ASPELL there are no callers for it
+# This rule would probably just fail; normally with no ASPELL there are no callers for it
 */*-spellchecked *-spellchecked: Makefile.am $(abs_srcdir)/$(NUT_SPELL_DICT)
 	@echo "  SKIP-ASPELL   $@ : Documentation spell check not available since 'aspell' was not found (or missing its English dictionary)." >&2
 spellcheck:


### PR DESCRIPTION
When aspell is not unavailable, the cause can either be that aspell itself is not installed, or it has no English dictionary (`aspell-en`). I've wasted several minutes today due to this oversight. Add this reminder in the error message to give clue to future developers.
