### PR TITLE
.github/workflows/codeql.yml: make a CodeQL matrix…

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -75,7 +75,7 @@ jobs:
     - if: matrix.language == 'cpp'
       name: NUT CI Build (default-all-errors matrix)
       run: |
-        BUILD_TYPE=default-all-errors ${{ matrix.compiler }} NUT_SSL_VARIANTS=${{ matrix.NUT_SSL_VARIANTS }} NUT_USB_VARIANTS=${{ matrix.NUT_USB_VARIANTS }} ./ci_build.sh
+        BUILD_TYPE=default-all-errors BUILD_SSL_ONCE=true DO_DISTCHECK=no CI_SKIP_CHECK=true CANBUILD_DOCS_ALL=no ${{ matrix.compiler }} NUT_SSL_VARIANTS=${{ matrix.NUT_SSL_VARIANTS }} NUT_USB_VARIANTS=${{ matrix.NUT_USB_VARIANTS }} ./ci_build.sh
 
     #- if: matrix.language == 'cpp'
     #  name: NUT CI Build (fightwarn-all)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'cpp', 'python' ]
+        # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs
+        language: [ 'cpp' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
         os: ['ubuntu-latest']
@@ -40,6 +41,13 @@ jobs:
         compiler: ['CC=gcc CXX=g++', 'CC=clang CXX=clang++']
         NUT_SSL_VARIANTS: ['no', 'nss', 'openssl']
         NUT_USB_VARIANTS: ['no', '1.0', '0.1']
+        include:
+          # Add cell(s) to the matrix, beside the combinatorics made above
+          - language: 'python'
+            os: 'ubuntu-latest'
+            compiler: 'PYTHON=python3'
+            NUT_SSL_VARIANTS: 'no'
+            NUT_USB_VARIANTS: 'no'
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,7 +40,7 @@ jobs:
         # TOTHINK: windows-latest, macos-latest
         compiler: ['CC=gcc CXX=g++', 'CC=clang CXX=clang++']
         NUT_SSL_VARIANTS: ['no', 'nss', 'openssl']
-        NUT_USB_VARIANTS: ['no', '1.0', '0.1']
+        NUT_USB_VARIANTS: ['no', 'libusb-1.0', 'libusb-0.1']
         include:
           # Add cell(s) to the matrix, beside the combinatorics made above
           - language: 'python'
@@ -80,22 +80,25 @@ jobs:
     #- name: Autobuild
     #  uses: github/codeql-action/autobuild@v3
 
-    - if: matrix.language == 'cpp'
-      name: NUT CI Build (default-all-errors matrix)
-      run: |
-        BUILD_TYPE=default-all-errors BUILD_SSL_ONCE=true DO_DISTCHECK=no CI_SKIP_CHECK=true CANBUILD_DOCS_ALL=no ${{ matrix.compiler }} NUT_SSL_VARIANTS=${{ matrix.NUT_SSL_VARIANTS }} NUT_USB_VARIANTS=${{ matrix.NUT_USB_VARIANTS }} ./ci_build.sh
+    #- if: matrix.language == 'cpp'
+    #  name: NUT CI Build (default-all-errors matrix)
+    #  run: |
+    #    BUILD_TYPE=default-all-errors BUILD_SSL_ONCE=true DO_DISTCHECK=no CI_SKIP_CHECK=true CANBUILD_DOCS_ALL=no ${{ matrix.compiler }} NUT_SSL_VARIANTS=${{ matrix.NUT_SSL_VARIANTS }} NUT_USB_VARIANTS=${{ matrix.NUT_USB_VARIANTS }} ./ci_build.sh
 
     #- if: matrix.language == 'cpp'
     #  name: NUT CI Build (fightwarn-all)
     #  run: |
     #    BUILD_TYPE=fightwarn-all ./ci_build.sh
 
-    #- if: matrix.language == 'x-cpp'
-    #  name: NUT CI Build
-    #  run: |
-    #    ./autogen.sh
-    #    ./configure --with-all=auto --with-dev --without-docs
-    #    make -j 8
+    # TOTHINK: Can we prepare the working area once (apt, autogen => containers?)
+    # and then spread it out for builds and analyses?
+    # Can ccache be used across builds?
+    - if: matrix.language == 'cpp'
+      name: NUT CI Build
+      run: |
+        ./autogen.sh
+        ./configure --enable-warnings --enable-Werror --enable-Wcolor --with-all=auto --with-dev --without-docs ${{matrix.compiler}} --with-ssl=${{matrix.NUT_SSL_VARIANTS}} --with-usb=${{matrix.NUT_USB_VARIANTS}}
+        make -s -j 8
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,6 +37,9 @@ jobs:
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
         os: ['ubuntu-latest']
         # TOTHINK: windows-latest, macos-latest
+        compiler: ['CC=gcc CXX=g++', 'CC=clang CXX=clang++']
+        NUT_SSL_VARIANTS: ['no', 'nss', 'openssl']
+        NUT_USB_VARIANTS: ['no', '1.0', '0.1']
 
     steps:
     - name: Checkout repository
@@ -70,9 +73,14 @@ jobs:
     #  uses: github/codeql-action/autobuild@v3
 
     - if: matrix.language == 'cpp'
-      name: NUT CI Build (fightwarn-all)
+      name: NUT CI Build (default-all-errors matrix)
       run: |
-        BUILD_TYPE=fightwarn-all ./ci_build.sh
+        BUILD_TYPE=default-all-errors ${{ matrix.compiler }} NUT_SSL_VARIANTS=${{ matrix.NUT_SSL_VARIANTS }} NUT_USB_VARIANTS=${{ matrix.NUT_USB_VARIANTS }} ./ci_build.sh
+
+    #- if: matrix.language == 'cpp'
+    #  name: NUT CI Build (fightwarn-all)
+    #  run: |
+    #    BUILD_TYPE=fightwarn-all ./ci_build.sh
 
     #- if: matrix.language == 'x-cpp'
     #  name: NUT CI Build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -71,9 +71,8 @@ jobs:
       name: NUT CI Prerequisite packages (Ubuntu)
       run: |
         sudo apt update
-        sudo apt install libltdl-dev libtool libtool-bin cppcheck gcc g++ clang ccache
-        sudo apt install libgd-dev libcppunit-dev libsystemd-dev libssl-dev libnss3-dev augeas-tools libaugeas-dev augeas-lenses libusb-dev libusb-1.0-0-dev libi2c-dev libmodbus-dev libsnmp-dev libpowerman0-dev libfreeipmi-dev libipmimonitoring-dev libavahi-common-dev libavahi-core-dev libavahi-client-dev libgpiod-dev
-        sudo apt install libi2c-dev i2c-tools lm-sensors || true
+        case x"${{matrix.compiler}}" in x*clang*) sudo apt install clang ;; x*) sudo apt install gcc g++ ;; esac
+        sudo apt install libltdl-dev libtool libtool-bin cppcheck ccache libgd-dev libcppunit-dev libsystemd-dev libssl-dev libnss3-dev augeas-tools libaugeas-dev augeas-lenses libusb-dev libusb-1.0-0-dev libmodbus-dev libsnmp-dev libpowerman0-dev libfreeipmi-dev libipmimonitoring-dev libavahi-common-dev libavahi-core-dev libavahi-client-dev libgpiod-dev libneon27-dev libi2c-dev i2c-tools lm-sensors
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)


### PR DESCRIPTION
… of compiler/NUT_SSL_VARIANTS/NUT_USB_VARIANTS instead of single fightwarn-all

Follow-up to #1726 and #2250

...if arbitrary matrix labels would work