### PR TITLE
Regenerate `ChangeLog` file only if git metadata got updated

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -344,13 +344,23 @@ endif
 
 # Be sure to not confuse with a DIST'ed file (and so try to overwrite it);
 # do however avoid re-generating it if already made on a previous pass and
-# the Git HEAD pointer did not change since then (subsequent generation of
-# the huge PDF/HTML files can cost dearly):
+# the Git HEAD pointer (branch) or its actual "index" or "object" database
+# did not change since then - meaning the local developer or CI did not
+# modify the metadata (subsequent generation of the huge PDF/HTML files
+# can cost dearly).
+# Note there's a bit more fuss about Git internals which NUT should not
+# really care about encapsulation-wise (detection of NUT_GITDIR location
+# which may reside elsewhere, e.g. with local repo clones with reference
+# repo configuration, or submodules). But this is a Git-crawling target
+# anyway, and in the worst case (Git's design changes) we would spend a
+# bit of time researching the FS in vain, and go on to re-generate the
+# ChangeLog when maybe we should not have - oh well:
 $(abs_top_builddir)/ChangeLog: tools/gitlog2changelog.py dummy-stamp
 	@cd $(abs_top_srcdir) && \
 	    if test -e .git ; then \
-	        if test -e .git/HEAD && ( rm -f "`find "$@" -not -newer .git/HEAD`" || true ) 2>/dev/null && ls -la .git/HEAD "$@" 2>/dev/null ; then \
-	            echo "Using still-valid ChangeLog file generated earlier from same revision of Git source metadata" >&2 ; \
+	        NUT_GITDIR=".git" ; if test -r "$${NUT_GITDIR}" -a ! -d "$${NUT_GITDIR}" ; then GD="`grep -E '^gitdir:' "$${NUT_GITDIR}" | sed 's/^gitdir: *//'`" && test -n "$$GD" -a -d "$$GD" && NUT_GITDIR="$$GD" ; fi ; \
+	        if test -s "$@" -a -d "$${NUT_GITDIR}" -a -z "`find "$${NUT_GITDIR}" -newer "$@"`" 2>/dev/null ; then \
+	            echo "Using still-valid ChangeLog file generated earlier from same revision of Git source metadata in '$${NUT_GITDIR}'" >&2 ; \
 	        else \
 	            CHANGELOG_FILE="$@" $(WITH_PDF_NONASCII_TITLES_ENVVAR) $(abs_top_builddir)/tools/gitlog2changelog.py $(GITLOG_START_POINT) || \
 	            { printf "gitlog2changelog.py failed to generate the ChangeLog.\n\nNOTE: See https://github.com/networkupstools/nut/commits/master for change history.\n\n" > "$@" ; } ; \

--- a/Makefile.am
+++ b/Makefile.am
@@ -360,18 +360,27 @@ $(abs_top_builddir)/ChangeLog: tools/gitlog2changelog.py dummy-stamp
 	    if test -e .git ; then \
 	        NUT_GITDIR=".git" ; if test -r "$${NUT_GITDIR}" -a ! -d "$${NUT_GITDIR}" ; then GD="`grep -E '^gitdir:' "$${NUT_GITDIR}" | sed 's/^gitdir: *//'`" && test -n "$$GD" -a -d "$$GD" && NUT_GITDIR="$$GD" ; fi ; \
 	        if test -s "$@" -a -d "$${NUT_GITDIR}" -a -z "`find "$${NUT_GITDIR}" -newer "$@"`" 2>/dev/null ; then \
+	            echo "  DOC-CHANGELOG-GENERATE        $@ : SKIP (keep existing)" ; \
 	            echo "Using still-valid ChangeLog file generated earlier from same revision of Git source metadata in '$${NUT_GITDIR}'" >&2 ; \
 	        else \
-	            CHANGELOG_FILE="$@" $(WITH_PDF_NONASCII_TITLES_ENVVAR) $(abs_top_builddir)/tools/gitlog2changelog.py $(GITLOG_START_POINT) || \
-	            { printf "gitlog2changelog.py failed to generate the ChangeLog.\n\nNOTE: See https://github.com/networkupstools/nut/commits/master for change history.\n\n" > "$@" ; } ; \
+	            echo "  DOC-CHANGELOG-GENERATE        $@" ; \
+	            CHANGELOG_FILE="$@" $(WITH_PDF_NONASCII_TITLES_ENVVAR) $(abs_top_builddir)/tools/gitlog2changelog.py $(GITLOG_START_POINT) || { \
+	                echo "  DOC-CHANGELOG-GENERATE        $@ : FAILED (non-fatal)" >&2 ; \
+	                printf "gitlog2changelog.py failed to generate the ChangeLog.\n\nNOTE: See https://github.com/networkupstools/nut/commits/master for change history.\n\n" > "$@" ; \
+	            } ; \
 	        fi ; \
 	    else \
 	        if test x"$(abs_top_srcdir)" != x"$(abs_top_builddir)" -a -s ./ChangeLog ; then \
+	            echo "  DOC-CHANGELOG-GENERATE        $@ : SKIP (keep existing)" ; \
 	            echo "Using distributed ChangeLog file from sources" >&2 ; \
 	            rm -f "$@" || true ; \
 	            cat ./ChangeLog > "$@" ; \
 	        else \
-	            if ! test -s "$@" ; then \
+	            if test -s "$@" ; then \
+	                echo "  DOC-CHANGELOG-GENERATE        $@ : SKIP (keep existing)" ; \
+	                echo "Using distributed ChangeLog file from sources" >&2 ; \
+	            else \
+	                echo "  DOC-CHANGELOG-GENERATE        $@ : FAILED (non-fatal)" >&2 ; \
 	                printf "Failed to generate the ChangeLog.\n\nNOTE: See https://github.com/networkupstools/nut/commits/master for change history.\n\n" > "$@" ; \
 	            fi ; \
 	        fi ; \

--- a/Makefile.am
+++ b/Makefile.am
@@ -342,12 +342,19 @@ else
 WITH_PDF_NONASCII_TITLES_ENVVAR = WITH_PDF_NONASCII_TITLES=no
 endif
 
-# Be sure to not confuse with a DIST'ed file (and so try to overwrite it):
+# Be sure to not confuse with a DIST'ed file (and so try to overwrite it);
+# do however avoid re-generating it if already made on a previous pass and
+# the Git HEAD pointer did not change since then (subsequent generation of
+# the huge PDF/HTML files can cost dearly):
 $(abs_top_builddir)/ChangeLog: tools/gitlog2changelog.py dummy-stamp
 	@cd $(abs_top_srcdir) && \
 	    if test -e .git ; then \
-	        CHANGELOG_FILE="$@" $(WITH_PDF_NONASCII_TITLES_ENVVAR) $(abs_top_builddir)/tools/gitlog2changelog.py $(GITLOG_START_POINT) || \
-	        { printf "gitlog2changelog.py failed to generate the ChangeLog.\n\nNOTE: See https://github.com/networkupstools/nut/commits/master for change history.\n\n" > "$@" ; } ; \
+	        if test -e .git/HEAD && ( rm -f "`find "$@" -not -newer .git/HEAD`" || true ) 2>/dev/null && ls -la .git/HEAD "$@" 2>/dev/null ; then \
+	            echo "Using still-valid ChangeLog file generated earlier from same revision of Git source metadata" >&2 ; \
+	        else \
+	            CHANGELOG_FILE="$@" $(WITH_PDF_NONASCII_TITLES_ENVVAR) $(abs_top_builddir)/tools/gitlog2changelog.py $(GITLOG_START_POINT) || \
+	            { printf "gitlog2changelog.py failed to generate the ChangeLog.\n\nNOTE: See https://github.com/networkupstools/nut/commits/master for change history.\n\n" > "$@" ; } ; \
+	        fi ; \
 	    else \
 	        if test x"$(abs_top_srcdir)" != x"$(abs_top_builddir)" -a -s ./ChangeLog ; then \
 	            echo "Using distributed ChangeLog file from sources" >&2 ; \

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -238,7 +238,7 @@ DOCBUILD_CONVERT_GITHUB_LINKS = { \
 	@$(DOCBUILD_CONVERT_GITHUB_LINKS)
 
 $(top_builddir)/ChangeLog:
-	+@echo "  DOC-CHANGELOG-GENERATE	$@" \
+	+@echo "  DOC-CHANGELOG-GENERATE	$@ : call parent Makefile" \
 	 && cd $(top_builddir) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
 # BSD Make dislikes the path resolution here and does not always populate "$<"

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -237,7 +237,8 @@ DOCBUILD_CONVERT_GITHUB_LINKS = { \
 .adoc.adoc-parsed:
 	@$(DOCBUILD_CONVERT_GITHUB_LINKS)
 
-$(top_builddir)/ChangeLog:
+dummy:
+$(top_builddir)/ChangeLog: dummy
 	+@echo "  DOC-CHANGELOG-GENERATE	$@ : call parent Makefile" \
 	 && cd $(top_builddir) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 


### PR DESCRIPTION
This should allow for some faster development cycles (not causing `ChangeLog` re-generation for every call that resolves to `make ChangeLog`, and subsequently taking a minutes or two for the HTML/PDF variants of the huge file).

Goes into guts of Git a bit too much, maybe, but this particular recipe is about being intimate with it anyway, and at worst we would keep generating the file when maybe we should not (if git repo filesystem backend design changes).

Should also help with https://github.com/networkupstools/nut-website/issues/52 tangentially (at least regarding development cycles to fix that).

Example results in a `nut-website` build area (where `nut` is a submodule):
````
~/nut-website/nut$ ls -la .git
-rw-r--r-- 1 jim jim 28 Sep 12  2022 .git

~/nut-website/nut$ cat .git
gitdir: ../.git/modules/nut

~/nut-website/nut$ touch ../.git/modules/nut/HEAD
~/nut-website/nut$ time make ChangeLog
make[1]: Entering directory '/home/jim/nut-website/nut'
  DOC-CHANGELOG-GENERATE        /home/jim/nut-website/nut/ChangeLog
make[1]: Leaving directory '/home/jim/nut-website/nut'

real    0m3.484s
user    0m3.293s
sys     0m0.384s

~/nut-website/nut$ time make ChangeLog
make[1]: Entering directory '/home/jim/nut-website/nut'
  DOC-CHANGELOG-GENERATE        /home/jim/nut-website/nut/ChangeLog : SKIP (keep existing)
Using still-valid ChangeLog file generated earlier from same revision of Git source metadata in '../.git/modules/nut'
make[1]: Leaving directory '/home/jim/nut-website/nut'

real    0m0.020s
user    0m0.015s
sys     0m0.006s
````

The actual impact is about HTML/PDF files however - or rather about avoiding the remakes where possible:
````
~/nut-website/nut$ (cd docs/ && time make ChangeLog.pdf)
  DOC-CHANGELOG-ASCIIDOC        ../ChangeLog => ../ChangeLog.adoc
  DOC-ASCIIDOC-GITHUB-LINKS    Parsing GitHub link patterns ../ChangeLog.adoc => ../ChangeLog.adoc-parsed
  DOC-PDF  Generating ChangeLog.pdf
a2x: WARNING: --destination-dir option is only applicable to HTML and manpage based outputs

real    1m1.160s
user    1m0.312s
sys     0m0.622s

~/nut-website/nut$ (cd docs/ && time make ChangeLog.html)
  DOC-HTML Generating ChangeLog.html

real    0m14.491s
user    0m14.112s
sys     0m0.335s

### And re-runs are now no-ops:
~/nut-website/nut$ (cd docs/ && time make ChangeLog.html ChangeLog.pdf)
  DOC-CHANGELOG-GENERATE        ../ChangeLog : call parent Makefile
make[1]: Entering directory '/home/jim/nut-website/nut'
make[2]: Entering directory '/home/jim/nut-website/nut'
  DOC-CHANGELOG-GENERATE        /home/jim/nut-website/nut/ChangeLog : SKIP (keep existing)
Using still-valid ChangeLog file generated earlier from same revision of Git source metadata in '../.git/modules/nut'
make[2]: Leaving directory '/home/jim/nut-website/nut'
make[1]: Leaving directory '/home/jim/nut-website/nut'

real    0m0.028s
user    0m0.013s
sys     0m0.015s


### However, a Git change does cause a new document to appear:
~/nut-website/nut$ touch ../.git/modules/nut/HEAD
~/nut-website/nut$ (cd docs/ && time make ChangeLog.html)
  DOC-CHANGELOG-GENERATE        ../ChangeLog : call parent Makefile
make[1]: Entering directory '/home/jim/nut-website/nut'
make[2]: Entering directory '/home/jim/nut-website/nut'
  DOC-CHANGELOG-GENERATE        /home/jim/nut-website/nut/ChangeLog
make[2]: Leaving directory '/home/jim/nut-website/nut'
make[1]: Leaving directory '/home/jim/nut-website/nut'
  DOC-CHANGELOG-ASCIIDOC        ../ChangeLog => ../ChangeLog.adoc
  DOC-ASCIIDOC-GITHUB-LINKS    Parsing GitHub link patterns ../ChangeLog.adoc => ../ChangeLog.adoc-parsed
  DOC-HTML Generating ChangeLog.html

real    0m17.942s
user    0m17.504s
sys     0m0.663s
````