### PR TITLE
Remember shared-object file names seen during build for later run-time `dlopen()` preference

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -129,6 +129,18 @@ https://github.com/networkupstools/nut/milestone/11
      exiting (and/or start-up has aborted due to configuration or run-time
      issues). Warning about "world readable" files clarified. [#2417]
 
+ - nut-scanner:
+   * the tool relies on dynamic loading of shared objects (library files)
+     orchestrated at run-time rather than pre-compiled, to avoid excessively
+     huge package footprints. This however relies on knowing (or sufficiently
+     safely guessing) the library file names to use, and short `libname.so`
+     is not ubiquitously available. With the new `m4` macro `AX_REALPATH_LIB`
+     we can store and try to use the file name which was present on the build
+     system, while we search for a suitable library. [#2431]
++
+NOTE: Currently both the long and short names for `libupsclient` should be
+installed.
+
  - common code:
    * introduced a `NUT_DEBUG_SYSLOG` environment variable to tweak activation
      of syslog message emission (and related detachment of `stderr` when

--- a/UPGRADING.adoc
+++ b/UPGRADING.adoc
@@ -33,6 +33,14 @@ Changes from 2.8.2 to 2.8.3
   pages which are delivered automatically. Packaging recipes can likely
   be simplified now. [#2445]
 
+- NUT products like `nut-scanner`, which dynamically load shared libraries
+  at run-time without persistent pre-linking, should now know the library
+  file names that were present during build (likely encumbered with version
+  suffixes), and prefer them over plain `libname.so` patterns used previously
+  (which on some platforms are only delivered by development packages as
+  symlinks). Packaging recipes can likely be simplified now: some distros
+  certainly did patch NUT source to similar effect). [#2431]
+
 - Internal API change for `sendsignalpid()` and `sendsignalfn()` methods,
   which can impact NUT forks which build using `libcommon.la` and similar
   libraries.  Added new last argument with `const char *progname` (may be

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3173 utf-8
+personal_ws-1.1 en 3175 utf-8
 AAC
 AAS
 ABI
@@ -969,6 +969,7 @@ RDLCK
 RDNT
 RDWR
 README
+REALPATH
 REDi
 REFREPO
 REPLBATT
@@ -2160,6 +2161,7 @@ libipmimonitoring
 libltdl
 liblzma
 libmodbus
+libname
 libneon
 libnetsnmp
 libnss

--- a/m4/ax_realpath_lib.m4
+++ b/m4/ax_realpath_lib.m4
@@ -76,8 +76,10 @@ AC_DEFUN([AX_REALPATH_LIB],
                     dnl ...which we then resolve with dlltool into a libnetsnmp-40.dll
                     dnl and finally find one in /usr/x86_64-w64-mingw32/bin/libnetsnmp-40.dll
                     dnl (note the version number embedded into base name).
-                    myLIBPATH="`$LD --verbose -Bdynamic ${myLIBNAME_LD} | grep -wi dll | tail -1`" \
-                    && test -n "${myLIBPATH}" && test -s "${myLIBPATH}" \
+                    { myLIBPATH="`$LD --verbose -Bdynamic ${myLIBNAME_LD} | grep -wi dll | tail -1`" \
+                    && test -n "${myLIBPATH}" && test -s "${myLIBPATH}" ; } \
+                    || { myLIBPATH="`$LD $LDFLAGS $LIBS --verbose -Bdynamic ${myLIBNAME_LD} | grep -wi dll | tail -1`" \
+                    && test -n "${myLIBPATH}" && test -s "${myLIBPATH}" ; } \
                     || myLIBPATH=""
 
                     dnl Resolve dynamic library "internal" name from its stub, if needed
@@ -109,8 +111,11 @@ AC_DEFUN([AX_REALPATH_LIB],
                         ]
                     )
                 ])
-            ], [ dnl # POSIX builds
-                myLIBPATH="`${CC} --print-file-name="$myLIBNAME"`" || myLIBPATH=""
+            ], [ dnl # POSIX/MacOS builds
+                { myLIBPATH="`${CC} --print-file-name="$myLIBNAME"`" && test -n "$myLIBPATH" && test -s "$myLIBPATH" ; } \
+                || { myLIBPATH="`${CC} $CFLAGS --print-file-name="$myLIBNAME"`" && test -n "$myLIBPATH" && test -s "$myLIBPATH" ; } \
+                || { myLIBPATH="`${CC} $CFLAGS $LDFLAGS $LIBS --print-file-name="$myLIBNAME"`" && test -n "$myLIBPATH" && test -s "$myLIBPATH" ; } \
+                || myLIBPATH=""
             ])
 
         AS_IF([test -n "${myLIBPATH}" && test -s "${myLIBPATH}"], [

--- a/m4/ax_realpath_lib.m4
+++ b/m4/ax_realpath_lib.m4
@@ -1,0 +1,139 @@
+dnl Resolve real path (if we can) to a library file that would be used
+dnl by gcc/clang compatible toolkit. Relies on AX_REALPATH macro and
+dnl may benefit from a REALPATH envvar pointing to a command-line tool
+dnl (otherwise m4/shell implementation gets used), and NUT_COMPILER_FAMILY.
+dnl Copyright (C) 2024 by Jim Klimov <jimklimov+nut@gmail.com>
+dnl Licensed under the terms of GPLv2 or newer.
+
+dnl Calling script is welcome to pre-detect external REALPATH implementation,
+dnl otherwise shell implementation would be used (hopefully capable enough):
+dnl AC_CHECK_PROGS([REALPATH], [realpath], [])
+
+AC_DEFUN([AX_REALPATH_LIB_PREREQ],
+[
+if test -z "${nut_ax_realpath_lib_prereq_seen}"; then
+    nut_ax_realpath_lib_prereq_seen=yes
+
+    AC_REQUIRE([NUT_COMPILER_FAMILY])dnl
+    AS_CASE(["${target_os}"],
+        [*mingw*], [
+            AS_IF([test x"${DLLTOOL-}" = x],
+                [AC_CHECK_TOOLS([DLLTOOL], [dlltool dlltool.exe], [false])])
+            AS_IF([test x"${OBJDUMP-}" = x],
+                [AC_CHECK_TOOLS([OBJDUMP], [objdump objdump.exe], [false])])
+            dnl # Assuming mingw (sourceware) x86_64-w64-mingw32-ld or similar
+            AS_IF([test x"${LD-}" = x],
+                [AC_CHECK_TOOLS([LD], [ld ld.exe], [false])])
+        ]
+    )
+fi
+])
+
+AC_DEFUN([AX_REALPATH_LIB],
+[
+    dnl # resolve libname - #1 value (not quoted by caller) if we can;
+    dnl # save into varname #2.
+    dnl # In case of problems return #3 (optional, defaults to empty).
+    AC_REQUIRE([AX_REALPATH_LIB_PREREQ])dnl
+
+    AS_IF([test x"$1" = x], [AC_MSG_ERROR([Bad call to REALPATH_LIB macro (arg1)])])
+    AS_IF([test x"$2" = x], [AC_MSG_ERROR([Bad call to REALPATH_LIB macro (arg2)])])
+
+    AS_IF([test "x$GCC" = xyes -o "x$CLANGCC" = xyes], [
+        myLIBNAME="$1"
+        AS_CASE(["${myLIBNAME}"],
+            [-l*], [myLIBNAME="`echo "$myLIBNAME" | sed 's/^-l/lib/'`"]
+        )
+
+        dnl # Primarily we care to know dynamically linked (shared object)
+        dnl # files, so inject the extension to the presumed base name
+        AS_CASE(["${myLIBNAME}"],
+            [*.so*|*.a|*.o|*.lo|*.la|*.dll|*.dll.a|*.lib], [],
+            [
+                AS_CASE(["${target_os}"],
+                    [*mingw*], [myLIBNAME="${myLIBNAME}.dll"],
+                               [myLIBNAME="${myLIBNAME}.so"])
+            ]
+        )
+
+        AC_MSG_CHECKING([for real path to $1 (${myLIBNAME})])
+        myLIBPATH=""
+        AS_CASE(["${target_os}"],
+            [*mingw*], [
+                AS_IF([test x"${LD}" != x -a x"${LD}" != xfalse -a x"${DLLTOOL}" != x -a x"${DLLTOOL}" != xfalse], [
+                    AS_CASE(["${myLIBNAME}"],
+                        [lib*], [
+                            myLIBNAME_LD="`echo "$myLIBNAME" | sed -e 's/^lib/-l/' -e 's/\.\(dll\|dll\.a\|a\)$//i'`"
+                        ], [myLIBNAME_LD="-l$myLIBNAME"]    dnl best-effort...
+                    )
+
+                    dnl Expected output (Linux mingw cross-build) ends like:
+                    dnl   ==================================================
+                    dnl   x86_64-w64-mingw32-ld: mode i386pep
+                    dnl   attempt to open /usr/x86_64-w64-mingw32/lib/libnetsnmp.dll.a succeeded
+                    dnl   /usr/x86_64-w64-mingw32/lib/libnetsnmp.dll.a
+                    dnl ...which we then resolve with dlltool into a libnetsnmp-40.dll
+                    dnl and finally find one in /usr/x86_64-w64-mingw32/bin/libnetsnmp-40.dll
+                    dnl (note the version number embedded into base name).
+                    myLIBPATH="`$LD --verbose -Bdynamic ${myLIBNAME_LD} | grep -wi dll | tail -1`" \
+                    && test -n "${myLIBPATH}" && test -s "${myLIBPATH}" \
+                    || myLIBPATH=""
+
+                    dnl Resolve dynamic library "internal" name from its stub, if needed
+                    AS_CASE(["${myLIBPATH}"],
+                        [*.dll.a], [
+                            myLIBPATH="`$DLLTOOL -I "${myLIBPATH}"`" || myLIBPATH=""
+                            ]
+                    )
+
+                    dnl Internal name may be just that, with no path info
+                    AS_CASE(["${myLIBPATH}"],
+                        [*/*], [],
+                        [
+                            for D in \
+                                "/usr/${target}/bin" \
+                                "/usr/${target}/lib" \
+                                "${MSYSTEM_PREFIX}/bin" \
+                                "${MSYSTEM_PREFIX}/lib" \
+                                "${MINGW_PREFIX}/bin" \
+                                "${MINGW_PREFIX}/lib" \
+                                `${CC} --print-search-dirs 2>/dev/null | grep libraries: | sed 's,^libraries: *=/,/,'` \
+                            ; do
+                                if test -s "$D/${myLIBPATH}" 2>/dev/null ; then
+                                    myLIBPATH="$D/${myLIBPATH}"
+                                    break
+                                fi
+                            done
+                            unset D
+                        ]
+                    )
+                ])
+            ], [ dnl # POSIX builds
+                myLIBPATH="`${CC} --print-file-name="$myLIBNAME"`" || myLIBPATH=""
+            ])
+
+        AS_IF([test -n "${myLIBPATH}" && test -s "${myLIBPATH}"], [
+            AC_MSG_RESULT([initially '${myLIBPATH}'])
+
+            dnl # Resolving the directory location is a nice bonus
+            dnl # (usually the paths are relative to toolkit and ugly,
+            dnl # though maybe arguably portable with regard to symlinks).
+            dnl # The primary goal is to resolve the actual library file
+            dnl # name like "libnetsnmp.so.1.2.3", so we can preferentially
+            dnl # try to dlopen() it on a system with a packaged footprint
+            dnl # that does not serve short (developer-friendly) links like
+            dnl # "libnetsnmp.so".
+            myLIBPATH_REAL="${myLIBPATH}"
+            AX_REALPATH([${myLIBPATH}], [myLIBPATH_REAL])
+            AC_MSG_RESULT(${myLIBPATH_REAL})
+            $2="${myLIBPATH_REAL}"
+            ],[
+            AC_MSG_RESULT([not found])
+            $2="$3"
+            ])
+        ],
+        [AC_MSG_WARN([Compiler not detected as GCC/CLANG-compatible, skipping REALPATH_LIB($1)])
+         $2="$3"
+        ]
+    )
+])

--- a/m4/ax_realpath_lib.m4
+++ b/m4/ax_realpath_lib.m4
@@ -48,11 +48,12 @@ AC_DEFUN([AX_REALPATH_LIB],
         dnl # Primarily we care to know dynamically linked (shared object)
         dnl # files, so inject the extension to the presumed base name
         AS_CASE(["${myLIBNAME}"],
-            [*.so*|*.a|*.o|*.lo|*.la|*.dll|*.dll.a|*.lib], [],
+            [*.so*|*.a|*.o|*.lo|*.la|*.dll|*.dll.a|*.lib|*.dylib], [],
             [
                 AS_CASE(["${target_os}"],
-                    [*mingw*], [myLIBNAME="${myLIBNAME}.dll"],
-                               [myLIBNAME="${myLIBNAME}.so"])
+                    [*mingw*],  [myLIBNAME="${myLIBNAME}.dll"],
+                    [*darwin*], [myLIBNAME="${myLIBNAME}.dylib"],
+                                [myLIBNAME="${myLIBNAME}.so"])
             ]
         )
 

--- a/m4/nut_check_libavahi.m4
+++ b/m4/nut_check_libavahi.m4
@@ -83,6 +83,22 @@ if test -z "${nut_have_avahi_seen}"; then
 			LIBAVAHI_CFLAGS="${CFLAGS}"
 			LIBAVAHI_LIBS="${LIBS}"
 		fi
+
+		dnl Help ltdl if we can (nut-scanner etc.)
+		for TOKEN in $LIBS ; do
+			AS_CASE(["${TOKEN}"],
+				[-l*avahi*], [
+					AX_REALPATH_LIB([${TOKEN}], [SOPATH_LIBAVAHI], [])
+					AS_IF([test -n "${SOPATH_LIBAVAHI}" && test -s "${SOPATH_LIBAVAHI}"], [
+						AC_DEFINE_UNQUOTED([SOPATH_LIBAVAHI],["${SOPATH_LIBAVAHI}"],[Path to dynamic library on build system])
+						SOFILE_LIBAVAHI="`basename "$SOPATH_LIBAVAHI"`"
+						AC_DEFINE_UNQUOTED([SOFILE_LIBAVAHI],["${SOFILE_LIBAVAHI}"],[Base file name of dynamic library on build system])
+						break
+					])
+				]
+			)
+		done
+		unset TOKEN
 	fi
 
 	dnl restore original CFLAGS and LIBS

--- a/m4/nut_check_libfreeipmi.m4
+++ b/m4/nut_check_libfreeipmi.m4
@@ -92,6 +92,22 @@ if test -z "${nut_have_libfreeipmi_seen}"; then
 		AC_DEFINE(HAVE_FREEIPMI, 1, [Define if FreeIPMI support is available])
 		LIBIPMI_CFLAGS="${CFLAGS}"
 		LIBIPMI_LIBS="${LIBS}"
+
+		dnl Help ltdl if we can (nut-scanner etc.)
+		for TOKEN in $LIBS ; do
+			AS_CASE(["${TOKEN}"],
+				[-l*ipmi*], [
+					AX_REALPATH_LIB([${TOKEN}], [SOPATH_LIBFREEIPMI], [])
+					AS_IF([test -n "${SOPATH_LIBFREEIPMI}" && test -s "${SOPATH_LIBFREEIPMI}"], [
+						AC_DEFINE_UNQUOTED([SOPATH_LIBFREEIPMI],["${SOPATH_LIBFREEIPMI}"],[Path to dynamic library on build system])
+						SOFILE_LIBFREEIPMI="`basename "$SOPATH_LIBFREEIPMI"`"
+						AC_DEFINE_UNQUOTED([SOFILE_LIBFREEIPMI],["${SOFILE_LIBFREEIPMI}"],[Base file name of dynamic library on build system])
+						break
+					])
+				]
+			)
+		done
+		unset TOKEN
 	fi
 
 	if test "${nut_have_freeipmi_11x_12x}" = "yes"; then

--- a/m4/nut_check_libneon.m4
+++ b/m4/nut_check_libneon.m4
@@ -78,6 +78,22 @@ if test -z "${nut_have_neon_seen}"; then
 		AC_CHECK_FUNCS(ne_set_connect_timeout ne_sock_connect_timeout)
 		LIBNEON_CFLAGS="${CFLAGS}"
 		LIBNEON_LIBS="${LIBS}"
+
+		dnl Help ltdl if we can (nut-scanner etc.)
+		for TOKEN in $LIBS ; do
+			AS_CASE(["${TOKEN}"],
+				[-l*neon*], [
+					AX_REALPATH_LIB([${TOKEN}], [SOPATH_LIBNEON], [])
+					AS_IF([test -n "${SOPATH_LIBNEON}" && test -s "${SOPATH_LIBNEON}"], [
+						AC_DEFINE_UNQUOTED([SOPATH_LIBNEON],["${SOPATH_LIBNEON}"],[Path to dynamic library on build system])
+						SOFILE_LIBNEON="`basename "$SOPATH_LIBNEON"`"
+						AC_DEFINE_UNQUOTED([SOFILE_LIBNEON],["${SOFILE_LIBNEON}"],[Base file name of dynamic library on build system])
+						break
+					])
+				]
+			)
+		done
+		unset TOKEN
 	fi
 
 	dnl restore original CFLAGS and LIBS

--- a/m4/nut_check_libnetsnmp.m4
+++ b/m4/nut_check_libnetsnmp.m4
@@ -347,7 +347,23 @@ int num = NETSNMP_DRAFT_BLUMENTHAL_AES_04 + 1; /* if defined, NETSNMP_DRAFT_BLUM
 			 AC_DEFINE_UNQUOTED(NUT_HAVE_LIBNETSNMP_DRAFT_BLUMENTHAL_AES_04, 0, [Variable or macro by this name is not resolvable])
 			])
 
+		dnl Help ltdl if we can (nut-scanner etc.)
+		for TOKEN in $LIBS ; do
+			AS_CASE(["${TOKEN}"],
+				[-l*snmp*], [
+					AX_REALPATH_LIB([${TOKEN}], [SOPATH_LIBNETSNMP], [])
+					AS_IF([test -n "${SOPATH_LIBNETSNMP}" && test -s "${SOPATH_LIBNETSNMP}"], [
+						AC_DEFINE_UNQUOTED([SOPATH_LIBNETSNMP],["${SOPATH_LIBNETSNMP}"],[Path to dynamic library on build system])
+						SOFILE_LIBNETSNMP="`basename "$SOPATH_LIBNETSNMP"`"
+						AC_DEFINE_UNQUOTED([SOFILE_LIBNETSNMP],["${SOFILE_LIBNETSNMP}"],[Base file name of dynamic library on build system])
+						break
+					])
+				]
+			)
+		done
+		unset TOKEN
 	])
+
 	AC_LANG_POP([C])
 
 	dnl restore original CFLAGS and LIBS

--- a/m4/nut_check_libusb.m4
+++ b/m4/nut_check_libusb.m4
@@ -371,14 +371,48 @@ if test -z "${nut_have_libusb_seen}"; then
 	dnl with some value.
 	AS_IF([test "${nut_with_usb}" = "yes" && test "${nut_usb_lib}" = "(libusb-1.0)"],
 		[AC_DEFINE([WITH_LIBUSB_1_0], [1],
-			[Define to 1 for version 1.0 of the libusb (via pkg-config).])],
+			[Define to 1 for version 1.0 of the libusb (via pkg-config).])
+
+		 dnl Help ltdl if we can (nut-scanner etc.)
+		 for TOKEN in $LIBS ; do
+			AS_CASE(["${TOKEN}"],
+				[-l*usb*], [
+					AX_REALPATH_LIB([${TOKEN}], [SOPATH_LIBUSB1], [])
+					AS_IF([test -n "${SOPATH_LIBUSB1}" && test -s "${SOPATH_LIBUSB1}"], [
+						AC_DEFINE_UNQUOTED([SOPATH_LIBUSB1],["${SOPATH_LIBUSB1}"],[Path to dynamic library on build system])
+						SOFILE_LIBUSB1="`basename "$SOPATH_LIBUSB1"`"
+						AC_DEFINE_UNQUOTED([SOFILE_LIBUSB1],["${SOFILE_LIBUSB1}"],[Base file name of dynamic library on build system])
+						break
+					])
+				]
+			)
+		 done
+		 unset TOKEN
+                ],
 		[AC_DEFINE([WITH_LIBUSB_1_0], [0],
 			[Define to 1 for version 1.0 of the libusb (via pkg-config).])]
 	)
 
 	AS_IF([test "${nut_with_usb}" = "yes" && test "${nut_usb_lib}" = "(libusb-0.1)" -o "${nut_usb_lib}" = "(libusb-0.1-config)"],
 		[AC_DEFINE([WITH_LIBUSB_0_1], [1],
-			[Define to 1 for version 0.1 of the libusb (via pkg-config or libusb-config).])],
+			[Define to 1 for version 0.1 of the libusb (via pkg-config or libusb-config).])
+
+		 dnl Help ltdl if we can (nut-scanner etc.)
+		 for TOKEN in $LIBS ; do
+			AS_CASE(["${TOKEN}"],
+				[-l*usb*], [
+					AX_REALPATH_LIB([${TOKEN}], [SOPATH_LIBUSB0], [])
+					AS_IF([test -n "${SOPATH_LIBUSB0}" && test -s "${SOPATH_LIBUSB0}"], [
+						AC_DEFINE_UNQUOTED([SOPATH_LIBUSB0],["${SOPATH_LIBUSB0}"],[Path to dynamic library on build system])
+						SOFILE_LIBUSB0="`basename "$SOPATH_LIBUSB0"`"
+						AC_DEFINE_UNQUOTED([SOFILE_LIBUSB0],["${SOFILE_LIBUSB0}"],[Base file name of dynamic library on build system])
+						break
+					])
+				]
+			)
+		 done
+		 unset TOKEN
+                ],
 		[AC_DEFINE([WITH_LIBUSB_0_1], [0],
 			[Define to 1 for version 0.1 of the libusb (via pkg-config or libusb-config).])]
 	)

--- a/m4/nut_compiler_family.m4
+++ b/m4/nut_compiler_family.m4
@@ -2,6 +2,9 @@ dnl detect if current compiler is clang or gcc (or...)
 
 AC_DEFUN([NUT_COMPILER_FAMILY],
 [
+if test -z "${nut_compiler_family_seen}"; then
+  nut_compiler_family_seen=yes
+
   CC_VERSION_FULL="`LANG=C LC_ALL=C $CC --version 2>&1`"   || CC_VERSION_FULL=""
   CXX_VERSION_FULL="`LANG=C LC_ALL=C $CXX --version 2>&1`" || CXX_VERSION_FULL=""
   CPP_VERSION_FULL="`LANG=C LC_ALL=C $CPP --version 2>&1`" || CPP_VERSION_FULL=""
@@ -86,6 +89,7 @@ AC_DEFUN([NUT_COMPILER_FAMILY],
   AS_IF([test "x$CC_VERSION" = x],  [CC_VERSION="`echo "${CC_VERSION_FULL}" | head -1`"])
   AS_IF([test "x$CXX_VERSION" = x], [CXX_VERSION="`echo "${CXX_VERSION_FULL}" | head -1`"])
   AS_IF([test "x$CPP_VERSION" = x], [CPP_VERSION="`echo "${CPP_VERSION_FULL}" | head -1`"])
+fi
 ])
 
 AC_DEFUN([NUT_CHECK_COMPILE_FLAG],

--- a/tools/nut-scanner/nutscan-init.c
+++ b/tools/nut-scanner/nutscan-init.c
@@ -35,10 +35,14 @@
 #include <string.h>
 #include "nut-scan.h"
 
-#ifndef WIN32
-#define SOEXT ".so"
+#ifdef WIN32
+# define SOEXT ".dll"
 #else
-#define SOEXT ".dll"
+# if defined WITH_MACOSX && WITH_MACOSX
+#  define SOEXT ".dylib"
+# else	/* not WIN32, not MACOS */
+#  define SOEXT ".so"
+# endif
 #endif
 
 /* Flags for code paths we can support in this run (libs available or not

--- a/tools/nut-scanner/nutscan-init.c
+++ b/tools/nut-scanner/nutscan-init.c
@@ -195,6 +195,7 @@ void nutscan_init(void)
 			__func__, libname, "LibUSB");
 		nutscan_avail_usb = nutscan_load_usb_library(libname);
 		free(libname);
+		libname = NULL;
 	} else {
 		/* let libtool (lt_dlopen) do its default magic maybe better */
 		upsdebugx(1, "%s: get_libname() did not resolve libname for %s, "
@@ -245,6 +246,7 @@ void nutscan_init(void)
 			__func__, libname, "LibSNMP");
 		nutscan_avail_snmp = nutscan_load_snmp_library(libname);
 		free(libname);
+		libname = NULL;
 	} else {
 		/* let libtool (lt_dlopen) do its default magic maybe better */
 		upsdebugx(1, "%s: get_libname() did not resolve libname for %s, "
@@ -283,6 +285,7 @@ void nutscan_init(void)
 			__func__, libname, "LibNeon");
 		nutscan_avail_xml_http = nutscan_load_neon_library(libname);
 		free(libname);
+		libname = NULL;
 	} else {
 		/* let libtool (lt_dlopen) do its default magic maybe better */
 		upsdebugx(1, "%s: get_libname() did not resolve libname for %s, "
@@ -315,6 +318,7 @@ void nutscan_init(void)
 			__func__, libname, "LibAvahi");
 		nutscan_avail_avahi = nutscan_load_avahi_library(libname);
 		free(libname);
+		libname = NULL;
 	} else {
 		/* let libtool (lt_dlopen) do its default magic maybe better */
 		upsdebugx(1, "%s: get_libname() did not resolve libname for %s, "
@@ -336,6 +340,7 @@ void nutscan_init(void)
 			__func__, libname, "LibFreeIPMI");
 		nutscan_avail_ipmi = nutscan_load_ipmi_library(libname);
 		free(libname);
+		libname = NULL;
 	} else {
 		/* let libtool (lt_dlopen) do its default magic maybe better */
 		upsdebugx(1, "%s: get_libname() did not resolve libname for %s, "
@@ -367,6 +372,7 @@ void nutscan_init(void)
 			__func__, libname, "NUT Client library");
 		nutscan_avail_nut = nutscan_load_upsclient_library(libname);
 		free(libname);
+		libname = NULL;
 	} else {
 		/* let libtool (lt_dlopen) do its default magic maybe better */
 		upsdebugx(1, "%s: get_libname() did not resolve libname for %s, "


### PR DESCRIPTION
This change allows to remember string values of library names (and full paths) seen during build, and prefer them over bland `libsomething.so` symlinks which may be not even available in non-dev packages on some systems. Addresses most of issue #2431

One remaining bit is the name of our own `libupsclient.so/dll/...`

Maybe the logic put into `m4` now should become a standalone shell script, to generate a `#define` one-line header after we build our library?..

This should also be applied to DMF branch (loads more libs in other code paths).