### PR TITLE
Hardening: verify that we send signals by PID to programs with expected name

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -131,6 +131,11 @@ https://github.com/networkupstools/nut/milestone/11
      by the `configure` script during build, but can override it with a
      `NUT_PIDPATH` environment variable in certain use-cases (such as
      tests). [#2407]
+   * introduced a check for daemons working with PID files to double-check
+     that if they can resolve the program name of a running process with
+     this identifier, that such name matches the current program (avoid
+     failures to start NUT daemons if PID files are on persistent storage,
+     and some unrelated program got that PID after a reboot). [#2463]
 
  - various recipe, documentation and source files were revised to address
    respective warnings issued by the new generations of analysis tools.

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -52,7 +52,7 @@ https://github.com/networkupstools/nut/milestone/11
      broke detection of (in-)ability to find and query "Old NUT" servers via
      `libupsclient.so` (internal flag got always enabled). [#2246]
 
- - drivers, upsd, upsmon: reduce "scary noise" about failure to `fopen()`
+ - drivers, `upsd`, `upsmon`: reduce "scary noise" about failure to `fopen()`
    the PID file (which most of the time means that no previous instance of
    the daemon was running to potentially conflict with), especially useless
    since in recent NUT releases the verdicts from `sendsignal*()` methods
@@ -87,6 +87,10 @@ https://github.com/networkupstools/nut/milestone/11
      string values reported by devices via USB are welcome), so these devices
      would now report `battery.voltage` and `battery.voltage.nominal`. [#2380]
 
+ - bicker_ser: added new driver for Bicker 12/24Vdc UPS via RS-232 serial
+   communication protocol, which supports any UPS shipped with the PSZ-1053
+   extension module. [PR #2448]
+
  - USB drivers could log `(nut_)libusb_get_string: Success` due to either
    reading an empty string or getting a success code `0` from libusb.
    This difference should now be better logged, and not into syslog. [#2399]
@@ -116,16 +120,21 @@ https://github.com/networkupstools/nut/milestone/11
      exiting (and/or start-up has aborted due to configuration or run-time
      issues). Warning about "world readable" files clarified. [#2417]
 
- - common code: introduced a `NUT_DEBUG_SYSLOG` environment variable to tweak
-   activation of syslog message emission (and related detachment of `stderr`
-   when backgrounding), primarily useful for NIT and perhaps systemd. Most
-   methods relied on logging bits being set, so this change aims to be minimally
-   invasive to impact setting of those bits (or not) in the first place. [#2394]
+ - common code:
+   * introduced a `NUT_DEBUG_SYSLOG` environment variable to tweak activation
+     of syslog message emission (and related detachment of `stderr` when
+     backgrounding), primarily useful for NIT and perhaps systemd. Most
+     methods relied on logging bits being set, so this change aims to be
+     minimally invasive to impact setting of those bits (or not) in the
+     first place. [#2394]
+   * `root`-owned daemons now use not the hard-coded `PIDPATH` value set
+     by the `configure` script during build, but can override it with a
+     `NUT_PIDPATH` environment variable in certain use-cases (such as
+     tests). [#2407]
 
- - common code: root-owned daemons now use not the hard-coded `PIDPATH` value
-   set by the `configure` script during build, but can override it with a
-   `NUT_PIDPATH` environment variable in certain use-cases (such as tests).
-   [#2407]
+ - various recipe, documentation and source files were revised to address
+   respective warnings issued by the new generations of analysis tools.
+   [#823, #2437, link:https://github.com/networkupstools/nut-website/issues/52[nut-website issue #52]]
 
  - revised `nut.exe` (the NUT for Windows wrapper for all-in-one service)
    to be more helpful with command-line use (report that it failed to start
@@ -147,14 +156,6 @@ https://github.com/networkupstools/nut/milestone/11
    they should be able to parse common simple use-cases but not certain types
    of more complex configurations (e.g. some line patterns that involve too
    many double-quote characters) which are valid for NUT proper. [#657]
-
- - various recipe, documentation and source files were revised to address
-   respective warnings issued by the new generations of analysis tools.
-   [#823, #2437, link:https://github.com/networkupstools/nut-website/issues/52[nut-website issue #52]]
-
- - bicker_ser: added new driver for Bicker 12/24Vdc UPS via RS-232 serial
-   communication protocol, which supports any UPS shipped with the PSZ-1053
-   extension module. [PR #2448]
 
 
 Release notes for NUT 2.8.2 - what's new since 2.8.1

--- a/UPGRADING.adoc
+++ b/UPGRADING.adoc
@@ -33,6 +33,12 @@ Changes from 2.8.2 to 2.8.3
   pages which are delivered automatically. Packaging recipes can likely
   be simplified now. [#2445]
 
+- Internal API change for `sendsignalpid()` and `sendsignalfn()` methods,
+  which can impact NUT forks which build using `libcommon.la` and similar
+  libraries.  Added new last argument with `const char *progname` (may be
+  `NULL`) to check that we are signalling an expected program name when we
+  work with a PID. [#2463]
+
 
 Changes from 2.8.1 to 2.8.2
 ---------------------------

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -3018,7 +3018,7 @@ int main(int argc, char *argv[])
 	if (oldpid < 0) {
 		cmdret = sendsignal(prog, cmd);
 	} else {
-		cmdret = sendsignalpid(oldpid, cmd);
+		cmdret = sendsignalpid(oldpid, cmd, prog);
 	}
 
 #else	/* WIN32 */

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -97,8 +97,8 @@ endif HAVE_WINDOWS
 
 # ensure inclusion of local implementation of missing systems functions
 # using LTLIBOBJS. Refer to configure.in/.ac -> AC_REPLACE_FUNCS
-libcommon_la_LIBADD = libparseconf.la @LTLIBOBJS@ @NETLIBS@
-libcommonclient_la_LIBADD = libparseconf.la @LTLIBOBJS@ @NETLIBS@
+libcommon_la_LIBADD = libparseconf.la @LTLIBOBJS@ @NETLIBS@ @BSDKVMPROCLIBS@
+libcommonclient_la_LIBADD = libparseconf.la @LTLIBOBJS@ @NETLIBS@ @BSDKVMPROCLIBS@
 
 libcommon_la_CFLAGS = $(AM_CFLAGS)
 libcommonclient_la_CFLAGS = $(AM_CFLAGS)

--- a/common/common.c
+++ b/common/common.c
@@ -586,7 +586,7 @@ process_stat_symlink:
 #endif	/* HAVE_READLINK */
 
 process_parse_file:
-		upsdebugx(3, "%s: try to parse some files under /proc", __func__);
+		upsdebugx(5, "%s: try to parse some files under /proc", __func__);
 
 		/* Check /proc/NNN/cmdline (may start with a '-' to ignore, for
 		 * a title string like "-bash" where programs edit their argv[0]
@@ -617,7 +617,7 @@ process_parse_file:
 								__func__, pathname);
 							if ((procname = (char*)calloc(procnamelen + 1, sizeof(char)))) {
 								if (snprintf(procname, procnamelen + 1, "%s", first) < 1) {
-									upsdebug_with_errno(3, "%s: failed to snprintf pathname: Linux-like", __func__);
+									upsdebug_with_errno(3, "%s: failed to snprintf procname: Linux-like", __func__);
 								}
 							} else {
 								upsdebug_with_errno(3, "%s: failed to allocate the procname "
@@ -668,11 +668,11 @@ process_parse_file:
 								__func__, pathname);
 							if ((procname = (char*)calloc(procnamelen + 1, sizeof(char)))) {
 								if (snprintf(procname, procnamelen + 1, "%s", first) < 1) {
-									upsdebug_with_errno(3, "%s: failed to snprintf pathname: Linux-like", __func__);
+									upsdebug_with_errno(3, "%s: failed to snprintf procname: Linux-like", __func__);
 								}
 							} else {
 								upsdebug_with_errno(3, "%s: failed to allocate the procname "
-									"string to store token from 'cmdline' size %" PRIuSIZE,
+									"string to store token from 'stat' size %" PRIuSIZE,
 									__func__, procnamelen);
 							}
 
@@ -723,11 +723,12 @@ process_parse_file:
 						if ((procnamelen = strlen(kp[i].p_comm))) {
 							if ((procname = (char*)calloc(procnamelen + 1, sizeof(char)))) {
 								if (snprintf(procname, procnamelen + 1, "%s", kp[i].p_comm) < 1) {
-									upsdebug_with_errno(3, "%s: failed to snprintf pathname: BSD-like", __func__);
+									upsdebug_with_errno(3, "%s: failed to snprintf procname: BSD-like", __func__);
 								}
 							} else {
 								upsdebug_with_errno(3, "%s: failed to allocate the procname "
-									"string to store token from 'cmdline' size %" PRIuSIZE,
+									"string to store token from BSD KVM process info "
+									"snapsnot size %" PRIuSIZE,
 									__func__, procnamelen);
 							}
 

--- a/common/common.c
+++ b/common/common.c
@@ -879,6 +879,8 @@ int sendsignalpid(pid_t pid, int sig)
 #ifndef WIN32
 	int	ret;
 
+	/* TOTHINK: What about containers where a NUT daemon *is* the only process
+	 * and is the PID=1 of the container (recycle if dead)? */
 	if (pid < 2 || pid > get_max_pid_t()) {
 		if (nut_debug_level > 0 || nut_sendsignal_debug_level > 0)
 			upslogx(LOG_NOTICE,

--- a/configure.ac
+++ b/configure.ac
@@ -1111,6 +1111,44 @@ AS_IF([test x"${ac_cv_func_usleep}" = xyes],
     [AC_MSG_WARN([Required C library routine usleep not found; try adding -D_POSIX_C_SOURCE=200112L])]
     )
 
+dnl OpenBSD (at least) methods to query process info, per
+dnl https://github.com/openbsd/src/blob/master/bin/ps/ps.c
+dnl https://kaashif.co.uk/2015/06/18/how-to-get-a-list-of-processes-on-openbsd-in-c/
+BSDKVMPROCLIBS=""
+myLIBS="$LIBS"
+LIBS="$LIBS -lkvm"
+AC_CACHE_CHECK([for BSD KVM process info libs],
+    [ac_cv_lib_bsd_kvm_proc],
+    [AC_LINK_IFELSE(
+        [AC_LANG_PROGRAM([[
+#include <stdio.h>
+#include <kvm.h>
+#include <limits.h>
+#include <sys/param.h>
+#include <sys/sysctl.h>
+        ]],
+            [[
+    char errbuf[_POSIX2_LINE_MAX];
+    kvm_t *kernel = kvm_openfiles(NULL, NULL, NULL, KVM_NO_FILES, errbuf);
+    int nentries = 0;
+    struct kinfo_proc *kinfo = kvm_getprocs(kernel, KERN_PROC_ALL, 0, sizeof(struct kinfo_proc), &nentries);
+    int i;
+    for (i = 0; i < nentries; ++i) {
+        printf("%s\n", kinfo[i].p_comm);
+    }
+/* autoconf adds ";return 0;" */
+/* we hope the code above fails if type is not defined or range is not sufficient */
+]])],
+        [ac_cv_lib_bsd_kvm_proc=yes
+        BSDKVMPROCLIBS="-lkvm"
+        ], [ac_cv_lib_bsd_kvm_proc=no]
+    )])
+LIBS="$myLIBS"
+
+AS_IF([test x"${ac_cv_lib_bsd_kvm_proc}" = xyes],
+    [AC_DEFINE([HAVE_LIB_BSD_KVM_PROC], 1, [defined if we have libs, includes and methods for BSD KVM process info])]
+    )
+
 AC_LANG_POP([C])
 
 dnl These routines' arg types differ in strict C standard mode
@@ -4329,6 +4367,7 @@ AC_SUBST(DRIVER_BUILD_LIST)
 AC_SUBST(DRIVER_MAN_LIST)
 AC_SUBST(DRIVER_MAN_LIST_PAGES)
 AC_SUBST(DRIVER_INSTALL_TARGET)
+AC_SUBST(BSDKVMPROCLIBS)
 AC_SUBST(NETLIBS)
 AC_SUBST(SERLIBS)
 AC_SUBST(SEMLIBS)

--- a/configure.ac
+++ b/configure.ac
@@ -1149,6 +1149,30 @@ AS_IF([test x"${ac_cv_lib_bsd_kvm_proc}" = xyes],
     [AC_DEFINE([HAVE_LIB_BSD_KVM_PROC], 1, [defined if we have libs, includes and methods for BSD KVM process info])]
     )
 
+dnl https://github.com/illumos/illumos-gate/blob/master/usr/src/uts/common/sys/procfs.h#L318
+dnl https://github.com/illumos/illumos-gate/blob/master/usr/src/cmd/ps/ps.c
+AC_CACHE_CHECK([for Solaris/illumos process info libs],
+    [ac_cv_lib_illumos_proc],
+    [AC_LINK_IFELSE(
+        [AC_LANG_PROGRAM([[
+#include <stdio.h>
+#include <procfs.h>
+        ]],
+            [[
+    psinfo_t info;
+    printf("%s", info.pr_fname)
+/* autoconf adds ";return 0;" */
+/* we hope the code above fails if type is not defined or range is not sufficient */
+]])],
+        [ac_cv_lib_illumos_proc=yes
+        ], [ac_cv_lib_illumos_proc=no]
+    )])
+LIBS="$myLIBS"
+
+AS_IF([test x"${ac_cv_lib_illumos_proc}" = xyes],
+    [AC_DEFINE([HAVE_LIB_ILLUMOS_PROC], 1, [defined if we have libs, includes and methods for Solaris/illumos process info])]
+    )
+
 AC_LANG_POP([C])
 
 dnl These routines' arg types differ in strict C standard mode

--- a/configure.ac
+++ b/configure.ac
@@ -1047,6 +1047,12 @@ AC_CHECK_HEADER([sys/select.h],
     [AC_DEFINE([HAVE_SYS_SELECT_H], [1],
         [Define to 1 if you have <sys/select.h>.])])
 
+AC_CHECK_HEADER([unistd.h],
+    [AC_DEFINE([HAVE_UNISTD_H], [1],
+        [Define to 1 if you have <unistd.h>.])])
+
+AC_CHECK_FUNCS(readlink)
+
 AC_CACHE_CHECK([for suseconds_t],
     [ac_cv_type_suseconds_t],
     [AC_COMPILE_IFELSE(

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3165 utf-8
+personal_ws-1.1 en 3168 utf-8
 AAC
 AAS
 ABI
@@ -2569,6 +2569,7 @@ probu
 proc
 productid
 prog
+progname
 prtconf
 ps
 psu
@@ -2702,6 +2703,8 @@ sendback
 sendline
 sendmail
 sendsignal
+sendsignalfn
+sendsignalpid
 sequentialized
 ser
 seria

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -2223,9 +2223,9 @@ int main(int argc, char **argv)
 			int cmdret = -1;
 			/* Send a signal to older copy of the driver, if any */
 			if (oldpid < 0) {
-				cmdret = sendsignalfn(pidfnbuf, cmd);
+				cmdret = sendsignalfn(pidfnbuf, cmd, progname);
 			} else {
-				cmdret = sendsignalpid(oldpid, cmd);
+				cmdret = sendsignalpid(oldpid, cmd, progname);
 			}
 
 			switch (cmdret) {
@@ -2321,7 +2321,7 @@ int main(int argc, char **argv)
 
 			upslogx(LOG_WARNING, "Duplicate driver instance detected (PID file %s exists)! Terminating other driver!", pidfnbuf);
 
-			if ((sigret = sendsignalfn(pidfnbuf, SIGTERM) != 0)) {
+			if ((sigret = sendsignalfn(pidfnbuf, SIGTERM, progname) != 0)) {
 				upsdebugx(1, "Can't send signal to PID, assume invalid PID file %s; "
 					"sendsignalfn() returned %d (errno=%d): %s",
 					pidfnbuf, sigret, errno, strerror(errno));
@@ -2339,9 +2339,9 @@ int main(int argc, char **argv)
 			struct stat	st;
 			if (stat(pidfnbuf, &st) == 0) {
 				upslogx(LOG_WARNING, "Duplicate driver instance is still alive (PID file %s exists) after several termination attempts! Killing other driver!", pidfnbuf);
-				if (sendsignalfn(pidfnbuf, SIGKILL) == 0) {
+				if (sendsignalfn(pidfnbuf, SIGKILL, progname) == 0) {
 					sleep(5);
-					if (sendsignalfn(pidfnbuf, 0) == 0) {
+					if (sendsignalfn(pidfnbuf, 0, progname) == 0) {
 						upslogx(LOG_WARNING, "Duplicate driver instance is still alive (could signal the process)");
 						/* TODO: Should we writepid() below in this case?
 						 * Or if driver init fails, restore the old content

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -304,9 +304,9 @@ socket_error:
 	nut_sendsignal_debug_level = NUT_SENDSIGNAL_DEBUG_LEVEL_KILL_SIG0PING - 1;
 #ifndef WIN32
 	if (ups->pid == -1) {
-		ret = sendsignalfn(pidfn, cmd);
+		ret = sendsignalfn(pidfn, cmd, ups->driver);
 	} else {
-		ret = sendsignalpid(ups->pid, cmd);
+		ret = sendsignalpid(ups->pid, cmd, ups->driver);
 		/* reap zombie if this child died */
 		if (waitpid(ups->pid, NULL, WNOHANG) == ups->pid) {
 			upslog_with_errno(LOG_WARNING,
@@ -381,9 +381,9 @@ static void stop_driver(const ups_t *ups)
 
 #ifndef WIN32
 	if (ups->pid == -1) {
-		ret = sendsignalfn(pidfn, SIGTERM);
+		ret = sendsignalfn(pidfn, SIGTERM, ups->driver);
 	} else {
-		ret = sendsignalpid(ups->pid, SIGTERM);
+		ret = sendsignalpid(ups->pid, SIGTERM, ups->driver);
 		/* reap zombie if this child died */
 		if (waitpid(ups->pid, NULL, WNOHANG) == ups->pid) {
 			goto clean_return;
@@ -397,9 +397,9 @@ static void stop_driver(const ups_t *ups)
 #ifndef WIN32
 		upsdebugx(2, "SIGTERM to %s failed, retrying with SIGKILL", pidfn);
 		if (ups->pid == -1) {
-			ret = sendsignalfn(pidfn, SIGKILL);
+			ret = sendsignalfn(pidfn, SIGKILL, ups->driver);
 		} else {
-			ret = sendsignalpid(ups->pid, SIGKILL);
+			ret = sendsignalpid(ups->pid, SIGKILL, ups->driver);
 			/* reap zombie if this child died */
 			if (waitpid(ups->pid, NULL, WNOHANG) == ups->pid) {
 				goto clean_return;
@@ -419,16 +419,16 @@ static void stop_driver(const ups_t *ups)
 	for (i = 0; i < 5 ; i++) {
 #ifndef WIN32
 		if (ups->pid == -1) {
-			ret = sendsignalfn(pidfn, 0);
+			ret = sendsignalfn(pidfn, 0, ups->driver);
 		} else {
 			/* reap zombie if this child died */
 			if (waitpid(ups->pid, NULL, WNOHANG) == ups->pid) {
 				goto clean_return;
 			}
-			ret = sendsignalpid(ups->pid, 0);
+			ret = sendsignalpid(ups->pid, 0, ups->driver);
 		}
 #else
-		ret = sendsignalfn(pidfn, 0);
+		ret = sendsignalfn(pidfn, 0, ups->driver);
 #endif
 		if (ret != 0) {
 			upsdebugx(2, "Sending signal to %s failed, driver is finally down or wrongly owned", pidfn);
@@ -440,13 +440,13 @@ static void stop_driver(const ups_t *ups)
 #ifndef WIN32
 	upslog_with_errno(LOG_ERR, "Stopping %s failed, retrying harder", pidfn);
 	if (ups->pid == -1) {
-		ret = sendsignalfn(pidfn, SIGKILL);
+		ret = sendsignalfn(pidfn, SIGKILL, ups->driver);
 	} else {
 		/* reap zombie if this child died */
 		if (waitpid(ups->pid, NULL, WNOHANG) == ups->pid) {
 			goto clean_return;
 		}
-		ret = sendsignalpid(ups->pid, SIGKILL);
+		ret = sendsignalpid(ups->pid, SIGKILL, ups->driver);
 	}
 #else
 	upslog_with_errno(LOG_ERR, "Stopping %s failed, retrying again", pidfn);
@@ -456,16 +456,16 @@ static void stop_driver(const ups_t *ups)
 		for (i = 0; i < 5 ; i++) {
 #ifndef WIN32
 			if (ups->pid == -1) {
-				ret = sendsignalfn(pidfn, 0);
+				ret = sendsignalfn(pidfn, 0, ups->driver);
 			} else {
 				/* reap zombie if this child died */
 				if (waitpid(ups->pid, NULL, WNOHANG) == ups->pid) {
 					goto clean_return;
 				}
-				ret = sendsignalpid(ups->pid, 0);
+				ret = sendsignalpid(ups->pid, 0, ups->driver);
 			}
 #else
-			ret = sendsignalfn(pidfn, 0);
+			ret = sendsignalfn(pidfn, 0, ups->driver);
 #endif
 			if (ret != 0) {
 				upsdebugx(2, "Sending signal to %s failed, driver is finally down or wrongly owned", pidfn);

--- a/include/common.h
+++ b/include/common.h
@@ -1,6 +1,7 @@
 /* common.h - prototypes for the common useful functions
 
    Copyright (C) 2000  Russell Kroll <rkroll@exploits.org>
+   Copyright (C) 2021-2024  Jim Klimov <jimklimov+nut@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/include/common.h
+++ b/include/common.h
@@ -264,7 +264,7 @@ void writepid(const char *name);
  * a few sanity checks; returns -1 on error */
 pid_t parsepid(const char *buf);
 
-/* send a signal to another running process */
+/* send a signal to another running NUT process */
 #ifndef WIN32
 int sendsignal(const char *progname, int sig);
 #else
@@ -279,7 +279,7 @@ pid_t get_max_pid_t(void);
 
 /* send sig to pid after some sanity checks, returns
  * -1 for error, or zero for a successfully sent signal */
-int sendsignalpid(pid_t pid, int sig);
+int sendsignalpid(pid_t pid, int sig, const char *progname);
 
 /* open <pidfn>, get the pid, then send it <sig>
  * returns zero for successfully sent signal,
@@ -289,10 +289,13 @@ int sendsignalpid(pid_t pid, int sig);
  * -1   Error sending signal
  */
 #ifndef WIN32
-/* open <pidfn>, get the pid, then send it <sig> */
-int sendsignalfn(const char *pidfn, int sig);
+/* open <pidfn>, get the pid, then send it <sig>
+ * if executable process with that pid has suitable progname
+ */
+int sendsignalfn(const char *pidfn, int sig, const char *progname);
 #else
-int sendsignalfn(const char *pidfn, const char * sig);
+/* No progname here - communications via named pipe */
+int sendsignalfn(const char *pidfn, const char * sig, const char *progname_ignored);
 #endif
 
 const char *xbasename(const char *file);

--- a/include/common.h
+++ b/include/common.h
@@ -226,6 +226,37 @@ void become_user(struct passwd *pw);
 /* drop down into a directory and throw away pointers to the old path */
 void chroot_start(const char *path);
 
+/* Try to identify process (program) name for the given PID,
+ * return NULL if we can not for any reason (does not run,
+ * no rights, do not know how to get it on current OS, etc.)
+ * If the returned value is not NULL, caller should free() it.
+ * Some implementation pieces borrowed from
+ * https://man7.org/linux/man-pages/man2/readlink.2.html and
+ * https://github.com/openbsd/src/blob/master/bin/ps/ps.c
+ * NOTE: Very much platform-dependent! */
+char * getprocname(pid_t pid);
+
+/* Determine the base name of specified progname (may be full path)
+ * and the location of the last "." dot character in it for extension
+ * (caller's len and dot populated only if pointers are not NULL).
+ */
+size_t parseprogbasename(char *buf, size_t buflen, const char *progname, size_t *pprogbasenamelen, size_t *pprogbasenamedot);
+
+/* If we can determine the binary path name of the specified "pid",
+ * check if it matches the assumed name of the current program.
+ * Returns:
+ *	-2	Could not parse a program name (ok to proceed,
+ *		risky - but matches legacy behavior)
+ *	-1	Could not identify a program name (ok to proceed,
+ *		risky - but matches legacy behavior)
+ *	0	Process name identified, does not seem to match
+ *	1+	Process name identified, and seems to match with
+ *		varying precision
+ * Generally speaking, if (checkprocname(...)) then ok to proceed
+ */
+int checkprocname(pid_t pid, const char *progname);
+
+
 /* write a pid file - <name> is a full pathname *or* just the program name */
 void writepid(const char *name);
 

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -2049,9 +2049,9 @@ int main(int argc, char **argv)
 	 */
 
 	if (oldpid < 0) {
-		cmdret = sendsignalfn(pidfn, cmd);
+		cmdret = sendsignalfn(pidfn, cmd, progname);
 	} else {
-		cmdret = sendsignalpid(oldpid, cmd);
+		cmdret = sendsignalpid(oldpid, cmd, progname);
 	}
 #else	/* if WIN32 */
 	if (cmd) {


### PR DESCRIPTION
Closes: #2463

Per discussion in the issue above, blind PID signalling is a problem on embedded platforms which do not differentiate user accounts, so a NUT driver can kill some unrelated program assuming it is a stuck driver (just by PID file matching) and not be stopped by permissions to send a signal to a program not owned by a `nut` account.

This is a platform-dependent solution, so by default if we can not determine a program name - we do not forbid signal-sending. Likewise, if a name is detected and seems to match expectations (modulo directory prefix, or on some platforms - case-sensitivity or `.exe` suffix) we also consider it a match. Finally, only if we detect a name of the running process with the specified PID and it is not anything like our expectation, the check is failed.

With current NUT master (or with the PR in place and `NULL` instead of `progname` passed to the method), the test command below signals (and kills) the current shell process as `$$` - owned by the same user as `upsmon` in the test. With the change in the PR, such a name is detected and rejected:

````
:; make -ksj && ./clients/upsmon -DDDDDD -c reload -P $$
...
Network UPS Tools upsmon 2.8.2-315-g41ce7c7c6
   0.000000     [D3] getprocname: /proc is an accessible directory, investigating
   0.000034     [D3] getprocname: located symlink for PID 40107 at: /proc/40107/exe
   0.000064     [D1] getprocname: determined process name for PID 40107: /usr/bin/bash
   0.000086     [D1] checkprocname: did not find any match of program names for PID 40107 of '/usr/bin/bash'=>'bash' and checked 'upsmon'=>'upsmon'
   0.000106     Tried to signal PID 40107 which exists but is not of program 'upsmon'
   0.000125     [D1] Just failed to send signal, no daemon was running
   0.000142     Failed to signal the currently running daemon (if any)
   0.000149     Try 'systemctl reload nut-monitor.service'
````

There are a few more platform-specific code paths to handle, expected with later commits.

CC @arnaudquette-eaton @ericclappier-eaton : this internal API change for `sendsignal*()` methods may impact or benefit your work too, pinging just in case :)