### PR TITLE
`usbhid-ups.c`: complete the support of `onlinedischarge_log_throttle_hovercharge` setting

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -76,6 +76,10 @@ https://github.com/networkupstools/nut/milestone/11
    as known supported by `nutdrv_qx` (Megatec protocol) since at least
    NUT v2.7.4 release [#2395]
 
+ - usbhid-ups updates:
+   * Support of the `onlinedischarge_log_throttle_hovercharge` in the NUT
+     v2.8.2 release was found to be incomplete. [#2423, follow-up to #2215]
+
  - USB drivers could log `(nut_)libusb_get_string: Success` due to either
    reading an empty string or getting a success code `0` from libusb.
    This difference should now be better logged, and not into syslog. [#2399]


### PR DESCRIPTION
Follows-up from: #2215 / #2216

Closes: #2423

CC @desertwitch : you seem to be great at testing strange corner cases with shutdown criteria and logging settings like this, may I ask for a bit of your time to look at this feature? Seems to have been touted for NUT v2.8.2, but not actually completed by the earlier PR - at least as far as end-user ability to practically configure it is concerned. So probably not well tested either :\

As a reminder, this started for UPSes which normally only charge up to a 100% level and then let their battery seep away until it hits a threshold (90-95%) so it is boosted back to 100% again. With this setting, if in such case the UPS reports OL+DISCHRG state, we can throttle logging of the situation and avoid the needless log spam.