### PR TITLE
Implement an `INSTCMD driver.exit` as alternative to PID files and signals

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -40,6 +40,10 @@ https://github.com/networkupstools/nut/milestone/11
  - (expected) Bug fixes for fallout possible due to "fightwarn" effort in 2.8.0
 
 
+ - Extended instant commands for driver reloading with a `driver.exit`
+   command for a protocol equivalent of sending a `SIGTERM`, e.g. when
+   a newer instance of the driver program tries to start. [#1903, #2392]
+
  - riello_ser updates:
    * added `localcalculation` option to compute `battery.runtime` and
      `battery.charge` if the device provides bogus values [issue #2390,

--- a/data/cmdvartab
+++ b/data/cmdvartab
@@ -194,6 +194,7 @@ VARDESC driver.version.usb "USB library version"
 # VARDESC driver.parameter.[[:alpha:]]+ "Driver parameter: <name>"
 # VARDESC driver.flag.[[:alpha:]]+ "Driver flag: <name>"
 
+CMDDESC driver.exit "Tell the driver daemon to just exit its program (so the caller or service management framework can restart it with new options)"
 CMDDESC driver.killpower "Tell the driver daemon to initiate UPS shutdown; should be unlocked with driver.flag.allow_killpower option or variable setting"
 CMDDESC driver.reload "Reload running driver configuration from the file system (only works for changes in some options)"
 CMDDESC driver.reload-or-error "Reload running driver configuration from the file system (only works for changes in some options); return an error if something changed and could not be applied live (so the caller can restart it with new options)"

--- a/docs/man/nutupsdrv.txt
+++ b/docs/man/nutupsdrv.txt
@@ -114,6 +114,13 @@ are:
 	           which can not be applied "on the fly" (may fail for
 	           critical changes like run-time user/group accounts)
 /////////
+	*exit*;;   tell the currently running driver instance to just exit
+	           (so an external caller like the new driver instance, or
+	           the systemd or SMF frameworks would start another copy)
+
+With recent NUT releases, such commands can be sent using the Unix socket
+for driver-server interaction. As a fallback, like older releases, signals
+can be sent to the old driver instance's PID (where possible).
 
 *-P* 'pid'::
 Send the command signal above using specified PID number, rather than

--- a/docs/man/upsdrvctl.txt
+++ b/docs/man/upsdrvctl.txt
@@ -142,6 +142,9 @@ are:
                    which can not be applied "on the fly" (may fail for
                    critical changes like run-time user/group accounts)
 /////////
+        *exit*;;   tell the currently running driver instance to just exit
+                   (so an external caller like the new driver instance, or
+                   the systemd or SMF frameworks would start another copy)
 
 If the `upsdrvctl` was launched to remain in memory and manage NUT driver
 processes, it can receive supported signals and pass them to those drivers.

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -2061,8 +2061,26 @@ int main(int argc, char **argv)
 #endif
 			cmdname = "exit";
 
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_FORMAT_OVERFLOW || defined HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION)
+# pragma GCC diagnostic push
+# ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_FORMAT_OVERFLOW
+#  pragma GCC diagnostic ignored "-Wformat-overflow"
+# endif
+# ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION
+#  pragma GCC diagnostic ignored "-Wformat-truncation"
+# endif
+#endif
+		/* Some compilers do detect a chance of cmdname=NULL with
+		 * NUT builds on systems where libc does not care and prints
+		 * the right thing anyway (so NUT_STRARG macro is trivial).
+		 * In this weird case gotta silence the static checks.
+		 */
 		upsdebugx(1, "Signalling UPS [%s]: driver.%s",
 			upsname, NUT_STRARG(cmdname));
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_FORMAT_OVERFLOW || defined HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_TRUNCATION)
+# pragma GCC diagnostic pop
+#endif
+
 		if (!cmdname)
 			fatalx(EXIT_FAILURE, "Command not recognized");
 

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -2113,6 +2113,10 @@ int main(int argc, char **argv)
 	 * earlier instance to exit cleanly. After all, this socket file
 	 * should exist for the driver to talk to the NUT data server...
 	 */
+
+	/* Hush the fopen(pidfile) message but let "real errors" be seen */
+	nut_sendsignal_debug_level = NUT_SENDSIGNAL_DEBUG_LEVEL_FOPEN_PIDFILE - 1;
+
 	if (!cmd && (!do_forceshutdown)) {
 		ssize_t	cmdret = -1;
 		char	buf[LARGEBUF];
@@ -2187,15 +2191,19 @@ int main(int argc, char **argv)
 				 * but as we report a fault here - let the
 				 * user know that not all is lost right now :)
 				 */
+
+				/* Restore the signal errors verbosity, so that
+				 * e.g. follow-up fopen() issues can be seen -
+				 * we did probably encounter a sibling driver
+				 * instance after all, so can talk about it.
+				 */
+				nut_sendsignal_debug_level = NUT_SENDSIGNAL_DEBUG_LEVEL_DEFAULT;
 			}
 		}
 
-		/* Restore the signal errors verbosity */
+		/* Restore the socket protocol errors verbosity */
 		nut_upsdrvquery_debug_level = NUT_UPSDRVQUERY_DEBUG_LEVEL_DEFAULT;
 	}
-
-	/* Hush the fopen(pidfile) message but let "real errors" be seen */
-	nut_sendsignal_debug_level = NUT_SENDSIGNAL_DEBUG_LEVEL_FOPEN_PIDFILE - 1;
 
 #ifndef WIN32
 	/* Setup PID file to receive signals to communicate with this driver

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -2147,7 +2147,8 @@ int main(int argc, char **argv)
 			 * driver instance has stopped (just that it responded
 			 * "yes, sir!" - actual wind-down can take some time.
 			 */
-			upslogx(LOG_WARNING, "Duplicate driver instance detected (local %s exists)! Asking other driver to self-terminate!",
+			upslogx(LOG_WARNING, "Duplicate driver instance detected (local %s exists)! "
+				"Asked the other driver nicely to self-terminate!",
 #ifndef WIN32
 				"Unix socket"
 #else
@@ -2179,7 +2180,13 @@ int main(int argc, char **argv)
 			}
 
 			if (i < 1) {
-				upslogx(LOG_WARNING, "Duplicate driver instance did not respond to termination requests! Is it stuck or from an older NUT release?");
+				upslogx(LOG_WARNING, "Duplicate driver instance did not respond to termination requests! "
+					"Is it stuck or from an older NUT release? "
+					"Will retry via PID file and signals, if available.");
+				/* NOTE: We would try via PID in any case,
+				 * but as we report a fault here - let the
+				 * user know that not all is lost right now :)
+				 */
 			}
 		}
 

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -2203,6 +2203,9 @@ int main(int argc, char **argv)
 
 			/* Allow driver some time to quit */
 			sleep(5);
+
+			if (exit_flag)
+				fatalx(EXIT_FAILURE, "Got a break signal during attempt to terminate other driver");
 		}
 
 		if (i > 0) {

--- a/drivers/main.h
+++ b/drivers/main.h
@@ -131,6 +131,7 @@ void setup_signals(void);
 #ifndef WIN32
 # define SIGCMD_RELOAD                  SIGHUP
 /* not a signal, so negative; relies on socket protocol */
+# define SIGCMD_EXIT                    -SIGTERM
 # define SIGCMD_RELOAD_OR_ERROR         -SIGCMD_RELOAD
 # define SIGCMD_RELOAD_OR_EXIT          SIGUSR1
 /* // FIXME: Implement this self-recycling in drivers (keeping the PID):
@@ -153,6 +154,7 @@ void setup_signals(void);
 # endif
 #else
 /* FIXME: handle WIN32 builds for other signals too */
+# define SIGCMD_EXIT                    "driver.exit"
 # define SIGCMD_RELOAD_OR_ERROR         "driver.reload-or-error"
 #endif	/* WIN32 */
 

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -938,7 +938,7 @@ static void help(const char *arg_progname)
 	printf("  -FF			driver stays foregrounded and still saves the PID file\n");
 	printf("  -B			driver(s) stay backgrounded even if debugging is bumped\n");
 
-	printf("Signalling a running driver:\n");
+	printf("\nSignalling a running driver:\n");
 	printf("  -c <command>		send <command> via signal to running driver(s)\n");
 	printf("              		supported commands:\n");
 #ifndef WIN32
@@ -966,7 +966,7 @@ static void help(const char *arg_progname)
 	printf("              		  systemd or SMF frameworks would start another copy)\n");
 #endif /* WIN32 */
 
-	printf("Driver life cycle options:\n");
+	printf("\nDriver life cycle options:\n");
 	printf("  start			start all UPS drivers in ups.conf\n");
 	printf("  start	<ups>		only start driver for UPS <ups>\n");
 	printf("  stop			stop all UPS drivers in ups.conf\n");

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -196,32 +196,48 @@ static void signal_driver_cmd(const ups_t *ups,
 	int	ret;
 
 #ifndef WIN32
-	if (cmd == SIGCMD_RELOAD_OR_ERROR)
+	if (cmd == SIGCMD_RELOAD_OR_ERROR || cmd == SIGCMD_EXIT)
 #else
-	if (cmd && !strcmp(cmd, SIGCMD_RELOAD_OR_ERROR))
+	if (cmd && (!strcmp(cmd, SIGCMD_RELOAD_OR_ERROR) || !strcmp(cmd, SIGCMD_EXIT)))
 #endif
 	{
 		/* not a signal, use socket protocol */
-		char buf[LARGEBUF];
+		char buf[LARGEBUF], cmdbuf[LARGEBUF];
 		struct timeval	tv;
+		char *cmdname = NULL;
 
-		upsdebugx(1, "Signalling UPS [%s]: %s",
-			ups->upsname, "driver.reload-or-error");
+#ifndef WIN32
+		if (cmd == SIGCMD_RELOAD_OR_ERROR)
+#else
+		if (!strcmp(cmd, SIGCMD_RELOAD_OR_ERROR))
+#endif
+			cmdname = "reload-or-error";
+		else
+#ifndef WIN32
+		if (cmd == SIGCMD_EXIT)
+#else
+		if (!strcmp(cmd, SIGCMD_EXIT))
+#endif
+			cmdname = "exit";
 
-		if (testmode)
+		upsdebugx(1, "Signalling UPS [%s]: driver.%s",
+			ups->upsname, NUT_STRARG(cmdname));
+
+		if (testmode || !cmdname)
 			return;
 
 		/* Post the query and wait for reply */
 		/* FIXME: coordinate with pollfreq? */
 		tv.tv_sec = 15;
 		tv.tv_usec = 0;
+		snprintf(cmdbuf, sizeof(cmdbuf), "INSTCMD driver.%s\n", cmdname);
 		ret = upsdrvquery_oneshot(ups->driver, ups->upsname,
-			"INSTCMD driver.reload-or-error\n",
-			buf, sizeof(buf), &tv);
+			cmdbuf, buf, sizeof(buf), &tv);
 		if (ret < 0) {
 			goto socket_error;
 		} else {
-			upslogx(LOG_INFO, "Request to reload-or-error returned code %d", ret);
+			upslogx(LOG_INFO, "Request for driver to %s returned code %d",
+				cmdname, ret);
 			if (ret != STAT_INSTCMD_HANDLED)
 				exec_error++;
 			/* TODO: Propagate "ret" to caller, eventually CLI exit-code? */
@@ -495,7 +511,7 @@ static void reset_signal_flag(void)
 }
 
 #ifndef WIN32
-/* TODO: Equivalent for WIN32 - see SIGCMD_RELOAD in upd and upsmon */
+/* TODO: Equivalent for WIN32 - see SIGCMD_RELOAD in upsd and upsmon */
 static void set_reload_flag(const
 #ifndef WIN32
 	int
@@ -518,6 +534,10 @@ static void set_reload_flag(const
 			reload_flag = 3;
 			break;
 # endif
+
+		case SIGCMD_EXIT:	/* Not even a signal, but a socket protocol action */
+			reload_flag = 15;
+			break;
 
 		case SIGCMD_RELOAD:     /* SIGHUP */
 		case SIGCMD_RELOAD_OR_ERROR:	/* Not even a signal, but a socket protocol action */
@@ -965,6 +985,9 @@ static void help(const char *arg_progname)
 	printf("              		  driver instance if needed, so an external caller like the\n");
 	printf("              		  systemd or SMF frameworks would start another copy)\n");
 #endif /* WIN32 */
+	printf("              		- exit: tell the currently running driver instance to just exit\n");
+	printf("              		  (so an external caller like the new driver instance, or the\n");
+	printf("              		  systemd or SMF frameworks would start another copy)\n");
 
 	printf("\nDriver life cycle options:\n");
 	printf("  start			start all UPS drivers in ups.conf\n");
@@ -1192,6 +1215,10 @@ int main(int argc, char **argv)
 				if (!strncmp(optarg, "reload-or-error", strlen(optarg))) {
 					signal_flag = SIGCMD_RELOAD_OR_ERROR;
 				}
+				else
+				if (!strncmp(optarg, "exit", strlen(optarg))) {
+					signal_flag = SIGCMD_EXIT;
+				}
 #ifndef WIN32
 /* FIXME: port event loop from upsd/upsmon to allow messaging fellow drivers in WIN32 builds */
 				else
@@ -1222,9 +1249,14 @@ int main(int argc, char **argv)
 
 				pt_cmd = optarg;
 #ifndef WIN32
-				upsdebugx(1, "Will send signal %d (%s) for command '%s' "
-					"to already-running driver (if any) and exit",
-					signal_flag, strsignal(signal_flag), optarg);
+				if (signal_flag > 0)
+					upsdebugx(1, "Will send signal %d (%s) for command '%s' "
+						"to already-running driver (if any) and exit",
+						signal_flag, strsignal(signal_flag), optarg);
+				else
+					upsdebugx(1, "Will send request for command '%s' (internal code %d) "
+						"to already-running driver (if any) and exit",
+						optarg, signal_flag);
 #else
 				upsdebugx(1, "Will send request '%s' for command '%s' "
 					"to already-running driver (if any) and exit",

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -1,6 +1,9 @@
 /* upsdrvctl.c - UPS driver controller
 
-   Copyright (C) 2001  Russell Kroll <rkroll@exploits.org>
+   Copyright (C)
+   2001		Russell Kroll <rkroll@exploits.org>
+   2005 - 2017	Arnaud Quette <arnaud.quette@free.fr>
+   2017 - 2024	Jim Klimov <jimklimov+nut@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/drivers/upsdrvquery.c
+++ b/drivers/upsdrvquery.c
@@ -2,7 +2,7 @@
                    tracked until a response arrives, returning
                    that line and closing a connection
 
-   Copyright (C) 2023  Jim Klimov <jimklimov+nut@gmail.com>
+   Copyright (C) 2023-2024  Jim Klimov <jimklimov+nut@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -39,6 +39,19 @@
 #include "upsdrvquery.h"
 #include "nut_stdint.h"
 
+/* Normally the upsdrvquery*() methods call upslogx() to report issues
+ * such as failed fopen() of Unix socket file, or a dialog timeout or
+ * different error.
+ * In a few cases we call these methods opportunistically, and so if
+ * they fail - we do not care enough to raise a lot of "scary noise";
+ * the caller can take care of logging as/if needed.
+ * This variable and its values are a bit of internal detail between
+ * certain NUT programs to hush the low-level reports when they are
+ * not being otherwise debugged (e.g. nut_debug_level < 1).
+ * Default value allows all those messages to appear.
+ */
+int nut_upsdrvquery_debug_level = NUT_UPSDRVQUERY_DEBUG_LEVEL_DEFAULT;
+
 udq_pipe_conn_t *upsdrvquery_connect(const char *sockfn) {
 	udq_pipe_conn_t	*conn = (udq_pipe_conn_t*)xcalloc(1, sizeof(udq_pipe_conn_t));
 
@@ -54,13 +67,15 @@ udq_pipe_conn_t *upsdrvquery_connect(const char *sockfn) {
 	conn->sockfd = socket(AF_UNIX, SOCK_STREAM, 0);
 
 	if (conn->sockfd < 0) {
-		upslog_with_errno(LOG_ERR, "open socket");
+		if (nut_debug_level > 0 || nut_upsdrvquery_debug_level >= NUT_UPSDRVQUERY_DEBUG_LEVEL_CONNECT)
+			upslog_with_errno(LOG_ERR, "open socket");
 		free(conn);
 		return NULL;
 	}
 
 	if (connect(conn->sockfd, (struct sockaddr *) &sa, sizeof(sa)) < 0) {
-		upslog_with_errno(LOG_ERR, "connect to driver socket at %s", sockfn);
+		if (nut_debug_level > 0 || nut_upsdrvquery_debug_level >= NUT_UPSDRVQUERY_DEBUG_LEVEL_CONNECT)
+			upslog_with_errno(LOG_ERR, "connect to driver socket at %s", sockfn);
 		close(conn->sockfd);
 		free(conn);
 		return NULL;
@@ -68,14 +83,16 @@ udq_pipe_conn_t *upsdrvquery_connect(const char *sockfn) {
 
 	ret = fcntl(conn->sockfd, F_GETFL, 0);
 	if (ret < 0) {
-		upslog_with_errno(LOG_ERR, "fcntl get on driver socket %s failed", sockfn);
+		if (nut_debug_level > 0 || nut_upsdrvquery_debug_level >= NUT_UPSDRVQUERY_DEBUG_LEVEL_CONNECT)
+			upslog_with_errno(LOG_ERR, "fcntl get on driver socket %s failed", sockfn);
 		close(conn->sockfd);
 		free(conn);
 		return NULL;
 	}
 
 	if (fcntl(conn->sockfd, F_SETFL, ret | O_NDELAY) < 0) {
-		upslog_with_errno(LOG_ERR, "fcntl set O_NDELAY on driver socket %s failed", sockfn);
+		if (nut_debug_level > 0 || nut_upsdrvquery_debug_level >= NUT_UPSDRVQUERY_DEBUG_LEVEL_CONNECT)
+			upslog_with_errno(LOG_ERR, "fcntl set O_NDELAY on driver socket %s failed", sockfn);
 		close(conn->sockfd);
 		free(conn);
 		return NULL;
@@ -84,7 +101,8 @@ udq_pipe_conn_t *upsdrvquery_connect(const char *sockfn) {
 	BOOL	result = WaitNamedPipe(sockfn, NMPWAIT_USE_DEFAULT_WAIT);
 
 	if (result == FALSE) {
-		upslog_with_errno(LOG_ERR, "WaitNamedPipe : %d\n", GetLastError());
+		if (nut_debug_level > 0 || nut_upsdrvquery_debug_level >= NUT_UPSDRVQUERY_DEBUG_LEVEL_CONNECT)
+			upslog_with_errno(LOG_ERR, "WaitNamedPipe : %d\n", GetLastError());
 		return NULL;
 	}
 
@@ -99,7 +117,8 @@ udq_pipe_conn_t *upsdrvquery_connect(const char *sockfn) {
 			NULL);          /* no template file */
 
 	if (conn->sockfd == INVALID_HANDLE_VALUE) {
-		upslog_with_errno(LOG_ERR, "CreateFile : %d\n", GetLastError());
+		if (nut_debug_level > 0 || nut_upsdrvquery_debug_level >= NUT_UPSDRVQUERY_DEBUG_LEVEL_CONNECT)
+			upslog_with_errno(LOG_ERR, "CreateFile : %d\n", GetLastError());
 		free(conn);
 		return NULL;
 	}
@@ -114,7 +133,8 @@ udq_pipe_conn_t *upsdrvquery_connect(const char *sockfn) {
 	);
 
 	if (conn->overlapped.hEvent == NULL) {
-		upslogx(LOG_ERR, "Can't create event for reading event log");
+		if (nut_debug_level > 0 || nut_upsdrvquery_debug_level >= NUT_UPSDRVQUERY_DEBUG_LEVEL_CONNECT)
+			upslogx(LOG_ERR, "Can't create event for reading event log");
 		free(conn);
 		return NULL;
 	}
@@ -145,7 +165,8 @@ udq_pipe_conn_t *upsdrvquery_connect_drvname_upsname(const char *drvname, const 
 		dflt_statepath(), drvname, upsname);
 	check_unix_socket_filename(pidfn);
 	if (stat(pidfn, &fs)) {
-		upslog_with_errno(LOG_ERR, "Can't open %s", pidfn);
+		if (nut_debug_level > 0 || nut_upsdrvquery_debug_level >= NUT_UPSDRVQUERY_DEBUG_LEVEL_CONNECT)
+			upslog_with_errno(LOG_ERR, "Can't open %s", pidfn);
 		return NULL;
 	}
 #else
@@ -170,9 +191,10 @@ void upsdrvquery_close(udq_pipe_conn_t *conn) {
 
 	if (VALID_FD(conn->sockfd)) {
 		if (DisconnectNamedPipe(conn->sockfd) == 0) {
-			upslogx(LOG_ERR,
-				"DisconnectNamedPipe error : %d",
-				(int)GetLastError());
+			if (nut_debug_level > 0 || nut_upsdrvquery_debug_level >= NUT_UPSDRVQUERY_DEBUG_LEVEL_CONNECT)
+				upslogx(LOG_ERR,
+					"DisconnectNamedPipe error : %d",
+					(int)GetLastError());
 		}
 		CloseHandle(conn->sockfd);
 	}
@@ -196,7 +218,8 @@ ssize_t upsdrvquery_read_timeout(udq_pipe_conn_t *conn, struct timeval tv) {
 #endif
 
 	if (!conn || INVALID_FD(conn->sockfd)) {
-		upslog_with_errno(LOG_ERR, "socket not initialized");
+		if (nut_debug_level > 0 || nut_upsdrvquery_debug_level >= NUT_UPSDRVQUERY_DEBUG_LEVEL_CONNECT)
+			upslog_with_errno(LOG_ERR, "socket not initialized");
 		return -1;
 	}
 
@@ -205,7 +228,8 @@ ssize_t upsdrvquery_read_timeout(udq_pipe_conn_t *conn, struct timeval tv) {
 	FD_SET(conn->sockfd, &rfds);
 
 	if (select(conn->sockfd + 1, &rfds, NULL, NULL, &tv) < 0) {
-		upslog_with_errno(LOG_ERR, "select with socket");
+		if (nut_debug_level > 0 || nut_upsdrvquery_debug_level >= NUT_UPSDRVQUERY_DEBUG_LEVEL_DIALOG)
+			upslog_with_errno(LOG_ERR, "select with socket");
 		/* upsdrvquery_close(conn); */
 		return -1;
 	}
@@ -219,7 +243,8 @@ ssize_t upsdrvquery_read_timeout(udq_pipe_conn_t *conn, struct timeval tv) {
 	ret = read(conn->sockfd, conn->buf, sizeof(conn->buf));
 #else
 /*
-	upslog_with_errno(LOG_ERR, "Support for this platform is not currently implemented");
+	if (nut_debug_level > 0 || nut_upsdrvquery_debug_level > 0)
+		upslog_with_errno(LOG_ERR, "Support for this platform is not currently implemented");
 	return -1;
 */
 
@@ -333,7 +358,8 @@ ssize_t upsdrvquery_write(udq_pipe_conn_t *conn, const char *buf) {
 	upsdebugx(5, "%s: write to driver socket: %s", __func__, buf);
 
 	if (!conn || INVALID_FD(conn->sockfd)) {
-		upslog_with_errno(LOG_ERR, "socket not initialized");
+		if (nut_debug_level > 0 || nut_upsdrvquery_debug_level >= NUT_UPSDRVQUERY_DEBUG_LEVEL_CONNECT)
+			upslog_with_errno(LOG_ERR, "socket not initialized");
 		return -1;
 	}
 
@@ -341,7 +367,8 @@ ssize_t upsdrvquery_write(udq_pipe_conn_t *conn, const char *buf) {
 	ret = write(conn->sockfd, buf, buflen);
 
 	if (ret < 0 || ret != (int)buflen) {
-		upslog_with_errno(LOG_ERR, "Write to socket %d failed", conn->sockfd);
+		if (nut_debug_level > 0 || nut_upsdrvquery_debug_level >= NUT_UPSDRVQUERY_DEBUG_LEVEL_DIALOG)
+			upslog_with_errno(LOG_ERR, "Write to socket %d failed", conn->sockfd);
 		goto socket_error;
 	}
 
@@ -349,7 +376,8 @@ ssize_t upsdrvquery_write(udq_pipe_conn_t *conn, const char *buf) {
 #else
 	result = WriteFile(conn->sockfd, buf, buflen, &bytesWritten, NULL);
 	if (result == 0 || bytesWritten != (DWORD)buflen) {
-		upslog_with_errno(LOG_ERR, "Write to handle %p failed", conn->sockfd);
+		if (nut_debug_level > 0 || nut_upsdrvquery_debug_level >= NUT_UPSDRVQUERY_DEBUG_LEVEL_DIALOG)
+			upslog_with_errno(LOG_ERR, "Write to handle %p failed", conn->sockfd);
 		goto socket_error;
 	}
 
@@ -433,7 +461,8 @@ ssize_t upsdrvquery_prepare(udq_pipe_conn_t *conn, struct timeval tv) {
 	if (upsdrvquery_read_timeout(conn, tv) < 1)
 		goto socket_error;
 	if (strcmp(conn->buf, "ON")) {
-		upslog_with_errno(LOG_ERR, "Driver does not have TRACKING support enabled");
+		if (nut_debug_level > 0 || nut_upsdrvquery_debug_level >= NUT_UPSDRVQUERY_DEBUG_LEVEL_DIALOG)
+			upslog_with_errno(LOG_ERR, "Driver does not have TRACKING support enabled");
 		goto socket_error;
 	}
 */

--- a/drivers/upsdrvquery.h
+++ b/drivers/upsdrvquery.h
@@ -2,7 +2,7 @@
                    tracked until a response arrives, returning
                    that line and closing a connection
 
-   Copyright (C) 2023  Jim Klimov <jimklimov+nut@gmail.com>
+   Copyright (C) 2023-2024  Jim Klimov <jimklimov+nut@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -47,5 +47,12 @@ ssize_t upsdrvquery_request(udq_pipe_conn_t *conn, struct timeval tv, const char
 
 /* if buf != NULL, last reply is copied there */
 ssize_t upsdrvquery_oneshot(const char *drvname, const char *upsname, const char *query, char *buf, const size_t bufsz, struct timeval *tv);
+
+/* Internal toggle for some NUT programs that deal with Unix socket chatter.
+ * For a detailed rationale comment see upsdrvquery.c */
+extern int nut_upsdrvquery_debug_level;
+#define NUT_UPSDRVQUERY_DEBUG_LEVEL_DEFAULT	6
+#define NUT_UPSDRVQUERY_DEBUG_LEVEL_CONNECT	5
+#define NUT_UPSDRVQUERY_DEBUG_LEVEL_DIALOG	4
 
 #endif	/* NUT_UPSDRVQUERY_H_SEEN */


### PR DESCRIPTION
When a NUT driver starts, by default it checks the PID file (if present) to kill off its earlier running instance, if any, to have the device connection available and no logical conflicts at run-time.

Problems can arise when the PID file is not available (e.g. not saved due to service unit set-up). Technically we have a fallback capability of checking for the old driver instance via Unix socket made for driver-server communications, and since #1903 and numerous later issues and PRs we can have driver instances (and `upsdrvctl`) interact over this channel.

This PR adds a new Unix socket protocol command, `driver.exit` which can be used similar to `SIGTERM` and so cleanly exit the NUT driver program (with the goal of a new instance being able to start). Note that if the deceased instance was managed by systemd, it would be restarted after a short throttling timeout.

At this time of initial posting, this was implemented and tested as a `driver -a upscfg -c exit` sort of CLI operation, and tested with `usbhid-ups` and with `upsdrvctl` vs. a driver running as a systemd unit.

Next step would be to add a similar call to where we check for PID files and ensure "clean-up" before starting the NUT driver for monitoring (as opposed to killpower, instant commands and other side activities).

Closes: #2392