### PR TITLE
Revise recipes for MacOS builds and general portability some more, and update docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,7 @@ jobs:
             #brew reinstall openssl@3
             if ps -ef | grep -v grep | grep sshd ; then
                 brew install mc
+                ifconfig -a || true
             fi
 
       # https://github.com/Homebrew/legacy-homebrew/issues/15488

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,9 @@ jobs:
                 nss openssl \
                 libmodbus freeipmi powerman $BREW_MORE
             #brew reinstall openssl@3
+            if ps -ef | grep -v grep | grep sshd ; then
+                brew install mc
+            fi
 
       # https://github.com/Homebrew/legacy-homebrew/issues/15488
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,9 @@ jobs:
       CXX:
         type: string
         default: "" # e.g. "clang++"
+      CPP:
+        type: string
+        default: "" # e.g. "clang -E"
       CC_STDVER:
         type: string
         default: "" # e.g. "-std=gnu17"
@@ -54,6 +57,7 @@ jobs:
     environment:
       CC: << parameters.CC >>
       CXX: << parameters.CXX >>
+      CPP: << parameters.CPP >>
       CC_STDVER: << parameters.CC_STDVER >>
       CXX_STDVER: << parameters.CXX_STDVER >>
       BUILD_TYPE: << parameters.BUILD_TYPE >>
@@ -221,6 +225,7 @@ workflows:
           name: "gnu11-clang-xcode13_4_1-out-of-tree"
           CC: "clang"
           CXX: "clang++"
+          CPP: "clang -E"
           CC_STDVER: "-std=gnu11"
           CXX_STDVER: "-std=gnu++11"
           # Try an out-of-tree build:
@@ -230,6 +235,7 @@ workflows:
           name: "c99-cxx11-clang-xcode13_4_1-default-distcheck"
           CC: "clang"
           CXX: "clang++"
+          CPP: "clang -E"
           CC_STDVER: "-std=c99"
           CXX_STDVER: "-std=c++11"
           # Try usual and distchecked build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
       - run:
           name: "homebrew"
           command: |-
-            HOMEBREW_NO_AUTO_UPDATE=1; export HOMEBREW_NO_AUTO_UPDATE;
+            #HOMEBREW_NO_AUTO_UPDATE=1; export HOMEBREW_NO_AUTO_UPDATE;
             brew install ccache bash libtool binutils autoconf automake git m4 \
                 pkg-config aspell asciidoc docbook-xsl cppunit gd \
                 libusb neon net-snmp \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,8 @@ jobs:
       # uses of sem_init() and sem_destroy() in nut-scanner.c)
       # NOTE: CANBUILD_NIT_TESTS=yes to check if single-executor environments
       # do not have a problem with it.
+      # NOTE: python3.11 is available but broken on some of the workers
+      # (no homebrew dirs in search path)
       - run:
           name: "ci_build"
           command: |-
@@ -152,6 +154,7 @@ jobs:
             CANBUILD_NIT_TESTS=yes \
             CFLAGS="$CC_STDVER" \
             CXXFLAGS="$CXX_STDVER" \
+            PYTHON=python3.12 \
             ./ci_build.sh
 
       - run:

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -55,7 +55,9 @@ case "$BUILD_TYPE" in
     fightwarn-gcc)
         CC="gcc"
         CXX="g++"
-        CPP="cpp"
+        # Avoid "cpp" directly as it may be too "traditional"
+        #CPP="cpp"
+        CPP="gcc -E"
         BUILD_TYPE=fightwarn
         ;;
     fightwarn-clang)
@@ -967,13 +969,13 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
         # Note: can be a multi-token name like "clang -E" or just not a full pathname
         ( [ -x "$CPP" ] || $CPP --help >/dev/null 2>/dev/null ) && export CPP
     else
-        if is_gnucc "cpp" ; then
-            CPP=cpp && export CPP
-        else
-            case "$COMPILER_FAMILY" in
-                CLANG*|GCC*) CPP="$CC -E" && export CPP ;;
-            esac
-        fi
+        # Avoid "cpp" directly as it may be too "traditional"
+        case "$COMPILER_FAMILY" in
+            CLANG*|GCC*) CPP="$CC -E" && export CPP ;;
+            *) if is_gnucc "cpp" ; then
+                CPP=cpp && export CPP
+               fi ;;
+        esac
     fi
 
     if [ -z "${CANBUILD_LIBGD_CGI-}" ]; then

--- a/docs/developers.txt
+++ b/docs/developers.txt
@@ -1080,6 +1080,10 @@ To display in a rough example:
 	}
 -------------------------------------------------------------------------------
 
+All this having been said, we do detect and use the support for pragmas
+to quiesce the complaints about such situations, but limit their use to
+processing of certain third-party header files.
+
 Miscellaneous coding style tools
 --------------------------------
 

--- a/docs/developers.txt
+++ b/docs/developers.txt
@@ -978,6 +978,34 @@ offsets divisible by 4 or 8 (consistently for the whole table):
 #define SOMETHING_WITH_A_VERY_LONG_NAME     255	/* flag comment */
 --------------------------------------------------------------------------------
 
+While at it, we encourage indentation of nested preprocessor macros
+and pragmas, by adding a single space character for each inner level,
+as well as commenting the `#else` and `#endif` parts (especially if
+they are far away from their opening `#if`/`#ifdef`/`#ifndef` statement)
+to help visual navigation in the source code base. Please take care to
+keep the hash `#` character of the preprocessor lines in the left-most
+column, since some implementations of `cpp` parser used for analysis
+default to "traditional" (pre-C89) syntax shared with other languages,
+and then ignore lines which do not start with the hash character (or
+worse, ignore only some of them but not others).
+
+--------------------------------------------------------------------------------
+#ifdef WITH_SSL
+# ifdef WITH_NSS
+	/* some code for NSS */
+# endif	/* WITH_NSS */
+# ifdef WITH_OPENSSL
+#  ifndef WIN32
+	/* some code for OpenSSL on POSIX systems */
+#  else	/* not WIN32 */
+	/* some code for OpenSSL on Windows */
+#  endif	/* not WIN32 */
+# endif	/* WITH_OPENSSL */
+#else	/* not WITH_SSL */
+	/* report that crypto support is not built */
+#endif	/* WITH_SSL */
+--------------------------------------------------------------------------------
+
 If you write something that uses leading spaces, you may get away with
 it in a driver that's relatively secluded.  However, if we have to work
 on that code, expect it to get reformatted according to the above.


### PR DESCRIPTION
Follows up from #2506 and earlier work.

One notable change here is about preference of `CPP="$CC -E"` in `ci_build.sh` detection, to avoid the pitfalls of "traditional" parsers. Due to this the PR is tested separately from earlier completed iteration.