### PR TITLE
upsmon: introduce `OBLBDURATION` config toggle

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -71,12 +71,14 @@ https://github.com/networkupstools/nut/milestone/11
    reading an empty string or getting a success code `0` from libusb.
    This difference should now be better logged, and not into syslog. [#2399]
 
- - upsmon: it was realized that the `POWERDOWNFLAG` must be explicitly set in
-   the configuration file, there is no built-in default in the binary program
-   (the settings facilitated by the `configure` script during build "only"
-   impact the `upsmon.conf.sample`, init-scripts and similar files generated
-   from templates). [issue #321, PR #2383]
-
+ - upsmon:
+   * it was realized that the `POWERDOWNFLAG` must be explicitly set in the
+     configuration file, there is no built-in default in the binary program
+     (the settings facilitated by the `configure` script during build "only"
+     impact the `upsmon.conf.sample`, init-scripts and similar files generated
+     from templates). [issue #321, PR #2383]
+   * added an `OBLBDURATION` (seconds) setting to optionally delay raising
+     the alarm for immediate shutdown in critical situation. [#321]
 
 
 Release notes for NUT 2.8.2 - what's new since 2.8.1

--- a/clients/upsmon.h
+++ b/clients/upsmon.h
@@ -1,6 +1,9 @@
 /* upsmon.h - headers and other useful things for upsmon.h
 
-   Copyright (C) 2000  Russell Kroll <rkroll@exploits.org>
+   Copyright (C)
+     2000  Russell Kroll <rkroll@exploits.org>
+     2012  Arnaud Quette <arnaud.quette.free.fr>
+     2020-2024  Jim Klimov <jimklimov+nut@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -79,6 +82,7 @@ typedef struct {
 	time_t	lastncwarn;		/* time of last NOCOMM warning	*/
 
 	time_t	offsince;		/* time of recent entry into OFF state	*/
+	time_t	oblbsince;		/* time of recent entry into OB LB state (normally this causes immediate shutdown alert, unless we are configured to delay it)	*/
 
 	void	*next;
 }	utype_t;

--- a/conf/upsmon.conf.sample.in
+++ b/conf/upsmon.conf.sample.in
@@ -401,6 +401,29 @@ POWERDOWNFLAG "@POWERDOWNFLAG@"
 OFFDURATION 30
 
 # --------------------------------------------------------------------------
+# OBLBDURATION - put "OB LB" state into effect if it persists for this many
+# seconds
+#
+# NUT normally raises alarms for immediate shutdown (FSD) for consumers of an
+# UPS known to be on battery (OB) and achieving the low battery status (LB),
+# if that is their last remaining power source to satisfy their MINSUPPLIES
+# setting. In some special cases, users may want to delay raising the alarm
+# (using the OBLBDURATION option) at their discretion and risk of an ungraceful
+# shutdown.
+#
+# A non-positive value makes the FSD effect of detected "OB LB" state immediate.
+# Built-in default value is 0 (seconds).
+#
+# NOTE: If both `OBLBDURATION` and `HOSTSYNC` options are set on the same
+# (secondary) `upsmon` client system, and `HOSTSYNC` is shorter, it would be
+# effectively ignored: `upsmon` would wait for up to `OBLBDURATION` seconds
+# for the "OB LB" state to clear, and then the secondary client logic would
+# fall through to immediate shutdown. If the primary system issues an FSD on
+# this UPS, that would take an even higher-priority effect as soon as seen.
+#
+#OBLBDURATION 0
+
+# --------------------------------------------------------------------------
 # RBWARNTIME - replace battery warning time in seconds
 #
 # upsmon will normally warn you about a battery that needs to be replaced

--- a/docs/man/upsmon.conf.txt
+++ b/docs/man/upsmon.conf.txt
@@ -371,6 +371,26 @@ NOTE: so far we support the device reporting an "OFF" state which usually
 means completely un-powering the load; a bug-tracker issue was logged to
 design similar support for just some manageable outlets or outlet groups.
 
+*OBLBDURATION* 'seconds'::
+
+NUT normally raises alarms for immediate shutdown (FSD) for consumers of an
+UPS known to be on battery ("OB") and achieving the low battery status ("LB"),
+if that is their last remaining power source to satisfy their `MINSUPPLIES`
+setting. In some special cases, users may want to delay raising the alarm
+(using the `OBLBDURATION` option) at their discretion and risk of an ungraceful
+shutdown.
++
+A positive value puts "OB LB" state into effect only if it persists for this
+many seconds. A non-positive value makes the FSD effect of detected "OB LB"
+state immediate. Built-in default value is 0 (seconds).
++
+NOTE: If both `OBLBDURATION` and `HOSTSYNC` options are set on the same
+(secondary) `upsmon` client system, and `HOSTSYNC` is shorter, it would be
+effectively ignored: `upsmon` would wait for up to `OBLBDURATION` seconds
+for the "OB LB" state to clear, and then the secondary client logic would
+fall through to immediate shutdown. If the primary system issues an FSD on
+this UPS, that would take an even higher-priority effect as soon as seen.
+
 *RBWARNTIME* 'seconds'::
 
 When a UPS says that it needs to have its battery replaced, upsmon will

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3490 utf-8
+personal_ws-1.1 en 3491 utf-8
 AAC
 AAS
 ABI
@@ -866,6 +866,7 @@ OC
 ODH
 OEM
 OEM'ed
+OBLBDURATION
 OFFDURATION
 OID
 OIDs


### PR DESCRIPTION
Largely follows in the footsteps of #2104 which introduced the `OFFDURATION` toggle.

This PR adds an `OBLBDURATION` toggle to delay issuing FSD (primary) or commencing a shutdown after `HOSTSYNC` (secondary without a seen FSD alert), for users that deem this desirable (some use-cases suggested in issue #321 discussion - primarily to survive short hiccups that happen at the wrong moment) at their discretion and risk of an ungraceful shutdown.

Closes: #321

CC @desertwitch @dark-penguin @clepple @aquette 

Testing in practice would be as welcome as code review :)