### PR TITLE
clients/upsmon: restore handling of comm failure while on battery

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -51,6 +51,10 @@ https://github.com/networkupstools/nut/milestone/11
    * Addition of "NUT Simulated devices" support to `nut-scanner` in v2.8.2
      broke detection of (in-)ability to find and query "Old NUT" servers via
      `libupsclient.so` (internal flag got always enabled). [#2246]
+   * A fix for `upsmon` v2.8.1 setting of `OFFDURATION` [PR #2108, issue #2104,
+     revisiting PR #2055, issue #2044] was overly zealous and impacted also
+     the `OB` state in cases where communications to the data server were
+     severed and `DEADTIME` setting was not honored. [PR #2462, issue #2454]
 
  - drivers, upsd, upsmon: reduce "scary noise" about failure to `fopen()`
    the PID file (which most of the time means that no previous instance of

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -1111,14 +1111,6 @@ static int is_ups_critical(utype_t *ups)
 				ups->sys);
 			return 1;
 		}
-
-		if (ups->linestate == 0) {
-			upslogx(LOG_WARNING,
-				"UPS [%s] was last known to be not fully online "
-				"and currently is not communicating, assuming dead",
-				ups->sys);
-			return 1;
-		}
 	}
 
 	/* administratively OFF (long enough, see OFFDURATION) */


### PR DESCRIPTION
Addresses #2454

Commit 2647f026f7f0 from #2108 updated `is_ups_critical()` such that a communication failure (`commstate == 0`) while on battery (`linestate == 0`) would be treated as immediately entering critical state.

There was no way to disable that behavior or add any grace period.  As such, that change made `DEADTIME` parameter ineffective as `lastpoll` being stuck should be equivalent to `commstate == 0` because any `lastpoll` update would set `commstate` to 1.

Also, that change in how a communication failure affects OB state was no explicitly communicated in the commit message or the pull request. They talked only about OFF, BYPASS and CAL states.

This change removes special handling of that condition from `is_ups_critical()` and reverts to the prior behavior where `recalc()` looks at `lastpoll` and `deadtime` to set LB flag after the configured communication timeout.