### PR TITLE
Upstream from FTY branch: `make distcheck-light-man` and `./confgure --with-doc=man=dist-auto` features

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -92,7 +92,7 @@ memcheck distcheck-valgrind:
 	+$(MAKE) $(AM_MAKEFLAGS) DISTCHECK_FLAGS="$(DISTCHECK_VALGRIND_FLAGS)" distcheck
 
 distcheck-light-man:
-	$(MAKE) $(AM_MAKEFLAGS) DISTCHECK_FLAGS="$(DISTCHECK_LIGHT_MAN_FLAGS)" distcheck
+	+$(MAKE) $(AM_MAKEFLAGS) DISTCHECK_FLAGS="$(DISTCHECK_LIGHT_MAN_FLAGS)" distcheck
 
 # workaround the dist generated files that are also part of the distribution
 # Note that distcleancheck is disabled for now, while waiting for a proper

--- a/Makefile.am
+++ b/Makefile.am
@@ -70,7 +70,7 @@ endif
 
 DISTCHECK_FLAGS = --with-all --with-ssl --with-doc=auto --with-pynut=app --with-nut_monitor=force
 DISTCHECK_LIGHT_FLAGS = --with-all=auto --with-ssl=auto --with-doc=auto --with-pynut=app --with-nut_monitor=force
-DISTCHECK_LIGHT_MAN_FLAGS = --with-all=auto --with-ssl=auto --with-doc=man
+DISTCHECK_LIGHT_MAN_FLAGS = --with-all=auto --with-ssl=auto --with-doc=man --with-pynut=app --with-nut_monitor=force
 DISTCHECK_VALGRIND_FLAGS = --with-all=auto --with-ssl=auto --with-doc=skip --with-valgrind CXXFLAGS='$(CXXFLAGS) -g' CFLAGS='$(CFLAGS) -g' --with-pynut=app --with-nut_monitor=force
 
 # Note: this rule uses envvar DISTCHECK_FLAGS expanded at run-time

--- a/Makefile.am
+++ b/Makefile.am
@@ -70,6 +70,7 @@ endif
 
 DISTCHECK_FLAGS = --with-all --with-ssl --with-doc=auto --with-pynut=app --with-nut_monitor=force
 DISTCHECK_LIGHT_FLAGS = --with-all=auto --with-ssl=auto --with-doc=auto --with-pynut=app --with-nut_monitor=force
+DISTCHECK_LIGHT_MAN_FLAGS = --with-all=auto --with-ssl=auto --with-doc=man
 DISTCHECK_VALGRIND_FLAGS = --with-all=auto --with-ssl=auto --with-doc=skip --with-valgrind CXXFLAGS='$(CXXFLAGS) -g' CFLAGS='$(CFLAGS) -g' --with-pynut=app --with-nut_monitor=force
 
 # Note: this rule uses envvar DISTCHECK_FLAGS expanded at run-time
@@ -89,6 +90,9 @@ distcheck-light:
 # Make a distcheck (and check in particular) with enabled valgrind and debug info
 memcheck distcheck-valgrind:
 	+$(MAKE) $(AM_MAKEFLAGS) DISTCHECK_FLAGS="$(DISTCHECK_VALGRIND_FLAGS)" distcheck
+
+distcheck-light-man:
+	$(MAKE) $(AM_MAKEFLAGS) DISTCHECK_FLAGS="$(DISTCHECK_LIGHT_MAN_FLAGS)" distcheck
 
 # workaround the dist generated files that are also part of the distribution
 # Note that distcleancheck is disabled for now, while waiting for a proper

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -164,6 +164,12 @@ https://github.com/networkupstools/nut/milestone/11
 +
    NOTE: The `html-chunked` documents are currently still not installed.
 
+ - added support to `./confgure --with-doc=man=dist-auto` to use distributed
+   manual page files if present; only fall back to build them if we can. [#2473]
+
+ - added a `make distcheck-light-man` recipe to require verification that the
+   manual page files can be built using the prepared "tarball" archive. [#2473]
+
  - brought keyword dictionaries of `nutconf` and `augeas` NUT configuration
    file parsers up to date; restored automated checks for `augeas` lenses.
    [issue #657, issue #2294]

--- a/configure.ac
+++ b/configure.ac
@@ -2686,6 +2686,9 @@ case "${nut_with_doc}" in
 	skip|all=skip)
 		nut_doc_build_list="man=skip html-single=skip html-chunked=skip pdf=skip"
 		;;
+	dist-auto) # Experimental, currently only for MANs: prefer disted files if present, auto otherwise
+		nut_doc_build_list="man=dist-auto html-single=dist-auto html-chunked=dist-auto pdf=dist-auto"
+		;;
 	no|all=no)
 		nut_doc_build_list=""
 		;;
@@ -2726,7 +2729,7 @@ for nut_doc_build_target in $nut_doc_build_list; do
 		;;
 	esac
 	case "${nut_doc_build_target_flag}" in
-	yes|no|auto|skip) ;;
+	yes|no|auto|skip|dist-auto) ;;
 	"") nut_doc_build_target_flag="yes" ;;
 	*)	rm -rf "${DOCTESTDIR}"
 		AC_MSG_ERROR([Invalid documentation format option: ${nut_doc_build_target}]) ;;
@@ -2817,25 +2820,39 @@ dnl not fail if we have no tools to generate it (so add to SKIP list).
 		;;
 
 	man*)
+		dnl Experimental support for --with-doc=man=dist-auto to prefer pre-disted docs if available, below
 		AC_MSG_CHECKING([if we can build ${nut_doc_build_target_base}])
 		can_build_doc_man=no
+		have_disted_doc_man=no
+		want_disted_doc_man=no
+		if test -s "${abs_srcdir}"/docs/man/snmp-ups.8 ; then
+			dnl Test that groff files exist (building from dist'ed tarball, not git repo)
+			have_disted_doc_man=yes
+		fi
+		if test x"${nut_doc_build_target}" = x"man=dist-auto" || test "${nut_doc_build_target_flag}" = "dist-auto"; then
+			want_disted_doc_man=yes
+		fi
 		if test "${nut_have_asciidoc}" = yes ; then
 			( cd "$DOCTESTDIR" && ${A2X} --format manpage --destination-dir=. --xsltproc-opts="--nonet" "${abs_srcdir}"/docs/man/snmp-ups.txt && test -s snmp-ups.8 ) && can_build_doc_man=yes
 			rm -f "${DOCTESTDIR}"/snmp-ups.8
 		fi
-		if test "${can_build_doc_man}" = yes ; then
+		if test "${want_disted_doc_man}" = yes && test "${have_disted_doc_man}" = yes ; then
+			AC_MSG_NOTICE([Requested, and can, install pre-built dist'ed copies of ${nut_doc_build_target_base} documentation])
+			DOC_SKIPBUILD_LIST="${DOC_SKIPBUILD_LIST} ${nut_doc_build_target_base}"
+			DOC_INSTALL_DISTED_MANS="yes"
+		else
+		  if test "${can_build_doc_man}" = yes ; then
 			AC_MSG_RESULT(yes)
 			DOC_BUILD_LIST="${DOC_BUILD_LIST} ${nut_doc_build_target_base}"
-		else
+		  else
 			AC_MSG_RESULT(no)
 			if test "${nut_doc_build_target_flag}" = "yes" ; then
 				DOC_CANNOTBUILD_LIST="${DOC_CANNOTBUILD_LIST} ${nut_doc_build_target_base}"
 				AC_MSG_WARN([Unable to build ${nut_doc_build_target_base} documentation which you requested])
 			else
 				DOC_SKIPBUILD_LIST="${DOC_SKIPBUILD_LIST} ${nut_doc_build_target_base}"
-				if test "${nut_doc_build_target_flag}" = "auto" ; then
-dnl Test that groff files exist (building from distributed tarball, not git repo)
-					if test -s "${abs_srcdir}"/docs/man/snmp-ups.8 ; then
+				if test "${nut_doc_build_target_flag}" = "auto" || test "${nut_doc_build_target_flag}" = "dist-auto" ; then
+					if test "${have_disted_doc_man}" = yes ; then
 						AC_MSG_WARN([Unable to build ${nut_doc_build_target_base} documentation, but can install pre-built distributed copies])
 						DOC_INSTALL_DISTED_MANS="yes"
 					else
@@ -2843,6 +2860,7 @@ dnl Test that groff files exist (building from distributed tarball, not git repo
 					fi
 				fi  # Other variants include "no", "skip"...
 			fi
+		  fi
 		fi
 		;;
 

--- a/configure.ac
+++ b/configure.ac
@@ -2826,7 +2826,7 @@ dnl not fail if we have no tools to generate it (so add to SKIP list).
 		have_disted_doc_man=no
 		want_disted_doc_man=no
 		if test -s "${abs_srcdir}"/docs/man/snmp-ups.8 ; then
-			dnl Test that groff files exist (building from dist'ed tarball, not git repo)
+			dnl Test that groff files exist (building from distributed tarball, not git repo)
 			have_disted_doc_man=yes
 		fi
 		if test x"${nut_doc_build_target}" = x"man=dist-auto" || test "${nut_doc_build_target_flag}" = "dist-auto"; then
@@ -2837,7 +2837,7 @@ dnl not fail if we have no tools to generate it (so add to SKIP list).
 			rm -f "${DOCTESTDIR}"/snmp-ups.8
 		fi
 		if test "${want_disted_doc_man}" = yes && test "${have_disted_doc_man}" = yes ; then
-			AC_MSG_NOTICE([Requested, and can, install pre-built dist'ed copies of ${nut_doc_build_target_base} documentation])
+			AC_MSG_NOTICE([Requested, and can, install pre-built distributed copies of ${nut_doc_build_target_base} documentation])
 			DOC_SKIPBUILD_LIST="${DOC_SKIPBUILD_LIST} ${nut_doc_build_target_base}"
 			DOC_INSTALL_DISTED_MANS="yes"
 		else

--- a/configure.ac
+++ b/configure.ac
@@ -2840,6 +2840,8 @@ dnl not fail if we have no tools to generate it (so add to SKIP list).
 			AC_MSG_NOTICE([Requested, and can, install pre-built distributed copies of ${nut_doc_build_target_base} documentation])
 			DOC_SKIPBUILD_LIST="${DOC_SKIPBUILD_LIST} ${nut_doc_build_target_base}"
 			DOC_INSTALL_DISTED_MANS="yes"
+			dnl Avoid rebuilding existing build products due to their timestamp dependencies:
+			touch -r "${abs_srcdir}"/docs/man/Makefile.am "${abs_srcdir}"/docs/man/*.{1,2,3,4,5,6,7,8,9}* "${abs_srcdir}"/docs/man/*.{txt,xml,html,pdf} || true
 		else
 		  if test "${can_build_doc_man}" = yes ; then
 			AC_MSG_RESULT(yes)

--- a/configure.ac
+++ b/configure.ac
@@ -2291,6 +2291,8 @@ fi
 NUT_REPORT_FEATURE([enable libltdl (Libtool dlopen abstraction) support], [${nut_with_libltdl}], [],
 					[WITH_LIBLTDL], [Define to enable libltdl (Libtool dlopen abstraction) support])
 
+dnl Explicitly report if we are building nut-scanner or not
+dnl since it requires libltdl
 if test x"${nut_with_libltdl}" = x"no" && test x"${nut_with_nut_scanner}" = x"yes"; then
     AC_MSG_ERROR([libltdl support was disabled or not found, but --with-nut-scanner was requested and requires it])
 fi

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -255,9 +255,16 @@ Other values understood for this option are listed below:
 * A `--with-doc=no` quietly skips generation of all types of documentation,
   including manpages.
 
-* `--with-doc=skip` is used to configure some of the `make distcheck*`
+* A `--with-doc=skip` is used to configure some of the `make distcheck*`
   scenarios to re-use man page files built and distributed by the main
   build and not waste time on re-generation of those.
+
+* A `--with-doc=dist-auto` allows to use pre-distributed MAN pages if present
+  (should be in "tarball" release archives; should not be among Git-tracked
+  sources; may be left over from earlier builds in same workspace), or build
+  those if we can (the `auto` part). Practically this is implemented in detail
+  only for `--with-doc=man=dist-auto`, as we do not dist HTML and PDF products;
+  it is a placeholder for those to simplify the generic configuration calls.
 
 Multiple documentation format values can be specified, separated with comma.
 Each such value can be suffixed with `=yes` to require building of this one


### PR DESCRIPTION
Address part of #1316 regarding a couple of features:

* `make distcheck-light-man` allows to automate `distcheck`-style tests with a requirement to re-build MAN pages in the dist'ed directory (make sure we have enough files in the tarball to do so);
* `./confgure --with-doc=man=dist-auto` allows to use pre-distributed MAN pages if present (should be in tarballs; should not be in git; may be left over from earlier builds in same workspace) or build those if we can (the `auto` part)
  * Nominally this adds generic `./confgure --with-doc=dist-auto` as well, but is implemented in detail only for `man` as we do not `dist` HTML and PDF products; is a placeholder for those.

The FTY branch further uses the `--with-doc=man=dist-auto` feature in reference DEB/RPM packaging recipes (not upstreamed yet), and utilized `BUILD_TYPE=default-tgt:distcheck-light-man` in Travis CI tests (now defunct).