### PR TITLE
Fix `nut-scanner` caveats about USB optional fields and simulation file discovery

### DIFF
--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -239,7 +239,8 @@ static void show_usage(void)
 	printf("  -C, --complete_scan: Scan all available devices except serial ports (default).\n");
 	if (nutscan_avail_usb) {
 		printf("  -U, --usb_scan: Scan USB devices. Specify twice or more to report different\n"
-			"                  detail levels of (change-prone) physical properties.\n");
+			"                  detail levels of (change-prone) physical properties.\n"
+			"                  This usage can be combined with '-C' or other scan types.\n");
 	} else {
 		printf("* Options for USB devices scan not enabled: library not detected.\n");
 	}
@@ -683,7 +684,8 @@ int main(int argc, char *argv[])
 					goto display_help;
 				}
 				allow_usb = 1;
-				/* NOTE: Starts as -1, so the first -U sets it to 0 (minimal detail) */
+				/* NOTE: Starts as -1, so the first -U sets it to 0
+				 * (minimal detail); further -U can bump it */
 				if (cli_link_detail_level < 3)
 					cli_link_detail_level++;
 				break;
@@ -809,6 +811,11 @@ display_help:
 
 	if (allow_all) {
 		allow_usb = 1;
+		/* NOTE: Starts as -1, so when we scan everything - set
+		 * it to 0 (minimal detail); further -U can bump it */
+		if (cli_link_detail_level < 0)
+			cli_link_detail_level++;
+
 		allow_snmp = 1;
 		allow_xml = 1;
 		allow_oldnut = 1;

--- a/tools/nut-scanner/scan_nut_simulation.c
+++ b/tools/nut-scanner/scan_nut_simulation.c
@@ -45,10 +45,13 @@ nutscan_device_t * nutscan_scan_nut_simulation(void)
 	pthread_mutex_init(&dev_mutex, NULL);
 #endif /* HAVE_PTHREAD */
 
-	upsdebugx(1,"Scanning: %s", CONFPATH);
+	upsdebugx(1, "Scanning: %s", CONFPATH);
 
 	if ((dp = opendir(CONFPATH)) == NULL) {
-		fatal_with_errno(EXIT_FAILURE, "Failed to open %s", CONFPATH);
+		upsdebugx(1, "%s: Failed to open %s: %s (%d)",
+			__func__, CONFPATH, strerror(errno), errno);
+		upsdebugx(0, "Failed to open %s, skip NUT simulation scan",
+			CONFPATH);
 		return NULL;
 	}
 
@@ -63,7 +66,7 @@ nutscan_device_t * nutscan_scan_nut_simulation(void)
 
 		/* Filter on '.dev' and '.seq' extensions' */
 		if ((strcmp(ext, ".dev") == 0) || (strcmp(ext, ".seq") == 0)) {
-			upsdebugx(1,"Found simulation file: %s", dirp->d_name);
+			upsdebugx(1, "Found simulation file: %s", dirp->d_name);
 
 			dev = nutscan_new_device();
 			dev->type = TYPE_NUT_SIMULATION;


### PR DESCRIPTION
Closes: #2334
Closes: #2335

CC @aquette @desertwitch 