### PR TITLE
WIP: Bicker serial driver

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -146,6 +146,10 @@ https://github.com/networkupstools/nut/milestone/11
    respective warnings issued by the new generations of analysis tools.
    [#823, #2437, link:https://github.com/networkupstools/nut-website/issues/52[nut-website issue #52]]
 
+ - bicker_ser: added new driver for Bicker 12/24Vdc UPS via RS-232 serial
+   communication protocol, which supports any UPS shipped with the PSZ-1053
+   extension module. [PR #2448]
+
 
 Release notes for NUT 2.8.2 - what's new since 2.8.1
 ----------------------------------------------------

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -196,6 +196,11 @@
 "Best Power"	"ups"	"1"	"Micro-Ferrups"	""	"bestuferrups"
 "Best Power"	"ups"	"1"	"Fortress/Ferrups"	"f-command support"	"bestfcom"
 
+"Bicker"	"ups"	"3"	"UPSIC-1205"	""	"bicker_ser"
+"Bicker"	"ups"	"3"	"UPSIC-2403"	""	"bicker_ser"
+"Bicker"	"ups"	"3"	"DC2412-UPS"	""	"bicker_ser"
+"Bicker"	"ups"	"3"	"DC2412-UPS-LD"	""	"bicker_ser"
+
 "Borri"	"ups"	"2"	"B400-010-B/B400-020-B/B400-030-B/B400-010-C/B400-020-C/B400-030-C"	"USB"	"blazer_usb"
 "Borri"	"ups"	"2"	"B400-R010-B/B400-R020-B/B400-R030-B/B400-R010-C/B400-R020-C/B400-R030-C"	"USB"	"blazer_usb"
 "Borri"	"ups"	"2"	"B500-060-B/B500-100-B/B500-060-C/B500-100-C"	"USB"	"blazer_usb"

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -430,6 +430,7 @@ SRC_SERIAL_PAGES = \
 	bestuferrups.txt	\
 	bestups.txt 	\
 	bestfcom.txt	\
+	bicker_ser.txt	\
 	blazer-common.txt	\
 	blazer_ser.txt	\
 	clone.txt \
@@ -477,6 +478,7 @@ MAN_SERIAL_PAGES = \
 	bestuferrups.8	\
 	bestups.8 	\
 	bestfcom.8	\
+	bicker_ser.8	\
 	blazer_ser.8	\
 	clone.8 \
 	dummy-ups.8	\
@@ -526,6 +528,7 @@ HTML_SERIAL_MANS = \
 	bestuferrups.html	\
 	bestups.html 	\
 	bestfcom.html	\
+	bicker_ser.html	\
 	blazer_ser.html	\
 	clone.html \
 	dummy-ups.html	\

--- a/docs/man/bicker_ser.txt
+++ b/docs/man/bicker_ser.txt
@@ -1,0 +1,66 @@
+BICKER_SER(8)
+=============
+
+NAME
+----
+
+bicker_ser - Driver for Bicker DC UPS via serial port connections
+
+SYNOPSIS
+--------
+
+*bicker_ser* -h
+
+*bicker_ser* -a 'UPS_NAME' ['OPTIONS']
+
+NOTE: This man page only documents the hardware-specific features of the
+*bicker_ser* driver.  For information about the core driver, see
+linkman:nutupsdrv[8].
+
+SUPPORTED HARDWARE
+------------------
+
+*bicker_ser* supports all Bicker UPSes shipped with the PSZ-1053 extension
+module such as UPSIC-1205, UPSIC-2403, DC2412-UPS and DC2412-UPS-LD.
+
+CABLING
+-------
+
+The needed cable is a standard pin-to-pin serial cable with pins 2, 3 and 5
+(on DB9 connector) connected.
+
+EXTRA ARGUMENTS
+---------------
+
+This driver supports no extra arguments from linkman:ups.conf[5].
+
+INSTANT COMMANDS
+----------------
+
+*shutdown.return*::
+Turn off the load and return when power is back.
+
+KNOWN ISSUES AND BUGS
+---------------------
+
+*ups.delay.shutdown is not honored*::
+Although that delay is properly set when sending the shutdown command, it seems
+some UPS ignore it and use a fixed 2 seconds delay instead.
+
+AUTHOR
+------
+
+Nicola Fontana <ntd@entidi.it>
+
+SEE ALSO
+--------
+
+The core driver:
+~~~~~~~~~~~~~~~~
+
+linkman:nutupsdrv[8]
+
+Internet resources:
+~~~~~~~~~~~~~~~~~~~
+
+The NUT (Network UPS Tools) home page: https://www.networkupstools.org/

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3149 utf-8
+personal_ws-1.1 en 3151 utf-8
 AAC
 AAS
 ABI
@@ -373,6 +373,7 @@ Fideltronik
 Filipozzi
 Fiskars
 FlossMetrics
+Fontana
 Forza
 Fosshost
 Frama
@@ -858,6 +859,7 @@ PSSENTR
 PSUs
 PSW
 PSX
+PSZ
 PThreads
 PULS
 PV
@@ -1245,6 +1247,7 @@ UPS's
 UPSCONN
 UPSDESC
 UPSHOST
+UPSIC
 UPSIMAGEPATH
 UPSLC
 UPSNOTIFY

--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -57,7 +57,7 @@ SERIAL_DRIVERLIST = al175 bcmxcp belkin belkinunv bestfcom	\
  gamatronic genericups isbmex liebert liebert-esp2 masterguard metasys	\
  mge-utalk microdowell microsol-apc mge-shut oneac optiups powercom rhino 	\
  safenet nutdrv_siemens-sitop solis tripplite tripplitesu upscode2 victronups powerpanel \
- blazer_ser ivtscd apcsmart apcsmart-old riello_ser sms_ser
+ blazer_ser ivtscd apcsmart apcsmart-old riello_ser sms_ser bicker_ser
 SNMP_DRIVERLIST = snmp-ups
 USB_LIBUSB_DRIVERLIST = usbhid-ups bcmxcp_usb tripplite_usb \
  blazer_usb richcomm_usb riello_usb \
@@ -186,6 +186,8 @@ riello_ser_SOURCES = riello.c riello_ser.c
 riello_ser_LDADD = $(LDADD) -lm
 sms_ser_SOURCES = sms_ser.c
 sms_ser_LDADD = $(LDADD) -lm
+bicker_ser_SOURCES = bicker_ser.c
+bicker_ser_LDADD = $(LDADD) -lm
 
 # non-serial drivers: these use custom LDADD and/or CFLAGS
 

--- a/drivers/bicker_ser.c
+++ b/drivers/bicker_ser.c
@@ -240,7 +240,7 @@ static ssize_t bicker_receive(char idx, char cmd, void *data)
 			TOUINT(buf[datalen + 4]), TOUINT(BICKER_EOT));
 		return -1;
 	} else if (idx != '\xEE' && buf[2] == '\xEE') {
-		/* I found sperimentally that, when the syntax is
+		/* I found experimentally that, when the syntax is
 		 * formally correct but a feature is not supported,
 		 * the device returns "\x01\x03\xEE\x07\x04". */
 		upsdebugx(2, "Command is not supported");
@@ -267,10 +267,10 @@ static ssize_t bicker_receive(char idx, char cmd, void *data)
  * @param idx     Command index
  * @param cmd     Command
  * @param data    Destination buffer or NULL to discard the data field
- * @param datalen  The expected size of the data field
+ * @param datalen The expected size of the data field
  * @return        The size of the data field on success or -1 on errors.
  *
- * `data`, if specified, must have at least `datalen` bytes. If
+ * `data`, if not NULL, must have at least `datalen` bytes. If
  * `datalen` is less than the received data size, an error is thrown.
  */
 static ssize_t bicker_receive_known(char idx, char cmd, void *data, size_t datalen)
@@ -363,10 +363,11 @@ static ssize_t bicker_read_int16(char idx, char cmd, int16_t *dst)
  * Execute a command that returns a string.
  * @param idx Command index
  * @param cmd Command
- * @param dst Destination for the string
+ * @param dst Destination for the string or NULL to discard
+ * @return    The size of the data field on success or -1 on errors.
  *
- * `dst` must have at least BICKER_MAXDATA+1 bytes, the additional byte
- * needed to accomodate the ending '\0'.
+ * `dst`, if not NULL, must have at least BICKER_MAXDATA+1 bytes, the
+ * additional byte needed to accomodate the ending '\0'.
  */
 static ssize_t bicker_read_string(char idx, char cmd, char *dst)
 {
@@ -472,7 +473,7 @@ static ssize_t bicker_set(BickerParameter *parameter)
 /* For some reason the `seconds` delay (at least on my UPSIC-2403D)
  * is not honored: the shutdown is always delayed by 2 seconds. This
  * fixed delay seems to be independent from the state of the UPS (on
- * line or on battery) and from the dip switches setting.
+ * line or on battery) and from the DIP switches setting.
  *
  * As response I get the same command with `0xE0` in the data field.
  */

--- a/drivers/bicker_ser.c
+++ b/drivers/bicker_ser.c
@@ -550,15 +550,15 @@ void upsdrv_initinfo(void)
 	dstate_setinfo("device.type", "ups");
 
 	if (bicker_read_string('\x01', '\x60', string) >= 0) {
-		dstate_setinfo("device.mfr", string);
+		dstate_setinfo("device.mfr", "%s", string);
 	}
 
 	if (bicker_read_string('\x01', '\x61', string) >= 0) {
-		dstate_setinfo("device.serial", string);
+		dstate_setinfo("device.serial", "%s", string);
 	}
 
 	if (bicker_read_string('\x01', '\x62', string) >= 0) {
-		dstate_setinfo("device.model", string);
+		dstate_setinfo("device.model", "%s", string);
 	}
 
 	upsh.instcmd = bicker_instcmd;
@@ -717,18 +717,18 @@ void upsdrv_initups(void)
 	dstate_setinfo("ups.delay.shutdown", "%u", BICKER_DELAY);
 
 	if (bicker_read_string('\x01', '\x63', string) >= 0) {
-		dstate_setinfo("ups.firmware", string);
+		dstate_setinfo("ups.firmware", "%s", string);
 	}
 
 	if (bicker_read_string('\x01', '\x64', string) >= 0) {
-		dstate_setinfo("battery.type", string);
+		dstate_setinfo("battery.type", "%s", string);
 	}
 
 	dstate_setinfo("battery.charge.low", "%d", 30);
 
 	/* Not implemented on all UPSes */
 	if (bicker_read_string('\x01', '\x65', string) >= 0) {
-		dstate_setinfo("ups.firmware.aux", string);
+		dstate_setinfo("ups.firmware.aux", "%s", string);
 	}
 
 	parameter.id = 0x05;

--- a/drivers/bicker_ser.c
+++ b/drivers/bicker_ser.c
@@ -1,0 +1,306 @@
+/*
+ * bicker_ser.c: support for Bicker SuperCapacitors DC UPSes
+ *
+ * Copyright (C) 2024 - Nicola Fontana <ntd@entidi.it>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+/* The protocol is detailed in section 14 of the DC/UPSIC user's manual,
+ * downloadable somewhere from the Bicker website.
+ *
+ * Basically, this is a binary protocol without checksums:
+ *
+ *  1 byte  1 byte  1 byte  1 byte  0..252 bytes  1 byte
+ * +-------+-------+-------+-------+--- - - - ---+-------+
+ * |  SOH  | Size  | Index |  CMD  |    Data     |  EOT  |
+ * +-------+-------+-------+-------+--- - - - ---+-------+
+ *
+ * where:
+ * - `SOH` is the start signal ('\x01')
+ * - `Size` is the length of the `Data` field (in bytes) plus 3
+ * - `Index` is the command index (always '\x03')
+ * - `CMD` is the command code to execute
+ * - `Data` is the (optional) argument of the command
+ * - `EOT` is the end signal ('\x04')
+ *
+ * The same format is used for incoming and outcoming packets. Although
+ * not explicitly documented, the data returned by the `Data` field
+ * seems to be in little-endian order.
+ */
+
+#include "config.h"
+#include "main.h"
+#include "attribute.h"
+
+#include "serial.h"
+
+#define DRIVER_NAME	"Bicker serial protocol"
+#define DRIVER_VERSION	"0.01"
+
+#define BICKER_PACKET	(1+1+1+1+252+1)
+#define BICKER_SOH	'\x01'
+#define BICKER_EOT	'\x04'
+
+upsdrv_info_t upsdrv_info = {
+	DRIVER_NAME,
+	DRIVER_VERSION,
+	"Nicola Fontana <ntd@entidi.it>",
+	DRV_EXPERIMENTAL,
+	{ NULL }
+};
+
+static ssize_t bicker_send(char cmd, const char *data)
+{
+	char buf[BICKER_PACKET];
+	size_t datalen, buflen;
+	ssize_t ret;
+
+	ser_flush_io(upsfd);
+
+	if (data != NULL) {
+		datalen = strlen(data);
+		if (datalen > 252) {
+			upslogx(LOG_ERR, "Data size exceeded: %d > 252",
+				(int)datalen);
+			return 0;
+		}
+		memcpy(buf + 4, data, datalen);
+	} else {
+		datalen = 0;
+	}
+
+	buf[0] = BICKER_SOH;
+	buf[1] = datalen + 3; /* Packet size must include the header */
+	buf[2] = '\x03'; /* Command index is always 3 */
+	buf[3] = cmd;
+	buf[4 + datalen] = BICKER_EOT;
+
+	/* The full packet includes SOH and EOT bytes too */
+	buflen = datalen + 3 + 2;
+
+	ret = ser_send_buf(upsfd, buf, buflen);
+	if (ret < 0) {
+		upslog_with_errno(LOG_WARNING, "ser_send_buf failed");
+		return ret;
+	} else if ((size_t) ret != buflen) {
+		upslogx(LOG_WARNING, "ser_send_buf returned %d instead of %d",
+			(int)ret, (int)buflen);
+		return 0;
+	}
+
+	upsdebug_hex(3, "bicker_send", buf, buflen);
+	return ret;
+}
+
+static ssize_t bicker_receive_buf(void *dst, size_t dstlen)
+{
+	ssize_t ret;
+
+	ret = ser_get_buf(upsfd, dst, dstlen, 1, 1);
+	if (ret < 0) {
+		upslog_with_errno(LOG_WARNING, "ser_get_buf failed");
+		return ret;
+	} else if ((size_t) ret != dstlen) {
+		upslogx(LOG_WARNING, "ser_get_buf returned %d instead of %d",
+			(int)ret, (int)dstlen);
+		return 0;
+	}
+
+	upsdebug_hex(3, "bicker_receive_buf", dst, dstlen);
+	return ret;
+}
+
+static ssize_t bicker_receive(char cmd, void *dst, size_t dstlen)
+{
+	ssize_t ret;
+	size_t datalen;
+	char buf[BICKER_PACKET];
+
+	ret = bicker_receive_buf(buf, 1);
+	if (ret <= 0) {
+		return ret;
+	} else if (buf[0] != BICKER_SOH) {
+		upslogx(LOG_WARNING, "Received 0x%02X instead of SOH (0x%02X)",
+			(unsigned)buf[0], (unsigned)BICKER_SOH);
+		return 0;
+	}
+
+	ret = bicker_receive_buf(buf + 1, 1);
+	if (ret <= 0) {
+		return ret;
+	}
+
+	datalen = buf[1] - 3;
+
+	ret = bicker_receive_buf(buf + 2, datalen + 3);
+	if (ret <= 0) {
+		return ret;
+	} else if (buf[datalen + 4] != BICKER_EOT) {
+		upslogx(LOG_WARNING, "Received 0x%02X instead of EOT (0x%02X)",
+			(unsigned)buf[datalen + 4], (unsigned)BICKER_EOT);
+		return 0;
+	} else if (buf[3] != cmd) {
+		upslogx(LOG_WARNING, "Commands do not match: sent 0x%02X, received 0x%02X",
+			(unsigned)cmd, (unsigned)buf[1]);
+		return 0;
+	} else if (dstlen < datalen) {
+		upslogx(LOG_ERR, "Not enough space for the payload: %d < %d",
+			(int)dstlen, (int)datalen);
+		return 0;
+	}
+
+	memcpy(dst, buf + 4, datalen);
+
+	upsdebug_hex(3, "bicker_receive", buf, datalen + 5);
+	return datalen;
+}
+
+static ssize_t bicker_read_int16(char cmd, int16_t *dst)
+{
+	ssize_t ret;
+
+	ret = bicker_send(cmd, NULL);
+	if (ret <= 0) {
+		return ret;
+	}
+
+	/* XXX: by default, data is stored in little-endian so,
+	 * on big-endian platforms, a byte swap should be needed */
+	return bicker_receive(cmd, dst, 2);
+}
+
+void upsdrv_initinfo(void)
+{
+	dstate_setinfo("device.type", "ups");
+	dstate_setinfo("device.mfr", "Bicker Elektronik GmbH");
+	/* No way to detect the UPS model within the protocol but the
+	 * serial communication is provided by the PSZ-1063 extension
+	 * module, so it seems correct to put that into the model */
+	dstate_setinfo("device.model", "PSZ-1063");
+}
+
+void upsdrv_updateinfo(void)
+{
+	int16_t data, charge_current;
+	ssize_t ret;
+
+	ret = bicker_read_int16('\x25', &data);
+	if (ret <= 0) {
+		dstate_datastale();
+		return;
+	}
+	dstate_setinfo("input.voltage", "%.1f", (double) data / 1000);
+
+	ret = bicker_read_int16('\x28', &data);
+	if (ret <= 0) {
+		dstate_datastale();
+		return;
+	}
+	dstate_setinfo("input.current", "%.3f", (double) data / 1000);
+
+	ret = bicker_read_int16('\x27', &data);
+	if (ret <= 0) {
+		dstate_datastale();
+		return;
+	}
+	dstate_setinfo("output.voltage", "%.3f", (double) data / 1000);
+
+	/* This is a supercap UPS so, in this context,
+	 * the "battery" is the supercap stack */
+	ret = bicker_read_int16('\x26', &data);
+	if (ret <= 0) {
+		dstate_datastale();
+		return;
+	}
+	dstate_setinfo("battery.voltage", "%.3f", (double) data / 1000);
+
+	ret = bicker_read_int16('\x29', &charge_current);
+	if (ret <= 0) {
+		dstate_datastale();
+		return;
+	}
+	dstate_setinfo("battery.current", "%.3f", (double) charge_current / 1000);
+
+	/* GetChargeStaturRegister returns a 16 bit register:
+	 *
+	 *  0. SD Shows that the device is in step-down (charging) mode.
+	 *  1. SU Shows that the device is in step-up (backup) mode.
+	 *  2. CV Shows that the charger is in constant voltage mode.
+	 *  3. UV Shows that the charger is in undervoltage lockout.
+	 *  4. CL Shows that the device is in input current limit.
+	 *  5. CG Shows that the capacitor voltage is above power good threshold.
+	 *  6. CS Shows that the capacitor manager is shunting.
+	 *  7. CB Shows that the capacitor manager is balancing.
+	 *  8. CD Shows that the charger is temporarily disabled for capacitance measurement.
+	 *  9. CC Shows that the charger is in constant current mode.
+	 * 10. RV Reserved Bit
+	 * 11. PF Shows that the input voltage is below the Power Fail Input (PFI) threshold.
+	 * 12. RV Reserved Bit
+	 * 13. RV Reserved Bit
+	 * 14. RV Reserved Bit
+	 * 15. RV Reserved Bit
+	 */
+	ret = bicker_read_int16('\x1B', &data);
+	if (ret <= 0) {
+		dstate_datastale();
+		return;
+	}
+
+	status_init();
+
+	/* Check PF (bit 11) to know if the UPS is on line/battery */
+	status_set((data & 0x0800) > 0 ? "OB" : "OL");
+
+	/* Check CG (bit 5) to know if the battery is low */
+	if ((data & 0x0020) == 0) {
+		status_set("LB");
+	}
+
+	/* If there is a current of more than 1 A flowing towards
+	 * the supercaps, consider the battery in charging mode */
+	if (charge_current > 1000) {
+		status_set("CHRG");
+	}
+
+	status_commit();
+
+	dstate_dataok();
+}
+
+void upsdrv_shutdown(void)
+{
+	upslogx(LOG_ERR, "shutdown not supported");
+	set_exit_flag(-1);
+}
+
+void upsdrv_help(void)
+{
+}
+
+void upsdrv_makevartable(void)
+{
+}
+
+void upsdrv_initups(void)
+{
+	upsfd = ser_open(device_path);
+	ser_set_speed(upsfd, device_path, B38400);
+}
+
+void upsdrv_cleanup(void)
+{
+	ser_close(upsfd, device_path);
+}

--- a/drivers/bicker_ser.c
+++ b/drivers/bicker_ser.c
@@ -18,8 +18,10 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 
-/* The protocol is detailed in section 14 of the DC/UPSIC user's manual,
- * downloadable somewhere from the Bicker website.
+/* The protocol is reported in many Bicker's manuals but (according to
+ * Bicker itself) the best source is the UPS Gen Software's user manual:
+ *
+ * https://www.bicker.de/media/pdf/ff/cc/fe/en_user_manual_ups-gen2-configuration-software.pdf
  *
  * Basically, this is a binary protocol without checksums:
  *
@@ -32,14 +34,70 @@
  * where:
  * - `SOH` is the start signal ('\x01')
  * - `Size` is the length (in bytes) of the header and the data field
- * - `Index` is the command index (always '\x03')
- * - `CMD` is the command code to execute
+ * - `Index` is the command index: see AVAILABLE COMMANDS
+ * - `CMD` is the command code to execute: see AVAILABLE COMMANDS
  * - `Data` is the (optional) argument of the command
  * - `EOT` is the end signal ('\x04')
  *
- * The same format is used for incoming and outcoming packets. Although
- * not explicitly documented, the data returned by the `Data` field
- * seems to be in little-endian order.
+ * The same format is used for incoming and outcoming packets. The data
+ * returned in the `Data` field is always in little-endian order.
+ *
+ * AVAILABLE COMMANDS
+ * ------------------
+ *
+ * - Index = 0x01 (GENERIC)
+ *   - CMD = 0x40 (status flags)
+ *   - CMD = 0x41 (input voltage)
+ *   - CMD = 0x42 (input current)
+ *   - CMD = 0x43 (output voltage)
+ *   - CMD = 0x44 (output current)
+ *   - CMD = 0x45 (battery voltage)
+ *   - CMD = 0x46 (battery current)
+ *   - CMD = 0x47 (battery state of charge)
+ *   - CMD = 0x48 (battery state of health)
+ *   - CMD = 0x49 (battery cycles)
+ *   - CMD = 0x4A (battery temperature)
+ *   - CMD = 0x60 (manufacturer)
+ *   - CMD = 0x61 (serial number)
+ *   - CMD = 0x62 (device name)
+ *   - CMD = 0x63 (firmware version)
+ *   - CMD = 0x64 (battery pack)
+ *   - CMD = 0x65 (firmware core version)
+ *   - CMD = 0x66 (CPU temperature)
+ *   - CMD = 0x67 (hardware revision)
+ *   - CMD = 0x21 (UPS output)
+ *   - CMD = 0x2F (shutdown flag)
+ *   - CMD = 0x7A (reset parameter settings)
+ *
+ * - Index = 0x07 (PARAMETER)
+ *   - CMD = 0x00 (get/set dummy entry: do not use!)
+ *   - CMD = 0x01 (get/set load sensor)
+ *   - CMD = 0x02 (get/set maximum backup time)
+ *   - CMD = 0x03 (get/set os shutdown by timer)
+ *   - CMD = 0x04 (get/set restart delay timer)
+ *   - CMD = 0x05 (get/set minimum capacity to start)
+ *   - CMD = 0x06 (get/set maximum backup time by in-1)
+ *   - CMD = 0x07 (get/set os shutdown by soc)
+ *   - CMD = 0x08 (get/set battery soc low threshold)
+ *   - CMD = 0x09 (get/set relay event configuration)
+ *   - CMD = 0x0A (get/set RS232 port configuration: place holder!)
+ *
+ * - Index = 0x03 (COMMANDS GOT FROM UPSIC MANUAL)
+ *   - CMD = 0x1B (GetChargeStatusRegister)
+ *   - CMD = 0x1C (GetMonitorStatusRegister)
+ *   - CMD = 0x1E (GetCapacity)
+ *   - CMD = 0x1F (GetEsr)
+ *   - CMD = 0x20 (GetVCap1Voltage)
+ *   - CMD = 0x21 (GetVCap2Voltage)
+ *   - CMD = 0x22 (GetVCap3Voltage)
+ *   - CMD = 0x23 (GetVCap4Voltage)
+ *   - CMD = 0x25 (GetInputVoltage)
+ *   - CMD = 0x26 (GetCapStackVoltage)
+ *   - CMD = 0x27 (GetOutputVoltage)
+ *   - CMD = 0x28 (GetInputCurrent)
+ *   - CMD = 0x29 (GetChargeCurrent)
+ *   - CMD = 0x31 (StartCapEsrMeasurement)
+ *   - CMD = 0x32 (SetTimeToShutdown)
  */
 
 #include "config.h"

--- a/drivers/bicker_ser.c
+++ b/drivers/bicker_ser.c
@@ -443,6 +443,7 @@ void upsdrv_initinfo(void)
 
 void upsdrv_updateinfo(void)
 {
+	const char *str;
 	uint8_t u8;
 	uint16_t u16;
 	int16_t i16;
@@ -512,7 +513,8 @@ void upsdrv_updateinfo(void)
 	status_init();
 
 	/* Consider the battery low when its charge is < 30% */
-	if (u8 < 30) {
+	str = dstate_getinfo("battery.charge.low");
+	if (u8 < atoi(str)) {
 		status_set("LB");
 	}
 
@@ -596,6 +598,8 @@ void upsdrv_initups(void)
 	if (bicker_read_string('\x01', '\x64', string) >= 0) {
 		dstate_setinfo("battery.type", string);
 	}
+
+	dstate_setinfo("battery.charge.low", "%d", 30);
 
 	/* Not implemented on all UPSes */
 	if (bicker_read_string('\x01', '\x65', string) >= 0) {

--- a/drivers/bicker_ser.c
+++ b/drivers/bicker_ser.c
@@ -115,6 +115,7 @@
 #define BICKER_TIMEOUT	1
 #define BICKER_DELAY	20
 #define BICKER_RETRIES	3
+#define BICKER_MAXID	0x0A /* Max parameter ID */
 
 /* Protocol lengths */
 #define BICKER_HEADER		3
@@ -460,6 +461,17 @@ static ssize_t bicker_set(uint8_t id, uint8_t enabled, uint16_t value, BickerPar
 {
 	ssize_t ret;
 	uint8_t data[3];
+
+	if (id < 1 || id > BICKER_MAXID) {
+		upslogx(LOG_ERR, "bicker_set(0x%02X, %d, %u): id out of range (0x01..0x%02X)",
+			(unsigned)id, enabled, (unsigned)value,
+			(unsigned)BICKER_MAXID);
+		return -1;
+	} else if (enabled > 1) {
+		upslogx(LOG_ERR, "bicker_set(0x%02X, %d, %u): enabled must be 0 or 1",
+			(unsigned)id, enabled, (unsigned)value);
+		return -1;
+	}
 
 	/* Format of `data` is "[EE] [ffFF]"
 	 * where:

--- a/drivers/bicker_ser.c
+++ b/drivers/bicker_ser.c
@@ -243,12 +243,15 @@ static ssize_t bicker_receive(char idx, char cmd, void *data)
 		upslogx(LOG_WARNING, "Received 0x%02X instead of EOT (0x%02X)",
 			TOUINT(buf[datalen + 4]), TOUINT(BICKER_EOT));
 		return -1;
+	} else if (idx != '\xEE' && buf[2] == '\xEE') {
+		/* I found sperimentally that, when the syntax is
+		 * formally correct but a feature is not supported,
+		 * the device returns "\x01\x03\xEE\x07\x04". */
+		upsdebugx(2, "Command is not supported");
+		return -1;
 	} else if (buf[2] != idx) {
-		/* This probably suggests the command is correct but not
-		 * supported, so no logging performed here */
-		upsdebugx(2, "Indexes do not match, maybe the command is not supported?"
-			  " Sent 0x%02X, received 0x%02X",
-			  TOUINT(idx), TOUINT(buf[2]));
+		upslogx(LOG_WARNING, "Indexes do not match: sent 0x%02X, received 0x%02X",
+			TOUINT(idx), TOUINT(buf[2]));
 		return -1;
 	} else if (buf[3] != cmd) {
 		upslogx(LOG_WARNING, "Commands do not match: sent 0x%02X, received 0x%02X",


### PR DESCRIPTION
This driver supports some interesting supercap DC UPSes manufactured by [Bicker](https://www.bicker.de/en/products/ups-systems/dc-ups). I'm planning to use them in the near future on small Linux-based industrial PC (mainly amd64 or arm64).

AFAICS, there are two main issues:
1. the code does not work on big-endian platforms (see the [relevant comment](https://github.com/ntd/nut/blob/bicker/drivers/bicker_ser.c#L183-L184))
2. the way I'm using `ups.delay.shutdown` stinks: most drivers defines it in `upsdrv_initinfo` but then my `upsdrv_shutdown` function crashes when trying to access it. I followed the `usbhid-ups.c` example and put it inside `upsdrv_initups`.