### PR TITLE
Introduce `NUT_DEBUG_SYSLOG` envvar to completely disable `syslog` (e.g. in NIT)

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -116,6 +116,12 @@ https://github.com/networkupstools/nut/milestone/11
      exiting (and/or start-up has aborted due to configuration or run-time
      issues). Warning about "world readable" files clarified. [#2417]
 
+ - common code: introduced a `NUT_DEBUG_SYSLOG` environment variable to tweak
+   activation of syslog message emission (and related detachment of `stderr`
+   when backgrounding), primarily useful for NIT and perhaps systemd. Most
+   methods relied on logging bits being set, so this change aims to be minimally
+   invasive to impact setting of those bits (or not) in the first place. [#2394]
+
  - common code: root-owned daemons now use not the hard-coded `PIDPATH` value
    set by the `configure` script during build, but can override it with a
    `NUT_PIDPATH` environment variable in certain use-cases (such as tests).

--- a/conf/nut.conf.sample
+++ b/conf/nut.conf.sample
@@ -91,3 +91,13 @@ MODE=none
 # verbosity passed to NUT daemons. As an environment variable, its priority sits
 # between that of 'DEBUG_MIN' setting of a driver and the command-line options.
 #NUT_DEBUG_LEVEL=0
+
+# Normally NUT can (attempt to) use the syslog or Event Log (WIN32), but the
+# environment variable 'NUT_DEBUG_SYSLOG' allows to bypass it, and perhaps keep
+# the daemons logging to stderr (useful e.g. in NUT Integration Test suite to
+# not pollute the OS logs, or in systemd where stderr and syslog both go into
+# the same journal). Recognized values:
+#  `stderr`  Disabled and background() keeps stderr attached
+#  `none`    Disabled and background() detaches stderr as usual
+#  `default`/unset/other   Not disabled
+#NUT_DEBUG_SYSLOG=stderr

--- a/docs/man/nut.conf.txt
+++ b/docs/man/nut.conf.txt
@@ -117,6 +117,23 @@ Optional, defaults to `0`. This setting controls the default debugging message
 verbosity passed to NUT daemons. As an environment variable, its priority sits
 between that of 'DEBUG_MIN' setting of a driver and the command-line options.
 
+*NUT_DEBUG_SYSLOG*::
+Optional, unset by default.
+Normally NUT can (attempt to) use the syslog or Event Log (WIN32), but the
+environment variable 'NUT_DEBUG_SYSLOG' allows to bypass it, and perhaps keep
+the daemons logging to stderr (useful e.g. in NUT Integration Test suite to
+not pollute the OS logs, or in systemd where stderr and syslog both go into
+the same journal). Recognized values:
++
+[options="header"]
+|===========================================================================
+| Value       | Description
+| `stderr`    | Disabled and background() keeps stderr attached
+| `none`      | Disabled and background() detaches stderr as usual
+| `default`   | Not disabled
+| unset/other | Not disabled
+|===========================================================================
+
 EXAMPLE
 -------
 

--- a/include/common.h
+++ b/include/common.h
@@ -199,6 +199,18 @@ extern const char *UPS_VERSION;
 /** @brief Default timeout (in seconds) for retrieving the result of a `TRACKING`-enabled operation (e.g. `INSTCMD`, `SET VAR`). */
 #define DEFAULT_TRACKING_TIMEOUT	10
 
+/* Normally we can (attempt to) use the syslog or Event Log (WIN32),
+ * but environment variable NUT_DEBUG_SYSLOG allows to bypass it, and
+ * perhaps keep daemons logging to stderr (e.g. in NUT Integration Test
+ * suite to not pollute the OS logs, or in systemd where stderr and
+ * syslog both go into the same journal). Returns:
+ *  0  Not disabled (NUT_DEBUG_SYSLOG not set to a value below; unset or "default"
+ *     values are handled quietly, but others emit a warning)
+ *  1  Disabled and background() keeps stderr attached (NUT_DEBUG_SYSLOG="stderr")
+ *  2  Disabled and background() detaches stderr as usual (NUT_DEBUG_SYSLOG="none")
+ */
+int syslog_is_disabled(void);
+
 /* get the syslog ready for us */
 void open_syslog(const char *progname);
 

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -37,6 +37,10 @@ export NUT_QUIET_INIT_SSL
 NUT_QUIET_INIT_UPSNOTIFY="true"
 export NUT_QUIET_INIT_UPSNOTIFY
 
+# Avoid noise in syslog and OS console
+NUT_DEBUG_SYSLOG="stderr"
+export NUT_DEBUG_SYSLOG
+
 NUT_DEBUG_PID="true"
 export NUT_DEBUG_PID
 


### PR DESCRIPTION
This was tested with NIT (log messages indeed disappear from OS text console).

This feature is expected to help with systemd log line duplication (see issue #2394) but was not tested that way yet.