### PR TITLE
Enable installation of built HTML and PDF documents

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -177,7 +177,7 @@ spellcheck spellcheck-interactive:
 # texts, man pages and HTML rendering of man pages, as enabled by tools.
 doc spellcheck-sortdict spellcheck-report-dict-usage \
 all-docs check-docs \
-man all-man man-man check-man man-html all-html:
+man all-man man-man check-man html-man all-html:
 	+cd $(abs_top_builddir)/docs && $(MAKE) $(AM_MAKEFLAGS) -s $(abs_top_builddir)/docs/.prep-src-docs
 	+cd $(abs_top_builddir)/docs/man && $(MAKE) $(AM_MAKEFLAGS) -s $(abs_top_builddir)/docs/man/.prep-src-docs
 	+cd $(abs_top_builddir)/docs && $(MAKE) $(AM_MAKEFLAGS) $@

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -107,6 +107,11 @@ https://github.com/networkupstools/nut/milestone/11
    `NUT_PIDPATH` environment variable in certain use-cases (such as tests).
    [#2407]
 
+ - enabled installation of built PDF and HTML (including man page renditions)
+   files under the configured `docdir`. It seems previously they were only
+   built (if requested) but not installed via `make`, unlike the common man
+   pages which are delivered automatically. [#2445]
+
  - brought keyword dictionaries of `nutconf` and `augeas` NUT configuration
    file parsers up to date; restored automated checks for `augeas` lenses.
    [issue #657, issue #2294]

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -107,10 +107,12 @@ https://github.com/networkupstools/nut/milestone/11
    `NUT_PIDPATH` environment variable in certain use-cases (such as tests).
    [#2407]
 
- - enabled installation of built PDF and HTML (including man page renditions)
-   files under the configured `docdir`. It seems previously they were only
-   built (if requested) but not installed via `make`, unlike the common man
-   pages which are delivered automatically. [#2445]
+ - enabled installation of built single-file PDF and HTML (including man page
+   renditions) under the configured `docdir`. It seems previously they were
+   only built (if requested) but not installed via `make`, unlike the common
+   man pages which are delivered automatically. [#2445]
++
+   NOTE: The `html-chunked` documents are currently still not installed.
 
  - brought keyword dictionaries of `nutconf` and `augeas` NUT configuration
    file parsers up to date; restored automated checks for `augeas` lenses.

--- a/UPGRADING.adoc
+++ b/UPGRADING.adoc
@@ -27,6 +27,13 @@ Changes from 2.8.2 to 2.8.3
 - PLANNED: Keep track of any further API clean-up?
 
 
+- Enabled installation of built PDF and HTML (including man page renditions)
+  files under the configured `docdir`. It seems previously they were only
+  built (if requested) but not installed via `make`, unlike the common man
+  pages which are delivered automatically. Packaging recipes can likely
+  be simplified now. [#2445]
+
+
 Changes from 2.8.1 to 2.8.2
 ---------------------------
 

--- a/configure.ac
+++ b/configure.ac
@@ -252,7 +252,10 @@ AS_CASE([${target_os}],
 
 cgiexecdir='${exec_prefix}/cgi-bin'
 driverexecdir='${exec_prefix}/bin'
+dnl Note: htmldir per se is originally for nut-cgi resources
 htmldir='${prefix}/html'
+htmldocdir='${docdir}/html-doc'
+htmlmandir='${docdir}/html-man'
 pkgconfigdir='${libdir}/pkgconfig'
 auglensdir='/usr/share/augeas/lenses/dist'
 if test ! -d "${auglensdir}"; then
@@ -2840,6 +2843,39 @@ AM_CONDITIONAL(WITH_MANS, test "${WITH_MANS}" = "yes")
 AM_CONDITIONAL(SKIP_MANS, test "${SKIP_MANS}" = "yes")
 AM_CONDITIONAL(DOC_INSTALL_DISTED_MANS, test "${DOC_INSTALL_DISTED_MANS}" = "yes")
 
+WITH_HTML_SINGLE=no
+SKIP_HTML_SINGLE=no
+if echo "${DOC_BUILD_LIST}" | grep -w "html-single" >/dev/null ; then
+	WITH_HTML_SINGLE=yes
+fi
+if echo "${DOC_SKIPBUILD_LIST}" | grep -w "html-single" >/dev/null ; then
+	SKIP_HTML_SINGLE=yes
+fi
+AM_CONDITIONAL(WITH_HTML_SINGLE, test "${WITH_HTML_SINGLE}" = "yes")
+AM_CONDITIONAL(SKIP_HTML_SINGLE, test "${SKIP_HTML_SINGLE}" = "yes")
+
+WITH_HTML_CHUNKED=no
+SKIP_HTML_CHUNKED=no
+if echo "${DOC_BUILD_LIST}" | grep -w "html-chunked" >/dev/null ; then
+	WITH_HTML_CHUNKED=yes
+fi
+if echo "${DOC_SKIPBUILD_LIST}" | grep -w "html-chunked" >/dev/null ; then
+	SKIP_HTML_CHUNKED=yes
+fi
+AM_CONDITIONAL(WITH_HTML_CHUNKED, test "${WITH_HTML_CHUNKED}" = "yes")
+AM_CONDITIONAL(SKIP_HTML_CHUNKED, test "${SKIP_HTML_CHUNKED}" = "yes")
+
+WITH_PDFS=no
+SKIP_PDFS=no
+if echo "${DOC_BUILD_LIST}" | grep -w "pdf" >/dev/null ; then
+	WITH_PDFS=yes
+fi
+if echo "${DOC_SKIPBUILD_LIST}" | grep -w "pdf" >/dev/null ; then
+	SKIP_PDFS=yes
+fi
+AM_CONDITIONAL(WITH_PDFS, test "${WITH_PDFS}" = "yes")
+AM_CONDITIONAL(SKIP_PDFS, test "${SKIP_PDFS}" = "yes")
+
 dnl ----------------------------------------------------------------------
 dnl checks related to --with-dev
 
@@ -4314,6 +4350,8 @@ AC_SUBST(devddir)
 AC_SUBST(driverexecdir)
 AC_SUBST(freebsdquirksdir)
 AC_SUBST(htmldir)
+AC_SUBST(htmldocdir)
+AC_SUBST(htmlmandir)
 AC_SUBST(pkgconfigdir)
 AC_SUBST(systemdsystemunitdir)
 AC_SUBST(systemdshutdowndir)

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -161,6 +161,18 @@ pdf: $(ASCIIDOC_PDF)
 html-single: $(ASCIIDOC_HTML_SINGLE)
 html-chunked: $(ASCIIDOC_HTML_CHUNKED)
 
+# htmldocdir and pdfdir are set by autoconf/automake
+htmldoc_DATA =
+if WITH_HTML_SINGLE
+htmldoc_DATA += $(ASCIIDOC_HTML_SINGLE)
+endif
+if WITH_HTML_CHUNKED
+htmldoc_DATA += $(ASCIIDOC_HTML_CHUNKED)
+endif
+if WITH_PDFS
+pdf_DATA = $(ASCIIDOC_PDFS)
+endif
+
 # the "for" loops might better use $^ but it might be not portable
 check-pdf: $(ASCIIDOC_PDF)
 	@FAILED=""; LANG=C; LC_ALL=C; export LANG; export LC_ALL; \

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -166,9 +166,12 @@ htmldoc_DATA =
 if WITH_HTML_SINGLE
 htmldoc_DATA += $(ASCIIDOC_HTML_SINGLE)
 endif
-if WITH_HTML_CHUNKED
-htmldoc_DATA += $(ASCIIDOC_HTML_CHUNKED)
-endif
+# FIXME: Install tools refuse to work with directories in this context
+# and html-chunked documentation has a separate tree per document.
+# Maybe an "(un)install-data-local" or "install-data-hook" for this?
+#if WITH_HTML_CHUNKED
+#htmldoc_DATA += $(ASCIIDOC_HTML_CHUNKED)
+#endif
 if WITH_PDFS
 pdf_DATA = $(ASCIIDOC_PDFS)
 endif

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -834,6 +834,16 @@ HTML_MANS = \
 	$(HTML_LINUX_I2C_MANS) \
 	$(HTML_GPIO_MANS)
 
+# htmlmandir is set by autoconf/automake
+htmlman_DATA =
+if WITH_HTML_SINGLE
+htmlman_DATA += $(HTML_MANS)
+else !WITH_HTML_SINGLE
+if WITH_HTML_CHUNKED
+htmlman_DATA += $(HTML_MANS)
+endif WITH_HTML_CHUNKED
+endif !WITH_HTML_SINGLE
+
 # Note: target documents, except nutupsdrv.txt itself, start the
 # list of drivers with `- linkman:nutupsdrv[8]` entry
 # To regenerate these files, do `make distclean` first

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3132 utf-8
+personal_ws-1.1 en 3133 utf-8
 AAC
 AAS
 ABI
@@ -1751,6 +1751,7 @@ dnf
 dnl
 dnsmasq
 docbook
+docdir
 docs
 dod
 domxml

--- a/scripts/Windows/build-mingw-nut.sh
+++ b/scripts/Windows/build-mingw-nut.sh
@@ -116,10 +116,11 @@ if [ "$cmd" == "all64" ] || [ "$cmd" == "b64" ] || [ "$cmd" == "all32" ] || [ "$
 
 	# Note: installation prefix here is "/" and desired INSTALL_DIR
 	# location is passed to `make install` as DESTDIR below.
+	# FIXME: Implement support for --without-pkg-config in m4 and use it
 	$CONFIGURE_SCRIPT $HOST_FLAG $BUILD_FLAG --prefix=/ \
 	    $KEEP_NUT_REPORT_FEATURE_FLAG \
 	    PKG_CONFIG_PATH="${ARCH_PREFIX}/lib/pkgconfig" \
-	    --without-pkg-config --with-all=auto \
+	    --with-all=auto \
 	    --without-systemdsystemunitdir \
 	    --with-pynut=app \
 	    --with-augeas-lenses-dir=/augeas-lenses \

--- a/scripts/Windows/build-mingw-nut.sh
+++ b/scripts/Windows/build-mingw-nut.sh
@@ -121,6 +121,7 @@ if [ "$cmd" == "all64" ] || [ "$cmd" == "b64" ] || [ "$cmd" == "all32" ] || [ "$
 	    $KEEP_NUT_REPORT_FEATURE_FLAG \
 	    PKG_CONFIG_PATH="${ARCH_PREFIX}/lib/pkgconfig" \
 	    --with-all=auto \
+	    --with-doc="man=auto html-single=auto html-chunked=skip pdf=skip" \
 	    --without-systemdsystemunitdir \
 	    --with-pynut=app \
 	    --with-augeas-lenses-dir=/augeas-lenses \

--- a/scripts/Windows/build-mingw-nut.sh
+++ b/scripts/Windows/build-mingw-nut.sh
@@ -130,6 +130,8 @@ if [ "$cmd" == "all64" ] || [ "$cmd" == "b64" ] || [ "$cmd" == "all32" ] || [ "$
 	echo "$0: configure phase complete ($?)" >&2
 
 	make 1>/dev/null || exit
+	make doc 1>/dev/null || exit
+	make -k man-man html-man 1>/dev/null || true
 	echo "$0: build phase complete ($?)" >&2
 
 	if [ "x$INSTALL_WIN_BUNDLE" = xtrue ] ; then

--- a/scripts/augeas/Makefile.am
+++ b/scripts/augeas/Makefile.am
@@ -30,15 +30,15 @@ check-local:
 	@echo "augparse proceeding to lenses verification job..."; \
 	 echo "DISABLED for now due to https://github.com/networkupstools/nut/issues/657 -" ; \
 	 echo "as a developer, you can run the tests below manually but not automatically:" ; \
-	 echo "    $(AUGPARSE) -I $(srcdir)/ $(srcdir)/tests/test_nut.aug" ; \
+	 echo "    $(AUGPARSE) -I $(builddir)/ -I $(srcdir)/ $(srcdir)/tests/test_nut.aug" ; \
 	 echo "or 'make check-augeas' or 'make check-augeas-all' in `pwd`"
 
 check-augeas:
-	$(AUGPARSE) -I $(srcdir)/ $(srcdir)/tests/test_nut.aug
+	$(AUGPARSE) -I $(builddir)/ -I $(srcdir)/ $(srcdir)/tests/test_nut.aug
 
 check-augeas-all: check-augeas
-	$(AUGPARSE) -I $(srcdir)/ $(srcdir)/tests/test_nut_flaky.aug
-	$(AUGPARSE) -I $(srcdir)/ $(srcdir)/tests/test_nut_fixme.aug
+	$(AUGPARSE) -I $(builddir)/ -I $(srcdir)/ $(srcdir)/tests/test_nut_flaky.aug
+	$(AUGPARSE) -I $(builddir)/ -I $(srcdir)/ $(srcdir)/tests/test_nut_fixme.aug
 endif
 
 if WITH_AUGLENS


### PR DESCRIPTION
Previously these advanced documentation formats were only built, but I found no examples of them being installed by `make`.