### PR TITLE
.circleci/config.yml: bump XCode version…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,8 @@ jobs:
     parameters:
       XCODE_VER:
         type: string
-        default: "12.5.1"
+        # https://circleci.com/docs/using-macos/#supported-xcode-versions-silicon
+        default: "13.4.1"
       CC:
         type: string
         default: "" # e.g. "clang"
@@ -136,15 +137,15 @@ workflows:
 ### This scenario is a subset of fightwarn-all below (modulo C standard),
 ### so disabled to not waste time from free CircleCI allowance limit:
 #      - osx-xcode:
-#          name: "gnu17-clang-xcode12_5_1-default-all-errors"
-#          XCODE_VER: "12.5.1"
+#          name: "gnu17-clang-xcode13_4_1-default-all-errors"
+#          XCODE_VER: "13.4.1"
 #          CC: "clang"
 #          CXX: "clang++"
 #          CC_STDVER: "-std=gnu17"
 #          CXX_STDVER: "-std=gnu++17"
 
       - osx-xcode:
-          name: "gnu11-gcc-xcode12_5_1-out-of-tree"
+          name: "gnu11-gcc-xcode13_4_1-out-of-tree"
           CC: "gcc"
           CXX: "g++"
           CC_STDVER: "-std=gnu11"
@@ -153,7 +154,7 @@ workflows:
           CI_BUILDDIR: "obj"
 
       - osx-xcode:
-          name: "c99-cxx11-gcc-xcode12_5_1-default-distcheck"
+          name: "c99-cxx11-gcc-xcode13_4_1-default-distcheck"
           CC: "gcc"
           CXX: "g++"
           CC_STDVER: "-std=c99"
@@ -162,7 +163,7 @@ workflows:
           BUILD_TYPE: "default"
 
       - osx-xcode:
-          name: "stdDefault-xcode12_5_1-fightwarn-all"
+          name: "stdDefault-xcode13_4_1-fightwarn-all"
           # Run "default-all-errors" with both compiler families,
           # using their default C/C++ standard for current release:
           BUILD_TYPE: "fightwarn-all"
@@ -170,8 +171,8 @@ workflows:
 ### This does not work due to missing dependencies built for MacOS in homebrew:
 ### TODO? Evaluate other packagers (MacPorts, fink...)?
 #      - osx-xcode:
-#          name: "c17-clang-xcode12_5_1-alldrv"
-#          XCODE_VER: "12.5.1"
+#          name: "c17-clang-xcode13_4_1-alldrv"
+#          XCODE_VER: "13.4.1"
 #          CC: "clang"
 #          CXX: "clang++"
 #          CC_STDVER: "-std=c17"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,10 +111,11 @@ jobs:
       # uses of sem_init() and sem_destroy() in nut-scanner.c)
       # NOTE: CANBUILD_NIT_TESTS=yes to check if single-executor environments
       # do not have a problem with it.
+      # NOTE: Older Homebrew versions used CI_CCACHE_SYMLINKDIR="/usr/local/opt/ccache/libexec"
       - run:
           name: "ci_build"
           command: |-
-            CI_CCACHE_SYMLINKDIR="/usr/local/opt/ccache/libexec" \
+            CI_CCACHE_SYMLINKDIR="/opt/homebrew/opt/ccache/libexec" \
             CANBUILD_NIT_TESTS=yes \
             CFLAGS="$CC_STDVER -Wno-poison-system-directories -Wno-deprecated-declarations" \
             CXXFLAGS="$CXX_STDVER -Wno-poison-system-directories" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,9 +117,9 @@ jobs:
           command: |-
             CI_CCACHE_SYMLINKDIR="/opt/homebrew/opt/ccache/libexec" \
             CANBUILD_NIT_TESTS=yes \
-            CFLAGS="$CC_STDVER -Wno-poison-system-directories -Wno-deprecated-declarations" \
-            CXXFLAGS="$CXX_STDVER -Wno-poison-system-directories" \
-            LDFLAGS="-L/usr/local/lib" \
+            CFLAGS="$CC_STDVER -Wno-poison-system-directories -Wno-deprecated-declarations -I/opt/homebrew/include" \
+            CXXFLAGS="$CXX_STDVER -Wno-poison-system-directories -I/opt/homebrew/include" \
+            LDFLAGS="-L/opt/homebrew/lib -L/usr/local/lib" \
             ./ci_build.sh
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,6 +137,10 @@ jobs:
             - ~/.ccache
           key: ccache-{{ .Branch }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
 
+      - store_artifacts:
+          path: config.log
+
+
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,17 @@ jobs:
             - ccache-{{ .Branch }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
             - ccache-master-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
 
+      # Fail fast if we had a problem with prerequisites - this
+      # situation would likely impact all build branches anyway.
+      # Requires a Personal API token in the building account:
+      # https://support.circleci.com/hc/en-us/articles/360052058811-Exit-Build-Early-if-Any-Test-Fails
+      - run:
+          name: Fail Fast
+          when: on_fail
+          command: |-
+            echo "Canceling workflow as a step resulted in failure"
+            curl -X POST --header "Content-Type: application/json" "https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/cancel?circle-token=${CIRCLE_TOKEN}"
+
 #      - run:
 #          name: "check shell"
 #          command: /usr/bin/env bash --version || true; command -v bash || true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,12 +72,13 @@ jobs:
             HOMEBREW_NO_AUTO_UPDATE=1; export HOMEBREW_NO_AUTO_UPDATE;
             brew install ccache bash libtool binutils autoconf automake git m4 pkg-config gd libusb neon net-snmp openssl $BREW_MORE
 
-#      - run:
-#          name: "homebrew-libtool"
-#          command: |-
-#            #find /usr /opt /lib* -name '*ltdl*' -ls 2>/dev/null || true
-#            brew unlink libtool && brew link libtool
-#            #find /usr /opt /lib* -name '*ltdl*' -ls 2>/dev/null || true
+      # https://github.com/Homebrew/legacy-homebrew/issues/15488
+      - run:
+          name: "homebrew-libtool"
+          command: |-
+            #find /usr /opt /lib* -name '*ltdl*' -ls 2>/dev/null || true
+            brew unlink libtool && brew link libtool
+            #find /usr /opt /lib* -name '*ltdl*' -ls 2>/dev/null || true
 
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,12 +66,11 @@ jobs:
 
       # Note: MacOS default /bin/bash 3.x is too old for ci_build.sh
       # Brew brings /usr/local/bin/bash 5.x as of this writing
-      # TODO: Are Binutils needed?
       - run:
           name: "homebrew"
           command: |-
             HOMEBREW_NO_AUTO_UPDATE=1; export HOMEBREW_NO_AUTO_UPDATE;
-            brew install ccache bash libtool pkg-config gd libusb neon net-snmp openssl $BREW_MORE #binutils
+            brew install ccache bash libtool binutils autoconf automake git m4 pkg-config gd libusb neon net-snmp openssl $BREW_MORE
 
 #      - run:
 #          name: "homebrew-libtool"

--- a/configure.ac
+++ b/configure.ac
@@ -2573,6 +2573,18 @@ AC_SUBST([nut_with_pynut_py], [${nut_with_pynut_py}])
 AC_SUBST([nut_with_pynut_py2], [${nut_with_pynut_py2}])
 AC_SUBST([nut_with_pynut_py3], [${nut_with_pynut_py3}])
 
+dnl MacOS Darwin has a problem with script shebangs, and tends to run anything
+dnl with shell. On the upside, it has no limit on length or amount of tokens
+dnl in the shebang line.
+dnl https://github.com/NixOS/nixpkgs/issues/65351/
+AS_CASE([${target_os}],
+	[*darwin*], [
+		AS_IF([test -n "${PYTHON}"  -a x"${PYTHON}"  != xno], [ PYTHON=" /usr/bin/env ${PYTHON}"])
+		AS_IF([test -n "${PYTHON2}" -a x"${PYTHON2}" != xno], [PYTHON2=" /usr/bin/env ${PYTHON2}"])
+		AS_IF([test -n "${PYTHON3}" -a x"${PYTHON3}" != xno], [PYTHON3=" /usr/bin/env ${PYTHON3}"])
+		]
+)
+
 AS_IF([test "${nut_with_nut_monitor}" != no -o "${nut_with_pynut}" != no], [
     NUT_REPORT([use default  Python  interpreter],   [${PYTHON}])
     NUT_REPORT([use specific Python2 interpreter],   [${PYTHON2}])

--- a/docs/config-prereqs.txt
+++ b/docs/config-prereqs.txt
@@ -1349,16 +1349,21 @@ Currently known dependencies for basic build include:
 :; HOMEBREW_NO_AUTO_UPDATE=1; export HOMEBREW_NO_AUTO_UPDATE
 
 # Required:
-:; brew install ccache bash libtool pkg-config gd libusb neon net-snmp openssl
+:; brew install ccache bash libtool pkg-config gd libusb neon net-snmp openssl \
+        binutils autoconf automake git m4
 ----
 
 Note that ccache is installed in a different location than expected by default
 in the `ci_build.sh` script, so if your system allows to add the symbolic link
-to `/usr/local/opt/ccache/libexec` as `/usr/lib/ccache` -- please do so as the
-easiest way out. Alternatively, to prepare building sessions with `ci_build.sh`
-you can:
+to `/opt/homebrew/opt/ccache/libexec` (earlier `/usr/local/opt/ccache/libexec`)
+as `/usr/lib/ccache` -- please do so as the easiest way out.
+
+Alternatively, to prepare building sessions with `ci_build.sh` you can:
 ----
-:; export CI_CCACHE_SYMLINKDIR="/usr/local/opt/ccache/libexec"
+:; export CI_CCACHE_SYMLINKDIR="/opt/homebrew/opt/ccache/libexec"
+
+### ...or for older builders:
+#:; export CI_CCACHE_SYMLINKDIR="/usr/local/opt/ccache/libexec"
 ----
 
 

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -1129,6 +1129,7 @@ isTestablePython() {
     if [ x"${PY_SHEBANG}" = x"#!no" ] ; then
         return 1
     fi
+    log_info "Detected python shebang: '${PY_SHEBANG}'"
     return 0
 }
 


### PR DESCRIPTION
…to the oldest currently available now [#2502]

Closes: #2502

In a way, follows up from #1419 and #823 efforts.

Also this effort stepped on newer Homebrew'ed packages than we encountered (coded recipes for) earlier, so these had to be updated. In particular, found that MacOS Darwin has a problem with shebangs in (Python) scripts, had to add weird tricks to handle those.

One visible problem is how the build does not find the `ltdl.h`; adding the path to the library/header into CFLAGS/LDFLAGS did not help. Also, maybe there are other bits we can in fact build against but I did not pick the package names for them while I tried?.. This bit might be better addressed interactively than waiting for cloud builds... CC @clepple 