### PR TITLE
drivers/main.c: move "-d" CLI option handling also to start of program

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -40,6 +40,12 @@ https://github.com/networkupstools/nut/milestone/11
  - (expected) Bug fixes for fallout possible due to "fightwarn" effort in 2.8.0
 
 
+ - Fix fallout of development in NUT v2.8.0 and/or v2.8.1 and/or v2.8.2:
+   * Move of `NUT_DEBUG_LEVEL` and "-D" CLI option handling to start of
+     driver programs for issue #2259 in NUT v2.8.2 release misfired with
+     regard to data-dump mode (it no longer caused foreground by default).
+     [#2408]
+
  - drivers, upsd, upsmon: reduce "scary noise" about failure to `fopen()`
    the PID file (which most of the time means that no previous instance of
    the daemon was running to potentially conflict with), especially useless

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -1685,6 +1685,9 @@ int main(int argc, char **argv)
 				nut_debug_level++;
 				nut_debug_level_args++;
 				break;
+			case 'd':
+				dump_data = atoi(optarg);
+				break;
 		}
 	}
 	/* Reset the index, read argv[1] next time (loop below)
@@ -1805,7 +1808,7 @@ int main(int argc, char **argv)
 				/* Processed above */
 				break;
 			case 'd':
-				dump_data = atoi(optarg);
+				/* Processed above */
 				break;
 			case 'i': { /* scope */
 					int ipv = atoi(optarg);

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -3315,7 +3315,7 @@ bool_t snmp_ups_walk(int mode)
 
 #ifdef COUNT_ITERATIONS
 			/* check stale elements only on each PN_STALE_RETRY iteration. */
-	 		if ((su_info_p->flags & SU_FLAG_STALE) &&
+			if ((su_info_p->flags & SU_FLAG_STALE) &&
 					(iterations % SU_STALE_RETRY) != 0)
 				continue;
 #endif


### PR DESCRIPTION
Fallout of #2259 / PR #2260 (regression in NUT v2.8.2 release, not a default code path and can be worked around with explicit `-F`/`-B` CLI options, though - so not extremely critical)

Thanks to @ericclappier-eaton @arnaudquette-eaton @FrancoisRegisDegott-eaton and 42ITy team.