### PR TITLE
Avoid printing NUT banners at `exit()` of each forked child process

### DIFF
--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -2788,6 +2788,7 @@ int main(int argc, char *argv[])
 #endif
 
 	printf("Network UPS Tools %s %s\n", prog, UPS_VERSION);
+	fflush(stdout);
 
 	/* if no configuration file is specified on the command line, use default */
 	configfile = xmalloc(SMALLBUF);

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -325,6 +325,8 @@ static void notify(const char *notice, int flags, const char *ntype,
 		}
 	}
 
+	upsdebugx(6, "%s (child): exiting after notifications", __func__);
+
 	exit(EXIT_SUCCESS);
 #else
 	async_notify_t * data;
@@ -379,6 +381,10 @@ static void do_notify(const utype_t *ups, int ntype)
 #endif
 			notify(msg, notifylist[i].flags, notifylist[i].name,
 				upsname);
+
+			upsdebugx(3, "%s: ntype 0x%04x (%s) finished",
+				__func__, ntype, notifylist[i].name);
+
 			return;
 		}
 	}
@@ -3169,5 +3175,6 @@ int main(int argc, char *argv[])
 	upsnotify(NOTIFY_STATE_STOPPING, "Signal %d: exiting", exit_flag);
 	upsmon_cleanup();
 
+	upsdebugx(1, "Finally exiting due to signal %d", exit_flag);
 	exit(EXIT_SUCCESS);
 }

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -155,6 +155,8 @@ void upsdrv_banner (void)
 		printf("%s %s\n", upsdrv_info.subdrv_info[i]->name,
 			upsdrv_info.subdrv_info[i]->version);
 	}
+
+	fflush(stdout);
 }
 
 #ifndef DRIVERS_MAIN_WITHOUT_MAIN

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -1137,6 +1137,7 @@ int main(int argc, char **argv)
 
 	printf("Network UPS Tools - UPS driver controller %s\n",
 		UPS_VERSION);
+	fflush(stdout);
 
 	prog = argv[0];
 	while ((i = getopt(argc, argv, "+htu:r:DdFBVc:")) != -1) {

--- a/scripts/misc/notifyme-debug
+++ b/scripts/misc/notifyme-debug
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# This is a sample NUT notification script aimed to aid debugging of upsmon
+# behavior. It creates or appends to a log file named per user ID in the
+# temporary location with an entry per line like this:
+#   Sat Apr  6 17:23:06 UTC 2024    [uid=77(nut) gid=77(nut) groups=77(nut)]        COMMBAD [eco650]:        Communications with UPS eco650 lost     (1 tokens)
+#   Sat Apr  6 17:28:01 UTC 2024    [uid=77(nut) gid=77(nut) groups=77(nut)]        NOCOMM  [eco650]:        UPS eco650 is unavailable       (1 tokens)
+#
+# Copyright (C) 2023-2024 by Jim Klimov <jimklimov+nut@gmail.com>
+# Licensed under the terms of the Network UPS Tools source license (GPLv2+)
+
+printf '%s\t[%s]\t%s\t[%s]:\t%s\t(%s tokens)\n' "`date -u`" "`id`" "${NOTIFYTYPE-}" "${UPSNAME-}" "$*" "$#" >> "/tmp/notifyme-`id -u`.log"

--- a/scripts/systemd/README.adoc
+++ b/scripts/systemd/README.adoc
@@ -11,6 +11,16 @@ These files are automatically installed, upon detection (at `configure` time)
 of a systemd enabled target system, or if corresponding configuration options
 were requested.
 
+If you need to tweak some of the services, prefer to use systemd "drop-in"
+configuration files rather than editing the installed unit files directly
+(lest your changes be lost upon upgrade), e.g.:
+----
+# cat /etc/systemd/system/nut-monitor.service.d/debug.conf
+[Service]
+Environment="NUT_DEBUG_PID=yes"
+----
+...followed up by `systemctl daemon-reload` and a restart of the unit itself.
+
 This also uses the `nut-driver-enumerator.sh` (service and implementation
 method) and `upsdrvsvcctl` (tool) to manage NUT drivers as service instances
 located in `../upsdrvsvcctl/` source subdirectory.

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -1924,6 +1924,7 @@ int main(int argc, char **argv)
 	snprintf(pidfn, sizeof(pidfn), "%s/%s.pid", altpidpath(), progname);
 
 	printf("Network UPS Tools %s %s\n", progname, UPS_VERSION);
+	fflush(stdout);
 
 	while ((i = getopt(argc, argv, "+h46p:qr:i:fu:Vc:P:DFB")) != -1) {
 		switch (i) {


### PR DESCRIPTION
Closes: #1783

Initially noticed for `upsmon` doing this for every `notify()`, but later found to happen for other daemons' exit as well.