### PR TITLE
bicker_ser: allow changing of non-volatile variables with `upsrw`

### DIFF
--- a/docs/man/bicker_ser.txt
+++ b/docs/man/bicker_ser.txt
@@ -82,11 +82,14 @@ Currently this setting is only valid for relay signaling. Cannot be disabled.
 *experimental.ups.relay.mode* (default `0x01`)::
 This parameter controls the behavior of the relay in case of different events.
 Cannot be disabled.
-- `0x01` On power fail (normally closed)
-- `0x02` On power fail (normally opened)
-- `0x03` Shutdown impulse (1 second)
-- `0x04` Battery low signal (normally closed)
-- `0x05` Battery defect signal (normally closed)
++
+Available relay modes:
+[horizontal]
+`0x01`::: On power fail (normally closed)
+`0x02`::: On power fail (normally opened)
+`0x03`::: Shutdown impulse (1 second)
+`0x04`::: Battery low signal (normally closed)
+`0x05`::: Battery defect signal (normally closed)
 
 INSTANT COMMANDS
 ----------------

--- a/docs/man/bicker_ser.txt
+++ b/docs/man/bicker_ser.txt
@@ -43,18 +43,9 @@ UPS, it will not be made available. Whenever not explicitly stated, any variable
 can be disabled, in which case the action it performs will not be executed. To
 disable a variable, set it to an empty value.
 
-*output.current.low* (in mA, default `200`)::
-If activated and the UPS is in battery mode and the current drops below the set
-value, the output of the UPS will shut down and disconnect the energy storage to
-prevent self-discharge.
-
 *ups.delay.shutdown* (in seconds, default disabled)::
 If activated and the UPS is in battery mode and the set time has expired, the
 output will be disabled, and the UPS and energy storage will be disconnected.
-
-*ups.delay.shutdown.signal* (in seconds, default disabled)::
-If activated and the UPS is in battery mode and the set time has elapsed, a
-shutdown command via USB or relay (relay event) is signaled.
 
 *ups.delay.start* (in seconds, default disabled)::
 If activated and a restart condition switches the UPS output off and on again,
@@ -66,20 +57,29 @@ If activated and the UPS is off or restarts, the UPS output will not be released
 until the energy storage device has the set charge state. The energy storage
 device is charged in the meantime.
 
-*ups.delay.shutdown.in1* (in seconds, default disabled)::
-If activated and the UPS is in battery mode and the signal at the IN-1 input is
-high and the set time has expired, a shutdown command via relay event is
-signaled.
-
 *battery.charge.low* (in percent, default `20`)::
 If activated and the UPS is in battery mode and the battery level drops below
 the set value, a shutdown command via relay event is signaled.
 
-*battery.charge.low.empty* (in percent, default `20`)::
+*experimental.output.current.low* (in mA, default `200`)::
+If activated and the UPS is in battery mode and the current drops below the set
+value, the output of the UPS will shut down and disconnect the energy storage to
+prevent self-discharge.
+
+*experimental.ups.delay.shutdown.signal* (in seconds, default disabled)::
+If activated and the UPS is in battery mode and the set time has elapsed, a
+shutdown command via relay event is signaled.
+
+*experimental.ups.delay.shutdown.signal.masked* (in seconds, default disabled)::
+If activated and the UPS is in battery mode and the signal at the IN-1 input is
+high and the set time has expired, a shutdown command via relay event is
+signaled.
+
+*experimental.battery.charge.low.empty* (in percent, default `20`)::
 This parameter stores the threshold value for the "Battery Empty" signal.
 Currently this setting is only valid for relay signaling. Cannot be disabled.
 
-*ups.relay.mode* (default `0x01`)::
+*experimental.ups.relay.mode* (default `0x01`)::
 This parameter controls the behavior of the relay in case of different events.
 Cannot be disabled.
 - `0x01` On power fail (normally closed)

--- a/docs/man/bicker_ser.txt
+++ b/docs/man/bicker_ser.txt
@@ -34,6 +34,60 @@ EXTRA ARGUMENTS
 
 This driver supports no extra arguments from linkman:ups.conf[5].
 
+VARIABLES
+---------
+
+Depending on the type of your UPS unit, some of the following variables may
+be changed with linkman:upsrw[8]. If the driver can't read a variable from the
+UPS, it will not be made available. Whenever not explicitly stated, any variable
+can be disabled, in which case the action it performs will not be executed. To
+disable a variable, set it to an empty value.
+
+*output.current.low* (in mA, default `200`)::
+If activated and the UPS is in battery mode and the current drops below the set
+value, the output of the UPS will shut down and disconnect the energy storage to
+prevent self-discharge.
+
+*ups.delay.shutdown* (in seconds, default disabled)::
+If activated and the UPS is in battery mode and the set time has expired, the
+output will be disabled, and the UPS and energy storage will be disconnected.
+
+*ups.delay.shutdown.signal* (in seconds, default disabled)::
+If activated and the UPS is in battery mode and the set time has elapsed, a
+shutdown command via USB or relay (relay event) is signaled.
+
+*ups.delay.start* (in seconds, default disabled)::
+If activated and a restart condition switches the UPS output off and on again,
+the set time is the delay between switching on and off. The time should cause a
+defined off time so that capacities in the application can be discharged.
+
+*battery.charge.restart* (in percent, default disabled)::
+If activated and the UPS is off or restarts, the UPS output will not be released
+until the energy storage device has the set charge state. The energy storage
+device is charged in the meantime.
+
+*ups.delay.shutdown.in1* (in seconds, default disabled)::
+If activated and the UPS is in battery mode and the signal at the IN-1 input is
+high and the set time has expired, a shutdown command via relay event is
+signaled.
+
+*battery.charge.low* (in percent, default `20`)::
+If activated and the UPS is in battery mode and the battery level drops below
+the set value, a shutdown command via relay event is signaled.
+
+*battery.charge.low.empty* (in percent, default `20`)::
+This parameter stores the threshold value for the "Battery Empty" signal.
+Currently this setting is only valid for relay signaling. Cannot be disabled.
+
+*ups.relay.mode* (default `0x01`)::
+This parameter controls the behavior of the relay in case of different events.
+Cannot be disabled.
+- `0x01` On power fail (normally closed)
+- `0x02` On power fail (normally opened)
+- `0x03` Shutdown impulse (1 second)
+- `0x04` Battery low signal (normally closed)
+- `0x05` Battery defect signal (normally closed)
+
 INSTANT COMMANDS
 ----------------
 

--- a/drivers/bicker_ser.c
+++ b/drivers/bicker_ser.c
@@ -108,7 +108,7 @@
 #include "serial.h"
 
 #define DRIVER_NAME	"Bicker serial protocol"
-#define DRIVER_VERSION	"0.01"
+#define DRIVER_VERSION	"0.02"
 
 #define BICKER_SOH	0x01
 #define BICKER_EOT	0x04

--- a/drivers/bicker_ser.c
+++ b/drivers/bicker_ser.c
@@ -740,6 +740,8 @@ void upsdrv_initinfo(void)
 		dstate_setinfo("device.model", "%s", string);
 	}
 
+	dstate_addcmd("shutdown.return");
+
 	upsh.instcmd = bicker_instcmd;
 	upsh.setvar = bicker_setvar;
 }

--- a/drivers/bicker_ser.c
+++ b/drivers/bicker_ser.c
@@ -681,7 +681,6 @@ void upsdrv_initinfo(void)
 
 void upsdrv_updateinfo(void)
 {
-	const char *str;
 	uint8_t u8;
 	uint16_t u16;
 	int16_t i16;
@@ -750,9 +749,8 @@ void upsdrv_updateinfo(void)
 
 	status_init();
 
-	/* On no "battery.charge.low" variable, use 30% */
-	str = dstate_getinfo("battery.charge.low");
-	if (u8 < (str != NULL ? atoi(str) : 30)) {
+	/* In `u8` we already have the battery charge */
+	if (u8 < atoi(dstate_getinfo("battery.charge.low"))) {
 		status_set("LB");
 	}
 
@@ -848,6 +846,11 @@ void upsdrv_initups(void)
 			dstate_setinfo(mapping->nut_name, "%u",
 				       (unsigned)parameter.value);
 		}
+	}
+
+	/* Ensure "battery.charge.low" variable is defined */
+	if (dstate_getinfo("battery.charge.low") == NULL) {
+		dstate_setinfo("battery.charge.low", "%d", 20);
 	}
 }
 

--- a/drivers/bicker_ser.c
+++ b/drivers/bicker_ser.c
@@ -687,6 +687,18 @@ static int bicker_setvar(const char *varname, const char *val)
 	unsigned i;
 	BickerParameter parameter;
 
+	/* This should not be needed because when `bicker_write()` is
+	 * successful the `parameter` struct is populated but gcc seems
+	 * not to be smart enough to realize that and errors out with
+	 * "error: ‘parameter...’ may be used uninitialized in this function"
+	 */
+	parameter.id = 0;
+	parameter.min = 0;
+	parameter.max = BICKER_MAXVAL;
+	parameter.std = 0;
+	parameter.enabled = 0;
+	parameter.value = 0;
+
 	/* Handle mapped parameters */
 	for (i = 0; i < SIZEOF_ARRAY(bicker_mappings); ++i) {
 		mapping = &bicker_mappings[i];

--- a/drivers/bicker_ser.c
+++ b/drivers/bicker_ser.c
@@ -152,7 +152,7 @@ typedef struct {
 } BickerMapping;
 
 static const BickerMapping bicker_mappings[] = {
-	/* In docs/nut-names.txt: names and descriptions from there */
+	/* Official variables present in docs/nut-names.txt */
 	{ 0x02, "ups.delay.shutdown",
 		"Interval to wait after shutdown with delay command (seconds)" },
 	{ 0x04, "ups.delay.start",
@@ -162,16 +162,16 @@ static const BickerMapping bicker_mappings[] = {
 	{ 0x07, "battery.charge.low",
 		"Remaining battery level when UPS switches to LB (percent)" },
 
-	/* Not in docs/nut-names.txt: crafted names and descriptions */
-	{ 0x01, "output.current.low",
+	/* Unofficial variables under the "experimental" namespace */
+	{ 0x01, "experimental.output.current.low",
 		"Current threshold under which the power will be cut (mA)" },
-	{ 0x03, "ups.delay.shutdown.signal",
+	{ 0x03, "experimental.ups.delay.shutdown.signal",
 		"Interval to wait before sending the shutdown signal (seconds)" },
-	{ 0x06, "ups.delay.shutdown.in1",
+	{ 0x06, "experimental.ups.delay.shutdown.signal.masked",
 		"Interval to wait with IN1 high before sending the shutdown signal (seconds)" },
-	{ 0x08, "battery.charge.low.empty",
+	{ 0x08, "experimental.battery.charge.low.empty",
 		"Battery level threshold for the empty signal (percent)" },
-	{ 0x09, "ups.relay.mode",
+	{ 0x09, "experimental.ups.relay.mode",
 		"Behavior of the relay" },
 };
 


### PR DESCRIPTION
I exposed all parameters and mapped them 1:1 to NUT names. I used `nut-names.txt` whenever possible and mapped the rest to other (hopefully logical) names. I then added the possibility to change everything with `upsrw` and added documentation. I don't know the policy on driver versioning, so I bumped the version in a separate commit: if not needed it can be easily dropped.

My Bicker UPS is still broken but it funnily responds to any request "almost" properly, so (apart from the disabling of parameters with an empty value) I tested everything. With "almost" I mean the returned parameter always has 0xFFFF as min/max and 0xFF as enabled.

One thing that could be a source of problems is parameter `0x01`, mapped to NUT `output.current.low`, is expressed in mA. Not sure if I need to convert it to A, as that name is not "official" (i.e. not present in `nut-names.txt`).