### PR TITLE
common/Makefile.am, tools/nut-scanner/Makefile.am: Introduce `libcommonstr.la`

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -54,7 +54,7 @@ libcommonclient_la_SOURCES = state.c str.c
 noinst_LTLIBRARIES += libcommonstr.la
 libcommonstr_la_SOURCES = str.c
 libcommonstr_la_CFLAGS = $(AM_CFLAGS) -DWITHOUT_LIBSYSTEMD=1
-libcommonstr_la_LIBADD = @LTLIBOBJS@
+libcommonstr_la_LIBADD = @LTLIBOBJS@ @BSDKVMPROCLIBS@
 
 if BUILDING_IN_TREE
   libcommon_la_SOURCES += common.c

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -47,11 +47,22 @@ $(top_builddir)/include/nut_version.h:
 
 libcommon_la_SOURCES = state.c str.c upsconf.c
 libcommonclient_la_SOURCES = state.c str.c
+
+# several other Makefiles include the two helpers common.c str.c (and
+# perhaps some other string-related code), so make them a library too;
+# note that LTLIBOBJS pulls in snprintf.c contents too.
+noinst_LTLIBRARIES += libcommonstr.la
+libcommonstr_la_SOURCES = str.c
+libcommonstr_la_CFLAGS = $(AM_CFLAGS) -DWITHOUT_LIBSYSTEMD=1
+libcommonstr_la_LIBADD = @LTLIBOBJS@
+
 if BUILDING_IN_TREE
   libcommon_la_SOURCES += common.c
+  libcommonstr_la_SOURCES += common.c
   libcommonclient_la_SOURCES += common.c
 else !BUILDING_IN_TREE
   nodist_libcommon_la_SOURCES = common.c
+  nodist_libcommonstr_la_SOURCES = common.c
   nodist_libcommonclient_la_SOURCES = common.c
   CLEANFILES += $(top_builddir)/common/common.c
   BUILT_SOURCES = common.c
@@ -62,6 +73,7 @@ if HAVE_STRPTIME
 else !HAVE_STRPTIME
   # fall back to NetBSD implem
   libcommon_la_SOURCES += strptime.c
+  libcommonstr_la_SOURCES += strptime.c
   libcommonclient_la_SOURCES += strptime.c
 endif !HAVE_STRPTIME
 
@@ -70,6 +82,7 @@ if HAVE_STRNLEN
 else !HAVE_STRNLEN
   # fall back to FreeBSD implem
   libcommon_la_SOURCES += strnlen.c
+  libcommonstr_la_SOURCES += strnlen.c
   libcommonclient_la_SOURCES += strnlen.c
 endif !HAVE_STRNLEN
 
@@ -78,6 +91,7 @@ if HAVE_STRSEP
 else !HAVE_STRSEP
   # fall back to simple implem
   libcommon_la_SOURCES += strsep.c
+  libcommonstr_la_SOURCES += strsep.c
   libcommonclient_la_SOURCES += strsep.c
 endif !HAVE_STRSEP
 
@@ -92,6 +106,7 @@ if HAVE_WINDOWS
   noinst_LTLIBRARIES += libnutwincompat.la
 
   libcommon_la_SOURCES += wincompat.c $(top_srcdir)/include/wincompat.h
+  libcommonstr_la_SOURCES += wincompat.c $(top_srcdir)/include/wincompat.h
   libcommonclient_la_SOURCES += wincompat.c $(top_srcdir)/include/wincompat.h
 endif HAVE_WINDOWS
 
@@ -111,6 +126,9 @@ endif WITH_NUTCONF
 if HAVE_LIBREGEX
   libcommon_la_CFLAGS += $(LIBREGEX_CFLAGS)
   libcommon_la_LIBADD += $(LIBREGEX_LIBS)
+
+  libcommonstr_la_CFLAGS += $(LIBREGEX_CFLAGS)
+  libcommonstr_la_LIBADD += $(LIBREGEX_LIBS)
 
   libcommonclient_la_CFLAGS += $(LIBREGEX_CFLAGS)
   libcommonclient_la_LIBADD += $(LIBREGEX_LIBS)

--- a/tools/nut-scanner/Makefile.am
+++ b/tools/nut-scanner/Makefile.am
@@ -28,7 +28,7 @@ $(NUT_SCANNER_DEPS): dummy
 
 # Make sure out-of-dir dependencies exist (especially when dev-building parts):
 $(top_builddir)/include/nut_version.h \
-$(top_builddir)/common/libcommonclient.la \
+$(top_builddir)/common/libcommonstr.la \
 $(top_builddir)/common/libcommon.la: dummy
 	+@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
@@ -68,7 +68,7 @@ libnutscan_la_LIBADD = $(NETLIBS)
 if WITH_LIBLTDL
 libnutscan_la_LIBADD += $(LIBLTDL_LIBS)
 endif WITH_LIBLTDL
-libnutscan_la_LIBADD += $(top_builddir)/common/libcommonclient.la
+
 if HAVE_SEMAPHORE_LIBS
 # Are additional libraries needed for semaphore support?
 libnutscan_la_LIBADD += $(SEMLIBS)
@@ -103,6 +103,8 @@ libnutscan_la_LDFLAGS += -version-info 2:5:0
 libnutscan_la_LDFLAGS += -export-symbols-regex '^(nutscan_|nut_debug_level|s_upsdebugx|max_threads|curr_threads|nut_report_config_flags|upsdebugx_report_search_paths|nut_prepare_search_paths)'
 libnutscan_la_CFLAGS = -I$(top_srcdir)/clients -I$(top_srcdir)/include \
 			$(LIBLTDL_CFLAGS) -I$(top_srcdir)/drivers
+
+libnutscan_la_LIBADD += $(top_builddir)/common/libcommonstr.la
 
 nut_scanner_SOURCES = nut-scanner.c
 nut_scanner_CFLAGS = -I$(top_srcdir)/clients -I$(top_srcdir)/include


### PR DESCRIPTION
Address part of #1316

A smaller helper library than `libcommonclient.la` which is sometimes an overkill, e.g. in `nut-scanner` where the `libupsclient.so/.dll` is loaded dynamically for "Old NUT" scans and there is no specific use for object files included into `libcommonclient.la`.

More use-cases with DMF codebase (currently not yet upstreamed).

Combined from a series of commits like
* 3ba6b576cd2248484eaad41a9e2a480cbd2aa6a6
* c418728e6ed7879f4a569ca0e3fd6f38fcb27eae
* 5f16b7b7c89fa341090e886e7ca5cf8d981430eb
* bc4cd957280c67778a36b49b524092dc15d1aa8b