### PR TITLE
clients/upsclient.h: include sys/types.h

### DIFF
--- a/clients/upsclient.h
+++ b/clients/upsclient.h
@@ -53,6 +53,10 @@
 # endif
 #endif
 
+#if defined HAVE_SYS_TYPES_H
+  #include <sys/types.h>
+#endif
+
 #ifdef __cplusplus
 /* *INDENT-OFF* */
 extern "C" {


### PR DESCRIPTION
Include `sys/types.h` to avoid the following uclibc build failure with collectd raised since version 2.8.0 and
https://github.com/networkupstools/nut/commit/3f3851eab0d51e029f67e7db359860cc983557f4:

```
configure:109633: checking int type of port argument for NUT upscli_splitname
configure:109665: /home/buildroot/instance-0/output-1/host/bin/x86_64-linux-gcc -c -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -O2 -g0   -Wall -Werror -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  conftest.c >&5
In file included from conftest.c:172:
/home/buildroot/instance-0/output-1/host/x86_64-buildroot-linux-uclibc/sysroot/usr/include/upsclient.h:114:1: error: unknown type name 'ssize_t'; did you mean 'size_t'?
  114 | ssize_t upscli_sendline_timeout(UPSCONN_t *ups, const char *buf, size_t buflen, const time_t timeout);
      | ^~~~~~~
      | size_t
```

Fixes:
 - http://autobuild.buildroot.org/results/205/2058f87ad7dbf7fbc62c8747855c82da4157ea35/collectd-5.12.0/config.log