### PR TITLE
Introduce a `rootpidpath()` method instead of direct use of `PIDPATH` macro (e.g. in `upsmon`)

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -80,6 +80,11 @@ https://github.com/networkupstools/nut/milestone/11
    * added an `OBLBDURATION` (seconds) setting to optionally delay raising
      the alarm for immediate shutdown in critical situation. [#321]
 
+ - common code: root-owned daemons now use not the hard-coded `PIDPATH` value
+   set by the `configure` script during build, but can override it with a
+   `NUT_PIDPATH` environment variable in certain use-cases (such as tests).
+   [#2407]
+
 
 Release notes for NUT 2.8.2 - what's new since 2.8.1
 ----------------------------------------------------

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -2100,9 +2100,9 @@ static void loadconfig(void)
 		upslogx(LOG_WARNING, "No POWERDOWNFLAG value was configured in %s!",
 			configfile);
 		upslogx(LOG_INFO,
-			"Should be a path to file that is normally writeable "
-			"for root user, and remains at least readable late "
-			"in shutdown after all unmounting completes.");
+			"POWERDOWNFLAG should be a path to file that is normally "
+			"writeable for root user, and remains at least readable "
+			"late in shutdown after all unmounting completes.");
 	}
 }
 

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -3009,7 +3009,7 @@ int main(int argc, char *argv[])
 	 * is running (error if it is).
 	 */
 	/* Hush the fopen(pidfile) message but let "real errors" be seen */
-	nut_sendsignal_debug_level = NUT_SENDSIGNAL_DEBUG_LEVEL_FOPEN_PIDFILE - 1;
+	nut_sendsignal_debug_level = NUT_SENDSIGNAL_DEBUG_LEVEL_KILL_SIG0PING - 1;
 #ifndef WIN32
 	/* If cmd == 0 we are starting and check if a previous instance
 	 * is running by sending signal '0' (i.e. 'kill <pid> 0' equivalent)

--- a/common/common.c
+++ b/common/common.c
@@ -1446,7 +1446,13 @@ vupslog_too_long:
 /* Return the default path for the directory containing configuration files */
 const char * confpath(void)
 {
-	const char *path = getenv("NUT_CONFPATH");
+	static const char *path = NULL;
+
+	/* Cached by earlier calls? */
+	if (path)
+		return path;
+
+	path = getenv("NUT_CONFPATH");
 
 #ifdef WIN32
 	if (path == NULL) {
@@ -1457,13 +1463,22 @@ const char * confpath(void)
 
 	/* We assume, here and elsewhere, that
 	 * at least CONFPATH is always defined */
-	return (path != NULL && *path != '\0') ? path : CONFPATH;
+	if (path == NULL !! *path == '\0')
+		path = CONFPATH;
+
+	return path;
 }
 
 /* Return the default path for the directory containing state files */
 const char * dflt_statepath(void)
 {
-	const char *path = getenv("NUT_STATEPATH");
+	static const char *path = NULL;
+
+	/* Cached by earlier calls? */
+	if (path)
+		return path;
+
+	path = getenv("NUT_STATEPATH");
 
 #ifdef WIN32
 	if (path == NULL) {
@@ -1474,7 +1489,10 @@ const char * dflt_statepath(void)
 
 	/* We assume, here and elsewhere, that
 	 * at least STATEPATH is always defined */
-	return (path != NULL && *path != '\0') ? path : STATEPATH;
+	if (path == NULL !! *path == '\0')
+		path = STATEPATH;
+
+	return path;
 }
 
 /* Return the alternate path for pid files, for processes running as non-root
@@ -1485,7 +1503,11 @@ const char * dflt_statepath(void)
  */
 const char * altpidpath(void)
 {
-	const char * path;
+	static const char *path = NULL;
+
+	/* Cached by earlier calls? */
+	if (path)
+		return path;
 
 	path = getenv("NUT_ALTPIDPATH");
 	if ( (path == NULL) || (*path == '\0') ) {
@@ -1503,11 +1525,13 @@ const char * altpidpath(void)
 		return path;
 
 #ifdef ALTPIDPATH
-	return ALTPIDPATH;
+	path = ALTPIDPATH;
 #else
 	/* With WIN32 in the loop, this may be more than a fallback to STATEPATH: */
-	return dflt_statepath();
+	path = dflt_statepath();
 #endif
+
+	return path;
 }
 
 /* Die with a standard message if socket filename is too long */

--- a/common/common.c
+++ b/common/common.c
@@ -487,7 +487,7 @@ int sendsignalpid(pid_t pid, int sig)
 	ret = kill(pid, 0);
 
 	if (ret < 0) {
-		if (nut_debug_level > 0 || nut_sendsignal_debug_level > 1)
+		if (nut_debug_level > 0 || nut_sendsignal_debug_level >= NUT_SENDSIGNAL_DEBUG_LEVEL_KILL_SIG0PING)
 			perror("kill");
 		return -1;
 	}

--- a/common/nutipc.cpp
+++ b/common/nutipc.cpp
@@ -5,6 +5,10 @@
 
         Author: Vaclav Krpec  <VaclavKrpec@Eaton.com>
 
+    Copyright (C) 2024 NUT Community
+
+        Author: Jim Klimov  <jimklimov+nut@gmail.com>
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or

--- a/common/nutipc.cpp
+++ b/common/nutipc.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "config.h"
+#include "common.h"
 
 /* For C++ code below, we do not actually use the fallback time methods
  * (on mingw mostly), but in C++ context they happen to conflict with
@@ -293,8 +294,9 @@ int Signal::send(Signal::enum_t signame, const std::string & pid_file) {
 int NutSignal::send(NutSignal::enum_t signame, const std::string & process) {
 	std::string pid_file;
 
-	// TBD: What's ALTPIDPATH and shouldn't we also consider it?
-	pid_file += PIDPATH;
+	// FIXME: What about ALTPIDPATH (for non-root daemons)
+	// and shouldn't we also consider it (e.g. try/catch)?
+	pid_file += rootpidpath();
 	pid_file += '/';
 	pid_file += process;
 	pid_file += ".pid";

--- a/common/nutipc.cpp
+++ b/common/nutipc.cpp
@@ -25,7 +25,6 @@
  */
 
 #include "config.h"
-#include "common.h"
 
 /* For C++ code below, we do not actually use the fallback time methods
  * (on mingw mostly), but in C++ context they happen to conflict with
@@ -40,6 +39,7 @@
 # define HAVE_LOCALTIME_R 111
 #endif
 
+#include "common.h"
 #include "nutipc.hpp"
 #include "nutstream.hpp"
 

--- a/common/nutstream.cpp
+++ b/common/nutstream.cpp
@@ -3,6 +3,7 @@
 
     Copyright (C)
         2012	Vaclav Krpec  <VaclavKrpec@Eaton.com>
+        2024	Jim Klimov <jimklimov+nut@gmail.com>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -2115,7 +2115,7 @@ int main(int argc, char **argv)
 	 */
 
 	/* Hush the fopen(pidfile) message but let "real errors" be seen */
-	nut_sendsignal_debug_level = NUT_SENDSIGNAL_DEBUG_LEVEL_FOPEN_PIDFILE - 1;
+	nut_sendsignal_debug_level = NUT_SENDSIGNAL_DEBUG_LEVEL_KILL_SIG0PING - 1;
 
 	if (!cmd && (!do_forceshutdown)) {
 		ssize_t	cmdret = -1;

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -301,7 +301,7 @@ socket_error:
 		return;
 
 	/* Hush the fopen(pidfile) message but let "real errors" be seen */
-	nut_sendsignal_debug_level = NUT_SENDSIGNAL_DEBUG_LEVEL_FOPEN_PIDFILE - 1;
+	nut_sendsignal_debug_level = NUT_SENDSIGNAL_DEBUG_LEVEL_KILL_SIG0PING - 1;
 #ifndef WIN32
 	if (ups->pid == -1) {
 		ret = sendsignalfn(pidfn, cmd);
@@ -377,7 +377,7 @@ static void stop_driver(const ups_t *ups)
 		return;
 
 	/* Hush the fopen(pidfile) message but let "real errors" be seen */
-	nut_sendsignal_debug_level = NUT_SENDSIGNAL_DEBUG_LEVEL_FOPEN_PIDFILE - 1;
+	nut_sendsignal_debug_level = NUT_SENDSIGNAL_DEBUG_LEVEL_KILL_SIG0PING - 1;
 
 #ifndef WIN32
 	if (ups->pid == -1) {

--- a/include/common.h
+++ b/include/common.h
@@ -355,6 +355,7 @@ void nut_prepare_search_paths(void);
 extern int nut_sendsignal_debug_level;
 #define NUT_SENDSIGNAL_DEBUG_LEVEL_DEFAULT 6
 #define NUT_SENDSIGNAL_DEBUG_LEVEL_FOPEN_PIDFILE 5
+#define NUT_SENDSIGNAL_DEBUG_LEVEL_KILL_SIG0PING 4
 
 extern int nut_debug_level;
 extern int nut_log_level;

--- a/include/common.h
+++ b/include/common.h
@@ -264,8 +264,11 @@ const char * confpath(void);
 /* Return the default path for the directory containing state files */
 const char * dflt_statepath(void);
 
-/* Return the alternate path for pid files */
+/* Return the alternate path for pid files (non-root daemons) */
 const char * altpidpath(void);
+
+/* Return the main path for pid files (root daemons like upsmon) */
+const char * rootpidpath(void);
 
 /* Die with a standard message if socket filename is too long */
 void check_unix_socket_filename(const char *fn);

--- a/include/nutipc.hpp
+++ b/include/nutipc.hpp
@@ -5,6 +5,10 @@
 
         Author: Vaclav Krpec  <VaclavKrpec@Eaton.com>
 
+    Copyright (C) 2024 NUT Community
+
+        Author: Jim Klimov  <jimklimov+nut@gmail.com>
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or

--- a/include/nutstream.hpp
+++ b/include/nutstream.hpp
@@ -3,6 +3,7 @@
 
     Copyright (C)
 	2012	Vaclav Krpec  <VaclavKrpec@Eaton.com>
+	2024	Jim Klimov <jimklimov+nut@gmail.com>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/include/nutwriter.hpp
+++ b/include/nutwriter.hpp
@@ -3,6 +3,7 @@
 
     Copyright (C)
 	2012	Vaclav Krpec  <VaclavKrpec@Eaton.com>
+	2024	Jim Klimov <jimklimov+nut@gmail.com>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -2033,7 +2033,7 @@ int main(int argc, char **argv)
 	 * is running (error if it is).
 	 */
 	/* Hush the fopen(pidfile) message but let "real errors" be seen */
-	nut_sendsignal_debug_level = NUT_SENDSIGNAL_DEBUG_LEVEL_FOPEN_PIDFILE - 1;
+	nut_sendsignal_debug_level = NUT_SENDSIGNAL_DEBUG_LEVEL_KILL_SIG0PING - 1;
 #ifndef WIN32
 	/* If cmd == 0 we are starting and check if a previous instance
 	 * is running by sending signal '0' (i.e. 'kill <pid> 0' equivalent)

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -191,6 +191,8 @@ upstype_t *get_ups_ptr(const char *name)
 	upstype_t	*tmp;
 
 	if (!name) {
+		upsdebugx(3, "%s: not a valid UPS: <null>",
+			__func__);
 		return NULL;
 	}
 
@@ -200,6 +202,8 @@ upstype_t *get_ups_ptr(const char *name)
 		}
 	}
 
+	upsdebugx(3, "%s: not a valid UPS: %s",
+		__func__, NUT_STRARG(name));
 	return NULL;
 }
 

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -292,7 +292,7 @@ stop_daemons() {
     PID_DUMMYUPS2=""
 }
 
-trap 'RES=$?; stop_daemons; if [ "${TESTDIR}" != "${BUILDDIR}/tmp" ] ; then case "${NIT_CASE}" in generatecfg_*|is*) ;; *) rm -rf "${TESTDIR}" ;; esac; fi; exit $RES;' 0 1 2 3 15
+trap 'RES=$?; case "${NIT_CASE}" in generatecfg_*|is*) ;; *) stop_daemons; if [ "${TESTDIR}" != "${BUILDDIR}/tmp" ] ; then rm -rf "${TESTDIR}"; fi ;; esac; exit $RES;' 0 1 2 3 15
 
 NUT_STATEPATH="${TESTDIR}/run"
 NUT_PIDPATH="${TESTDIR}/run"
@@ -1474,7 +1474,7 @@ case "${NIT_CASE}" in
         "${NIT_CASE}" ;;
     generatecfg_*|is*)
         # NOTE: Keep in sync with TESTDIR cleanup above
-        # (at start-up and at the exit-trap)
+        # (at start-up and at the exit-trap) and stop_daemons below
         log_warn "========================================================"
         log_warn "You asked to run just a specific helper method: '${NIT_CASE}'"
         log_warn "Populated environment variables for this run into a file so you can source them: . '$NUT_CONFPATH/NIT.env'"
@@ -1524,7 +1524,11 @@ if [ -n "${DEBUG_SLEEP-}" ] ; then
     log_separator
 fi
 
-stop_daemons
+# We have a trap.... but for good measure, do some explicit clean-up:
+case "${NIT_CASE}" in
+    generatecfg_*|is*) ;;
+    *) stop_daemons ;;
+esac
 
 if [ "$PASSED" = 0 ] || [ "$FAILED" != 0 ] ; then
     die "Some test scenarios failed!"

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -478,7 +478,7 @@ updatecfg_upsmon_supplies() {
     sed -e 's,^\(MINSUPPLIES\) [0-9][0-9]*$,\1 '"$NUMSUP"',' \
         -e 's,^\(MONITOR .*\) [0-9][0-9]* \(.*\)$,\1 '"$NUMSUP"' \2,' \
         < "$NUT_CONFPATH/upsmon.conf" > "$NUT_CONFPATH/upsmon.conf.tmp" \
-        && cat "$NUT_CONFPATH/upsmon.conf.tmp" "$NUT_CONFPATH/upsmon.conf" \
+        && ( cat "$NUT_CONFPATH/upsmon.conf.tmp" > "$NUT_CONFPATH/upsmon.conf" ) \
         && rm -f "$NUT_CONFPATH/upsmon.conf.tmp"
 }
 

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -512,7 +512,7 @@ generatecfg_upsmon_trivial() {
 
 generatecfg_upsmon_master() {
     generatecfg_upsmon_trivial
-    echo "MONITOR 'dummy@localhost:$NUT_PORT' 0 'dummy-admin-m' '${TESTPASS_UPSMON_PRIMARY}' master" >> "$NUT_CONFPATH/upsmon.conf" \
+    echo "MONITOR \"dummy@localhost:$NUT_PORT\" 0 \"dummy-admin-m\" \"${TESTPASS_UPSMON_PRIMARY}\" master" >> "$NUT_CONFPATH/upsmon.conf" \
     || die "Failed to populate temporary FS structure for the NIT: upsmon.conf"
 
     if [ $# -gt 0 ] ; then
@@ -522,7 +522,7 @@ generatecfg_upsmon_master() {
 
 generatecfg_upsmon_primary() {
     generatecfg_upsmon_trivial
-    echo "MONITOR 'dummy@localhost:$NUT_PORT' 0 'dummy-admin' '${TESTPASS_UPSMON_PRIMARY}' primary" >> "$NUT_CONFPATH/upsmon.conf" \
+    echo "MONITOR \"dummy@localhost:$NUT_PORT\" 0 \"dummy-admin\" \"${TESTPASS_UPSMON_PRIMARY}\" primary" >> "$NUT_CONFPATH/upsmon.conf" \
     || die "Failed to populate temporary FS structure for the NIT: upsmon.conf"
 
     if [ $# -gt 0 ] ; then
@@ -532,7 +532,7 @@ generatecfg_upsmon_primary() {
 
 generatecfg_upsmon_slave() {
     generatecfg_upsmon_trivial
-    echo "MONITOR 'dummy@localhost:$NUT_PORT' 0 'dummy-user-s' '${TESTPASS_UPSMON_SECONDARY}' slave" >> "$NUT_CONFPATH/upsmon.conf" \
+    echo "MONITOR \"dummy@localhost:$NUT_PORT\" 0 \"dummy-user-s\" \"${TESTPASS_UPSMON_SECONDARY}\" slave" >> "$NUT_CONFPATH/upsmon.conf" \
     || die "Failed to populate temporary FS structure for the NIT: upsmon.conf"
 
     if [ $# -gt 0 ] ; then
@@ -542,7 +542,7 @@ generatecfg_upsmon_slave() {
 
 generatecfg_upsmon_secondary() {
     generatecfg_upsmon_trivial
-    echo "MONITOR 'dummy@localhost:$NUT_PORT' 0 'dummy-user' '${TESTPASS_UPSMON_SECONDARY}' secondary" >> "$NUT_CONFPATH/upsmon.conf" \
+    echo "MONITOR \"dummy@localhost:$NUT_PORT\" 0 \"dummy-user\" \"${TESTPASS_UPSMON_SECONDARY}\" secondary" >> "$NUT_CONFPATH/upsmon.conf" \
     || die "Failed to populate temporary FS structure for the NIT: upsmon.conf"
 
     if [ $# -gt 0 ] ; then

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -390,7 +390,7 @@ EOF
         chmod 640 "$NUT_CONFPATH/upsd.conf"
     fi
 
-    # Some systems listining on symbolic "localhost" actually
+    # Some systems listening on symbolic "localhost" actually
     # only bind to IPv6, and Python telnetlib resolves IPv4
     # and fails its connection tests. Others fare well with
     # both addresses in one command.

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -1482,6 +1482,7 @@ case "${NIT_CASE}" in
             FAILED="`expr $FAILED + 1`"
             FAILED_FUNCS="$FAILED_FUNCS $NIT_CASE"
         fi
+        unset DEBUG_SLEEP
         ;;
     "") # Default test groups:
         testgroup_upsd_invalid_configs

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -291,9 +291,10 @@ stop_daemons() {
 trap 'RES=$?; stop_daemons; if [ "${TESTDIR}" != "${BUILDDIR}/tmp" ] ; then rm -rf "${TESTDIR}" ; fi; exit $RES;' 0 1 2 3 15
 
 NUT_STATEPATH="${TESTDIR}/run"
+NUT_PIDPATH="${TESTDIR}/run"
 NUT_ALTPIDPATH="${TESTDIR}/run"
 NUT_CONFPATH="${TESTDIR}/etc"
-export NUT_STATEPATH NUT_ALTPIDPATH NUT_CONFPATH
+export NUT_STATEPATH NUT_PIDPATH NUT_ALTPIDPATH NUT_CONFPATH
 
 # TODO: Find a portable way to (check and) grab a random unprivileged port?
 if [ -n "${NUT_PORT-}" ] && [ "$NUT_PORT" -gt 0 ] && [ "$NUT_PORT" -lt 65536 ] ; then

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -479,8 +479,9 @@ updatecfg_upsmon_supplies() {
 
 generatecfg_upsmon_trivial() {
     # Populate the configs for the run
+    rm -f "$NUT_STATEPATH/upsmon.sd.log"
     (  echo 'MINSUPPLIES 0' > "$NUT_CONFPATH/upsmon.conf" || exit
-       echo 'SHUTDOWNCMD "echo TESTING_DUMMY_SHUTDOWN_NOW"' >> "$NUT_CONFPATH/upsmon.conf" || exit
+       echo 'SHUTDOWNCMD "echo \"`date`: TESTING_DUMMY_SHUTDOWN_NOW\" | tee \"$NUT_STATEPATH\"/upsmon.sd.log"' >> "$NUT_CONFPATH/upsmon.conf" || exit
 
        if [ -n "${NUT_DEBUG_MIN-}" ] ; then
            echo "DEBUG_MIN ${NUT_DEBUG_MIN}" >> "$NUT_CONFPATH/upsmon.conf" || exit

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -1568,7 +1568,7 @@ if [ -n "${DEBUG_SLEEP-}" ] ; then
     log_separator
     log_info "Sleeping now as asked (for ${DEBUG_SLEEP} seconds starting `date -u`), so you can play with the driver and server running"
     log_info "Populated environment variables for this run into a file so you can source them: . '$NUT_CONFPATH/NIT.env'"
-    printf "NIT_SCRIPT_PID='%s'\nexport NIT_SCRIPT_PID\n" "$$" >> "$NUT_CONFPATH/NIT.env"
+    printf "PID_NIT_SCRIPT='%s'\nexport PID_NIT_SCRIPT\n" "$$" >> "$NUT_CONFPATH/NIT.env"
     log_separator
     cat "$NUT_CONFPATH/NIT.env"
     log_separator

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -350,6 +350,10 @@ log_info "Using NUT_PORT=${NUT_PORT} for this test run"
 # aid for "DEBUG_SLEEP=X" mode so the caller can
 # quickly source needed values into their shell.
 #
+# WARNING: Variables in this file are not guaranteed
+# to impact subsequent runs of this script (nit.sh),
+# e.g. NUT_PORT may be inherited, but paths would not be!
+#
 # NOTE: `set` typically wraps the values in quotes,
 # but (maybe?) not all shell implementations do.
 # Just in case, we have a fallback with single quotes.

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -1462,6 +1462,21 @@ case "${NIT_CASE}" in
         log_warn "   have exported the NUT_PORT upsd is listening on!"
         log_warn "========================================================"
         "${NIT_CASE}" ;;
+    generatecfg_*|is*)
+        log_warn "========================================================"
+        log_warn "You asked to run just a specific helper method: '${NIT_CASE}'"
+        log_warn "Populated environment variables for this run into a file so you can source them: . '$NUT_CONFPATH/NIT.env'"
+        log_warn "Notably, NUT_CONFPATH='$NUT_CONFPATH' now"
+        log_warn "========================================================"
+        # NOTE: Not quoted, can have further arguments
+        eval ${NIT_CASE}
+        if [ $? = 0 ] ; then
+            PASSED="`expr $PASSED + 1`"
+        else
+            FAILED="`expr $FAILED + 1`"
+            FAILED_FUNCS="$FAILED_FUNCS $NIT_CASE"
+        fi
+        ;;
     "") # Default test groups:
         testgroup_upsd_invalid_configs
         testgroup_upsd_questionable_configs

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -367,6 +367,7 @@ set | grep -E '^(NUT_|LD_LIBRARY_PATH|DEBUG|PATH).*=' \
         LD_LIBRARY_PATH_CLIENT|LD_LIBRARY_PATH_ORIG|PATH_*|NUT_PORT_*)
             continue
             ;;
+        DEBUG_SLEEP|PATH|LD_LIBRARY_PATH*) printf '### ' ;;
     esac
 
     case "$V" in

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -491,7 +491,7 @@ generatecfg_upsmon_trivial() {
     # Populate the configs for the run
     rm -f "$NUT_STATEPATH/upsmon.sd.log"
     (  echo 'MINSUPPLIES 0' > "$NUT_CONFPATH/upsmon.conf" || exit
-       echo 'SHUTDOWNCMD "echo \"`date`: TESTING_DUMMY_SHUTDOWN_NOW\" | tee \"$NUT_STATEPATH\"/upsmon.sd.log"' >> "$NUT_CONFPATH/upsmon.conf" || exit
+       echo 'SHUTDOWNCMD "echo \"`date`: TESTING_DUMMY_SHUTDOWN_NOW\" | tee \"'"$NUT_STATEPATH"'/upsmon.sd.log\" "' >> "$NUT_CONFPATH/upsmon.conf" || exit
 
        if [ -n "${NUT_DEBUG_MIN-}" ] ; then
            echo "DEBUG_MIN ${NUT_DEBUG_MIN}" >> "$NUT_CONFPATH/upsmon.conf" || exit

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -361,10 +361,10 @@ log_info "Using NUT_PORT=${NUT_PORT} for this test run"
 # the values when fallback is used. If this is a
 # problem on any platform (Win/Mac and spaces in
 # paths?) please investigate and fix accordingly.
-set | grep -E '^(NUT_|LD_LIBRARY_PATH|DEBUG).*=' \
+set | grep -E '^(NUT_|LD_LIBRARY_PATH|DEBUG|PATH).*=' \
 | while IFS='=' read K V ; do
     case "$K" in
-        LD_LIBRARY_PATH_CLIENT|LD_LIBRARY_PATH_ORIG|NUT_PORT_*)
+        LD_LIBRARY_PATH_CLIENT|LD_LIBRARY_PATH_ORIG|PATH_*|NUT_PORT_*)
             continue
             ;;
     esac

--- a/tests/cpputest-client.cpp
+++ b/tests/cpputest-client.cpp
@@ -6,7 +6,8 @@
    as opposed to nutclienttest.cpp which unit-tests the class API etc.
    in isolated-binary fashion.
 
-   Copyright (C) 2022  Jim Klimov <jimklimov@gmail.com>
+   Copyright (C)
+	2022-2024	Jim Klimov <jimklimov+nut@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/tests/cpputest.cpp
+++ b/tests/cpputest.cpp
@@ -2,7 +2,7 @@
 
    Copyright (C)
 	2012	Emilien Kia <emilienkia-guest@alioth.debian.org>
-	2020	Jim Klimov <jimklimov@gmail.com>
+	2020-2024	Jim Klimov <jimklimov+nut@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/tests/example.cpp
+++ b/tests/example.cpp
@@ -2,7 +2,7 @@
 
    Copyright (C)
 	2012	Emilien Kia <emilienkia-guest@alioth.debian.org>
-	2020	Jim Klimov <jimklimov@gmail.com>
+	2020-2024	Jim Klimov <jimklimov+nut@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/tests/nutclienttest.cpp
+++ b/tests/nutclienttest.cpp
@@ -1,7 +1,8 @@
 /* nutclienttest - CppUnit nutclient unit test
 
-   Copyright (C) 2016  Emilien Kia <emilien.kia@gmail.com>
-   Copyright (C) 2020 - 2021  Jim Klimov <jimklimov@gmail.com>
+   Copyright (C)
+	2016  Emilien Kia <emilien.kia@gmail.com>
+	2020 - 2024  Jim Klimov <jimklimov+nut@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/tests/nutconf_parser_ut.cpp
+++ b/tests/nutconf_parser_ut.cpp
@@ -3,6 +3,7 @@
 
     Copyright (C)
 	2012	Emilien Kia <emilienkia-guest@alioth.debian.org>
+	2024	Jim Klimov <jimklimov+nut@gmail.com>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/tests/nutipc_ut.cpp
+++ b/tests/nutipc_ut.cpp
@@ -5,6 +5,10 @@
 
             \author Vaclav Krpec <VaclavKrpec@Eaton.com>
 
+        Copyright (C) 2024
+
+            \author Jim Klimov <jimklimov+nut@gmail.com>
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or

--- a/tests/nutstream_ut.cpp
+++ b/tests/nutstream_ut.cpp
@@ -3,6 +3,7 @@
 
     Copyright (C)
         2012	Vaclav Krpec <VaclavKrpec@Eaton.com>
+        2024	Jim Klimov <jimklimov+nut@gmail.com>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Also update the NIT script regarding `upsmon.conf` generation and friendliness to run NUT programs against the prepared testbed, and improve the ability to generate variants of upsmon configuration and to launch the daemon in tests (no particular tests added so far).

And bump (C) on C++ code, due to a few changes there and noticing some staleness in the file headings.

Also introduced value caching for this and other path-getting methods - so that subsequent calls return the same value quickly (less work, more reproducibility. Checked that no NUT C programs use `setenv` along the way (at all, and notably not for path-related envvars in particular), which could potentially impact this logic change.

Regarding the `rootpidpath()` - an envvar is now honoured:
````
:; ./clients/upsmon -DDDDDD
Network UPS Tools upsmon 2.8.2-80-g405031c5a
   0.000000     fopen /home/jim/nut/tmp/run/upsmon.pid: No such file or directory
   0.000054     Could not find PID file to see if previous upsmon instance is already running!
   0.000077     [D1:84462] loadconfig: Loading /home/jim/nut/tmp/etc/upsmon.conf
...
````

Before this change, `upsmon` insisted on `fopen /run/upsmon.pid` per (lack of) config from `ci_build.sh`

As of this posting, manual testing with NIT involved:
````
:; DEBUG_SLEEP=600 ./tests/NIT/nit.sh &

### Wait for tests to pass - until the message that it sleeps with daemons alive
### and the path of file with envvars to source, e.g.
### Wed Apr 17 09:41:42 UTC 2024 [INFO] Sleeping now as asked (for 600 seconds starting Wed Apr 17 09:41:42 UTC 2024), so you can play with the driver and server running
### Wed Apr 17 09:41:42 UTC 2024 [INFO] Populated environment variables for this run into a file so you can source them: . 
'/home/jim/nut/tmp/etc/NIT.env'
### (content printout follows)

:; . '/home/jim/nut/tmp/etc/NIT.env'

### Note that currently no test generated the file
### (or at least did not customize the PSU count)
:; cat "$NUT_CONFPATH/upsmon.conf"
cat: /home/jim/nut/tmp/etc/upsmon.conf: No such file or directory

:; NIT_CASE="generatecfg_upsmon_master 2" ./tests/NIT/nit.sh

:; cat "$NUT_CONFPATH/upsmon.conf"
MINSUPPLIES 2
SHUTDOWNCMD "echo \"`date`: TESTING_DUMMY_SHUTDOWN_NOW\" | tee \"$NUT_STATEPATH\"/upsmon.sd.log"
MONITOR 'dummy@localhost:35017' 2 'dummy-admin-m' 'P@ssW0rdAdm' master

:; ./clients/upsmon -DDDDDD
...
````