### PR TITLE
Update `nutconf` and `augeas` lenses with support for NUT keywords added between releases 2.6.5 and 2.8.2

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -102,6 +102,11 @@ https://github.com/networkupstools/nut/milestone/11
  - brought keyword dictionaries of `nutconf` and `augeas` NUT configuration
    file parsers up to date; restored automated checks for `augeas` lenses.
    [issue #657, issue #2294]
++
+   NOTE: Some known issues remain with augeas lens definitions so currently
+   they should be able to parse common simple use-cases but not certain types
+   of more complex configurations (e.g. some line patterns that involve too
+   many double-quote characters) which are valid for NUT proper. [#657]
 
 
 Release notes for NUT 2.8.2 - what's new since 2.8.1

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -91,6 +91,10 @@ https://github.com/networkupstools/nut/milestone/11
    `NUT_PIDPATH` environment variable in certain use-cases (such as tests).
    [#2407]
 
+ - brought keyword dictionaries of `nutconf` and `augeas` NUT configuration
+   file parsers up to date; restored automated checks for `augeas` lenses.
+   [issue #657, issue #2294]
+
 
 Release notes for NUT 2.8.2 - what's new since 2.8.1
 ----------------------------------------------------

--- a/common/nutconf.cpp
+++ b/common/nutconf.cpp
@@ -1423,14 +1423,14 @@ void UpsmonConfigParser::onParseDirective(const std::string& directiveName, char
 		{
 			if(values.size()>0)
 			{
-				_config->poolFreq = StringToSettableNumber<unsigned int>(values.front());
+				_config->pollFreq = StringToSettableNumber<unsigned int>(values.front());
 			}
 		}
 		else if(directiveName == "POLLFREQALERT")
 		{
 			if(values.size()>0)
 			{
-				_config->poolFreqAlert = StringToSettableNumber<unsigned int>(values.front());
+				_config->pollFreqAlert = StringToSettableNumber<unsigned int>(values.front());
 			}
 		}
 		else if(directiveName == "POLLFAIL_LOG_THROTTLE_MAX")

--- a/common/nutconf.cpp
+++ b/common/nutconf.cpp
@@ -1053,13 +1053,17 @@ bool GenericConfiguration::getFlag(
 
 void GenericConfiguration::setFlag(
 		const std::string & section,
-		const std::string & entry)
+		const std::string & entry,
+		bool                val)
 {
 	ConfigParamList param;
 
-	param.push_back("true");
-
-	set(section, entry, param);
+	if (val) {
+		param.push_back("true");
+		set(section, entry, param);
+	} else {
+		remove(section, entry);
+	}
 }
 
 

--- a/common/nutconf.cpp
+++ b/common/nutconf.cpp
@@ -97,44 +97,53 @@ void NutParser::setOptions(unsigned int options, bool set)
 	}
 }
 
-char NutParser::get() {
+char NutParser::get()
+{
 	if (_pos >= _buffer.size())
 		return 0;
 	else
 		return _buffer[_pos++];
 }
 
-char NutParser::peek() {
+char NutParser::peek()
+{
 	return _buffer[_pos];
 }
 
-size_t NutParser::getPos()const {
+size_t NutParser::getPos()const
+{
 	return _pos;
 }
 
-void NutParser::setPos(size_t pos) {
+void NutParser::setPos(size_t pos)
+{
 	_pos = pos;
 }
 
-char NutParser::charAt(size_t pos)const {
+char NutParser::charAt(size_t pos)const
+{
 	return _buffer[pos];
 }
 
-void NutParser::pushPos() {
+void NutParser::pushPos()
+{
 	_stack.push_back(_pos);
 }
 
-size_t NutParser::popPos() {
+size_t NutParser::popPos()
+{
 	size_t pos = _stack.back();
 	_stack.pop_back();
 	return pos;
 }
 
-void NutParser::rewind() {
+void NutParser::rewind()
+{
 	_pos = popPos();
 }
 
-void NutParser::back() {
+void NutParser::back()
+{
 	if (_pos > 0)
 		--_pos;
 }
@@ -145,7 +154,8 @@ void NutParser::back() {
  *             | '\\' ( __SPACES__ | '\\' | '\"' | '#' )
  * TODO: accept "\t", "\s", "\r", "\n" ??
  */
-std::string NutParser::parseCHARS() {
+std::string NutParser::parseCHARS()
+{
 	bool escaped = false; // Is char escaped ?
 	std::string res; // Stored string
 
@@ -181,7 +191,8 @@ std::string NutParser::parseCHARS() {
  *             | '\\' ( '\\' | '\"' )
  * TODO: accept "\t", "\s", "\r", "\n" ??
  */
-std::string NutParser::parseSTRCHARS() {
+std::string NutParser::parseSTRCHARS()
+{
 	bool escaped = false; // Is char escaped ?
 	std::string str; // Stored string
 
@@ -214,7 +225,8 @@ std::string NutParser::parseSTRCHARS() {
 /** Parse a string source for getting the next token, ignoring spaces.
  * \return Token type.
  */
-NutParser::Token NutParser::parseToken() {
+NutParser::Token NutParser::parseToken()
+{
 
 	/** Lexical parsing machine state enumeration.*/
 	typedef enum {
@@ -388,7 +400,8 @@ NutParser::Token NutParser::parseToken() {
 	return token;
 }
 
-std::list<NutParser::Token> NutParser::parseLine() {
+std::list<NutParser::Token> NutParser::parseLine()
+{
 	std::list<NutParser::Token> res;
 
 	while (true) {
@@ -420,19 +433,23 @@ std::list<NutParser::Token> NutParser::parseLine() {
 //
 
 NutConfigParser::NutConfigParser(const char* buffer, unsigned int options) :
-NutParser(buffer, options) {
+NutParser(buffer, options)
+{
 }
 
 NutConfigParser::NutConfigParser(const std::string& buffer, unsigned int options) :
-NutParser(buffer, options) {
+NutParser(buffer, options)
+{
 }
 
-void NutConfigParser::parseConfig(BaseConfiguration* config) {
+void NutConfigParser::parseConfig(BaseConfiguration* config)
+{
 	NUT_UNUSED_VARIABLE(config);
 	parseConfig();
 }
 
-void NutConfigParser::parseConfig() {
+void NutConfigParser::parseConfig()
+{
 	onParseBegin();
 
 	enum ConfigParserState {
@@ -714,23 +731,31 @@ void NutConfigParser::parseConfig() {
 //
 
 DefaultConfigParser::DefaultConfigParser(const char* buffer) :
-NutConfigParser(buffer) {
+NutConfigParser(buffer)
+{
 }
 
 DefaultConfigParser::DefaultConfigParser(const std::string& buffer) :
-NutConfigParser(buffer) {
+NutConfigParser(buffer)
+{
 }
 
-void DefaultConfigParser::onParseBegin() {
+void DefaultConfigParser::onParseBegin()
+{
 	// Start with empty section (i.e. global one)
 	_section.clear();
 }
 
-void DefaultConfigParser::onParseComment(const std::string& /*comment*/) {
+void DefaultConfigParser::onParseComment(
+		const std::string& /*comment*/)
+{
 	// Comments are ignored for now
 }
 
-void DefaultConfigParser::onParseSectionName(const std::string& sectionName, const std::string& /*comment*/) {
+void DefaultConfigParser::onParseSectionName(
+		const std::string& sectionName,
+		const std::string& /*comment*/)
+{
 	// Comments are ignored for now
 
 	// Process current section.
@@ -743,7 +768,12 @@ void DefaultConfigParser::onParseSectionName(const std::string& sectionName, con
 	_section.name = sectionName;
 }
 
-void DefaultConfigParser::onParseDirective(const std::string& directiveName, char /*sep*/, const ConfigParamList& values, const std::string& /*comment*/) {
+void DefaultConfigParser::onParseDirective(
+		const std::string& directiveName,
+		char /*sep*/,
+		const ConfigParamList& values,
+		const std::string& /*comment*/)
+{
 	// Comments are ignored for now
 	// Separator has no specific semantic in this context
 
@@ -754,7 +784,8 @@ void DefaultConfigParser::onParseDirective(const std::string& directiveName, cha
 	// TODO Can probably be optimized.
 }
 
-void DefaultConfigParser::onParseEnd() {
+void DefaultConfigParser::onParseEnd()
+{
 	// Process current (last) section
 	if (!_section.empty()) {
 		onParseSection(_section);
@@ -767,11 +798,13 @@ void DefaultConfigParser::onParseEnd() {
 // GenericConfigSection
 //
 
-bool GenericConfigSection::empty()const {
+bool GenericConfigSection::empty()const
+{
 	return name.empty() && entries.empty();
 }
 
-void GenericConfigSection::clear() {
+void GenericConfigSection::clear()
+{
 	name.clear();
 	entries.clear();
 }
@@ -977,7 +1010,10 @@ void GenericConfiguration::setStr(
 }
 
 
-long long int GenericConfiguration::getInt(const std::string & section, const std::string & entry, long long int val) const
+long long int GenericConfiguration::getInt(
+		const std::string & section,
+		const std::string & entry,
+		long long int val) const
 {
 	ConfigParamList params;
 
@@ -996,7 +1032,10 @@ long long int GenericConfiguration::getInt(const std::string & section, const st
 }
 
 
-void GenericConfiguration::setInt(const std::string & section, const std::string & entry, long long int val)
+void GenericConfiguration::setInt(
+		const std::string & section,
+		const std::string & entry,
+		long long int val)
 {
 	std::stringstream val_str;
 	val_str << val;

--- a/common/nutconf.cpp
+++ b/common/nutconf.cpp
@@ -1097,6 +1097,26 @@ void GenericConfiguration::setInt(
 }
 
 
+nut::BoolInt GenericConfiguration::getBoolInt(
+		const std::string & section,
+		const std::string & entry,
+		nut::BoolInt val) const
+{
+	ConfigParamList params;
+
+	if (!get(section, entry, params))
+		return val;
+
+	if (params.empty())
+		return val;
+
+	// TBD: What if there are multiple values?
+	nut::BoolInt bi(params.front());
+
+	return bi;
+}
+
+
 bool GenericConfiguration::str2bool(const std::string & str)
 {
 	if ("true" == str) return true;

--- a/common/nutconf.cpp
+++ b/common/nutconf.cpp
@@ -1025,6 +1025,32 @@ void GenericConfiguration::setStr(
 }
 
 
+bool GenericConfiguration::getFlag(
+		const std::string & section,
+		const std::string & entry) const
+{
+	ConfigParamList params;
+
+	if (!get(section, entry, params))
+		return false;
+
+	// Flag - if exists then "true"
+	return true;
+}
+
+
+void GenericConfiguration::setFlag(
+		const std::string & section,
+		const std::string & entry)
+{
+	ConfigParamList param;
+
+	param.push_back("true");
+
+	set(section, entry, param);
+}
+
+
 long long int GenericConfiguration::getInt(
 		const std::string & section,
 		const std::string & entry,

--- a/common/nutconf.cpp
+++ b/common/nutconf.cpp
@@ -1275,7 +1275,16 @@ void UpsmonConfigParser::onParseDirective(const std::string& directiveName, char
 
 	if(_config)
 	{
-		if(directiveName == "RUN_AS_USER")
+		if(!(::strcasecmp(directiveName.c_str(), "DEBUG_MIN")))
+		{
+			// NOTE: We allow DEBUG_MIN in any casing as it can be copy-pasted
+			// between different configs and they use different historic casing
+			if(values.size()>0)
+			{
+				_config->debugMin = StringToSettableNumber<int>(values.front());
+			}
+		}
+		else if(directiveName == "RUN_AS_USER")
 		{
 			if(values.size()>0)
 			{
@@ -1339,6 +1348,83 @@ void UpsmonConfigParser::onParseDirective(const std::string& directiveName, char
 			if(values.size()>0)
 			{
 				_config->poolFreqAlert = StringToSettableNumber<unsigned int>(values.front());
+			}
+		}
+		else if(directiveName == "POLLFAIL_LOG_THROTTLE_MAX")
+		{
+			if(values.size()>0)
+			{
+				_config->pollFailLogThrottleMax = StringToSettableNumber<int>(values.front());
+			}
+		}
+		else if(directiveName == "OFFDURATION")
+		{
+			if(values.size()>0)
+			{
+				_config->offDuration = StringToSettableNumber<int>(values.front());
+			}
+		}
+		else if(directiveName == "OBLBDURATION")
+		{
+			if(values.size()>0)
+			{
+				_config->oblbDuration = StringToSettableNumber<int>(values.front());
+			}
+		}
+		else if(directiveName == "SHUTDOWNEXIT")
+		{
+			if(values.size()>0)
+			{
+				nut::BoolInt bi;
+				bi << values.front();
+				_config->shutdownExit = bi;
+			}
+		}
+		else if(directiveName == "CERTPATH")
+		{
+			if(values.size()>0)
+			{
+				_config->certPath = values.front();
+			}
+		}
+		else if(directiveName == "CERTIDENT")
+		{
+			if(values.size()==2)
+			{
+				_config->certIdent.certName = values.front();
+				_config->certIdent.certDbPass = (*(++values.begin()));
+			}
+		}
+		else if(directiveName == "CERTHOST")
+		{
+			if(values.size()==4)
+			{
+				nut::CertHost certHost;
+				ConfigParamList::const_iterator it = values.begin();
+				certHost.host       = *it++;
+				certHost.certName   = *it++;
+				certHost.certVerify = *it++;
+				certHost.forceSsl   = *it++;
+
+				_config->certHosts.push_back(certHost);
+			}
+		}
+		else if(directiveName == "CERTVERIFY")
+		{
+			if(values.size()>0)
+			{
+				nut::BoolInt bi;
+				bi << values.front();
+				_config->certVerify = bi;
+			}
+		}
+		else if(directiveName == "FORCESSL")
+		{
+			if(values.size()>0)
+			{
+				nut::BoolInt bi;
+				bi << values.front();
+				_config->forceSsl = bi;
 			}
 		}
 		else if(directiveName == "HOSTSYNC")

--- a/common/nutconf.cpp
+++ b/common/nutconf.cpp
@@ -56,15 +56,30 @@ NutParser::~NutParser() {}
 template <typename T>
 Settable<T> StringToSettableNumber(const std::string & src)
 {
-	std::stringstream ss(src);
-	T result;
-	if(ss >> result)
-	{
-		return Settable<T>(result);
-	}
-	else
-	{
-		return Settable<T>();
+	if (typeid(T) == typeid(bool)) {
+		static const Settable<T> b0(false);
+		static const Settable<T> b1(true);
+
+		// See also: GenericConfiguration::str2bool()
+		// FIXME: Can these two methods be merged?
+		if ("true" == src) return b1;
+		if ("on"   == src) return b1;
+		if ("1"    == src) return b1;
+		if ("yes"  == src) return b1;
+		if ("ok"   == src) return b1;
+
+		return b0;
+	} else {
+		std::stringstream ss(src);
+		T result;
+		if(ss >> result)
+		{
+			return Settable<T>(result);
+		}
+		else
+		{
+			return Settable<T>();
+		}
 	}
 }
 
@@ -1048,7 +1063,7 @@ bool GenericConfiguration::str2bool(const std::string & str)
 {
 	if ("true" == str) return true;
 	if ("on"   == str) return true;
-	if ("1"	== str) return true;
+	if ("1"    == str) return true;
 	if ("yes"  == str) return true;
 	if ("ok"   == str) return true;
 

--- a/common/nutconf.cpp
+++ b/common/nutconf.cpp
@@ -1097,6 +1097,55 @@ void GenericConfiguration::setInt(
 }
 
 
+long long int GenericConfiguration::getIntHex(
+		const std::string & section,
+		const std::string & entry,
+		long long int val) const
+{
+	ConfigParamList params;
+
+	if (!get(section, entry, params))
+		return val;
+
+	if (params.empty())
+		return val;
+
+	// TBD: What if there are multiple values?
+	std::string s = params.front();
+	size_t foundPos = s.rfind("0x", 0);
+	if (foundPos == std::string::npos || foundPos != 0) {
+		// Add the prefix for hex conversion
+		s = "0x" + s;
+	}
+	std::stringstream val_str;
+	val_str << std::hex << s;
+
+	// Output into int type
+	val_str >> std::hex >> val;
+
+	return val;
+}
+
+
+void GenericConfiguration::setIntHex(
+		const std::string & section,
+		const std::string & entry,
+		long long int val)
+{
+	std::stringstream val_str;
+
+	// Note NUT v2.8.1 introduced these as "hexnum" values,
+	// but the strtoul() underneath knows to strip "0x" for
+	// base16 conversions - so can we write them either way:
+
+	// https://stackoverflow.com/a/61060765/4715872
+	// << std::showbase for "0x" in saved printouts
+	val_str << std::nouppercase << std::hex << val;
+
+	set(section, entry, ConfigParamList(1, val_str.str()));
+}
+
+
 nut::BoolInt GenericConfiguration::getBoolInt(
 		const std::string & section,
 		const std::string & entry,

--- a/common/nutconf.cpp
+++ b/common/nutconf.cpp
@@ -1229,7 +1229,7 @@ void UpsmonConfigParser::onParseDirective(const std::string& directiveName, char
 				monitor.powerValue = StringToSettableNumber<unsigned int>(*it++);
 				monitor.username = *it++;
 				monitor.password = *it++;
-				monitor.isMaster = (*it) == "primary";	// master for NUT v2.7.4 and older
+				monitor.isPrimary = (*it) == "primary";	// master for NUT v2.7.4 and older
 				_config->monitors.push_back(monitor);
 			}
 		}

--- a/common/nutconf.cpp
+++ b/common/nutconf.cpp
@@ -1611,16 +1611,70 @@ void NutConfConfigParser::onParseDirective(const std::string& directiveName, cha
 {
 	// Comments are ignored for now
 	// NOTE: although sep must be '=', sep is not verified.
-	if(_config && directiveName=="MODE" && values.size()==1)
+	if(_config)
 	{
-		std::string val = values.front();
-		NutConfiguration::NutMode mode = NutConfiguration::NutModeFromString(val);
-		if(mode != NutConfiguration::MODE_UNKNOWN)
-			_config->mode = mode;
-	}
-	else
-	{
-		// TODO WTF with errors ?
+		if(directiveName == "MODE")
+		{
+			if (values.size()==1) {
+				std::string val = values.front();
+				NutConfiguration::NutMode mode = NutConfiguration::NutModeFromString(val);
+				if(mode != NutConfiguration::MODE_UNKNOWN)
+					_config->mode = mode;
+			}
+		}
+		else if(directiveName == "ALLOW_NO_DEVICE")
+		{
+			if(values.size()>0)
+			{
+				_config->allowNoDevice = StringToSettableNumber<bool>(values.front());
+			}
+		}
+		else if(directiveName == "ALLOW_NOT_ALL_LISTENERS")
+		{
+			if(values.size()>0)
+			{
+				_config->allowNotAllListeners = StringToSettableNumber<bool>(values.front());
+			}
+		}
+		else if(directiveName == "UPSD_OPTIONS")
+		{
+			if(values.size()>0)
+			{
+				_config->upsdOptions = values.front();
+			}
+		}
+		else if(directiveName == "UPSMON_OPTIONS")
+		{
+			if(values.size()>0)
+			{
+				_config->upsmonOptions = values.front();
+			}
+		}
+		else if(directiveName == "POWEROFF_WAIT")
+		{
+			if(values.size()>0)
+			{
+				_config->poweroffWait = StringToSettableNumber<unsigned int>(values.front());
+			}
+		}
+		else if(directiveName == "POWEROFF_QUIET")
+		{
+			if(values.size()>0)
+			{
+				_config->poweroffQuiet = StringToSettableNumber<bool>(values.front());
+			}
+		}
+		else if(directiveName == "NUT_DEBUG_LEVEL")
+		{
+			if(values.size()>0)
+			{
+				_config->debugLevel = StringToSettableNumber<int>(values.front());
+			}
+		}
+		else
+		{
+			// TODO WTF with errors ?
+		}
 	}
 }
 

--- a/common/nutconf.cpp
+++ b/common/nutconf.cpp
@@ -1025,6 +1025,18 @@ void GenericConfiguration::setStr(
 }
 
 
+bool GenericConfiguration::getBool(
+		const std::string & section,
+		const std::string & entry,
+		bool                val) const
+{
+		std::string s = getStr(section, entry);
+		if (s.empty())
+			return val;
+		return str2bool(s);
+}
+
+
 bool GenericConfiguration::getFlag(
 		const std::string & section,
 		const std::string & entry) const

--- a/common/nutconf.cpp
+++ b/common/nutconf.cpp
@@ -1146,6 +1146,40 @@ void GenericConfiguration::setIntHex(
 }
 
 
+double GenericConfiguration::getDouble(
+		const std::string & section,
+		const std::string & entry,
+		double val) const
+{
+	ConfigParamList params;
+
+	if (!get(section, entry, params))
+		return val;
+
+	if (params.empty())
+		return val;
+
+	// TBD: What if there are multiple values?
+	std::stringstream val_str(params.front());
+
+	val_str >> val;
+
+	return val;
+}
+
+
+void GenericConfiguration::setDouble(
+		const std::string & section,
+		const std::string & entry,
+		double val)
+{
+	std::stringstream val_str;
+	val_str << val;
+
+	set(section, entry, ConfigParamList(1, val_str.str()));
+}
+
+
 nut::BoolInt GenericConfiguration::getBoolInt(
 		const std::string & section,
 		const std::string & entry,

--- a/common/nutconf.cpp
+++ b/common/nutconf.cpp
@@ -1633,7 +1633,16 @@ void UpsdConfigParser::onParseDirective(const std::string& directiveName, char s
 
 	if(_config)
 	{
-		if(directiveName == "MAXAGE")
+		if(!(::strcasecmp(directiveName.c_str(), "DEBUG_MIN")))
+		{
+			// NOTE: We allow DEBUG_MIN in any casing as it can be copy-pasted
+			// between different configs and they use different historic casing
+			if(values.size()>0)
+			{
+				_config->debugMin = StringToSettableNumber<int>(values.front());
+			}
+		}
+		else if(directiveName == "MAXAGE")
 		{
 			if(values.size()>0)
 			{
@@ -1654,11 +1663,61 @@ void UpsdConfigParser::onParseDirective(const std::string& directiveName, char s
 				_config->maxConn = StringToSettableNumber<unsigned int>(values.front());
 			}
 		}
+		else if(directiveName == "TRACKINGDELAY")
+		{
+			if(values.size()>0)
+			{
+				_config->trackingDelay = StringToSettableNumber<unsigned int>(values.front());
+			}
+		}
+		else if(directiveName == "ALLOW_NO_DEVICE")
+		{
+			if(values.size()>0)
+			{
+				_config->allowNoDevice = StringToSettableNumber<bool>(values.front());
+			}
+		}
+		else if(directiveName == "ALLOW_NOT_ALL_LISTENERS")
+		{
+			if(values.size()>0)
+			{
+				_config->allowNotAllListeners = StringToSettableNumber<bool>(values.front());
+			}
+		}
+		else if(directiveName == "DISABLE_WEAK_SSL")
+		{
+			if(values.size()>0)
+			{
+				_config->allowNotAllListeners = StringToSettableNumber<bool>(values.front());
+			}
+		}
 		else if(directiveName == "CERTFILE")
 		{
 			if(values.size()>0)
 			{
 				_config->certFile = values.front();
+			}
+		}
+		else if(directiveName == "CERTPATH")
+		{
+			if(values.size()>0)
+			{
+				_config->certPath = values.front();
+			}
+		}
+		else if(directiveName == "CERTIDENT")
+		{
+			if(values.size()==2)
+			{
+				_config->certIdent.certName = values.front();
+				_config->certIdent.certDbPass = (*(++values.begin()));
+			}
+		}
+		else if(directiveName == "CERTREQUEST")
+		{
+			if(values.size()>0)
+			{
+				_config->certRequestLevel = StringToSettableNumber<unsigned int>(values.front());
 			}
 		}
 		else if(directiveName == "LISTEN")

--- a/common/nutwriter.cpp
+++ b/common/nutwriter.cpp
@@ -137,13 +137,17 @@ static std::string serializeCertHost(const nut::CertHost & certHost) {
 	directive << "CERTHOST \"" << val1 << "\" \"" << val2 << "\"";
 
 	// Spec says to write these as 0/1 integers
+	nut::BoolInt bi;
 	int i;
+	bi.bool01 = true;	// relaxed mode for 0/1 as false/true handling
 
 	// Assumed to be set() - exception otherwise
-	i = certHost.certVerify;
+	bi = certHost.certVerify;
+	i = bi;
 	directive << " " << i;
 
-	i = certHost.forceSsl;
+	bi = certHost.forceSsl;
+	i = bi;
 	directive << " " << i;
 
 	return directive.str();

--- a/common/nutwriter.cpp
+++ b/common/nutwriter.cpp
@@ -123,6 +123,33 @@ static std::string serializeCertIdent(const nut::CertIdent & ident) {
 }
 
 
+/**
+ *  \brief  NSS certificate-protected host info serializer
+ *
+ *  \param  certHost  Certificate-protected host info object
+ *
+ *  \return Serialized certificate-protected host info
+ */
+static std::string serializeCertHost(const nut::CertHost & certHost) {
+	std::stringstream directive;
+	const std::string & val1 = (certHost.host), val2 = (certHost.certName);
+
+	directive << "CERTHOST \"" << val1 << "\" \"" << val2 << "\"";
+
+	// Spec says to write these as 0/1 integers
+	int i;
+
+	// Assumed to be set() - exception otherwise
+	i = certHost.certVerify;
+	directive << " " << i;
+
+	i = certHost.forceSsl;
+	directive << " " << i;
+
+	return directive.str();
+}
+
+
 NutWriter::status_t NutWriter::writeEachLine(const std::string & str, const std::string & pref) {
 	for (size_t pos = 0; pos < str.size(); ) {
 		// Prefix every line

--- a/common/nutwriter.cpp
+++ b/common/nutwriter.cpp
@@ -65,6 +65,50 @@
 	} while (0)
 
 
+/**
+ *  \brief  Shell (envvar) configuration directive generator
+ *
+ *  The macro is used to simplify generation of
+ *  nut.conf file directives.
+ *
+ *  IMPORTANT NOTE:
+ *  In case of writing error, the macro causes immediate
+ *  return from the calling function (propagating the writing status).
+ *
+ *  \param  name       Directive name
+ *  \param  arg_t      Directive argument implementation type
+ *  \param  arg        Directive argument
+ *  \param  quote_arg  Boolean flag; check to quote the argument
+ */
+// NOTE: Due to this being a macro applied to any argument type,
+// implementation for e.g. bool handling jumps through hoops like
+// stringification and back. FIXME: working optimization welcome.
+#define SHELL_CONFIG_DIRECTIVEX(name, arg_t, arg, quote_arg) \
+	do { \
+		if ((arg).set()) { \
+			const arg_t & arg_val = (arg); \
+			std::stringstream ss; \
+			ss << name << '='; \
+			if (quote_arg) \
+				ss << '\''; \
+			if (typeid(arg_val) == typeid(bool&)) { \
+				std::stringstream ssb; \
+				ssb << arg_val; \
+				std::string sb = ssb.str(); \
+				if ("1" == sb) { ss << "true"; } \
+				else if ("0" == sb) { ss << "false"; } \
+				else { ss << arg_val; } \
+			} else \
+				ss << arg_val; \
+			if (quote_arg) \
+				ss << '\''; \
+			status_t status = writeDirective(ss.str()); \
+			if (NUTW_OK != status) \
+				return status; \
+		} \
+	} while (0)
+
+
 namespace nut {
 
 

--- a/common/nutwriter.cpp
+++ b/common/nutwriter.cpp
@@ -575,6 +575,10 @@ NutWriter::status_t UpsmonConfigWriter::writeConfig(const UpsmonConfiguration & 
 	// need to add relaxed mode for 0/1 as false/true handling:
 	// bi.bool01 = true;
 	bi2.bool01 = false;	// strict mode for 0/1 as int handling
+	// Avoid static analysis concerns that the internal _value
+	// "may be used uninitialized in this function" (ETOOSMART):
+	bi = false;
+	bi2 = false;
 
 	if (config.certVerify.set()) {
 		bi = config.certVerify;

--- a/common/nutwriter.cpp
+++ b/common/nutwriter.cpp
@@ -72,10 +72,18 @@ namespace nut {
  * error: 'ClassName' has no out-of-line virtual method definitions; its vtable
  *   will be emitted in every translation unit [-Werror,-Wweak-vtables]
  */
-NutConfigWriter::~NutConfigWriter() {}
-NutConfConfigWriter::~NutConfConfigWriter() {}
-UpsmonConfigWriter::~UpsmonConfigWriter() {}
-UpsdConfigWriter::~UpsdConfigWriter() {}
+NutConfigWriter::~NutConfigWriter() {}	// generic interface/base class
+// Flat-config classes:
+NutConfConfigWriter::~NutConfConfigWriter() {}	// nut.conf, shell format
+UpsmonConfigWriter::~UpsmonConfigWriter() {}	// upsmon.conf
+UpsdConfigWriter::~UpsdConfigWriter() {}		// upsd.conf
+// Structured-config classes R/W is handled via GenericConfiguration:
+//	UpsConfiguration:		ups.conf
+//	UpsdUsersConfiguration:	upsd.users
+// Not handled currently:
+//	xxx:	upssched.conf
+//	xxx:	upsset.conf
+//	xxx:	hosts.conf
 
 // End-of-Line separators (arch. dependent)
 

--- a/common/nutwriter.cpp
+++ b/common/nutwriter.cpp
@@ -30,7 +30,7 @@
 #include <list>
 #include <map>
 #include <cassert>
-
+#include <typeinfo>
 
 /**
  *  \brief  NUT configuration directive generator

--- a/common/nutwriter.cpp
+++ b/common/nutwriter.cpp
@@ -556,8 +556,8 @@ NutWriter::status_t UpsmonConfigWriter::writeConfig(const UpsmonConfiguration & 
 	UPSMON_DIRECTIVEX("NOTIFYCMD",      std::string,  config.notifyCmd,      true);
 	UPSMON_DIRECTIVEX("POWERDOWNFLAG",  std::string,  config.powerDownFlag,  true);
 	UPSMON_DIRECTIVEX("MINSUPPLIES",    unsigned int, config.minSupplies,    false);
-	UPSMON_DIRECTIVEX("POLLFREQ",       unsigned int, config.poolFreq,       false);
-	UPSMON_DIRECTIVEX("POLLFREQALERT",  unsigned int, config.poolFreqAlert,  false);
+	UPSMON_DIRECTIVEX("POLLFREQ",       unsigned int, config.pollFreq,       false);
+	UPSMON_DIRECTIVEX("POLLFREQALERT",  unsigned int, config.pollFreqAlert,  false);
 	UPSMON_DIRECTIVEX("POLLFAIL_LOG_THROTTLE_MAX", int, config.pollFailLogThrottleMax,  false);
 	UPSMON_DIRECTIVEX("OFFDURATION",    int,          config.offDuration,    false);
 	UPSMON_DIRECTIVEX("OBLBDURATION",   int,          config.oblbDuration,   false);

--- a/common/nutwriter.cpp
+++ b/common/nutwriter.cpp
@@ -106,6 +106,23 @@ const std::string GenericConfigWriter::s_default_section_entry_indent("\t");
 const std::string GenericConfigWriter::s_default_section_entry_separator(" = ");
 
 
+/**
+ *  \brief  NSS certificate identity serializer
+ *
+ *  \param  ident  Certificate identity object
+ *
+ *  \return Serialized certificate identity
+ */
+static std::string serializeCertIdent(const nut::CertIdent & ident) {
+	std::stringstream directive;
+	const std::string & val1 = (ident.certName), val2 = (ident.certDbPass);
+
+	directive << "CERTIDENT \"" << val1 << "\" \"" << val2 << "\"";
+
+	return directive.str();
+}
+
+
 NutWriter::status_t NutWriter::writeEachLine(const std::string & str, const std::string & pref) {
 	for (size_t pos = 0; pos < str.size(); ) {
 		// Prefix every line

--- a/common/nutwriter.cpp
+++ b/common/nutwriter.cpp
@@ -407,8 +407,8 @@ static std::string serializeMonitor(const UpsmonConfiguration::Monitor & monitor
 	directive << monitor.username << ' ' << monitor.password << ' ';
 
 	// Primary/secondary (legacy master/slave)
-	directive << (monitor.isMaster ? "primary" : "secondary");
-	/* NUT v2.7.4 and older: directive << (monitor.isMaster ? "master" : "slave");*/
+	directive << (monitor.isPrimary ? "primary" : "secondary");
+	/* NUT v2.7.4 and older: directive << (monitor.isPrimary ? "master" : "slave");*/
 
 	return directive.str();
 }

--- a/common/nutwriter.cpp
+++ b/common/nutwriter.cpp
@@ -250,11 +250,10 @@ NutWriter::status_t SectionlessConfigWriter::writeSectionName(const std::string 
 
 
 NutWriter::status_t NutConfConfigWriter::writeConfig(const NutConfiguration & config) {
-	status_t status;
-
 	// Mode
 	// TBD: How should I serialize an unknown mode?
 	if (config.mode.set()) {
+		status_t status;
 		std::string mode_str;
 
 		NutConfiguration::NutMode mode = config.mode;
@@ -293,6 +292,14 @@ NutWriter::status_t NutConfConfigWriter::writeConfig(const NutConfiguration & co
 		if (NUTW_OK != status)
 			return status;
 	}
+
+	SHELL_CONFIG_DIRECTIVEX("ALLOW_NO_DEVICE",		bool,			config.allowNoDevice,	false);
+	SHELL_CONFIG_DIRECTIVEX("ALLOW_NOT_ALL_LISTENERS",	bool,		config.allowNotAllListeners,	false);
+	SHELL_CONFIG_DIRECTIVEX("UPSD_OPTIONS",			std::string,	config.upsdOptions,		true);
+	SHELL_CONFIG_DIRECTIVEX("UPSMON_OPTIONS",		std::string,	config.upsmonOptions,	true);
+	SHELL_CONFIG_DIRECTIVEX("POWEROFF_WAIT",		unsigned int,	config.poweroffWait,	false);
+	SHELL_CONFIG_DIRECTIVEX("POWEROFF_QUIET",		bool,			config.poweroffQuiet,	false);
+	SHELL_CONFIG_DIRECTIVEX("NUT_DEBUG_LEVEL",		int,			config.debugLevel,		false);
 
 	return NUTW_OK;
 }

--- a/common/nutwriter.cpp
+++ b/common/nutwriter.cpp
@@ -656,10 +656,17 @@ NutWriter::status_t UpsdConfigWriter::writeConfig(const UpsdConfiguration & conf
 # pragma clang diagnostic push
 # pragma clang diagnostic ignored "-Wunreachable-code"
 #endif
-	UPSD_DIRECTIVEX("MAXAGE",    unsigned int, config.maxAge);
-	UPSD_DIRECTIVEX("MAXCONN",   unsigned int, config.maxConn);
-	UPSD_DIRECTIVEX("STATEPATH", std::string,  config.statePath);
-	UPSD_DIRECTIVEX("CERTFILE",  std::string,  config.certFile);
+	UPSD_DIRECTIVEX("DEBUG_MIN",                int,          config.debugMin);
+	UPSD_DIRECTIVEX("MAXAGE",                   unsigned int, config.maxAge);
+	UPSD_DIRECTIVEX("MAXCONN",                  unsigned int, config.maxConn);
+	UPSD_DIRECTIVEX("TRACKINGDELAY",            unsigned int, config.trackingDelay);
+	UPSD_DIRECTIVEX("ALLOW_NO_DEVICE",          bool,         config.allowNoDevice);
+	UPSD_DIRECTIVEX("ALLOW_NOT_ALL_LISTENERS",  bool,         config.allowNotAllListeners);
+	UPSD_DIRECTIVEX("DISABLE_WEAK_SSL",         bool,         config.disableWeakSsl);
+	CONFIG_DIRECTIVEX("STATEPATH",              std::string,  config.statePath, true);
+	CONFIG_DIRECTIVEX("CERTFILE",               std::string,  config.certFile, true);
+	CONFIG_DIRECTIVEX("CERTPATH",               std::string,  config.certPath, true);
+	UPSD_DIRECTIVEX("CERTREQUEST",              unsigned int, config.certRequestLevel);
 #ifdef __clang__
 # pragma clang diagnostic pop
 #endif
@@ -668,6 +675,16 @@ NutWriter::status_t UpsdConfigWriter::writeConfig(const UpsdConfiguration & conf
 #endif
 
 	#undef UPSD_DIRECTIVEX
+
+	// Certificate identity
+	if (config.certIdent.set()) {
+		std::string directive = serializeCertIdent(config.certIdent);
+
+		status_t status = writeDirective(directive);
+
+		if (NUTW_OK != status)
+			return status;
+	}
 
 	// Listen addresses
 	std::list<UpsdConfiguration::Listen>::const_iterator la_iter = config.listens.begin();

--- a/common/nutwriter.cpp
+++ b/common/nutwriter.cpp
@@ -293,6 +293,17 @@ NutWriter::status_t NutConfConfigWriter::writeConfig(const NutConfiguration & co
 			return status;
 	}
 
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE)
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+# pragma GCC diagnostic ignored "-Wunreachable-code"
+#endif
+/* Older CLANG (e.g. clang-3.4) seems to not support the GCC pragmas above */
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunreachable-code"
+#endif
 	SHELL_CONFIG_DIRECTIVEX("ALLOW_NO_DEVICE",		bool,			config.allowNoDevice,	false);
 	SHELL_CONFIG_DIRECTIVEX("ALLOW_NOT_ALL_LISTENERS",	bool,		config.allowNotAllListeners,	false);
 	SHELL_CONFIG_DIRECTIVEX("UPSD_OPTIONS",			std::string,	config.upsdOptions,		true);
@@ -300,6 +311,12 @@ NutWriter::status_t NutConfConfigWriter::writeConfig(const NutConfiguration & co
 	SHELL_CONFIG_DIRECTIVEX("POWEROFF_WAIT",		unsigned int,	config.poweroffWait,	false);
 	SHELL_CONFIG_DIRECTIVEX("POWEROFF_QUIET",		bool,			config.poweroffQuiet,	false);
 	SHELL_CONFIG_DIRECTIVEX("NUT_DEBUG_LEVEL",		int,			config.debugLevel,		false);
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE)
+# pragma GCC diagnostic pop
+#endif
 
 	return NUTW_OK;
 }

--- a/conf/nut.conf.sample
+++ b/conf/nut.conf.sample
@@ -86,3 +86,8 @@ MODE=none
 # via logs or console captures.
 # Set to `true` to avoid that trove of information, if you consider it noise.
 #POWEROFF_QUIET=true
+
+# The optional 'NUT_DEBUG_LEVEL' setting controls the default debugging message
+# verbosity passed to NUT daemons. As an environment variable, its priority sits
+# between that of 'DEBUG_MIN' setting of a driver and the command-line options.
+#NUT_DEBUG_LEVEL=0

--- a/docs/man/nut.conf.txt
+++ b/docs/man/nut.conf.txt
@@ -112,6 +112,11 @@ integration scripts or service units would emit messages about their activity
 troubleshooting via logs or console captures.  Set to `true` to avoid that
 trove of information, if you consider it noise.
 
+*NUT_DEBUG_LEVEL*::
+Optional, defaults to `0`. This setting controls the default debugging message
+verbosity passed to NUT daemons. As an environment variable, its priority sits
+between that of 'DEBUG_MIN' setting of a driver and the command-line options.
+
 EXAMPLE
 -------
 

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3151 utf-8
+personal_ws-1.1 en 3152 utf-8
 AAC
 AAS
 ABI
@@ -2460,6 +2460,7 @@ parallelized
 param
 parsable
 parseconf
+parsers
 passname
 passphrase
 passthrough

--- a/drivers/blazer.c
+++ b/drivers/blazer.c
@@ -554,7 +554,7 @@ void blazer_makevartable(void)
 	addvar(VAR_FLAG, "norating", "Skip reading rating information from UPS");
 	addvar(VAR_FLAG, "novendor", "Skip reading vendor information from UPS");
 
-	addvar(VAR_FLAG, "protocol", "Preselect communication protocol (skip autodetection)");
+	addvar(VAR_VALUE, "protocol", "Preselect communication protocol (skip autodetection)");
 }
 
 

--- a/drivers/blazer_ser.c
+++ b/drivers/blazer_ser.c
@@ -31,7 +31,7 @@
 #include "blazer.h"
 
 #define DRIVER_NAME	"Megatec/Q1 protocol serial driver"
-#define DRIVER_VERSION	"1.61"
+#define DRIVER_VERSION	"1.62"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/blazer_usb.c
+++ b/drivers/blazer_usb.c
@@ -37,7 +37,7 @@
 #endif
 
 #define DRIVER_NAME	"Megatec/Q1 protocol USB driver"
-#define DRIVER_VERSION	"0.18"
+#define DRIVER_VERSION	"0.19"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/nut-ipmipsu.c
+++ b/drivers/nut-ipmipsu.c
@@ -183,7 +183,8 @@ void upsdrv_help(void)
 /* list flags and values that you want to receive via -x */
 void upsdrv_makevartable(void)
 {
-	/* FIXME: need more params.
+	/* FIXME: need more params. */
+/*
 	addvar(VAR_VALUE, "username", "Remote server username");
 	addvar(VAR_VALUE, "password", "Remote server password");
 	addvar(VAR_VALUE, "authtype",
@@ -192,7 +193,9 @@ void upsdrv_makevartable(void)
 		"Type of the device to match ('psu' for \"Power Supply\")");
 
 	addvar(VAR_VALUE, "serial", "Serial number to match a specific device");
-	addvar(VAR_VALUE, "fruid", "FRU identifier to match a specific device"); */
+	addvar(VAR_VALUE, "fruid", "FRU identifier to match a specific device");
+	addvar(VAR_VALUE, "sensorid", "Sensor identifier to match a specific device");
+*/
 }
 
 void upsdrv_initups(void)

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -164,8 +164,46 @@ public:
 
 	/** Leave all contents un-set */
 	BoolInt() {}
+
+	BoolInt(const bool val) {
+		*this = val;
+	}
+	BoolInt(const bool val, bool newBool01) {
+		this->bool01 = newBool01;
+		*this = val;
+	}
+
+	BoolInt(const int val) {
+		*this = val;
+	}
+	BoolInt(const int val, bool newBool01) {
+		this->bool01 = newBool01;
+		*this = val;
+	}
+
+	BoolInt(const char* val) {
+		*this = val;
+	}
+	BoolInt(const char* val, bool newBool01) {
+		this->bool01 = newBool01;
+		*this = val;
+	}
+
+	BoolInt(const std::string &val) {
+		*this = val;
+	}
+	BoolInt(const std::string &val, bool newBool01) {
+		this->bool01 = newBool01;
+		*this = val;
+	}
+
 	BoolInt(const BoolInt& other) {
 		*this = other;
+	}
+	BoolInt(const BoolInt& other, bool newBool01) {
+		this->bool01 = newBool01;
+		*this = other;
+		this->bool01 = newBool01;
 	}
 
 	inline void clear()

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -679,7 +679,7 @@ public:
 		uint16_t port;
 		unsigned int powerValue;
 		std::string username, password;
-		bool isMaster;
+		bool isPrimary;
 	};
 
 	std::list<Monitor> monitors;

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -1634,15 +1634,6 @@ public:
 	inline void setOverrideDouble(const std::string & ups, const std::string & key, double val)           { setDouble(ups, "override." + key, val); }
 
 	/** UPS-specific configuration attributes getters and setters \{ */
-	inline std::string getDriver(const std::string & ups)              const { return getStr(ups, "driver"); }
-	inline std::string getDescription(const std::string & ups)         const { return getStr(ups, "desc"); }
-	inline std::string getCP(const std::string & ups)                  const { return getStr(ups, "CP"); }
-	inline std::string getCS(const std::string & ups)                  const { return getStr(ups, "CS"); }
-	inline std::string getID(const std::string & ups)                  const { return getStr(ups, "ID"); }
-	inline std::string getLB(const std::string & ups)                  const { return getStr(ups, "LB"); }
-	inline std::string getLowBatt(const std::string & ups)             const { return getStr(ups, "LowBatt"); }
-	inline std::string getOL(const std::string & ups)                  const { return getStr(ups, "OL"); }
-	inline std::string getSD(const std::string & ups)                  const { return getStr(ups, "SD"); }
 	inline std::string getAuthPassword(const std::string & ups)        const { return getStr(ups, "authPassword"); }
 	inline std::string getAuthProtocol(const std::string & ups)        const { return getStr(ups, "authProtocol"); }
 	inline std::string getAuthType(const std::string & ups)            const { return getStr(ups, "authtype"); }
@@ -1650,10 +1641,20 @@ public:
 	inline std::string getBatText(const std::string & ups)             const { return getStr(ups, "battext"); }
 	inline std::string getBus(const std::string & ups)                 const { return getStr(ups, "bus"); }
 	inline std::string getCommunity(const std::string & ups)           const { return getStr(ups, "community"); }
+	inline std::string getDriver(const std::string & ups)              const { return getStr(ups, "driver"); }
+	inline std::string getDescription(const std::string & ups)         const { return getStr(ups, "desc"); }
 	inline std::string getFRUID(const std::string & ups)               const { return getStr(ups, "fruid"); }
+	inline std::string getGenericUPS_BYPASS(const std::string & ups)   const { return getStr(ups, "BYPASS"); }
+	inline std::string getGenericUPS_CP(const std::string & ups)       const { return getStr(ups, "CP"); }
+	inline std::string getGenericUPS_LB(const std::string & ups)       const { return getStr(ups, "LB"); }
+	inline std::string getGenericUPS_OL(const std::string & ups)       const { return getStr(ups, "OL"); }
+	inline std::string getGenericUPS_RB(const std::string & ups)       const { return getStr(ups, "RB"); }
+	inline std::string getGenericUPS_SD(const std::string & ups)       const { return getStr(ups, "SD"); }
 	inline std::string getGroup(const std::string & ups)               const { return getStr(ups, "group"); }
+	inline std::string getID(const std::string & ups)                  const { return getStr(ups, "ID"); }
 	inline std::string getLoadStatus(const std::string & ups)          const { return getStr(ups, "load.status"); }
 	inline std::string getLogin(const std::string & ups)               const { return getStr(ups, "login"); }
+	inline std::string getLowBatt(const std::string & ups)             const { return getStr(ups, "LowBatt"); }
 	inline std::string getLowbatt(const std::string & ups)             const { return getStr(ups, "lowbatt"); }
 	inline std::string getManufacturer(const std::string & ups)        const { return getStr(ups, "manufacturer"); }
 	inline std::string getMethodOfFlowControl(const std::string & ups) const { return getStr(ups, "methodOfFlowControl"); }
@@ -1661,7 +1662,6 @@ public:
 	inline std::string getModel(const std::string & ups)               const { return getStr(ups, "model"); }
 	inline std::string getModelName(const std::string & ups)           const { return getStr(ups, "modelname"); }
 	inline std::string getNotification(const std::string & ups)        const { return getStr(ups, "notification"); }
-	inline std::string getOldMAC(const std::string & ups)              const { return getStr(ups, "oldmac"); }
 	inline std::string getPassword(const std::string & ups)            const { return getStr(ups, "password"); }
 	inline std::string getPort(const std::string & ups)                const { return getStr(ups, "port"); }
 	inline std::string getPrefix(const std::string & ups)              const { return getStr(ups, "prefix"); }
@@ -1734,9 +1734,11 @@ public:
 	inline long long int getUPSdelayShutdown(const std::string & ups)  const { return getInt(ups, "ups.delay.shutdown"); }  // CHECKME
 	inline long long int getUPSdelayStart(const std::string & ups)     const { return getInt(ups, "ups.delay.start"); }     // CHECKME
 	inline long long int getVoltage(const std::string & ups)           const { return getInt(ups, "voltage"); }             // CHECKME
-	inline long long int getWait(const std::string & ups)              const { return getInt(ups, "wait"); }                // CHECKME
 
-	// May be a flag or a number; 0 is among valid values (default -1 for unset)
+	/** belkinunv: both a flag (wait for AC power) and value (also wait for charge level) */
+	inline long long int getWait(const std::string & ups)              const { return getInt(ups, "wait"); }
+
+	/** May be a flag or a number; 0 is among valid values (default -1 for unset) */
 	inline long long int getUsbSetAltInterface(const std::string & ups)          const { return getInt(ups, "usb_set_altinterface", -1); }      // CHECKME
 
 	// NUT specifies these as "hexnum" values (optionally with prefixed 0x but hex anyway)
@@ -1747,36 +1749,33 @@ public:
 	inline long long int getUsbHidEndpointOut(const std::string & ups)           const { return getIntHex(ups, "usb_hid_ep_out"); }             // CHECKME
 
 	// Flag - if exists then "true"
+	inline bool getCancelShutdown(const std::string & ups) const { return getFlag(ups, "CS"); }
+	inline bool getDumbTerm(const std::string & ups)       const { return getFlag(ups, "dumbterm"); }
+	inline bool getExplore(const std::string & ups)        const { return getFlag(ups, "explore"); }
+	inline bool getFakeLowBatt(const std::string & ups)    const { return getFlag(ups, "fake_lowbatt"); }
+	inline bool getFlash(const std::string & ups)          const { return getFlag(ups, "flash"); }
 	inline bool getIgnoreLB(const std::string & ups)       const { return getFlag(ups, "ignorelb"); }
+	inline bool getNoHang(const std::string & ups)         const { return getFlag(ups, "nohang"); }
+	inline bool getNoRating(const std::string & ups)       const { return getFlag(ups, "norating"); }
+	inline bool getNoTransferOIDs(const std::string & ups) const { return getFlag(ups, "notransferoids"); }
+	inline bool getNoVendor(const std::string & ups)       const { return getFlag(ups, "novendor"); }
+	inline bool getNoWarnNoImp(const std::string & ups)    const { return getFlag(ups, "nowarn_noimp"); }
+	inline bool getOldMAC(const std::string & ups)         const { return getFlag(ups, "oldmac"); }
+	inline bool getPollOnly(const std::string & ups)       const { return getFlag(ups, "pollonly"); }
+	inline bool getSilent(const std::string & ups)         const { return getFlag(ups, "silent"); }
+	inline bool getStatusOnly(const std::string & ups)     const { return getFlag(ups, "status_only"); }
+	inline bool getSubscribe(const std::string & ups)      const { return getFlag(ups, "subscribe"); }
+	inline bool getUseCRLF(const std::string & ups)        const { return getFlag(ups, "use_crlf"); }
+	inline bool getUsePreLF(const std::string & ups)       const { return getFlag(ups, "use_pre_lf"); }
 
 	inline bool getNolock(const std::string & ups)         const { return getBool(ups, "nolock"); }
 	inline bool getCable(const std::string & ups)          const { return getBool(ups, "cable"); }
-	inline bool getDumbTerm(const std::string & ups)       const { return getBool(ups, "dumbterm"); }
-	inline bool getExplore(const std::string & ups)        const { return getBool(ups, "explore"); }
-	inline bool getFakeLowBatt(const std::string & ups)    const { return getBool(ups, "fake_lowbatt"); }
-	inline bool getFlash(const std::string & ups)          const { return getBool(ups, "flash"); }
 	inline bool getFullUpdate(const std::string & ups)     const { return getBool(ups, "full_update"); }
 	inline bool getLangIDfix(const std::string & ups)      const { return getBool(ups, "langid_fix"); }
 	inline bool getLoadOff(const std::string & ups)        const { return getBool(ups, "load.off"); }
 	inline bool getLoadOn(const std::string & ups)         const { return getBool(ups, "load.on"); }
-	inline bool getNoHang(const std::string & ups)         const { return getBool(ups, "nohang"); }
-	inline bool getNoRating(const std::string & ups)       const { return getBool(ups, "norating"); }
-	inline bool getNoTransferOIDs(const std::string & ups) const { return getBool(ups, "notransferoids"); }
-	inline bool getNoVendor(const std::string & ups)       const { return getBool(ups, "novendor"); }
-	inline bool getNoWarnNoImp(const std::string & ups)    const { return getBool(ups, "nowarn_noimp"); }
-	inline bool getPollOnly(const std::string & ups)       const { return getBool(ups, "pollonly"); }
-	inline bool getSilent(const std::string & ups)         const { return getBool(ups, "silent"); }
-	inline bool getStatusOnly(const std::string & ups)     const { return getBool(ups, "status_only"); }
-	inline bool getSubscribe(const std::string & ups)      const { return getBool(ups, "subscribe"); }
-	inline bool getUseCRLF(const std::string & ups)        const { return getBool(ups, "use_crlf"); }
-	inline bool getUsePreLF(const std::string & ups)       const { return getBool(ups, "use_pre_lf"); }
 
 
-	inline void setDriver(const std::string & ups, const std::string & driver)                { setStr(ups, "driver",              driver); }
-	inline void setDescription(const std::string & ups, const std::string & desc)             { setStr(ups, "desc",                desc); }
-	inline void setLowBatt(const std::string & ups, const std::string & lowbatt)              { setStr(ups, "LowBatt",             lowbatt); }
-	inline void setOL(const std::string & ups, const std::string & ol)                        { setStr(ups, "OL",                  ol); }
-	inline void setSD(const std::string & ups, const std::string & sd)                        { setStr(ups, "SD",                  sd); }
 	inline void setAuthPassword(const std::string & ups, const std::string & auth_passwd)     { setStr(ups, "authPassword",        auth_passwd); }
 	inline void setAuthProtocol(const std::string & ups, const std::string & auth_proto)      { setStr(ups, "authProtocol",        auth_proto); }
 	inline void setAuthType(const std::string & ups, const std::string & authtype)            { setStr(ups, "authtype",            authtype); }
@@ -1784,10 +1783,19 @@ public:
 	inline void setBatText(const std::string & ups, const std::string & battext)              { setStr(ups, "battext",             battext); }
 	inline void setBus(const std::string & ups, const std::string & bus)                      { setStr(ups, "bus",                 bus); }
 	inline void setCommunity(const std::string & ups, const std::string & community)          { setStr(ups, "community",           community); }
+	inline void setDriver(const std::string & ups, const std::string & driver)                { setStr(ups, "driver",              driver); }
+	inline void setDescription(const std::string & ups, const std::string & desc)             { setStr(ups, "desc",                desc); }
 	inline void setFRUID(const std::string & ups, const std::string & fruid)                  { setStr(ups, "fruid",               fruid); }
+	inline void setGenericUPS_BYPASS(const std::string & ups, const std::string & bypass)     { setStr(ups, "BYPASS",              bypass); }
+	inline void setGenericUPS_CP(const std::string & ups, const std::string & cp)             { setStr(ups, "CP",                  cp); }
+	inline void setGenericUPS_LB(const std::string & ups, const std::string & lb)             { setStr(ups, "LB",                  lb); }
+	inline void setGenericUPS_OL(const std::string & ups, const std::string & ol)             { setStr(ups, "OL",                  ol); }
+	inline void setGenericUPS_RB(const std::string & ups, const std::string & rb)             { setStr(ups, "RB",                  rb); }
+	inline void setGenericUPS_SD(const std::string & ups, const std::string & sd)             { setStr(ups, "SD",                  sd); }
 	inline void setGroup(const std::string & ups, const std::string & group)                  { setStr(ups, "group",               group); }
 	inline void setLoadStatus(const std::string & ups, const std::string & load_status)       { setStr(ups, "load.status",         load_status); }
 	inline void setLogin(const std::string & ups, const std::string & login)                  { setStr(ups, "login",               login); }
+	inline void setLowBatt(const std::string & ups, const std::string & lowbatt)              { setStr(ups, "LowBatt",             lowbatt); }
 	inline void setLowbatt(const std::string & ups, const std::string & lowbatt)              { setStr(ups, "lowbatt",             lowbatt); }
 	inline void setManufacturer(const std::string & ups, const std::string & manufacturer)    { setStr(ups, "manufacturer",        manufacturer); }
 	inline void setMethodOfFlowControl(const std::string & ups, const std::string & method)   { setStr(ups, "methodOfFlowControl", method); }
@@ -1795,7 +1803,6 @@ public:
 	inline void setModel(const std::string & ups, const std::string & model)                  { setStr(ups, "model",               model); }
 	inline void setModelName(const std::string & ups, const std::string & modelname)          { setStr(ups, "modelname",           modelname); }
 	inline void setNotification(const std::string & ups, const std::string & notification)    { setStr(ups, "notification",        notification); }
-	inline void setOldMAC(const std::string & ups, const std::string & oldmac)                { setStr(ups, "oldmac",              oldmac); }
 	inline void setPassword(const std::string & ups, const std::string & password)            { setStr(ups, "password",            password); }
 	inline void setPort(const std::string & ups, const std::string & port)                    { setStr(ups, "port",                port); }
 	inline void setPrefix(const std::string & ups, const std::string & prefix)                { setStr(ups, "prefix",              prefix); }
@@ -1867,9 +1874,11 @@ public:
 	inline void setUPSdelayShutdown(const std::string & ups, long long int delay)  { setInt(ups, "ups.delay.shutdown", delay); }        // CHECKME
 	inline void setUPSdelayStart(const std::string & ups, long long int delay)     { setInt(ups, "ups.delay.start",    delay); }        // CHECKME
 	inline void setVoltage(const std::string & ups, long long int voltage)         { setInt(ups, "voltage",            voltage); }      // CHECKME
+
+	/** belkinunv: both a flag (wait for AC power) and value (also wait for charge level) */
 	inline void setWait(const std::string & ups, long long int wait)               { setInt(ups, "wait",               wait); }         // CHECKME
 
-	// May be a flag or a number; 0 is among valid values (default -1 for unset)
+	/** May be a flag or a number; 0 is among valid values (default -1 for unset) */
 	inline void setUsbSetAltInterface(const std::string & ups, long long int val = 0)       { if (val >= 0) { setInt(ups, "usb_set_altinterface", val); } else { remove(ups, "usb_set_altinterface"); } }         // CHECKME
 
 	// NUT specifies these as "hexnum" values (optionally with prefixed 0x but hex anyway)
@@ -1880,29 +1889,31 @@ public:
 	inline void setUsbHidEndpointOut(const std::string & ups, long long int val)            { setIntHex(ups, "usb_hid_ep_out",                 val); }         // CHECKME
 
 	// Flag - if exists then "true"; remove() to "unset" => "false"
-	inline void setIgnoreLB(const std::string & ups, bool val = true)       { setFlag(ups, "ignorelb", val); }
+	inline void setCancelShutdown(const std::string & ups, bool set = true) { setFlag(ups, "CS",             set); }
+	inline void setDumbTerm(const std::string & ups, bool set = true)       { setFlag(ups, "dumbterm",       set); }
+	inline void setExplore(const std::string & ups, bool set = true)        { setFlag(ups, "explore",        set); }
+	inline void setFakeLowBatt(const std::string & ups, bool set = true)    { setFlag(ups, "fake_lowbatt",   set); }
+	inline void setFlash(const std::string & ups, bool set = true)          { setFlag(ups, "flash",          set); }
+	inline void setIgnoreLB(const std::string & ups, bool set = true)       { setFlag(ups, "ignorelb",       set); }
+	inline void setNoHang(const std::string & ups, bool set = true)         { setFlag(ups, "nohang",         set); }
+	inline void setNoRating(const std::string & ups, bool set = true)       { setFlag(ups, "norating",       set); }
+	inline void setNoTransferOIDs(const std::string & ups, bool set = true) { setFlag(ups, "notransferoids", set); }
+	inline void setNoVendor(const std::string & ups, bool set = true)       { setFlag(ups, "novendor",       set); }
+	inline void setNoWarnNoImp(const std::string & ups, bool set = true)    { setFlag(ups, "nowarn_noimp",   set); }
+	inline void setOldMAC(const std::string & ups, bool set = true)         { setFlag(ups, "oldmac",         set); }
+	inline void setPollOnly(const std::string & ups, bool set = true)       { setFlag(ups, "pollonly",       set); }
+	inline void setSilent(const std::string & ups, bool set = true)         { setFlag(ups, "silent",         set); }
+	inline void setStatusOnly(const std::string & ups, bool set = true)     { setFlag(ups, "status_only",    set); }	// aka OPTI_MINPOLL
+	inline void setSubscribe(const std::string & ups, bool set = true)      { setFlag(ups, "subscribe",      set); }
+	inline void setUseCRLF(const std::string & ups, bool set = true)        { setFlag(ups, "use_crlf",       set); }
+	inline void setUsePreLF(const std::string & ups, bool set = true)       { setFlag(ups, "use_pre_lf",     set); }
 
 	inline void setNolock(const std::string & ups, bool set = true)         { setBool(ups, "nolock",         set); }
 	inline void setCable(const std::string & ups, bool set = true)          { setBool(ups, "cable",          set); }
-	inline void setDumbTerm(const std::string & ups, bool set = true)       { setBool(ups, "dumbterm",       set); }
-	inline void setExplore(const std::string & ups, bool set = true)        { setBool(ups, "explore",        set); }
-	inline void setFakeLowBatt(const std::string & ups, bool set = true)    { setBool(ups, "fake_lowbatt",   set); }
-	inline void setFlash(const std::string & ups, bool set = true)          { setBool(ups, "flash",          set); }
 	inline void setFullUpdate(const std::string & ups, bool set = true)     { setBool(ups, "full_update",    set); }
 	inline void setLangIDfix(const std::string & ups, bool set = true)      { setBool(ups, "langid_fix",     set); }
 	inline void setLoadOff(const std::string & ups, bool set = true)        { setBool(ups, "load.off",       set); }
 	inline void setLoadOn(const std::string & ups, bool set = true)         { setBool(ups, "load.on",        set); }
-	inline void setNoHang(const std::string & ups, bool set = true)         { setBool(ups, "nohang",         set); }
-	inline void setNoRating(const std::string & ups, bool set = true)       { setBool(ups, "norating",       set); }
-	inline void setNoTransferOIDs(const std::string & ups, bool set = true) { setBool(ups, "notransferoids", set); }
-	inline void setNoVendor(const std::string & ups, bool set = true)       { setBool(ups, "novendor",       set); }
-	inline void setNoWarnNoImp(const std::string & ups, bool set = true)    { setBool(ups, "nowarn_noimp",   set); }
-	inline void setPollOnly(const std::string & ups, bool set = true)       { setBool(ups, "pollonly",       set); }
-	inline void setSilent(const std::string & ups, bool set = true)         { setBool(ups, "silent",         set); }
-	inline void setStatusOnly(const std::string & ups, bool set = true)     { setBool(ups, "status_only",    set); }
-	inline void setSubscribe(const std::string & ups, bool set = true)      { setBool(ups, "subscribe",      set); }
-	inline void setUseCRLF(const std::string & ups, bool set = true)        { setBool(ups, "use_crlf",       set); }
-	inline void setUsePreLF(const std::string & ups, bool set = true)       { setBool(ups, "use_pre_lf",     set); }
 
 	/** \} */
 

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -1693,6 +1693,13 @@ public:
 	inline void setUseCRLF(const std::string & ups, bool set = true)        { setBool(ups, "use_crlf",       set); }
 	inline void setUsePreLF(const std::string & ups, bool set = true)       { setBool(ups, "use_pre_lf",     set); }
 
+	// FIXME: What to do about "default.*" and "override.*"
+	// settings that apply to anything (vars!) that follows?
+	// Maybe nest the UpsConfiguration objects, and so query
+	// e.g. upscfg.default.getBatteryNominalVoltage() ?
+	// Or just keep that info in ConfigParamList per section
+	// and wrap free-style queries?
+
 	/** \} */
 
 	virtual ~UpsConfiguration() override;

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -1179,6 +1179,58 @@ protected:
 	}
 
 	/**
+	 *  \brief  Configuration floating-point number getter
+	 *
+	 *  \param  section  Section name
+	 *  \param  entry    Entry name
+	 *  \param  val      Default value
+	 *
+	 *  \return Configuration parameter as number (or the default if not defined)
+	 */
+	double getDouble(
+		const std::string & section,
+		const std::string & entry,
+		double              val = 0.0) const;
+
+	/**
+	 *  \brief  Global scope configuration floating-point number getter
+	 *
+	 *  \param  entry    Entry name
+	 *  \param  val      Default value
+	 *
+	 *  \return Configuration parameter as number (or the default if not defined)
+	 */
+	inline double getDouble(const std::string & entry, double val = 0.0) const
+	{
+		return getDouble("", entry, val);
+	}
+
+	/**
+	 *  \brief  Configuration floating-point number setter
+	 *
+	 *  \param  section  Section name
+	 *  \param  entry    Entry name
+	 *  \param  val      Default value
+	 */
+	void setDouble(
+		const std::string & section,
+		const std::string & entry,
+		double              val);
+
+	/**
+	 *  \brief  Global scope configuration floating-point number setter
+	 *
+	 *  \param  entry    Entry name
+	 *  \param  val      Default value
+	 */
+	inline void setDouble(
+		const std::string & entry,
+		double              val)
+	{
+		setDouble("", entry, val);
+	}
+
+	/**
 	 *  \brief  Cast numeric type with range check
 	 *
 	 *  Throws an exception on cast error.

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -1373,7 +1373,7 @@ public:
 	Settable<std::string>  certPath;
 	CertIdent              certIdent;
 	std::list<CertHost>    certHosts;
-	Settable<unsigned int> minSupplies, poolFreq, poolFreqAlert, hostSync;
+	Settable<unsigned int> minSupplies, pollFreq, pollFreqAlert, hostSync;
 	Settable<unsigned int> deadTime, rbWarnTime, noCommWarnTime, finalDelay;
 
 	enum NotifyFlag {

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -1553,6 +1553,35 @@ protected:
 /** UPS configuration */
 class UpsConfiguration : public GenericConfiguration
 {
+	/* Note: key words for ups.conf are well collected from sources
+	 * by augeas lens preparation scripts. Maintainers of this class
+	 * can consume that information like this to see key words in
+	 * context of their use in sources and documentation (omit the
+	 * `continue` in grep of `nutconf.hpp` to see details of ALL
+	 * keywords and not just those not yet covered by this class
+	 * (e.g. to verify handling as str/int/bool/flag... types):
+
+:; ( cd scripts/augeas && python ./gen-nutupsconf-aug.py.in )
+
+:; grep -E '[=|] "' scripts/augeas/nutupsconf.aug.in | awk '{print $NF}' | tr -d '"' \
+  | while read O ; do echo "=== $O :" ; \
+    grep -w '"'"$O"'"' ./include/nutconf.hpp && continue ; \
+    grep -A10 -w "$O" ./docs/man/*.txt || echo '!!! UNDOCUMENTED !!!' ; \
+    echo "-----"; grep -A10 -w '"'"$O"'"' ./drivers/*.{c,h} || echo '!!! NOT USED IN CODE !!!' ; \
+    echo "-----"; echo "" ; done | less
+
+	 * Arrange found new keywords into two columns (first would be
+	 * "C names" camel-cased and expanded as deemed fit) and generate
+	 * lines for code blocks below as e.g.:
+:; while read C O ; do \
+   printf '\tinline std::string get%-45sconst { return getStr(ups, "%s"); }\n' \
+      "$C"'(const std::string & ups)' "$O"; \
+   printf '\tinline void set%-75s{ setStr(ups, "%-22s val); }\n' \
+      "$C"'(const std::string & ups, const std::string & val)' "$O"'",' ; \
+   done  < nutupsconf-newnames.bool | sort
+
+	 */
+
 public:
 	/** Global configuration attributes getters and setters \{ */
 

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -1555,27 +1555,27 @@ public:
 	inline long long int getVoltage(const std::string & ups)           const { return getInt(ups, "voltage"); }             // CHECKME
 	inline long long int getWait(const std::string & ups)              const { return getInt(ups, "wait"); }                // CHECKME
 
-	inline bool getNolock(const std::string & ups)         const { return str2bool(getStr(ups, "nolock")); }
-	inline bool getCable(const std::string & ups)          const { return str2bool(getStr(ups, "cable")); }
-	inline bool getDumbTerm(const std::string & ups)       const { return str2bool(getStr(ups, "dumbterm")); }
-	inline bool getExplore(const std::string & ups)        const { return str2bool(getStr(ups, "explore")); }
-	inline bool getFakeLowBatt(const std::string & ups)    const { return str2bool(getStr(ups, "fake_lowbatt")); }
-	inline bool getFlash(const std::string & ups)          const { return str2bool(getStr(ups, "flash")); }
-	inline bool getFullUpdate(const std::string & ups)     const { return str2bool(getStr(ups, "full_update")); }
-	inline bool getLangIDfix(const std::string & ups)      const { return str2bool(getStr(ups, "langid_fix")); }
-	inline bool getLoadOff(const std::string & ups)        const { return str2bool(getStr(ups, "load.off")); }
-	inline bool getLoadOn(const std::string & ups)         const { return str2bool(getStr(ups, "load.on")); }
-	inline bool getNoHang(const std::string & ups)         const { return str2bool(getStr(ups, "nohang")); }
-	inline bool getNoRating(const std::string & ups)       const { return str2bool(getStr(ups, "norating")); }
-	inline bool getNoTransferOIDs(const std::string & ups) const { return str2bool(getStr(ups, "notransferoids")); }
-	inline bool getNoVendor(const std::string & ups)       const { return str2bool(getStr(ups, "novendor")); }
-	inline bool getNoWarnNoImp(const std::string & ups)    const { return str2bool(getStr(ups, "nowarn_noimp")); }
-	inline bool getPollOnly(const std::string & ups)       const { return str2bool(getStr(ups, "pollonly")); }
-	inline bool getSilent(const std::string & ups)         const { return str2bool(getStr(ups, "silent")); }
-	inline bool getStatusOnly(const std::string & ups)     const { return str2bool(getStr(ups, "status_only")); }
-	inline bool getSubscribe(const std::string & ups)      const { return str2bool(getStr(ups, "subscribe")); }
-	inline bool getUseCRLF(const std::string & ups)        const { return str2bool(getStr(ups, "use_crlf")); }
-	inline bool getUsePreLF(const std::string & ups)       const { return str2bool(getStr(ups, "use_pre_lf")); }
+	inline bool getNolock(const std::string & ups)         const { return getBool(ups, "nolock"); }
+	inline bool getCable(const std::string & ups)          const { return getBool(ups, "cable"); }
+	inline bool getDumbTerm(const std::string & ups)       const { return getBool(ups, "dumbterm"); }
+	inline bool getExplore(const std::string & ups)        const { return getBool(ups, "explore"); }
+	inline bool getFakeLowBatt(const std::string & ups)    const { return getBool(ups, "fake_lowbatt"); }
+	inline bool getFlash(const std::string & ups)          const { return getBool(ups, "flash"); }
+	inline bool getFullUpdate(const std::string & ups)     const { return getBool(ups, "full_update"); }
+	inline bool getLangIDfix(const std::string & ups)      const { return getBool(ups, "langid_fix"); }
+	inline bool getLoadOff(const std::string & ups)        const { return getBool(ups, "load.off"); }
+	inline bool getLoadOn(const std::string & ups)         const { return getBool(ups, "load.on"); }
+	inline bool getNoHang(const std::string & ups)         const { return getBool(ups, "nohang"); }
+	inline bool getNoRating(const std::string & ups)       const { return getBool(ups, "norating"); }
+	inline bool getNoTransferOIDs(const std::string & ups) const { return getBool(ups, "notransferoids"); }
+	inline bool getNoVendor(const std::string & ups)       const { return getBool(ups, "novendor"); }
+	inline bool getNoWarnNoImp(const std::string & ups)    const { return getBool(ups, "nowarn_noimp"); }
+	inline bool getPollOnly(const std::string & ups)       const { return getBool(ups, "pollonly"); }
+	inline bool getSilent(const std::string & ups)         const { return getBool(ups, "silent"); }
+	inline bool getStatusOnly(const std::string & ups)     const { return getBool(ups, "status_only"); }
+	inline bool getSubscribe(const std::string & ups)      const { return getBool(ups, "subscribe"); }
+	inline bool getUseCRLF(const std::string & ups)        const { return getBool(ups, "use_crlf"); }
+	inline bool getUsePreLF(const std::string & ups)       const { return getBool(ups, "use_pre_lf"); }
 
 
 	inline void setDriver(const std::string & ups, const std::string & driver)                { setStr(ups, "driver",              driver); }
@@ -1671,27 +1671,27 @@ public:
 	inline void setVoltage(const std::string & ups, long long int voltage)         { setInt(ups, "voltage",            voltage); }      // CHECKME
 	inline void setWait(const std::string & ups, long long int wait)               { setInt(ups, "wait",               wait); }         // CHECKME
 
-	inline void setNolock(const std::string & ups, bool set = true)         { setStr(ups, "nolock",         bool2str(set)); }
-	inline void setCable(const std::string & ups, bool set = true)          { setStr(ups, "cable",          bool2str(set)); }
-	inline void setDumbTerm(const std::string & ups, bool set = true)       { setStr(ups, "dumbterm",       bool2str(set)); }
-	inline void setExplore(const std::string & ups, bool set = true)        { setStr(ups, "explore",        bool2str(set)); }
-	inline void setFakeLowBatt(const std::string & ups, bool set = true)    { setStr(ups, "fake_lowbatt",   bool2str(set)); }
-	inline void setFlash(const std::string & ups, bool set = true)          { setStr(ups, "flash",          bool2str(set)); }
-	inline void setFullUpdate(const std::string & ups, bool set = true)     { setStr(ups, "full_update",    bool2str(set)); }
-	inline void setLangIDfix(const std::string & ups, bool set = true)      { setStr(ups, "langid_fix",     bool2str(set)); }
-	inline void setLoadOff(const std::string & ups, bool set = true)        { setStr(ups, "load.off",       bool2str(set)); }
-	inline void setLoadOn(const std::string & ups, bool set = true)         { setStr(ups, "load.on",        bool2str(set)); }
-	inline void setNoHang(const std::string & ups, bool set = true)         { setStr(ups, "nohang",         bool2str(set)); }
-	inline void setNoRating(const std::string & ups, bool set = true)       { setStr(ups, "norating",       bool2str(set)); }
-	inline void setNoTransferOIDs(const std::string & ups, bool set = true) { setStr(ups, "notransferoids", bool2str(set)); }
-	inline void setNoVendor(const std::string & ups, bool set = true)       { setStr(ups, "novendor",       bool2str(set)); }
-	inline void setNoWarnNoImp(const std::string & ups, bool set = true)    { setStr(ups, "nowarn_noimp",   bool2str(set)); }
-	inline void setPollOnly(const std::string & ups, bool set = true)       { setStr(ups, "pollonly",       bool2str(set)); }
-	inline void setSilent(const std::string & ups, bool set = true)         { setStr(ups, "silent",         bool2str(set)); }
-	inline void setStatusOnly(const std::string & ups, bool set = true)     { setStr(ups, "status_only",    bool2str(set)); }
-	inline void setSubscribe(const std::string & ups, bool set = true)      { setStr(ups, "subscribe",      bool2str(set)); }
-	inline void setUseCRLF(const std::string & ups, bool set = true)        { setStr(ups, "use_crlf",       bool2str(set)); }
-	inline void setUsePreLF(const std::string & ups, bool set = true)       { setStr(ups, "use_pre_lf",     bool2str(set)); }
+	inline void setNolock(const std::string & ups, bool set = true)         { setBool(ups, "nolock",         set); }
+	inline void setCable(const std::string & ups, bool set = true)          { setBool(ups, "cable",          set); }
+	inline void setDumbTerm(const std::string & ups, bool set = true)       { setBool(ups, "dumbterm",       set); }
+	inline void setExplore(const std::string & ups, bool set = true)        { setBool(ups, "explore",        set); }
+	inline void setFakeLowBatt(const std::string & ups, bool set = true)    { setBool(ups, "fake_lowbatt",   set); }
+	inline void setFlash(const std::string & ups, bool set = true)          { setBool(ups, "flash",          set); }
+	inline void setFullUpdate(const std::string & ups, bool set = true)     { setBool(ups, "full_update",    set); }
+	inline void setLangIDfix(const std::string & ups, bool set = true)      { setBool(ups, "langid_fix",     set); }
+	inline void setLoadOff(const std::string & ups, bool set = true)        { setBool(ups, "load.off",       set); }
+	inline void setLoadOn(const std::string & ups, bool set = true)         { setBool(ups, "load.on",        set); }
+	inline void setNoHang(const std::string & ups, bool set = true)         { setBool(ups, "nohang",         set); }
+	inline void setNoRating(const std::string & ups, bool set = true)       { setBool(ups, "norating",       set); }
+	inline void setNoTransferOIDs(const std::string & ups, bool set = true) { setBool(ups, "notransferoids", set); }
+	inline void setNoVendor(const std::string & ups, bool set = true)       { setBool(ups, "novendor",       set); }
+	inline void setNoWarnNoImp(const std::string & ups, bool set = true)    { setBool(ups, "nowarn_noimp",   set); }
+	inline void setPollOnly(const std::string & ups, bool set = true)       { setBool(ups, "pollonly",       set); }
+	inline void setSilent(const std::string & ups, bool set = true)         { setBool(ups, "silent",         set); }
+	inline void setStatusOnly(const std::string & ups, bool set = true)     { setBool(ups, "status_only",    set); }
+	inline void setSubscribe(const std::string & ups, bool set = true)      { setBool(ups, "subscribe",      set); }
+	inline void setUseCRLF(const std::string & ups, bool set = true)        { setBool(ups, "use_crlf",       set); }
+	inline void setUsePreLF(const std::string & ups, bool set = true)       { setBool(ups, "use_pre_lf",     set); }
 
 	/** \} */
 

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -1163,12 +1163,80 @@ protected:
 	}
 
 	/**
+	 *  \brief  Configuration mixed boolean/int option getter
+	 *
+	 *  Value depends on original string representation of a setting.
+	 *
+	 *  \param  section  Section name
+	 *  \param  entry    Entry name
+	 *  \param  val      Default value
+	 *
+	 *  \return Configuration parameter as BoolInt type for original
+	 *          values which have a boolean or integer-numeric meaning
+	 *          (or the default if not defined)
+	 */
+	nut::BoolInt getBoolInt(
+		const std::string & section,
+		const std::string & entry,
+		nut::BoolInt        val = false) const;
+
+	/**
+	 *  \brief  Global scope configuration mixed boolean/int option getter
+	 *
+	 *  Value depends on original string representation of a setting.
+	 *
+	 *  \param  entry    Entry name
+	 *  \param  val      Default value
+	 *
+	 *  \return Configuration parameter as BoolInt type for original
+	 *          values which have a boolean or integer-numeric meaning
+	 *          (or the default if not defined)
+	 */
+	inline nut::BoolInt getBoolInt(const std::string & entry, nut::BoolInt val = false) const
+	{
+		return getBoolInt("", entry, val);
+	}
+
+	/**
+	 *  \brief  Configuration mixed boolean/int option setter
+	 *
+	 *  Input value types are auto-converted through BoolInt
+	 *  type for sanity checks (e.g. throw exceptions for
+	 *  invalid string contents) and are stored as strings
+	 *  internally.
+	 *
+	 *  \param  section  Section name
+	 *  \param  entry    Entry name
+	 *  \param  val      Default value
+	 */
+	inline void setBoolInt(
+		const std::string & section,
+		const std::string & entry,
+		nut::BoolInt        val = true)
+	{
+		setStr(section, entry, val);
+	}
+
+	/**
+	 *  \brief  Global scope configuration mixed boolean/int option setter
+	 *
+	 *  \param  entry    Entry name
+	 *  \param  val      Default value
+	 */
+	inline void setBoolInt(
+		const std::string & entry,
+		nut::BoolInt        val = true)
+	{
+		setBoolInt("", entry, val);
+	}
+
+	/**
 	 *  \brief  Resolve string as Boolean value
 	 *
 	 *  \param  str  String
 	 *
 	 *  \retval true  IFF the string expresses a known true value
-	 *  \retval false otherwise
+	 *  \retval false otherwise (no errors emitted for bogus inputs)
 	 */
 	static bool str2bool(const std::string & str);
 

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -1673,6 +1673,7 @@ public:
 	inline std::string getDriver(const std::string & ups)              const { return getStr(ups, "driver"); }
 	inline std::string getDescription(const std::string & ups)         const { return getStr(ups, "desc"); }
 	inline std::string getFRUID(const std::string & ups)               const { return getStr(ups, "fruid"); }
+	inline std::string getGenericGPIO_Rules(const std::string & ups)   const { return getStr(ups, "rules"); }
 	inline std::string getGenericUPS_BYPASS(const std::string & ups)   const { return getStr(ups, "BYPASS"); }
 	inline std::string getGenericUPS_CP(const std::string & ups)       const { return getStr(ups, "CP"); }
 	inline std::string getGenericUPS_LB(const std::string & ups)       const { return getStr(ups, "LB"); }
@@ -1688,6 +1689,11 @@ public:
 	inline std::string getManufacturer(const std::string & ups)        const { return getStr(ups, "manufacturer"); }
 	inline std::string getMethodOfFlowControl(const std::string & ups) const { return getStr(ups, "methodOfFlowControl"); }
 	inline std::string getMIBs(const std::string & ups)                const { return getStr(ups, "mibs"); }
+	inline std::string getModbus_DeviceMfr(const std::string & ups)    const { return getStr(ups, "device_mfr"); }
+	inline std::string getModbus_DeviceModel(const std::string & ups)  const { return getStr(ups, "device_model"); }
+	inline std::string getModbus_Parity(const std::string & ups)       const { return getStr(ups, "parity"); }
+	inline std::string getModbus_PortType(const std::string & ups)     const { return getStr(ups, "porttype"); }
+	inline std::string getModbus_SerParity(const std::string & ups)    const { return getStr(ups, "ser_parity"); }
 	inline std::string getModel(const std::string & ups)               const { return getStr(ups, "model"); }
 	inline std::string getModelName(const std::string & ups)           const { return getStr(ups, "modelname"); }
 	inline std::string getNotification(const std::string & ups)        const { return getStr(ups, "notification"); }
@@ -1710,16 +1716,108 @@ public:
 	inline std::string getSNMPversion(const std::string & ups)         const { return getStr(ups, "snmp_version"); }
 	inline std::string getSubdriver(const std::string & ups)           const { return getStr(ups, "subdriver"); }
 	inline std::string getSynchronous(const std::string & ups)         const { return getStr(ups, "synchronous"); }
+	inline std::string getTtyMode(const std::string & ups)             const { return getStr(ups, "ttymode"); }
 	inline std::string getType(const std::string & ups)                const { return getStr(ups, "type"); }
 	inline std::string getUPStype(const std::string & ups)             const { return getStr(ups, "upstype"); }
+	inline std::string getUpsId(const std::string & ups)               const { return getStr(ups, "upsid"); }
+	inline std::string getUsbBusPort(const std::string & ups)          const { return getStr(ups, "busport"); }
+	inline std::string getUsbDevice(const std::string & ups)           const { return getStr(ups, "device"); }
 	inline std::string getUSD(const std::string & ups)                 const { return getStr(ups, "usd"); }
 	inline std::string getUser(const std::string & ups)                const { return getStr(ups, "user"); }
 	inline std::string getUsername(const std::string & ups)            const { return getStr(ups, "username"); }
 	inline std::string getValidationSequence(const std::string & ups)  const { return getStr(ups, "validationSequence"); }
 	inline std::string getVendor(const std::string & ups)              const { return getStr(ups, "vendor"); }
 	inline std::string getVendorID(const std::string & ups)            const { return getStr(ups, "vendorid"); }
+	inline std::string getWorkRangeType(const std::string & ups)       const { return getStr(ups, "work_range_type"); }
 	inline std::string getWUGrace(const std::string & ups)             const { return getStr(ups, "wugrace"); }
 
+	// Items below are "unused" - mostly set in
+	// drivers/nutdrv_qx_masterguard.c
+	inline std::string getFault1(const std::string & ups)              const { return getStr(ups, "fault_1"); }
+	inline std::string getFault2(const std::string & ups)              const { return getStr(ups, "fault_2"); }
+	inline std::string getFault3(const std::string & ups)              const { return getStr(ups, "fault_3"); }
+	inline std::string getFault4(const std::string & ups)              const { return getStr(ups, "fault_4"); }
+	inline std::string getFault5(const std::string & ups)              const { return getStr(ups, "fault_5"); }
+	inline std::string getInputFaultVoltage(const std::string & ups)   const { return getStr(ups, "input_fault_voltage"); }
+	inline std::string getNominalCellVoltage(const std::string & ups)  const { return getStr(ups, "nominal_cell_voltage"); }
+	inline std::string getNumberOfBatteryCells(const std::string & ups)const { return getStr(ups, "number_of_battery_cells"); }
+	inline std::string getOutputVoltages(const std::string & ups)      const { return getStr(ups, "output_voltages"); }
+	inline std::string getRechargeTime(const std::string & ups)        const { return getStr(ups, "recharge_time"); }
+	inline std::string getRuntimeFull(const std::string & ups)         const { return getStr(ups, "runtime_full"); }
+	inline std::string getRuntimeHalf(const std::string & ups)         const { return getStr(ups, "runtime_half"); }
+	inline std::string getSeries(const std::string & ups)              const { return getStr(ups, "series"); }
+
+	// Items below are essentially booleans (expected values
+	// are "enabled/disabled") -- refactoring planned per
+	// https://github.com/networkupstools/nut/issues/2421
+	inline std::string getAdvancedEcoMode(const std::string & ups)     const { return getStr(ups, "advanced_eco_mode"); }
+	inline std::string getAlarmControl(const std::string & ups)        const { return getStr(ups, "alarm_control"); }
+	inline std::string getBatteryAlarm(const std::string & ups)        const { return getStr(ups, "battery_alarm"); }
+	inline std::string getBatteryOpenStatusCheck(const std::string & ups)const { return getStr(ups, "battery_open_status_check"); }
+	inline std::string getBypassAlarm(const std::string & ups)         const { return getStr(ups, "bypass_alarm"); }
+	inline std::string getBypassForbidding(const std::string & ups)    const { return getStr(ups, "bypass_forbidding"); }
+	inline std::string getBypassWhenOff(const std::string & ups)       const { return getStr(ups, "bypass_when_off"); }
+	inline std::string getConstantPhaseAngle(const std::string & ups)  const { return getStr(ups, "constant_phase_angle"); }
+	inline std::string getConverterMode(const std::string & ups)       const { return getStr(ups, "converter_mode"); }
+	inline std::string getEcoMode(const std::string & ups)             const { return getStr(ups, "eco_mode"); }
+	inline std::string getLimitedRuntimeOnBattery(const std::string & ups)const { return getStr(ups, "limited_runtime_on_battery"); }
+	inline std::string getSiteFaultDetection(const std::string & ups)  const { return getStr(ups, "site_fault_detection"); }
+
+	inline long long int getAsem_HB(const std::string & ups)             const { return getInt(ups, "hb"); }
+	inline long long int getAsem_LB(const std::string & ups)             const { return getInt(ups, "lb"); }
+	inline long long int getBatteryNumber(const std::string & ups)       const { return getInt(ups, "battery_number"); }
+	inline long long int getI2C_address(const std::string & ups)         const { return getInt(ups, "i2c_address"); }
+	inline long long int getInterruptSize(const std::string & ups)       const { return getInt(ups, "interruptsize"); }
+	inline long long int getMaxPollsWithoutData(const std::string & ups) const { return getInt(ups, "max_polls_without_data"); }
+	inline long long int getModbus_ByteTimeoutSec(const std::string & ups)const { return getInt(ups, "mod_byte_to_s"); }
+	inline long long int getModbus_ByteTimeoutUsec(const std::string & ups)const { return getInt(ups, "mod_byte_to_us"); }
+	inline long long int getModbus_CHRG_addr(const std::string & ups)    const { return getInt(ups, "CHRG_addr"); }
+	inline long long int getModbus_CHRG_noro(const std::string & ups)    const { return getInt(ups, "CHRG_noro"); }
+	inline long long int getModbus_CHRG_regtype(const std::string & ups) const { return getInt(ups, "CHRG_regtype"); }
+	inline long long int getModbus_DISCHRG_addr(const std::string & ups) const { return getInt(ups, "DISCHRG_addr"); }
+	inline long long int getModbus_DISCHRG_noro(const std::string & ups) const { return getInt(ups, "DISCHRG_noro"); }
+	inline long long int getModbus_DISCHRG_regtype(const std::string & ups)const { return getInt(ups, "DISCHRG_regtype"); }
+	inline long long int getModbus_DataBits(const std::string & ups)     const { return getInt(ups, "databits"); }
+	inline long long int getModbus_DeviceSlaveId(const std::string & ups)const { return getInt(ups, "dev_slave_id"); }
+	inline long long int getModbus_FSD_addr(const std::string & ups)     const { return getInt(ups, "FSD_addr"); }
+	inline long long int getModbus_FSD_noro(const std::string & ups)     const { return getInt(ups, "FSD_noro"); }
+	inline long long int getModbus_FSD_pulse_duration(const std::string & ups)const { return getInt(ups, "FSD_pulse_duration"); }
+	inline long long int getModbus_FSD_regtype(const std::string & ups)  const { return getInt(ups, "FSD_regtype"); }
+	inline long long int getModbus_HB_addr(const std::string & ups)      const { return getInt(ups, "HB_addr"); }
+	inline long long int getModbus_HB_noro(const std::string & ups)      const { return getInt(ups, "HB_noro"); }
+	inline long long int getModbus_HB_regtype(const std::string & ups)   const { return getInt(ups, "HB_regtype"); }
+	inline long long int getModbus_LB_addr(const std::string & ups)      const { return getInt(ups, "LB_addr"); }
+	inline long long int getModbus_LB_noro(const std::string & ups)      const { return getInt(ups, "LB_noro"); }
+	inline long long int getModbus_LB_regtype(const std::string & ups)   const { return getInt(ups, "LB_regtype"); }
+	inline long long int getModbus_OB_addr(const std::string & ups)      const { return getInt(ups, "OB_addr"); }
+	inline long long int getModbus_OB_noro(const std::string & ups)      const { return getInt(ups, "OB_noro"); }
+	inline long long int getModbus_OB_regtype(const std::string & ups)   const { return getInt(ups, "OB_regtype"); }
+	inline long long int getModbus_OL_addr(const std::string & ups)      const { return getInt(ups, "OL_addr"); }
+	inline long long int getModbus_OL_noro(const std::string & ups)      const { return getInt(ups, "OL_noro"); }
+	inline long long int getModbus_OL_regtype(const std::string & ups)   const { return getInt(ups, "OL_regtype"); }
+	inline long long int getModbus_RB_addr(const std::string & ups)      const { return getInt(ups, "RB_addr"); }
+	inline long long int getModbus_RB_noro(const std::string & ups)      const { return getInt(ups, "RB_noro"); }
+	inline long long int getModbus_RB_regtype(const std::string & ups)   const { return getInt(ups, "RB_regtype"); }
+	inline long long int getModbus_ResponseTimeoutMsec(const std::string & ups)const { return getInt(ups, "response_timeout_ms"); }
+	inline long long int getModbus_ResponseTimeoutSec(const std::string & ups)const { return getInt(ups, "mod_resp_to_s"); }
+	inline long long int getModbus_ResponseTimeoutUsec(const std::string & ups)const { return getInt(ups, "mod_resp_to_us"); }
+	inline long long int getModbus_RioSlaveId(const std::string & ups)   const { return getInt(ups, "rio_slave_id"); }
+	inline long long int getModbus_SerBaudRate(const std::string & ups)  const { return getInt(ups, "ser_baud_rate"); }
+	inline long long int getModbus_SerDataBit(const std::string & ups)   const { return getInt(ups, "ser_data_bit"); }
+	inline long long int getModbus_SerStopBit(const std::string & ups)   const { return getInt(ups, "ser_stop_bit"); }
+	inline long long int getModbus_SlaveId(const std::string & ups)      const { return getInt(ups, "slaveid"); }
+	inline long long int getModbus_StopBits(const std::string & ups)     const { return getInt(ups, "stopbits"); }
+	inline long long int getOnlineDischargeLogThrottleHovercharge(const std::string & ups)const { return getInt(ups, "onlinedischarge_log_throttle_hovercharge"); }
+	inline long long int getOnlineDischargeLogThrottleSec(const std::string & ups)const { return getInt(ups, "onlinedischarge_log_throttle_sec"); }
+	inline long long int getOutputPhaseAngle(const std::string & ups)    const { return getInt(ups, "output_phase_angle"); }
+	inline long long int getPinsShutdownMode(const std::string & ups)    const { return getInt(ups, "pins_shutdown_mode"); }
+	inline long long int getSemistaticFreq(const std::string & ups)      const { return getInt(ups, "semistaticfreq"); }
+	inline long long int getShutdownDuration(const std::string & ups)    const { return getInt(ups, "shutdown_duration"); }
+	inline long long int getShutdownTimer(const std::string & ups)       const { return getInt(ups, "shutdown_timer"); }
+	inline long long int getSlaveAddress(const std::string & ups)        const { return getInt(ups, "slave_address"); }
+	inline long long int getSnmpRetries(const std::string & ups)         const { return getInt(ups, "snmp_retries"); }
+	inline long long int getSnmpTimeout(const std::string & ups)         const { return getInt(ups, "snmp_timeout"); }
+	inline long long int getWaitBeforeReconnect(const std::string & ups) const { return getInt(ups, "waitbeforereconnect"); }
 
 	inline long long int getDebugMin(const std::string & ups)          const { return getInt(ups, "debug_min"); }
 	inline long long int getSDOrder(const std::string & ups)           const { return getInt(ups, "sdorder"); }             // TODO: Is that a number?
@@ -1777,6 +1875,14 @@ public:
 	inline long long int getUsbHidEndpointIn(const std::string & ups)            const { return getIntHex(ups, "usb_hid_ep_in"); }              // CHECKME
 	inline long long int getUsbHidEndpointOut(const std::string & ups)           const { return getIntHex(ups, "usb_hid_ep_out"); }             // CHECKME
 
+	inline double getBatteryMax(const std::string & ups)          const { return getDouble(ups, "battery_max"); }
+	inline double getBatteryMin(const std::string & ups)          const { return getDouble(ups, "battery_min"); }
+	inline double getCSHackDelay(const std::string & ups)         const { return getDouble(ups, "cshdelay"); }
+	inline double getMaxBypassFreq(const std::string & ups)       const { return getDouble(ups, "max_bypass_freq"); }
+	inline double getMaxBypassVolt(const std::string & ups)       const { return getDouble(ups, "max_bypass_volt"); }
+	inline double getMinBypassFreq(const std::string & ups)       const { return getDouble(ups, "min_bypass_freq"); }
+	inline double getMinBypassVolt(const std::string & ups)       const { return getDouble(ups, "min_bypass_volt"); }
+
 	// Flag - if exists then "true"
 	inline bool getCancelShutdown(const std::string & ups) const { return getFlag(ups, "CS"); }
 	inline bool getDumbTerm(const std::string & ups)       const { return getFlag(ups, "dumbterm"); }
@@ -1804,7 +1910,6 @@ public:
 	inline bool getLoadOff(const std::string & ups)        const { return getBool(ups, "load.off"); }
 	inline bool getLoadOn(const std::string & ups)         const { return getBool(ups, "load.on"); }
 
-
 	inline void setAuthPassword(const std::string & ups, const std::string & auth_passwd)     { setStr(ups, "authPassword",        auth_passwd); }
 	inline void setAuthProtocol(const std::string & ups, const std::string & auth_proto)      { setStr(ups, "authProtocol",        auth_proto); }
 	inline void setAuthType(const std::string & ups, const std::string & authtype)            { setStr(ups, "authtype",            authtype); }
@@ -1815,6 +1920,7 @@ public:
 	inline void setDriver(const std::string & ups, const std::string & driver)                { setStr(ups, "driver",              driver); }
 	inline void setDescription(const std::string & ups, const std::string & desc)             { setStr(ups, "desc",                desc); }
 	inline void setFRUID(const std::string & ups, const std::string & fruid)                  { setStr(ups, "fruid",               fruid); }
+	inline void setGenericGPIO_Rules(const std::string & ups, const std::string & val)        { setStr(ups, "rules",                val); }
 	inline void setGenericUPS_BYPASS(const std::string & ups, const std::string & bypass)     { setStr(ups, "BYPASS",              bypass); }
 	inline void setGenericUPS_CP(const std::string & ups, const std::string & cp)             { setStr(ups, "CP",                  cp); }
 	inline void setGenericUPS_LB(const std::string & ups, const std::string & lb)             { setStr(ups, "LB",                  lb); }
@@ -1829,6 +1935,11 @@ public:
 	inline void setManufacturer(const std::string & ups, const std::string & manufacturer)    { setStr(ups, "manufacturer",        manufacturer); }
 	inline void setMethodOfFlowControl(const std::string & ups, const std::string & method)   { setStr(ups, "methodOfFlowControl", method); }
 	inline void setMIBs(const std::string & ups, const std::string & mibs)                    { setStr(ups, "mibs",                mibs); }
+	inline void setModbus_DeviceMfr(const std::string & ups, const std::string & val)         { setStr(ups, "device_mfr",           val); }
+	inline void setModbus_DeviceModel(const std::string & ups, const std::string & val)       { setStr(ups, "device_model",         val); }
+	inline void setModbus_Parity(const std::string & ups, const std::string & val)            { setStr(ups, "parity",               val); }
+	inline void setModbus_PortType(const std::string & ups, const std::string & val)          { setStr(ups, "porttype",             val); }
+	inline void setModbus_SerParity(const std::string & ups, const std::string & val)         { setStr(ups, "ser_parity",           val); }
 	inline void setModel(const std::string & ups, const std::string & model)                  { setStr(ups, "model",               model); }
 	inline void setModelName(const std::string & ups, const std::string & modelname)          { setStr(ups, "modelname",           modelname); }
 	inline void setNotification(const std::string & ups, const std::string & notification)    { setStr(ups, "notification",        notification); }
@@ -1851,15 +1962,76 @@ public:
 	inline void setSNMPversion(const std::string & ups, const std::string & snmp_version)     { setStr(ups, "snmp_version",        snmp_version); }
 	inline void setSubdriver(const std::string & ups, const std::string & subdriver)          { setStr(ups, "subdriver",           subdriver); }
 	inline void setSynchronous(const std::string & ups, const std::string & synchronous)      { setStr(ups, "synchronous",         synchronous); }
+	inline void setTtyMode(const std::string & ups, const std::string & val)                  { setStr(ups, "ttymode",              val); }
 	inline void setType(const std::string & ups, const std::string & type)                    { setStr(ups, "type",                type); }
 	inline void setUPStype(const std::string & ups, const std::string & upstype)              { setStr(ups, "upstype",             upstype); }
+	inline void setUpsId(const std::string & ups, const std::string & val)                    { setStr(ups, "upsid",                val); }
+	inline void setUsbBusPort(const std::string & ups, const std::string & val)               { setStr(ups, "busport",              val); }
+	inline void setUsbDevice(const std::string & ups, const std::string & val)                { setStr(ups, "device",               val); }
 	inline void setUSD(const std::string & ups, const std::string & usd)                      { setStr(ups, "usd",                 usd); }
 	inline void setUsername(const std::string & ups, const std::string & username)            { setStr(ups, "username",            username); }
 	inline void setUser(const std::string & ups, const std::string & user)                    { setStr(ups, "user",                user); }
 	inline void setValidationSequence(const std::string & ups, const std::string & valid_seq) { setStr(ups, "validationSequence",  valid_seq); }
 	inline void setVendor(const std::string & ups, const std::string & vendor)                { setStr(ups, "vendor",              vendor); }
 	inline void setVendorID(const std::string & ups, const std::string & vendorid)            { setStr(ups, "vendorid",            vendorid); }
+	inline void setWorkRangeType(const std::string & ups, const std::string & val)            { setStr(ups, "work_range_type",      val); }
 	inline void setWUGrace(const std::string & ups, const std::string & wugrace)              { setStr(ups, "wugrace",             wugrace); }
+
+	inline void setAsem_HB(const std::string & ups, long long int val)                        { setInt(ups, "hb",                   val); }
+	inline void setAsem_LB(const std::string & ups, long long int val)                        { setInt(ups, "lb",                   val); }
+	inline void setBatteryNumber(const std::string & ups, long long int val)                  { setInt(ups, "battery_number",       val); }
+	inline void setI2C_address(const std::string & ups, long long int val)                    { setInt(ups, "i2c_address",          val); }
+	inline void setInterruptSize(const std::string & ups, long long int val)                  { setInt(ups, "interruptsize",        val); }
+	inline void setMaxPollsWithoutData(const std::string & ups, long long int val)            { setInt(ups, "max_polls_without_data", val); }
+	inline void setModbus_ByteTimeoutSec(const std::string & ups, long long int val)          { setInt(ups, "mod_byte_to_s",        val); }
+	inline void setModbus_ByteTimeoutUsec(const std::string & ups, long long int val)         { setInt(ups, "mod_byte_to_us",       val); }
+	inline void setModbus_CHRG_addr(const std::string & ups, long long int val)               { setInt(ups, "CHRG_addr",            val); }
+	inline void setModbus_CHRG_noro(const std::string & ups, long long int val)               { setInt(ups, "CHRG_noro",            val); }
+	inline void setModbus_CHRG_regtype(const std::string & ups, long long int val)            { setInt(ups, "CHRG_regtype",         val); }
+	inline void setModbus_DISCHRG_addr(const std::string & ups, long long int val)            { setInt(ups, "DISCHRG_addr",         val); }
+	inline void setModbus_DISCHRG_noro(const std::string & ups, long long int val)            { setInt(ups, "DISCHRG_noro",         val); }
+	inline void setModbus_DISCHRG_regtype(const std::string & ups, long long int val)         { setInt(ups, "DISCHRG_regtype",      val); }
+	inline void setModbus_DataBits(const std::string & ups, long long int val)                { setInt(ups, "databits",             val); }
+	inline void setModbus_DeviceSlaveId(const std::string & ups, long long int val)           { setInt(ups, "dev_slave_id",         val); }
+	inline void setModbus_FSD_addr(const std::string & ups, long long int val)                { setInt(ups, "FSD_addr",             val); }
+	inline void setModbus_FSD_noro(const std::string & ups, long long int val)                { setInt(ups, "FSD_noro",             val); }
+	inline void setModbus_FSD_pulse_duration(const std::string & ups, long long int val)      { setInt(ups, "FSD_pulse_duration",   val); }
+	inline void setModbus_FSD_regtype(const std::string & ups, long long int val)             { setInt(ups, "FSD_regtype",          val); }
+	inline void setModbus_HB_addr(const std::string & ups, long long int val)                 { setInt(ups, "HB_addr",              val); }
+	inline void setModbus_HB_noro(const std::string & ups, long long int val)                 { setInt(ups, "HB_noro",              val); }
+	inline void setModbus_HB_regtype(const std::string & ups, long long int val)              { setInt(ups, "HB_regtype",           val); }
+	inline void setModbus_LB_addr(const std::string & ups, long long int val)                 { setInt(ups, "LB_addr",              val); }
+	inline void setModbus_LB_noro(const std::string & ups, long long int val)                 { setInt(ups, "LB_noro",              val); }
+	inline void setModbus_LB_regtype(const std::string & ups, long long int val)              { setInt(ups, "LB_regtype",           val); }
+	inline void setModbus_OB_addr(const std::string & ups, long long int val)                 { setInt(ups, "OB_addr",              val); }
+	inline void setModbus_OB_noro(const std::string & ups, long long int val)                 { setInt(ups, "OB_noro",              val); }
+	inline void setModbus_OB_regtype(const std::string & ups, long long int val)              { setInt(ups, "OB_regtype",           val); }
+	inline void setModbus_OL_addr(const std::string & ups, long long int val)                 { setInt(ups, "OL_addr",              val); }
+	inline void setModbus_OL_noro(const std::string & ups, long long int val)                 { setInt(ups, "OL_noro",              val); }
+	inline void setModbus_OL_regtype(const std::string & ups, long long int val)              { setInt(ups, "OL_regtype",           val); }
+	inline void setModbus_RB_addr(const std::string & ups, long long int val)                 { setInt(ups, "RB_addr",              val); }
+	inline void setModbus_RB_noro(const std::string & ups, long long int val)                 { setInt(ups, "RB_noro",              val); }
+	inline void setModbus_RB_regtype(const std::string & ups, long long int val)              { setInt(ups, "RB_regtype",           val); }
+	inline void setModbus_ResponseTimeoutMsec(const std::string & ups, long long int val)     { setInt(ups, "response_timeout_ms",  val); }
+	inline void setModbus_ResponseTimeoutSec(const std::string & ups, long long int val)      { setInt(ups, "mod_resp_to_s",        val); }
+	inline void setModbus_ResponseTimeoutUsec(const std::string & ups, long long int val)     { setInt(ups, "mod_resp_to_us",       val); }
+	inline void setModbus_RioSlaveId(const std::string & ups, long long int val)              { setInt(ups, "rio_slave_id",         val); }
+	inline void setModbus_SerBaudRate(const std::string & ups, long long int val)             { setInt(ups, "ser_baud_rate",        val); }
+	inline void setModbus_SerDataBit(const std::string & ups, long long int val)              { setInt(ups, "ser_data_bit",         val); }
+	inline void setModbus_SerStopBit(const std::string & ups, long long int val)              { setInt(ups, "ser_stop_bit",         val); }
+	inline void setModbus_SlaveId(const std::string & ups, long long int val)                 { setInt(ups, "slaveid",              val); }
+	inline void setModbus_StopBits(const std::string & ups, long long int val)                { setInt(ups, "stopbits",             val); }
+	inline void setOnlineDischargeLogThrottleHovercharge(const std::string & ups, long long int val){ setInt(ups, "onlinedischarge_log_throttle_hovercharge", val); }
+	inline void setOnlineDischargeLogThrottleSec(const std::string & ups, long long int val)  { setInt(ups, "onlinedischarge_log_throttle_sec", val); }
+	inline void setOutputPhaseAngle(const std::string & ups, long long int val)               { setInt(ups, "output_phase_angle",   val); }
+	inline void setPinsShutdownMode(const std::string & ups, long long int val)               { setInt(ups, "pins_shutdown_mode",   val); }
+	inline void setSemistaticFreq(const std::string & ups, long long int val)                 { setInt(ups, "semistaticfreq",       val); }
+	inline void setShutdownDuration(const std::string & ups, long long int val)               { setInt(ups, "shutdown_duration",    val); }
+	inline void setShutdownTimer(const std::string & ups, long long int val)                  { setInt(ups, "shutdown_timer",       val); }
+	inline void setSlaveAddress(const std::string & ups, long long int val)                   { setInt(ups, "slave_address",        val); }
+	inline void setSnmpRetries(const std::string & ups, long long int val)                    { setInt(ups, "snmp_retries",         val); }
+	inline void setSnmpTimeout(const std::string & ups, long long int val)                    { setInt(ups, "snmp_timeout",         val); }
+	inline void setWaitBeforeReconnect(const std::string & ups, long long int val)            { setInt(ups, "waitbeforereconnect",  val); }
 
 	inline void setDebugMin(const std::string & ups, long long int val)            { setInt(ups, "debug_min",          val); }
 	inline void setSDOrder(const std::string & ups, long long int ord)             { setInt(ups, "sdorder",            ord); }
@@ -1904,6 +2076,38 @@ public:
 	inline void setUPSdelayStart(const std::string & ups, long long int delay)     { setInt(ups, "ups.delay.start",    delay); }        // CHECKME
 	inline void setVoltage(const std::string & ups, long long int voltage)         { setInt(ups, "voltage",            voltage); }      // CHECKME
 
+	// Items below are "unused" - mostly set in
+	// drivers/nutdrv_qx_masterguard.c
+	inline void setFault1(const std::string & ups, const std::string & val)                   { setStr(ups, "fault_1",              val); }
+	inline void setFault2(const std::string & ups, const std::string & val)                   { setStr(ups, "fault_2",              val); }
+	inline void setFault3(const std::string & ups, const std::string & val)                   { setStr(ups, "fault_3",              val); }
+	inline void setFault4(const std::string & ups, const std::string & val)                   { setStr(ups, "fault_4",              val); }
+	inline void setFault5(const std::string & ups, const std::string & val)                   { setStr(ups, "fault_5",              val); }
+	inline void setInputFaultVoltage(const std::string & ups, const std::string & val)        { setStr(ups, "input_fault_voltage",  val); }
+	inline void setNominalCellVoltage(const std::string & ups, const std::string & val)       { setStr(ups, "nominal_cell_voltage", val); }
+	inline void setNumberOfBatteryCells(const std::string & ups, const std::string & val)     { setStr(ups, "number_of_battery_cells", val); }
+	inline void setOutputVoltages(const std::string & ups, const std::string & val)           { setStr(ups, "output_voltages",      val); }
+	inline void setRechargeTime(const std::string & ups, const std::string & val)             { setStr(ups, "recharge_time",        val); }
+	inline void setRuntimeFull(const std::string & ups, const std::string & val)              { setStr(ups, "runtime_full",         val); }
+	inline void setRuntimeHalf(const std::string & ups, const std::string & val)              { setStr(ups, "runtime_half",         val); }
+	inline void setSeries(const std::string & ups, const std::string & val)                   { setStr(ups, "series",               val); }
+
+	// Items below are essentially booleans (expected values
+	// are "enabled/disabled") -- refactoring planned per
+	// https://github.com/networkupstools/nut/issues/2421
+	inline void setAdvancedEcoMode(const std::string & ups, const std::string & val)          { setStr(ups, "advanced_eco_mode",    val); }
+	inline void setAlarmControl(const std::string & ups, const std::string & val)             { setStr(ups, "alarm_control",        val); }
+	inline void setBatteryAlarm(const std::string & ups, const std::string & val)             { setStr(ups, "battery_alarm",        val); }
+	inline void setBatteryOpenStatusCheck(const std::string & ups, const std::string & val)   { setStr(ups, "battery_open_status_check", val); }
+	inline void setBypassAlarm(const std::string & ups, const std::string & val)              { setStr(ups, "bypass_alarm",         val); }
+	inline void setBypassForbidding(const std::string & ups, const std::string & val)         { setStr(ups, "bypass_forbidding",    val); }
+	inline void setBypassWhenOff(const std::string & ups, const std::string & val)            { setStr(ups, "bypass_when_off",      val); }
+	inline void setConstantPhaseAngle(const std::string & ups, const std::string & val)       { setStr(ups, "constant_phase_angle", val); }
+	inline void setConverterMode(const std::string & ups, const std::string & val)            { setStr(ups, "converter_mode",       val); }
+	inline void setEcoMode(const std::string & ups, const std::string & val)                  { setStr(ups, "eco_mode",             val); }
+	inline void setLimitedRuntimeOnBattery(const std::string & ups, const std::string & val)  { setStr(ups, "limited_runtime_on_battery", val); }
+	inline void setSiteFaultDetection(const std::string & ups, const std::string & val)       { setStr(ups, "site_fault_detection", val); }
+
 	/** belkinunv: both a flag (wait for AC power) and value (also wait for charge level) */
 	inline void setWait(const std::string & ups, long long int wait)               { setInt(ups, "wait",               wait); }         // CHECKME
 
@@ -1916,6 +2120,14 @@ public:
 	inline void setUsbHidRepIndex(const std::string & ups, long long int val)               { setIntHex(ups, "usb_hid_rep_index",              val); }         // CHECKME
 	inline void setUsbHidEndpointIn(const std::string & ups, long long int val)             { setIntHex(ups, "usb_hid_ep_in",                  val); }         // CHECKME
 	inline void setUsbHidEndpointOut(const std::string & ups, long long int val)            { setIntHex(ups, "usb_hid_ep_out",                 val); }         // CHECKME
+
+	inline void setBatteryMax(const std::string & ups, double val)                          { setDouble(ups, "battery_max",          val); }
+	inline void setBatteryMin(const std::string & ups, double val)                          { setDouble(ups, "battery_min",          val); }
+	inline void setCSHackDelay(const std::string & ups, double val)                         { setDouble(ups, "cshdelay",             val); }
+	inline void setMaxBypassFreq(const std::string & ups, double val)                       { setDouble(ups, "max_bypass_freq",      val); }
+	inline void setMaxBypassVolt(const std::string & ups, double val)                       { setDouble(ups, "max_bypass_volt",      val); }
+	inline void setMinBypassFreq(const std::string & ups, double val)                       { setDouble(ups, "min_bypass_freq",      val); }
+	inline void setMinBypassVolt(const std::string & ups, double val)                       { setDouble(ups, "min_bypass_volt",      val); }
 
 	// Flag - if exists then "true"; remove() to "unset" => "false"
 	inline void setCancelShutdown(const std::string & ups, bool set = true) { setFlag(ups, "CS",             set); }

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -1259,7 +1259,16 @@ public:
 	UpsmonConfiguration();
 	void parseFromString(const std::string& str);
 
+	Settable<int>          debugMin, pollFailLogThrottleMax;
+	Settable<int>          offDuration, oblbDuration;
 	Settable<std::string>  runAsUser, shutdownCmd, notifyCmd, powerDownFlag;
+	/* yes|no (boolean) or a delay */
+	Settable<nut::BoolInt> shutdownExit;
+	/* practically boolean, but in 0|1 written form (bool01 fiddling) */
+	Settable<nut::BoolInt> certVerify, forceSsl;
+	Settable<std::string>  certPath;
+	CertIdent              certIdent;
+	std::list<CertHost>    certHosts;
 	Settable<unsigned int> minSupplies, poolFreq, poolFreqAlert, hostSync;
 	Settable<unsigned int> deadTime, rbWarnTime, noCommWarnTime, finalDelay;
 

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -1127,6 +1127,58 @@ protected:
 	}
 
 	/**
+	 *  \brief  Configuration number getter (hex value even if without leading "0x")
+	 *
+	 *  \param  section  Section name
+	 *  \param  entry    Entry name
+	 *  \param  val      Default value
+	 *
+	 *  \return Configuration parameter as number (or the default if not defined)
+	 */
+	long long int getIntHex(
+		const std::string & section,
+		const std::string & entry,
+		long long int       val = 0) const;
+
+	/**
+	 *  \brief  Global scope configuration number getter (hex value even if without leading "0x")
+	 *
+	 *  \param  entry    Entry name
+	 *  \param  val      Default value
+	 *
+	 *  \return Configuration parameter as number (or the default if not defined)
+	 */
+	inline long long int getIntHex(const std::string & entry, long long int val = 0) const
+	{
+		return getIntHex("", entry, val);
+	}
+
+	/**
+	 *  \brief  Configuration number setter (hex value even if without leading "0x")
+	 *
+	 *  \param  section  Section name
+	 *  \param  entry    Entry name
+	 *  \param  val      Default value
+	 */
+	void setIntHex(
+		const std::string & section,
+		const std::string & entry,
+		long long int       val);
+
+	/**
+	 *  \brief  Global scope configuration number setter (hex value even if without leading "0x")
+	 *
+	 *  \param  entry    Entry name
+	 *  \param  val      Default value
+	 */
+	inline void setIntHex(
+		const std::string & entry,
+		long long int       val)
+	{
+		setIntHex("", entry, val);
+	}
+
+	/**
 	 *  \brief  Cast numeric type with range check
 	 *
 	 *  Throws an exception on cast error.

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -417,7 +417,10 @@ public:
 		if (i.set()) return i;
 		if (bool01.set() && bool01 == true) {
 			if (b.set()) {
-				if (b) return 1;
+				/** Cause use of operator to avoid warnings like
+				 * "may be used uninitialized in this function"
+				 */
+				if (b == true) return 1;
 				return 0;
 			}
 		} else {
@@ -447,7 +450,7 @@ public:
 
 	inline std::string toString()const {
 		if (b.set()) {
-			if (b) return "yes";
+			if (b == true) return "yes";
 			return "no";
 		}
 

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -1763,117 +1763,116 @@ public:
 	inline std::string getLimitedRuntimeOnBattery(const std::string & ups)const { return getStr(ups, "limited_runtime_on_battery"); }
 	inline std::string getSiteFaultDetection(const std::string & ups)  const { return getStr(ups, "site_fault_detection"); }
 
-	inline long long int getAsem_HB(const std::string & ups)             const { return getInt(ups, "hb"); }
-	inline long long int getAsem_LB(const std::string & ups)             const { return getInt(ups, "lb"); }
-	inline long long int getBatteryNumber(const std::string & ups)       const { return getInt(ups, "battery_number"); }
-	inline long long int getI2C_address(const std::string & ups)         const { return getInt(ups, "i2c_address"); }
-	inline long long int getInterruptSize(const std::string & ups)       const { return getInt(ups, "interruptsize"); }
-	inline long long int getMaxPollsWithoutData(const std::string & ups) const { return getInt(ups, "max_polls_without_data"); }
-	inline long long int getModbus_ByteTimeoutSec(const std::string & ups)const { return getInt(ups, "mod_byte_to_s"); }
-	inline long long int getModbus_ByteTimeoutUsec(const std::string & ups)const { return getInt(ups, "mod_byte_to_us"); }
-	inline long long int getModbus_CHRG_addr(const std::string & ups)    const { return getInt(ups, "CHRG_addr"); }
-	inline long long int getModbus_CHRG_noro(const std::string & ups)    const { return getInt(ups, "CHRG_noro"); }
-	inline long long int getModbus_CHRG_regtype(const std::string & ups) const { return getInt(ups, "CHRG_regtype"); }
-	inline long long int getModbus_DISCHRG_addr(const std::string & ups) const { return getInt(ups, "DISCHRG_addr"); }
-	inline long long int getModbus_DISCHRG_noro(const std::string & ups) const { return getInt(ups, "DISCHRG_noro"); }
-	inline long long int getModbus_DISCHRG_regtype(const std::string & ups)const { return getInt(ups, "DISCHRG_regtype"); }
-	inline long long int getModbus_DataBits(const std::string & ups)     const { return getInt(ups, "databits"); }
-	inline long long int getModbus_DeviceSlaveId(const std::string & ups)const { return getInt(ups, "dev_slave_id"); }
-	inline long long int getModbus_FSD_addr(const std::string & ups)     const { return getInt(ups, "FSD_addr"); }
-	inline long long int getModbus_FSD_noro(const std::string & ups)     const { return getInt(ups, "FSD_noro"); }
-	inline long long int getModbus_FSD_pulse_duration(const std::string & ups)const { return getInt(ups, "FSD_pulse_duration"); }
-	inline long long int getModbus_FSD_regtype(const std::string & ups)  const { return getInt(ups, "FSD_regtype"); }
-	inline long long int getModbus_HB_addr(const std::string & ups)      const { return getInt(ups, "HB_addr"); }
-	inline long long int getModbus_HB_noro(const std::string & ups)      const { return getInt(ups, "HB_noro"); }
-	inline long long int getModbus_HB_regtype(const std::string & ups)   const { return getInt(ups, "HB_regtype"); }
-	inline long long int getModbus_LB_addr(const std::string & ups)      const { return getInt(ups, "LB_addr"); }
-	inline long long int getModbus_LB_noro(const std::string & ups)      const { return getInt(ups, "LB_noro"); }
-	inline long long int getModbus_LB_regtype(const std::string & ups)   const { return getInt(ups, "LB_regtype"); }
-	inline long long int getModbus_OB_addr(const std::string & ups)      const { return getInt(ups, "OB_addr"); }
-	inline long long int getModbus_OB_noro(const std::string & ups)      const { return getInt(ups, "OB_noro"); }
-	inline long long int getModbus_OB_regtype(const std::string & ups)   const { return getInt(ups, "OB_regtype"); }
-	inline long long int getModbus_OL_addr(const std::string & ups)      const { return getInt(ups, "OL_addr"); }
-	inline long long int getModbus_OL_noro(const std::string & ups)      const { return getInt(ups, "OL_noro"); }
-	inline long long int getModbus_OL_regtype(const std::string & ups)   const { return getInt(ups, "OL_regtype"); }
-	inline long long int getModbus_RB_addr(const std::string & ups)      const { return getInt(ups, "RB_addr"); }
-	inline long long int getModbus_RB_noro(const std::string & ups)      const { return getInt(ups, "RB_noro"); }
-	inline long long int getModbus_RB_regtype(const std::string & ups)   const { return getInt(ups, "RB_regtype"); }
+	inline long long int getAdvOrder(const std::string & ups)                  const { return getInt(ups, "advorder"); }            // CHECKME
+	inline long long int getAsem_HB(const std::string & ups)                   const { return getInt(ups, "hb"); }
+	inline long long int getAsem_LB(const std::string & ups)                   const { return getInt(ups, "lb"); }
+	inline long long int getBatteryNumber(const std::string & ups)             const { return getInt(ups, "battery_number"); }
+	inline long long int getBatteryPercentage(const std::string & ups)         const { return getInt(ups, "batteryPercentage"); }   // CHECKME
+	inline long long int getBattVoltMult(const std::string & ups)              const { return getInt(ups, "battvoltmult"); }        // CHECKME
+	inline long long int getBaudRate(const std::string & ups)                  const { return getInt(ups, "baud_rate"); }           // CHECKME
+	inline long long int getBaudrate(const std::string & ups)                  const { return getInt(ups, "baudrate"); }            // CHECKME
+	inline long long int getCablePower(const std::string & ups)                const { return getInt(ups, "cablepower"); }          // CHECKME
+	inline long long int getChargeTime(const std::string & ups)                const { return getInt(ups, "chargetime"); }          // CHECKME
+	inline long long int getDaysOff(const std::string & ups)                   const { return getInt(ups, "daysoff"); }             // CHECKME
+	inline long long int getDaySweek(const std::string & ups)                  const { return getInt(ups, "daysweek"); }            // CHECKME
+	inline long long int getDebugMin(const std::string & ups)                  const { return getInt(ups, "debug_min"); }
+	inline long long int getFrequency(const std::string & ups)                 const { return getInt(ups, "frequency"); }           // CHECKME
+	inline long long int getHourOff(const std::string & ups)                   const { return getInt(ups, "houroff"); }             // CHECKME
+	inline long long int getHourOn(const std::string & ups)                    const { return getInt(ups, "houron"); }              // CHECKME
+	inline long long int getI2C_address(const std::string & ups)               const { return getInt(ups, "i2c_address"); }
+	inline long long int getIdleLoad(const std::string & ups)                  const { return getInt(ups, "idleload"); }            // CHECKME
+	inline long long int getInputTimeout(const std::string & ups)              const { return getInt(ups, "input_timeout"); }       // CHECKME
+	inline long long int getInterruptSize(const std::string & ups)             const { return getInt(ups, "interruptsize"); }
+	inline long long int getLineVoltage(const std::string & ups)               const { return getInt(ups, "linevoltage"); }         // CHECKME
+	inline long long int getLoadpercentage(const std::string & ups)            const { return getInt(ups, "loadPercentage"); }      // CHECKME
+	inline long long int getMaxLoad(const std::string & ups)                   const { return getInt(ups, "max_load"); }            // CHECKME
+	inline long long int getMaxPollsWithoutData(const std::string & ups)       const { return getInt(ups, "max_polls_without_data"); }
+	inline long long int getMaxStartDelay(const std::string & ups)             const { return getInt(ups, "maxstartdelay"); }
+	inline long long int getMFR(const std::string & ups)                       const { return getInt(ups, "mfr"); }                 // CHECKME
+	inline long long int getMinCharge(const std::string & ups)                 const { return getInt(ups, "mincharge"); }           // CHECKME
+	inline long long int getMinRuntime(const std::string & ups)                const { return getInt(ups, "minruntime"); }          // CHECKME
+	inline long long int getModbus_ByteTimeoutSec(const std::string & ups)     const { return getInt(ups, "mod_byte_to_s"); }
+	inline long long int getModbus_ByteTimeoutUsec(const std::string & ups)    const { return getInt(ups, "mod_byte_to_us"); }
+	inline long long int getModbus_CHRG_addr(const std::string & ups)          const { return getInt(ups, "CHRG_addr"); }
+	inline long long int getModbus_CHRG_noro(const std::string & ups)          const { return getInt(ups, "CHRG_noro"); }
+	inline long long int getModbus_CHRG_regtype(const std::string & ups)       const { return getInt(ups, "CHRG_regtype"); }
+	inline long long int getModbus_DISCHRG_addr(const std::string & ups)       const { return getInt(ups, "DISCHRG_addr"); }
+	inline long long int getModbus_DISCHRG_noro(const std::string & ups)       const { return getInt(ups, "DISCHRG_noro"); }
+	inline long long int getModbus_DISCHRG_regtype(const std::string & ups)    const { return getInt(ups, "DISCHRG_regtype"); }
+	inline long long int getModbus_DataBits(const std::string & ups)           const { return getInt(ups, "databits"); }
+	inline long long int getModbus_DeviceSlaveId(const std::string & ups)      const { return getInt(ups, "dev_slave_id"); }
+	inline long long int getModbus_FSD_addr(const std::string & ups)           const { return getInt(ups, "FSD_addr"); }
+	inline long long int getModbus_FSD_noro(const std::string & ups)           const { return getInt(ups, "FSD_noro"); }
+	inline long long int getModbus_FSD_pulse_duration(const std::string & ups) const { return getInt(ups, "FSD_pulse_duration"); }
+	inline long long int getModbus_FSD_regtype(const std::string & ups)        const { return getInt(ups, "FSD_regtype"); }
+	inline long long int getModbus_HB_addr(const std::string & ups)            const { return getInt(ups, "HB_addr"); }
+	inline long long int getModbus_HB_noro(const std::string & ups)            const { return getInt(ups, "HB_noro"); }
+	inline long long int getModbus_HB_regtype(const std::string & ups)         const { return getInt(ups, "HB_regtype"); }
+	inline long long int getModbus_LB_addr(const std::string & ups)            const { return getInt(ups, "LB_addr"); }
+	inline long long int getModbus_LB_noro(const std::string & ups)            const { return getInt(ups, "LB_noro"); }
+	inline long long int getModbus_LB_regtype(const std::string & ups)         const { return getInt(ups, "LB_regtype"); }
+	inline long long int getModbus_OB_addr(const std::string & ups)            const { return getInt(ups, "OB_addr"); }
+	inline long long int getModbus_OB_noro(const std::string & ups)            const { return getInt(ups, "OB_noro"); }
+	inline long long int getModbus_OB_regtype(const std::string & ups)         const { return getInt(ups, "OB_regtype"); }
+	inline long long int getModbus_OL_addr(const std::string & ups)            const { return getInt(ups, "OL_addr"); }
+	inline long long int getModbus_OL_noro(const std::string & ups)            const { return getInt(ups, "OL_noro"); }
+	inline long long int getModbus_OL_regtype(const std::string & ups)         const { return getInt(ups, "OL_regtype"); }
+	inline long long int getModbus_RB_addr(const std::string & ups)            const { return getInt(ups, "RB_addr"); }
+	inline long long int getModbus_RB_noro(const std::string & ups)            const { return getInt(ups, "RB_noro"); }
+	inline long long int getModbus_RB_regtype(const std::string & ups)         const { return getInt(ups, "RB_regtype"); }
 	inline long long int getModbus_ResponseTimeoutMsec(const std::string & ups)const { return getInt(ups, "response_timeout_ms"); }
-	inline long long int getModbus_ResponseTimeoutSec(const std::string & ups)const { return getInt(ups, "mod_resp_to_s"); }
+	inline long long int getModbus_ResponseTimeoutSec(const std::string & ups) const { return getInt(ups, "mod_resp_to_s"); }
 	inline long long int getModbus_ResponseTimeoutUsec(const std::string & ups)const { return getInt(ups, "mod_resp_to_us"); }
-	inline long long int getModbus_RioSlaveId(const std::string & ups)   const { return getInt(ups, "rio_slave_id"); }
-	inline long long int getModbus_SerBaudRate(const std::string & ups)  const { return getInt(ups, "ser_baud_rate"); }
-	inline long long int getModbus_SerDataBit(const std::string & ups)   const { return getInt(ups, "ser_data_bit"); }
-	inline long long int getModbus_SerStopBit(const std::string & ups)   const { return getInt(ups, "ser_stop_bit"); }
-	inline long long int getModbus_SlaveId(const std::string & ups)      const { return getInt(ups, "slaveid"); }
-	inline long long int getModbus_StopBits(const std::string & ups)     const { return getInt(ups, "stopbits"); }
+	inline long long int getModbus_RioSlaveId(const std::string & ups)         const { return getInt(ups, "rio_slave_id"); }
+	inline long long int getModbus_SerBaudRate(const std::string & ups)        const { return getInt(ups, "ser_baud_rate"); }
+	inline long long int getModbus_SerDataBit(const std::string & ups)         const { return getInt(ups, "ser_data_bit"); }
+	inline long long int getModbus_SerStopBit(const std::string & ups)         const { return getInt(ups, "ser_stop_bit"); }
+	inline long long int getModbus_SlaveId(const std::string & ups)            const { return getInt(ups, "slaveid"); }
+	inline long long int getModbus_StopBits(const std::string & ups)           const { return getInt(ups, "stopbits"); }
+	inline long long int getNomBattVolt(const std::string & ups)               const { return getInt(ups, "nombattvolt"); }         // CHECKME
+	inline long long int getNumOfBytesFromUPS(const std::string & ups)         const { return getInt(ups, "numOfBytesFromUPS"); }   // CHECKME
+	inline long long int getOffDelay(const std::string & ups)                  const { return getInt(ups, "OffDelay"); }            // CHECKME
+	inline long long int getOffdelay(const std::string & ups)                  const { return getInt(ups, "offdelay"); }            // CHECKME
+	inline long long int getOnDelay(const std::string & ups)                   const { return getInt(ups, "OnDelay"); }             // CHECKME
+	inline long long int getOndelay(const std::string & ups)                   const { return getInt(ups, "ondelay"); }             // CHECKME
 	inline long long int getOnlineDischargeLogThrottleHovercharge(const std::string & ups)const { return getInt(ups, "onlinedischarge_log_throttle_hovercharge"); }
 	inline long long int getOnlineDischargeLogThrottleSec(const std::string & ups)const { return getInt(ups, "onlinedischarge_log_throttle_sec"); }
-	inline long long int getOutputPhaseAngle(const std::string & ups)    const { return getInt(ups, "output_phase_angle"); }
-	inline long long int getPinsShutdownMode(const std::string & ups)    const { return getInt(ups, "pins_shutdown_mode"); }
-	inline long long int getSemistaticFreq(const std::string & ups)      const { return getInt(ups, "semistaticfreq"); }
-	inline long long int getShutdownDuration(const std::string & ups)    const { return getInt(ups, "shutdown_duration"); }
-	inline long long int getShutdownTimer(const std::string & ups)       const { return getInt(ups, "shutdown_timer"); }
-	inline long long int getSlaveAddress(const std::string & ups)        const { return getInt(ups, "slave_address"); }
-	inline long long int getSnmpRetries(const std::string & ups)         const { return getInt(ups, "snmp_retries"); }
-	inline long long int getSnmpTimeout(const std::string & ups)         const { return getInt(ups, "snmp_timeout"); }
-	inline long long int getWaitBeforeReconnect(const std::string & ups) const { return getInt(ups, "waitbeforereconnect"); }
-
-	inline long long int getDebugMin(const std::string & ups)          const { return getInt(ups, "debug_min"); }
-	inline long long int getSDOrder(const std::string & ups)           const { return getInt(ups, "sdorder"); }             // TODO: Is that a number?
-	inline long long int getMaxStartDelay(const std::string & ups)     const { return getInt(ups, "maxstartdelay"); }
-	inline long long int getAdvOrder(const std::string & ups)          const { return getInt(ups, "advorder"); }            // CHECKME
-	inline long long int getBatteryPercentage(const std::string & ups) const { return getInt(ups, "batteryPercentage"); }   // CHECKME
-	inline long long int getOffDelay(const std::string & ups)          const { return getInt(ups, "OffDelay"); }            // CHECKME
-	inline long long int getOnDelay(const std::string & ups)           const { return getInt(ups, "OnDelay"); }             // CHECKME
-	inline long long int getBattVoltMult(const std::string & ups)      const { return getInt(ups, "battvoltmult"); }        // CHECKME
-	inline long long int getBaudRate(const std::string & ups)          const { return getInt(ups, "baud_rate"); }           // CHECKME
-	inline long long int getBaudrate(const std::string & ups)          const { return getInt(ups, "baudrate"); }            // CHECKME
-	inline long long int getCablePower(const std::string & ups)        const { return getInt(ups, "cablepower"); }          // CHECKME
-	inline long long int getChargeTime(const std::string & ups)        const { return getInt(ups, "chargetime"); }          // CHECKME
-	inline long long int getDaysOff(const std::string & ups)           const { return getInt(ups, "daysoff"); }             // CHECKME
-	inline long long int getDaySweek(const std::string & ups)          const { return getInt(ups, "daysweek"); }            // CHECKME
-	inline long long int getFrequency(const std::string & ups)         const { return getInt(ups, "frequency"); }           // CHECKME
-	inline long long int getHourOff(const std::string & ups)           const { return getInt(ups, "houroff"); }             // CHECKME
-	inline long long int getHourOn(const std::string & ups)            const { return getInt(ups, "houron"); }              // CHECKME
-	inline long long int getIdleLoad(const std::string & ups)          const { return getInt(ups, "idleload"); }            // CHECKME
-	inline long long int getInputTimeout(const std::string & ups)      const { return getInt(ups, "input_timeout"); }       // CHECKME
-	inline long long int getLineVoltage(const std::string & ups)       const { return getInt(ups, "linevoltage"); }         // CHECKME
-	inline long long int getLoadpercentage(const std::string & ups)    const { return getInt(ups, "loadPercentage"); }      // CHECKME
-	inline long long int getMaxLoad(const std::string & ups)           const { return getInt(ups, "max_load"); }            // CHECKME
-	inline long long int getMFR(const std::string & ups)               const { return getInt(ups, "mfr"); }                 // CHECKME
-	inline long long int getMinCharge(const std::string & ups)         const { return getInt(ups, "mincharge"); }           // CHECKME
-	inline long long int getMinRuntime(const std::string & ups)        const { return getInt(ups, "minruntime"); }          // CHECKME
-	inline long long int getNomBattVolt(const std::string & ups)       const { return getInt(ups, "nombattvolt"); }         // CHECKME
-	inline long long int getNumOfBytesFromUPS(const std::string & ups) const { return getInt(ups, "numOfBytesFromUPS"); }   // CHECKME
-	inline long long int getOffdelay(const std::string & ups)          const { return getInt(ups, "offdelay"); }            // CHECKME
-	inline long long int getOndelay(const std::string & ups)           const { return getInt(ups, "ondelay"); }             // CHECKME
-	inline long long int getOutputPace(const std::string & ups)        const { return getInt(ups, "output_pace"); }         // CHECKME
-	inline long long int getPollFreq(const std::string & ups)          const { return getInt(ups, "pollfreq"); }            // CHECKME
-	inline long long int getPowerUp(const std::string & ups)           const { return getInt(ups, "powerup"); }             // CHECKME
-	inline long long int getPrgShut(const std::string & ups)           const { return getInt(ups, "prgshut"); }             // CHECKME
-	inline long long int getRebootDelay(const std::string & ups)       const { return getInt(ups, "rebootdelay"); }         // CHECKME
-	inline long long int getSDtime(const std::string & ups)            const { return getInt(ups, "sdtime"); }              // CHECKME
-	inline long long int getShutdownDelay(const std::string & ups)     const { return getInt(ups, "shutdown_delay"); }      // CHECKME
-	inline long long int getStartDelay(const std::string & ups)        const { return getInt(ups, "startdelay"); }          // CHECKME
-	inline long long int getTestTime(const std::string & ups)          const { return getInt(ups, "testtime"); }            // CHECKME
-	inline long long int getTimeout(const std::string & ups)           const { return getInt(ups, "timeout"); }             // CHECKME
-	inline long long int getUPSdelayShutdown(const std::string & ups)  const { return getInt(ups, "ups.delay.shutdown"); }  // CHECKME
-	inline long long int getUPSdelayStart(const std::string & ups)     const { return getInt(ups, "ups.delay.start"); }     // CHECKME
-	inline long long int getVoltage(const std::string & ups)           const { return getInt(ups, "voltage"); }             // CHECKME
+	inline long long int getOutputPace(const std::string & ups)                const { return getInt(ups, "output_pace"); }         // CHECKME
+	inline long long int getOutputPhaseAngle(const std::string & ups)          const { return getInt(ups, "output_phase_angle"); }
+	inline long long int getPinsShutdownMode(const std::string & ups)          const { return getInt(ups, "pins_shutdown_mode"); }
+	inline long long int getPollFreq(const std::string & ups)                  const { return getInt(ups, "pollfreq"); }            // CHECKME
+	inline long long int getPowerUp(const std::string & ups)                   const { return getInt(ups, "powerup"); }             // CHECKME
+	inline long long int getPrgShut(const std::string & ups)                   const { return getInt(ups, "prgshut"); }             // CHECKME
+	inline long long int getRebootDelay(const std::string & ups)               const { return getInt(ups, "rebootdelay"); }         // CHECKME
+	inline long long int getSDOrder(const std::string & ups)                   const { return getInt(ups, "sdorder"); }             // TODO: Is that a number?
+	inline long long int getSDtime(const std::string & ups)                    const { return getInt(ups, "sdtime"); }              // CHECKME
+	inline long long int getSemistaticFreq(const std::string & ups)            const { return getInt(ups, "semistaticfreq"); }
+	inline long long int getShutdownDelay(const std::string & ups)             const { return getInt(ups, "shutdown_delay"); }      // CHECKME
+	inline long long int getShutdownDuration(const std::string & ups)          const { return getInt(ups, "shutdown_duration"); }
+	inline long long int getShutdownTimer(const std::string & ups)             const { return getInt(ups, "shutdown_timer"); }
+	inline long long int getSlaveAddress(const std::string & ups)              const { return getInt(ups, "slave_address"); }
+	inline long long int getSnmpRetries(const std::string & ups)               const { return getInt(ups, "snmp_retries"); }
+	inline long long int getSnmpTimeout(const std::string & ups)               const { return getInt(ups, "snmp_timeout"); }
+	inline long long int getStartDelay(const std::string & ups)                const { return getInt(ups, "startdelay"); }          // CHECKME
+	inline long long int getTestTime(const std::string & ups)                  const { return getInt(ups, "testtime"); }            // CHECKME
+	inline long long int getTimeout(const std::string & ups)                   const { return getInt(ups, "timeout"); }             // CHECKME
+	inline long long int getUPSdelayShutdown(const std::string & ups)          const { return getInt(ups, "ups.delay.shutdown"); }  // CHECKME
+	inline long long int getUPSdelayStart(const std::string & ups)             const { return getInt(ups, "ups.delay.start"); }     // CHECKME
+	inline long long int getVoltage(const std::string & ups)                   const { return getInt(ups, "voltage"); }             // CHECKME
+	inline long long int getWaitBeforeReconnect(const std::string & ups)       const { return getInt(ups, "waitbeforereconnect"); }
 
 	/** belkinunv: both a flag (wait for AC power) and value (also wait for charge level) */
-	inline long long int getWait(const std::string & ups)              const { return getInt(ups, "wait"); }
+	inline long long int getWait(const std::string & ups)                      const { return getInt(ups, "wait"); }
 
 	/** May be a flag or a number; 0 is among valid values (default -1 for unset) */
-	inline long long int getUsbSetAltInterface(const std::string & ups)          const { return getInt(ups, "usb_set_altinterface", -1); }      // CHECKME
+	inline long long int getUsbSetAltInterface(const std::string & ups)        const { return getInt(ups, "usb_set_altinterface", -1); }      // CHECKME
 
 	// NUT specifies these as "hexnum" values (optionally with prefixed 0x but hex anyway)
-	inline long long int getUsbConfigIndex(const std::string & ups)              const { return getIntHex(ups, "usb_config_index"); }           // CHECKME
-	inline long long int getUsbHidDescIndex(const std::string & ups)             const { return getIntHex(ups, "usb_hid_desc_index"); }         // CHECKME
-	inline long long int getUsbHidRepIndex(const std::string & ups)              const { return getIntHex(ups, "usb_hid_rep_index"); }          // CHECKME
-	inline long long int getUsbHidEndpointIn(const std::string & ups)            const { return getIntHex(ups, "usb_hid_ep_in"); }              // CHECKME
-	inline long long int getUsbHidEndpointOut(const std::string & ups)           const { return getIntHex(ups, "usb_hid_ep_out"); }             // CHECKME
+	inline long long int getUsbConfigIndex(const std::string & ups)            const { return getIntHex(ups, "usb_config_index"); }           // CHECKME
+	inline long long int getUsbHidDescIndex(const std::string & ups)           const { return getIntHex(ups, "usb_hid_desc_index"); }         // CHECKME
+	inline long long int getUsbHidRepIndex(const std::string & ups)            const { return getIntHex(ups, "usb_hid_rep_index"); }          // CHECKME
+	inline long long int getUsbHidEndpointIn(const std::string & ups)          const { return getIntHex(ups, "usb_hid_ep_in"); }              // CHECKME
+	inline long long int getUsbHidEndpointOut(const std::string & ups)         const { return getIntHex(ups, "usb_hid_ep_out"); }             // CHECKME
 
 	inline double getBatteryMax(const std::string & ups)          const { return getDouble(ups, "battery_max"); }
 	inline double getBatteryMin(const std::string & ups)          const { return getDouble(ups, "battery_min"); }
@@ -1920,7 +1919,7 @@ public:
 	inline void setDriver(const std::string & ups, const std::string & driver)                { setStr(ups, "driver",              driver); }
 	inline void setDescription(const std::string & ups, const std::string & desc)             { setStr(ups, "desc",                desc); }
 	inline void setFRUID(const std::string & ups, const std::string & fruid)                  { setStr(ups, "fruid",               fruid); }
-	inline void setGenericGPIO_Rules(const std::string & ups, const std::string & val)        { setStr(ups, "rules",                val); }
+	inline void setGenericGPIO_Rules(const std::string & ups, const std::string & val)        { setStr(ups, "rules",               val); }
 	inline void setGenericUPS_BYPASS(const std::string & ups, const std::string & bypass)     { setStr(ups, "BYPASS",              bypass); }
 	inline void setGenericUPS_CP(const std::string & ups, const std::string & cp)             { setStr(ups, "CP",                  cp); }
 	inline void setGenericUPS_LB(const std::string & ups, const std::string & lb)             { setStr(ups, "LB",                  lb); }
@@ -1935,11 +1934,11 @@ public:
 	inline void setManufacturer(const std::string & ups, const std::string & manufacturer)    { setStr(ups, "manufacturer",        manufacturer); }
 	inline void setMethodOfFlowControl(const std::string & ups, const std::string & method)   { setStr(ups, "methodOfFlowControl", method); }
 	inline void setMIBs(const std::string & ups, const std::string & mibs)                    { setStr(ups, "mibs",                mibs); }
-	inline void setModbus_DeviceMfr(const std::string & ups, const std::string & val)         { setStr(ups, "device_mfr",           val); }
-	inline void setModbus_DeviceModel(const std::string & ups, const std::string & val)       { setStr(ups, "device_model",         val); }
-	inline void setModbus_Parity(const std::string & ups, const std::string & val)            { setStr(ups, "parity",               val); }
-	inline void setModbus_PortType(const std::string & ups, const std::string & val)          { setStr(ups, "porttype",             val); }
-	inline void setModbus_SerParity(const std::string & ups, const std::string & val)         { setStr(ups, "ser_parity",           val); }
+	inline void setModbus_DeviceMfr(const std::string & ups, const std::string & val)         { setStr(ups, "device_mfr",          val); }
+	inline void setModbus_DeviceModel(const std::string & ups, const std::string & val)       { setStr(ups, "device_model",        val); }
+	inline void setModbus_Parity(const std::string & ups, const std::string & val)            { setStr(ups, "parity",              val); }
+	inline void setModbus_PortType(const std::string & ups, const std::string & val)          { setStr(ups, "porttype",            val); }
+	inline void setModbus_SerParity(const std::string & ups, const std::string & val)         { setStr(ups, "ser_parity",          val); }
 	inline void setModel(const std::string & ups, const std::string & model)                  { setStr(ups, "model",               model); }
 	inline void setModelName(const std::string & ups, const std::string & modelname)          { setStr(ups, "modelname",           modelname); }
 	inline void setNotification(const std::string & ups, const std::string & notification)    { setStr(ups, "notification",        notification); }
@@ -1962,151 +1961,150 @@ public:
 	inline void setSNMPversion(const std::string & ups, const std::string & snmp_version)     { setStr(ups, "snmp_version",        snmp_version); }
 	inline void setSubdriver(const std::string & ups, const std::string & subdriver)          { setStr(ups, "subdriver",           subdriver); }
 	inline void setSynchronous(const std::string & ups, const std::string & synchronous)      { setStr(ups, "synchronous",         synchronous); }
-	inline void setTtyMode(const std::string & ups, const std::string & val)                  { setStr(ups, "ttymode",              val); }
+	inline void setTtyMode(const std::string & ups, const std::string & val)                  { setStr(ups, "ttymode",             val); }
 	inline void setType(const std::string & ups, const std::string & type)                    { setStr(ups, "type",                type); }
 	inline void setUPStype(const std::string & ups, const std::string & upstype)              { setStr(ups, "upstype",             upstype); }
-	inline void setUpsId(const std::string & ups, const std::string & val)                    { setStr(ups, "upsid",                val); }
-	inline void setUsbBusPort(const std::string & ups, const std::string & val)               { setStr(ups, "busport",              val); }
-	inline void setUsbDevice(const std::string & ups, const std::string & val)                { setStr(ups, "device",               val); }
+	inline void setUpsId(const std::string & ups, const std::string & val)                    { setStr(ups, "upsid",               val); }
+	inline void setUsbBusPort(const std::string & ups, const std::string & val)               { setStr(ups, "busport",             val); }
+	inline void setUsbDevice(const std::string & ups, const std::string & val)                { setStr(ups, "device",              val); }
 	inline void setUSD(const std::string & ups, const std::string & usd)                      { setStr(ups, "usd",                 usd); }
 	inline void setUsername(const std::string & ups, const std::string & username)            { setStr(ups, "username",            username); }
 	inline void setUser(const std::string & ups, const std::string & user)                    { setStr(ups, "user",                user); }
 	inline void setValidationSequence(const std::string & ups, const std::string & valid_seq) { setStr(ups, "validationSequence",  valid_seq); }
 	inline void setVendor(const std::string & ups, const std::string & vendor)                { setStr(ups, "vendor",              vendor); }
 	inline void setVendorID(const std::string & ups, const std::string & vendorid)            { setStr(ups, "vendorid",            vendorid); }
-	inline void setWorkRangeType(const std::string & ups, const std::string & val)            { setStr(ups, "work_range_type",      val); }
+	inline void setWorkRangeType(const std::string & ups, const std::string & val)            { setStr(ups, "work_range_type",     val); }
 	inline void setWUGrace(const std::string & ups, const std::string & wugrace)              { setStr(ups, "wugrace",             wugrace); }
 
-	inline void setAsem_HB(const std::string & ups, long long int val)                        { setInt(ups, "hb",                   val); }
-	inline void setAsem_LB(const std::string & ups, long long int val)                        { setInt(ups, "lb",                   val); }
-	inline void setBatteryNumber(const std::string & ups, long long int val)                  { setInt(ups, "battery_number",       val); }
-	inline void setI2C_address(const std::string & ups, long long int val)                    { setInt(ups, "i2c_address",          val); }
-	inline void setInterruptSize(const std::string & ups, long long int val)                  { setInt(ups, "interruptsize",        val); }
+	inline void setADVorder(const std::string & ups, long long int advorder)                  { setInt(ups, "advorder",            advorder); }     // CHECKME
+	inline void setAsem_HB(const std::string & ups, long long int val)                        { setInt(ups, "hb",                  val); }
+	inline void setAsem_LB(const std::string & ups, long long int val)                        { setInt(ups, "lb",                  val); }
+	inline void setBatteryNumber(const std::string & ups, long long int val)                  { setInt(ups, "battery_number",      val); }
+	inline void setBatteryPercentage(const std::string & ups, long long int batt)             { setInt(ups, "batteryPercentage",   batt); }         // CHECKME
+	inline void setBattVoltMult(const std::string & ups, long long int mult)                  { setInt(ups, "battvoltmult",        mult); }         // CHECKME
+	inline void setBaudRate(const std::string & ups, long long int baud_rate)                 { setInt(ups, "baud_rate",           baud_rate); }    // CHECKME
+	inline void setBaudrate(const std::string & ups, long long int baudrate)                  { setInt(ups, "baudrate",            baudrate); }     // CHECKME
+	inline void setCablePower(const std::string & ups, long long int cablepower)              { setInt(ups, "cablepower",          cablepower); }   // CHECKME
+	inline void setChargeTime(const std::string & ups, long long int chargetime)              { setInt(ups, "chargetime",          chargetime); }   // CHECKME
+	inline void setDaysOff(const std::string & ups, long long int daysoff)                    { setInt(ups, "daysoff",             daysoff); }      // CHECKME
+	inline void setDaysWeek(const std::string & ups, long long int daysweek)                  { setInt(ups, "daysweek",            daysweek); }     // CHECKME
+	inline void setDebugMin(const std::string & ups, long long int val)                       { setInt(ups, "debug_min",           val); }
+	inline void setFrequency(const std::string & ups, long long int frequency)                { setInt(ups, "frequency",           frequency); }    // CHECKME
+	inline void setHourOff(const std::string & ups, long long int houroff)                    { setInt(ups, "houroff",             houroff); }      // CHECKME
+	inline void setHourOn(const std::string & ups, long long int houron)                      { setInt(ups, "houron",              houron); }       // CHECKME
+	inline void setI2C_address(const std::string & ups, long long int val)                    { setInt(ups, "i2c_address",         val); }
+	inline void setIdleLoad(const std::string & ups, long long int idleload)                  { setInt(ups, "idleload",            idleload); }     // CHECKME
+	inline void setInputTimeout(const std::string & ups, long long int timeout)               { setInt(ups, "input_timeout",       timeout); }      // CHECKME
+	inline void setInterruptSize(const std::string & ups, long long int val)                  { setInt(ups, "interruptsize",       val); }
+	inline void setLineVoltage(const std::string & ups, long long int linevoltage)            { setInt(ups, "linevoltage",         linevoltage); }  // CHECKME
+	inline void setLoadpercentage(const std::string & ups, long long int load)                { setInt(ups, "loadPercentage",      load); }         // CHECKME
+	inline void setMaxLoad(const std::string & ups, long long int max_load)                   { setInt(ups, "max_load",            max_load); }     // CHECKME
 	inline void setMaxPollsWithoutData(const std::string & ups, long long int val)            { setInt(ups, "max_polls_without_data", val); }
-	inline void setModbus_ByteTimeoutSec(const std::string & ups, long long int val)          { setInt(ups, "mod_byte_to_s",        val); }
-	inline void setModbus_ByteTimeoutUsec(const std::string & ups, long long int val)         { setInt(ups, "mod_byte_to_us",       val); }
-	inline void setModbus_CHRG_addr(const std::string & ups, long long int val)               { setInt(ups, "CHRG_addr",            val); }
-	inline void setModbus_CHRG_noro(const std::string & ups, long long int val)               { setInt(ups, "CHRG_noro",            val); }
-	inline void setModbus_CHRG_regtype(const std::string & ups, long long int val)            { setInt(ups, "CHRG_regtype",         val); }
-	inline void setModbus_DISCHRG_addr(const std::string & ups, long long int val)            { setInt(ups, "DISCHRG_addr",         val); }
-	inline void setModbus_DISCHRG_noro(const std::string & ups, long long int val)            { setInt(ups, "DISCHRG_noro",         val); }
-	inline void setModbus_DISCHRG_regtype(const std::string & ups, long long int val)         { setInt(ups, "DISCHRG_regtype",      val); }
-	inline void setModbus_DataBits(const std::string & ups, long long int val)                { setInt(ups, "databits",             val); }
-	inline void setModbus_DeviceSlaveId(const std::string & ups, long long int val)           { setInt(ups, "dev_slave_id",         val); }
-	inline void setModbus_FSD_addr(const std::string & ups, long long int val)                { setInt(ups, "FSD_addr",             val); }
-	inline void setModbus_FSD_noro(const std::string & ups, long long int val)                { setInt(ups, "FSD_noro",             val); }
-	inline void setModbus_FSD_pulse_duration(const std::string & ups, long long int val)      { setInt(ups, "FSD_pulse_duration",   val); }
-	inline void setModbus_FSD_regtype(const std::string & ups, long long int val)             { setInt(ups, "FSD_regtype",          val); }
-	inline void setModbus_HB_addr(const std::string & ups, long long int val)                 { setInt(ups, "HB_addr",              val); }
-	inline void setModbus_HB_noro(const std::string & ups, long long int val)                 { setInt(ups, "HB_noro",              val); }
-	inline void setModbus_HB_regtype(const std::string & ups, long long int val)              { setInt(ups, "HB_regtype",           val); }
-	inline void setModbus_LB_addr(const std::string & ups, long long int val)                 { setInt(ups, "LB_addr",              val); }
-	inline void setModbus_LB_noro(const std::string & ups, long long int val)                 { setInt(ups, "LB_noro",              val); }
-	inline void setModbus_LB_regtype(const std::string & ups, long long int val)              { setInt(ups, "LB_regtype",           val); }
-	inline void setModbus_OB_addr(const std::string & ups, long long int val)                 { setInt(ups, "OB_addr",              val); }
-	inline void setModbus_OB_noro(const std::string & ups, long long int val)                 { setInt(ups, "OB_noro",              val); }
-	inline void setModbus_OB_regtype(const std::string & ups, long long int val)              { setInt(ups, "OB_regtype",           val); }
-	inline void setModbus_OL_addr(const std::string & ups, long long int val)                 { setInt(ups, "OL_addr",              val); }
-	inline void setModbus_OL_noro(const std::string & ups, long long int val)                 { setInt(ups, "OL_noro",              val); }
-	inline void setModbus_OL_regtype(const std::string & ups, long long int val)              { setInt(ups, "OL_regtype",           val); }
-	inline void setModbus_RB_addr(const std::string & ups, long long int val)                 { setInt(ups, "RB_addr",              val); }
-	inline void setModbus_RB_noro(const std::string & ups, long long int val)                 { setInt(ups, "RB_noro",              val); }
-	inline void setModbus_RB_regtype(const std::string & ups, long long int val)              { setInt(ups, "RB_regtype",           val); }
-	inline void setModbus_ResponseTimeoutMsec(const std::string & ups, long long int val)     { setInt(ups, "response_timeout_ms",  val); }
-	inline void setModbus_ResponseTimeoutSec(const std::string & ups, long long int val)      { setInt(ups, "mod_resp_to_s",        val); }
-	inline void setModbus_ResponseTimeoutUsec(const std::string & ups, long long int val)     { setInt(ups, "mod_resp_to_us",       val); }
-	inline void setModbus_RioSlaveId(const std::string & ups, long long int val)              { setInt(ups, "rio_slave_id",         val); }
-	inline void setModbus_SerBaudRate(const std::string & ups, long long int val)             { setInt(ups, "ser_baud_rate",        val); }
-	inline void setModbus_SerDataBit(const std::string & ups, long long int val)              { setInt(ups, "ser_data_bit",         val); }
-	inline void setModbus_SerStopBit(const std::string & ups, long long int val)              { setInt(ups, "ser_stop_bit",         val); }
-	inline void setModbus_SlaveId(const std::string & ups, long long int val)                 { setInt(ups, "slaveid",              val); }
-	inline void setModbus_StopBits(const std::string & ups, long long int val)                { setInt(ups, "stopbits",             val); }
-	inline void setOnlineDischargeLogThrottleHovercharge(const std::string & ups, long long int val){ setInt(ups, "onlinedischarge_log_throttle_hovercharge", val); }
+	inline void setMaxStartDelay(const std::string & ups, long long int delay)                { setInt(ups, "maxstartdelay",       delay); }
+	inline void setMFR(const std::string & ups, long long int mfr)                            { setInt(ups, "mfr",                 mfr); }          // CHECKME
+	inline void setMinCharge(const std::string & ups, long long int mincharge)                { setInt(ups, "mincharge",           mincharge); }    // CHECKME
+	inline void setMinRuntime(const std::string & ups, long long int minruntime)              { setInt(ups, "minruntime",          minruntime); }   // CHECKME
+	inline void setModbus_ByteTimeoutSec(const std::string & ups, long long int val)          { setInt(ups, "mod_byte_to_s",       val); }
+	inline void setModbus_ByteTimeoutUsec(const std::string & ups, long long int val)         { setInt(ups, "mod_byte_to_us",      val); }
+	inline void setModbus_CHRG_addr(const std::string & ups, long long int val)               { setInt(ups, "CHRG_addr",           val); }
+	inline void setModbus_CHRG_noro(const std::string & ups, long long int val)               { setInt(ups, "CHRG_noro",           val); }
+	inline void setModbus_CHRG_regtype(const std::string & ups, long long int val)            { setInt(ups, "CHRG_regtype",        val); }
+	inline void setModbus_DISCHRG_addr(const std::string & ups, long long int val)            { setInt(ups, "DISCHRG_addr",        val); }
+	inline void setModbus_DISCHRG_noro(const std::string & ups, long long int val)            { setInt(ups, "DISCHRG_noro",        val); }
+	inline void setModbus_DISCHRG_regtype(const std::string & ups, long long int val)         { setInt(ups, "DISCHRG_regtype",     val); }
+	inline void setModbus_DataBits(const std::string & ups, long long int val)                { setInt(ups, "databits",            val); }
+	inline void setModbus_DeviceSlaveId(const std::string & ups, long long int val)           { setInt(ups, "dev_slave_id",        val); }
+	inline void setModbus_FSD_addr(const std::string & ups, long long int val)                { setInt(ups, "FSD_addr",            val); }
+	inline void setModbus_FSD_noro(const std::string & ups, long long int val)                { setInt(ups, "FSD_noro",            val); }
+	inline void setModbus_FSD_pulse_duration(const std::string & ups, long long int val)      { setInt(ups, "FSD_pulse_duration",  val); }
+	inline void setModbus_FSD_regtype(const std::string & ups, long long int val)             { setInt(ups, "FSD_regtype",         val); }
+	inline void setModbus_HB_addr(const std::string & ups, long long int val)                 { setInt(ups, "HB_addr",             val); }
+	inline void setModbus_HB_noro(const std::string & ups, long long int val)                 { setInt(ups, "HB_noro",             val); }
+	inline void setModbus_HB_regtype(const std::string & ups, long long int val)              { setInt(ups, "HB_regtype",          val); }
+	inline void setModbus_LB_addr(const std::string & ups, long long int val)                 { setInt(ups, "LB_addr",             val); }
+	inline void setModbus_LB_noro(const std::string & ups, long long int val)                 { setInt(ups, "LB_noro",             val); }
+	inline void setModbus_LB_regtype(const std::string & ups, long long int val)              { setInt(ups, "LB_regtype",          val); }
+	inline void setModbus_OB_addr(const std::string & ups, long long int val)                 { setInt(ups, "OB_addr",             val); }
+	inline void setModbus_OB_noro(const std::string & ups, long long int val)                 { setInt(ups, "OB_noro",             val); }
+	inline void setModbus_OB_regtype(const std::string & ups, long long int val)              { setInt(ups, "OB_regtype",          val); }
+	inline void setModbus_OL_addr(const std::string & ups, long long int val)                 { setInt(ups, "OL_addr",             val); }
+	inline void setModbus_OL_noro(const std::string & ups, long long int val)                 { setInt(ups, "OL_noro",             val); }
+	inline void setModbus_OL_regtype(const std::string & ups, long long int val)              { setInt(ups, "OL_regtype",          val); }
+	inline void setModbus_RB_addr(const std::string & ups, long long int val)                 { setInt(ups, "RB_addr",             val); }
+	inline void setModbus_RB_noro(const std::string & ups, long long int val)                 { setInt(ups, "RB_noro",             val); }
+	inline void setModbus_RB_regtype(const std::string & ups, long long int val)              { setInt(ups, "RB_regtype",          val); }
+	inline void setModbus_ResponseTimeoutMsec(const std::string & ups, long long int val)     { setInt(ups, "response_timeout_ms", val); }
+	inline void setModbus_ResponseTimeoutSec(const std::string & ups, long long int val)      { setInt(ups, "mod_resp_to_s",       val); }
+	inline void setModbus_ResponseTimeoutUsec(const std::string & ups, long long int val)     { setInt(ups, "mod_resp_to_us",      val); }
+	inline void setModbus_RioSlaveId(const std::string & ups, long long int val)              { setInt(ups, "rio_slave_id",        val); }
+	inline void setModbus_SerBaudRate(const std::string & ups, long long int val)             { setInt(ups, "ser_baud_rate",       val); }
+	inline void setModbus_SerDataBit(const std::string & ups, long long int val)              { setInt(ups, "ser_data_bit",        val); }
+	inline void setModbus_SerStopBit(const std::string & ups, long long int val)              { setInt(ups, "ser_stop_bit",        val); }
+	inline void setModbus_SlaveId(const std::string & ups, long long int val)                 { setInt(ups, "slaveid",             val); }
+	inline void setModbus_StopBits(const std::string & ups, long long int val)                { setInt(ups, "stopbits",            val); }
+	inline void setNomBattVolt(const std::string & ups, long long int nombattvolt)            { setInt(ups, "nombattvolt",         nombattvolt); }  // CHECKME
+	inline void setNumOfBytesFromUPS(const std::string & ups, long long int bytes)            { setInt(ups, "numOfBytesFromUPS",   bytes); }        // CHECKME
+	inline void setOffDelay(const std::string & ups, long long int offdelay)                  { setInt(ups, "OffDelay",            offdelay); }     // CHECKME
+	inline void setOffdelay(const std::string & ups, long long int offdelay)                  { setInt(ups, "offdelay",            offdelay); }     // CHECKME
+	inline void setOnDelay(const std::string & ups, long long int ondelay)                    { setInt(ups, "OnDelay",             ondelay); }      // CHECKME
+	inline void setOndelay(const std::string & ups, long long int ondelay)                    { setInt(ups, "ondelay",             ondelay); }      // CHECKME
+	inline void setOnlineDischargeLogThrottleHovercharge(const std::string & ups, long long int val) { setInt(ups, "onlinedischarge_log_throttle_hovercharge", val); }
 	inline void setOnlineDischargeLogThrottleSec(const std::string & ups, long long int val)  { setInt(ups, "onlinedischarge_log_throttle_sec", val); }
-	inline void setOutputPhaseAngle(const std::string & ups, long long int val)               { setInt(ups, "output_phase_angle",   val); }
-	inline void setPinsShutdownMode(const std::string & ups, long long int val)               { setInt(ups, "pins_shutdown_mode",   val); }
-	inline void setSemistaticFreq(const std::string & ups, long long int val)                 { setInt(ups, "semistaticfreq",       val); }
-	inline void setShutdownDuration(const std::string & ups, long long int val)               { setInt(ups, "shutdown_duration",    val); }
-	inline void setShutdownTimer(const std::string & ups, long long int val)                  { setInt(ups, "shutdown_timer",       val); }
-	inline void setSlaveAddress(const std::string & ups, long long int val)                   { setInt(ups, "slave_address",        val); }
-	inline void setSnmpRetries(const std::string & ups, long long int val)                    { setInt(ups, "snmp_retries",         val); }
-	inline void setSnmpTimeout(const std::string & ups, long long int val)                    { setInt(ups, "snmp_timeout",         val); }
-	inline void setWaitBeforeReconnect(const std::string & ups, long long int val)            { setInt(ups, "waitbeforereconnect",  val); }
-
-	inline void setDebugMin(const std::string & ups, long long int val)            { setInt(ups, "debug_min",          val); }
-	inline void setSDOrder(const std::string & ups, long long int ord)             { setInt(ups, "sdorder",            ord); }
-	inline void setMaxStartDelay(const std::string & ups, long long int delay)     { setInt(ups, "maxstartdelay",      delay); }
-	inline void setADVorder(const std::string & ups, long long int advorder)       { setInt(ups, "advorder",           advorder); }     // CHECKME
-	inline void setBatteryPercentage(const std::string & ups, long long int batt)  { setInt(ups, "batteryPercentage",  batt); }         // CHECKME
-	inline void setOffDelay(const std::string & ups, long long int offdelay)       { setInt(ups, "OffDelay",           offdelay); }     // CHECKME
-	inline void setOnDelay(const std::string & ups, long long int ondelay)         { setInt(ups, "OnDelay",            ondelay); }      // CHECKME
-	inline void setBattVoltMult(const std::string & ups, long long int mult)       { setInt(ups, "battvoltmult",       mult); }         // CHECKME
-	inline void setBaudRate(const std::string & ups, long long int baud_rate)      { setInt(ups, "baud_rate",          baud_rate); }    // CHECKME
-	inline void setBaudrate(const std::string & ups, long long int baudrate)       { setInt(ups, "baudrate",           baudrate); }     // CHECKME
-	inline void setCablePower(const std::string & ups, long long int cablepower)   { setInt(ups, "cablepower",         cablepower); }   // CHECKME
-	inline void setChargeTime(const std::string & ups, long long int chargetime)   { setInt(ups, "chargetime",         chargetime); }   // CHECKME
-	inline void setDaysOff(const std::string & ups, long long int daysoff)         { setInt(ups, "daysoff",            daysoff); }      // CHECKME
-	inline void setDaysWeek(const std::string & ups, long long int daysweek)       { setInt(ups, "daysweek",           daysweek); }     // CHECKME
-	inline void setFrequency(const std::string & ups, long long int frequency)     { setInt(ups, "frequency",          frequency); }    // CHECKME
-	inline void setHourOff(const std::string & ups, long long int houroff)         { setInt(ups, "houroff",            houroff); }      // CHECKME
-	inline void setHourOn(const std::string & ups, long long int houron)           { setInt(ups, "houron",             houron); }       // CHECKME
-	inline void setIdleLoad(const std::string & ups, long long int idleload)       { setInt(ups, "idleload",           idleload); }     // CHECKME
-	inline void setInputTimeout(const std::string & ups, long long int timeout)    { setInt(ups, "input_timeout",      timeout); }      // CHECKME
-	inline void setLineVoltage(const std::string & ups, long long int linevoltage) { setInt(ups, "linevoltage",        linevoltage); }  // CHECKME
-	inline void setLoadpercentage(const std::string & ups, long long int load)     { setInt(ups, "loadPercentage",     load); }         // CHECKME
-	inline void setMaxLoad(const std::string & ups, long long int max_load)        { setInt(ups, "max_load",           max_load); }     // CHECKME
-	inline void setMFR(const std::string & ups, long long int mfr)                 { setInt(ups, "mfr",                mfr); }          // CHECKME
-	inline void setMinCharge(const std::string & ups, long long int mincharge)     { setInt(ups, "mincharge",          mincharge); }    // CHECKME
-	inline void setMinRuntime(const std::string & ups, long long int minruntime)   { setInt(ups, "minruntime",         minruntime); }   // CHECKME
-	inline void setNomBattVolt(const std::string & ups, long long int nombattvolt) { setInt(ups, "nombattvolt",        nombattvolt); }  // CHECKME
-	inline void setNumOfBytesFromUPS(const std::string & ups, long long int bytes) { setInt(ups, "numOfBytesFromUPS",  bytes); }        // CHECKME
-	inline void setOffdelay(const std::string & ups, long long int offdelay)       { setInt(ups, "offdelay",           offdelay); }     // CHECKME
-	inline void setOndelay(const std::string & ups, long long int ondelay)         { setInt(ups, "ondelay",            ondelay); }      // CHECKME
-	inline void setOutputPace(const std::string & ups, long long int output_pace)  { setInt(ups, "output_pace",        output_pace); }  // CHECKME
-	inline void setPollFreq(const std::string & ups, long long int pollfreq)       { setInt(ups, "pollfreq",           pollfreq); }     // CHECKME
-	inline void setPowerUp(const std::string & ups, long long int powerup)         { setInt(ups, "powerup",            powerup); }      // CHECKME
-	inline void setPrgShut(const std::string & ups, long long int prgshut)         { setInt(ups, "prgshut",            prgshut); }      // CHECKME
-	inline void setRebootDelay(const std::string & ups, long long int delay)       { setInt(ups, "rebootdelay",        delay); }        // CHECKME
-	inline void setSDtime(const std::string & ups, long long int sdtime)           { setInt(ups, "sdtime",             sdtime); }       // CHECKME
-	inline void setShutdownDelay(const std::string & ups, long long int delay)     { setInt(ups, "shutdown_delay",     delay); }        // CHECKME
-	inline void setStartDelay(const std::string & ups, long long int delay)        { setInt(ups, "startdelay",         delay); }        // CHECKME
-	inline void setTestTime(const std::string & ups, long long int testtime)       { setInt(ups, "testtime",           testtime); }     // CHECKME
-	inline void setTimeout(const std::string & ups, long long int timeout)         { setInt(ups, "timeout",            timeout); }      // CHECKME
-	inline void setUPSdelayShutdown(const std::string & ups, long long int delay)  { setInt(ups, "ups.delay.shutdown", delay); }        // CHECKME
-	inline void setUPSdelayStart(const std::string & ups, long long int delay)     { setInt(ups, "ups.delay.start",    delay); }        // CHECKME
-	inline void setVoltage(const std::string & ups, long long int voltage)         { setInt(ups, "voltage",            voltage); }      // CHECKME
+	inline void setOutputPace(const std::string & ups, long long int output_pace)             { setInt(ups, "output_pace",         output_pace); }  // CHECKME
+	inline void setOutputPhaseAngle(const std::string & ups, long long int val)               { setInt(ups, "output_phase_angle",  val); }
+	inline void setPinsShutdownMode(const std::string & ups, long long int val)               { setInt(ups, "pins_shutdown_mode",  val); }
+	inline void setPollFreq(const std::string & ups, long long int pollfreq)                  { setInt(ups, "pollfreq",            pollfreq); }     // CHECKME
+	inline void setPowerUp(const std::string & ups, long long int powerup)                    { setInt(ups, "powerup",             powerup); }      // CHECKME
+	inline void setPrgShut(const std::string & ups, long long int prgshut)                    { setInt(ups, "prgshut",             prgshut); }      // CHECKME
+	inline void setRebootDelay(const std::string & ups, long long int delay)                  { setInt(ups, "rebootdelay",         delay); }        // CHECKME
+	inline void setSDtime(const std::string & ups, long long int sdtime)                      { setInt(ups, "sdtime",              sdtime); }       // CHECKME
+	inline void setSDOrder(const std::string & ups, long long int ord)                        { setInt(ups, "sdorder",             ord); }
+	inline void setSemistaticFreq(const std::string & ups, long long int val)                 { setInt(ups, "semistaticfreq",      val); }
+	inline void setShutdownDelay(const std::string & ups, long long int delay)                { setInt(ups, "shutdown_delay",      delay); }        // CHECKME
+	inline void setShutdownDuration(const std::string & ups, long long int val)               { setInt(ups, "shutdown_duration",   val); }
+	inline void setShutdownTimer(const std::string & ups, long long int val)                  { setInt(ups, "shutdown_timer",      val); }
+	inline void setSlaveAddress(const std::string & ups, long long int val)                   { setInt(ups, "slave_address",       val); }
+	inline void setSnmpRetries(const std::string & ups, long long int val)                    { setInt(ups, "snmp_retries",        val); }
+	inline void setSnmpTimeout(const std::string & ups, long long int val)                    { setInt(ups, "snmp_timeout",        val); }
+	inline void setStartDelay(const std::string & ups, long long int delay)                   { setInt(ups, "startdelay",          delay); }        // CHECKME
+	inline void setTestTime(const std::string & ups, long long int testtime)                  { setInt(ups, "testtime",            testtime); }     // CHECKME
+	inline void setTimeout(const std::string & ups, long long int timeout)                    { setInt(ups, "timeout",             timeout); }      // CHECKME
+	inline void setUPSdelayShutdown(const std::string & ups, long long int delay)             { setInt(ups, "ups.delay.shutdown",  delay); }        // CHECKME
+	inline void setUPSdelayStart(const std::string & ups, long long int delay)                { setInt(ups, "ups.delay.start",     delay); }        // CHECKME
+	inline void setVoltage(const std::string & ups, long long int voltage)                    { setInt(ups, "voltage",             voltage); }      // CHECKME
+	inline void setWaitBeforeReconnect(const std::string & ups, long long int val)            { setInt(ups, "waitbeforereconnect", val); }
 
 	// Items below are "unused" - mostly set in
 	// drivers/nutdrv_qx_masterguard.c
-	inline void setFault1(const std::string & ups, const std::string & val)                   { setStr(ups, "fault_1",              val); }
-	inline void setFault2(const std::string & ups, const std::string & val)                   { setStr(ups, "fault_2",              val); }
-	inline void setFault3(const std::string & ups, const std::string & val)                   { setStr(ups, "fault_3",              val); }
-	inline void setFault4(const std::string & ups, const std::string & val)                   { setStr(ups, "fault_4",              val); }
-	inline void setFault5(const std::string & ups, const std::string & val)                   { setStr(ups, "fault_5",              val); }
-	inline void setInputFaultVoltage(const std::string & ups, const std::string & val)        { setStr(ups, "input_fault_voltage",  val); }
-	inline void setNominalCellVoltage(const std::string & ups, const std::string & val)       { setStr(ups, "nominal_cell_voltage", val); }
+	inline void setFault1(const std::string & ups, const std::string & val)                   { setStr(ups, "fault_1",             val); }
+	inline void setFault2(const std::string & ups, const std::string & val)                   { setStr(ups, "fault_2",             val); }
+	inline void setFault3(const std::string & ups, const std::string & val)                   { setStr(ups, "fault_3",             val); }
+	inline void setFault4(const std::string & ups, const std::string & val)                   { setStr(ups, "fault_4",             val); }
+	inline void setFault5(const std::string & ups, const std::string & val)                   { setStr(ups, "fault_5",             val); }
+	inline void setInputFaultVoltage(const std::string & ups, const std::string & val)        { setStr(ups, "input_fault_voltage", val); }
+	inline void setNominalCellVoltage(const std::string & ups, const std::string & val)       { setStr(ups, "nominal_cell_voltage",val); }
 	inline void setNumberOfBatteryCells(const std::string & ups, const std::string & val)     { setStr(ups, "number_of_battery_cells", val); }
-	inline void setOutputVoltages(const std::string & ups, const std::string & val)           { setStr(ups, "output_voltages",      val); }
-	inline void setRechargeTime(const std::string & ups, const std::string & val)             { setStr(ups, "recharge_time",        val); }
-	inline void setRuntimeFull(const std::string & ups, const std::string & val)              { setStr(ups, "runtime_full",         val); }
-	inline void setRuntimeHalf(const std::string & ups, const std::string & val)              { setStr(ups, "runtime_half",         val); }
-	inline void setSeries(const std::string & ups, const std::string & val)                   { setStr(ups, "series",               val); }
+	inline void setOutputVoltages(const std::string & ups, const std::string & val)           { setStr(ups, "output_voltages",     val); }
+	inline void setRechargeTime(const std::string & ups, const std::string & val)             { setStr(ups, "recharge_time",       val); }
+	inline void setRuntimeFull(const std::string & ups, const std::string & val)              { setStr(ups, "runtime_full",        val); }
+	inline void setRuntimeHalf(const std::string & ups, const std::string & val)              { setStr(ups, "runtime_half",        val); }
+	inline void setSeries(const std::string & ups, const std::string & val)                   { setStr(ups, "series",              val); }
 
 	// Items below are essentially booleans (expected values
 	// are "enabled/disabled") -- refactoring planned per
 	// https://github.com/networkupstools/nut/issues/2421
-	inline void setAdvancedEcoMode(const std::string & ups, const std::string & val)          { setStr(ups, "advanced_eco_mode",    val); }
-	inline void setAlarmControl(const std::string & ups, const std::string & val)             { setStr(ups, "alarm_control",        val); }
-	inline void setBatteryAlarm(const std::string & ups, const std::string & val)             { setStr(ups, "battery_alarm",        val); }
+	inline void setAdvancedEcoMode(const std::string & ups, const std::string & val)          { setStr(ups, "advanced_eco_mode",   val); }
+	inline void setAlarmControl(const std::string & ups, const std::string & val)             { setStr(ups, "alarm_control",       val); }
+	inline void setBatteryAlarm(const std::string & ups, const std::string & val)             { setStr(ups, "battery_alarm",       val); }
 	inline void setBatteryOpenStatusCheck(const std::string & ups, const std::string & val)   { setStr(ups, "battery_open_status_check", val); }
-	inline void setBypassAlarm(const std::string & ups, const std::string & val)              { setStr(ups, "bypass_alarm",         val); }
-	inline void setBypassForbidding(const std::string & ups, const std::string & val)         { setStr(ups, "bypass_forbidding",    val); }
-	inline void setBypassWhenOff(const std::string & ups, const std::string & val)            { setStr(ups, "bypass_when_off",      val); }
-	inline void setConstantPhaseAngle(const std::string & ups, const std::string & val)       { setStr(ups, "constant_phase_angle", val); }
-	inline void setConverterMode(const std::string & ups, const std::string & val)            { setStr(ups, "converter_mode",       val); }
-	inline void setEcoMode(const std::string & ups, const std::string & val)                  { setStr(ups, "eco_mode",             val); }
+	inline void setBypassAlarm(const std::string & ups, const std::string & val)              { setStr(ups, "bypass_alarm",        val); }
+	inline void setBypassForbidding(const std::string & ups, const std::string & val)         { setStr(ups, "bypass_forbidding",   val); }
+	inline void setBypassWhenOff(const std::string & ups, const std::string & val)            { setStr(ups, "bypass_when_off",     val); }
+	inline void setConstantPhaseAngle(const std::string & ups, const std::string & val)       { setStr(ups, "constant_phase_angle",val); }
+	inline void setConverterMode(const std::string & ups, const std::string & val)            { setStr(ups, "converter_mode",      val); }
+	inline void setEcoMode(const std::string & ups, const std::string & val)                  { setStr(ups, "eco_mode",            val); }
 	inline void setLimitedRuntimeOnBattery(const std::string & ups, const std::string & val)  { setStr(ups, "limited_runtime_on_battery", val); }
-	inline void setSiteFaultDetection(const std::string & ups, const std::string & val)       { setStr(ups, "site_fault_detection", val); }
+	inline void setSiteFaultDetection(const std::string & ups, const std::string & val)       { setStr(ups, "site_fault_detection",val); }
 
 	/** belkinunv: both a flag (wait for AC power) and value (also wait for charge level) */
 	inline void setWait(const std::string & ups, long long int wait)               { setInt(ups, "wait",               wait); }         // CHECKME
@@ -2121,13 +2119,13 @@ public:
 	inline void setUsbHidEndpointIn(const std::string & ups, long long int val)             { setIntHex(ups, "usb_hid_ep_in",                  val); }         // CHECKME
 	inline void setUsbHidEndpointOut(const std::string & ups, long long int val)            { setIntHex(ups, "usb_hid_ep_out",                 val); }         // CHECKME
 
-	inline void setBatteryMax(const std::string & ups, double val)                          { setDouble(ups, "battery_max",          val); }
-	inline void setBatteryMin(const std::string & ups, double val)                          { setDouble(ups, "battery_min",          val); }
-	inline void setCSHackDelay(const std::string & ups, double val)                         { setDouble(ups, "cshdelay",             val); }
-	inline void setMaxBypassFreq(const std::string & ups, double val)                       { setDouble(ups, "max_bypass_freq",      val); }
-	inline void setMaxBypassVolt(const std::string & ups, double val)                       { setDouble(ups, "max_bypass_volt",      val); }
-	inline void setMinBypassFreq(const std::string & ups, double val)                       { setDouble(ups, "min_bypass_freq",      val); }
-	inline void setMinBypassVolt(const std::string & ups, double val)                       { setDouble(ups, "min_bypass_volt",      val); }
+	inline void setBatteryMax(const std::string & ups, double val)                          { setDouble(ups, "battery_max",        val); }
+	inline void setBatteryMin(const std::string & ups, double val)                          { setDouble(ups, "battery_min",        val); }
+	inline void setCSHackDelay(const std::string & ups, double val)                         { setDouble(ups, "cshdelay",           val); }
+	inline void setMaxBypassFreq(const std::string & ups, double val)                       { setDouble(ups, "max_bypass_freq",    val); }
+	inline void setMaxBypassVolt(const std::string & ups, double val)                       { setDouble(ups, "max_bypass_volt",    val); }
+	inline void setMinBypassFreq(const std::string & ups, double val)                       { setDouble(ups, "min_bypass_freq",    val); }
+	inline void setMinBypassVolt(const std::string & ups, double val)                       { setDouble(ups, "min_bypass_volt",    val); }
 
 	// Flag - if exists then "true"; remove() to "unset" => "false"
 	inline void setCancelShutdown(const std::string & ups, bool set = true) { setFlag(ups, "CS",             set); }

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -35,6 +35,7 @@
 #include <list>
 #include <map>
 #include <stdexcept>
+#include <typeinfo>
 
 /* See include/common.h for details behind this */
 #ifndef NUT_UNUSED_VARIABLE

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -1360,6 +1360,11 @@ public:
 
 	Settable<NutMode> mode;
 
+	Settable<bool>		allowNoDevice, allowNotAllListeners, poweroffQuiet;
+	Settable<std::string>	upsdOptions, upsmonOptions;
+	Settable<unsigned int>	poweroffWait;
+	Settable<int>		debugLevel;
+
 	static NutMode NutModeFromString(const std::string& str);
 
 	/** Serialisable interface implementation \{ */

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -1566,8 +1566,8 @@ class UpsConfiguration : public GenericConfiguration
 :; grep -E '[=|] "' scripts/augeas/nutupsconf.aug.in | awk '{print $NF}' | tr -d '"' \
   | while read O ; do echo "=== $O :" ; \
     grep -w '"'"$O"'"' ./include/nutconf.hpp && continue ; \
-    grep -A10 -w "$O" ./docs/man/*.txt || echo '!!! UNDOCUMENTED !!!' ; \
-    echo "-----"; grep -A10 -w '"'"$O"'"' ./drivers/*.{c,h} || echo '!!! NOT USED IN CODE !!!' ; \
+    { cd ./docs/man/ && grep -A10 -w "$O" *.txt || echo '!!! UNDOCUMENTED !!!' ; } ; \
+    echo "-----"; { cd ./drivers && grep -A10 -w '"'"$O"'"' *.{c,h} || echo '!!! NOT USED IN CODE !!!' ; } ; \
     echo "-----"; echo "" ; done | less
 
 	 * Arrange found new keywords into two columns (first would be

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -512,7 +512,7 @@ struct CertIdent
 struct CertHost
 {
 	Settable<std::string> host, certName;
-	Settable<int> certVerify, forceSsl;
+	nut::BoolInt certVerify, forceSsl;
 
 	inline bool operator==(const CertHost& other)const
 	{

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -1384,8 +1384,10 @@ public:
 	UpsdConfiguration();
 	void parseFromString(const std::string& str);
 
-	Settable<unsigned int> maxAge, maxConn;
-	Settable<std::string>  statePath, certFile;
+	Settable<int> debugMin;
+	Settable<unsigned int> maxAge, maxConn, trackingDelay, certRequestLevel;
+	Settable<std::string>  statePath, certFile, certPath;
+	Settable<bool> allowNoDevice, allowNotAllListeners, disableWeakSsl;
 
 	struct Listen
 	{
@@ -1398,6 +1400,8 @@ public:
 		}
 	};
 	std::list<Listen> listens;
+
+	CertIdent certIdent;
 
 	/** Serialisable interface implementation \{ */
 	bool parseFrom(NutStream & istream) override;

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -276,6 +276,30 @@ public:
 			"' string not understood as bool nor int");
 	}
 
+	inline BoolInt& operator<<(bool other)
+	{
+		*this = other;
+		return *this;
+	}
+
+	inline BoolInt& operator<<(int other)
+	{
+		*this = other;
+		return *this;
+	}
+
+	inline BoolInt& operator<<(std::string other)
+	{
+		*this = other;
+		return *this;
+	}
+
+	inline BoolInt& operator<<(const char* other)
+	{
+		*this = other;
+		return *this;
+	}
+
 	inline bool operator==(const BoolInt& other)const
 	{
 		// Either direct values are set and then equal; optionally
@@ -377,13 +401,18 @@ public:
 			"BoolInt value not set, neither to bool nor to int");
 	}
 
-	operator std::string() {
+	inline std::string toString()const {
 		if (b.set()) {
 			if (b) return "yes";
 			return "no";
 		}
 
 		if (i.set()) {
+			if (bool01.set() && bool01 == true) {
+				if (i == 0) return "no";
+				if (i == 1) return "yes";
+			}
+
 			std::ostringstream ss;
 			ss << i;
 			return ss.str();
@@ -392,7 +421,22 @@ public:
 		throw std::invalid_argument(
 			"BoolInt value not set, neither to bool nor to int");
 	}
+
+	// FIXME: `std::string s = bi;` just won't work
+	// but we can use `s = bi.toString()` or `cout << bi`
+	operator std::string()const {
+		return this->toString();
+	}
+
+	operator std::string&()const {
+		return *(new std::string(this->operator std::string()));
+	}
 };
+
+std::ostream& operator << (std::ostream &os, const BoolInt &bi);
+inline std::ostream& operator << (std::ostream &os, const BoolInt &bi) {
+	return (os << bi.toString());
+}
 
 
 /**

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -1092,6 +1092,8 @@ public:
 
 	inline std::string getPassword(const std::string & user) const { return getStr(user, "password"); }
 
+	/** Currently valid actions include "SET" and "FSD",
+	 *  but the method does not constrain the values */
 	inline ConfigParamList getActions(const std::string & user) const
 	{
 		ConfigParamList actions;
@@ -1099,6 +1101,8 @@ public:
 		return actions;
 	}
 
+	/** Valid commands are "ALL" or a list of specific commands
+	 *  supported by the device (NUT driver dependent) */
 	inline ConfigParamList getInstantCommands(const std::string & user) const
 	{
 		ConfigParamList cmds;
@@ -1124,6 +1128,9 @@ public:
 	 *
 	 *  \param  mode  Mode
 	 */
+	/* TOTHINK: Do we need a writer (other method, optional parameter
+	 * to this one) for obsolete wordings of the upsmon mode?
+	 * Note: reader in the getter accepts both old and new values. */
 	void setUpsmonMode(upsmon_mode_t mode);
 
 	/** \} */

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -162,6 +162,12 @@ public:
 	 */
 	Settable<bool> bool01;
 
+	/** Leave all contents un-set */
+	BoolInt() {}
+	BoolInt(const BoolInt& other) {
+		*this = other;
+	}
+
 	inline void clear()
 	{
 		i.clear();

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -965,6 +965,116 @@ protected:
 	}
 
 	/**
+	 *  \brief  Configuration boolean option getter
+	 *
+	 *  Value depends on original string representation of a setting.
+	 *
+	 *  \param  section  Section name
+	 *  \param  entry    Entry name
+	 *  \param  val      Default value
+	 *
+	 *  \return Configuration parameter as boolean (or the default if not defined)
+	 */
+	bool getBool(
+		const std::string & section,
+		const std::string & entry,
+		bool                val = false) const;
+
+	/**
+	 *  \brief  Configuration boolean option getter
+	 *
+	 *  Value depends on original string representation of a setting.
+	 *
+	 *  \param  section  Section name
+	 *  \param  entry    Entry name
+	 *  \param  val      Default value
+	 *
+	 *  \return Configuration parameter as boolean (or the default if not defined)
+	 */
+	// Avoid error: implicit conversion turns string literal
+	//       into bool: 'const char[7]' to 'bool'
+	bool getBool(
+		const std::string & section,
+		const char        * entry,
+		bool                val = false) const
+	{
+		return getBool(section, std::string(entry), val);
+	}
+
+	/**
+	 *  \brief  Global scope configuration boolean option getter
+	 *
+	 *  Value depends on original string representation of a setting.
+	 *
+	 *  \param  entry  Entry name
+	 *  \param  val      Default value
+	 *
+	 *  \return Configuration parameter as boolean (or the default if not defined)
+	 */
+	inline bool getBool(const std::string & entry, bool val = false) const
+	{
+		return getBool("", entry, val);
+	}
+
+	/**
+	 *  \brief  Configuration boolean option setter
+	 *
+	 *  \param  section  Section name
+	 *  \param  entry    Entry name
+	 *  \param  val      Default value
+	 */
+	inline void setBool(
+		const std::string & section,
+		const std::string & entry,
+		bool                val = true)
+	{
+		setStr(section, entry, bool2str(val));
+	}
+
+	/**
+	 *  \brief  Global scope configuration boolean option setter
+	 *
+	 *  \param  entry    Entry name
+	 *  \param  val      Default value
+	 */
+	inline void setBool(
+		const std::string & entry,
+		bool                val = true)
+	{
+		setBool("", entry, val);
+	}
+
+	/**
+	 *  \brief  Configuration boolean option setter from a string
+	 *
+	 *  \param  section  Section name
+	 *  \param  entry    Entry name
+	 *  \param  val      Default value
+	 */
+	inline void setBool(
+		const std::string & section,
+		const std::string & entry,
+		const std::string & val = "true")
+	{
+		// Normalize:
+		bool b = str2bool(val);
+		setStr(section, entry, bool2str(b));
+	}
+
+	/**
+	 *  \brief  Global scope configuration boolean option setter from a string
+	 *
+	 *  \param  entry    Entry name
+	 *  \param  val      Default value
+	 */
+	inline void setBool(
+		const std::string & entry,
+		const std::string & val = "true")
+	{
+		setBool("", entry, val);
+	}
+
+	/**
 	 *  \brief  Configuration number getter
 	 *
 	 *  \param  section  Section name

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -1452,17 +1452,32 @@ public:
 
 	inline std::string getChroot()     const { return getStr("chroot"); }
 	inline std::string getDriverPath() const { return getStr("driverpath"); }
+	inline std::string getGroup()      const { return getStr("group"); }
+	inline std::string getSynchronous() const { return getStr("synchronous"); }
 	inline std::string getUser()       const { return getStr("user"); }
 
+	// Flag - if exists then "true"
+	inline bool getNoWait()            const { return getFlag("nowait"); }
+
+	inline long long int getDebugMin()      const { return getInt("debug_min"); }
+	inline long long int getMaxRetry()      const { return getInt("maxretry"); }
 	inline long long int getMaxStartDelay() const { return getInt("maxstartdelay"); }
-	inline long long int getPollInterval() const  { return getInt("pollinterval", 5); }  // TODO: check the default
+	inline long long int getPollInterval()  const { return getInt("pollinterval", 5); }  // TODO: check the default
+	inline long long int getRetryDelay()    const { return getInt("retrydelay"); }
 
 	inline void setChroot(const std::string & path)     { setStr("chroot",     path); }
 	inline void setDriverPath(const std::string & path) { setStr("driverpath", path); }
+	inline void setGroup(const std::string & group)     { setStr("group",      group); }
+	inline void setSynchronous(const std::string & val) { setStr("synchronous", val); }
 	inline void setUser(const std::string & user)       { setStr("user",       user); }
 
+	inline void setNoWait()                             { setFlag("nowait"); }
+
+	inline void setDebugMin(long long int num)          { setInt("debug_min",     num); }
+	inline void setMaxRetry(long long int num)          { setInt("maxretry",      num); }
 	inline void setMaxStartDelay(long long int delay)   { setInt("maxstartdelay", delay); }
 	inline void setPollInterval(long long int interval) { setInt("pollinterval",  interval); }
+	inline void setRetryDelay(long long int delay)      { setInt("retrydelay",    delay); }
 
 	/** \} */
 
@@ -1492,6 +1507,7 @@ public:
 	inline std::string getBus(const std::string & ups)                 const { return getStr(ups, "bus"); }
 	inline std::string getCommunity(const std::string & ups)           const { return getStr(ups, "community"); }
 	inline std::string getFRUID(const std::string & ups)               const { return getStr(ups, "fruid"); }
+	inline std::string getGroup(const std::string & ups)               const { return getStr(ups, "group"); }
 	inline std::string getLoadStatus(const std::string & ups)          const { return getStr(ups, "load.status"); }
 	inline std::string getLogin(const std::string & ups)               const { return getStr(ups, "login"); }
 	inline std::string getLowbatt(const std::string & ups)             const { return getStr(ups, "lowbatt"); }
@@ -1520,9 +1536,11 @@ public:
 	inline std::string getShutdownArguments(const std::string & ups)   const { return getStr(ups, "shutdownArguments"); }
 	inline std::string getSNMPversion(const std::string & ups)         const { return getStr(ups, "snmp_version"); }
 	inline std::string getSubdriver(const std::string & ups)           const { return getStr(ups, "subdriver"); }
+	inline std::string getSynchronous(const std::string & ups)         const { return getStr(ups, "synchronous"); }
 	inline std::string getType(const std::string & ups)                const { return getStr(ups, "type"); }
 	inline std::string getUPStype(const std::string & ups)             const { return getStr(ups, "upstype"); }
 	inline std::string getUSD(const std::string & ups)                 const { return getStr(ups, "usd"); }
+	inline std::string getUser(const std::string & ups)                const { return getStr(ups, "user"); }
 	inline std::string getUsername(const std::string & ups)            const { return getStr(ups, "username"); }
 	inline std::string getValidationSequence(const std::string & ups)  const { return getStr(ups, "validationSequence"); }
 	inline std::string getVendor(const std::string & ups)              const { return getStr(ups, "vendor"); }
@@ -1530,6 +1548,7 @@ public:
 	inline std::string getWUGrace(const std::string & ups)             const { return getStr(ups, "wugrace"); }
 
 
+	inline long long int getDebugMin(const std::string & ups)          const { return getInt(ups, "debug_min"); }
 	inline long long int getSDOrder(const std::string & ups)           const { return getInt(ups, "sdorder"); }             // TODO: Is that a number?
 	inline long long int getMaxStartDelay(const std::string & ups)     const { return getInt(ups, "maxstartdelay"); }
 	inline long long int getAdvOrder(const std::string & ups)          const { return getInt(ups, "advorder"); }            // CHECKME
@@ -1573,6 +1592,9 @@ public:
 	inline long long int getVoltage(const std::string & ups)           const { return getInt(ups, "voltage"); }             // CHECKME
 	inline long long int getWait(const std::string & ups)              const { return getInt(ups, "wait"); }                // CHECKME
 
+	// Flag - if exists then "true"
+	inline bool getIgnoreLB(const std::string & ups)       const { return getFlag(ups, "ignorelb"); }
+
 	inline bool getNolock(const std::string & ups)         const { return getBool(ups, "nolock"); }
 	inline bool getCable(const std::string & ups)          const { return getBool(ups, "cable"); }
 	inline bool getDumbTerm(const std::string & ups)       const { return getBool(ups, "dumbterm"); }
@@ -1609,6 +1631,7 @@ public:
 	inline void setBus(const std::string & ups, const std::string & bus)                      { setStr(ups, "bus",                 bus); }
 	inline void setCommunity(const std::string & ups, const std::string & community)          { setStr(ups, "community",           community); }
 	inline void setFRUID(const std::string & ups, const std::string & fruid)                  { setStr(ups, "fruid",               fruid); }
+	inline void setGroup(const std::string & ups, const std::string & group)                  { setStr(ups, "group",               group); }
 	inline void setLoadStatus(const std::string & ups, const std::string & load_status)       { setStr(ups, "load.status",         load_status); }
 	inline void setLogin(const std::string & ups, const std::string & login)                  { setStr(ups, "login",               login); }
 	inline void setLowbatt(const std::string & ups, const std::string & lowbatt)              { setStr(ups, "lowbatt",             lowbatt); }
@@ -1637,15 +1660,18 @@ public:
 	inline void setShutdownArguments(const std::string & ups, const std::string & sd_args)    { setStr(ups, "shutdownArguments",   sd_args); }
 	inline void setSNMPversion(const std::string & ups, const std::string & snmp_version)     { setStr(ups, "snmp_version",        snmp_version); }
 	inline void setSubdriver(const std::string & ups, const std::string & subdriver)          { setStr(ups, "subdriver",           subdriver); }
+	inline void setSynchronous(const std::string & ups, const std::string & synchronous)      { setStr(ups, "synchronous",         synchronous); }
 	inline void setType(const std::string & ups, const std::string & type)                    { setStr(ups, "type",                type); }
 	inline void setUPStype(const std::string & ups, const std::string & upstype)              { setStr(ups, "upstype",             upstype); }
 	inline void setUSD(const std::string & ups, const std::string & usd)                      { setStr(ups, "usd",                 usd); }
 	inline void setUsername(const std::string & ups, const std::string & username)            { setStr(ups, "username",            username); }
+	inline void setUser(const std::string & ups, const std::string & user)                    { setStr(ups, "user",                user); }
 	inline void setValidationSequence(const std::string & ups, const std::string & valid_seq) { setStr(ups, "validationSequence",  valid_seq); }
 	inline void setVendor(const std::string & ups, const std::string & vendor)                { setStr(ups, "vendor",              vendor); }
 	inline void setVendorID(const std::string & ups, const std::string & vendorid)            { setStr(ups, "vendorid",            vendorid); }
 	inline void setWUGrace(const std::string & ups, const std::string & wugrace)              { setStr(ups, "wugrace",             wugrace); }
 
+	inline void setDebugMin(const std::string & ups, long long int val)            { setInt(ups, "debug_min",          val); }
 	inline void setSDOrder(const std::string & ups, long long int ord)             { setInt(ups, "sdorder",            ord); }
 	inline void setMaxStartDelay(const std::string & ups, long long int delay)     { setInt(ups, "maxstartdelay",      delay); }
 	inline void setADVorder(const std::string & ups, long long int advorder)       { setInt(ups, "advorder",           advorder); }     // CHECKME
@@ -1688,6 +1714,9 @@ public:
 	inline void setUPSdelayStart(const std::string & ups, long long int delay)     { setInt(ups, "ups.delay.start",    delay); }        // CHECKME
 	inline void setVoltage(const std::string & ups, long long int voltage)         { setInt(ups, "voltage",            voltage); }      // CHECKME
 	inline void setWait(const std::string & ups, long long int wait)               { setInt(ups, "wait",               wait); }         // CHECKME
+
+	// Flag - if exists then "true"; remove() to "unset" => "false"
+	inline void setIgnoreLB(const std::string & ups)                        { setFlag(ups, "ignorelb"); }
 
 	inline void setNolock(const std::string & ups, bool set = true)         { setBool(ups, "nolock",         set); }
 	inline void setCable(const std::string & ups, bool set = true)          { setBool(ups, "cable",          set); }

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -1541,6 +1541,44 @@ public:
 		setStr(ups, key, val);
 	}
 
+	/** PUZZLE: What to do about "default.*" and "override.*"
+	 * settings that apply to anything (vars!) that follows?
+	 * Maybe nest the UpsConfiguration objects, and so query
+	 * e.g. upscfg.default.getBatteryNominalVoltage() ?
+	 * Or just keep that info in ConfigParamList per section
+	 * and wrap free-style queries? */
+	inline std::string   getDefaultStr(const std::string & ups, const std::string & key)            const { return getStr(ups, "default." + key); }
+	inline long long int getDefaultInt(const std::string & ups, const std::string & key)            const { return getInt(ups, "default." + key); }
+	inline long long int getDefaultIntHex(const std::string & ups, const std::string & key)         const { return getIntHex(ups, "default." + key); }
+	inline bool          getDefaultFlag(const std::string & ups, const std::string & key)           const { return getFlag(ups, "default." + key); }
+	inline bool          getDefaultBool(const std::string & ups, const std::string & key)           const { return getBool(ups, "default." + key); }
+	inline nut::BoolInt  getDefaultBoolInt(const std::string & ups, const std::string & key)        const { return getBoolInt(ups, "default." + key); }
+	inline double        getDefaultDouble(const std::string & ups, const std::string & key)         const { return getDouble(ups, "default." + key); }
+
+	inline std::string   getOverrideStr(const std::string & ups, const std::string & key)           const { return getStr(ups, "override." + key); }
+	inline long long int getOverrideInt(const std::string & ups, const std::string & key)           const { return getInt(ups, "override." + key); }
+	inline long long int getOverrideIntHex(const std::string & ups, const std::string & key)        const { return getIntHex(ups, "override." + key); }
+	inline bool          getOverrideFlag(const std::string & ups, const std::string & key)          const { return getFlag(ups, "override." + key); }
+	inline bool          getOverrideBool(const std::string & ups, const std::string & key)          const { return getBool(ups, "override." + key); }
+	inline nut::BoolInt  getOverrideBoolInt(const std::string & ups, const std::string & key)       const { return getBoolInt(ups, "override." + key); }
+	inline double        getOverrideDouble(const std::string & ups, const std::string & key)        const { return getDouble(ups, "override." + key); }
+
+	inline void setDefaultStr(const std::string & ups, const std::string & key, const std::string & val)  { setStr(ups, "default." + key, val); }
+	inline void setDefaultInt(const std::string & ups, const std::string & key, long long int val)        { setInt(ups, "default." + key, val); }
+	inline void setDefaultIntHex(const std::string & ups, const std::string & key, long long int val)     { setIntHex(ups, "default." + key, val); }
+	inline void setDefaultFlag(const std::string & ups, const std::string & key)                          { setFlag(ups, "default." + key); }
+	inline void setDefaultBool(const std::string & ups, const std::string & key, bool val)                { setBool(ups, "default." + key, val); }
+	inline void setDefaultBoolInt(const std::string & ups, const std::string & key, nut::BoolInt val)     { setBoolInt(ups, "default." + key, val); }
+	inline void setDefaultDouble(const std::string & ups, const std::string & key, double val)            { setDouble(ups, "default." + key, val); }
+
+	inline void setOverrideStr(const std::string & ups, const std::string & key, const std::string & val) { setStr(ups, "override." + key, val); }
+	inline void setOverrideInt(const std::string & ups, const std::string & key, long long int val)       { setInt(ups, "override." + key, val); }
+	inline void setOverrideIntHex(const std::string & ups, const std::string & key, long long int val)    { setIntHex(ups, "override." + key, val); }
+	inline void setOverrideFlag(const std::string & ups, const std::string & key)                         { setFlag(ups, "override." + key); }
+	inline void setOverrideBool(const std::string & ups, const std::string & key, bool val)               { setBool(ups, "override." + key, val); }
+	inline void setOverrideBoolInt(const std::string & ups, const std::string & key, nut::BoolInt val)    { setBoolInt(ups, "override." + key, val); }
+	inline void setOverrideDouble(const std::string & ups, const std::string & key, double val)           { setDouble(ups, "override." + key, val); }
+
 	/** UPS-specific configuration attributes getters and setters \{ */
 	inline std::string getDriver(const std::string & ups)              const { return getStr(ups, "driver"); }
 	inline std::string getDescription(const std::string & ups)         const { return getStr(ups, "desc"); }
@@ -1643,6 +1681,16 @@ public:
 	inline long long int getUPSdelayStart(const std::string & ups)     const { return getInt(ups, "ups.delay.start"); }     // CHECKME
 	inline long long int getVoltage(const std::string & ups)           const { return getInt(ups, "voltage"); }             // CHECKME
 	inline long long int getWait(const std::string & ups)              const { return getInt(ups, "wait"); }                // CHECKME
+
+	// May be a flag or a number; 0 is among valid values (default -1 for unset)
+	inline long long int getUsbSetAltInterface(const std::string & ups)          const { return getInt(ups, "usb_set_altinterface", -1); }      // CHECKME
+
+	// NUT specifies these as "hexnum" values (optionally with prefixed 0x but hex anyway)
+	inline long long int getUsbConfigIndex(const std::string & ups)              const { return getIntHex(ups, "usb_config_index"); }           // CHECKME
+	inline long long int getUsbHidDescIndex(const std::string & ups)             const { return getIntHex(ups, "usb_hid_desc_index"); }         // CHECKME
+	inline long long int getUsbHidRepIndex(const std::string & ups)              const { return getIntHex(ups, "usb_hid_rep_index"); }          // CHECKME
+	inline long long int getUsbHidEndpointIn(const std::string & ups)            const { return getIntHex(ups, "usb_hid_ep_in"); }              // CHECKME
+	inline long long int getUsbHidEndpointOut(const std::string & ups)           const { return getIntHex(ups, "usb_hid_ep_out"); }             // CHECKME
 
 	// Flag - if exists then "true"
 	inline bool getIgnoreLB(const std::string & ups)       const { return getFlag(ups, "ignorelb"); }
@@ -1767,6 +1815,16 @@ public:
 	inline void setVoltage(const std::string & ups, long long int voltage)         { setInt(ups, "voltage",            voltage); }      // CHECKME
 	inline void setWait(const std::string & ups, long long int wait)               { setInt(ups, "wait",               wait); }         // CHECKME
 
+	// May be a flag or a number; 0 is among valid values (default -1 for unset)
+	inline void setUsbSetAltInterface(const std::string & ups, long long int val = 0)       { setInt(ups, "usb_set_altinterface",              val); }         // CHECKME
+
+	// NUT specifies these as "hexnum" values (optionally with prefixed 0x but hex anyway)
+	inline void setUsbConfigIndex(const std::string & ups, long long int val)               { setIntHex(ups, "usb_config_index",               val); }         // CHECKME
+	inline void setUsbHidDescIndex(const std::string & ups, long long int val)              { setIntHex(ups, "usb_hid_desc_index",             val); }         // CHECKME
+	inline void setUsbHidRepIndex(const std::string & ups, long long int val)               { setIntHex(ups, "usb_hid_rep_index",              val); }         // CHECKME
+	inline void setUsbHidEndpointIn(const std::string & ups, long long int val)             { setIntHex(ups, "usb_hid_ep_in",                  val); }         // CHECKME
+	inline void setUsbHidEndpointOut(const std::string & ups, long long int val)            { setIntHex(ups, "usb_hid_ep_out",                 val); }         // CHECKME
+
 	// Flag - if exists then "true"; remove() to "unset" => "false"
 	inline void setIgnoreLB(const std::string & ups)                        { setFlag(ups, "ignorelb"); }
 
@@ -1791,13 +1849,6 @@ public:
 	inline void setSubscribe(const std::string & ups, bool set = true)      { setBool(ups, "subscribe",      set); }
 	inline void setUseCRLF(const std::string & ups, bool set = true)        { setBool(ups, "use_crlf",       set); }
 	inline void setUsePreLF(const std::string & ups, bool set = true)       { setBool(ups, "use_pre_lf",     set); }
-
-	// FIXME: What to do about "default.*" and "override.*"
-	// settings that apply to anything (vars!) that follows?
-	// Maybe nest the UpsConfiguration objects, and so query
-	// e.g. upscfg.default.getBatteryNominalVoltage() ?
-	// Or just keep that info in ConfigParamList per section
-	// and wrap free-style queries?
 
 	/** \} */
 

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -1868,7 +1868,7 @@ public:
 	inline void setWait(const std::string & ups, long long int wait)               { setInt(ups, "wait",               wait); }         // CHECKME
 
 	// May be a flag or a number; 0 is among valid values (default -1 for unset)
-	inline void setUsbSetAltInterface(const std::string & ups, long long int val = 0)       { setInt(ups, "usb_set_altinterface",              val); }         // CHECKME
+	inline void setUsbSetAltInterface(const std::string & ups, long long int val = 0)       { if (val >= 0) { setInt(ups, "usb_set_altinterface", val); } else { remove(ups, "usb_set_altinterface"); } }         // CHECKME
 
 	// NUT specifies these as "hexnum" values (optionally with prefixed 0x but hex anyway)
 	inline void setUsbConfigIndex(const std::string & ups, long long int val)               { setIntHex(ups, "usb_config_index",               val); }         // CHECKME

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -163,6 +163,33 @@ struct CertIdent
 	}
 };
 
+
+/**
+ * \brief	Certificate protected host structure for NUT
+ *
+ * Contains a host name, certificate name and option flags
+ */
+struct CertHost
+{
+	Settable<std::string> host, certName;
+	Settable<int> certVerify, forceSsl;
+
+	inline bool operator==(const CertHost& other)const
+	{
+		return certName == other.certName
+			&& host == other.host
+			&& certVerify == other.certVerify
+			&& forceSsl == other.forceSsl;
+	}
+
+	inline bool set()const
+	{
+		return certName.set() && host.set()
+			&& certVerify.set() && forceSsl.set();
+	}
+};
+
+
 /**
  * NUT config parser.
  */

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -908,6 +908,63 @@ protected:
 	}
 
 	/**
+	 *  \brief  Configuration flag getter
+	 *
+	 *  False is returned if the section or entry doesn't exist.
+	 *  If a flag exists in configuration (any value is ignored),
+	 *  it is effectively True.
+	 *
+	 *  \param  section  Section name
+	 *  \param  entry    Entry name
+	 *
+	 *  \return Configuration parameter as boolean
+	 */
+	bool getFlag(
+		const std::string & section,
+		const std::string & entry) const;
+
+	/**
+	 *  \brief  Global scope configuration flag getter
+	 *
+	 *  False is returned if the entry doesn't exist.
+	 *  If a flag exists in configuration (any value is ignored),
+	 *  it is effectively True.
+	 *
+	 *  \param  entry  Entry name
+	 *
+	 *  \return Configuration parameter as boolean
+	 */
+	inline bool getFlag(const std::string & entry) const
+	{
+		return getFlag("", entry);
+	}
+
+	/**
+	 *  \brief  Configuration flag setter (mentioned == true)
+	 *
+	 *  Note: to unset a flag, just use remove() method.
+	 *
+	 *  \param  section  Section name
+	 *  \param  entry    Entry name
+	 */
+	void setFlag(
+		const std::string & section,
+		const std::string & entry);
+
+	/**
+	 *  \brief  Global scope configuration flag setter (mentioned == true)
+	 *
+	 *  Note: to unset a flag, just use remove() method.
+	 *
+	 *  \param  entry    Entry name
+	 */
+	inline void setFlag(
+		const std::string & entry)
+	{
+		setFlag("", entry);
+	}
+
+	/**
 	 *  \brief  Configuration number getter
 	 *
 	 *  \param  section  Section name

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -942,26 +942,28 @@ protected:
 	/**
 	 *  \brief  Configuration flag setter (mentioned == true)
 	 *
-	 *  Note: to unset a flag, just use remove() method.
+	 *  Note: to unset a flag, we just use remove() method.
 	 *
 	 *  \param  section  Section name
 	 *  \param  entry    Entry name
 	 */
 	void setFlag(
 		const std::string & section,
-		const std::string & entry);
+		const std::string & entry,
+		bool                val = true);
 
 	/**
 	 *  \brief  Global scope configuration flag setter (mentioned == true)
 	 *
-	 *  Note: to unset a flag, just use remove() method.
+	 *  Note: to unset a flag, we just use remove() method.
 	 *
 	 *  \param  entry    Entry name
 	 */
 	inline void setFlag(
-		const std::string & entry)
+		const std::string & entry,
+		bool                val = true)
 	{
-		setFlag("", entry);
+		setFlag("", entry, val);
 	}
 
 	/**
@@ -1575,7 +1577,7 @@ public:
 	inline void setSynchronous(const std::string & val) { setStr("synchronous", val); }
 	inline void setUser(const std::string & user)       { setStr("user",       user); }
 
-	inline void setNoWait()                             { setFlag("nowait"); }
+	inline void setNoWait(bool val = true)              { setFlag("nowait",    val); }
 
 	inline void setDebugMin(long long int num)          { setInt("debug_min",     num); }
 	inline void setMaxRetry(long long int num)          { setInt("maxretry",      num); }
@@ -1618,7 +1620,7 @@ public:
 	inline void setDefaultStr(const std::string & ups, const std::string & key, const std::string & val)  { setStr(ups, "default." + key, val); }
 	inline void setDefaultInt(const std::string & ups, const std::string & key, long long int val)        { setInt(ups, "default." + key, val); }
 	inline void setDefaultIntHex(const std::string & ups, const std::string & key, long long int val)     { setIntHex(ups, "default." + key, val); }
-	inline void setDefaultFlag(const std::string & ups, const std::string & key)                          { setFlag(ups, "default." + key); }
+	inline void setDefaultFlag(const std::string & ups, const std::string & key, bool val = true)         { setFlag(ups, "default." + key, val); }
 	inline void setDefaultBool(const std::string & ups, const std::string & key, bool val)                { setBool(ups, "default." + key, val); }
 	inline void setDefaultBoolInt(const std::string & ups, const std::string & key, nut::BoolInt val)     { setBoolInt(ups, "default." + key, val); }
 	inline void setDefaultDouble(const std::string & ups, const std::string & key, double val)            { setDouble(ups, "default." + key, val); }
@@ -1626,7 +1628,7 @@ public:
 	inline void setOverrideStr(const std::string & ups, const std::string & key, const std::string & val) { setStr(ups, "override." + key, val); }
 	inline void setOverrideInt(const std::string & ups, const std::string & key, long long int val)       { setInt(ups, "override." + key, val); }
 	inline void setOverrideIntHex(const std::string & ups, const std::string & key, long long int val)    { setIntHex(ups, "override." + key, val); }
-	inline void setOverrideFlag(const std::string & ups, const std::string & key)                         { setFlag(ups, "override." + key); }
+	inline void setOverrideFlag(const std::string & ups, const std::string & key, bool val = true)        { setFlag(ups, "override." + key, val); }
 	inline void setOverrideBool(const std::string & ups, const std::string & key, bool val)               { setBool(ups, "override." + key, val); }
 	inline void setOverrideBoolInt(const std::string & ups, const std::string & key, nut::BoolInt val)    { setBoolInt(ups, "override." + key, val); }
 	inline void setOverrideDouble(const std::string & ups, const std::string & key, double val)           { setDouble(ups, "override." + key, val); }
@@ -1878,7 +1880,7 @@ public:
 	inline void setUsbHidEndpointOut(const std::string & ups, long long int val)            { setIntHex(ups, "usb_hid_ep_out",                 val); }         // CHECKME
 
 	// Flag - if exists then "true"; remove() to "unset" => "false"
-	inline void setIgnoreLB(const std::string & ups)                        { setFlag(ups, "ignorelb"); }
+	inline void setIgnoreLB(const std::string & ups, bool val = true)       { setFlag(ups, "ignorelb", val); }
 
 	inline void setNolock(const std::string & ups, bool set = true)         { setBool(ups, "nolock",         set); }
 	inline void setCable(const std::string & ups, bool set = true)          { setBool(ups, "cable",          set); }

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -144,6 +144,26 @@ public:
 
 
 /**
+ * \brief	Certificate Identification structure for NUT
+ *
+ * Contains a certificate name and database password
+ */
+struct CertIdent
+{
+	Settable<std::string> certName, certDbPass;
+
+	inline bool operator==(const CertIdent& ident)const
+	{
+		return certName == ident.certName && certDbPass == ident.certDbPass;
+	}
+
+	inline bool set()const
+	{
+		return certName.set() && certDbPass.set();
+	}
+};
+
+/**
  * NUT config parser.
  */
 class NutParser

--- a/include/nutwriter.hpp
+++ b/include/nutwriter.hpp
@@ -127,7 +127,7 @@ class NutWriter {
 
 
 /**
- *  \brief  NUT configuration writer interface
+ *  \brief  NUT configuration writer interface (generic)
  */
 class NutConfigWriter: public NutWriter {
 	protected:

--- a/scripts/augeas/Makefile.am
+++ b/scripts/augeas/Makefile.am
@@ -29,9 +29,10 @@ if HAVE_AUGPARSE
 check-local:
 	@echo "augparse proceeding to lenses verification job..."; \
 	echo "DISABLED for now due to https://github.com/networkupstools/nut/issues/657"
-endif
+
 # FIXME
 #	augparse -I $(srcdir)/ $(srcdir)/tests/test_nut.aug
+endif
 
 if WITH_AUGLENS
 # Now "make install" should cover delivery of Augeas lenses...

--- a/scripts/augeas/Makefile.am
+++ b/scripts/augeas/Makefile.am
@@ -28,7 +28,17 @@ dist-hook:
 if HAVE_AUGPARSE
 check-local:
 	@echo "augparse proceeding to lenses verification job..."; \
+	 echo "DISABLED for now due to https://github.com/networkupstools/nut/issues/657 -" ; \
+	 echo "as a developer, you can run the tests below manually but not automatically:" ; \
+	 echo "    $(AUGPARSE) -I $(srcdir)/ $(srcdir)/tests/test_nut.aug" ; \
+	 echo "or 'make check-augeas' or 'make check-augeas-all' in `pwd`"
+
+check-augeas:
 	$(AUGPARSE) -I $(srcdir)/ $(srcdir)/tests/test_nut.aug
+
+check-augeas-all: check-augeas
+	$(AUGPARSE) -I $(srcdir)/ $(srcdir)/tests/test_nut_flaky.aug
+	$(AUGPARSE) -I $(srcdir)/ $(srcdir)/tests/test_nut_fixme.aug
 endif
 
 if WITH_AUGLENS

--- a/scripts/augeas/Makefile.am
+++ b/scripts/augeas/Makefile.am
@@ -28,10 +28,7 @@ dist-hook:
 if HAVE_AUGPARSE
 check-local:
 	@echo "augparse proceeding to lenses verification job..."; \
-	echo "DISABLED for now due to https://github.com/networkupstools/nut/issues/657"
-
-# FIXME
-#	augparse -I $(srcdir)/ $(srcdir)/tests/test_nut.aug
+	$(AUGPARSE) -I $(srcdir)/ $(srcdir)/tests/test_nut.aug
 endif
 
 if WITH_AUGLENS

--- a/scripts/augeas/gen-nutupsconf-aug.py.in
+++ b/scripts/augeas/gen-nutupsconf-aug.py.in
@@ -1,5 +1,7 @@
 #!@PYTHON@
-#   Copyright (C) 2010 - Arnaud Quette <arnaud.quette@gmail.com>
+#   Copyright (C)
+#     2010 -        Arnaud Quette <arnaud.quette@gmail.com>
+#     2020 - 2024   Jim Klimov <jimklimov+nut@gmail.com>
 #
 #   This program is free software; you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by

--- a/scripts/augeas/nutnutconf.aug.in
+++ b/scripts/augeas/nutnutconf.aug.in
@@ -3,6 +3,7 @@ Module: NutNutConf
  Parses @CONFPATH@/nut.conf
 
 Author: Frederic Bohe  <fredericbohe@eaton.com>
+        Jim Klimov     <jimklimov+nut@gmail.com>
 
 About: License
   This file is licensed under the GPL.
@@ -32,15 +33,48 @@ let eol      = Util.eol
 let comment  = Util.comment
 let empty    = Util.empty
 
+(* note different definitions than in other configs - this one is shell-syntax *)
+let bool     = /true|false|"true"|"false"|'true'|'false'/
+let num      = /[0-9]+|"[0-9]+"|'[0-9]+'/
+let num_signed      = /[+-]?[0-9]+|"[+-]?[0-9]+"|'[+-]?[0-9]+'/
+let word     = /[^"#; \t\n]+/
+
+(* Variable: quoted_word *)
+let word_space  = /"[^"\n]+"/
+let quoted_word = /"[^" \t\n]+"|'[^' \t\n]+'/
+
+(* Variable: word_all *)
+let word_all = word_space | word | quoted_word
 
 let nut_possible_mode = "none"
 			| "standalone"
 			| "netserver"
 			| "netclient"
+			| "controlled"
+			| "manual"
 
 let nut_mode = [ sep_spc . key "MODE" . def_sep . sep_spc . store nut_possible_mode . eol ]
 
-let nut_lns  = (nut_mode|comment|empty)*
+let nut_bool_re = "ALLOW_NO_DEVICE"
+                  | "ALLOW_NOT_ALL_LISTENERS"
+                  | "POWEROFF_QUIET"
+
+let nut_bool          = [ sep_spc . key nut_bool_re . def_sep . sep_spc . store bool . eol ]
+
+let nut_num_re = "POWEROFF_WAIT"
+
+let nut_num          = [ sep_spc . key nut_num_re . def_sep . sep_spc . store num . eol ]
+
+let nut_num_signed_re = "NUT_DEBUG_LEVEL"
+
+let nut_num_signed          = [ sep_spc . key nut_num_signed_re . def_sep . sep_spc . store num_signed . eol ]
+
+let nut_word_all_re = "UPSD_OPTIONS"
+                  | "UPSMON_OPTIONS"
+
+let nut_word_all          = [ sep_spc . key nut_word_all_re . def_sep . sep_spc . store word_all . eol ]
+
+let nut_lns  = (nut_mode|nut_bool|nut_num|nut_num_signed|nut_word_all|comment|empty)*
 
 let nut_filter = ( incl "@CONFPATH@/nut.conf" )
 			. Util.stdexcl

--- a/scripts/augeas/nutupsconf.aug.tpl
+++ b/scripts/augeas/nutupsconf.aug.tpl
@@ -4,7 +4,8 @@ Module: NutUpsConf
 
 Author: Raphael Pinson <raphink@gmail.com>
         Frederic Bohe  <fredericbohe@eaton.com>
-        Arnaud Quette <arnaud.quette@gmail.com>
+        Arnaud Quette  <arnaud.quette@gmail.com>
+        Jim Klimov     <jimklimov+nut@gmail.com>
 
 About: License
   This file is licensed under the GPL.
@@ -34,10 +35,13 @@ let ups_global   = "chroot"
                  | "driverpath"
                  | "maxstartdelay"
                  | "maxretry"
+                 | "nowait"
                  | "retrydelay"
                  | "pollinterval"
                  | "synchronous"
                  | "user"
+                 | "group"
+                 | "debug_min"
 
 let ups_fields   = "driver"
                  | "port"
@@ -47,6 +51,11 @@ let ups_fields   = "driver"
                  | "ignorelb"
                  | "maxstartdelay"
                  | "synchronous"
+                 | "user"
+                 | "group"
+                 | "debug_min"
+                 | "default\.[^ \t]+"
+                 | "override\.[^ \t]+"
 @SPECIFIC_DRV_VARS@
 
 let ups_entry    = IniFile.indented_entry (ups_global|ups_fields) ups_sep ups_comment

--- a/scripts/augeas/nutupsconf.aug.tpl
+++ b/scripts/augeas/nutupsconf.aug.tpl
@@ -44,7 +44,7 @@ let ups_global   = "chroot"
                  | "debug_min"
 
 (* This expression did involve a lot of courtship around the parser *)
-let ups_fields_re = /(default|override)\.[^:=#\t\n\r ]+/
+let ups_fields_re = /(default|override)\.[^:=#\r\t\n ]+/
 
 let ups_fields   = "driver"
                  | "port"

--- a/scripts/augeas/nutupsconf.aug.tpl
+++ b/scripts/augeas/nutupsconf.aug.tpl
@@ -44,7 +44,7 @@ let ups_global   = "chroot"
                  | "debug_min"
 
 (* This expression did involve a lot of courtship around the parser *)
-let ups_fields_re = /(default|override)\.[^:=#\r\t\n ]+/
+let ups_fields_re = /(default|override)\.[^:=#\r\t\n \/]+/
 
 let ups_fields   = "driver"
                  | "port"

--- a/scripts/augeas/nutupsconf.aug.tpl
+++ b/scripts/augeas/nutupsconf.aug.tpl
@@ -43,6 +43,9 @@ let ups_global   = "chroot"
                  | "group"
                  | "debug_min"
 
+(* This expression did involve a lot of courtship around the parser *)
+let ups_fields_re = /(default|override)\.[^:=#\t\n\r ]+/
+
 let ups_fields   = "driver"
                  | "port"
                  | "sdorder"
@@ -54,11 +57,9 @@ let ups_fields   = "driver"
                  | "user"
                  | "group"
                  | "debug_min"
-                 | "default\.[^ \t]+"
-                 | "override\.[^ \t]+"
 @SPECIFIC_DRV_VARS@
 
-let ups_entry    = IniFile.indented_entry (ups_global|ups_fields) ups_sep ups_comment
+let ups_entry    = IniFile.indented_entry (ups_global|ups_fields|ups_fields_re) ups_sep ups_comment
 
 let ups_title    = IniFile.indented_title IniFile.record_re
 

--- a/scripts/augeas/nutupsdconf.aug.in
+++ b/scripts/augeas/nutupsdconf.aug.in
@@ -4,7 +4,8 @@ Module: NutUpsdConf
 
 Author: Raphael Pinson <raphink@gmail.com>
         Frederic Bohe  <fredericbohe@eaton.com>
-        Arnaud Quette <arnaud.quette@gmail.com>
+        Arnaud Quette  <arnaud.quette@gmail.com>
+        Jim Klimov     <jimklimov+nut@gmail.com>
 
 About: License
   This file is licensed under the GPL.
@@ -37,24 +38,36 @@ let word     = /[^"#; \t\n]+/
 let empty    = Util.empty
 let comment  = Util.comment
 let path     = word
+(* TOTHINK: What if we have spaces? Is "word" good? *)
+let certname = word
+let dbpass   = word
 
+let upsd_debug_min = [ opt_spc . key "DEBUG_MIN" . sep_spc . store num  . eol ]
 let upsd_maxage    = [ opt_spc . key "MAXAGE"    . sep_spc . store num  . eol ]
 let upsd_trackingdelay = [ opt_spc . key "TRACKINGDELAY"    . sep_spc . store num  . eol ]
 let upsd_allow_no_device = [ opt_spc . key "ALLOW_NO_DEVICE"    . sep_spc . store num  . eol ]
 let upsd_allow_not_all_listeners = [ opt_spc . key "ALLOW_NOT_ALL_LISTENERS"    . sep_spc . store num  . eol ]
+let upsd_disable_weak_ssl = [ opt_spc . key "DISABLE_WEAK_SSL"    . sep_spc . store num  . eol ]
 let upsd_statepath = [ opt_spc . key "STATEPATH" . sep_spc . store path . eol ]
 let upsd_listen    = [ opt_spc . key "LISTEN"    . sep_spc 
                           . [ label "interface" . store ip ]
                           . [ sep_spc . label "port" . store num]? ]
 let upsd_listen_list = upsd_listen . eol 
-let upsd_maxconn  = [ opt_spc . key "MAXCONN"    . sep_spc . store num  . eol ]
+let upsd_maxconn  = [ opt_spc . key "MAXCONN"  . sep_spc . store num  . eol ]
 let upsd_certfile = [ opt_spc . key "CERTFILE" . sep_spc . store path . eol ]
+let upsd_certpath = [ opt_spc . key "CERTPATH" . sep_spc . store path . eol ]
+let upsd_certident = [ opt_spc . key "CERTIDENT" . sep_spc
+                          . [ label "certname" . store certname ]
+                          . [ sep_spc . label "dbpass" . store dbpass ] . eol ]
+let upsd_certrequest = [ opt_spc . key "CERTREQUEST"    . sep_spc . store num  . eol ]
 
 (************************************************************************
+ * DEBUG_MIN level
  * MAXAGE seconds
  * TRACKINGDELAY seconds
  * ALLOW_NO_DEVICE Boolean
  * ALLOW_NOT_ALL_LISTENERS Boolean
+ * DISABLE_WEAK_SSL Boolean
  * STATEPATH path
  * LISTEN interface port
  *    Multiple lines each with one LISTEN address (or host name) and an optional
@@ -65,9 +78,23 @@ let upsd_certfile = [ opt_spc . key "CERTFILE" . sep_spc . store path . eol ]
  *    LISTEN 192.168.50.1
  *    LISTEN ::1
  *    LISTEN 2001:0db8:1234:08d3:1319:8a2e:0370:7344
+ * MAXCONN count
+ * CERTFILE path
+ *    Single certificate file (SSL with OpenSSL)
+ * CERTPATH path
+ *    Path to certificate database split into 3 files (SSL with NSS)
+ * CERTIDENT certname dbpass
+ *    Certificate identity to use by the server, and database password
+ *    as needed to read it (SSL with NSS)
+ * CERTREQUEST level
+ *    Request or require client cert? (SSL with NSS)
+ *    Possible values are :
+ *    - 0 to not request to clients to provide any certificate
+ *    - 1 to require to all clients a certificate
+ *    - 2 to require to all clients a valid certificate
  *
  *************************************************************************)
-let upsd_other  =  upsd_maxage | upsd_trackingdelay | upsd_allow_no_device | upsd_allow_not_all_listeners | upsd_statepath | upsd_listen_list | upsd_maxconn | upsd_certfile
+let upsd_other  =  upsd_debug_min | upsd_maxage | upsd_trackingdelay | upsd_allow_no_device | upsd_allow_not_all_listeners | upsd_disable_weak_ssl | upsd_statepath | upsd_listen_list | upsd_maxconn | upsd_certfile | upsd_certpath | upsd_certident | upsd_certrequest
 
 let upsd_lns    = (upsd_other|comment|empty)*
 

--- a/scripts/augeas/nutupsdusers.aug.in
+++ b/scripts/augeas/nutupsdusers.aug.in
@@ -4,6 +4,7 @@ Module: NutUpsdUsers
 
 Author: Raphael Pinson <raphink@gmail.com>
         Frederic Bohe  <fredericbohe@eaton.com>
+        Jim Klimov     <jimklimov+nut@gmail.com>
 
 About: License
   This file is licensed under the GPL.
@@ -65,9 +66,11 @@ let upsd_users_instcmds   = [ del_spc
                                . ( sep_spc . upsd_users_instcmds_entry )* 
                                . ( upsd_users_comment|eol ) ]
 
+let upsd_users_upsmon_type_re     = /(master|primary|slave|secondary)/
+
 let upsd_users_upsmon    = [ del_spc
                                . key "upsmon" . sep_spc
-                               . store /master|primary|slave|secondary/ . eol ]
+                               . store upsd_users_upsmon_type_re . eol ]
 
 let upsd_users_title    = IniFile.indented_title IniFile.record_re
 

--- a/scripts/augeas/nutupsmonconf.aug.in
+++ b/scripts/augeas/nutupsmonconf.aug.in
@@ -4,6 +4,7 @@ Module: NutUpsmonConf
 
 Author: Raphael Pinson <raphink@gmail.com>
         Frederic Bohe  <fredericbohe@eaton.com>
+        Jim Klimov     <jimklimov+nut@gmail.com>
 
 About: License
   This file is licensed under the GPL.
@@ -31,6 +32,9 @@ let del_spc  = Util.del_opt_ws ""
 let sep_spc  = Util.del_ws_spc
 let eol      = Util.eol
 let num      = /[0-9]+/
+let num_signed = /[+-]?[0-9]+/
+let bool      = /([01]|yes|no|true|false|on|off|ok)/
+let num_bool  = /([0-9]+|yes|no|true|false|on|off|ok)/
 let word     = /[^"#; \t\n]+/
 let empty    = Util.empty
 let comment  = Util.comment
@@ -42,6 +46,8 @@ let quoted_string = del "\"" "\"" . store /[^"\n]+/ . del "\"" "\""
  * There might be a cleaner way to write this
  *  but I'm stuck with (hostname | hostname . port)?
  *)
+(* Disregard named ports, we use numbers *)
+let hostspec   = /([^ \t\n:]+|[^ \t\n:]+:[0-9]+)/
 let hostname   = [ label "hostname" . store /[^ \t\n:]+/ ]
 let port       = [ label "port"     . store num ]
 let identifier = [ label "upsname" . store /[^ \t\n@]+/ ]
@@ -59,27 +65,48 @@ let upsmon_num_re = "DEADTIME"
                   | "POLLFREQALERT"
                   | "RBWARNTIME"
 
+let upsmon_num_signed_re = "DEBUG_MIN"
+                  | "POLLFAIL_LOG_THROTTLE_MAX"
+                  | "OFFDURATION"
+                  | "OBLBDURATION"
+
+let upsmon_num_bool_re = "SHUTDOWNEXIT"
+
+let upsmon_bool_re = "CERTVERIFY"
+                  | "FORCESSL"
+
 let upsmon_num    = [ del_spc . key upsmon_num_re . sep_spc . store num . eol ]
+
+let upsmon_num_signed    = [ del_spc . key upsmon_num_signed_re . sep_spc . store num_signed . eol ]
+
+let upsmon_num_bool      = [ del_spc . key upsmon_num_bool_re . sep_spc . store num_bool . eol ]
+
+let upsmon_bool          = [ del_spc . key upsmon_bool_re . sep_spc . store bool . eol ]
 
 let upsmon_word   = [ del_spc . key "RUN_AS_USER" . sep_spc . store word . eol ]
 
 let upsmon_file_re = "NOTIFYCMD"
                   | "POWERDOWNFLAG"
                   | "SHUTDOWNCMD"
+                  | "CERTFILE"
+                  | "CERTPATH"
 
 let sto_to_eol = IniFile.sto_to_eol
-(* here we should support both quoted and not quotted
+(* here we should support both quoted and not quoted
  * string but I can't manage to find the right way of doing this
  *)
 let upsmon_file   = [ del_spc . key upsmon_file_re . sto_to_eol . eol ]
 
 (* MONITOR system powervalue username password type *)
+let upsmon_monitor_type_re     = /(master|primary|slave|secondary)/
+
+(* TOTHINK: What if we have spaces? Is "word" good? *)
 let upsmon_monitor = [ del_spc . key "MONITOR" . sep_spc
                          . [ label "system"     . identifier ] . sep_spc
                          . [ label "powervalue" . store num  ] . sep_spc
                          . [ label "username"   . store word ] . sep_spc
                          . [ label "password"   . store word ] . sep_spc
-                         . [ label "type"       . store word ] . eol  ]
+                         . [ label "type"       . store upsmon_monitor_type_re ] . eol  ]
 
 let upsmon_notify_type = "ONLINE"
 			| "ONBATT"
@@ -101,7 +128,7 @@ let upsmon_notify = [ del_spc . key "NOTIFYMSG" . sep_spc
                          . [ label "type" . store upsmon_notify_type . sep_spc ]
                          . [ label "message" . quoted_string ] . eol ]
 
- let flags = "IGNORE"
+let flags = "IGNORE"
 		| "SYSLOG"
 		| "WALL"
 		| "EXEC"
@@ -117,7 +144,23 @@ let upsmon_notify_flag = [ counter "record"
 			. [ label "type" . store upsmon_notify_type . sep_spc ]
 			. record+ . eol ]
 
-let upsmon_record = upsmon_num|upsmon_word|upsmon_file|upsmon_monitor|upsmon_notify|upsmon_notify_flag
+(* TOTHINK: What if we have spaces? Is "word" good? *)
+let certname = word
+let dbpass   = word
+let upsmon_certident = [ del_spc . key "CERTIDENT" . sep_spc
+                          . [ label "certname" . store certname ]
+                          . [ sep_spc . label "dbpass" . store dbpass ] . eol ]
+
+(* we can have an array of these *)
+let upsmon_certhost = [ del_spc . key "CERTHOST" . sep_spc
+                          . [ label "hostspec" . store hostspec ]
+                          . [ sep_spc . label "certname" . store certname ]
+                          . [ sep_spc . label "certverify" . store num_bool ]
+                          . [ sep_spc . label "forcessl" . store num_bool ] . eol ]
+
+let upsmon_certhost_list = upsmon_certhost . eol
+
+let upsmon_record = upsmon_num|upsmon_num_signed|upsmon_num_bool|upsmon_bool|upsmon_word|upsmon_file|upsmon_monitor|upsmon_notify|upsmon_notify_flag|upsmon_certident|upsmon_certhost_list
 
 let upsmon_lns    = (upsmon_record|comment|empty)*
 

--- a/scripts/augeas/tests/test_nut.aug
+++ b/scripts/augeas/tests/test_nut.aug
@@ -33,7 +33,7 @@ let ups_conf2 = "
 [testups]
 	driver = dummy-ups
 	port = auto
-	desc = \"\\\"Dummy UPS\"
+	desc = \"\\\"Dummy UPS\" # comment line
 "
 
 test NutUpsConf.ups_lns get ups_conf2 =
@@ -41,7 +41,10 @@ test NutUpsConf.ups_lns get ups_conf2 =
 	{ "testups"
 		{ "driver" = "dummy-ups"   }
 		{ "port"   = "auto" }
-		{ "desc"   = "\\\"Dummy UPS"    } }
+		{ "desc"   = "\\\"Dummy UPS"
+			{ "#comment" = "comment line" }
+		}
+	}
 
 (* desc is a single token made of two words surrounded by quotes
  * as part of its content below (escaped by backslashes) *)

--- a/scripts/augeas/tests/test_nut.aug
+++ b/scripts/augeas/tests/test_nut.aug
@@ -16,7 +16,6 @@ let ups_conf1 = "
 	driver = dummy-ups
 	port = auto
 	desc = \"Dummy UPS Driver\"
-	default.battery.voltage.high = 28.8
 "
 
 test NutUpsConf.ups_lns get ups_conf1 =
@@ -24,8 +23,7 @@ test NutUpsConf.ups_lns get ups_conf1 =
 	{ "testups"
 		{ "driver" = "dummy-ups"   }
 		{ "port"   = "auto" }
-		{ "desc"   = "Dummy UPS Driver"    }
-		{ "default.battery.voltage.high" = "28.8" } }
+		{ "desc"   = "Dummy UPS Driver"    } }
 
 (* desc is a single token made of two words prefixed by one quote
  * as part of its content below (escaped by backslashes) *)

--- a/scripts/augeas/tests/test_nut.aug
+++ b/scripts/augeas/tests/test_nut.aug
@@ -15,7 +15,8 @@ let ups_conf1 = "
 [testups]
 	driver = dummy-ups
 	port = auto
-	desc = \"Dummy UPS\"
+	desc = \"Dummy UPS Driver\"
+	default.battery.voltage.high = 28.8
 "
 
 test NutUpsConf.ups_lns get ups_conf1 =
@@ -23,7 +24,8 @@ test NutUpsConf.ups_lns get ups_conf1 =
 	{ "testups"
 		{ "driver" = "dummy-ups"   }
 		{ "port"   = "auto" }
-		{ "desc"   = "Dummy UPS"    } }
+		{ "desc"   = "Dummy UPS Driver"    }
+		{ "default.battery.voltage.high" = "28.8" } }
 
 (* desc is a single token made of two words prefixed by one quote
  * as part of its content below (escaped by backslashes) *)

--- a/scripts/augeas/tests/test_nut.aug
+++ b/scripts/augeas/tests/test_nut.aug
@@ -10,19 +10,66 @@ test NutNutConf.nut_lns get nut_conf =
 	{ }
 	{ "MODE" = "standalone" }
 
-let ups_conf  = "
+(* desc is a single token made of two words below *)
+let ups_conf1 = "
 [testups]
 	driver = dummy-ups
 	port = auto
 	desc = \"Dummy UPS\"
 "
 
-test NutUpsConf.ups_lns get ups_conf = 
+test NutUpsConf.ups_lns get ups_conf1 =
 	{ }
-	{ "testups" 
+	{ "testups"
 		{ "driver" = "dummy-ups"   }
 		{ "port"   = "auto" }
-		{ "desc"   = "\"Dummy UPS\""    } }
+		{ "desc"   = "Dummy UPS"    } }
+
+(* desc is a single token made of two words prefixed by one quote
+ * as part of its content below (escaped by backslashes) *)
+let ups_conf2 = "
+[testups]
+	driver = dummy-ups
+	port = auto
+	desc = \"\\\"Dummy UPS\"
+"
+
+test NutUpsConf.ups_lns get ups_conf2 =
+	{ }
+	{ "testups"
+		{ "driver" = "dummy-ups"   }
+		{ "port"   = "auto" }
+		{ "desc"   = "\\\"Dummy UPS"    } }
+
+(* desc is a single token made of two words surrounded by quotes
+ * as part of its content below (escaped by backslashes) *)
+(* FIXME: Lens fails to parse the second escaped slash,
+ *        test below is truncated so far:
+ * ./tests/test_nut.aug:53.0-58.41:exception thrown in test
+ * ./tests/test_nut.aug:53.5-.37:exception: Get did not match entire input
+ *     Lens: /usr/share/augeas/lenses/dist/inifile.aug:497.25-.43:
+ *     Error encountered at 5:0 (44 characters into string)
+ *     <er = dummy-ups\n\tport = auto\n|=|\tdesc = "\"Dummy UPS\""\n>
+ *
+ *     Tree generated so far:
+ *     /testups
+ * /testups/driver = "dummy-ups"
+ * /testups/port = "auto"
+ *)
+let ups_conf3 = "
+[testups]
+	driver = dummy-ups
+	port = auto
+	desc = \"\\\"Dummy UPS\\\"
+"
+
+test NutUpsConf.ups_lns get ups_conf3 =
+	{ }
+	{ "testups"
+		{ "driver" = "dummy-ups"   }
+		{ "port"   = "auto" }
+		{ "desc"   = "\\\"Dummy UPS\\"    } }
+
 
 
 let upsd_conf = "

--- a/scripts/augeas/tests/test_nut.aug
+++ b/scripts/augeas/tests/test_nut.aug
@@ -61,6 +61,11 @@ test NutUpsConf.ups_lns get ups_conf2 =
  *     /testups
  * /testups/driver = "dummy-ups"
  * /testups/port = "auto"
+ *
+ * NOTE That for NUT parsing, such trailing slash is likely a problem
+ * that is not caught by lens parser either: it should mean escaping
+ * the next character (quote) and so an unfinished line. This test case
+ * should have failed but currently does not.
  *)
 let ups_conf3 = "
 [testups]

--- a/scripts/augeas/tests/test_nut.aug
+++ b/scripts/augeas/tests/test_nut.aug
@@ -48,7 +48,8 @@ test NutUpsConf.ups_lns get ups_conf2 =
 
 (* desc is a single token made of two words surrounded by quotes
  * as part of its content below (escaped by backslashes) *)
-(* FIXME: Lens fails to parse the second escaped slash,
+(* FIXME: Lens fails to parse the second escaped slash, probably
+ *        because of "to_comment_re" or "entry_generic_nocomment"
  *        test below is truncated so far:
  * ./tests/test_nut.aug:53.0-58.41:exception thrown in test
  * ./tests/test_nut.aug:53.5-.37:exception: Get did not match entire input

--- a/scripts/augeas/tests/test_nut_fixme.aug
+++ b/scripts/augeas/tests/test_nut_fixme.aug
@@ -1,0 +1,50 @@
+(* Tests for the Nut module *)
+(* FIXME: More development is needed in NUT lens definitions for corner cases
+ * e.g. with multiple quote characters in a line, whether escaped or not.
+ * :; ./gen-nutupsconf-aug.py ; make ; augparse --trace -I ./ ./tests/test_nut_fixme.aug && echo PASSED
+ *)
+
+module Test_nut_fixme =
+
+(* desc is a single token made of two words surrounded by quotes
+ * as part of its content below (escaped by backslashes - literally
+ * a "backslash-doublequote-Dummy-doublequote-backslash" spelling)
+ *)
+let ups_conf3 = "
+[testups]
+	driver = dummy-ups
+	port = auto
+	desc = \"A \\\"Dummy\\\" UPS\"
+"
+
+test NutUpsConf.ups_lns get ups_conf3 =
+	{ }
+	{ "testups"
+		{ "driver" = "dummy-ups"   }
+		{ "port"   = "auto" }
+		{ "desc"   = "A \\\"Dummy\\\" UPS"    } }
+
+
+
+let upsd_conf = "
+MAXAGE 30
+TRACKINGDELAY 600
+ALLOW_NO_DEVICE 1
+LISTEN 0.0.0.0 3493
+MAXCONN 1024
+CERTIDENT \"My Server Cert\" \"Db Pass Phr@se\"
+"
+
+test NutUpsdConf.upsd_lns get upsd_conf = 
+	{ }
+	{ "MAXAGE"      = "30" }
+	{ "TRACKINGDELAY" = "600" }
+	{ "ALLOW_NO_DEVICE" = "1" }
+	{ "LISTEN"
+		{ "interface" = "0.0.0.0" }
+		{ "port"     = "3493"     } }
+	{ "MAXCONN"      = "1024" }
+	{ "CERTIDENT"
+		{ "certname"   = "My Server Cert" }
+		{ "dbpass"     = "Db Pass Phr@se" } }
+

--- a/scripts/augeas/tests/test_nut_flaky.aug
+++ b/scripts/augeas/tests/test_nut_flaky.aug
@@ -1,0 +1,27 @@
+(* Tests below pass on some systems and/or augeas versions and fail on others.
+ * Sometimes it involves same formal release with different packaging.
+ * For peace of mind, these are not currently added to common "test_nut"
+ * which is expected to pass everywhere.
+ *)
+
+module Test_nut_flaky =
+
+(* desc is a single token made of two words below
+ * encountering the "default..." line seems troublesome
+ * for some versions of augtools regardless of line position
+ *)
+let ups_conf1 = "
+[testups]
+	driver = dummy-ups
+	port = auto
+	desc = \"Dummy UPS Driver\"
+	default.battery.voltage.high = 28.8
+"
+
+test NutUpsConf.ups_lns get ups_conf1 =
+	{ }
+	{ "testups"
+		{ "driver" = "dummy-ups"   }
+		{ "port"   = "auto" }
+		{ "desc"   = "Dummy UPS Driver"    }
+		{ "default.battery.voltage.high" = "28.8" } }

--- a/tests/nutconf_parser_ut.cpp
+++ b/tests/nutconf_parser_ut.cpp
@@ -34,6 +34,10 @@ using namespace nut;
 #include <algorithm>
 using namespace std;
 
+extern "C" {
+	extern bool verbose;
+}
+
 class NutConfTest : public CppUnit::TestFixture
 {
 	CPPUNIT_TEST_SUITE( NutConfTest );
@@ -274,6 +278,36 @@ void NutConfTest::testParseBoolInt()
 	CPPUNIT_ASSERT_THROW_MESSAGE("BoolInt assignment from invalid strings must throw exceptions",
 		(bi = "OFF"), std::invalid_argument);
 
+	// Not-strict comparisons: int or string 0/1 values are bools
+	std::string s;
+	bi << "true";
+	s = bi.toString();
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should get printed as expected string value", (s == "yes"));
+
+	bi << false;
+	s = bi.toString();
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should get printed as expected string value", (s == "no"));
+
+	bi << 1;
+	s = bi.toString();
+	if (verbose)
+		std::cerr << "Non-strict? " << bi.bool01 << " : numeric 1 "
+				<< "=> (string)'" << s << "' aka (ostream)'" << bi << "'"
+				<< std::endl;
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should get printed as expected string value (0/1 => bool)", (s == "yes"));
+
+	bi = 0;
+	s = bi.toString();
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should get printed as expected string value (0/1 => bool)", (s == "no"));
+
+	bi = "1";
+	s = bi.toString();
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should get printed as expected string value (0/1 => bool)", (s == "yes"));
+
+	bi = "0";
+	s = bi.toString();
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should get printed as expected string value (0/1 => bool)", (s == "no"));
+
 	bi.clear();
 	CPPUNIT_ASSERT_MESSAGE("BoolInt should be not 'set()' after 'clear()", !(bi.set()));
 }
@@ -416,6 +450,32 @@ void NutConfTest::testParseBoolIntStrict()
 	// Standard casing only
 	CPPUNIT_ASSERT_THROW_MESSAGE("BoolInt assignment from invalid strings must throw exceptions",
 		(bi = "OFF"), std::invalid_argument);
+
+	// Strict comparisons: int or string 0/1 values are int not bool
+	std::string s;
+	bi << "true";
+	s = bi.toString();
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should get printed as expected string value", (s == "yes"));
+
+	bi << false;
+	s = bi.toString();
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should get printed as expected string value", (s == "no"));
+
+	bi << 1;
+	s = bi.toString();
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should get printed as expected string value (0/1 => int)", (s == "1"));
+
+	bi = 0;
+	s = bi.toString();
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should get printed as expected string value (0/1 => int)", (s == "0"));
+
+	bi = "1";
+	s = bi.toString();
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should get printed as expected string value (0/1 => int)", (s == "1"));
+
+	bi << "0";
+	s = bi.toString();
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should get printed as expected string value (0/1 => int)", (s == "0"));
 
 	bi.clear();
 	CPPUNIT_ASSERT_MESSAGE("BoolInt should be not 'set()' after 'clear()", !(bi.set()));

--- a/tests/nutconf_parser_ut.cpp
+++ b/tests/nutconf_parser_ut.cpp
@@ -40,6 +40,7 @@ class NutConfTest : public CppUnit::TestFixture
 		CPPUNIT_TEST( testOptions );
 		CPPUNIT_TEST( testParseCHARS );
 		CPPUNIT_TEST( testParseSTRCHARS );
+		CPPUNIT_TEST( testParseBoolInt );
 		CPPUNIT_TEST( testParseToken );
 		CPPUNIT_TEST( testParseTokenWithoutColon );
 		CPPUNIT_TEST( testGenericConfigParser );
@@ -55,6 +56,7 @@ public:
 	void testOptions();
 	void testParseCHARS();
 	void testParseSTRCHARS();
+	void testParseBoolInt();
 	void testParseToken();
 	void testParseTokenWithoutColon();
 
@@ -138,6 +140,126 @@ void NutConfTest::testParseSTRCHARS()
         NutParser parse("To\\\"to");
         CPPUNIT_ASSERT_EQUAL_MESSAGE("Cannot find quoted-escaped string 'To\"to'", string("To\"to"), parse.parseSTRCHARS());
     }
+}
+
+void NutConfTest::testParseBoolInt()
+{
+	// NOTE: Can not use CPPUNIT_ASSERT_EQUAL() below, requires an assertEqual() method
+	BoolInt bi;
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be not 'set()' initially", !(bi.set()));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("Unassigned BoolInt should not be equal to an int",
+		CPPUNIT_ASSERT(bi == 0));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("Unassigned BoolInt should not be equal to an int",
+		CPPUNIT_ASSERT(bi == 1));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("Unassigned BoolInt should not be equal to a bool",
+		CPPUNIT_ASSERT(bi == true));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("Unassigned BoolInt should not be equal to a bool",
+		CPPUNIT_ASSERT(bi == false));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("Unassigned BoolInt should not be equal to a string",
+		CPPUNIT_ASSERT(bi == "2"));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("Unassigned BoolInt should not be equal to a string",
+		CPPUNIT_ASSERT(bi == "on"));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("Unassigned BoolInt should not be equal to a string",
+		CPPUNIT_ASSERT(bi == "no"));
+/*
+	// Actually not "must throw", just returns false for any comparisons - see above
+	CPPUNIT_ASSERT_THROW_MESSAGE("Unassigned BoolInt comparisons must throw exceptions (string)",
+		if (bi == "1")  {}, std::invalid_argument);
+	CPPUNIT_ASSERT_THROW_MESSAGE("Unassigned BoolInt comparisons must throw exceptions (int)",
+		if (bi == 1)    {}, std::invalid_argument);
+	CPPUNIT_ASSERT_THROW_MESSAGE("Unassigned BoolInt comparisons must throw exceptions (bool)",
+		if (bi == true) {}, std::invalid_argument);
+*/
+
+	bi = 42;
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be 'set()' after assignment from int", bi.set());
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the int", (bi == 42));
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the string value of int", (bi == "42"));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to another int",
+		CPPUNIT_ASSERT(bi == 2));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to a bool",
+		CPPUNIT_ASSERT(bi == true));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to a bool",
+		CPPUNIT_ASSERT(bi == false));
+
+	bi = true;
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be 'set()' after assignment from bool", bi.set());
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the bool", (bi == true));
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the int value of bool", (bi == 1));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to another bool",
+		CPPUNIT_ASSERT(bi == false));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to int value of another bool",
+		CPPUNIT_ASSERT(bi == 0));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to another int",
+		CPPUNIT_ASSERT(bi == 2));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to old int",
+		CPPUNIT_ASSERT(bi == 42));
+
+	bi = false;
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be 'set()' after assignment from bool", bi.set());
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the bool", (bi == false));
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the int value of bool", (bi == 0));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to another bool",
+		CPPUNIT_ASSERT(bi == true));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to int value of another bool",
+		CPPUNIT_ASSERT(bi == 1));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to another int",
+		CPPUNIT_ASSERT(bi == 2));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to old int",
+		CPPUNIT_ASSERT(bi == 42));
+
+	bi = "-1";
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be 'set()' after assignment from string", bi.set());
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the int", (bi == -1));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to another int",
+		CPPUNIT_ASSERT(bi == 2));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to a bool",
+		CPPUNIT_ASSERT(bi == true));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to a bool",
+		CPPUNIT_ASSERT(bi == false));
+
+	bi = "off";
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be 'set()' after assignment from string", bi.set());
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the bool", (bi == false));
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the int value of bool", (bi == 0));
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the string value of bool", (bi == "off"));
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the string value of bool", (bi == "false"));
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the string value of bool", (bi == "0"));
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the string value of bool", (bi == "no"));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to the string value of another bool",
+		CPPUNIT_ASSERT(bi == "yes"));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to the string value of another bool",
+		CPPUNIT_ASSERT(bi == "true"));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to the string value of another bool",
+		CPPUNIT_ASSERT(bi == "1"));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to the string value of another bool",
+		CPPUNIT_ASSERT(bi == "on"));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to the string value of another bool",
+		CPPUNIT_ASSERT(bi == "ok"));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to another bool",
+		CPPUNIT_ASSERT(bi == true));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to int value of another bool",
+		CPPUNIT_ASSERT(bi == 1));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to another int",
+		CPPUNIT_ASSERT(bi == 2));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to old int",
+		CPPUNIT_ASSERT(bi == 42));
+
+	CPPUNIT_ASSERT_THROW_MESSAGE("BoolInt assignment from invalid strings must throw exceptions",
+		(bi = "AbraCadabra"), std::invalid_argument);
+
+	CPPUNIT_ASSERT_THROW_MESSAGE("BoolInt assignment from invalid strings must throw exceptions",
+		(bi = "1.5"), std::invalid_argument);
+
+	CPPUNIT_ASSERT_THROW_MESSAGE("BoolInt assignment from invalid strings must throw exceptions",
+		(bi = "-3.8"), std::invalid_argument);
+
+	// Standard casing only
+	CPPUNIT_ASSERT_THROW_MESSAGE("BoolInt assignment from invalid strings must throw exceptions",
+		(bi = "OFF"), std::invalid_argument);
+
+	bi.clear();
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be not 'set()' after 'clear()", !(bi.set()));
 }
 
 void NutConfTest::testParseToken()

--- a/tests/nutconf_parser_ut.cpp
+++ b/tests/nutconf_parser_ut.cpp
@@ -41,6 +41,7 @@ class NutConfTest : public CppUnit::TestFixture
 		CPPUNIT_TEST( testParseCHARS );
 		CPPUNIT_TEST( testParseSTRCHARS );
 		CPPUNIT_TEST( testParseBoolInt );
+		CPPUNIT_TEST( testParseBoolIntStrict );
 		CPPUNIT_TEST( testParseToken );
 		CPPUNIT_TEST( testParseTokenWithoutColon );
 		CPPUNIT_TEST( testGenericConfigParser );
@@ -57,6 +58,7 @@ public:
 	void testParseCHARS();
 	void testParseSTRCHARS();
 	void testParseBoolInt();
+	void testParseBoolIntStrict();
 	void testParseToken();
 	void testParseTokenWithoutColon();
 
@@ -146,6 +148,8 @@ void NutConfTest::testParseBoolInt()
 {
 	// NOTE: Can not use CPPUNIT_ASSERT_EQUAL() below, requires an assertEqual() method
 	BoolInt bi;
+	bi.bool01 = true;
+
 	CPPUNIT_ASSERT_MESSAGE("BoolInt should be not 'set()' initially", !(bi.set()));
 	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("Unassigned BoolInt should not be equal to an int",
 		CPPUNIT_ASSERT(bi == 0));
@@ -208,6 +212,18 @@ void NutConfTest::testParseBoolInt()
 	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to old int",
 		CPPUNIT_ASSERT(bi == 42));
 
+	bi = "1";
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the int", (bi == 1));
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the int as string", (bi == "1"));
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the bool", (bi == true));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to another bool",
+		CPPUNIT_ASSERT(bi == false));
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the bool as string", (bi == "true"));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to another bool as string",
+		CPPUNIT_ASSERT(bi == "false"));
+	CPPUNIT_ASSERT_THROW_MESSAGE("BoolInt comparison to invalid strings must throw exceptions",
+		if (bi == "1.8") {}, std::invalid_argument);
+
 	bi = "-1";
 	CPPUNIT_ASSERT_MESSAGE("BoolInt should be 'set()' after assignment from string", bi.set());
 	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the int", (bi == -1));
@@ -225,6 +241,149 @@ void NutConfTest::testParseBoolInt()
 	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the string value of bool", (bi == "off"));
 	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the string value of bool", (bi == "false"));
 	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the string value of bool", (bi == "0"));
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the string value of bool", (bi == "no"));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to the string value of another bool",
+		CPPUNIT_ASSERT(bi == "yes"));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to the string value of another bool",
+		CPPUNIT_ASSERT(bi == "true"));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to the string value of another bool",
+		CPPUNIT_ASSERT(bi == "1"));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to the string value of another bool",
+		CPPUNIT_ASSERT(bi == "on"));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to the string value of another bool",
+		CPPUNIT_ASSERT(bi == "ok"));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to another bool",
+		CPPUNIT_ASSERT(bi == true));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to int value of another bool",
+		CPPUNIT_ASSERT(bi == 1));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to another int",
+		CPPUNIT_ASSERT(bi == 2));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to old int",
+		CPPUNIT_ASSERT(bi == 42));
+
+	CPPUNIT_ASSERT_THROW_MESSAGE("BoolInt assignment from invalid strings must throw exceptions",
+		(bi = "AbraCadabra"), std::invalid_argument);
+
+	CPPUNIT_ASSERT_THROW_MESSAGE("BoolInt assignment from invalid strings must throw exceptions",
+		(bi = "1.5"), std::invalid_argument);
+
+	CPPUNIT_ASSERT_THROW_MESSAGE("BoolInt assignment from invalid strings must throw exceptions",
+		(bi = "-3.8"), std::invalid_argument);
+
+	// Standard casing only
+	CPPUNIT_ASSERT_THROW_MESSAGE("BoolInt assignment from invalid strings must throw exceptions",
+		(bi = "OFF"), std::invalid_argument);
+
+	bi.clear();
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be not 'set()' after 'clear()", !(bi.set()));
+}
+
+void NutConfTest::testParseBoolIntStrict()
+{
+	// NOTE: Can not use CPPUNIT_ASSERT_EQUAL() below, requires an assertEqual() method
+	BoolInt bi;
+	bi.bool01 = false;
+
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be not 'set()' initially", !(bi.set()));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("Unassigned BoolInt should not be equal to an int",
+		CPPUNIT_ASSERT(bi == 0));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("Unassigned BoolInt should not be equal to an int",
+		CPPUNIT_ASSERT(bi == 1));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("Unassigned BoolInt should not be equal to a bool",
+		CPPUNIT_ASSERT(bi == true));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("Unassigned BoolInt should not be equal to a bool",
+		CPPUNIT_ASSERT(bi == false));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("Unassigned BoolInt should not be equal to a string",
+		CPPUNIT_ASSERT(bi == "2"));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("Unassigned BoolInt should not be equal to a string",
+		CPPUNIT_ASSERT(bi == "on"));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("Unassigned BoolInt should not be equal to a string",
+		CPPUNIT_ASSERT(bi == "no"));
+/*
+	// Actually not "must throw", just returns false for any comparisons - see above
+	CPPUNIT_ASSERT_THROW_MESSAGE("Unassigned BoolInt comparisons must throw exceptions (string)",
+		if (bi == "1")  {}, std::invalid_argument);
+	CPPUNIT_ASSERT_THROW_MESSAGE("Unassigned BoolInt comparisons must throw exceptions (int)",
+		if (bi == 1)    {}, std::invalid_argument);
+	CPPUNIT_ASSERT_THROW_MESSAGE("Unassigned BoolInt comparisons must throw exceptions (bool)",
+		if (bi == true) {}, std::invalid_argument);
+*/
+
+	bi = 42;
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be 'set()' after assignment from int", bi.set());
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the int", (bi == 42));
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the string value of int", (bi == "42"));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to another int",
+		CPPUNIT_ASSERT(bi == 2));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to a bool",
+		CPPUNIT_ASSERT(bi == true));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to a bool",
+		CPPUNIT_ASSERT(bi == false));
+
+	bi = true;
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be 'set()' after assignment from bool", bi.set());
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the bool", (bi == true));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt (strict) should not be equal to the int value of bool",
+		CPPUNIT_ASSERT(bi == 1));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to another bool",
+		CPPUNIT_ASSERT(bi == false));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to int value of another bool",
+		CPPUNIT_ASSERT(bi == 0));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to another int",
+		CPPUNIT_ASSERT(bi == 2));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to old int",
+		CPPUNIT_ASSERT(bi == 42));
+
+	bi = false;
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be 'set()' after assignment from bool", bi.set());
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the bool", (bi == false));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt (strict) should not be equal to int value of bool",
+		CPPUNIT_ASSERT(bi == 0));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to another bool",
+		CPPUNIT_ASSERT(bi == true));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to int value of another bool",
+		CPPUNIT_ASSERT(bi == 1));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to another int",
+		CPPUNIT_ASSERT(bi == 2));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to old int",
+		CPPUNIT_ASSERT(bi == 42));
+
+	bi = "1";
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the int", (bi == 1));
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the int as string", (bi == "1"));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt (strict) should not be equal to the bool",
+		CPPUNIT_ASSERT(bi == true));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt (strict) should not be equal to the bool as string",
+		CPPUNIT_ASSERT(bi == "true"));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to another bool",
+		CPPUNIT_ASSERT(bi == false));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt (strict) should not be equal to the bool as string",
+		CPPUNIT_ASSERT(bi == "true"));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to another bool as string",
+		CPPUNIT_ASSERT(bi == "false"));
+	CPPUNIT_ASSERT_THROW_MESSAGE("BoolInt comparison to invalid strings must throw exceptions",
+		if (bi == "1.8") {}, std::invalid_argument);
+
+	bi = "-1";
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be 'set()' after assignment from string", bi.set());
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the int", (bi == -1));
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the string value of int", (bi == "-1"));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to another int",
+		CPPUNIT_ASSERT(bi == 2));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to a bool",
+		CPPUNIT_ASSERT(bi == true));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to a bool",
+		CPPUNIT_ASSERT(bi == false));
+
+	bi = "off";
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be 'set()' after assignment from string", bi.set());
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the bool", (bi == false));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt (strict) should not be equal to the int value of bool",
+		CPPUNIT_ASSERT(bi == 0));
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the string value of bool", (bi == "off"));
+	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the string value of bool", (bi == "false"));
+	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt (strict) should not be equal to the string value of bool (seemingly int)",
+		CPPUNIT_ASSERT(bi == "0"));
 	CPPUNIT_ASSERT_MESSAGE("BoolInt should be equal to the string value of bool", (bi == "no"));
 	CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("BoolInt should not be equal to the string value of another bool",
 		CPPUNIT_ASSERT(bi == "yes"));

--- a/tests/nutconf_parser_ut.cpp
+++ b/tests/nutconf_parser_ut.cpp
@@ -618,8 +618,8 @@ void NutConfTest::testUpsmonConfigParser()
 	CPPUNIT_ASSERT_EQUAL_MESSAGE("Cannot find SHUTDOWNCMD '/sbin/shutdown -h +0'", string("/sbin/shutdown -h +0"), *conf.shutdownCmd);
 	CPPUNIT_ASSERT_EQUAL_MESSAGE("Cannot find NOTIFYCMD '/usr/local/ups/bin/notifyme'", string("/usr/local/ups/bin/notifyme"), *conf.notifyCmd);
 	CPPUNIT_ASSERT_EQUAL_MESSAGE("Cannot find POWERDOWNFLAG '/etc/killpower'", string("/etc/killpower"), *conf.powerDownFlag);
-	CPPUNIT_ASSERT_EQUAL_MESSAGE("Cannot find POLLFREQ 30", 30u, *conf.poolFreq);
-	CPPUNIT_ASSERT_EQUAL_MESSAGE("Cannot find POLLFREQALERT 5", 5u, *conf.poolFreqAlert);
+	CPPUNIT_ASSERT_EQUAL_MESSAGE("Cannot find POLLFREQ 30", 30u, *conf.pollFreq);
+	CPPUNIT_ASSERT_EQUAL_MESSAGE("Cannot find POLLFREQALERT 5", 5u, *conf.pollFreqAlert);
 	CPPUNIT_ASSERT_EQUAL_MESSAGE("Cannot find HOSTSYNC 15", 15u, *conf.hostSync);
 	CPPUNIT_ASSERT_EQUAL_MESSAGE("Cannot find DEADTIME 15", 15u, *conf.deadTime);
 	CPPUNIT_ASSERT_EQUAL_MESSAGE("Cannot find RBWARNTIME 43200", 43200u, *conf.rbWarnTime);

--- a/tests/nutconf_parser_ut.cpp
+++ b/tests/nutconf_parser_ut.cpp
@@ -36,32 +36,32 @@ using namespace std;
 
 class NutConfTest : public CppUnit::TestFixture
 {
-  CPPUNIT_TEST_SUITE( NutConfTest );
-    CPPUNIT_TEST( testOptions );
-    CPPUNIT_TEST( testParseCHARS );
-    CPPUNIT_TEST( testParseSTRCHARS );
-    CPPUNIT_TEST( testPasreToken );
-    CPPUNIT_TEST( testPasreTokenWithoutColon );
-	CPPUNIT_TEST( testGenericConfigParser );
-	CPPUNIT_TEST( testUpsmonConfigParser );
-	CPPUNIT_TEST( testNutConfConfigParser );
-	CPPUNIT_TEST( testUpsdConfigParser );
-  CPPUNIT_TEST_SUITE_END();
+	CPPUNIT_TEST_SUITE( NutConfTest );
+		CPPUNIT_TEST( testOptions );
+		CPPUNIT_TEST( testParseCHARS );
+		CPPUNIT_TEST( testParseSTRCHARS );
+		CPPUNIT_TEST( testParseToken );
+		CPPUNIT_TEST( testParseTokenWithoutColon );
+		CPPUNIT_TEST( testGenericConfigParser );
+		CPPUNIT_TEST( testUpsmonConfigParser );
+		CPPUNIT_TEST( testNutConfConfigParser );
+		CPPUNIT_TEST( testUpsdConfigParser );
+	CPPUNIT_TEST_SUITE_END();
 
 public:
-  void setUp() override;
-  void tearDown() override;
+	void setUp() override;
+	void tearDown() override;
 
-  void testOptions();
-  void testParseCHARS();
-  void testParseSTRCHARS();
-  void testPasreToken();
-  void testPasreTokenWithoutColon();
+	void testOptions();
+	void testParseCHARS();
+	void testParseSTRCHARS();
+	void testParseToken();
+	void testParseTokenWithoutColon();
 
-  void testGenericConfigParser();
-  void testUpsmonConfigParser();
-  void testNutConfConfigParser();
-  void testUpsdConfigParser();
+	void testGenericConfigParser();
+	void testUpsmonConfigParser();
+	void testNutConfConfigParser();
+	void testUpsdConfigParser();
 };
 
 // Registers the fixture into the 'registry'
@@ -140,7 +140,7 @@ void NutConfTest::testParseSTRCHARS()
     }
 }
 
-void NutConfTest::testPasreToken()
+void NutConfTest::testParseToken()
 {
     static const char* src =
         "Bonjour monde\n"
@@ -177,7 +177,7 @@ void NutConfTest::testPasreToken()
 
 }
 
-void NutConfTest::testPasreTokenWithoutColon()
+void NutConfTest::testParseTokenWithoutColon()
 {
     static const char* src =
         "Bonjour monde\n"

--- a/tests/nutconf_ut.cpp
+++ b/tests/nutconf_ut.cpp
@@ -160,17 +160,55 @@ void NutConfigUnitTest::testUpsmonConfiguration() {
 	config.poolFreqAlert = 10;
 	config.deadTime      = 30;
 
+	config.debugMin      = 6;
+
+	// Note different bool wording expected below
+	// and generally try different input types here.
+	// Hm, maybe we need typed constructors to init
+	// the values for test? ("new" weirdness below
+	// is due to Settable<> formal type mismatch)
+	config.shutdownExit  = (*(new nut::BoolInt()) << "true");
+	config.oblbDuration  = -1;
+	config.certVerify    = (*(new nut::BoolInt()) << false);
+	config.forceSsl      = (*(new nut::BoolInt()) << "1");
+
+	config.certIdent.certName    = "My test cert";
+	config.certIdent.certDbPass  = "DbPwd!";
+
+	nut::CertHost certHost;
+	certHost.host        = "remote:3493";
+	certHost.certName    = "NUT server cert";
+	certHost.certVerify  = (*(new nut::BoolInt()) << "true");
+	certHost.forceSsl    = (*(new nut::BoolInt()) << 0);
+	config.certHosts.push_back(certHost);
+
+	certHost.host        = "localhost:13493";
+	certHost.certName    = "My NUT server cert";
+	certHost.certVerify  = (*(new nut::BoolInt()) << "false");
+	certHost.forceSsl    = (*(new nut::BoolInt()) << false);
+	config.certHosts.push_back(certHost);
+
+	// Note: More config data points come from the file loaded above
 	check(static_cast<nut::Serialisable *>(&config),
+		"DEBUG_MIN 6\n"
 		"SHUTDOWNCMD \"/sbin/shutdown -h +2 'System shutdown in 2 minutes!'\"\n"
-		"POWERDOWNFLAG /run/nut/killpower\n"
+		"POWERDOWNFLAG \"/run/nut/killpower\"\n"
 		"MINSUPPLIES 1\n"
 		"POLLFREQ 5\n"
 		"POLLFREQALERT 10\n"
+		"OFFDURATION 30\n"
+		"OBLBDURATION -1\n"
+		"SHUTDOWNEXIT yes\n"
+		"CERTVERIFY 0\n"
+		"FORCESSL 1\n"
 		"HOSTSYNC 15\n"
 		"DEADTIME 30\n"
 		"RBWARNTIME 43200\n"
 		"NOCOMMWARNTIME 300\n"
 		"FINALDELAY 5\n"
+		"CERTIDENT \"My test cert\" \"DbPwd!\"\n"
+		"CERTHOST \"remote:3493\" \"NUT server cert\" 1 0\n"
+		"CERTHOST \"localhost:13493\" \"My NUT server cert\" 0 0\n"
 	);
 }
 

--- a/tests/nutconf_ut.cpp
+++ b/tests/nutconf_ut.cpp
@@ -196,14 +196,15 @@ void NutConfigUnitTest::testUpsdConfiguration() {
 
 	config.listens.push_back(listen);
 
+	// NOTE: Three-arg check() here to retry (and succeed) with un-quoted paths
 	check(static_cast<nut::Serialisable *>(&config),
 		"MAXAGE 15\n"
 		"MAXCONN 1024\n"
-		"STATEPATH /var/run/nut\n"
+		"STATEPATH \"/var/run/nut\"\n"
 		"CERTFILE /usr/share/ssl-cert/ssleay.cnf\n"
 		"LISTEN 127.0.0.1 3493\n"
 		"LISTEN ::1 3493\n"
-	);
+	, false);
 }
 
 

--- a/tests/nutconf_ut.cpp
+++ b/tests/nutconf_ut.cpp
@@ -305,6 +305,11 @@ void NutConfigUnitTest::testUpsConfiguration() {
 	config.parseFromString(input2);
 	config.setUsbConfigIndex (my_ups, config.getUsbConfigIndex(my_ups));
 	config.setUsbHidDescIndex(my_ups, config.getUsbHidDescIndex(my_ups));
+
+	// Should retrieve "-1" for unset value by default in its getter,
+	// and auto-destroy the (missing) entry upon set() because < 0
+	config.setUsbSetAltInterface (my_ups, config.getUsbSetAltInterface(my_ups));
+
 	check(static_cast<nut::Serialisable *>(&config), expected);
 
 	CPPUNIT_ASSERT_EQUAL(static_cast<long long int>(129),

--- a/tests/nutconf_ut.cpp
+++ b/tests/nutconf_ut.cpp
@@ -143,8 +143,15 @@ void NutConfigUnitTest::testNutConfiguration() {
 
 	config.mode = nut::NutConfiguration::MODE_STANDALONE;
 
+	config.upsdOptions   = "-DDD -B";
+	config.allowNoDevice = true;
+	config.poweroffQuiet = false;
+
 	check(static_cast<nut::Serialisable *>(&config),
 		"MODE=standalone\n"
+		"ALLOW_NO_DEVICE=true\n"
+		"UPSD_OPTIONS='-DDD -B'\n"
+		"POWEROFF_QUIET=false\n"
 	);
 }
 

--- a/tests/nutconf_ut.cpp
+++ b/tests/nutconf_ut.cpp
@@ -339,6 +339,11 @@ void NutConfigUnitTest::testUpsConfiguration() {
 	check(static_cast<nut::Serialisable *>(&config),
 		"maxretry = 3\n\n" + expected3);
 
+	CPPUNIT_ASSERT_DOUBLES_EQUAL(28.3,
+			config.getDefaultDouble(my_ups, "battery.voltage.high"), 0.0001);
+	CPPUNIT_ASSERT_DOUBLES_EQUAL(12.4,
+			config.getOverrideDouble(my_ups, "battery.voltage.low"), 0.0001);
+
 	// TODO: Wipe method? Fix parse*() to clear global section
 	// like they do clear and repopulate an UPS section?
 	// Re-parse from scratch

--- a/tests/nutconf_ut.cpp
+++ b/tests/nutconf_ut.cpp
@@ -164,7 +164,7 @@ void NutConfigUnitTest::testUpsmonConfiguration() {
 
 	config.shutdownCmd   = "/sbin/shutdown -h +2 'System shutdown in 2 minutes!'";
 	config.powerDownFlag = "/run/nut/killpower";
-	config.poolFreqAlert = 10;
+	config.pollFreqAlert = 10;
 	config.deadTime      = 30;
 
 	config.debugMin      = 6;

--- a/tools/nutconf/nutconf-cli.cpp
+++ b/tools/nutconf/nutconf-cli.cpp
@@ -2090,7 +2090,7 @@ static nut::UpsmonConfiguration::Monitor monitor(
 	monitor.hostname   = host_port.substr(0, colon_idx);
 	monitor.port       = port;
 	monitor.powerValue = power_value;
-	monitor.isMaster   = ("primary" == mode || "master" == mode);
+	monitor.isPrimary  = ("primary" == mode || "master" == mode);
 
 	return monitor;
 }


### PR DESCRIPTION
Closes: #2294

Note: per #657 there is more work to improve flexibility of augeas lenses - simple cases should work, but not all combos that NUT own parser supports.

Note: It seems that per initial codebase import (from 2013-ish branch to NUT v2.8.2) the sprawl of C++ header/class/test code  is an internal detail of `nutconf` CLI tool - not a library delivered for external consumer linking. As such, there are no concerns currently about API versioning, backwards compatibility, variable/method name changes, etc. which would impact any code not visible from NUT repo itself and its regular builds. This frees up hands for refactoring like this, but eventually it could be useful to document and release the library for NUT configuration management... maybe? Or would the CLI suffice for external integrations?