### PR TITLE
[HCL] `data/driver.list.in`: Note known support for Visench C1K UPS

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -63,6 +63,10 @@ https://github.com/networkupstools/nut/milestone/11
      (similar to `runtimecal` in some other drivers, may be refactored
      to that configuration and logic model in later NUT releases)
 
+ - added Visench C1K (using serial port converter with USB ID `1a86:7523`)
+   as known supported by `nutdrv_qx` (Megatec protocol) since at least
+   NUT v2.7.4 release [#2395]
+
  - USB drivers could log `(nut_)libusb_get_string: Success` due to either
    reading an empty string or getting a success code `0` from libusb.
    This difference should now be better logged, and not into syslog. [#2399]

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -1384,6 +1384,8 @@
 
 "Viewsonic"	"ups"	"1"	"PowerES"	"420E"	"optiups"
 
+"Visench"	"ups"	"1"	"C1K"	"(/dev/ttyCH341USB0 with USB ID 1a86:7523)"	"nutdrv_qx"	# https://github.com/networkupstools/nut/issues/2395 : Visench C1K; mfr/model are strings of `2`'s; USB ID identifies as QinHeng Electronics CH340 serial converter chip
+
 "Vivaldi"	"ups"	"1"	"EA200 LED"	"USB"	"richcomm_usb"
 
 "Voltronic Power"	"ups"	"2"	"Apex 1KVA"	"Serial"	"nutdrv_qx"

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3487 utf-8
+personal_ws-1.1 en 3490 utf-8
 AAC
 AAS
 ABI
@@ -1459,6 +1459,7 @@ Viewpower
 Viewsonic
 Viktor
 VirCIO
+Visench
 Vout
 Vultech
 Václav

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -2256,7 +2256,7 @@ static qx_usb_device_id_t	qx_usb_id[] = {
 	{ USB_DEVICE(0x0001, 0x0000),	"ATCL FOR UPS",	"ATCL FOR UPS",		&fuji_subdriver },	/* Fuji UPSes */
 	{ USB_DEVICE(0x0001, 0x0000),	NULL,		NULL,			&krauler_subdriver },	/* Krauler UP-M500VA */
 	{ USB_DEVICE(0x0001, 0x0000),	NULL,		"MEC0003",		&snr_subdriver },	/* SNR-UPS-LID-XXXX UPSes */
-	{ USB_DEVICE(0x0925, 0x1234),	NULL,		NULL,					&armac_subdriver },	/* Armac UPS and maybe other richcomm-like or using old PowerManagerII software */
+	{ USB_DEVICE(0x0925, 0x1234),	NULL,		NULL,			&armac_subdriver },	/* Armac UPS and maybe other richcomm-like or using old PowerManagerII software */
 	/* End of list */
 	{ -1,	-1,	NULL,	NULL,	NULL }
 };


### PR DESCRIPTION
Closes: #2395

Given that this uses a serial port connection, not sure there is much more to "fix" on NUT code base side.