### PR TITLE
WIN32: Document `nut.exe` wrapper and improve its usability

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -107,6 +107,11 @@ https://github.com/networkupstools/nut/milestone/11
    `NUT_PIDPATH` environment variable in certain use-cases (such as tests).
    [#2407]
 
+ - revised `nut.exe` (the NUT for Windows wrapper for all-in-one service)
+   to be more helpful with command-line use (report that it failed to start
+   as a service, have a help message, pass debug verbosity to launched NUT
+   programs...) and add a man page for it. [issue #2432, PR #2446]
+
  - brought keyword dictionaries of `nutconf` and `augeas` NUT configuration
    file parsers up to date; restored automated checks for `augeas` lenses.
    [issue #657, issue #2294]

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -87,6 +87,13 @@ MAN_CLIENT_PAGES = \
 	upssched.8
 endif WITH_MANS
 
+if HAVE_WINDOWS
+SRC_CLIENT_PAGES += nut.exe.txt
+if WITH_MANS
+MAN_CLIENT_PAGES += nut.exe.8
+endif WITH_MANS
+endif HAVE_WINDOWS
+
 man8_MANS = $(MAN_CLIENT_PAGES)
 
 HTML_CLIENT_MANS = \
@@ -101,6 +108,10 @@ HTML_CLIENT_MANS = \
 	upsmon.html \
 	upsrw.html \
 	upssched.html
+
+if HAVE_WINDOWS
+HTML_CLIENT_MANS += nut.exe.html
+endif HAVE_WINDOWS
 
 SRC_TOOL_PAGES = nut-scanner.txt nut-recorder.txt nutconf.txt
 

--- a/docs/man/nut.exe.txt
+++ b/docs/man/nut.exe.txt
@@ -1,0 +1,83 @@
+NUT.EXE(8)
+==========
+
+NAME
+----
+
+nut.exe - NUT for Windows wrapper for all-in-one service
+
+SYNOPSIS
+--------
+
+*nut.exe* {-h | /?}
+
+*nut.exe* ['OPTIONS']
+
+*nut.exe* (as a service implementation)
+
+DESCRIPTION
+-----------
+
+*nut.exe* wraps NUT programs to start and stop as a Windows service.
+
+Depending on 'nut.conf' setting of 'MODE', it would manage the bundle of
+driver(s), 'upsd' data server and 'upsmon' client, as well as attempt an
+UPS shutdown command in case of FSD handling, or for mere 'netclient' systems
+it would run just the 'upsmon' client to monitor remote UPS device(s) and
+initiate the OS shut down on the local Windows system as applicable.
+
+OPTIONS
+-------
+
+*nut.exe* is currently launched with no arguments when it is intended to
+run as the implementation of a registered Windows service; it would error
+out otherwise.
+
+*/?*::
+Display the help text and exit.
+
+*-h*::
+Display the help text and exit.
+
+*-V*::
+Display NUT version and exit.
+
+*-D*::
+Raise the debug level.  Use this multiple times for additional details.
+The non-trivial debug level would be passed down to launched NUT programs.
+Primarily useful for troubleshooting with the non-service mode.
+
+*-I*::
+Install as a Windows service called "Network UPS Tools".
+
+*-U*::
+Uninstall the Windows service.
+
+*-N*::
+Run once in non-service mode (for troubleshooting).
+
+DIAGNOSTICS
+-----------
+
+*nut.exe* should not interact with console message buffers (stdout, stderr)
+much, except when explicitly asked to (e.g. displaying help and NUT version,
+running with verbose debug mode) or when exiting after an attempted service
+initialization while not running in a service context.
+
+Most of normal logging from *nut.exe* goes to the Windows Event Log.
+
+Launched NUT programs may emit messages of their own; their fate when no
+console is attached is questionable.
+
+SEE ALSO
+--------
+
+linkman:nut.conf[5], linkman:ups.conf[5], linkman:nutupsdrv[8],
+linkman:upsd[8], linkman:upsd.conf[5], linkman:upsd.users[5],
+linkman:upsmon[8], linkman:upsmon.conf[5]
+
+Internet resources:
+~~~~~~~~~~~~~~~~~~~
+
+The NUT (Network UPS Tools) home page: https://www.networkupstools.org/
+

--- a/scripts/Windows/wininit.c
+++ b/scripts/Windows/wininit.c
@@ -665,7 +665,8 @@ static void help(const char *arg_progname)
 	printf("Network UPS Tools %s %s\n\n", arg_progname, UPS_VERSION);
 
 	printf("NUT for Windows all-in-one wrapper for driver(s), data server and monitoring client\n");
-	printf("including shutdown and power-off handling (where supported).\n\n");
+	printf("including shutdown and power-off handling (where supported). All together they rely\n");
+	printf("on nut.conf and other files in %s\n\n", confpath());
 
 	printf("Usage: %s [OPTION]\n\n", arg_progname);
 

--- a/scripts/Windows/wininit.c
+++ b/scripts/Windows/wininit.c
@@ -122,7 +122,7 @@ static DWORD create_process(char * command)
 }
 
 /* return PID of created process or 0 on failure */
-static DWORD run_drivers()
+static DWORD run_drivers(void)
 {
 	char command[MAX_PATH];
 	char *path;
@@ -134,7 +134,7 @@ static DWORD run_drivers()
 }
 
 /* return PID of created process or 0 on failure */
-static DWORD stop_drivers()
+static DWORD stop_drivers(void)
 {
 	char command[MAX_PATH];
 	char *path;
@@ -146,7 +146,7 @@ static DWORD stop_drivers()
 }
 
 /* return PID of created process or 0 on failure */
-static void run_upsd()
+static void run_upsd(void)
 {
 	char command[MAX_PATH];
 	char *path;
@@ -157,7 +157,7 @@ static void run_upsd()
 	upsd_pid = create_process(command);
 }
 
-static void stop_upsd()
+static void stop_upsd(void)
 {
 	if (sendsignal(UPSD_PIPE_NAME, COMMAND_STOP)) {
 		print_event(LOG_ERR, "Error stopping upsd (%d)", GetLastError());
@@ -165,7 +165,7 @@ static void stop_upsd()
 }
 
 /* return PID of created process or 0 on failure */
-static void run_upsmon()
+static void run_upsmon(void)
 {
 	char command[MAX_PATH];
 	char *path;
@@ -176,7 +176,7 @@ static void run_upsmon()
 	upsmon_pid = create_process(command);
 }
 
-static void stop_upsmon()
+static void stop_upsmon(void)
 {
 	if (sendsignal(UPSMON_PIPE_NAME, COMMAND_STOP)) {
 		print_event(LOG_ERR, "Error stopping upsmon (%d)", GetLastError());
@@ -184,7 +184,7 @@ static void stop_upsmon()
 }
 
 /* Return 0 if powerdown flag is set */
-static DWORD test_powerdownflag()
+static DWORD test_powerdownflag(void)
 {
 	char command[MAX_PATH];
 	char *path;
@@ -237,7 +237,7 @@ static DWORD test_powerdownflag()
 	return 1;
 }
 
-static DWORD shutdown_ups()
+static DWORD shutdown_ups(void)
 {
 	char command[MAX_PATH];
 	char *path;

--- a/scripts/Windows/wininit.c
+++ b/scripts/Windows/wininit.c
@@ -688,6 +688,11 @@ int main(int argc, char **argv)
 				"exiting, this is a Windows service which can't "
 				"be run as a regular application by default. "
 				"Try -N to start it as a regular application.");
+
+			if (argc < 2) {
+				help(progname);
+				return EXIT_FAILURE;
+			}
 		}
 	}
 	else {

--- a/scripts/Windows/wininit.c
+++ b/scripts/Windows/wininit.c
@@ -283,16 +283,17 @@ static int parse_nutconf(BOOL start_flag)
 					return 1;
 				}
 				else {
-					print_event(LOG_INFO,"stop upsd");
+					print_event(LOG_INFO, "Stopping upsd");
 					stop_upsd();
-					print_event(LOG_INFO,"stop drivers");
+					print_event(LOG_INFO, "Stopping drivers");
 					stop_drivers();
-					print_event(LOG_INFO,"stop upsmon");
+					print_event(LOG_INFO, "Stopping upsmon");
 					stop_upsmon();
-					/* Give a chance to upsmon to write the POWERDOWNFLAG  file */
+
+					/* Give upsmon a chance to write the POWERDOWNFLAG file */
 					Sleep(1000);
 					if (test_powerdownflag() == 0) {
-						print_event(LOG_INFO, "shutdown ups");
+						print_event(LOG_INFO, "Shutting down the UPS");
 						shutdown_ups();
 					}
 					print_event(LOG_INFO, "End of NUT stop");
@@ -301,10 +302,12 @@ static int parse_nutconf(BOOL start_flag)
 			}
 			if (strstr(buf, "netclient") != NULL) {
 				if (start_flag == NUT_START) {
+					print_event(LOG_INFO, "Starting upsmon (client only)");
 					run_upsmon();
 					return 1;
 				}
 				else {
+					print_event(LOG_INFO, "Stopping upsmon (client only)");
 					stop_upsmon();
 					return 1;
 				}

--- a/scripts/Windows/wininit.c
+++ b/scripts/Windows/wininit.c
@@ -2,6 +2,7 @@
 
    Copyright (C)
 	2010	Frederic Bohe <fredericbohe@eaton.com>
+	2021-2024	Jim Klimov <jimklimov+nut@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -56,18 +57,19 @@ static void print_event(DWORD priority, const char * fmt, ...)
 	ret = vsnprintf(buf, LARGEBUF, fmt, ap);
 	va_end(ap);
 
-	if(ret<0) {
+	if (ret < 0) {
 		return;
 	}
 
-	if( !service_flag ) {
+	if (!service_flag) {
 		upslogx(LOG_ERR, "EventLog : %s\n",buf);
 	}
 
 	EventSource = RegisterEventSource(NULL, SVCNAME);
 
-	if( NULL != EventSource ) {
-		ReportEvent( EventSource,	/* event log handle */
+	if (NULL != EventSource) {
+		ReportEvent(
+				EventSource,	/* event log handle */
 				priority,	/* event type */
 				0,		/* event category */
 				SVC_EVENT,	/* event identifier */
@@ -81,7 +83,7 @@ static void print_event(DWORD priority, const char * fmt, ...)
 
 	}
 
-	if( buf )
+	if (buf)
 		free(buf);
 }
 
@@ -93,9 +95,9 @@ static DWORD create_process(char * command)
 	BOOL res;
 	DWORD LastError;
 
-	memset(&StartupInfo,0,sizeof(STARTUPINFO));
+	memset(&StartupInfo, 0, sizeof(STARTUPINFO));
 	StartupInfo.cb = sizeof(StartupInfo);
-	memset(&ProcessInformation,0,sizeof(ProcessInformation));
+	memset(&ProcessInformation, 0, sizeof(ProcessInformation));
 
 	res = CreateProcess(
 			NULL,
@@ -111,7 +113,7 @@ static DWORD create_process(char * command)
 			);
 	LastError = GetLastError();
 
-	if( res == 0 ) {
+	if (res == 0) {
 		print_event(LOG_ERR, "Can't create process %s : %d", command, LastError);
 		return 0;
 	}
@@ -126,7 +128,7 @@ static DWORD run_drivers()
 	char *path;
 
 	path = getfullpath(PATH_BIN);
-	snprintf(command,sizeof(command),"%s\\upsdrvctl.exe start",path);
+	snprintf(command, sizeof(command), "%s\\upsdrvctl.exe start", path);
 	free(path);
 	return create_process(command);
 }
@@ -138,7 +140,7 @@ static DWORD stop_drivers()
 	char *path;
 
 	path = getfullpath(PATH_BIN);
-	snprintf(command,sizeof(command),"%s\\upsdrvctl.exe stop",path);
+	snprintf(command, sizeof(command), "%s\\upsdrvctl.exe stop", path);
 	free(path);
 	return create_process(command);
 }
@@ -150,15 +152,15 @@ static void run_upsd()
 	char *path;
 
 	path = getfullpath(PATH_SBIN);
-	snprintf(command,sizeof(command),"%s\\upsd.exe",path);
+	snprintf(command, sizeof(command), "%s\\upsd.exe", path);
 	free(path);
 	upsd_pid = create_process(command);
 }
 
 static void stop_upsd()
 {
-	if ( sendsignal( UPSD_PIPE_NAME, COMMAND_STOP ) ) {
-		print_event(LOG_ERR, "Error stopping upsd (%d)",GetLastError());
+	if (sendsignal(UPSD_PIPE_NAME, COMMAND_STOP)) {
+		print_event(LOG_ERR, "Error stopping upsd (%d)", GetLastError());
 	}
 }
 
@@ -169,15 +171,15 @@ static void run_upsmon()
 	char *path;
 
 	path = getfullpath(PATH_SBIN);
-	snprintf(command,sizeof(command),"%s\\upsmon.exe",path);
+	snprintf(command, sizeof(command), "%s\\upsmon.exe", path);
 	free(path);
 	upsmon_pid = create_process(command);
 }
 
 static void stop_upsmon()
 {
-	if ( sendsignal( UPSMON_PIPE_NAME, COMMAND_STOP ) ) {
-		print_event(LOG_ERR, "Error stopping upsmon (%d)",GetLastError());
+	if (sendsignal(UPSMON_PIPE_NAME, COMMAND_STOP)) {
+		print_event(LOG_ERR, "Error stopping upsmon (%d)", GetLastError());
 	}
 }
 
@@ -195,12 +197,12 @@ static DWORD test_powerdownflag()
 	int timeout = 500;
 
 	path = getfullpath(PATH_SBIN);
-	snprintf(command,sizeof(command),"%s\\upsmon.exe -K",path);
+	snprintf(command, sizeof(command), "%s\\upsmon.exe -K", path);
 	free(path);
 
-	memset(&StartupInfo,0,sizeof(STARTUPINFO));
+	memset(&StartupInfo, 0, sizeof(STARTUPINFO));
 	StartupInfo.cb = sizeof(StartupInfo);
-	memset(&ProcessInformation,0,sizeof(ProcessInformation));
+	memset(&ProcessInformation, 0, sizeof(ProcessInformation));
 
 	res = CreateProcess(
 			NULL,
@@ -216,15 +218,15 @@ static DWORD test_powerdownflag()
 			);
 	LastError = GetLastError();
 
-	if( res == 0 ) {
+	if (res == 0) {
 		print_event(LOG_ERR, "Can't create process %s : %d", command, LastError);
 		return 1;
 	}
 
-	while( i > 0) {
+	while (i > 0) {
 		res = GetExitCodeProcess(ProcessInformation.hProcess, &status);
-		if( res != 0) {
-			if( status != STILL_ACTIVE) {
+		if (res != 0) {
+			if (status != STILL_ACTIVE) {
 				return status;
 			}
 		}
@@ -241,7 +243,7 @@ static DWORD shutdown_ups()
 	char *path;
 
 	path = getfullpath(PATH_BIN);
-	snprintf(command,sizeof(command),"%s\\upsdrvctl.exe shutdown",path);
+	snprintf(command, sizeof(command), "%s\\upsdrvctl.exe shutdown", path);
 	free(path);
 	return create_process(command);
 }
@@ -254,27 +256,29 @@ static int parse_nutconf(BOOL start_flag)
 	char	buf[SMALLBUF];
 	char	fullname[SMALLBUF];
 
-	snprintf(fn,sizeof(fn),"%s/nut.conf",confpath());
+	snprintf(fn, sizeof(fn), "%s/nut.conf", confpath());
 
 	nutf = fopen(fn, "r");
-	if(nutf == NULL) {
-		snprintf(buf,sizeof(buf),"Error opening %s",fn);
-		print_event(LOG_ERR,buf);
+	if (nutf == NULL) {
+		snprintf(buf, sizeof(buf), "Error opening %s", fn);
+		print_event(LOG_ERR, buf);
 		return 0;
 	}
 
-	while( fgets(buf,sizeof(buf),nutf) != NULL ) {
-		if(buf[0] != '#') {
-			if( strstr(buf,"standalone") != NULL ||
-					strstr(buf,"netserver") != NULL ) {
-				if( start_flag == NUT_START ) {
-					print_event(LOG_INFO,"Starting drivers");
+	while (fgets(buf, sizeof(buf), nutf) != NULL) {
+		if (buf[0] != '#') {
+			if (strstr(buf, "standalone") != NULL
+			||  strstr(buf, "netserver") != NULL
+			) {
+				if (start_flag == NUT_START) {
+					print_event(LOG_INFO, "Starting drivers");
 					run_drivers();
-					print_event(LOG_INFO,"Starting upsd");
+					print_event(LOG_INFO, "Starting upsd");
 					run_upsd();
+
 					/* Wait a moment for the drivers to start */
 					Sleep(5000);
-					print_event(LOG_INFO,"Starting upsmon");
+					print_event(LOG_INFO, "Starting upsmon");
 					run_upsmon();
 					return 1;
 				}
@@ -287,16 +291,16 @@ static int parse_nutconf(BOOL start_flag)
 					stop_upsmon();
 					/* Give a chance to upsmon to write the POWERDOWNFLAG  file */
 					Sleep(1000);
-					if( test_powerdownflag() == 0 ) {
-						print_event(LOG_INFO,"shutdown ups");
+					if (test_powerdownflag() == 0) {
+						print_event(LOG_INFO, "shutdown ups");
 						shutdown_ups();
 					}
-					print_event(LOG_INFO,"End of NUT stop");
+					print_event(LOG_INFO, "End of NUT stop");
 					return 1;
 				}
 			}
-			if( strstr(buf,"netclient") != NULL ) {
-				if( start_flag == NUT_START ) {
+			if (strstr(buf, "netclient") != NULL) {
+				if (start_flag == NUT_START) {
 					run_upsmon();
 					return 1;
 				}
@@ -308,9 +312,12 @@ static int parse_nutconf(BOOL start_flag)
 		}
 	}
 
-	GetFullPathName(fn,sizeof(fullname),fullname,NULL);
-	snprintf(buf,sizeof(buf),"nut disabled, please adjust the configuration to your needs. Then set MODE to a suitable value in %s to enable it.",fullname);
-	print_event(LOG_ERR,buf);
+	GetFullPathName(fn, sizeof(fullname), fullname, NULL);
+	snprintf(buf, sizeof(buf),
+		"NUT disabled, please adjust the configuration to your needs. "
+		"Then set MODE to a suitable value in %s to enable it.",
+		fullname);
+	print_event(LOG_ERR, buf);
 	return 0;
 }
 
@@ -320,12 +327,12 @@ static int SvcInstall(const char * SvcName, const char * args)
 	SC_HANDLE Service;
 	TCHAR Path[MAX_PATH];
 
-	if( !GetModuleFileName( NULL, Path, MAX_PATH ) ) {
+	if (!GetModuleFileName(NULL, Path, MAX_PATH)) {
 		printf("Cannot install service (%d)\n", (int)GetLastError());
 		return EXIT_FAILURE;
 	}
 
-	if( args != NULL ) {
+	if (args != NULL) {
 		snprintfcat(Path, sizeof(Path), " %s", args);
 	}
 
@@ -395,11 +402,11 @@ static int SvcUninstall(const char * SvcName)
 		return EXIT_FAILURE;
 	}
 
-	if (! DeleteService(Service) )  {
-		upslogx(LOG_ERR,"DeleteService failed (%d)\n", (int)GetLastError());
+	if (!DeleteService(Service))  {
+		upslogx(LOG_ERR, "DeleteService failed (%d)\n", (int)GetLastError());
 	}
 	else {
-		upslogx(LOG_ERR,"Service deleted successfully\n");
+		upslogx(LOG_ERR, "Service deleted successfully\n");
 	}
 
 	CloseServiceHandle(Service);
@@ -408,7 +415,8 @@ static int SvcUninstall(const char * SvcName)
 	return EXIT_SUCCESS;
 }
 
-static void ReportSvcStatus(   DWORD CurrentState,
+static void ReportSvcStatus(
+		DWORD CurrentState,
 		DWORD Win32ExitCode,
 		DWORD WaitHint)
 {
@@ -422,8 +430,9 @@ static void ReportSvcStatus(   DWORD CurrentState,
 		SvcStatus.dwControlsAccepted = 0;
 	else SvcStatus.dwControlsAccepted = SERVICE_ACCEPT_STOP | SERVICE_ACCEPT_SHUTDOWN;
 
-	if ( (CurrentState == SERVICE_RUNNING) ||
-			(CurrentState == SERVICE_STOPPED) ) {
+	if ( (CurrentState == SERVICE_RUNNING)
+	||   (CurrentState == SERVICE_STOPPED)
+	) {
 		SvcStatus.dwCheckPoint = 0;
 	}
 	else {
@@ -431,10 +440,10 @@ static void ReportSvcStatus(   DWORD CurrentState,
 	}
 
 	/* report the status of the service to the SCM */
-	SetServiceStatus( SvcStatusHandle, &SvcStatus );
+	SetServiceStatus(SvcStatusHandle, &SvcStatus);
 }
 
-static void WINAPI SvcCtrlHandler( DWORD Ctrl )
+static void WINAPI SvcCtrlHandler(DWORD Ctrl)
 {
 	switch(Ctrl)
 	{
@@ -463,7 +472,7 @@ static void SvcStart(char * SvcName)
 			SvcName,
 			SvcCtrlHandler);
 
-	if( !SvcStatusHandle ) {
+	if (!SvcStatusHandle) {
 		upslogx(LOG_ERR, "RegisterServiceCtrlHandler\n");
 		return;
 	}
@@ -472,7 +481,7 @@ static void SvcStart(char * SvcName)
 	SvcStatus.dwServiceSpecificExitCode = 0;
 
 	/* Report initial status to the SCM */
-	ReportSvcStatus( SERVICE_START_PENDING, NO_ERROR, 3000 );
+	ReportSvcStatus(SERVICE_START_PENDING, NO_ERROR, 3000);
 }
 
 static void SvcReady(void)
@@ -483,11 +492,11 @@ static void SvcReady(void)
 			FALSE,	/* not signaled */
 			NULL);	/* no name */
 
-	if( svc_stop == NULL ) {
-		ReportSvcStatus( SERVICE_STOPPED, NO_ERROR, 0);
+	if (svc_stop == NULL) {
+		ReportSvcStatus(SERVICE_STOPPED, NO_ERROR, 0);
 		return;
 	}
-	ReportSvcStatus( SERVICE_RUNNING, NO_ERROR, 0);
+	ReportSvcStatus(SERVICE_RUNNING, NO_ERROR, 0);
 }
 
 static void close_all(void)
@@ -500,19 +509,19 @@ static void close_all(void)
 
 }
 
-static void WINAPI SvcMain( DWORD argc, LPTSTR *argv )
+static void WINAPI SvcMain(DWORD argc, LPTSTR *argv)
 {
 	DWORD	ret;
 	HANDLE	handles[MAXIMUM_WAIT_OBJECTS];
 	int	maxhandle = 0;
 	pipe_conn_t	*conn;
-	DWORD priority;
-	char * buf;
+	DWORD	priority;
+	char	*buf;
 
 	NUT_UNUSED_VARIABLE(argc);
 	NUT_UNUSED_VARIABLE(argv);
 
-	if(service_flag) {
+	if (service_flag) {
 		SvcStart(SVCNAME);
 	}
 
@@ -521,63 +530,64 @@ static void WINAPI SvcMain( DWORD argc, LPTSTR *argv )
 	/* create a console which will be inherited by children */
 	AllocConsole();
 
-	print_event(LOG_INFO,"Starting");
+	print_event(LOG_INFO, "Starting");
 
 	/* pipe for event log proxy */
 	pipe_create(EVENTLOG_PIPE_NAME);
 
 	/* parse nut.conf and start relevant processes */
-	if ( parse_nutconf(NUT_START) == 0 ) {
+	if (parse_nutconf(NUT_START) == 0) {
 		print_event(LOG_INFO, "exiting");
-		if( service_flag ) {
-			ReportSvcStatus( SERVICE_STOPPED, NO_ERROR, 0);
+		if (service_flag) {
+			ReportSvcStatus(SERVICE_STOPPED, NO_ERROR, 0);
 		}
 		return;
 	}
 
-	if(service_flag) {
+	if (service_flag) {
 		SvcReady();
 	}
 
 	while (1) {
 		maxhandle = 0;
-		memset(&handles,0,sizeof(handles));
+		memset(&handles, 0, sizeof(handles));
 
 		/* Wait on the read IO of each connections */
 		for (conn = pipe_connhead; conn; conn = conn->next) {
 			handles[maxhandle] = conn->overlapped.hEvent;
 			maxhandle++;
 		}
+
 		/* Add the new pipe connected event */
 		handles[maxhandle] = pipe_connection_overlapped.hEvent;
 		maxhandle++;
 
 		/* Add SCM event handler in service mode*/
-		if(service_flag) {
+		if (service_flag) {
 			handles[maxhandle] = svc_stop;
 			maxhandle++;
 		}
 
-		ret = WaitForMultipleObjects(maxhandle,handles,FALSE,INFINITE);
+		ret = WaitForMultipleObjects(maxhandle, handles, FALSE, INFINITE);
 
 		if (ret == WAIT_FAILED) {
 			print_event(LOG_ERR, "Wait failed");
 			return;
 		}
 
-		if( handles[ret] == svc_stop && service_flag ) {
+		if (handles[ret] == svc_stop && service_flag) {
 			parse_nutconf(NUT_STOP);
-			if(service_flag) {
+			if (service_flag) {
 				print_event(LOG_INFO, "Exiting");
 				close_all();
-				ReportSvcStatus( SERVICE_STOPPED, NO_ERROR, 0);
+				ReportSvcStatus(SERVICE_STOPPED, NO_ERROR, 0);
 			}
 			return;
 		}
 
 		/* Retrieve the signaled connection */
-		for(conn = pipe_connhead; conn != NULL; conn = conn->next) {
-			if( conn->overlapped.hEvent == handles[ret-WAIT_OBJECT_0]) {
+		for (conn = pipe_connhead; conn != NULL; conn = conn->next) {
+			if (conn->overlapped.hEvent == handles[ret - WAIT_OBJECT_0]) {
 				break;
 			}
 		}
@@ -587,13 +597,13 @@ static void WINAPI SvcMain( DWORD argc, LPTSTR *argv )
 		}
 		/* one of the read event handle has been signaled */
 		else {
-			if( conn != NULL) {
-				if( pipe_ready(conn) ) {
+			if (conn != NULL) {
+				if (pipe_ready(conn)) {
 					buf = conn->buf;
 					/* a frame is a DWORD indicating priority followed by an array of char (not necessarily followed by a terminal 0 */
-					priority =*((DWORD *)buf);
+					priority = *((DWORD *)buf);
 					buf = buf + sizeof(DWORD);
-					print_event(priority,buf);
+					print_event(priority, buf);
 
 					pipe_disconnect(conn);
 				}
@@ -608,7 +618,7 @@ int main(int argc, char **argv)
 	while ((i = getopt(argc, argv, "+IUN")) != -1) {
 		switch (i) {
 			case 'I':
-				return SvcInstall(SVCNAME,NULL);
+				return SvcInstall(SVCNAME, NULL);
 			case 'U':
 				return SvcUninstall(SVCNAME);
 			case 'N':
@@ -627,15 +637,19 @@ int main(int argc, char **argv)
 		{ SVCNAME, (LPSERVICE_MAIN_FUNCTION) SvcMain },
 		{ NULL, NULL }
 	};
+
 	/* This call returns when the service has stopped */
-	if(service_flag ) {
-		if (!StartServiceCtrlDispatcher( DispatchTable ))
+	if (service_flag) {
+		if (!StartServiceCtrlDispatcher(DispatchTable))
 		{
-			print_event(LOG_ERR, "StartServiceCtrlDispatcher failed : exiting, this is a Windows service which can't be run as a regular application by default. Try -N to start it as a regular application");
+			print_event(LOG_ERR, "StartServiceCtrlDispatcher failed : "
+				"exiting, this is a Windows service which can't "
+				"be run as a regular application by default. "
+				"Try -N to start it as a regular application.");
 		}
 	}
 	else {
-		SvcMain(argc,argv);
+		SvcMain(argc, argv);
 	}
 
 	return EXIT_SUCCESS;

--- a/scripts/Windows/wininit.c
+++ b/scripts/Windows/wininit.c
@@ -594,16 +594,17 @@ static void WINAPI SvcMain(DWORD argc, LPTSTR *argv)
 				break;
 			}
 		}
-		/* a new pipe connection has been signaled */
+
 		if (handles[ret] == pipe_connection_overlapped.hEvent) {
+			/* a new pipe connection has been signaled */
 			pipe_connect();
 		}
-		/* one of the read event handle has been signaled */
 		else {
+			/* one of the read event handles has been signaled */
 			if (conn != NULL) {
 				if (pipe_ready(conn)) {
 					buf = conn->buf;
-					/* a frame is a DWORD indicating priority followed by an array of char (not necessarily followed by a terminal 0 */
+					/* a frame is a DWORD indicating priority followed by an array of char (not necessarily followed by a terminal 0) */
 					priority = *((DWORD *)buf);
 					buf = buf + sizeof(DWORD);
 					print_event(priority, buf);
@@ -629,6 +630,7 @@ int main(int argc, char **argv)
 				upslogx(LOG_ERR, "Running in non-service mode\n");
 				break;
 			default:
+				/* Assume console-app start would come up - and pass args there, quietly */
 				break;
 		}
 	}


### PR DESCRIPTION
* added `help()` method
* added CLI options to handle version, help, debug level
* improved error-reporting when running it in a terminal: seeing nothing with no error reporting is not fun (gotta dig in code to find out to go to Event Log for the error message)
* added a man page (see also #2445 about delivering it nicely)

Closes: #2432