### PR TITLE
feat: Add support for Liebert PSI5

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -180,6 +180,9 @@ https://github.com/networkupstools/nut/milestone/10
      useful as an UPS driver, not just a controller developer sandbox. [#2188]
    * `cps-hid` subdriver now supports devices branded as Cyber Energy and built
      by cooperation with Cyber Power Systems. [#2312]
+   * `belkin-hid` subdriver now supports Liebert PSI5 devices which have a
+     different numeric reading scale than earlier handled models. [issue #2271,
+     PR #2272, PR #2369]
    * The `onlinedischarge` configuration flag name was too ambiguous and got
      deprecated (will be supported but no longer promoted by documentation),
      introducing `onlinedischarge_onbattery` as the meaningful alias. [#2213]

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -555,6 +555,22 @@ info_lkp_t divide_by_10_conversion[] = {
 
 /* returns statically allocated string - must not use it again before
    done with result! */
+static const char *divide_by_100_conversion_fun(double value)
+{
+       static char buf[20];
+
+       snprintf(buf, sizeof(buf), "%0.1f", value * 0.01);
+
+       return buf;
+}
+
+/* FIXME? Do we need an inverse "nuf()" here? */
+info_lkp_t divide_by_100_conversion[] = {
+       { 0, NULL, divide_by_100_conversion_fun, NULL }
+};
+
+/* returns statically allocated string - must not use it again before
+   done with result! */
 static const char *kelvin_celsius_conversion_fun(double value)
 {
 	static char buf[20];
@@ -997,7 +1013,7 @@ void upsdrv_makevartable(void)
 
 	addvar(VAR_VALUE, "onlinedischarge_log_throttle_hovercharge",
 		"Set to throttle log messages about discharging while online (only if battery.charge is under this value)");
-	
+
 	addvar(VAR_FLAG, "disable_fix_report_desc",
 		"Set to disable fix-ups for broken USB encoding, etc. which we apply by default on certain vendors/products");
 

--- a/drivers/usbhid-ups.h
+++ b/drivers/usbhid-ups.h
@@ -122,6 +122,7 @@ extern info_lkp_t date_conversion[];
 extern info_lkp_t hex_conversion[];
 extern info_lkp_t stringid_conversion[];
 extern info_lkp_t divide_by_10_conversion[];
+extern info_lkp_t divide_by_100_conversion[];
 extern info_lkp_t kelvin_celsius_conversion[];
 
 /* ---------------------------------------------------------------------- */


### PR DESCRIPTION
Adding support for the Liebert PSI5 model of UPS, as discussed in #2271 initially.

Maybe addresses similar complaints posted in #2024 

Closes: #2271