### PR TITLE
Follow-up for `nut_telnetlib.py` stashed copy, and some more recipe refactoring around Python deliverables

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -3,7 +3,14 @@
  or (at your option) any later version. See "LICENSE-GPL2" in the root of this
  distribution.
 
- The files in the scripts/python/ directory are released under GNU General
+ The scripts/python/module/nut_telnetlib.py file is copied for fall-back
+ purposes from Python 3.10, and released under its original license (the
+ PSF License Version 2). It was only modified in the comment section to
+ describe the copy, purpose and provenance per section 3 of the license.
+ According to https://github.com/python/cpython/blob/3.10/LICENSE most of
+ the licenses Python was provided under over the years are GPL-compatible.
+
+ Other files in the scripts/python/ directory are released under GNU General
  Public License (GPL) version 3, or (at your option) any later version. See
  "LICENSE-GPL3" in the root of this distribution.
 

--- a/configure.ac
+++ b/configure.ac
@@ -1453,7 +1453,7 @@ AS_IF([test x"${ac_cv_struct_pollfd}" = xyes],
     )
 
 dnl ----------------------------------------------------------------------
-dnl Check for python binary program names per language version
+dnl Check for Python binary program names per language version
 dnl to embed into scripts and Make rules
 NUT_CHECK_PYTHON_DEFAULT
 
@@ -2334,8 +2334,8 @@ dnl The PYTHON*_REPORT vars also serve as flags that we have certain usable
 dnl Python interpreter versions to care about below, so we only test for
 dnl their existence once (in NUT_CHECK*PYTHON* m4 macros).
 
-dnl ${nut_with_nut_monitor}: TODO: arg values to request python 2 gtk2,
-dnl python 3 qt5, or both
+dnl ${nut_with_nut_monitor}: TODO: arg values to request Python 2 gtk2,
+dnl Python 3 qt5, or both
 AC_MSG_CHECKING([if we want install NUT-Monitor desktop application])
 AC_MSG_RESULT([${nut_with_nut_monitor}])
 nut_with_nut_monitor_py2gtk2=""
@@ -2348,14 +2348,14 @@ PYTHON_FAILED_TEST_DETAILS=""
 dnl ### AC_MSG_NOTICE([nut_with_nut_monitor-1: ${nut_with_nut_monitor}])
 if test x"${nut_with_nut_monitor}" != xno ; then
     dnl While we might just install for "yes" request, in hopes user would
-    dnl get their python ecosystem in place later, we need some criteria to
+    dnl get their Python ecosystem in place later, we need some criteria to
     dnl avoid installing it always :) Also, need to substitute the shebang.
     if test -z "${PYTHON}${PYTHON2}${PYTHON3}" ; then
         case "${nut_with_nut_monitor}" in
             "auto") nut_with_nut_monitor="no"
-                    PYTHON_FAILED_TEST_DETAILS="No python 2/3 interpreter was found"
+                    PYTHON_FAILED_TEST_DETAILS="No Python 2/3 interpreter was found"
                 ;;
-            "yes")  AC_MSG_ERROR([No python 2/3 interpreter was found, required for NUT-Monitor desktop application])
+            "yes")  AC_MSG_ERROR([No Python 2/3 interpreter was found, required for NUT-Monitor desktop application])
                 ;;
         esac
     fi
@@ -2369,7 +2369,7 @@ if test x"${nut_with_nut_monitor}" != xno ; then
     PYTHON2_TEST_MODULES="re,glob,codecs,gtk,gtk.glade,gobject,ConfigParser"
     PYTHON3_TEST_MODULES="re,glob,codecs,PyQt5.uic,configparser"
     if test -n "${PYTHON2_VERSION_INFO_REPORT}" ; then
-        AC_MSG_CHECKING([if have python2 prerequisites for NUT-Monitor desktop application])
+        AC_MSG_CHECKING([if we have Python2 prerequisites for NUT-Monitor desktop application])
         if ${PYTHON2} -c "import ${PYTHON2_TEST_MODULES}" 1>&5 2>&5 \
         ; then
             nut_with_nut_monitor_py2gtk2="yes"
@@ -2381,7 +2381,7 @@ if test x"${nut_with_nut_monitor}" != xno ; then
     fi
 
     if test -n "${PYTHON3_VERSION_INFO_REPORT}" ; then
-        AC_MSG_CHECKING([if have python3 prerequisites for NUT-Monitor desktop application])
+        AC_MSG_CHECKING([if we have Python3 prerequisites for NUT-Monitor desktop application])
         if ${PYTHON3} -c "import ${PYTHON3_TEST_MODULES}" 1>&5 2>&5 \
         ; then
             nut_with_nut_monitor_py3qt5="yes"
@@ -2402,7 +2402,7 @@ if test x"${nut_with_nut_monitor}" != xno ; then
     && test x"${PYTHON_VERSION_INFO_REPORT}" != x"${PYTHON3_VERSION_INFO_REPORT}" \
     && test x"${PYTHON_VERSION_INFO_REPORT}" != x"${PYTHON2_VERSION_INFO_REPORT}" \
     ; then
-        AC_MSG_CHECKING([if have python3 prerequisites for NUT-Monitor desktop application in default python])
+        AC_MSG_CHECKING([if we have Python3 prerequisites for NUT-Monitor desktop application in default Python])
         if ${PYTHON} -c "import ${PYTHON3_TEST_MODULES}" 1>&5 2>&5 \
         ; then
             nut_with_nut_monitor_py3qt5="yes"
@@ -2410,13 +2410,13 @@ if test x"${nut_with_nut_monitor}" != xno ; then
         else
             AC_MSG_RESULT([no])
             if test -n "${PYTHON_FAILED_TEST_DETAILS}" ; then
-                PYTHON_FAILED_TEST_DETAILS="${PYTHON_FAILED_TEST_DETAILS} and some or all of these Python3 modules in default python: '${PYTHON3_TEST_MODULES}'"
+                PYTHON_FAILED_TEST_DETAILS="${PYTHON_FAILED_TEST_DETAILS} and some or all of these Python3 modules in default Python: '${PYTHON3_TEST_MODULES}'"
             else
-                PYTHON_FAILED_TEST_DETAILS="Missing some or all of these Python3 modules in default python: '${PYTHON3_TEST_MODULES}'"
+                PYTHON_FAILED_TEST_DETAILS="Missing some or all of these Python3 modules in default Python: '${PYTHON3_TEST_MODULES}'"
             fi
         fi
 
-        AC_MSG_CHECKING([if have python2 prerequisites for NUT-Monitor desktop application in default python])
+        AC_MSG_CHECKING([if we have Python2 prerequisites for NUT-Monitor desktop application in default Python])
         if ${PYTHON} -c "import ${PYTHON2_TEST_MODULES}" 1>&5 2>&5 \
         ; then
             nut_with_nut_monitor_py2gtk2="yes"
@@ -2425,9 +2425,9 @@ if test x"${nut_with_nut_monitor}" != xno ; then
         else
             AC_MSG_RESULT([no])
             if test -n "${PYTHON_FAILED_TEST_DETAILS}" ; then
-                PYTHON_FAILED_TEST_DETAILS="${PYTHON_FAILED_TEST_DETAILS} and some or all of these Python2 modules in default python: '${PYTHON2_TEST_MODULES}'"
+                PYTHON_FAILED_TEST_DETAILS="${PYTHON_FAILED_TEST_DETAILS} and some or all of these Python2 modules in default Python: '${PYTHON2_TEST_MODULES}'"
             else
-                PYTHON_FAILED_TEST_DETAILS="Missing some or all of these Python2 modules in default python: '${PYTHON2_TEST_MODULES}'"
+                PYTHON_FAILED_TEST_DETAILS="Missing some or all of these Python2 modules in default Python: '${PYTHON2_TEST_MODULES}'"
             fi
         fi
     fi
@@ -2444,7 +2444,7 @@ if test x"${nut_with_nut_monitor}" != xno ; then
         case "${nut_with_nut_monitor}" in
             "auto") nut_with_nut_monitor="no" ;;
             "yes")
-                AC_MSG_ERROR([No python 2/3 interpreter with needed modules was found, as required for NUT-Monitor desktop application: ${PYTHON_FAILED_TEST_DETAILS}])
+                AC_MSG_ERROR([No Python 2/3 interpreter with needed modules was found, as required for NUT-Monitor desktop application: ${PYTHON_FAILED_TEST_DETAILS}])
                 ;;
         esac
     fi
@@ -2547,9 +2547,9 @@ if test x"${nut_with_pynut}" != xno \
     fi
 fi
 
-dnl ${nut_with_pynut}: TODO: arg values to request python 2, 3 or both
+dnl ${nut_with_pynut}: TODO: arg values to request Python 2, 3 or both
 dnl Note that per block above, nut_have_telnetlib_py* values are definitive
-dnl if checked, or empty if skipped (no such python, not nut_with_pynut, etc.)
+dnl if checked, or empty if skipped (no such Python, not nut_with_pynut, etc.)
 AC_MSG_CHECKING([if we can and should install PyNUT module])
 nut_with_pynut_py=""
 nut_with_pynut_py2=""
@@ -2608,7 +2608,7 @@ if test x"${nut_with_pynut}" != xno ; then
                 if test "${nut_with_nut_monitor}" = yes -o "${nut_with_nut_monitor}" = force ; then
                     nut_with_pynut="app"
                 else
-                    AC_MSG_ERROR([python interpreter and/or its site-packages location not found, but required for PyNUT])
+                    AC_MSG_ERROR([Python interpreter and/or its site-packages location not found, but required for PyNUT])
                 fi
                 ;;
         esac

--- a/configure.ac
+++ b/configure.ac
@@ -2446,38 +2446,48 @@ if test x"${nut_with_nut_monitor}" != xno ; then
     fi
 fi
 
-dnl ${nut_with_pynut}: TODO: arg values to request python 2, 3 or both
-AC_MSG_CHECKING([if we can and should install PyNUT module (note for warnings from Python 3.11 and beyond: we have a fallback nut_telnetlib module just in case)])
-nut_with_pynut_py=""
-nut_with_pynut_py2=""
-nut_with_pynut_py3=""
+nut_have_telnetlib_py=""
+nut_have_telnetlib_py2=""
+nut_have_telnetlib_py3=""
 if test x"${nut_with_pynut}" != xno \
     -a -n "${PYTHON}${PYTHON2}${PYTHON3}" \
 ; then
     if test -n "${PYTHON2}" \
     && (command -v ${PYTHON2} || which ${PYTHON2}) >/dev/null 2>/dev/null \
     ; then
+        AC_MSG_CHECKING([if we can use stock Python2 telnetlib module provided with interpreter ${PYTHON2}])
         if ${PYTHON2} -c "import telnetlib" \
         ; then
-            nut_with_pynut_py2="yes"
+            nut_have_telnetlib_py2="yes"
+        else
+            nut_have_telnetlib_py2="no"
         fi
+        AC_MSG_RESULT([${nut_have_telnetlib_py2}])
     fi
 
     if test -n "${PYTHON3}" \
     && (command -v ${PYTHON3} || which ${PYTHON3}) >/dev/null 2>/dev/null \
     ; then
+        AC_MSG_CHECKING([Checking below if we can use stock Python3 telnetlib module for PyNUTClient provided with interpreter ${PYTHON3} (note for warnings from Python 3.11 and beyond: we have a fallback nut_telnetlib module just in case)])
         if ${PYTHON3} -c "import telnetlib" \
         ; then
-            nut_with_pynut_py3="yes"
+            nut_have_telnetlib_py3="yes"
         else
+            nut_have_telnetlib_py3="no"
+        fi
+        AC_MSG_RESULT([${nut_have_telnetlib_py3}])
+
+        if test x"${nut_have_telnetlib_py3}" = x"no" ; then
             dnl We have a stashed copy from Python 3.10, so
             dnl this line essentially checks for presence of
             dnl a usable interpreter implementation compatible
             dnl with Python 3.x syntax.
+            AC_MSG_CHECKING([Checking below if we can use fallback Python3 nut_telnetlib module for PyNUTClient])
             if (cd "${srcdir}"/scripts/python/module && ${PYTHON3} -c "import nut_telnetlib as telnetlib") \
             ; then
-                nut_with_pynut_py3="yes"
+                nut_have_telnetlib_py3="yes"
             fi
+            AC_MSG_RESULT([${nut_have_telnetlib_py3}])
         fi
     fi
 
@@ -2486,16 +2496,47 @@ if test x"${nut_with_pynut}" != xno \
     && (command -v ${PYTHON} || which ${PYTHON}) >/dev/null 2>/dev/null \
     && test "${PYTHON}" != "${PYTHON2}" -a "${PYTHON}" != "${PYTHON3}" \
     ; then
+        AC_MSG_CHECKING([Checking below if we can use stock Python telnetlib module for PyNUTClient provided with interpreter ${PYTHON} (note for warnings from Python 3.11 and beyond: we have a fallback nut_telnetlib module just in case)])
         if ${PYTHON} -c "import telnetlib" \
         ; then
-            nut_with_pynut_py="yes"
+            nut_have_telnetlib_py="yes"
         else
+            nut_have_telnetlib_py="no"
+        fi
+        AC_MSG_RESULT([${nut_have_telnetlib_py}])
+
+        if test x"${nut_have_telnetlib_py}" = x"no" ; then
             dnl See comments above
+            AC_MSG_CHECKING([Checking below if we can use fallback Python nut_telnetlib module for PyNUTClient])
             if (cd "${srcdir}"/scripts/python/module && ${PYTHON} -c "import nut_telnetlib as telnetlib") \
             ; then
-                nut_with_pynut_py="yes"
+                nut_have_telnetlib_py="yes"
             fi
+            AC_MSG_RESULT([${nut_have_telnetlib_py}])
         fi
+    fi
+fi
+
+dnl ${nut_with_pynut}: TODO: arg values to request python 2, 3 or both
+dnl Note that per block above, nut_have_telnetlib_py* values are definitive
+dnl if checked, or empty if skipped (no such python, not nut_with_pynut, etc.)
+AC_MSG_CHECKING([if we can and should install PyNUT module])
+nut_with_pynut_py=""
+nut_with_pynut_py2=""
+nut_with_pynut_py3=""
+if test x"${nut_with_pynut}" != xno \
+    -a -n "${PYTHON}${PYTHON2}${PYTHON3}" \
+; then
+    if test x"${nut_have_telnetlib_py2}" = x"yes" ; then
+        nut_with_pynut_py2="yes"
+    fi
+
+    if test x"${nut_have_telnetlib_py3}" = x"yes" ; then
+        nut_with_pynut_py3="yes"
+    fi
+
+    if test x"${nut_have_telnetlib_py}" = x"yes" ; then
+        nut_with_pynut_py="yes"
     fi
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -2474,7 +2474,7 @@ if test x"${nut_with_pynut}" != xno \
             dnl this line essentially checks for presence of
             dnl a usable interpreter implementation compatible
             dnl with Python 3.x syntax.
-            if (cd scripts/python/module && ${PYTHON3} -c "import nut_telnetlib as telnetlib") \
+            if (cd "${srcdir}"/scripts/python/module && ${PYTHON3} -c "import nut_telnetlib as telnetlib") \
             ; then
                 nut_with_pynut_py3="yes"
             fi
@@ -2491,7 +2491,7 @@ if test x"${nut_with_pynut}" != xno \
             nut_with_pynut_py="yes"
         else
             dnl See comments above
-            if (cd scripts/python/module && ${PYTHON} -c "import nut_telnetlib as telnetlib") \
+            if (cd "${srcdir}"/scripts/python/module && ${PYTHON} -c "import nut_telnetlib as telnetlib") \
             ; then
                 nut_with_pynut_py="yes"
             fi

--- a/configure.ac
+++ b/configure.ac
@@ -2474,7 +2474,7 @@ if test x"${nut_with_pynut}" != xno \
             dnl this line essentially checks for presence of
             dnl a usable interpreter implementation compatible
             dnl with Python 3.x syntax.
-            if (cd script/python/module && ${PYTHON3} -c "import nut_telnetlib as telnetlib") \
+            if (cd scripts/python/module && ${PYTHON3} -c "import nut_telnetlib as telnetlib") \
             ; then
                 nut_with_pynut_py3="yes"
             fi
@@ -2491,7 +2491,7 @@ if test x"${nut_with_pynut}" != xno \
             nut_with_pynut_py="yes"
         else
             dnl See comments above
-            if (cd script/python/module && ${PYTHON} -c "import nut_telnetlib as telnetlib") \
+            if (cd scripts/python/module && ${PYTHON} -c "import nut_telnetlib as telnetlib") \
             ; then
                 nut_with_pynut_py="yes"
             fi

--- a/configure.ac
+++ b/configure.ac
@@ -2330,82 +2330,9 @@ NUT_REPORT_FEATURE([build CGI programs], [${nut_with_cgi}], [],
 dnl ----------------------------------------------------------------------
 dnl checks related to --with-pynut and --with-nut_monitor
 
-dnl These also serve as flags that we have certain Python interpreter
-dnl versions to care about below, so we only test their existence once.
-nut_have_syspath_py=""
-nut_have_syspath_py2=""
-nut_have_syspath_py3=""
-nut_have_sysver_py=""
-nut_have_sysver_py2=""
-nut_have_sysver_py3=""
-nut_have_sysverinfo_py=""
-nut_have_sysverinfo_py2=""
-nut_have_sysverinfo_py3=""
-if test x"${nut_with_pynut}" != xno \
-    -a -n "${PYTHON}${PYTHON2}${PYTHON3}" \
-; then
-    if test -n "${PYTHON2}" \
-    && (command -v ${PYTHON2} || which ${PYTHON2}) >/dev/null 2>/dev/null \
-    ; then
-        AC_MSG_CHECKING([Python2 interpreter ${PYTHON2} sys.path])
-        nut_have_syspath_py2="`${PYTHON2} -c 'import sys; print(sys.path);'`" \
-        || nut_have_syspath_py2=""
-        AC_MSG_RESULT([${nut_have_syspath_py2}])
-
-        dnl Can have extra lines about compiler used, etc.
-        AC_MSG_CHECKING([Python2 interpreter ${PYTHON2} sys.version])
-        nut_have_sysver_py2="`${PYTHON2} -c 'import sys; print(sys.version);' | tr '\n' ' '`" \
-        || nut_have_sysver_py2=""
-        AC_MSG_RESULT([${nut_have_sysver_py2}])
-
-        AC_MSG_CHECKING([Python2 interpreter ${PYTHON2} sys.version_info])
-        nut_have_sysverinfo_py2="`${PYTHON2} -c 'import sys; print(sys.version_info);'`" \
-        || nut_have_sysverinfo_py2=""
-        AC_MSG_RESULT([${nut_have_sysverinfo_py2}])
-    fi
-
-    if test -n "${PYTHON3}" \
-    && (command -v ${PYTHON3} || which ${PYTHON3}) >/dev/null 2>/dev/null \
-    ; then
-        AC_MSG_CHECKING([Python3 interpreter ${PYTHON3} sys.path])
-        nut_have_syspath_py3="`${PYTHON3} -c 'import sys; print(sys.path);'`" \
-        || nut_have_syspath_py3=""
-        AC_MSG_RESULT([${nut_have_syspath_py3}])
-
-        dnl Can have extra lines about compiler used, etc.
-        AC_MSG_CHECKING([Python3 interpreter ${PYTHON3} sys.version])
-        nut_have_sysver_py3="`${PYTHON3} -c 'import sys; print(sys.version);' | tr '\n' ' '`" \
-        || nut_have_sysver_py3=""
-        AC_MSG_RESULT([${nut_have_sysver_py3}])
-
-        AC_MSG_CHECKING([Python3 interpreter ${PYTHON3} sys.version_info])
-        nut_have_sysverinfo_py3="`${PYTHON3} -c 'import sys; print(sys.version_info);'`" \
-        || nut_have_sysverinfo_py3=""
-        AC_MSG_RESULT([${nut_have_sysverinfo_py3}])
-    fi
-
-    dnl Test same-ness of pythons with sys.version also?
-    if test -n "${PYTHON}" \
-    && test "${PYTHON}" != "${PYTHON2}" -a "${PYTHON}" != "${PYTHON3}" \
-    && (command -v ${PYTHON} || which ${PYTHON}) >/dev/null 2>/dev/null \
-    ; then
-        AC_MSG_CHECKING([Default Python interpreter ${PYTHON} sys.path])
-        nut_have_syspath_py="`${PYTHON} -c 'import sys; print(sys.path);'`" \
-        || nut_have_syspath_py=""
-        AC_MSG_RESULT([${nut_have_syspath_py}])
-
-        dnl Can have extra lines about compiler used, etc.
-        AC_MSG_CHECKING([Default Python interpreter ${PYTHON} sys.version])
-        nut_have_sysver_py="`${PYTHON} -c 'import sys; print(sys.version);' | tr '\n' ' '`" \
-        || nut_have_sysver_py=""
-        AC_MSG_RESULT([${nut_have_sysver_py}])
-
-        AC_MSG_CHECKING([Default Python interpreter ${PYTHON} sys.version_info])
-        nut_have_sysverinfo_py="`${PYTHON} -c 'import sys; print(sys.version_info);'`" \
-        || nut_have_sysverinfo_py=""
-        AC_MSG_RESULT([${nut_have_sysverinfo_py}])
-    fi
-fi
+dnl The PYTHON*_REPORT vars also serve as flags that we have certain usable
+dnl Python interpreter versions to care about below, so we only test for
+dnl their existence once (in NUT_CHECK*PYTHON* m4 macros).
 
 dnl ${nut_with_nut_monitor}: TODO: arg values to request python 2 gtk2,
 dnl python 3 qt5, or both
@@ -2437,7 +2364,7 @@ if test x"${nut_with_nut_monitor}" != xno ; then
     dnl for "config.log" details since... forever? Still, hardcoded numbers...
     PYTHON2_TEST_MODULES="re,glob,codecs,gtk,gtk.glade,gobject,ConfigParser"
     PYTHON3_TEST_MODULES="re,glob,codecs,PyQt5.uic,configparser"
-    if test -n "${nut_have_sysverinfo_py2}" ; then
+    if test -n "${PYTHON2_VERSION_INFO_REPORT}" ; then
         if ${PYTHON2} -c "import ${PYTHON2_TEST_MODULES}" 1>&5 2>&5 \
         ; then
             nut_with_nut_monitor_py2gtk2="yes"
@@ -2446,7 +2373,7 @@ if test x"${nut_with_nut_monitor}" != xno ; then
         fi
     fi
 
-    if test -n "${nut_have_sysverinfo_py3}" ; then
+    if test -n "${PYTHON3_VERSION_INFO_REPORT}" ; then
         if ${PYTHON3} -c "import ${PYTHON3_TEST_MODULES}" 1>&5 2>&5 \
         ; then
             nut_with_nut_monitor_py3qt5="yes"
@@ -2457,7 +2384,9 @@ if test x"${nut_with_nut_monitor}" != xno ; then
 
     dnl Fall back to default interpreter
     if test -z "${nut_with_nut_monitor_py2gtk2}${nut_with_nut_monitor_py3qt5}" \
-    && test -n "${nut_have_sysverinfo_py}" \
+    && test -n "${PYTHON_VERSION_INFO_REPORT}" \
+    && test x"${PYTHON_VERSION_INFO_REPORT}" != x"${PYTHON3_VERSION_INFO_REPORT}" \
+    && test x"${PYTHON_VERSION_INFO_REPORT}" != x"${PYTHON2_VERSION_INFO_REPORT}" \
     ; then
         if ${PYTHON} -c "import ${PYTHON3_TEST_MODULES}" 1>&5 2>&5 \
         ; then
@@ -2525,7 +2454,7 @@ nut_have_telnetlib_py3=""
 if test x"${nut_with_pynut}" != xno \
     -a -n "${PYTHON}${PYTHON2}${PYTHON3}" \
 ; then
-    if test -n "${nut_have_sysverinfo_py2}" ; then
+    if test -n "${PYTHON2_VERSION_INFO_REPORT}" ; then
         AC_MSG_CHECKING([if we can use stock Python2 telnetlib module provided with interpreter ${PYTHON2}])
         if ${PYTHON2} -c "import telnetlib" \
         ; then
@@ -2536,7 +2465,7 @@ if test x"${nut_with_pynut}" != xno \
         AC_MSG_RESULT([${nut_have_telnetlib_py2}])
     fi
 
-    if test -n "${nut_have_sysverinfo_py3}" ; then
+    if test -n "${PYTHON3_VERSION_INFO_REPORT}" ; then
         AC_MSG_CHECKING([Checking below if we can use stock Python3 telnetlib module for PyNUTClient provided with interpreter ${PYTHON3} (note for warnings from Python 3.11 and beyond: we have a fallback nut_telnetlib module just in case)])
         if ${PYTHON3} -c "import telnetlib" \
         ; then
@@ -2561,7 +2490,10 @@ if test x"${nut_with_pynut}" != xno \
     fi
 
     dnl Test same-ness of pythons with sys.version also?
-    if test -n "${nut_have_sysverinfo_py}" ; then
+    if test -n "${PYTHON_VERSION_INFO_REPORT}" \
+    && test x"${PYTHON_VERSION_INFO_REPORT}" != x"${PYTHON3_VERSION_INFO_REPORT}" \
+    && test x"${PYTHON_VERSION_INFO_REPORT}" != x"${PYTHON2_VERSION_INFO_REPORT}" \
+    ; then
         AC_MSG_CHECKING([Checking below if we can use stock Python telnetlib module for PyNUTClient provided with interpreter ${PYTHON} (note for warnings from Python 3.11 and beyond: we have a fallback nut_telnetlib module just in case)])
         if ${PYTHON} -c "import telnetlib" \
         ; then

--- a/configure.ac
+++ b/configure.ac
@@ -2336,13 +2336,16 @@ dnl their existence once (in NUT_CHECK*PYTHON* m4 macros).
 
 dnl ${nut_with_nut_monitor}: TODO: arg values to request python 2 gtk2,
 dnl python 3 qt5, or both
-AC_MSG_CHECKING([if we can and should install NUT-Monitor desktop application])
+AC_MSG_CHECKING([if we want install NUT-Monitor desktop application])
+AC_MSG_RESULT([${nut_with_nut_monitor}])
 nut_with_nut_monitor_py2gtk2=""
 nut_with_nut_monitor_py3qt5=""
 nut_with_nut_monitor_desktop=""
 dnl TODO: Add a way to define this path? will have app/ maybe module/ inside...
 nut_with_nut_monitor_dir="${datarootdir}/nut-monitor"
+
 PYTHON_FAILED_TEST_DETAILS=""
+dnl ### AC_MSG_NOTICE([nut_with_nut_monitor-1: ${nut_with_nut_monitor}])
 if test x"${nut_with_nut_monitor}" != xno ; then
     dnl While we might just install for "yes" request, in hopes user would
     dnl get their python ecosystem in place later, we need some criteria to
@@ -2357,6 +2360,7 @@ if test x"${nut_with_nut_monitor}" != xno ; then
         esac
     fi
 fi
+dnl ### AC_MSG_NOTICE([nut_with_nut_monitor-2: ${nut_with_nut_monitor}])
 
 if test x"${nut_with_nut_monitor}" != xno ; then
     dnl Note: no double-quoting for use, the command string may be multi-token
@@ -2365,19 +2369,25 @@ if test x"${nut_with_nut_monitor}" != xno ; then
     PYTHON2_TEST_MODULES="re,glob,codecs,gtk,gtk.glade,gobject,ConfigParser"
     PYTHON3_TEST_MODULES="re,glob,codecs,PyQt5.uic,configparser"
     if test -n "${PYTHON2_VERSION_INFO_REPORT}" ; then
+        AC_MSG_CHECKING([if have python2 prerequisites for NUT-Monitor desktop application])
         if ${PYTHON2} -c "import ${PYTHON2_TEST_MODULES}" 1>&5 2>&5 \
         ; then
             nut_with_nut_monitor_py2gtk2="yes"
+            AC_MSG_RESULT([yes])
         else
+            AC_MSG_RESULT([no])
             PYTHON_FAILED_TEST_DETAILS="Missing some or all of these Python2 modules: '${PYTHON2_TEST_MODULES}'"
         fi
     fi
 
     if test -n "${PYTHON3_VERSION_INFO_REPORT}" ; then
+        AC_MSG_CHECKING([if have python3 prerequisites for NUT-Monitor desktop application])
         if ${PYTHON3} -c "import ${PYTHON3_TEST_MODULES}" 1>&5 2>&5 \
         ; then
             nut_with_nut_monitor_py3qt5="yes"
+            AC_MSG_RESULT([yes])
         else
+            AC_MSG_RESULT([no])
             PYTHON_FAILED_TEST_DETAILS="Missing some or all of these Python3 modules: '${PYTHON3_TEST_MODULES}'"
         fi
     fi
@@ -2388,18 +2398,24 @@ if test x"${nut_with_nut_monitor}" != xno ; then
     && test x"${PYTHON_VERSION_INFO_REPORT}" != x"${PYTHON3_VERSION_INFO_REPORT}" \
     && test x"${PYTHON_VERSION_INFO_REPORT}" != x"${PYTHON2_VERSION_INFO_REPORT}" \
     ; then
+        AC_MSG_CHECKING([if have python3 prerequisites for NUT-Monitor desktop application in default python])
         if ${PYTHON} -c "import ${PYTHON3_TEST_MODULES}" 1>&5 2>&5 \
         ; then
             nut_with_nut_monitor_py3qt5="yes"
+            AC_MSG_RESULT([yes])
         else
+            AC_MSG_RESULT([no])
             PYTHON_FAILED_TEST_DETAILS="Missing some or all of these Python3 modules: '${PYTHON3_TEST_MODULES}'"
         fi
 
+        AC_MSG_CHECKING([if have python2 prerequisites for NUT-Monitor desktop application in default python])
         if ${PYTHON} -c "import ${PYTHON2_TEST_MODULES}" 1>&5 2>&5 \
         ; then
             nut_with_nut_monitor_py2gtk2="yes"
             PYTHON_FAILED_TEST_DETAILS=""
+            AC_MSG_RESULT([yes])
         else
+            AC_MSG_RESULT([no])
             if test -n "${PYTHON_FAILED_TEST_DETAILS}" ; then
                 PYTHON_FAILED_TEST_DETAILS="${PYTHON_FAILED_TEST_DETAILS} and some or all of these Python2 modules: '${PYTHON2_TEST_MODULES}'"
             else
@@ -2408,6 +2424,9 @@ if test x"${nut_with_nut_monitor}" != xno ; then
         fi
     fi
 
+    dnl ### AC_MSG_NOTICE([nut_with_nut_monitor-3: ${nut_with_nut_monitor}])
+    dnl ### AC_MSG_NOTICE([nut_with_nut_monitor_py2gtk2: ${nut_with_nut_monitor_py2gtk2}])
+    dnl ### AC_MSG_NOTICE([nut_with_nut_monitor_py3qt5: ${nut_with_nut_monitor_py3qt5}])
     dnl Can we satisfy any NUT-Monitor installation request?
     if test -n "${nut_with_nut_monitor_py2gtk2}${nut_with_nut_monitor_py3qt5}" ; then
         case "${nut_with_nut_monitor}" in
@@ -2422,6 +2441,9 @@ if test x"${nut_with_nut_monitor}" != xno ; then
         esac
     fi
 fi
+
+AC_MSG_CHECKING([if we can and should install NUT-Monitor desktop application])
+dnl ### AC_MSG_NOTICE([nut_with_nut_monitor-4: ${nut_with_nut_monitor}])
 case "${nut_with_nut_monitor}" in
     "no") if test -n "${PYTHON_FAILED_TEST_DETAILS}" ; then
             AC_MSG_RESULT([${nut_with_nut_monitor}: ${PYTHON_FAILED_TEST_DETAILS}])
@@ -2432,6 +2454,7 @@ case "${nut_with_nut_monitor}" in
     *) AC_MSG_RESULT([${nut_with_nut_monitor}]) ;;
 esac
 
+dnl ### AC_MSG_NOTICE([nut_with_nut_monitor-5: ${nut_with_nut_monitor}])
 if test x"${nut_with_nut_monitor}" != xno ; then
     if (command -v desktop-file-install || which desktop-file-install) >/dev/null 2>/dev/null ; then
         case "${nut_with_nut_monitor}" in
@@ -2446,6 +2469,7 @@ if test x"${nut_with_nut_monitor}" != xno ; then
         esac
     fi
 fi
+dnl ### AC_MSG_NOTICE([nut_with_nut_monitor-6: ${nut_with_nut_monitor}])
 
 dnl Check if we can use distributed or fallback telnetlib module for PyNUTClient
 nut_have_telnetlib_py=""

--- a/configure.ac
+++ b/configure.ac
@@ -2388,7 +2388,11 @@ if test x"${nut_with_nut_monitor}" != xno ; then
             AC_MSG_RESULT([yes])
         else
             AC_MSG_RESULT([no])
-            PYTHON_FAILED_TEST_DETAILS="Missing some or all of these Python3 modules: '${PYTHON3_TEST_MODULES}'"
+            if test -n "${PYTHON_FAILED_TEST_DETAILS}" ; then
+                PYTHON_FAILED_TEST_DETAILS="${PYTHON_FAILED_TEST_DETAILS} and some or all of these Python3 modules: '${PYTHON3_TEST_MODULES}'"
+            else
+                PYTHON_FAILED_TEST_DETAILS="Missing some or all of these Python3 modules: '${PYTHON3_TEST_MODULES}'"
+            fi
         fi
     fi
 
@@ -2405,7 +2409,11 @@ if test x"${nut_with_nut_monitor}" != xno ; then
             AC_MSG_RESULT([yes])
         else
             AC_MSG_RESULT([no])
-            PYTHON_FAILED_TEST_DETAILS="Missing some or all of these Python3 modules: '${PYTHON3_TEST_MODULES}'"
+            if test -n "${PYTHON_FAILED_TEST_DETAILS}" ; then
+                PYTHON_FAILED_TEST_DETAILS="${PYTHON_FAILED_TEST_DETAILS} and some or all of these Python3 modules in default python: '${PYTHON3_TEST_MODULES}'"
+            else
+                PYTHON_FAILED_TEST_DETAILS="Missing some or all of these Python3 modules in default python: '${PYTHON3_TEST_MODULES}'"
+            fi
         fi
 
         AC_MSG_CHECKING([if have python2 prerequisites for NUT-Monitor desktop application in default python])
@@ -2417,9 +2425,9 @@ if test x"${nut_with_nut_monitor}" != xno ; then
         else
             AC_MSG_RESULT([no])
             if test -n "${PYTHON_FAILED_TEST_DETAILS}" ; then
-                PYTHON_FAILED_TEST_DETAILS="${PYTHON_FAILED_TEST_DETAILS} and some or all of these Python2 modules: '${PYTHON2_TEST_MODULES}'"
+                PYTHON_FAILED_TEST_DETAILS="${PYTHON_FAILED_TEST_DETAILS} and some or all of these Python2 modules in default python: '${PYTHON2_TEST_MODULES}'"
             else
-                PYTHON_FAILED_TEST_DETAILS="Missing some or all of these Python2 modules: '${PYTHON2_TEST_MODULES}'"
+                PYTHON_FAILED_TEST_DETAILS="Missing some or all of these Python2 modules in default python: '${PYTHON2_TEST_MODULES}'"
             fi
         fi
     fi

--- a/configure.ac
+++ b/configure.ac
@@ -2330,6 +2330,83 @@ NUT_REPORT_FEATURE([build CGI programs], [${nut_with_cgi}], [],
 dnl ----------------------------------------------------------------------
 dnl checks related to --with-pynut and --with-nut_monitor
 
+dnl These also serve as flags that we have certain Python interpreter
+dnl versions to care about below, so we only test their existence once.
+nut_have_syspath_py=""
+nut_have_syspath_py2=""
+nut_have_syspath_py3=""
+nut_have_sysver_py=""
+nut_have_sysver_py2=""
+nut_have_sysver_py3=""
+nut_have_sysverinfo_py=""
+nut_have_sysverinfo_py2=""
+nut_have_sysverinfo_py3=""
+if test x"${nut_with_pynut}" != xno \
+    -a -n "${PYTHON}${PYTHON2}${PYTHON3}" \
+; then
+    if test -n "${PYTHON2}" \
+    && (command -v ${PYTHON2} || which ${PYTHON2}) >/dev/null 2>/dev/null \
+    ; then
+        AC_MSG_CHECKING([Python2 interpreter ${PYTHON2} sys.path])
+        nut_have_syspath_py2="`${PYTHON2} -c 'import sys; print(sys.path);'`" \
+        || nut_have_syspath_py2=""
+        AC_MSG_RESULT([${nut_have_syspath_py2}])
+
+        dnl Can have extra lines about compiler used, etc.
+        AC_MSG_CHECKING([Python2 interpreter ${PYTHON2} sys.version])
+        nut_have_sysver_py2="`${PYTHON2} -c 'import sys; print(sys.version);' | tr '\n' ' '`" \
+        || nut_have_sysver_py2=""
+        AC_MSG_RESULT([${nut_have_sysver_py2}])
+
+        AC_MSG_CHECKING([Python2 interpreter ${PYTHON2} sys.version_info])
+        nut_have_sysverinfo_py2="`${PYTHON2} -c 'import sys; print(sys.version_info);'`" \
+        || nut_have_sysverinfo_py2=""
+        AC_MSG_RESULT([${nut_have_sysverinfo_py2}])
+    fi
+
+    if test -n "${PYTHON3}" \
+    && (command -v ${PYTHON3} || which ${PYTHON3}) >/dev/null 2>/dev/null \
+    ; then
+        AC_MSG_CHECKING([Python3 interpreter ${PYTHON3} sys.path])
+        nut_have_syspath_py3="`${PYTHON3} -c 'import sys; print(sys.path);'`" \
+        || nut_have_syspath_py3=""
+        AC_MSG_RESULT([${nut_have_syspath_py3}])
+
+        dnl Can have extra lines about compiler used, etc.
+        AC_MSG_CHECKING([Python3 interpreter ${PYTHON3} sys.version])
+        nut_have_sysver_py3="`${PYTHON3} -c 'import sys; print(sys.version);' | tr '\n' ' '`" \
+        || nut_have_sysver_py3=""
+        AC_MSG_RESULT([${nut_have_sysver_py3}])
+
+        AC_MSG_CHECKING([Python3 interpreter ${PYTHON3} sys.version_info])
+        nut_have_sysverinfo_py3="`${PYTHON3} -c 'import sys; print(sys.version_info);'`" \
+        || nut_have_sysverinfo_py3=""
+        AC_MSG_RESULT([${nut_have_sysverinfo_py3}])
+    fi
+
+    dnl Test same-ness of pythons with sys.version also?
+    if test -n "${PYTHON}" \
+    && test "${PYTHON}" != "${PYTHON2}" -a "${PYTHON}" != "${PYTHON3}" \
+    && (command -v ${PYTHON} || which ${PYTHON}) >/dev/null 2>/dev/null \
+    ; then
+        AC_MSG_CHECKING([Default Python interpreter ${PYTHON} sys.path])
+        nut_have_syspath_py="`${PYTHON} -c 'import sys; print(sys.path);'`" \
+        || nut_have_syspath_py=""
+        AC_MSG_RESULT([${nut_have_syspath_py}])
+
+        dnl Can have extra lines about compiler used, etc.
+        AC_MSG_CHECKING([Default Python interpreter ${PYTHON} sys.version])
+        nut_have_sysver_py="`${PYTHON} -c 'import sys; print(sys.version);' | tr '\n' ' '`" \
+        || nut_have_sysver_py=""
+        AC_MSG_RESULT([${nut_have_sysver_py}])
+
+        AC_MSG_CHECKING([Default Python interpreter ${PYTHON} sys.version_info])
+        nut_have_sysverinfo_py="`${PYTHON} -c 'import sys; print(sys.version_info);'`" \
+        || nut_have_sysverinfo_py=""
+        AC_MSG_RESULT([${nut_have_sysverinfo_py}])
+    fi
+fi
+
 dnl ${nut_with_nut_monitor}: TODO: arg values to request python 2 gtk2,
 dnl python 3 qt5, or both
 AC_MSG_CHECKING([if we can and should install NUT-Monitor desktop application])
@@ -2360,9 +2437,7 @@ if test x"${nut_with_nut_monitor}" != xno ; then
     dnl for "config.log" details since... forever? Still, hardcoded numbers...
     PYTHON2_TEST_MODULES="re,glob,codecs,gtk,gtk.glade,gobject,ConfigParser"
     PYTHON3_TEST_MODULES="re,glob,codecs,PyQt5.uic,configparser"
-    if test -n "${PYTHON2}" \
-    && (command -v ${PYTHON2} || which ${PYTHON2}) >/dev/null 2>/dev/null \
-    ; then
+    if test -n "${nut_have_sysverinfo_py2}" ; then
         if ${PYTHON2} -c "import ${PYTHON2_TEST_MODULES}" 1>&5 2>&5 \
         ; then
             nut_with_nut_monitor_py2gtk2="yes"
@@ -2371,9 +2446,7 @@ if test x"${nut_with_nut_monitor}" != xno ; then
         fi
     fi
 
-    if test -n "${PYTHON3}" \
-    && (command -v ${PYTHON3} || which ${PYTHON3}) >/dev/null 2>/dev/null \
-    ; then
+    if test -n "${nut_have_sysverinfo_py3}" ; then
         if ${PYTHON3} -c "import ${PYTHON3_TEST_MODULES}" 1>&5 2>&5 \
         ; then
             nut_with_nut_monitor_py3qt5="yes"
@@ -2384,8 +2457,7 @@ if test x"${nut_with_nut_monitor}" != xno ; then
 
     dnl Fall back to default interpreter
     if test -z "${nut_with_nut_monitor_py2gtk2}${nut_with_nut_monitor_py3qt5}" \
-    && test -n "${PYTHON}" \
-    && (command -v ${PYTHON} || which ${PYTHON2}) >/dev/null 2>/dev/null \
+    && test -n "${nut_have_sysverinfo_py}" \
     ; then
         if ${PYTHON} -c "import ${PYTHON3_TEST_MODULES}" 1>&5 2>&5 \
         ; then
@@ -2446,15 +2518,14 @@ if test x"${nut_with_nut_monitor}" != xno ; then
     fi
 fi
 
+dnl Check if we can use distributed or fallback telnetlib module for PyNUTClient
 nut_have_telnetlib_py=""
 nut_have_telnetlib_py2=""
 nut_have_telnetlib_py3=""
 if test x"${nut_with_pynut}" != xno \
     -a -n "${PYTHON}${PYTHON2}${PYTHON3}" \
 ; then
-    if test -n "${PYTHON2}" \
-    && (command -v ${PYTHON2} || which ${PYTHON2}) >/dev/null 2>/dev/null \
-    ; then
+    if test -n "${nut_have_sysverinfo_py2}" ; then
         AC_MSG_CHECKING([if we can use stock Python2 telnetlib module provided with interpreter ${PYTHON2}])
         if ${PYTHON2} -c "import telnetlib" \
         ; then
@@ -2465,9 +2536,7 @@ if test x"${nut_with_pynut}" != xno \
         AC_MSG_RESULT([${nut_have_telnetlib_py2}])
     fi
 
-    if test -n "${PYTHON3}" \
-    && (command -v ${PYTHON3} || which ${PYTHON3}) >/dev/null 2>/dev/null \
-    ; then
+    if test -n "${nut_have_sysverinfo_py3}" ; then
         AC_MSG_CHECKING([Checking below if we can use stock Python3 telnetlib module for PyNUTClient provided with interpreter ${PYTHON3} (note for warnings from Python 3.11 and beyond: we have a fallback nut_telnetlib module just in case)])
         if ${PYTHON3} -c "import telnetlib" \
         ; then
@@ -2492,10 +2561,7 @@ if test x"${nut_with_pynut}" != xno \
     fi
 
     dnl Test same-ness of pythons with sys.version also?
-    if test -n "${PYTHON}" \
-    && (command -v ${PYTHON} || which ${PYTHON}) >/dev/null 2>/dev/null \
-    && test "${PYTHON}" != "${PYTHON2}" -a "${PYTHON}" != "${PYTHON3}" \
-    ; then
+    if test -n "${nut_have_sysverinfo_py}" ; then
         AC_MSG_CHECKING([Checking below if we can use stock Python telnetlib module for PyNUTClient provided with interpreter ${PYTHON} (note for warnings from Python 3.11 and beyond: we have a fallback nut_telnetlib module just in case)])
         if ${PYTHON} -c "import telnetlib" \
         ; then

--- a/configure.ac
+++ b/configure.ac
@@ -2447,7 +2447,7 @@ if test x"${nut_with_nut_monitor}" != xno ; then
 fi
 
 dnl ${nut_with_pynut}: TODO: arg values to request python 2, 3 or both
-AC_MSG_CHECKING([if we can and should install PyNUT module (note for warnings from python 3.11 and beyond: we have a fallback nut_telnetlib module just in case)])
+AC_MSG_CHECKING([if we can and should install PyNUT module (note for warnings from Python 3.11 and beyond: we have a fallback nut_telnetlib module just in case)])
 nut_with_pynut_py=""
 nut_with_pynut_py2=""
 nut_with_pynut_py3=""

--- a/configure.ac
+++ b/configure.ac
@@ -2490,7 +2490,7 @@ if test x"${nut_with_pynut}" != xno \
     fi
 
     if test -n "${PYTHON3_VERSION_INFO_REPORT}" ; then
-        AC_MSG_CHECKING([Checking below if we can use stock Python3 telnetlib module for PyNUTClient provided with interpreter ${PYTHON3} (note for warnings from Python 3.11 and beyond: we have a fallback nut_telnetlib module just in case)])
+        AC_MSG_CHECKING([if we can use stock Python3 telnetlib module for PyNUTClient provided with interpreter ${PYTHON3} (note for warnings from Python 3.11 and beyond: we have a fallback nut_telnetlib module just in case)])
         if ${PYTHON3} -c "import telnetlib" \
         ; then
             nut_have_telnetlib_py3="yes"
@@ -2504,7 +2504,7 @@ if test x"${nut_with_pynut}" != xno \
             dnl this line essentially checks for presence of
             dnl a usable interpreter implementation compatible
             dnl with Python 3.x syntax.
-            AC_MSG_CHECKING([Checking below if we can use fallback Python3 nut_telnetlib module for PyNUTClient])
+            AC_MSG_CHECKING([if we can use fallback Python3 nut_telnetlib module for PyNUTClient])
             if (cd "${srcdir}"/scripts/python/module && ${PYTHON3} -c "import nut_telnetlib as telnetlib") \
             ; then
                 nut_have_telnetlib_py3="yes"
@@ -2518,7 +2518,7 @@ if test x"${nut_with_pynut}" != xno \
     && test x"${PYTHON_VERSION_INFO_REPORT}" != x"${PYTHON3_VERSION_INFO_REPORT}" \
     && test x"${PYTHON_VERSION_INFO_REPORT}" != x"${PYTHON2_VERSION_INFO_REPORT}" \
     ; then
-        AC_MSG_CHECKING([Checking below if we can use stock Python telnetlib module for PyNUTClient provided with interpreter ${PYTHON} (note for warnings from Python 3.11 and beyond: we have a fallback nut_telnetlib module just in case)])
+        AC_MSG_CHECKING([if we can use stock Python telnetlib module for PyNUTClient provided with interpreter ${PYTHON} (note for warnings from Python 3.11 and beyond: we have a fallback nut_telnetlib module just in case)])
         if ${PYTHON} -c "import telnetlib" \
         ; then
             nut_have_telnetlib_py="yes"
@@ -2529,7 +2529,7 @@ if test x"${nut_with_pynut}" != xno \
 
         if test x"${nut_have_telnetlib_py}" = x"no" ; then
             dnl See comments above
-            AC_MSG_CHECKING([Checking below if we can use fallback Python nut_telnetlib module for PyNUTClient])
+            AC_MSG_CHECKING([if we can use fallback Python nut_telnetlib module for PyNUTClient])
             if (cd "${srcdir}"/scripts/python/module && ${PYTHON} -c "import nut_telnetlib as telnetlib") \
             ; then
                 nut_have_telnetlib_py="yes"

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3173 utf-8
+personal_ws-1.1 en 3174 utf-8
 AAC
 AAS
 ABI
@@ -856,6 +856,7 @@ PROTVER
 PRs
 PSA
 PSD
+PSF
 PSFn
 PSGPSER
 PSSENTR

--- a/m4/nut_check_python.m4
+++ b/m4/nut_check_python.m4
@@ -47,6 +47,8 @@ AC_DEFUN([NUT_CHECK_PYTHON],
         PYTHON=""
         PYTHON_SITE_PACKAGES=""
         PYTHON_VERSION_REPORT=""
+        PYTHON_VERSION_INFO_REPORT=""
+        PYTHON_SYSPATH_REPORT=""
         AS_CASE([${nut_with_python}],
             [auto|yes|""], [AC_CHECK_PROGS([PYTHON], [python python3 python2], [_python_runtime])],
             [no], [PYTHON="no"],
@@ -98,7 +100,7 @@ AC_DEFUN([NUT_CHECK_PYTHON],
 
         AS_IF([test -n "${PYTHON}" && test "${PYTHON}" != "no"], [
             AS_IF([test x"`$PYTHON -c 'import sys; print (sys.version_info >= (2, 6))'`" = xTrue],
-                [PYTHON_VERSION_REPORT=" (`$PYTHON -c 'import sys; print (sys.version_info)'`)"],
+                [PYTHON_VERSION_INFO_REPORT=" (`$PYTHON -c 'import sys; print (sys.version_info)'`)"],
                 [AC_MSG_WARN([Version reported by ${PYTHON} was not suitable as python])
                  PYTHON=no])
             ])
@@ -111,10 +113,21 @@ AC_DEFUN([NUT_CHECK_PYTHON],
             ])
 
         AC_MSG_CHECKING([python interpeter to call])
-        AC_MSG_RESULT([${PYTHON}${PYTHON_VERSION_REPORT}])
+        AC_MSG_RESULT([${PYTHON}${PYTHON_VERSION_INFO_REPORT}])
         AC_SUBST([PYTHON], [${PYTHON}])
         AM_CONDITIONAL([HAVE_PYTHON], [test -n "${PYTHON}" && test "${PYTHON}" != "no"])
         AS_IF([test -n "${PYTHON}" && test "${PYTHON}" != "no"], [
+            AC_MSG_CHECKING([python build sys.version])
+            dnl Can have extra lines about compiler used, etc.
+            PYTHON_VERSION_REPORT="`${PYTHON} -c 'import sys; print(sys.version);' | tr '\n' ' '`" \
+            || PYTHON_VERSION_REPORT=""
+            AC_MSG_RESULT([${PYTHON_VERSION_REPORT}])
+
+            AC_MSG_CHECKING([python sys.path used to search for modules])
+            PYTHON_SYSPATH_REPORT="`${PYTHON} -c 'import sys; print(sys.path);'`" \
+            || PYTHON_SYSPATH_REPORT=""
+            AC_MSG_RESULT([${PYTHON_SYSPATH_REPORT}])
+
             export PYTHON
             AC_CACHE_CHECK([python site-packages location], [nut_cv_PYTHON_SITE_PACKAGES], [
                 nut_cv_PYTHON_SITE_PACKAGES="`${PYTHON} -c 'import site; print(site.getsitepackages().pop(0))'`"
@@ -139,10 +152,12 @@ AC_DEFUN([NUT_CHECK_PYTHON2],
         PYTHON2=""
         PYTHON2_SITE_PACKAGES=""
         PYTHON2_VERSION_REPORT=""
+        PYTHON2_VERSION_INFO_REPORT=""
+        PYTHON2_SYSPATH_REPORT=""
         AS_CASE([${nut_with_python2}],
             [auto|yes|""], [
                 dnl Cross check --with-python results:
-                AS_CASE(["${PYTHON_VERSION_REPORT}"],
+                AS_CASE(["${PYTHON_VERSION_INFO_REPORT}"],
                     [*major=2,*], [
                         PYTHON2="`${PYTHON} -c 'import sys; print(sys.executable);' 2>/dev/null`" && test -n "${PYTHON2}" || PYTHON2="${PYTHON}"
                         PYTHON2="`realpath "${PYTHON2}" 2>/dev/null`" && test -n "${PYTHON2}" || {
@@ -210,7 +225,7 @@ AC_DEFUN([NUT_CHECK_PYTHON2],
 
         AS_IF([test -n "${PYTHON2}" && test "${PYTHON2}" != "no"], [
             AS_IF([test x"`$PYTHON2 -c 'import sys; print (sys.version_info >= (2, 6) and sys.version_info < (3, 0))'`" = xTrue],
-                [PYTHON2_VERSION_REPORT=" (`$PYTHON2 -c 'import sys; print (sys.version_info)'`)"],
+                [PYTHON2_VERSION_INFO_REPORT=" (`$PYTHON2 -c 'import sys; print (sys.version_info)'`)"],
                 [AC_MSG_WARN([Version reported by ${PYTHON2} was not suitable as python2])
                  PYTHON2=no])
             ])
@@ -223,10 +238,21 @@ AC_DEFUN([NUT_CHECK_PYTHON2],
             ])
 
         AC_MSG_CHECKING([python2 interpeter to call])
-        AC_MSG_RESULT([${PYTHON2}${PYTHON2_VERSION_REPORT}])
+        AC_MSG_RESULT([${PYTHON2}${PYTHON2_VERSION_INFO_REPORT}])
         AC_SUBST([PYTHON2], [${PYTHON2}])
         AM_CONDITIONAL([HAVE_PYTHON2], [test -n "${PYTHON2}" && test "${PYTHON2}" != "no"])
         AS_IF([test -n "${PYTHON2}" && test "${PYTHON2}" != "no"], [
+            AC_MSG_CHECKING([python2 build sys.version])
+            dnl Can have extra lines about compiler used, etc.
+            PYTHON2_VERSION_REPORT="`${PYTHON2} -c 'import sys; print(sys.version);' | tr '\n' ' '`" \
+            || PYTHON2_VERSION_REPORT=""
+            AC_MSG_RESULT([${PYTHON2_VERSION_REPORT}])
+
+            AC_MSG_CHECKING([python2 sys.path used to search for modules])
+            PYTHON2_SYSPATH_REPORT="`${PYTHON2} -c 'import sys; print(sys.path);'`" \
+            || PYTHON2_SYSPATH_REPORT=""
+            AC_MSG_RESULT([${PYTHON2_SYSPATH_REPORT}])
+
             export PYTHON2
             AC_CACHE_CHECK([python2 site-packages location], [nut_cv_PYTHON2_SITE_PACKAGES], [
                 nut_cv_PYTHON2_SITE_PACKAGES="`${PYTHON2} -c 'import site; print(site.getsitepackages().pop(0))'`"
@@ -251,10 +277,12 @@ AC_DEFUN([NUT_CHECK_PYTHON3],
         PYTHON3=""
         PYTHON3_SITE_PACKAGES=""
         PYTHON3_VERSION_REPORT=""
+        PYTHON3_VERSION_INFO_REPORT=""
+        PYTHON3_SYSPATH_REPORT=""
         AS_CASE([${nut_with_python3}],
             [auto|yes|""], [
                 dnl Cross check --with-python results:
-                AS_CASE(["${PYTHON_VERSION_REPORT}"],
+                AS_CASE(["${PYTHON_VERSION_INFO_REPORT}"],
                     [*major=3,*], [
                         PYTHON3="`${PYTHON} -c 'import sys; print(sys.executable);' 2>/dev/null`" && test -n "${PYTHON3}" || PYTHON3="${PYTHON}"
                         PYTHON3="`realpath "${PYTHON3}" 2>/dev/null`" && test -n "${PYTHON3}" || {
@@ -322,7 +350,7 @@ AC_DEFUN([NUT_CHECK_PYTHON3],
 
         AS_IF([test -n "${PYTHON3}" && test "${PYTHON3}" != "no"], [
             AS_IF([test x"`$PYTHON3 -c 'import sys; print (sys.version_info >= (3, 0))'`" = xTrue],
-                [PYTHON3_VERSION_REPORT=" (`$PYTHON3 -c 'import sys; print (sys.version_info)'`)"],
+                [PYTHON3_VERSION_INFO_REPORT=" (`$PYTHON3 -c 'import sys; print (sys.version_info)'`)"],
                 [AC_MSG_WARN([Version reported by ${PYTHON3} was not suitable as python3])
                  PYTHON3=no])
             ])
@@ -335,10 +363,21 @@ AC_DEFUN([NUT_CHECK_PYTHON3],
             ])
 
         AC_MSG_CHECKING([python3 interpeter to call])
-        AC_MSG_RESULT([${PYTHON3}${PYTHON3_VERSION_REPORT}])
+        AC_MSG_RESULT([${PYTHON3}${PYTHON3_VERSION_INFO_REPORT}])
         AC_SUBST([PYTHON3], [${PYTHON3}])
         AM_CONDITIONAL([HAVE_PYTHON3], [test -n "${PYTHON3}" && test "${PYTHON3}" != "no"])
         AS_IF([test -n "${PYTHON3}" && test "${PYTHON3}" != "no"], [
+            AC_MSG_CHECKING([python3 build sys.version])
+            dnl Can have extra lines about compiler used, etc.
+            PYTHON3_VERSION_REPORT="`${PYTHON3} -c 'import sys; print(sys.version);' | tr '\n' ' '`" \
+            || PYTHON3_VERSION_REPORT=""
+            AC_MSG_RESULT([${PYTHON3_VERSION_REPORT}])
+
+            AC_MSG_CHECKING([python3 sys.path used to search for modules])
+            PYTHON3_SYSPATH_REPORT="`${PYTHON3} -c 'import sys; print(sys.path);'`" \
+            || PYTHON3_SYSPATH_REPORT=""
+            AC_MSG_RESULT([${PYTHON3_SYSPATH_REPORT}])
+
             export PYTHON3
             AC_CACHE_CHECK([python3 site-packages location], [nut_cv_PYTHON3_SITE_PACKAGES], [
                 nut_cv_PYTHON3_SITE_PACKAGES="`${PYTHON3} -c 'import site; print(site.getsitepackages().pop(0))'`"

--- a/scripts/python/module/nut_telnetlib.py
+++ b/scripts/python/module/nut_telnetlib.py
@@ -4,6 +4,10 @@ r"""TELNET client class.
 This file has been copied for PyNUTClient fallback needs from Python 3.10
 (newer Python releases obsoleted the module) and not modified except for
 this notice.
+
+See https://github.com/python/cpython/blob/3.10/Lib/telnetlib.py as of
+https://raw.githubusercontent.com/python/cpython/60419a7e96577cf783b3b45bf3984f9fb0d7ddff/Lib/telnetlib.py
+and https://github.com/python/cpython/blob/3.10/LICENSE
 ------
 
 Based on RFC 854: TELNET Protocol Specification, by J. Postel and


### PR DESCRIPTION
Follow-up to issue #2183 and PR #2501
Thanks to @opoplawski for reviews there

````
:; PYTHON=python3.11 ./ci_build.sh
...
checking python interpeter to call... /usr/bin/python3.11 (sys.version_info(major=3, minor=11, micro=0, releaselevel='candidate', serial=1))
checking python site-packages location... /usr/local/lib/python3.11/dist-packages
checking for python2... python2
checking python2 interpeter to call... /usr/bin/python2 (sys.version_info(major=2, minor=7, micro=18, releaselevel='final', serial=0))
checking python2 site-packages location... /usr/local/lib/python2.7/dist-packages
configure: WARNING: A python3 program name was not specified during configuration, will default to '/usr/bin/python3.11' (derived from --with-python setting which has a suitable version)
checking python3 interpeter to call... /usr/bin/python3.11 (sys.version_info(major=3, minor=11, micro=0, releaselevel='candidate', serial=1))
checking python3 site-packages location... /usr/local/lib/python3.11/dist-packages
...
checking Python2 interpreter /usr/bin/python2 sys.path... ['', '/usr/lib/python2.7', '/usr/lib/python2.7/plat-x86_64-linux-gnu', '/usr/lib/python2.7/lib-tk', '/usr/lib/python2.7/lib-old', '/usr/lib/python2.7/lib-dynload', '/usr/local/lib/python2.7/dist-packages', '/usr/lib/python2.7/dist-packages']
checking Python2 interpreter /usr/bin/python2 sys.version... 2.7.18 (default, Jul  1 2022, 10:30:50)  [GCC 11.2.0]
checking Python2 interpreter /usr/bin/python2 sys.version_info... sys.version_info(major=2, minor=7, micro=18, releaselevel='final', serial=0)
checking Python3 interpreter /usr/bin/python3.11 sys.path... ['', '/usr/lib/python311.zip', '/usr/lib/python3.11', '/usr/lib/python3.11/lib-dynload', '/home/jim/.local/lib/python3.11/site-packages', '/usr/local/lib/python3.11/dist-packages', '/usr/lib/python3/dist-packages']
checking Python3 interpreter /usr/bin/python3.11 sys.version... 3.11.0rc1 (main, Aug 12 2022, 10:02:14) [GCC 11.2.0]
checking Python3 interpreter /usr/bin/python3.11 sys.version_info... sys.version_info(major=3, minor=11, micro=0, releaselevel='candidate', serial=1)
checking if we can and should install NUT-Monitor desktop application... no: Missing some or all of these Python3 modules: 're,glob,codecs,PyQt5.uic,configparser'
checking if we can use stock Python2 telnetlib module provided with interpreter /usr/bin/python2... yes
checking Checking below if we can use stock Python3 telnetlib module for PyNUTClient provided with interpreter /usr/bin/python3.11 (note for warnings from Python 3.11 and beyond: we have a fallback nut_telnetlib module just in case)... Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'telnetlib'
no
checking Checking below if we can use fallback Python3 nut_telnetlib module for PyNUTClient... yes
checking if we can and should install PyNUT module... yes
checking whether to install NUT-Monitor desktop application... no
checking whether to install PyNUT binding module... yes
...
````

Hm, got a bit of duplicated noise here. But the basic separation is seen working - what fails (with `telnetlib.py` AND `pyc` files removed from the 3.11 installation) and how retries happen and the outcome.