### PR TITLE
`nut-scanner`: Fix "Old NUT" detection and clarify some log messages

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -48,6 +48,9 @@ https://github.com/networkupstools/nut/milestone/11
    * The `nut-driver-enumerator.sh` improvements misfired in v2.8.2 release
      with an overlooked bit of shell syntax, and caused `nut-driver@upsname`
      instances to not auto-restart when `ups.conf` is edited. [#682, #2410]
+   * Addition of "NUT Simulated devices" support to `nut-scanner` in v2.8.2
+     broke detection of (in-)ability to find and query "Old NUT" servers via
+     `libupsclient.so` (internal flag got always enabled). [#2246]
 
  - drivers, upsd, upsmon: reduce "scary noise" about failure to `fopen()`
    the PID file (which most of the time means that no previous instance of

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -842,7 +842,7 @@ display_help:
 		dev[TYPE_USB] = nutscan_scan_usb(&cli_link_detail_level);
 #endif /* HAVE_PTHREAD */
 	} else {
-		upsdebugx(1, "USB SCAN: not requested, SKIPPED");
+		upsdebugx(1, "USB SCAN: not requested or supported, SKIPPED");
 	}
 
 	if (allow_snmp && nutscan_avail_snmp) {
@@ -864,7 +864,7 @@ display_help:
 #endif /* HAVE_PTHREAD */
 		}
 	} else {
-		upsdebugx(1, "SNMP SCAN: not requested, SKIPPED");
+		upsdebugx(1, "SNMP SCAN: not requested or supported, SKIPPED");
 	}
 
 	if (allow_xml && nutscan_avail_xml_http) {
@@ -881,7 +881,7 @@ display_help:
 		dev[TYPE_XML] = nutscan_scan_xml_http_range(start_ip, end_ip, timeout, &xml_sec);
 #endif /* HAVE_PTHREAD */
 	} else {
-		upsdebugx(1, "XML/HTTP SCAN: not requested, SKIPPED");
+		upsdebugx(1, "XML/HTTP SCAN: not requested or supported, SKIPPED");
 	}
 
 	if (allow_oldnut && nutscan_avail_nut) {
@@ -903,7 +903,7 @@ display_help:
 #endif /* HAVE_PTHREAD */
 		}
 	} else {
-		upsdebugx(1, "NUT bus (old) SCAN: not requested, SKIPPED");
+		upsdebugx(1, "NUT bus (old) SCAN: not requested or supported, SKIPPED");
 	}
 
 	if (allow_nut_simulation && nutscan_avail_nut_simulation) {
@@ -919,7 +919,7 @@ display_help:
 			dev[TYPE_NUT_SIMULATION] = nutscan_scan_nut_simulation(timeout);
 #endif /* HAVE_PTHREAD */
 	} else {
-		upsdebugx(1, "NUT simulation devices SCAN: not requested, SKIPPED");
+		upsdebugx(1, "NUT simulation devices SCAN: not requested or supported, SKIPPED");
 	}
 
 	if (allow_avahi && nutscan_avail_avahi) {
@@ -935,7 +935,7 @@ display_help:
 		dev[TYPE_AVAHI] = nutscan_scan_avahi(timeout);
 #endif /* HAVE_PTHREAD */
 	} else {
-		upsdebugx(1, "NUT bus (avahi) SCAN: not requested, SKIPPED");
+		upsdebugx(1, "NUT bus (avahi) SCAN: not requested or supported, SKIPPED");
 	}
 
 	if (allow_ipmi && nutscan_avail_ipmi) {
@@ -951,7 +951,7 @@ display_help:
 		dev[TYPE_IPMI] = nutscan_scan_ipmi(start_ip, end_ip, &ipmi_sec);
 #endif /* HAVE_PTHREAD */
 	} else {
-		upsdebugx(1, "IPMI SCAN: not requested, SKIPPED");
+		upsdebugx(1, "IPMI SCAN: not requested or supported, SKIPPED");
 	}
 
 	/* Eaton serial scan */
@@ -968,7 +968,7 @@ display_help:
 		dev[TYPE_EATON_SERIAL] = nutscan_scan_eaton_serial (serial_ports);
 #endif /* HAVE_PTHREAD */
 	} else {
-		upsdebugx(1, "SERIAL SCAN: not requested, SKIPPED");
+		upsdebugx(1, "SERIAL SCAN: not requested or supported, SKIPPED");
 	}
 
 #ifdef HAVE_PTHREAD

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -89,8 +89,8 @@ static const struct option longopts[] = {
 	{ "usb_scan", no_argument, NULL, 'U' },
 	{ "snmp_scan", no_argument, NULL, 'S' },
 	{ "xml_scan", no_argument, NULL, 'M' },
-	{ "oldnut_scan", no_argument, NULL, 'O' },
-	{ "avahi_scan", no_argument, NULL, 'A' },
+	{ "oldnut_scan", no_argument, NULL, 'O' },	/* "old" NUT libupsclient.so scan */
+	{ "avahi_scan", no_argument, NULL, 'A' },	/* "new" NUT scan where deployed */
 	{ "nut_simulation_scan", no_argument, NULL, 'n' },
 	{ "ipmi_scan", no_argument, NULL, 'I' },
 	{ "disp_nut_conf_with_sanity_check", no_argument, NULL, 'Q' },
@@ -256,11 +256,11 @@ static void show_usage(void)
 	} else {
 		printf("* Options for XML/HTTP devices scan not enabled: library not detected.\n");
 	}
-	printf("  -O, --oldnut_scan: Scan NUT devices (old method).\n");
+	printf("  -O, --oldnut_scan: Scan NUT devices (old method via libupsclient).\n");
 	if (nutscan_avail_avahi) {
-		printf("  -A, --avahi_scan: Scan NUT devices (avahi method).\n");
+		printf("  -A, --avahi_scan: Scan NUT devices (new avahi method).\n");
 	} else {
-		printf("* Options for NUT devices (avahi method) scan not enabled: library not detected.\n");
+		printf("* Options for NUT devices (new avahi method) scan not enabled: library not detected.\n");
 	}
 	printf("  -n, --nut_simulation_scan: Scan for NUT simulated devices (.dev files in $CONFPATH).\n");
 	if (nutscan_avail_ipmi) {
@@ -886,11 +886,11 @@ display_help:
 
 	if (allow_oldnut && nutscan_avail_nut) {
 		if (start_ip == NULL) {
-			upsdebugx(quiet, "No start IP, skipping NUT bus (old connect method)");
+			upsdebugx(quiet, "No start IP, skipping NUT bus (old libupsclient connect method)");
 			nutscan_avail_nut = 0;
 		}
 		else {
-			upsdebugx(quiet, "Scanning NUT bus (old connect method).");
+			upsdebugx(quiet, "Scanning NUT bus (old libupsclient connect method).");
 #ifdef HAVE_PTHREAD
 			upsdebugx(1, "NUT bus (old) SCAN: starting pthread_create with run_nut_old...");
 			if (pthread_create(&thread[TYPE_NUT], NULL, run_nut_old, NULL)) {

--- a/tools/nut-scanner/nutscan-init.c
+++ b/tools/nut-scanner/nutscan-init.c
@@ -1,6 +1,8 @@
 /*
  *  Copyright (C) 2011 - 2024 Arnaud Quette (Design and part of implementation)
- *  Copyright (C) 2011-2021 - EATON
+ *  Copyright (C) 2011 - 2021 EATON
+ *  Copyright (C) 2016 - 2021 Jim Klimov <EvgenyKlimov@eaton.com>
+ *  Copyright (C) 2022 - 2024 Jim Klimov <jimklimov+nut@gmail.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -21,7 +23,8 @@
     \brief init functions for nut scanner library
     \author Frederic Bohe <fredericbohe@eaton.com>
     \author Arnaud Quette <ArnaudQuette@Eaton.com>
-	\author Arnaud Quette <arnaudquette@free.fr>
+    \author Arnaud Quette <arnaudquette@free.fr>
+    \author Jim Klimov <jimklimov+nut@gmail.com>
 */
 
 #include "common.h"
@@ -38,10 +41,13 @@
 #define SOEXT ".dll"
 #endif
 
+/* Flags for code paths we can support in this run (libs available or not
+ * needed). For consistency, only set non-zero values via nutscan_init() call.
+ */
 int nutscan_avail_avahi = 0;
 int nutscan_avail_ipmi = 0;
-int nutscan_avail_nut = 0;
-int nutscan_avail_nut_simulation = 1;
+int nutscan_avail_nut = 0;	/* aka oldnut detection via libupsclient compared to avahi as newnut */
+int nutscan_avail_nut_simulation = 0;
 #ifdef WITH_SNMP_STATIC
 int nutscan_avail_snmp = 1;
 #else
@@ -363,7 +369,7 @@ void nutscan_init(void)
 
 /* start of "NUT Simulation" - unconditional */
 /* no need for additional library */
-	nutscan_avail_nut = 1;
+	nutscan_avail_nut_simulation = 1;
 
 }
 


### PR DESCRIPTION
It seems that commit 3eb96fe98f9bd75813fa243832732e61ac614726 (PR #2246 for issue #2242) released in NUT v2.8.2 broke detection that `libupsclient.so` is not available (not a really practical situation breaking end-user setups, outside of some weird packaging choices on constrained systems, or builds on systems where NUT is not installed into common paths - it did fire up in test cases investigated for another issue #2431).

Also this PR takes a moment to clarify what "old nut" is about in `nut-scanner` context (as opposed to "new" avahi-based detection where available) so `help()` and codebase reading is more comprehensible.

Finally, this PR changes all flags about detected scanning methods to be zeroed initially, only set to `1` (even if always) in the `nutscan_init()` method, to be consistent.