### PR TITLE
Unit-test and fix the Belkin/Liebert HID UPS exponents math

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -182,7 +182,9 @@ https://github.com/networkupstools/nut/milestone/10
      by cooperation with Cyber Power Systems. [#2312]
    * `belkin-hid` subdriver now supports Liebert PSI5 devices which have a
      different numeric reading scale than earlier handled models. [issue #2271,
-     PR #2272, PR #2369]
+     PR #2272, PR #2369] Generally the wrong-scale processing was addressed,
+     including a regression in NUT v2.8.0 which led to zero values
+     in voltage data points which NUT v2.7.4 reported well [#2371]
    * The `onlinedischarge` configuration flag name was too ambiguous and got
      deprecated (will be supported but no longer promoted by documentation),
      introducing `onlinedischarge_onbattery` as the meaningful alias. [#2213]

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -87,6 +87,10 @@ https://github.com/networkupstools/nut/milestone/10
      `configure` script option `--with-debuginfo`. Note that default autoconf
      behavior usually embeds moderate optimizations and debug information on
      its own. [PR #2310]
+   * A fix applied among clean-ups between NUT v2.7.4 and v2.8.0 releases
+     backfired for `usbhid-ups` subdriver `belkin-hid` which in practice
+     relied on the broken older behavior; more details in its entry below.
+     [PR #2371]
 
  - nut-usbinfo.pl, nut-scanner and libnutscan:
    * Library API version for `libnutscan` was bumped from 2.2.0 to 2.5.0

--- a/drivers/belkin-hid.c
+++ b/drivers/belkin-hid.c
@@ -33,7 +33,7 @@
 
 #include <math.h>     /* for fabs() */
 
-#define BELKIN_HID_VERSION      "Belkin/Liebert HID 0.21"
+#define BELKIN_HID_VERSION      "Belkin/Liebert HID 0.20"
 
 /* Belkin */
 #define BELKIN_VENDORID	0x050d
@@ -94,15 +94,13 @@ static const char *liebert_shutdownimm_fun(double value);
 /* These lookup functions also cover the 1e-7 factor which seems to
  * be due to a broken report descriptor in certain Liebert units.
  * Exposed for unit testing - not "static" */
-const char *liebert_config_voltage_fun(double value);
-const char *liebert_line_voltage_fun(double value);
-const char *liebert_psi5_line_voltage_fun(double value);
+static const char *liebert_config_voltage_fun(double value);
+static const char *liebert_line_voltage_fun(double value);
+static const char *liebert_psi5_line_voltage_fun(double value);
 
-extern double liebert_config_voltage_mult, liebert_line_voltage_mult;
-double liebert_config_voltage_mult = 1.0;
-double liebert_line_voltage_mult = 1.0;
+static double liebert_config_voltage_mult = 1.0;
+static double liebert_line_voltage_mult = 1.0;
 static char liebert_conversion_buf[10];
-
 
 static info_lkp_t liebert_online_info[] = {
 	{ 0, NULL, liebert_online_fun, NULL }
@@ -174,7 +172,7 @@ static const char *liebert_shutdownimm_fun(double value)
  * Logic is weird since the ConfigVoltage item comes after InputVoltage and
  * OutputVoltage.
  */
-const char *liebert_config_voltage_fun(double value)
+static const char *liebert_config_voltage_fun(double value)
 {
 	if( value < 1 ) {
 		if( fabs(value - 1e-7) < 1e-9 ) {
@@ -192,7 +190,7 @@ const char *liebert_config_voltage_fun(double value)
 	return liebert_conversion_buf;
 }
 
-const char *liebert_line_voltage_fun(double value)
+static const char *liebert_line_voltage_fun(double value)
 {
 	if( value < 1 ) {
 		if( fabs(value - 1e-7) < 1e-9 ) {
@@ -209,7 +207,7 @@ const char *liebert_line_voltage_fun(double value)
 	return liebert_conversion_buf;
 }
 
-const char *liebert_psi5_line_voltage_fun(double value)
+static const char *liebert_psi5_line_voltage_fun(double value)
 {
 	if( value < 1 ) {
 		if( fabs(value - 1e-3) < 1e-3 ) {

--- a/drivers/belkin-hid.c
+++ b/drivers/belkin-hid.c
@@ -3,7 +3,8 @@
  *  Copyright (C)
  *  2003 - 2008 Arnaud Quette <arnaud.quette@free.fr>
  *  2005        Peter Selinger <selinger@users.sourceforge.net>
- *  2011, 2014  Charles Lepple <clepple+nut@gmail>
+ *  2011, 2014  Charles Lepple <clepple+nut@gmail.com>
+ *  2024        James R. Parks <jrjparks@zathera.com>
  *
  *  Sponsored by MGE UPS SYSTEMS <http://www.mgeups.com>
  *

--- a/drivers/belkin-hid.c
+++ b/drivers/belkin-hid.c
@@ -98,23 +98,23 @@ static info_lkp_t liebert_online_info[] = {
 };
 
 static info_lkp_t liebert_discharging_info[] = {
-        { 0, NULL, liebert_discharging_fun, NULL }
+	{ 0, NULL, liebert_discharging_fun, NULL }
 };
 
 static info_lkp_t liebert_charging_info[] = {
-        { 0, NULL, liebert_charging_fun, NULL }
+	{ 0, NULL, liebert_charging_fun, NULL }
 };
 
 static info_lkp_t liebert_lowbatt_info[] = {
-        { 0, NULL, liebert_lowbatt_fun, NULL }
+	{ 0, NULL, liebert_lowbatt_fun, NULL }
 };
 
 static info_lkp_t liebert_replacebatt_info[] = {
-        { 0, NULL, liebert_replacebatt_fun, NULL }
+	{ 0, NULL, liebert_replacebatt_fun, NULL }
 };
 
 static info_lkp_t liebert_shutdownimm_info[] = {
-        { 0, NULL, liebert_shutdownimm_fun, NULL }
+	{ 0, NULL, liebert_shutdownimm_fun, NULL }
 };
 
 static info_lkp_t liebert_config_voltage_info[] = {

--- a/drivers/belkin-hid.c
+++ b/drivers/belkin-hid.c
@@ -174,8 +174,13 @@ static const char *liebert_shutdownimm_fun(double value)
  */
 static const char *liebert_config_voltage_fun(double value)
 {
-	if( value < 1 ) {
-		if( fabs(value - 1e-7) < 1e-9 ) {
+	/* Does not fire with devices seen diring investigation for
+	 *   https://github.com/networkupstools/nut/issues/2370
+	 * as the ones seen serve nominal "config" values as integers
+	 * (e.g. "230" for line and "24" for battery).
+	 */
+	if (value < 1) {
+		if (fabs(value - 1e-7) < 1e-9) {
 			liebert_config_voltage_mult = 1e8;
 			liebert_line_voltage_mult = 1e7; /* stomp this in case input voltage was low */
 			upsdebugx(2, "ConfigVoltage = %g -> assuming correction factor = %g",
@@ -192,8 +197,17 @@ static const char *liebert_config_voltage_fun(double value)
 
 static const char *liebert_line_voltage_fun(double value)
 {
-	if( value < 1 ) {
-		if( fabs(value - 1e-7) < 1e-9 ) {
+	/* Keep large readings like "230" or "24" as is */
+	if (value < 1) {
+		/* Practical use-case for mult=1e7:
+		 *   1.39e-06  =>  13.9
+		 *   2.201e-05 => 220.1
+		 * NOTE: The clause below is in fact broken for this use-case,
+		 * but was present in sources for ages (worked wrongly with an
+		 * integer-oriented abs() so collapsed into "if (0 < 1e-9) {")!
+		 *   if (fabs(value - 1e-7) < 1e-9) {
+		 */
+		if (fabs(value - 1e-7) < 1e-9) {
 			liebert_line_voltage_mult = 1e7;
 			upsdebugx(2, "Input/OutputVoltage = %g -> assuming correction factor = %g",
 				value, liebert_line_voltage_mult);
@@ -209,8 +223,12 @@ static const char *liebert_line_voltage_fun(double value)
 
 static const char *liebert_psi5_line_voltage_fun(double value)
 {
-	if( value < 1 ) {
-		if( fabs(value - 1e-3) < 1e-3 ) {
+	if (value < 1) {
+		/* Practical use-case for mult=1e5:
+		 *   0.000273 =>  27.3
+		 *   0.001212 => 121.2
+		 */
+		if (fabs(value - 1e-3) < 1e-3) {
 			liebert_line_voltage_mult = 1e5;
 			upsdebugx(2, "Input/OutputVoltage = %g -> assuming correction factor = %g",
 				value, liebert_line_voltage_mult);

--- a/drivers/belkin-hid.c
+++ b/drivers/belkin-hid.c
@@ -33,7 +33,7 @@
 
 #include <math.h>     /* for fabs() */
 
-#define BELKIN_HID_VERSION      "Belkin/Liebert HID 0.20"
+#define BELKIN_HID_VERSION      "Belkin/Liebert HID 0.21"
 
 /* Belkin */
 #define BELKIN_VENDORID	0x050d
@@ -207,7 +207,7 @@ static const char *liebert_line_voltage_fun(double value)
 		 * integer-oriented abs() so collapsed into "if (0 < 1e-9) {")!
 		 *   if (fabs(value - 1e-7) < 1e-9) {
 		 */
-		if (fabs(value - 1e-7) < 1e-9) {
+		if (fabs(value - 1e-5) < 4*1e-5) {
 			liebert_line_voltage_mult = 1e7;
 			upsdebugx(2, "Input/OutputVoltage = %g -> assuming correction factor = %g",
 				value, liebert_line_voltage_mult);
@@ -228,7 +228,7 @@ static const char *liebert_psi5_line_voltage_fun(double value)
 		 *   0.000273 =>  27.3
 		 *   0.001212 => 121.2
 		 */
-		if (fabs(value - 1e-3) < 1e-3) {
+		if (fabs(value - 1e-3) < 4*1e-3) {
 			liebert_line_voltage_mult = 1e5;
 			upsdebugx(2, "Input/OutputVoltage = %g -> assuming correction factor = %g",
 				value, liebert_line_voltage_mult);

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -16,9 +16,9 @@
 /nuttimetest
 /nuttimetest.log
 /nuttimetest.trs
-/getexponenttest
-/getexponenttest.log
-/getexponenttest.trs
+/getexponenttest-belkin-hid
+/getexponenttest-belkin-hid.log
+/getexponenttest-belkin-hid.trs
 /belkin-hid.c
 /getvaluetest
 /getvaluetest.log

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -16,6 +16,10 @@
 /nuttimetest
 /nuttimetest.log
 /nuttimetest.trs
+/getexponenttest
+/getexponenttest.log
+/getexponenttest.trs
+/belkin-hid.c
 /getvaluetest
 /getvaluetest.log
 /getvaluetest.trs

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -19,7 +19,6 @@
 /getexponenttest-belkin-hid
 /getexponenttest-belkin-hid.log
 /getexponenttest-belkin-hid.trs
-/belkin-hid.c
 /getvaluetest
 /getvaluetest.log
 /getvaluetest.trs

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -69,7 +69,7 @@ belkin-hid.c: $(top_srcdir)/drivers/belkin-hid.c
 	test -s "$@" || ln -s -f "$(top_srcdir)/drivers/belkin-hid.c" "$@"
 
 if WITH_USB
-TESTS += getvaluetest getexponenttest
+TESTS += getvaluetest getexponenttest-belkin-hid
 
 # We only need to call a few methods, not use the whole source - so
 # not linking it as a getvaluetest_SOURCE file (has too many deps):
@@ -78,10 +78,10 @@ nodist_libdriverstubusb_la_SOURCES = driver-stub-usb.c
 libdriverstubusb_la_CFLAGS = $(AM_CFLAGS) $(LIBUSB_CFLAGS)
 #libdriverstubusb_la_LIBADD = $(top_builddir)/common/libcommon.la
 
-getexponenttest.c: belkin-hid.c
-getexponenttest_SOURCES = getexponenttest.c
-getexponenttest_CFLAGS = $(AM_CFLAGS) $(LIBUSB_CFLAGS)
-getexponenttest_LDADD = $(top_builddir)/common/libcommon.la libdriverstubusb.la
+getexponenttest-belkin-hid.c: belkin-hid.c
+getexponenttest_belkin_hid_SOURCES = getexponenttest-belkin-hid.c
+getexponenttest_belkin_hid_CFLAGS = $(AM_CFLAGS) $(LIBUSB_CFLAGS)
+getexponenttest_belkin_hid_LDADD = $(top_builddir)/common/libcommon.la libdriverstubusb.la
 
 getvaluetest_SOURCES = getvaluetest.c
 nodist_getvaluetest_SOURCES = hidparser.c

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -73,14 +73,15 @@ TESTS += getvaluetest getexponenttest
 
 # We only need to call a few methods, not use the whole source - so
 # not linking it as a getvaluetest_SOURCE file (has too many deps):
-noinst_LTLIBRARIES += libbelkin.la
-nodist_libbelkin_la_SOURCES = belkin-hid.c driver-stub-usb.c
-libbelkin_la_CFLAGS = $(AM_CFLAGS) $(LIBUSB_CFLAGS)
-libbelkin_la_LIBADD = $(top_builddir)/common/libcommon.la
+noinst_LTLIBRARIES += libdriverstubusb.la
+nodist_libdriverstubusb_la_SOURCES = driver-stub-usb.c
+libdriverstubusb_la_CFLAGS = $(AM_CFLAGS) $(LIBUSB_CFLAGS)
+#libdriverstubusb_la_LIBADD = $(top_builddir)/common/libcommon.la
 
+getexponenttest.c: belkin-hid.c
 getexponenttest_SOURCES = getexponenttest.c
-#getexponenttest_CFLAGS = $(AM_CFLAGS) $(LIBUSB_CFLAGS)
-getexponenttest_LDADD = $(top_builddir)/common/libcommon.la libbelkin.la
+getexponenttest_CFLAGS = $(AM_CFLAGS) $(LIBUSB_CFLAGS)
+getexponenttest_LDADD = $(top_builddir)/common/libcommon.la libdriverstubusb.la
 
 getvaluetest_SOURCES = getvaluetest.c
 nodist_getvaluetest_SOURCES = hidparser.c

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -16,6 +16,7 @@ all: $(TESTS)
 EXTRA_DIST = nut-driver-enumerator-test.sh nut-driver-enumerator-test--ups.conf
 
 TESTS =
+noinst_LTLIBRARIES =
 CLEANFILES = *.trs *.log
 
 AM_CFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/drivers
@@ -57,15 +58,29 @@ nuttimetest_SOURCES = nuttimetest.c
 nuttimetest_LDADD = $(top_builddir)/common/libcommon.la
 
 # Separate the .deps of other dirs from this one
-LINKED_SOURCE_FILES = hidparser.c
+LINKED_SOURCE_FILES = hidparser.c belkin-hid.c
 
 # NOTE: Not using "$<" due to a legacy Sun/illumos dmake bug with resolver
 # of dynamic vars, see e.g. https://man.omnios.org/man1/make#BUGS
 hidparser.c: $(top_srcdir)/drivers/hidparser.c
 	test -s "$@" || ln -s -f "$(top_srcdir)/drivers/hidparser.c" "$@"
 
+belkin-hid.c: $(top_srcdir)/drivers/belkin-hid.c
+	test -s "$@" || ln -s -f "$(top_srcdir)/drivers/belkin-hid.c" "$@"
+
 if WITH_USB
-TESTS += getvaluetest
+TESTS += getvaluetest getexponenttest
+
+# We only need to call a few methods, not use the whole source - so
+# not linking it as a getvaluetest_SOURCE file (has too many deps):
+noinst_LTLIBRARIES += libbelkin.la
+nodist_libbelkin_la_SOURCES = belkin-hid.c driver-stub-usb.c
+libbelkin_la_CFLAGS = $(AM_CFLAGS) $(LIBUSB_CFLAGS)
+libbelkin_la_LIBADD = $(top_builddir)/common/libcommon.la
+
+getexponenttest_SOURCES = getexponenttest.c
+#getexponenttest_CFLAGS = $(AM_CFLAGS) $(LIBUSB_CFLAGS)
+getexponenttest_LDADD = $(top_builddir)/common/libcommon.la libbelkin.la
 
 getvaluetest_SOURCES = getvaluetest.c
 nodist_getvaluetest_SOURCES = hidparser.c
@@ -73,7 +88,7 @@ nodist_getvaluetest_SOURCES = hidparser.c
 getvaluetest_CFLAGS = $(AM_CFLAGS) $(LIBUSB_CFLAGS)
 getvaluetest_LDADD = $(top_builddir)/common/libcommon.la
 else !WITH_USB
-EXTRA_DIST += getvaluetest.c hidparser.c
+EXTRA_DIST += getvaluetest.c hidparser.c belkin-hid.c
 endif !WITH_USB
 
 if WITH_GPIO
@@ -101,6 +116,7 @@ EXTRA_DIST += generic_gpio_utest.h generic_gpio_test.txt
 # Make sure out-of-dir dependencies exist (especially when dev-building parts):
 $(top_builddir)/drivers/libdummy_mockdrv.la \
 $(top_builddir)/common/libnutconf.la \
+$(top_builddir)/common/libcommonclient.la \
 $(top_builddir)/common/libcommon.la: dummy
 	+@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -58,15 +58,12 @@ nuttimetest_SOURCES = nuttimetest.c
 nuttimetest_LDADD = $(top_builddir)/common/libcommon.la
 
 # Separate the .deps of other dirs from this one
-LINKED_SOURCE_FILES = hidparser.c belkin-hid.c
+LINKED_SOURCE_FILES = hidparser.c
 
 # NOTE: Not using "$<" due to a legacy Sun/illumos dmake bug with resolver
 # of dynamic vars, see e.g. https://man.omnios.org/man1/make#BUGS
 hidparser.c: $(top_srcdir)/drivers/hidparser.c
 	test -s "$@" || ln -s -f "$(top_srcdir)/drivers/hidparser.c" "$@"
-
-belkin-hid.c: $(top_srcdir)/drivers/belkin-hid.c
-	test -s "$@" || ln -s -f "$(top_srcdir)/drivers/belkin-hid.c" "$@"
 
 if WITH_USB
 TESTS += getvaluetest getexponenttest-belkin-hid
@@ -78,7 +75,7 @@ nodist_libdriverstubusb_la_SOURCES = driver-stub-usb.c
 libdriverstubusb_la_CFLAGS = $(AM_CFLAGS) $(LIBUSB_CFLAGS)
 #libdriverstubusb_la_LIBADD = $(top_builddir)/common/libcommon.la
 
-getexponenttest-belkin-hid.c: belkin-hid.c
+getexponenttest-belkin-hid.c: $(top_srcdir)/drivers/belkin-hid.c
 getexponenttest_belkin_hid_SOURCES = getexponenttest-belkin-hid.c
 getexponenttest_belkin_hid_CFLAGS = $(AM_CFLAGS) $(LIBUSB_CFLAGS)
 getexponenttest_belkin_hid_LDADD = $(top_builddir)/common/libcommon.la libdriverstubusb.la
@@ -89,7 +86,7 @@ nodist_getvaluetest_SOURCES = hidparser.c
 getvaluetest_CFLAGS = $(AM_CFLAGS) $(LIBUSB_CFLAGS)
 getvaluetest_LDADD = $(top_builddir)/common/libcommon.la
 else !WITH_USB
-EXTRA_DIST += getvaluetest.c hidparser.c belkin-hid.c
+EXTRA_DIST += getvaluetest.c hidparser.c
 endif !WITH_USB
 
 if WITH_GPIO

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -88,6 +88,7 @@ getvaluetest_LDADD = $(top_builddir)/common/libcommon.la
 else !WITH_USB
 EXTRA_DIST += getvaluetest.c hidparser.c
 endif !WITH_USB
+EXTRA_DIST += driver-stub-usb.c
 
 if WITH_GPIO
 TESTS += gpiotest

--- a/tests/driver-stub-usb.c
+++ b/tests/driver-stub-usb.c
@@ -1,5 +1,5 @@
-/* placeholder method implementations to just link the libbelkin stub
- * and eventually similar code by directly using driver source code
+/* placeholder/mock method implementations to just directly use driver
+ * source code as done for belkin-hid.c (and eventually similar code)
  * for almost-in-vivo testing (and minimal intrusion to that codebase).
  * See also: getexponenttest.c
  *

--- a/tests/driver-stub-usb.c
+++ b/tests/driver-stub-usb.c
@@ -1,7 +1,7 @@
 /* placeholder/mock method implementations to just directly use driver
  * source code as done for belkin-hid.c (and eventually similar code)
  * for almost-in-vivo testing (and minimal intrusion to that codebase).
- * See also: getexponenttest.c
+ * See also: getexponenttest-belkin-hid.c
  *
  * Copyright (C)
  *      2024   Jim Klimov <jimklimov+nut@gmail.com>

--- a/tests/driver-stub-usb.c
+++ b/tests/driver-stub-usb.c
@@ -1,0 +1,67 @@
+/* placeholder method implementations to just link the libbelkin stub
+ * and eventually similar code by directly using driver source code
+ * for almost-in-vivo testing (and minimal intrusion to that codebase).
+ * See also: getexponenttest.c
+ *
+ * Copyright (C)
+ *      2024   Jim Klimov <jimklimov+nut@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#include "common.h"
+
+#include "usb-common.h"
+int is_usb_device_supported(usb_device_id_t *usb_device_id_list, USBDevice_t *device) {
+	NUT_UNUSED_VARIABLE(usb_device_id_list);
+	NUT_UNUSED_VARIABLE(device);
+	return -1;
+}
+
+#include "usbhid-ups.h"
+hid_dev_handle_t udev = HID_DEV_HANDLE_CLOSED;
+info_lkp_t beeper_info[] = { { 0, NULL, NULL, NULL } };
+info_lkp_t date_conversion[] = { { 0, NULL, NULL, NULL } };
+info_lkp_t stringid_conversion[] = { { 0, NULL, NULL, NULL } };
+info_lkp_t divide_by_10_conversion[] = { { 0, NULL, NULL, NULL } };
+info_lkp_t divide_by_100_conversion[] = { { 0, NULL, NULL, NULL } };
+
+void possibly_supported(const char *mfr, HIDDevice_t *hd) {
+	NUT_UNUSED_VARIABLE(mfr);
+	NUT_UNUSED_VARIABLE(hd);
+}
+
+int fix_report_desc(HIDDevice_t *arg_pDev, HIDDesc_t *arg_pDesc) {
+	NUT_UNUSED_VARIABLE(arg_pDev);
+	NUT_UNUSED_VARIABLE(arg_pDesc);
+	return -1;
+}
+
+#include "libhid.h"
+usage_lkp_t hid_usage_lkp[] = { {NULL, 0} };
+char *HIDGetItemString(hid_dev_handle_t arg_udev, const char *hidpath, char *buf, size_t buflen, usage_tables_t *utab) {
+	NUT_UNUSED_VARIABLE(arg_udev);
+	NUT_UNUSED_VARIABLE(hidpath);
+	NUT_UNUSED_VARIABLE(buf);
+	NUT_UNUSED_VARIABLE(buflen);
+	NUT_UNUSED_VARIABLE(utab);
+	return NULL;
+}
+
+#include "main.h"
+char *getval(const char *var) {
+	NUT_UNUSED_VARIABLE(var);
+	return NULL;
+}

--- a/tests/getexponenttest-belkin-hid.c
+++ b/tests/getexponenttest-belkin-hid.c
@@ -75,9 +75,14 @@ static int RunBuiltInTests(char *argv[]) {
 	} testData[] = {
 		{.buf = "0.000273",	.expectedRawValue = 0.000273,	.type = 3, .expectedMult = 1e5, .expectedValue = 27.3	},
 		{.buf = "0.001212",	.expectedRawValue = 0.001212,	.type = 3, .expectedMult = 1e5, .expectedValue = 121.2	},
+		{.buf = "0.002456",	.expectedRawValue = 0.002456,	.type = 3, .expectedMult = 1e5, .expectedValue = 245.6	},
+		{.buf = "0.003801",	.expectedRawValue = 0.003801,	.type = 3, .expectedMult = 1e5, .expectedValue = 380.1	},
+		{.buf = "0.004151",	.expectedRawValue = 0.004151,	.type = 3, .expectedMult = 1e5, .expectedValue = 415.1	},
 
 		{.buf = "1.39e-06",	.expectedRawValue = 0.00000139,	.type = 2, .expectedMult = 1e7, .expectedValue = 13.9	},
+		{.buf = "1.273e-05",	.expectedRawValue = 0.00001273,	.type = 2, .expectedMult = 1e7, .expectedValue = 127.3	},
 		{.buf = "2.201e-05",	.expectedRawValue = 0.00002201,	.type = 2, .expectedMult = 1e7, .expectedValue = 220.1	},
+		{.buf = "4.201e-05",	.expectedRawValue = 0.00004201,	.type = 2, .expectedMult = 1e7, .expectedValue = 420.1	},
 
 		/* Edge cases - what should not be converted (good enough already) */
 		{.buf = "12",	.expectedRawValue = 12.0,	.type = 3, .expectedMult = 1, .expectedValue = 12.0	},

--- a/tests/getexponenttest-belkin-hid.c
+++ b/tests/getexponenttest-belkin-hid.c
@@ -1,7 +1,8 @@
-/* getexponenttest - check detection of correct multiplication exponent value
- * for miniscule readings from USB HID (as used in e.g. drivers/belkin-hid.c
- * subdriver). Eventually may be extended to similar tests for other driver
- * methods.
+/* getexponenttest-belkin-hid - check detection of correct multiplication
+ * exponent value for miniscule readings from USB HID (as used in the
+ * drivers/belkin-hid.c subdriver of usbhid-ups).
+ * Eventually may be extended to similar tests for other drivers' methods,
+ * or more likely cloned to #include them in similar fashion.
  *
  * See also:
  *  https://github.com/networkupstools/nut/issues/2370

--- a/tests/getexponenttest.c
+++ b/tests/getexponenttest.c
@@ -27,6 +27,7 @@
 #include "config.h"
 
 #include "nut_stdint.h"
+#include "nut_float.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -100,7 +101,7 @@ static int RunBuiltInTests(char *argv[]) {
 		liebert_config_voltage_mult = 1.0;
 
 		rawValue = strtod(testData[i].buf, NULL);
-		if (rawValue != testData[i].expectedRawValue) {
+		if (!d_equal(rawValue, testData[i].expectedRawValue)) {
 			printf(" value '%s' parsing FAIL: got %g expected %g\n",
 				testData[i].buf, rawValue, testData[i].expectedRawValue);
 			/* Fix testData definition! */
@@ -133,7 +134,7 @@ static int RunBuiltInTests(char *argv[]) {
 
 		printf("Test #%" PRIiSIZE "  \t", i + 1);
 		value = strtod(valueStr, NULL);
-		if (value == testData[i].expectedValue && mult == testData[i].expectedMult) {
+		if (d_equal(value, testData[i].expectedValue) && d_equal(mult, testData[i].expectedMult)) {
 			printf("%s\tGOT value %9g\tmult %6g PASS\n",
 				(testData[i].type < 1 || testData[i].type > 3 ? "<null>" : methodName[testData[i].type - 1]),
 				value, mult);

--- a/tests/getexponenttest.c
+++ b/tests/getexponenttest.c
@@ -1,0 +1,207 @@
+/* getexponenttest - check detection of correct multiplication exponent value
+ * for miniscule readings from USB HID (as used in e.g. drivers/belkin-hid.c
+ * subdriver). Eventually may be extended to similar tests for other driver
+ * methods.
+ *
+ * See also:
+ *  https://github.com/networkupstools/nut/issues/2370
+ *
+ * Copyright (C)
+ *      2024   Jim Klimov <jimklimov+nut@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#include "config.h"
+
+#include "nut_stdint.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "common.h"
+
+/* from drivers/belkin-hid.c: */
+extern double liebert_config_voltage_mult, liebert_line_voltage_mult;
+const char *liebert_config_voltage_fun(double value);
+const char *liebert_line_voltage_fun(double value);
+const char *liebert_psi5_line_voltage_fun(double value);
+
+static void Usage(char *name) {
+/*
+	printf("%s {-c <config_voltage> | -l <old_line_voltage> | -p <psi5_line_voltage>} <expected_multiplier> <expected_voltage>\n", name);
+	printf("\n");
+	printf("%s -c 12\n", name);
+	printf("%s -p 0.001212\n", name);
+	printf("%s -l 1.39e-06\n", name);
+*/
+	printf("%s\nIf no arguments are given a builtin set of tests are run.\n", name);
+}
+
+static int RunBuiltInTests(char *argv[]) {
+	int exitStatus = 0;
+	size_t i;
+
+	double	rawValue, value, mult;
+	const char	*valueStr;
+
+	static char* methodName[3] = {
+		"liebert_config_voltage_mult()   ",
+		"liebert_line_voltage_mult()     ",
+		"liebert_psi5_line_voltage_mult()"
+	};
+
+	static struct {
+		char *buf;			/* raw voltage as a string (from CLI input, e.g. NUT driver log trace) */
+		double expectedRawValue;	/* parsed raw voltage (as seen in USB HID reports) */
+		char type;			/* 1 = config, 2 = line, 3 = PSI5 line */
+		double expectedMult;		/* expected liebert_config_voltage_mult or liebert_line_voltage_mult */
+		double expectedValue;		/* the expected result of decoding the value in the buffer */
+	} testData[] = {
+		{.buf = "0.000273",	.expectedRawValue = 0.000273,	.type = 3, .expectedMult = 1e5, .expectedValue = 27.3	},
+		{.buf = "0.001212",	.expectedRawValue = 0.001212,	.type = 3, .expectedMult = 1e5, .expectedValue = 121.2	},
+
+		{.buf = "1.39e-06",	.expectedRawValue = 0.00000139,	.type = 2, .expectedMult = 1e7, .expectedValue = 13.9	},
+		{.buf = "2.201e-05",	.expectedRawValue = 0.00002201,	.type = 2, .expectedMult = 1e7, .expectedValue = 220.1	},
+
+		/* Edge cases - what should not be converted (good enough already) */
+		{.buf = "12",	.expectedRawValue = 12.0,	.type = 3, .expectedMult = 1, .expectedValue = 12.0	},
+		{.buf = "12.3",	.expectedRawValue = 12.3,	.type = 3, .expectedMult = 1, .expectedValue = 12.3	},
+		{.buf = "232.1",	.expectedRawValue = 232.1,	.type = 3, .expectedMult = 1, .expectedValue = 232.1	},
+		{.buf = "240",	.expectedRawValue = 240.0,	.type = 3, .expectedMult = 1, .expectedValue = 240.0	},
+
+		{.buf = "12",	.expectedRawValue = 12.0,	.type = 2, .expectedMult = 1, .expectedValue = 12.0	},
+		{.buf = "12.3",	.expectedRawValue = 12.3,	.type = 2, .expectedMult = 1, .expectedValue = 12.3	},
+		{.buf = "232.1",	.expectedRawValue = 232.1,	.type = 2, .expectedMult = 1, .expectedValue = 232.1	},
+		{.buf = "240",	.expectedRawValue = 240.0,	.type = 2, .expectedMult = 1, .expectedValue = 240.0	},
+
+		/* Config values (nominal battery/input/... voltage) are often integers: */
+		{.buf = "24",	.expectedRawValue = 24.0,	.type = 1, .expectedMult = 1, .expectedValue = 24.0	},
+		{.buf = "120",	.expectedRawValue = 120.0,	.type = 1, .expectedMult = 1, .expectedValue = 120.0	}
+	};
+
+	NUT_UNUSED_VARIABLE(argv);
+
+	for (i = 0; i < SIZEOF_ARRAY(testData); i++) {
+		liebert_line_voltage_mult = 1.0;
+		liebert_config_voltage_mult = 1.0;
+
+		rawValue = strtod(testData[i].buf, NULL);
+		if (rawValue != testData[i].expectedRawValue) {
+			printf(" value '%s' parsing FAIL: got %g expected %g\n",
+				testData[i].buf, rawValue, testData[i].expectedRawValue);
+			/* Fix testData definition! */
+			exitStatus = 1;
+		}
+
+		switch (testData[i].type) {
+			case 1:
+				valueStr = liebert_config_voltage_fun(rawValue);
+				mult = liebert_config_voltage_mult;
+				/* NOTE: The method does also set a default
+				 * liebert_line_voltage_mult if config voltage
+				 * is miniscule and not a plain integer */
+				break;
+
+			case 2:
+				valueStr = liebert_line_voltage_fun(rawValue);
+				mult = liebert_line_voltage_mult;
+				break;
+
+			case 3:
+				valueStr = liebert_psi5_line_voltage_fun(rawValue);
+				mult = liebert_line_voltage_mult;
+				break;
+
+			default:
+				printf(" invalid entry\n");
+				continue;
+		}
+
+		printf("Test #%" PRIiSIZE "  \t", i + 1);
+		value = strtod(valueStr, NULL);
+		if (value == testData[i].expectedValue && mult == testData[i].expectedMult) {
+			printf("%s\tGOT value %9g\tmult %6g PASS\n",
+				(testData[i].type < 1 || testData[i].type > 3 ? "<null>" : methodName[testData[i].type - 1]),
+				value, mult);
+		} else {
+			printf("%s\tGOT value %9g\tmult %6g FAIL"
+				"\tEXPECTED v=%7g\tm=%7g"
+				"\tORIGINAL (string)'%s'\t=> (double)%g\n",
+				(testData[i].type < 1 || testData[i].type > 3 ? "<null>" : methodName[testData[i].type - 1]),
+				value, mult,
+				testData[i].expectedValue,
+				testData[i].expectedMult,
+				testData[i].buf, rawValue);
+			exitStatus = 1;
+		}
+	}
+
+	return (exitStatus);
+}
+
+/*
+static int RunCommandLineTest(char *argv[]) {
+	uint8_t reportBuf[64];
+	size_t bufSize;
+	char *start, *end;
+	HIDData_t data;
+	long value, expectedValue;
+
+	start = argv[1];
+	end = NULL;
+	for (bufSize = 0; *start != 0; bufSize++) {
+		reportBuf[bufSize] = (uint8_t) strtol(start, (char **)&end, 16);
+		if (start == end) break;
+		start = end;
+	}
+	memset((void *)&data, 0, sizeof(data));
+	data.Offset = (uint8_t) atoi(argv[2]);
+	data.Size = (uint8_t) atoi(argv[3]);
+	data.LogMin = strtol(argv[4], 0, 0);
+	data.LogMax = strtol(argv[5], 0, 0);
+	expectedValue = strtol(argv[6], 0, 0);
+
+	GetValue(reportBuf, &data, &value);
+
+	printf("Test #0 ");
+	PrintBufAndData(reportBuf, bufSize, &data);
+	if (value == expectedValue) {
+		printf(" value %ld PASS\n", value);
+		return (0);
+	} else {
+		printf(" value %ld FAIL expected %ld\n", value, expectedValue);
+		return (1);
+	}
+}
+*/
+
+int main (int argc, char *argv[]) {
+	int status;
+
+	switch (argc) {
+	case 1:
+		status = RunBuiltInTests(argv);
+		break;
+/*
+	case 7:
+		status = RunCommandLineTest(argv);
+		break;
+*/
+	default:
+		Usage(argv[0]);
+		status = 2;
+	}
+	return(status);
+}

--- a/tests/getexponenttest.c
+++ b/tests/getexponenttest.c
@@ -32,11 +32,13 @@
 #include <string.h>
 #include "common.h"
 
-/* from drivers/belkin-hid.c: */
+#include "belkin-hid.c"
+/* from drivers/belkin-hid.c we test:
 extern double liebert_config_voltage_mult, liebert_line_voltage_mult;
 const char *liebert_config_voltage_fun(double value);
 const char *liebert_line_voltage_fun(double value);
 const char *liebert_psi5_line_voltage_fun(double value);
+ */
 
 static void Usage(char *name) {
 /*


### PR DESCRIPTION
As raised on the mailing list at https://alioth-lists.debian.net/pipermail/nut-upsuser/2024-March/013626.html as well as in discussions for #2271, #2369 and #2370, there is some mess in exponents calculation of `drivers/belkin-hid.c`, where the driver tries to adjust for what seems wrongly encoded voltage readings in USB HID reports, which may be off by some orders of magnitude (3, 7...) depending on reading type and HW/FW model.

As detailed in https://github.com/networkupstools/nut/issues/2370#issuecomment-2017664722 : The original logic which purported to fix this was broken, but by coincidence seems to have taken the right code path for the majority of devices up till NUT v2.7.4. This was fixed in NUT v2.8.0 to correct logic, but the order of magnitude estimation results no longer fit the devices' outputs, so the scaling was not applied and this caused various voltages to be reported as zeroes - causing a practical regression.

As suggested in recent discussions on the matter, this PR adds a (rather ugly, but functional) way to test the helper conversion methods "in-vivo" - in the practically unmodified sub-driver code, mocking the methods and variables it refers to elsewhere. Maybe this can be done even without the currently posted change to no longer mark `static` the variables and methods we need for a test, either by `#include` of the driver source into a test program, or by shipping test methods as part of a driver/program source and/or custom-built binary (ZeroMQ style) - something to refine later. UPDATE: Went for including at the moment, was not hard after the other mock preparations.

At the moment the test is functional in terms of calling one of the 3 methods currently provided by the driver source (1 added in #2369) and finding that the original method fixed in 2.8.0 (to check those clauses as floating-point numbers and not zeroed out rounded integers) indeed failed to work for the typical values it expected to process.
````
Test #1         liebert_psi5_line_voltage_mult()        GOT value      27.3     mult 100000 PASS
Test #2         liebert_psi5_line_voltage_mult()        GOT value     121.2     mult 100000 PASS
LineVoltage exponent looks wrong, but not correcting.
Test #3         liebert_line_voltage_mult()             GOT value         0     mult      1 FAIL        EXPECTED v=   13.9      m=  1e+07       ORIGINAL (string)'1.39e-06'     => (double)1.39e-06
LineVoltage exponent looks wrong, but not correcting.
Test #4         liebert_line_voltage_mult()             GOT value         0     mult      1 FAIL        EXPECTED v=  220.1      m=  1e+07       ORIGINAL (string)'2.201e-05'    => (double)2.201e-05
Test #5         liebert_psi5_line_voltage_mult()        GOT value        12     mult      1 PASS
Test #6         liebert_psi5_line_voltage_mult()        GOT value      12.3     mult      1 PASS
Test #7         liebert_psi5_line_voltage_mult()        GOT value     232.1     mult      1 PASS
Test #8         liebert_psi5_line_voltage_mult()        GOT value       240     mult      1 PASS
Test #9         liebert_line_voltage_mult()             GOT value        12     mult      1 PASS
Test #10        liebert_line_voltage_mult()             GOT value      12.3     mult      1 PASS
Test #11        liebert_line_voltage_mult()             GOT value     232.1     mult      1 PASS
Test #12        liebert_line_voltage_mult()             GOT value       240     mult      1 PASS
Test #13        liebert_config_voltage_mult()           GOT value        24     mult      1 PASS
Test #14        liebert_config_voltage_mult()           GOT value       120     mult      1 PASS
````

From this point, some TDD can be done to adjust the implementations... and I suppose the `liebert_psi5_line_voltage_mult()` checks can be merged with `liebert_line_voltage_mult()` as was originally intended in PoC code posted in issue #2271 - there's little left to break in the original one, it seems.

(CC @jrjparks @clepple @aquette @digitlman @electroflame)