### PR TITLE
Quieter docs builds

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -121,7 +121,7 @@ ASCIIDOC_PDF = user-manual.pdf \
 	FAQ.pdf
 
 SUBDIRS = man cables
-SUFFIXES = .txt .html .pdf -spellchecked .txt-prepped
+SUFFIXES = .txt .html .pdf .txt-spellchecked .txt-prepped
 
 # This list is defined by configure script choices and options:
 CHECK_LOCAL_TARGETS = @DOC_CHECK_LIST@

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -310,7 +310,7 @@ A2X_COMMON_OPTS = $(ASCIIDOC_VERBOSE) \
 # As of version 8.6.9 it lies, and the argument is required for our distcheck
 # (and does affect PDF builds, as found during work on collision-avoidance -
 # true with at least asciidoc/a2x versions 9.0.0rc2).
-# For more details see issues https://github.com/asciidoc/asciidoc/issues/44
+# For more details see issues https://web.archive.org/web/20201207082352/https://github.com/asciidoc/asciidoc/issues/44
 # and https://github.com/networkupstools/nut/pull/281 (in short, attempts
 # to "fix" this warning broke NUT build). If this is to be retried later, see
 # https://github.com/networkupstools/nut/pull/281/commits/fe17861c4ea12679b3ebfefa8a6d692d79d99f2d


### PR DESCRIPTION
Recent changes to docs building before NUT v2.8.2 release amplified the noise from "bogus spellcheck" `make` events so I got to investigate them. Seems like a side effect of having too open `SUFFIXES` defined in automake-parsed file (and source files that do not have an expected extension like `.txt` -- e.g. a `LICENSE` file name).

Also hoped to quiesce `a2x: WARNING: --destination-dir option is only applicable to HTML and manpage based outputs` but the current make files can actually use a dedicated `A2X_OUTDIR` for each document even with in-tree builds, so the solutions from other posters in https://web.archive.org/web/20201207082352/https://github.com/asciidoc/asciidoc/issues/44 (e.g. https://github.com/dfoxfranke/libaes_siv/commit/c0e282b218bb1a693dba25b96ecc866ccb27b857) do not seem to apply here now. This issue was tackled before in PR #281 and reverted there too, as it broke the builds on many scenarios.