### PR TITLE
`mge-hid.c`: extend `mge_model_names[]` for Eaton 5SC and 5PX series

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -79,6 +79,10 @@ https://github.com/networkupstools/nut/milestone/11
  - usbhid-ups updates:
    * Support of the `onlinedischarge_log_throttle_hovercharge` in the NUT
      v2.8.2 release was found to be incomplete. [#2423, follow-up to #2215]
+   * MGE HID list of `mge_model_names[]` was extended for Eaton 5PX and 5SC
+     series (largely guessing, feedback and PRs for adaptation to actual
+     string values reported by devices via USB are welcome), so these devices
+     would now report `battery.voltage` and `battery.voltage.nominal`. [#2380]
 
  - USB drivers could log `(nut_)libusb_get_string: Success` due to either
    reading an empty string or getting a success code `0` from libusb.

--- a/drivers/mge-hid.c
+++ b/drivers/mge-hid.c
@@ -50,7 +50,7 @@
 # endif
 #endif
 
-#define MGE_HID_VERSION		"MGE HID 1.46"
+#define MGE_HID_VERSION		"MGE HID 1.47"
 
 /* (prev. MGE Office Protection Systems, prev. MGE UPS SYSTEMS) */
 /* Eaton */
@@ -131,7 +131,7 @@ typedef enum {
 		MGE_PULSAR_M_2200,
 		MGE_PULSAR_M_3000,
 		MGE_PULSAR_M_3000_XL,
-	EATON_5P = 0x500			/* Eaton 5P / 5PX series */
+	EATON_5P = 0x500			/* Eaton 5P / 5PX / 5SC series */
 } models_type_t;
 
 /* Default to line-interactive or online (ie, not offline).
@@ -1122,6 +1122,27 @@ static models_name_t mge_model_names [] =
 	{ "Eaton 5P", "850", EATON_5P, "5P 850" },
 	{ "Eaton 5P", "1150", EATON_5P, "5P 1150" },
 	{ "Eaton 5P", "1550", EATON_5P, "5P 1550" },
+
+	/* Eaton 5PX, names assumed per VA numbers in
+	 * https://www.eaton.com/gb/en-gb/catalog/backup-power-ups-surge-it-power-distribution/eaton-5px-ups-emea.html#tab-2
+	 * and a user report in https://github.com/networkupstools/nut/issues/2380
+	 * Fixes for actual product/model names reported via USB are welcome
+	 */
+	{ "Eaton 5PX", "1500", EATON_5P, NULL },
+	{ "Eaton 5PX", "2200", EATON_5P, NULL },
+	{ "Eaton 5PX", "3000", EATON_5P, NULL },
+
+	/* Eaton 5SC, names assumed per VA numbers in
+	 * https://www.eaton.com/gb/en-gb/site-search.html.searchTerm$5sc.tabs$all.html
+	 * and a user report in https://github.com/networkupstools/nut/issues/2380
+	 * Fixes for actual product/model names reported via USB are welcome
+	 */
+	{ "Eaton 5SC", "500", EATON_5P, NULL },
+	{ "Eaton 5SC", "750", EATON_5P, NULL },
+	{ "Eaton 5SC", "1000", EATON_5P, NULL },
+	{ "Eaton 5SC", "1500", EATON_5P, NULL },
+	{ "Eaton 5SC", "2200", EATON_5P, NULL },
+	{ "Eaton 5SC", "3000", EATON_5P, NULL },
 
 	/* Pulsar M models */
 	{ "PULSAR M", "2200", MGE_PULSAR_M_2200, NULL },

--- a/drivers/mge-hid.c
+++ b/drivers/mge-hid.c
@@ -207,14 +207,14 @@ static long round (double value)
 static long round (LDOUBLE value)
 # endif
 {
-  long intpart;
+	long intpart;
 
-  intpart = (long)value;
-  value = value - intpart;
-  if (value >= 0.5)
-    intpart++;
+	intpart = (long)value;
+	value = value - intpart;
+	if (value >= 0.5)
+		intpart++;
 
-  return intpart;
+	return intpart;
 }
 #endif /* HAVE_DECL_ROUND */
 

--- a/drivers/mge-hid.c
+++ b/drivers/mge-hid.c
@@ -63,18 +63,18 @@
 #define POWERWARE_VENDORID	0x0592
 
 /* Hewlett Packard */
-#define HP_VENDORID 0x03f0
+#define HP_VENDORID		0x03f0
 
 /* AEG */
-#define AEG_VENDORID 0x2b2d
+#define AEG_VENDORID		0x2b2d
 
 /* Note that normally this VID is handled by Liebert/Phoenixtec HID mapping,
  * here it is just for for AEG PROTECT NAS devices: */
 /* Phoenixtec Power Co., Ltd */
-#define PHOENIXTEC 0x06da
+#define PHOENIXTEC		0x06da
 
 /* IBM */
-#define IBM_VENDORID 0x04b3
+#define IBM_VENDORID		0x04b3
 
 #if !((defined SHUT_MODE) && SHUT_MODE)
 #include "usb-common.h"

--- a/drivers/mge-hid.c
+++ b/drivers/mge-hid.c
@@ -2,7 +2,7 @@
  *
  *  Copyright (C)
  *        2003 - 2015 Arnaud Quette <arnaud.quette@free.fr>
- *        2015 - 2016 Eaton / Arnaud Quette <ArnaudQuette@Eaton.com>
+ *        2015 - 2024 Eaton / Arnaud Quette <ArnaudQuette@Eaton.com>
  *
  *  Sponsored by MGE UPS SYSTEMS <http://www.mgeups.com>
  *


### PR DESCRIPTION
Closes: #2380

Testing needed, CC @jstallard @lemeshovich

Confirmation that the added device names/models are what should be expected from hardware would be very welcome - CC @arnaudquette-eaton

Here so far I've added the basic VA numbers from model lists for 5PX and 5SC, but there are many models marketed for some of the same power ratings - no idea if they identify differently via USB.

* https://www.eaton.com/gb/en-gb/site-search.html.searchTerm$5sc.tabs$all.html
* https://www.eaton.com/gb/en-gb/catalog/backup-power-ups-surge-it-power-distribution/eaton-5px-ups-emea.html

Also note that original 5PX is discontinued; not sure if 5PX Gen2 should identify differently (and/or if it needs another "type" enum value).
