### PR TITLE
Quieter start-up of `upsmon`, `upsd` and driver daemons (avoid "scary" `fopen()` failure messages)

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -40,6 +40,12 @@ https://github.com/networkupstools/nut/milestone/11
  - (expected) Bug fixes for fallout possible due to "fightwarn" effort in 2.8.0
 
 
+ - drivers, upsd, upsmon: reduce "scary noise" about failure to `fopen()`
+   the PID file (which most of the time means that no previous instance of
+   the daemon was running to potentially conflict with), especially useless
+   since in recent NUT releases the verdicts from `sendsignal*()` methods
+   are analyzed and lead to layman worded situation reports in these programs.
+   [issue #1782]
 
  - upsmon: it was realized that the `POWERDOWNFLAG` must be explicitly set in
    the configuration file, there is no built-in default in the binary program

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -47,6 +47,11 @@ https://github.com/networkupstools/nut/milestone/11
    are analyzed and lead to layman worded situation reports in these programs.
    [issue #1782, PR #2384]
 
+ - drivers started with the `-FF` command-line option (e.g. wrapped into the
+   systemd units to stay "foregrounded" *and* save a PID file anyway) should
+   now also handle an existing PID file to interact with the earlier instance
+   of the driver program, if still running (e.g. started manually). [#2384]
+
  - riello_ser updates:
    * added `localcalculation` option to compute `battery.runtime` and
      `battery.charge` if the device provides bogus values [issue #2390,

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -3005,6 +3005,13 @@ int main(int argc, char *argv[])
 
 	open_syslog(prog);
 
+	if (checking_flag) {
+		/* Do not normally report the UPSes we would monitor, etc.
+		 * from loadconfig() for just checking the killpower flag */
+		if (nut_debug_level == 0)
+			nut_debug_level = -2;
+	}
+
 	loadconfig();
 
 	/* CLI debug level can not be smaller than debug_min specified

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -2887,6 +2887,8 @@ int main(int argc, char *argv[])
 	 * for probing whether a competing older instance of this program
 	 * is running (error if it is).
 	 */
+	/* Hush the fopen(pidfile) message but let "real errors" be seen */
+	nut_sendsignal_debug_level = NUT_SENDSIGNAL_DEBUG_LEVEL_FOPEN_PIDFILE - 1;
 #ifndef WIN32
 	/* If cmd == 0 we are starting and check if a previous instance
 	 * is running by sending signal '0' (i.e. 'kill <pid> 0' equivalent)
@@ -2999,6 +3001,9 @@ int main(int argc, char *argv[])
 
 		exit((cmdret == 0) ? EXIT_SUCCESS : EXIT_FAILURE);
 	}
+
+	/* Restore the signal errors verbosity */
+	nut_sendsignal_debug_level = NUT_SENDSIGNAL_DEBUG_LEVEL_DEFAULT;
 
 	argc -= optind;
 	argv += optind;

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -2948,8 +2948,9 @@ int main(int argc, char *argv[])
 		 */
 		upslogx(LOG_WARNING, "Could not %s PID file "
 			"to see if previous upsmon instance is "
-			"already running!",
-			(cmdret == -3 ? "find" : "parse"));
+			"already running!%s",
+			(cmdret == -3 ? "find" : "parse"),
+			(checking_flag ? " This is okay during OS shutdown, which is when checking POWERDOWNFLAG makes most sense." : ""));
 		break;
 
 	case -1:

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3484 utf-8
+personal_ws-1.1 en 3486 utf-8
 AAC
 AAS
 ABI
@@ -2091,6 +2091,7 @@ fmt
 fno
 fontconfig
 footnoteref
+fopen
 forceshutdown
 forcessl
 formatconfig
@@ -2988,6 +2989,7 @@ selftest
 sendback
 sendline
 sendmail
+sendsignal
 sequentialized
 ser
 seria

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -4,7 +4,7 @@
    1999			Russell Kroll <rkroll@exploits.org>
    2005 - 2017	Arnaud Quette <arnaud.quette@free.fr>
    2017 		Eaton (author: Emilien Kia <EmilienKia@Eaton.com>)
-   2017 - 2022	Jim Klimov <jimklimov+nut@gmail.com>
+   2017 - 2024	Jim Klimov <jimklimov+nut@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -2083,21 +2083,21 @@ int main(int argc, char **argv)
 				/* if cmd was nontrivial - speak up below, else be quiet */
 				upsdebugx(1, "Just failed to send signal, no daemon was running");
 				break;
-			}
+			} /* switch (cmdret) */
 
-		/* We were signalling a daemon, successfully or not - exit now...
-		 * Modulo the possibility of a "reload-or-something" where we
-		 * effectively terminate the old driver and start a new one due
-		 * to configuration changes that were not reloadable. Such mode
-		 * is not implemented currently.
-		 */
-		if (cmdret != 0) {
-			/* sendsignal*() above might have logged more details
-			 * for troubleshooting, e.g. about lack of PID file
+			/* We were signalling a daemon, successfully or not - exit now...
+			 * Modulo the possibility of a "reload-or-something" where we
+			 * effectively terminate the old driver and start a new one due
+			 * to configuration changes that were not reloadable. Such mode
+			 * is not implemented currently.
 			 */
-			upslogx(LOG_NOTICE, "Failed to signal the currently running daemon (if any)");
+			if (cmdret != 0) {
+				/* sendsignal*() above might have logged more details
+				 * for troubleshooting, e.g. about lack of PID file
+				 */
+				upslogx(LOG_NOTICE, "Failed to signal the currently running daemon (if any)");
 # ifdef HAVE_SYSTEMD
-			switch (cmd) {
+				switch (cmd) {
 				case SIGCMD_RELOAD:
 					upslogx(LOG_NOTICE, "Try something like "
 						"'systemctl reload nut-driver@%s.service'%s",
@@ -2122,7 +2122,7 @@ int main(int argc, char **argv)
 						upsname,
 						(oldpid < 0 ? " or add '-P $PID' argument" : ""));
 					break;
-				}
+				} /* switch (cmd) */
 				/* ... or edit nut-server.service locally to start `upsd -FF`
 				 * and so save the PID file for ability to manage the daemon
 				 * beside the service framework, possibly confusing things...
@@ -2132,10 +2132,10 @@ int main(int argc, char **argv)
 					upslogx(LOG_NOTICE, "Try to add '-P $PID' argument");
 				}
 # endif	/* HAVE_SYSTEMD */
-			}
+			} /* if (cmdret != 0) */
 
 			exit((cmdret == 0) ? EXIT_SUCCESS : EXIT_FAILURE);
-		}
+		} /* if (cmd) */
 
 		/* Try to prevent that driver is started multiple times. If a PID file */
 		/* already exists, send a TERM signal to the process and try if it goes */

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -2141,20 +2141,24 @@ int main(int argc, char **argv)
 		/* away. If not, retry a couple of times. */
 		for (i = 0; i < 3; i++) {
 			struct stat	st;
+			int	sigret;
 
-			if (stat(pidfnbuf, &st) != 0) {
-				/* PID file not found */
+			if ((sigret = stat(pidfnbuf, &st)) != 0) {
+				upsdebugx(1, "PID file %s not found; stat() returned %d (errno=%d): %s",
+					pidfnbuf, sigret, errno, strerror(errno));
 				break;
 			}
 
 			upslogx(LOG_WARNING, "Duplicate driver instance detected (PID file %s exists)! Terminating other driver!", pidfnbuf);
 
-			if (sendsignalfn(pidfnbuf, SIGTERM) != 0) {
-				/* Can't send signal to PID, assume invalid file */
+			if ((sigret = sendsignalfn(pidfnbuf, SIGTERM) != 0)) {
+				upsdebugx(1, "Can't send signal to PID, assume invalid PID file %s; "
+					"sendsignalfn() returned %d (errno=%d): %s",
+					pidfnbuf, sigret, errno, strerror(errno));
 				break;
 			}
 
-			/* Allow driver some time to quit */
+			upsdebugx(1, "Signal sent without errors, allow the other driver instance some time to quit");
 			sleep(5);
 		}
 

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -2034,6 +2034,9 @@ int main(int argc, char **argv)
 		exit(((cmdret < 0) || (((uintmax_t)cmdret) > ((uintmax_t)INT_MAX))) ? 255 : (int)cmdret);
 	}
 
+	/* Hush the fopen(pidfile) message but let "real errors" be seen */
+	nut_sendsignal_debug_level = NUT_SENDSIGNAL_DEBUG_LEVEL_FOPEN_PIDFILE - 1;
+
 #ifndef WIN32
 	/* Setup PID file to receive signals to communicate with this driver
 	 * instance once backgrounded, and to stop a competing older instance.
@@ -2223,6 +2226,9 @@ int main(int argc, char **argv)
 		}
 	}
 #endif	/* WIN32 */
+
+	/* Restore the signal errors verbosity */
+	nut_sendsignal_debug_level = NUT_SENDSIGNAL_DEBUG_LEVEL_DEFAULT;
 
 	/* clear out callback handler data */
 	memset(&upsh, '\0', sizeof(upsh));

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -2041,10 +2041,11 @@ int main(int argc, char **argv)
 
 #ifndef WIN32
 	/* Setup PID file to receive signals to communicate with this driver
-	 * instance once backgrounded, and to stop a competing older instance.
-	 * Or to send it a signal deliberately.
+	 * instance once backgrounded (or staying foregrounded with `-FF`),
+	 * and to stop a competing older instance. Or to send it a signal
+	 * deliberately.
 	 */
-	if (cmd || ((foreground == 0) && (!do_forceshutdown))) {
+	if (cmd || ((foreground == 0 || foreground == 2) && (!do_forceshutdown))) {
 		char	pidfnbuf[SMALLBUF];
 
 		snprintf(pidfnbuf, sizeof(pidfnbuf), "%s/%s-%s.pid", altpidpath(), progname, upsname);
@@ -2462,6 +2463,7 @@ sockname_ownership_finished:
 				snprintf(pidfnbuf, sizeof(pidfnbuf), "%s/%s-%s.pid", altpidpath(), progname, upsname);
 				pidfn = xstrdup(pidfnbuf);
 			}
+			/* Probably was saved above already, but better safe than sorry */
 			upslogx(LOG_WARNING, "Running as foreground process, but saving a PID file anyway");
 			writepid(pidfn);
 			break;

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -233,7 +233,7 @@ socket_error:
 	}
 
 #ifndef WIN32
-/* TODO: implement WIN32 */
+/* TODO: implement WIN32: https://github.com/networkupstools/nut/issues/1916 */
 /* handle generally signalling the UPS */
 	/* Real signals */
 #ifndef WIN32
@@ -301,7 +301,7 @@ socket_error:
 		upslog_with_errno(LOG_ERR, "Signalling %s failed: %d", pidfn, ret);
 		exec_error++;
 	}
-#endif	/* WIN32 */
+#endif	/* WIN32: https://github.com/networkupstools/nut/issues/1916 */
 }
 
 /* handle generally signalling the UPS with recently raised signal */
@@ -939,7 +939,7 @@ static void help(const char *arg_progname)
 	printf("  -c <command>		send <command> via signal to running driver(s)\n");
 	printf("              		supported commands:\n");
 #ifndef WIN32
-/* FIXME: port event loop from upsd/upsmon to allow messaging fellow drivers in WIN32 builds */
+/* FIXME: port event loop from upsd/upsmon to allow messaging fellow drivers in WIN32 builds: https://github.com/networkupstools/nut/issues/1916 */
 	printf("              		- data-dump: if the driver still has STDOUT attached (maybe\n");
 	printf("              		  to log), dump its currently collected information there\n");
 	printf("              		- reload: re-read configuration files, ignoring changed\n");
@@ -952,7 +952,7 @@ static void help(const char *arg_progname)
 	printf("              		  based on that count, so the caller can decide the fate of\n");
 	printf("              		  the currently running driver instance\n");
 #ifndef WIN32
-/* FIXME: port event loop from upsd/upsmon to allow messaging fellow drivers in WIN32 builds */
+/* FIXME: port event loop from upsd/upsmon to allow messaging fellow drivers in WIN32 builds: https://github.com/networkupstools/nut/issues/1916 */
 # ifdef SIGCMD_RELOAD_OR_RESTART
 	printf("              		- reload-or-restart: re-read configuration files (close the\n");
 	printf("              		  old driver instance device connection if needed, and have\n");
@@ -1190,7 +1190,7 @@ int main(int argc, char **argv)
 					signal_flag = SIGCMD_RELOAD_OR_ERROR;
 				}
 #ifndef WIN32
-/* FIXME: port event loop from upsd/upsmon to allow messaging fellow drivers in WIN32 builds */
+/* FIXME: port event loop from upsd/upsmon to allow messaging fellow drivers in WIN32 builds: https://github.com/networkupstools/nut/issues/1916 */
 				else
 				if (!strncmp(optarg, "dump", strlen(optarg))) {
 					signal_flag = SIGCMD_DATA_DUMP;
@@ -1209,7 +1209,7 @@ int main(int argc, char **argv)
 				if (!strncmp(optarg, "reload-or-exit", strlen(optarg))) {
 					signal_flag = SIGCMD_RELOAD_OR_EXIT;
 				}
-#endif	/* WIN32 */
+#endif	/* WIN32: https://github.com/networkupstools/nut/issues/1916 */
 
 				/* bad command given */
 				if (!signal_flag) {

--- a/include/common.h
+++ b/include/common.h
@@ -347,6 +347,12 @@ void nut_report_config_flags(void);
 void upsdebugx_report_search_paths(int level, int report_search_paths_builtin);
 void nut_prepare_search_paths(void);
 
+/* Internal toggle for some NUT programs that deal with signal sending.
+ * For a detailed rationale comment see common.c */
+extern int nut_sendsignal_debug_level;
+#define NUT_SENDSIGNAL_DEBUG_LEVEL_DEFAULT 6
+#define NUT_SENDSIGNAL_DEBUG_LEVEL_FOPEN_PIDFILE 5
+
 extern int nut_debug_level;
 extern int nut_log_level;
 

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -2031,6 +2031,8 @@ int main(int argc, char **argv)
 	 * for probing whether a competing older instance of this program
 	 * is running (error if it is).
 	 */
+	/* Hush the fopen(pidfile) message but let "real errors" be seen */
+	nut_sendsignal_debug_level = NUT_SENDSIGNAL_DEBUG_LEVEL_FOPEN_PIDFILE - 1;
 #ifndef WIN32
 	/* If cmd == 0 we are starting and check if a previous instance
 	 * is running by sending signal '0' (i.e. 'kill <pid> 0' equivalent)
@@ -2137,6 +2139,9 @@ int main(int argc, char **argv)
 
 		exit((cmdret == 0) ? EXIT_SUCCESS : EXIT_FAILURE);
 	}
+
+	/* Restore the signal errors verbosity */
+	nut_sendsignal_debug_level = NUT_SENDSIGNAL_DEBUG_LEVEL_DEFAULT;
 
 	argc -= optind;
 	argv += optind;


### PR DESCRIPTION
Follows up from issue #1782 and PR #2383

CC @gdt (is this reasonably quieter?)

Avoid a few lines of text (when running without boosted debug verbosity) here and there, and default to avoid the infamous `fopen /var/state/ups/upsd.pid: No such file or directory` sort of messages that regularly raise questions/concerns from new NUT users.

* With debug, all is seen as before:
````
:; ./server/upsd -D
Network UPS Tools upsd 2.8.2-29-g422cffad9
   0.000000     fopen /var/state/ups/upsd.pid: No such file or directory
   0.000032     Could not find PID file '/var/state/ups/upsd.pid' to see if previous upsd instance is already running!
   0.000100     stat /home/jim/nut/tmp/etc/nut/upsd.conf: No such file or directory
````

* Default is a little bit quiet(er) but importantly less confusing:
````
:; ./server/upsd
Network UPS Tools upsd 2.8.2-29-g422cffad9
Could not find PID file '/var/state/ups/upsd.pid' to see if previous upsd instance is already running!
````

* `upsmon -K` before the change (as of https://github.com/networkupstools/nut/pull/2383#issuecomment-2041066507):
````
:; ./clients/upsmon -K && echo KILLPOWER
Network UPS Tools upsmon 2.8.1-994-gbff0c6bc9
fopen /run/upsmon.pid: No such file or directory
Could not find PID file to see if previous upsmon instance is already running!
UPS: x (monitoring only)
Using power down flag file /run/nut/killpower
Power down flag is not set
````

* ...and after the change (with a longer message if `-K` is involved):
````
:; ./clients/upsmon -K && echo KILLPOWER
Network UPS Tools upsmon 2.8.2-29-g422cffad9
Could not find PID file to see if previous upsmon instance is already running! This is okay during OS shutdown, which is when checking POWERDOWNFLAG makes most sense.
Using power down flag file /run/nut/killpower
Power down flag is not set
````

* Note that as done before (in PR #2383), there is also special wording now for lack of `POWERDOWNFLAG` line in `upsmon.conf`, so the combined troubleshooting effect is:
````
Network UPS Tools upsmon 2.8.2-29-g422cffad9
Could not find PID file to see if previous upsmon instance is already running! This is okay during OS shutdown, which is when checking POWERDOWNFLAG makes most sense.
No POWERDOWNFLAG value was configured in /usr/local/ups/etc/upsmon.conf!
Should be a path to file that is normally writeable for root user, and remains at least readable late in shutdown after all unmounting completes.
Power down flag is not set
````