### PR TITLE
Hardening: Fall-back double-`checkprocname()` vs. current daemon program name (and add `NUT_IGNORE_CHECKPROCNAME=true` toggle)

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -139,7 +139,13 @@ https://github.com/networkupstools/nut/milestone/11
      that if they can resolve the program name of a running process with
      this identifier, that such name matches the current program (avoid
      failures to start NUT daemons if PID files are on persistent storage,
-     and some unrelated program got that PID after a reboot). [#2463]
+     and some unrelated program got that PID after a reboot).  This might
+     introduce regressions for heavily customized NUT builds (e.g. those
+     embedded in NAS or similar devices) where binary file names differ
+     significantly from a `progname` string defined in the respective NUT
+     source file, so a boolean `NUT_IGNORE_CHECKPROCNAME` environment
+     variable support was added to optionally disable this verification.
+     [issue #2463]
 
  - various recipe, documentation and source files were revised to address
    respective warnings issued by the new generations of analysis tools.

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -145,7 +145,8 @@ https://github.com/networkupstools/nut/milestone/11
      significantly from a `progname` string defined in the respective NUT
      source file, so a boolean `NUT_IGNORE_CHECKPROCNAME` environment
      variable support was added to optionally disable this verification.
-     [issue #2463]
+     Also the NUT daemons should request to double-check against their
+     run-time process name (if it can be detected). [issue #2463]
 
  - various recipe, documentation and source files were revised to address
    respective warnings issued by the new generations of analysis tools.

--- a/UPGRADING.adoc
+++ b/UPGRADING.adoc
@@ -37,7 +37,14 @@ Changes from 2.8.2 to 2.8.3
   which can impact NUT forks which build using `libcommon.la` and similar
   libraries.  Added new last argument with `const char *progname` (may be
   `NULL`) to check that we are signalling an expected program name when we
-  work with a PID. [#2463]
+  work with a PID.  With the same effort, NUT programs which deal with PID
+  files to send signals (`upsd`, `upsmon`, drivers and `upsdrvctl`) would
+  now default to a safety precaution -- checking that the running process
+  with that PID has the expected program name (on platforms where we can
+  determine one). This might introduce regressions for heavily customized
+  NUT builds (e.g. embedded in NAS or similar devices) whose binary file
+  names differ significantly from a `progname` defined in the respective
+  NUT source file. [issue #2463]
 
 
 Changes from 2.8.1 to 2.8.2

--- a/UPGRADING.adoc
+++ b/UPGRADING.adoc
@@ -44,7 +44,9 @@ Changes from 2.8.2 to 2.8.3
   determine one). This might introduce regressions for heavily customized
   NUT builds (e.g. embedded in NAS or similar devices) whose binary file
   names differ significantly from a `progname` defined in the respective
-  NUT source file. [issue #2463]
+  NUT source file, so a boolean `NUT_IGNORE_CHECKPROCNAME` environment
+  variable support was added to optionally disable this verification.
+  [issue #2463]
 
 
 Changes from 2.8.1 to 2.8.2

--- a/UPGRADING.adoc
+++ b/UPGRADING.adoc
@@ -46,7 +46,8 @@ Changes from 2.8.2 to 2.8.3
   names differ significantly from a `progname` defined in the respective
   NUT source file, so a boolean `NUT_IGNORE_CHECKPROCNAME` environment
   variable support was added to optionally disable this verification.
-  [issue #2463]
+  Also the NUT daemons should request to double-check against their
+  run-time process name (if it can be detected). [issue #2463]
 
 
 Changes from 2.8.1 to 2.8.2

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -3022,15 +3022,15 @@ int main(int argc, char *argv[])
 	 * is running by sending signal '0' (i.e. 'kill <pid> 0' equivalent)
 	 */
 	if (oldpid < 0) {
-		cmdret = sendsignal(prog, cmd);
+		cmdret = sendsignal(prog, cmd, 1);
 	} else {
-		cmdret = sendsignalpid(oldpid, cmd, prog);
+		cmdret = sendsignalpid(oldpid, cmd, prog, 1);
 	}
 
 #else	/* WIN32 */
 	if (cmd) {
 		/* Command the running daemon, it should be there */
-		cmdret = sendsignal(UPSMON_PIPE_NAME, cmd);
+		cmdret = sendsignal(UPSMON_PIPE_NAME, cmd, 1);
 	} else {
 		/* Starting new daemon, check for competition */
 		mutex = CreateMutex(NULL, TRUE, UPSMON_PIPE_NAME);

--- a/common/common.c
+++ b/common/common.c
@@ -1150,10 +1150,11 @@ void writepid(const char *name)
 /* send sig to pid, returns -1 for error, or
  * zero for a successfully sent signal
  */
-int sendsignalpid(pid_t pid, int sig, const char *progname)
+int sendsignalpid(pid_t pid, int sig, const char *progname, int check_current_progname)
 {
 #ifndef WIN32
-	int	ret;
+	int	ret, cpn1 = -10, cpn2 = -10;
+	char	*current_progname = NULL;
 
 	/* TOTHINK: What about containers where a NUT daemon *is* the only process
 	 * and is the PID=1 of the container (recycle if dead)? */
@@ -1165,12 +1166,113 @@ int sendsignalpid(pid_t pid, int sig, const char *progname)
 		return -1;
 	}
 
-	if (progname && !checkprocname(pid, progname)) {
-		if (nut_debug_level > 0 || nut_sendsignal_debug_level > 1)
-			upslogx(LOG_ERR, "Tried to signal PID %" PRIuMAX
-				" which exists but is not of program '%s'",
-				(uintmax_t)pid, progname);
+	ret = 0;
+	if (progname) {
+		/* Check against some expected (often built-in) name */
+		if (!(cpn1 = checkprocname(pid, progname))) {
+			/* Did not match expected (often built-in) name */
+			ret = -1;
+		} else {
+			if (cpn1 > 0) {
+				/* Matched expected name, ok to proceed */
+				ret = 1;
+			}
+			/* ...else could not determine name of PID; think later */
+		}
+	}
+	/* if (cpn1 == -3) => NUT_IGNORE_CHECKPROCNAME=true */
+	/* if (cpn1 == -1) => could not determine name of PID... retry just in case? */
+	if (ret <= 0 && check_current_progname && cpn1 != -3) {
+		/* NOTE: This could be optimized a bit by pre-finding the procname
+		 * of "pid" and re-using it, but this is not a hot enough code path
+		 * to bother much.
+		 */
+		current_progname = getprocname(getpid());
+		if (current_progname && (cpn2 = checkprocname(pid, current_progname))) {
+			if (cpn2 > 0) {
+				/* Matched current process as asked, ok to proceed */
+				ret = 2;
+			}
+			/* ...else could not determine name of PID; think later */
+		} else {
+			if (current_progname) {
+				/* Did not match current process name */
+				ret = -2;
+			} /* else just did not determine current process
+			   * name, so did not actually check either
+			   * // ret = -3;
+			   */
+		}
+	}
+
+	/* if ret == 0, ok to proceed - not asked for any sanity checks;
+	 * if ret > 0 we had some definitive match above
+	 */
+	if (ret < 0) {
+		upsdebugx(1,
+			"%s: ran at least one check, and all such checks "
+			"found a process name for PID %" PRIuMAX " and "
+			"failed to match: expected progname='%s' (res=%d), "
+			"current progname='%s' (res=%d)",
+			__func__, (uintmax_t)pid,
+			NUT_STRARG(progname), cpn1,
+			NUT_STRARG(current_progname), cpn2);
+
+		if (nut_debug_level > 0 || nut_sendsignal_debug_level > 1) {
+			switch (ret) {
+				case -1:
+					upslogx(LOG_ERR, "Tried to signal PID %" PRIuMAX
+						" which exists but is not of"
+						" expected program '%s'; not asked"
+						" to cross-check current PID's name",
+						(uintmax_t)pid, progname);
+					break;
+
+				/* Maybe we tried both data sources, maybe just current_progname */
+				case -2:
+				/*case -3:*/
+					if (progname && current_progname) {
+						/* Tried both, downgraded verdict further */
+						upslogx(LOG_ERR, "Tried to signal PID %" PRIuMAX
+							" which exists but is not of expected"
+							" program '%s' nor current '%s'",
+							(uintmax_t)pid, progname, current_progname);
+					} else if (current_progname) {
+						/* Not asked for progname==NULL */
+						upslogx(LOG_ERR, "Tried to signal PID %" PRIuMAX
+							" which exists but is not of"
+							" current program '%s'",
+							(uintmax_t)pid, current_progname);
+					} else if (progname) {
+						upslogx(LOG_ERR, "Tried to signal PID %" PRIuMAX
+							" which exists but is not of"
+							" expected program '%s'; could not"
+							" cross-check current PID's name",
+							(uintmax_t)pid, progname);
+					} else {
+						/* Both NULL; one not asked, another not detected;
+						 * should not actually get here (wannabe `ret==-3`)
+						 */
+						upslogx(LOG_ERR, "Tried to signal PID %" PRIuMAX
+							" but could not cross-check current PID's"
+							" name: did not expect to get here",
+							(uintmax_t)pid);
+					}
+					break;
+			}
+		}
+
+		if (current_progname) {
+			free(current_progname);
+			current_progname = NULL;
+		}
+
+		/* Logged or not, sanity-check was requested and failed */
 		return -1;
+	}
+	if (current_progname) {
+		free(current_progname);
+		current_progname = NULL;
 	}
 
 	/* see if this is going to work first - does the process exist,
@@ -1199,6 +1301,8 @@ int sendsignalpid(pid_t pid, int sig, const char *progname)
 	NUT_UNUSED_VARIABLE(pid);
 	NUT_UNUSED_VARIABLE(sig);
 	NUT_UNUSED_VARIABLE(progname);
+	NUT_UNUSED_VARIABLE(check_current_progname);
+	/* Windows builds use named pipes, not signals per se */
 	upslogx(LOG_ERR,
 		"%s: not implemented for Win32 and "
 		"should not have been called directly!",
@@ -1239,7 +1343,7 @@ pid_t parsepid(const char *buf)
  * zero for a successfully sent signal
  */
 #ifndef WIN32
-int sendsignalfn(const char *pidfn, int sig, const char *progname)
+int sendsignalfn(const char *pidfn, int sig, const char *progname, int check_current_progname)
 {
 	char	buf[SMALLBUF];
 	FILE	*pidf;
@@ -1275,7 +1379,7 @@ int sendsignalfn(const char *pidfn, int sig, const char *progname)
 
 	if (pid >= 0) {
 		/* this method actively reports errors, if any */
-		ret = sendsignalpid(pid, sig, progname);
+		ret = sendsignalpid(pid, sig, progname, check_current_progname);
 	}
 
 	fclose(pidf);
@@ -1284,10 +1388,11 @@ int sendsignalfn(const char *pidfn, int sig, const char *progname)
 
 #else	/* => WIN32 */
 
-int sendsignalfn(const char *pidfn, const char * sig, const char *progname_ignored)
+int sendsignalfn(const char *pidfn, const char * sig, const char *progname_ignored, int check_current_progname_ignored)
 {
 	BOOL	ret;
 	NUT_UNUSED_VARIABLE(progname_ignored);
+	NUT_UNUSED_VARIABLE(check_current_progname_ignored);
 
 	ret = send_to_named_pipe(pidfn, sig);
 
@@ -1350,19 +1455,21 @@ int snprintfcat(char *dst, size_t size, const char *fmt, ...)
 
 /* lazy way to send a signal if the program uses the PIDPATH */
 #ifndef WIN32
-int sendsignal(const char *progname, int sig)
+int sendsignal(const char *progname, int sig, int check_current_progname)
 {
 	char	fn[SMALLBUF];
 
 	snprintf(fn, sizeof(fn), "%s/%s.pid", rootpidpath(), progname);
 
-	return sendsignalfn(fn, sig, progname);
+	return sendsignalfn(fn, sig, progname, check_current_progname);
 }
 #else
-int sendsignal(const char *progname, const char * sig)
+int sendsignal(const char *progname, const char * sig, int check_current_progname)
 {
-	/* progname is used as the pipe name for WIN32 */
-	return sendsignalfn(progname, sig, NULL);
+	/* progname is used as the pipe name for WIN32
+	 * check_current_progname is de-facto ignored
+	 */
+	return sendsignalfn(progname, sig, NULL, check_current_progname);
 }
 #endif
 

--- a/conf/nut.conf.sample
+++ b/conf/nut.conf.sample
@@ -101,3 +101,12 @@ MODE=none
 #  `none`    Disabled and background() detaches stderr as usual
 #  `default`/unset/other   Not disabled
 #NUT_DEBUG_SYSLOG=stderr
+
+# Normally NUT can (attempt to) verify that the program file name matches the
+# name associated with a running process, when using PID files to send signals.
+# The `NUT_IGNORE_CHECKPROCNAME` boolean toggle allows to quickly skip such
+# verification, in case it causes problems (e.g. NUT programs were renamed and
+# do not match built-in expectations). This environment variable can also be
+# optionally set in init-scripts or service methods for `upsd`, `upsmon` and
+# NUT drivers/`upsdrvctl`.
+#NUT_IGNORE_CHECKPROCNAME=true

--- a/docs/man/nut.conf.txt
+++ b/docs/man/nut.conf.txt
@@ -134,6 +134,18 @@ the same journal). Recognized values:
 | unset/other | Not disabled
 |===========================================================================
 
+*NUT_IGNORE_CHECKPROCNAME*::
+Optional, defaults to `false`.  Normally NUT can (attempt to) verify that
+the program file name matches the name associated with a running process,
+when using PID files to send signals.
++
+The `NUT_IGNORE_CHECKPROCNAME` boolean toggle allows to quickly skip such
+verification, in case it causes problems (e.g. NUT programs were renamed
+and do not match built-in expectations).
++
+This environment variable can also be optionally set in init-scripts or
+service methods for `upsd`, `upsmon` and NUT drivers/`upsdrvctl`.
+
 EXAMPLE
 -------
 

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3168 utf-8
+personal_ws-1.1 en 3169 utf-8
 AAC
 AAS
 ABI
@@ -154,6 +154,7 @@ CERTIDENT
 CERTREQUEST
 CERTVERIF
 CEST
+CHECKPROCNAME
 CHOST
 CHRG
 CL

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -2223,9 +2223,9 @@ int main(int argc, char **argv)
 			int cmdret = -1;
 			/* Send a signal to older copy of the driver, if any */
 			if (oldpid < 0) {
-				cmdret = sendsignalfn(pidfnbuf, cmd, progname);
+				cmdret = sendsignalfn(pidfnbuf, cmd, progname, 1);
 			} else {
-				cmdret = sendsignalpid(oldpid, cmd, progname);
+				cmdret = sendsignalpid(oldpid, cmd, progname, 1);
 			}
 
 			switch (cmdret) {
@@ -2321,7 +2321,7 @@ int main(int argc, char **argv)
 
 			upslogx(LOG_WARNING, "Duplicate driver instance detected (PID file %s exists)! Terminating other driver!", pidfnbuf);
 
-			if ((sigret = sendsignalfn(pidfnbuf, SIGTERM, progname) != 0)) {
+			if ((sigret = sendsignalfn(pidfnbuf, SIGTERM, progname, 1) != 0)) {
 				upsdebugx(1, "Can't send signal to PID, assume invalid PID file %s; "
 					"sendsignalfn() returned %d (errno=%d): %s",
 					pidfnbuf, sigret, errno, strerror(errno));
@@ -2339,9 +2339,9 @@ int main(int argc, char **argv)
 			struct stat	st;
 			if (stat(pidfnbuf, &st) == 0) {
 				upslogx(LOG_WARNING, "Duplicate driver instance is still alive (PID file %s exists) after several termination attempts! Killing other driver!", pidfnbuf);
-				if (sendsignalfn(pidfnbuf, SIGKILL, progname) == 0) {
+				if (sendsignalfn(pidfnbuf, SIGKILL, progname, 1) == 0) {
 					sleep(5);
-					if (sendsignalfn(pidfnbuf, 0, progname) == 0) {
+					if (sendsignalfn(pidfnbuf, 0, progname, 1) == 0) {
 						upslogx(LOG_WARNING, "Duplicate driver instance is still alive (could signal the process)");
 						/* TODO: Should we writepid() below in this case?
 						 * Or if driver init fails, restore the old content
@@ -2385,7 +2385,7 @@ int main(int argc, char **argv)
 		upslogx(LOG_WARNING, "Duplicate driver instance detected! Terminating other driver!");
 		for(i=0;i<10;i++) {
 			DWORD res;
-			sendsignal(name, COMMAND_STOP);
+			sendsignal(name, COMMAND_STOP, 1);
 			if(mutex != NULL ) {
 				res = WaitForSingleObject(mutex,1000);
 				if(res==WAIT_OBJECT_0) {

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -304,9 +304,9 @@ socket_error:
 	nut_sendsignal_debug_level = NUT_SENDSIGNAL_DEBUG_LEVEL_KILL_SIG0PING - 1;
 #ifndef WIN32
 	if (ups->pid == -1) {
-		ret = sendsignalfn(pidfn, cmd, ups->driver);
+		ret = sendsignalfn(pidfn, cmd, ups->driver, 0);
 	} else {
-		ret = sendsignalpid(ups->pid, cmd, ups->driver);
+		ret = sendsignalpid(ups->pid, cmd, ups->driver, 0);
 		/* reap zombie if this child died */
 		if (waitpid(ups->pid, NULL, WNOHANG) == ups->pid) {
 			upslog_with_errno(LOG_WARNING,
@@ -315,7 +315,7 @@ socket_error:
 		}
 	}
 #else
-	ret = sendsignal(pidfn, cmd);
+	ret = sendsignal(pidfn, cmd, 0);
 #endif
 	/* Restore the signal errors verbosity */
 	nut_sendsignal_debug_level = NUT_SENDSIGNAL_DEBUG_LEVEL_DEFAULT;
@@ -381,25 +381,25 @@ static void stop_driver(const ups_t *ups)
 
 #ifndef WIN32
 	if (ups->pid == -1) {
-		ret = sendsignalfn(pidfn, SIGTERM, ups->driver);
+		ret = sendsignalfn(pidfn, SIGTERM, ups->driver, 0);
 	} else {
-		ret = sendsignalpid(ups->pid, SIGTERM, ups->driver);
+		ret = sendsignalpid(ups->pid, SIGTERM, ups->driver, 0);
 		/* reap zombie if this child died */
 		if (waitpid(ups->pid, NULL, WNOHANG) == ups->pid) {
 			goto clean_return;
 		}
 	}
 #else
-	ret = sendsignal(pidfn, COMMAND_STOP);
+	ret = sendsignal(pidfn, COMMAND_STOP, 0);
 #endif
 
 	if (ret < 0) {
 #ifndef WIN32
 		upsdebugx(2, "SIGTERM to %s failed, retrying with SIGKILL", pidfn);
 		if (ups->pid == -1) {
-			ret = sendsignalfn(pidfn, SIGKILL, ups->driver);
+			ret = sendsignalfn(pidfn, SIGKILL, ups->driver, 0);
 		} else {
-			ret = sendsignalpid(ups->pid, SIGKILL, ups->driver);
+			ret = sendsignalpid(ups->pid, SIGKILL, ups->driver, 0);
 			/* reap zombie if this child died */
 			if (waitpid(ups->pid, NULL, WNOHANG) == ups->pid) {
 				goto clean_return;
@@ -407,7 +407,7 @@ static void stop_driver(const ups_t *ups)
 		}
 #else
 		upsdebugx(2, "Stopping %s failed, retrying again", pidfn);
-		ret = sendsignal(pidfn, COMMAND_STOP);
+		ret = sendsignal(pidfn, COMMAND_STOP, 0);
 #endif
 		if (ret < 0) {
 			upslog_with_errno(LOG_ERR, "Stopping %s failed", pidfn);
@@ -419,16 +419,16 @@ static void stop_driver(const ups_t *ups)
 	for (i = 0; i < 5 ; i++) {
 #ifndef WIN32
 		if (ups->pid == -1) {
-			ret = sendsignalfn(pidfn, 0, ups->driver);
+			ret = sendsignalfn(pidfn, 0, ups->driver, 0);
 		} else {
 			/* reap zombie if this child died */
 			if (waitpid(ups->pid, NULL, WNOHANG) == ups->pid) {
 				goto clean_return;
 			}
-			ret = sendsignalpid(ups->pid, 0, ups->driver);
+			ret = sendsignalpid(ups->pid, 0, ups->driver, 0);
 		}
 #else
-		ret = sendsignalfn(pidfn, 0, ups->driver);
+		ret = sendsignalfn(pidfn, 0, ups->driver, 0);
 #endif
 		if (ret != 0) {
 			upsdebugx(2, "Sending signal to %s failed, driver is finally down or wrongly owned", pidfn);
@@ -440,32 +440,32 @@ static void stop_driver(const ups_t *ups)
 #ifndef WIN32
 	upslog_with_errno(LOG_ERR, "Stopping %s failed, retrying harder", pidfn);
 	if (ups->pid == -1) {
-		ret = sendsignalfn(pidfn, SIGKILL, ups->driver);
+		ret = sendsignalfn(pidfn, SIGKILL, ups->driver, 0);
 	} else {
 		/* reap zombie if this child died */
 		if (waitpid(ups->pid, NULL, WNOHANG) == ups->pid) {
 			goto clean_return;
 		}
-		ret = sendsignalpid(ups->pid, SIGKILL, ups->driver);
+		ret = sendsignalpid(ups->pid, SIGKILL, ups->driver, 0);
 	}
 #else
 	upslog_with_errno(LOG_ERR, "Stopping %s failed, retrying again", pidfn);
-	ret = sendsignal(pidfn, COMMAND_STOP);
+	ret = sendsignal(pidfn, COMMAND_STOP, 0);
 #endif
 	if (ret == 0) {
 		for (i = 0; i < 5 ; i++) {
 #ifndef WIN32
 			if (ups->pid == -1) {
-				ret = sendsignalfn(pidfn, 0, ups->driver);
+				ret = sendsignalfn(pidfn, 0, ups->driver, 0);
 			} else {
 				/* reap zombie if this child died */
 				if (waitpid(ups->pid, NULL, WNOHANG) == ups->pid) {
 					goto clean_return;
 				}
-				ret = sendsignalpid(ups->pid, 0, ups->driver);
+				ret = sendsignalpid(ups->pid, 0, ups->driver, 0);
 			}
 #else
-			ret = sendsignalfn(pidfn, 0, ups->driver);
+			ret = sendsignalfn(pidfn, 0, ups->driver, 0);
 #endif
 			if (ret != 0) {
 				upsdebugx(2, "Sending signal to %s failed, driver is finally down or wrongly owned", pidfn);

--- a/include/common.h
+++ b/include/common.h
@@ -246,6 +246,7 @@ size_t parseprogbasename(char *buf, size_t buflen, const char *progname, size_t 
 /* If we can determine the binary path name of the specified "pid",
  * check if it matches the assumed name of the current program.
  * Returns:
+ *	-3	Skipped because NUT_IGNORE_CHECKPROCNAME is set
  *	-2	Could not parse a program name (ok to proceed,
  *		risky - but matches legacy behavior)
  *	-1	Could not identify a program name (ok to proceed,

--- a/include/common.h
+++ b/include/common.h
@@ -268,9 +268,9 @@ pid_t parsepid(const char *buf);
 
 /* send a signal to another running NUT process */
 #ifndef WIN32
-int sendsignal(const char *progname, int sig);
+int sendsignal(const char *progname, int sig, int check_current_progname);
 #else
-int sendsignal(const char *progname, const char * sig);
+int sendsignal(const char *progname, const char * sig, int check_current_progname);
 #endif
 
 int snprintfcat(char *dst, size_t size, const char *fmt, ...)
@@ -281,7 +281,7 @@ pid_t get_max_pid_t(void);
 
 /* send sig to pid after some sanity checks, returns
  * -1 for error, or zero for a successfully sent signal */
-int sendsignalpid(pid_t pid, int sig, const char *progname);
+int sendsignalpid(pid_t pid, int sig, const char *progname, int check_current_progname);
 
 /* open <pidfn>, get the pid, then send it <sig>
  * returns zero for successfully sent signal,
@@ -293,11 +293,15 @@ int sendsignalpid(pid_t pid, int sig, const char *progname);
 #ifndef WIN32
 /* open <pidfn>, get the pid, then send it <sig>
  * if executable process with that pid has suitable progname
+ * (specified or that of the current process, depending on args:
+ * most daemons request to check_current_progname for their other
+ * process instancees, but upsdrvctl which manages differently
+ * named driver programs does not request it)
  */
-int sendsignalfn(const char *pidfn, int sig, const char *progname);
+int sendsignalfn(const char *pidfn, int sig, const char *progname, int check_current_progname);
 #else
 /* No progname here - communications via named pipe */
-int sendsignalfn(const char *pidfn, const char * sig, const char *progname_ignored);
+int sendsignalfn(const char *pidfn, const char * sig, const char *progname_ignored, int check_current_progname_ignored);
 #endif
 
 const char *xbasename(const char *file);

--- a/scripts/Windows/wininit.c
+++ b/scripts/Windows/wininit.c
@@ -193,7 +193,7 @@ static void run_upsd(void)
 
 static void stop_upsd(void)
 {
-	if (sendsignal(UPSD_PIPE_NAME, COMMAND_STOP)) {
+	if (sendsignal(UPSD_PIPE_NAME, COMMAND_STOP, 0)) {
 		print_event(LOG_ERR, "Error stopping upsd (%d)", GetLastError());
 	}
 }
@@ -215,7 +215,7 @@ static void run_upsmon(void)
 
 static void stop_upsmon(void)
 {
-	if (sendsignal(UPSMON_PIPE_NAME, COMMAND_STOP)) {
+	if (sendsignal(UPSMON_PIPE_NAME, COMMAND_STOP, 0)) {
 		print_event(LOG_ERR, "Error stopping upsmon (%d)", GetLastError());
 	}
 }

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -2049,14 +2049,14 @@ int main(int argc, char **argv)
 	 */
 
 	if (oldpid < 0) {
-		cmdret = sendsignalfn(pidfn, cmd, progname);
+		cmdret = sendsignalfn(pidfn, cmd, progname, 1);
 	} else {
-		cmdret = sendsignalpid(oldpid, cmd, progname);
+		cmdret = sendsignalpid(oldpid, cmd, progname, 1);
 	}
 #else	/* if WIN32 */
 	if (cmd) {
 		/* Command the running daemon, it should be there */
-		cmdret = sendsignal(UPSD_PIPE_NAME, cmd);
+		cmdret = sendsignal(UPSD_PIPE_NAME, cmd, 1);
 	} else {
 		/* Starting new daemon, check for competition */
 		mutex = CreateMutex(NULL, TRUE, UPSD_PIPE_NAME);


### PR DESCRIPTION
Follow-up to issue #2463 and PR #2464

Earlier work introduced a way to check that a running PID's process name (if we can detect it) matches our expectations (`upsmon`, `upsd`, driver name) before we send signals - as we did, blindly and naively.

This PR adds a way to disable this feature if it causes problems (e.g. embedded builds tend to have undecipherable NUT version strings to match a firmware name, and I can imagine someone tweaking program names or using symlinks as well... some `snmp-ups-dmf` comes to mind). 

It also adds a fallback ability to optionally check the other PID's process name against the current PID's process name (not requested from `upsdrvctl` which manages variously-named driver programs, but is requested from drivers, `upsd` and `upsmon`) to hopefully alleviate this problem with tweaked names, nip it in the bud.

CC @yoyoma2

CC @arnaudquette-eaton @ericclappier-eaton : this one more internal API change for `sendsignal*()` methods may impact or benefit your work too, pinging just in case :)

Screenshot with a tweaked `upsmon` that would check `NULL` instead of `progname` - this example looks for name of its own PID:
````
:; ./clients/upsmon -DDDDDD -c reload -P 140
Network UPS Tools upsmon 2.8.2-333-g82e5932d9
   0.000000     [D3] getprocname: /proc is an accessible directory, investigating
   0.000152     [D3] getprocname: located symlink for PID 46215 at: /proc/46215/exe
   0.000261     [D1] getprocname: determined process name for PID 46215: /home/jim/nut/clients/.libs/upsmon
   0.000345     [D3] getprocname: /proc is an accessible directory, investigating
   0.000479     [D3] getprocname: located symlink for PID 140 at: /proc/140/exe
   0.000581     [D1] getprocname: failed to readlink() from /proc/140/exe: Permission denied
   0.000645     [D5] getprocname: try to parse some files under /proc
   0.001356     [D3] getprocname: try to parse some files under /proc: processing /proc/140/cmdline
   0.001430     [D1] getprocname: determined process name for PID 140: sshd:
   0.001445     [D1] checkprocname: did not find any match of program names for PID 140 of 'sshd:'=>'sshd:' and checked '/home/jim/nut/clients/.libs/upsmon'=>'upsmon'
   0.001512     [D1] sendsignalpid: ran at least one check, and all such checks found a process name for PID 140 and failed to match: expected progname='(null)' (res=-10), current progname='/home/jim/nut/clients/.libs/upsmon' (res=0)
   0.001524     Tried to signal PID 140 which exists but is not of current program '/home/jim/nut/clients/.libs/upsmon'
   0.001530     [D1] Just failed to send signal, no daemon was running
   0.001534     Failed to signal the currently running daemon (if any)
   0.001538     Try 'systemctl reload nut-monitor.service'
````

...and with `upsmon.c` tweaked to just look for a `bogus-name`, so it falls back to `getpid()` when the first test fails:
````
:;  ./clients/upsmon -DDDDDD -c reload -P 140
Network UPS Tools upsmon 2.8.2-333-g82e5932d9
   0.000000     [D3] getprocname: /proc is an accessible directory, investigating
   0.000054     [D3] getprocname: located symlink for PID 140 at: /proc/140/exe
   0.000094     [D1] getprocname: failed to readlink() from /proc/140/exe: Permission denied
   0.000123     [D5] getprocname: try to parse some files under /proc
   0.000175     [D3] getprocname: try to parse some files under /proc: processing /proc/140/cmdline
   0.000204     [D1] getprocname: determined process name for PID 140: sshd:
   0.000211     [D1] checkprocname: did not find any match of program names for PID 140 of 'sshd:'=>'sshd:' and checked 'bogus-name'=>'bogus-name'
   0.000245     [D3] getprocname: /proc is an accessible directory, investigating
   0.000284     [D3] getprocname: located symlink for PID 50593 at: /proc/50593/exe
   0.000298     [D1] getprocname: determined process name for PID 50593: /home/jim/nut/clients/.libs/upsmon
   0.000341     [D3] getprocname: /proc is an accessible directory, investigating
   0.000376     [D3] getprocname: located symlink for PID 140 at: /proc/140/exe
   0.000388     [D1] getprocname: failed to readlink() from /proc/140/exe: Permission denied
   0.000415     [D5] getprocname: try to parse some files under /proc
   0.000461     [D3] getprocname: try to parse some files under /proc: processing /proc/140/cmdline
   0.000491     [D1] getprocname: determined process name for PID 140: sshd:
   0.000497     [D1] checkprocname: did not find any match of program names for PID 140 of 'sshd:'=>'sshd:' and checked '/home/jim/nut/clients/.libs/upsmon'=>'upsmon'
   0.000500     [D1] sendsignalpid: ran at least one check, and all such checks found a process name for PID 140 and failed to match: expected progname='bogus-name' (res=0), current progname='/home/jim/nut/clients/.libs/upsmon' (res=0)
   0.000525     Tried to signal PID 140 which exists but is not of expected program 'bogus-name' nor current '/home/jim/nut/clients/.libs/upsmon'
   0.000553     [D1] Just failed to send signal, no daemon was running
   0.000581     Failed to signal the currently running daemon (if any)
   0.000587     Try 'systemctl reload nut-monitor.service'
````

...and as before, by default it uses the built-in `progname` (`upsmon` here):
````
:; ./clients/upsmon -DDDDDD -c reload -P 140
Network UPS Tools upsmon 2.8.2-333-g82e5932d9
   0.000000     [D3] getprocname: /proc is an accessible directory, investigating
   0.000047     [D3] getprocname: located symlink for PID 140 at: /proc/140/exe
   0.000059     [D1] getprocname: failed to readlink() from /proc/140/exe: Permission denied
   0.000063     [D5] getprocname: try to parse some files under /proc
   0.000084     [D3] getprocname: try to parse some files under /proc: processing /proc/140/cmdline
   0.000114     [D1] getprocname: determined process name for PID 140: sshd:
   0.000143     [D1] checkprocname: did not find any match of program names for PID 140 of 'sshd:'=>'sshd:' and checked 'upsmon'=>'upsmon'
   0.000180     [D3] getprocname: /proc is an accessible directory, investigating
   0.000198     [D3] getprocname: located symlink for PID 50840 at: /proc/50840/exe
   0.000235     [D1] getprocname: determined process name for PID 50840: /home/jim/nut/clients/.libs/upsmon
   0.000277     [D3] getprocname: /proc is an accessible directory, investigating
   0.000317     [D3] getprocname: located symlink for PID 140 at: /proc/140/exe
   0.000363     [D1] getprocname: failed to readlink() from /proc/140/exe: Permission denied
   0.000401     [D5] getprocname: try to parse some files under /proc
   0.000473     [D3] getprocname: try to parse some files under /proc: processing /proc/140/cmdline
   0.000506     [D1] getprocname: determined process name for PID 140: sshd:
   0.000520     [D1] checkprocname: did not find any match of program names for PID 140 of 'sshd:'=>'sshd:' and checked '/home/jim/nut/clients/.libs/upsmon'=>'upsmon'
   0.000527     [D1] sendsignalpid: ran at least one check, and all such checks found a process name for PID 140 and failed to match: expected progname='upsmon' (res=0), current progname='/home/jim/nut/clients/.libs/upsmon' (res=0)
   0.000532     Tried to signal PID 140 which exists but is not of expected program 'upsmon' nor current '/home/jim/nut/clients/.libs/upsmon'
   0.000563     [D1] Just failed to send signal, no daemon was running
   0.000571     Failed to signal the currently running daemon (if any)
   0.000573     Try 'systemctl reload nut-monitor.service'

:; echo $?
1
````

Note the fallback check resolves the name of the other PID again. A small inefficiency on an infrequent code-path, can live with that.

Test of the emergency envvar toggle to disable the PID sanity check (still sending to un-owned `sshd` so fails):
````
:; NUT_IGNORE_CHECKPROCNAME=true ./clients/upsmon -DDDDDD -c reload -P 140
Network UPS Tools upsmon 2.8.2-333-g82e5932d9
   0.000000     [D1] checkprocname: skipping because caller set NUT_IGNORE_CHECKPROCNAME
kill: Operation not permitted
   0.000130     [D1] Just failed to send signal, no daemon was running
   0.000180     Failed to signal the currently running daemon (if any)
   0.000235     Try 'systemctl reload nut-monitor.service'
````

Note that "raw" `perror()` happens when debug is enabled or internal `nut_sendsignal_debug_level` is sufficiently high (e.g. toned down where we "just ping"), to not scare casual users. Normally this looks like this:
````
# With the check
:; ./clients/upsmon  -c reload -P 140
Network UPS Tools upsmon 2.8.2-333-g82e5932d9
Tried to signal PID 140 which exists but is not of expected program 'upsmon' nor current '/home/jim/nut/clients/.libs/upsmon'
Failed to signal the currently running daemon (if any)
Try 'systemctl reload nut-monitor.service'

:; echo $?
1

# Skipped check
:; NUT_IGNORE_CHECKPROCNAME=true ./clients/upsmon  -c reload -P 140
Network UPS Tools upsmon 2.8.2-333-g82e5932d9
Failed to signal the currently running daemon (if any)
Try 'systemctl reload nut-monitor.service'

:; echo $?
1
````
