### PR TITLE
Teach `nut-scanner` to discover locally connected subnets: implement `-m auto` mode

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -140,6 +140,8 @@ https://github.com/networkupstools/nut/milestone/11
 +
 NOTE: Currently both the long and short names for `libupsclient` should be
 installed.
+   * newly added support to scan several IP addresses (single or ranges)
+     with the same call, by repeating command-line options. [#2244]
 
  - common code:
    * introduced a `NUT_DEBUG_SYSLOG` environment variable to tweak activation

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -142,6 +142,8 @@ NOTE: Currently both the long and short names for `libupsclient` should be
 installed.
    * newly added support to scan several IP addresses (single or ranges)
      with the same call, by repeating command-line options. [#2244]
+   * bumped version of `libnutscan` to 2.5.2, it now includes a few more
+     methods and symbols from `libcommon`. [#2244]
 
  - common code:
    * introduced a `NUT_DEBUG_SYSLOG` environment variable to tweak activation

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -141,7 +141,9 @@ https://github.com/networkupstools/nut/milestone/11
 NOTE: Currently both the long and short names for `libupsclient` should be
 installed.
    * newly added support to scan several IP addresses (single or ranges)
-     with the same call, by repeating command-line options. [#2244]
+     with the same call, by repeating command-line options; also `-m auto`
+     can be specified (once) to select IP address ranges of configured
+     local network interfaces. [#2244]
    * bumped version of `libnutscan` to 2.5.2, it now includes a few more
      methods and symbols from `libcommon`. [#2244]
 

--- a/docs/man/nut-scanner.txt
+++ b/docs/man/nut-scanner.txt
@@ -146,6 +146,9 @@ less than 'start IP', both parameters are internally permuted.
 
 *-m* | *--mask_cidr* 'IP address/mask'::
 Set a range of IP addresses by using CIDR notation.
++
+A special form `-m auto` allows `nut-scanner` to detect local IP address(es)
+and scan corresponding subnet(s) on supported platforms.
 
 NUT DEVICE OPTION
 -----------------

--- a/docs/man/nut-scanner.txt
+++ b/docs/man/nut-scanner.txt
@@ -111,6 +111,11 @@ This option must be requested explicitly, even for a complete scan.
 NETWORK OPTIONS
 ---------------
 
+NOTE: Some of the networked buses (such as SNMP, NetXML, IPMI and "Old NUT")
+require IP address(es) to scan, and others have a
+different behavior when exactly no addresses are specified (it is not currently
+possible to mix the two behaviors in one invocation of the `nut-scanner` tool).
+
 *-t* | *--timeout* 'timeout'::
 Set the network timeout in seconds. Default timeout is 5 seconds.
 

--- a/docs/man/nut-scanner.txt
+++ b/docs/man/nut-scanner.txt
@@ -85,7 +85,7 @@ If IP address ranges are specified, they would be scanned instead of a broadcast
 Scan NUT devices (i.e. upsd daemon) on IP ranging from 'start IP' to 'end IP'.
 
 *-n* | *--nut_simulation_scan*::
-Scan NUT simulated devices (.dev files in $CONFPATH).
+Scan NUT simulated devices (`.dev` files in `$NUT_CONFPATH`).
 
 *-A* | *--avahi_scan*::
 Scan NUT servers using Avahi request on the current network interface(s).
@@ -99,12 +99,12 @@ or over the network if IP address ranges are specified.
 Scan Eaton devices (XCP and SHUT) available via serial bus on the current host.
 This option must be requested explicitly, even for a complete scan.
 'serial ports' can be expressed in various forms:
-
++
 - 'auto' to scan all serial ports.
 - a single character indicating a port number ('0' (zero) for /dev/ttyS0 and
-/dev/ttyUSB0 on Linux, '1' for COM1 on Windows, 'a' for /dev/ttya on Solaris...)
+  /dev/ttyUSB0 on Linux, '1' for COM1 on Windows, 'a' for /dev/ttya on Solaris...)
 - a range of N characters, hyphen separated, describing the range of
-ports using 'X-Y', where X and Y are characters referring to the port number.
+  ports using 'X-Y', where X and Y are characters referring to the port number.
 - a single port name.
 - a list of ports name, coma separated, like '/dev/ttyS1,/dev/ttyS4'.
 

--- a/docs/man/nut-scanner.txt
+++ b/docs/man/nut-scanner.txt
@@ -111,8 +111,15 @@ This option must be requested explicitly, even for a complete scan.
 NETWORK OPTIONS
 ---------------
 
-NOTE: Some of the networked buses (such as SNMP, NetXML, IPMI and "Old NUT")
-require IP address(es) to scan, and others have a
+NOTE: The networked buses (such as SNMP, NetXML, IPMI and "Old NUT") allow to
+specify several IP (IPv4 or IPv6) address ranges, down to individual single
+IP addresses.  Normally a new range is specified by a set of one `-s` and one
+`-e` options following each other (in any order).  Lone or consecutive `-s` or
+`-e` options present on the command line would translate to single-IP queries.
+Also a `-m` option squashed between two `-s` and `-e` options would be a new
+range, turning those two into single-IP queries.
++
+Also note that some buses require IP address(es) to scan, and others have a
 different behavior when exactly no addresses are specified (it is not currently
 possible to mix the two behaviors in one invocation of the `nut-scanner` tool).
 

--- a/docs/man/nut-scanner.txt
+++ b/docs/man/nut-scanner.txt
@@ -117,11 +117,19 @@ IP addresses.  Normally a new range is specified by a set of one `-s` and one
 `-e` options following each other (in any order).  Lone or consecutive `-s` or
 `-e` options present on the command line would translate to single-IP queries.
 Also a `-m` option squashed between two `-s` and `-e` options would be a new
-range, turning those two into single-IP queries.
+range, turning those two into single-IP queries.  This feature does not by
+itself recombine "neighboring" addresses into one range, nor even check for
+duplicate or overlapping specifications.
 +
 Also note that some buses require IP address(es) to scan, and others have a
 different behavior when exactly no addresses are specified (it is not currently
 possible to mix the two behaviors in one invocation of the `nut-scanner` tool).
++
+Finally note that currently even if multi-threaded support is available, each
+range specification is a separate fan-out of queries constrained by the timeout.
+Requests to scan many single IP addresses will take a while to complete, much
+longer than if they were a single range.  This will be hopefully fixed in later
+releases.
 
 *-t* | *--timeout* 'timeout'::
 Set the network timeout in seconds. Default timeout is 5 seconds.

--- a/docs/man/nut-scanner.txt
+++ b/docs/man/nut-scanner.txt
@@ -78,7 +78,8 @@ an 'end IP'. See specific SNMP OPTIONS for community and security settings.
 
 *-M* | *--xml_scan*::
 Scan XML/HTTP devices. Can broadcast a network message on the current network
-interfaces to retrieve XML/HTTP capable devices. No IP required in this mode.
+interface(s) to retrieve XML/HTTP capable devices. No IP required in this mode.
+If IP address ranges are specified, they would be scanned instead of a broadcast.
 
 *-O* | *--oldnut_scan*::
 Scan NUT devices (i.e. upsd daemon) on IP ranging from 'start IP' to 'end IP'.
@@ -87,12 +88,12 @@ Scan NUT devices (i.e. upsd daemon) on IP ranging from 'start IP' to 'end IP'.
 Scan NUT simulated devices (.dev files in $CONFPATH).
 
 *-A* | *--avahi_scan*::
-Scan NUT servers using Avahi request on the current network interfaces.
-No IP required.
+Scan NUT servers using Avahi request on the current network interface(s).
+No IP address options are required or used.
 
 *-I* | *--ipmi_scan*::
 Scan NUT compatible power supplies available via IPMI on the current host,
-or over the network.
+or over the network if IP address ranges are specified.
 
 *-E* | *--eaton_serial* 'serial ports'::
 Scan Eaton devices (XCP and SHUT) available via serial bus on the current host.
@@ -124,7 +125,7 @@ If this parameter is omitted, only the 'start IP' is scanned. If 'end IP' is
 less than 'start IP', both parameters are internally permuted.
 
 *-m* | *--mask_cidr* 'IP address/mask'::
-Set a range of IP using CIDR notation.
+Set a range of IP addresses by using CIDR notation.
 
 NUT DEVICE OPTION
 -----------------

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3177 utf-8
+personal_ws-1.1 en 3178 utf-8
 AAC
 AAS
 ABI
@@ -754,6 +754,7 @@ NetInvent
 NetPro
 NetServer
 NetUps
+NetXML
 Netman
 NetworkUPSTools
 Neus

--- a/drivers/libshut.c
+++ b/drivers/libshut.c
@@ -376,15 +376,10 @@ static int libshut_open(
 		            usb_ctrl_charbuf rdbuf, usb_ctrl_charbufsize rdlen))
 {
 	int ret, res;
-	/* Below we cast this buffer as sometimes containing entried of type
-	 * "struct device_descriptor_s" or "struct my_hid_descriptor".
-	 * Currently both of these are sized "2", and I don't see a way
-	 * to require a "max()" of such sizes to align for generally.
-	 */
 	usb_ctrl_char buf[20] __attribute__((aligned(4)));
 	char string[MAX_STRING_SIZE];
-	struct my_hid_descriptor *desc;
-	struct device_descriptor_s *dev_descriptor;
+	struct my_hid_descriptor	desc_buf, *desc = &desc_buf;
+	struct device_descriptor_s	dev_descriptor_buf, *dev_descriptor = &dev_descriptor_buf;
 
 	/* report descriptor */
 	usb_ctrl_char	rdbuf[MAX_REPORT_SIZE];
@@ -470,21 +465,7 @@ static int libshut_open(
 	}
 
 	/* Get DEVICE descriptor */
-#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_CAST_ALIGN)
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wcast-align"
-#endif
-#ifdef __clang__
-# pragma clang diagnostic push
-# pragma clang diagnostic ignored "-Wcast-align"
-#endif
-	dev_descriptor = (struct device_descriptor_s *)buf;
-#ifdef __clang__
-# pragma clang diagnostic pop
-#endif
-#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_CAST_ALIGN)
-# pragma GCC diagnostic pop
-#endif
+	memcpy(dev_descriptor, buf, sizeof(struct device_descriptor_s));
 	res = shut_get_descriptor(*arg_upsfd, USB_DT_DEVICE, 0, buf, USB_DT_DEVICE_SIZE);
 	/* res = shut_control_msg(devp, USB_ENDPOINT_IN+1, USB_REQ_GET_DESCRIPTOR,
 	(USB_DT_DEVICE << 8) + 0, 0, buf, 0x9, SHUT_TIMEOUT); */
@@ -587,21 +568,7 @@ static int libshut_open(
 	}
 
 	/* Get HID descriptor */
-#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_CAST_ALIGN)
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wcast-align"
-#endif
-#ifdef __clang__
-# pragma clang diagnostic push
-# pragma clang diagnostic ignored "-Wcast-align"
-#endif
-	desc = (struct my_hid_descriptor *)buf;
-#ifdef __clang__
-# pragma clang diagnostic pop
-#endif
-#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_CAST_ALIGN)
-# pragma GCC diagnostic pop
-#endif
+	memcpy(desc, buf, sizeof(struct my_hid_descriptor));
 	res = shut_get_descriptor(*arg_upsfd, USB_DT_HID, hid_desc_index, buf, 0x9);
 	/* res = shut_control_msg(devp, USB_ENDPOINT_IN+1, USB_REQ_GET_DESCRIPTOR,
 			(USB_DT_HID << 8) + 0, 0, buf, 0x9, SHUT_TIMEOUT); */

--- a/tools/nut-scanner/Makefile.am
+++ b/tools/nut-scanner/Makefile.am
@@ -83,7 +83,7 @@ endif HAVE_WINDOWS
 # object .so names would differ)
 #
 # libnutscan version information
-libnutscan_la_LDFLAGS += -version-info 2:5:1
+libnutscan_la_LDFLAGS += -version-info 2:5:2
 
 # libnutscan exported symbols regex
 # WARNING: Since the library includes parts of libcommon (as much as needed
@@ -94,7 +94,7 @@ libnutscan_la_LDFLAGS += -version-info 2:5:1
 # copies of "nut_debug_level" making fun of our debug-logging attempts.
 # One solution to tackle if needed for those cases would be to make some
 # dynamic/shared libnutcommon (etc.)
-libnutscan_la_LDFLAGS += -export-symbols-regex '^(nutscan_|nut_debug_level|s_upsdebugx|max_threads|curr_threads|nut_report_config_flags|upsdebugx_report_search_paths|nut_prepare_search_paths)'
+libnutscan_la_LDFLAGS += -export-symbols-regex '^(nutscan_|nut_debug_level|s_upsdebugx|fatalx|xcalloc|snprintfcat|max_threads|curr_threads|nut_report_config_flags|upsdebugx_report_search_paths|nut_prepare_search_paths)'
 libnutscan_la_CFLAGS = -I$(top_srcdir)/clients -I$(top_srcdir)/include \
 			$(LIBLTDL_CFLAGS) -I$(top_srcdir)/drivers
 

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -142,12 +142,7 @@ static size_t add_ip_range(char * start_ip, char * end_ip)
 		end_ip = start_ip;
 	}
 
-	/* no xcalloc() nor fatalx() linked here, oh well */
-	p = calloc(1, sizeof(ip_range_t));
-	if (!p) {
-		upsdebugx(0, "%s: failed to allocate some memory", __func__);
-		exit(EXIT_FAILURE);
-	}
+	p = xcalloc(1, sizeof(ip_range_t));
 
 	p->start_ip = start_ip;
 	p->end_ip = end_ip;

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -127,17 +127,17 @@ static size_t add_ip_range(char * start_ip, char * end_ip)
 	ip_range_t *p;
 
 	if (!start_ip && !end_ip) {
-		upsdebugx(1, "%s: skip, no addresses were provided", __func__);
+		upsdebugx(5, "%s: skip, no addresses were provided", __func__);
 		return ip_ranges_count;
 	}
 
 	if (start_ip == NULL) {
-		upsdebugx(1, "%s: only end address was provided, setting start to same: %s",
+		upsdebugx(5, "%s: only end address was provided, setting start to same: %s",
 			 __func__, end_ip);
 		start_ip = end_ip;
 	}
 	if (end_ip == NULL) {
-		upsdebugx(1, "%s: only start address was provided, setting end to same: %s",
+		upsdebugx(5, "%s: only start address was provided, setting end to same: %s",
 			 __func__, start_ip);
 		end_ip = start_ip;
 	}

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -252,6 +252,7 @@ static void * run_usb(void *arg)
 	dev[TYPE_USB] = nutscan_scan_usb(scanopts_ptr);
 	return NULL;
 }
+#endif	/* HAVE_PTHREAD */
 
 static void * run_snmp(void * arg)
 {
@@ -387,12 +388,11 @@ static void * run_ipmi(void * arg)
 
 static void * run_eaton_serial(void *arg)
 {
-	NUT_UNUSED_VARIABLE(arg);
+	char * arg_serial_ports = (char *)arg;
 
-	dev[TYPE_EATON_SERIAL] = nutscan_scan_eaton_serial(serial_ports);
+	dev[TYPE_EATON_SERIAL] = nutscan_scan_eaton_serial(arg_serial_ports);
 	return NULL;
 }
-#endif /* HAVE_PTHREAD */
 
 static void show_usage(void)
 {
@@ -1047,6 +1047,7 @@ display_help:
 		}
 #else
 		upsdebugx(1, "USB SCAN: no pthread support, starting nutscan_scan_usb...");
+		/* Not calling run_usb() here, as it re-processes the arg */
 		dev[TYPE_USB] = nutscan_scan_usb(&cli_link_detail_level);
 #endif /* HAVE_PTHREAD */
 	} else {
@@ -1068,7 +1069,8 @@ display_help:
 			}
 #else
 			upsdebugx(1, "SNMP SCAN: no pthread support, starting nutscan_scan_snmp...");
-			dev[TYPE_SNMP] = nutscan_scan_snmp(start_ip, end_ip, timeout, &snmp_sec);
+			/* dev[TYPE_SNMP] = nutscan_scan_snmp(start_ip, end_ip, timeout, &snmp_sec); */
+			run_snmp(&snmp_sec);
 #endif /* HAVE_PTHREAD */
 		}
 	} else {
@@ -1091,11 +1093,8 @@ display_help:
 		}
 #else
 		upsdebugx(1, "XML/HTTP SCAN: no pthread support, starting nutscan_scan_xml_http_range()...");
-		if (ip_ranges_count) {
-			dev[TYPE_XML] = nutscan_scan_xml_http_range(start_ip, end_ip, timeout, &xml_sec);
-		} else {
-			/* Probe broadcast */
-			dev[TYPE_XML] = nutscan_scan_xml_http_range(NULL, NULL, timeout, &xml_sec);
+		/* dev[TYPE_XML] = nutscan_scan_xml_http_range(start_ip, end_ip, timeout, &xml_sec); */
+		run_xml(&xml_sec);
 		}
 #endif /* HAVE_PTHREAD */
 	} else {
@@ -1117,7 +1116,8 @@ display_help:
 			}
 #else
 			upsdebugx(1, "NUT bus (old) SCAN: no pthread support, starting nutscan_scan_nut...");
-			dev[TYPE_NUT] = nutscan_scan_nut(start_ip, end_ip, port, timeout);
+			/*dev[TYPE_NUT] = nutscan_scan_nut(start_ip, end_ip, port, timeout);*/
+			run_nut_old(NULL);
 #endif /* HAVE_PTHREAD */
 		}
 	} else {
@@ -1133,8 +1133,9 @@ display_help:
 			nutscan_avail_nut_simulation = 0;
 		}
 #else
-			upsdebugx(1, "NUT simulation devices SCAN: no pthread support, starting nutscan_scan_nut_simulation...");
-			dev[TYPE_NUT_SIMULATION] = nutscan_scan_nut_simulation(timeout);
+		upsdebugx(1, "NUT simulation devices SCAN: no pthread support, starting nutscan_scan_nut_simulation...");
+		/* dev[TYPE_NUT_SIMULATION] = nutscan_scan_nut_simulation(); */
+		run_nut_simulation(NULL);
 #endif /* HAVE_PTHREAD */
 	} else {
 		upsdebugx(1, "NUT simulation devices SCAN: not requested or supported, SKIPPED");
@@ -1150,7 +1151,8 @@ display_help:
 		}
 #else
 		upsdebugx(1, "NUT bus (avahi) SCAN: no pthread support, starting nutscan_scan_avahi...");
-		dev[TYPE_AVAHI] = nutscan_scan_avahi(timeout);
+		/* dev[TYPE_AVAHI] = nutscan_scan_avahi(timeout); */
+		run_avahi(NULL);
 #endif /* HAVE_PTHREAD */
 	} else {
 		upsdebugx(1, "NUT bus (avahi) SCAN: not requested or supported, SKIPPED");
@@ -1171,12 +1173,8 @@ display_help:
 		}
 #else
 		upsdebugx(1, "IPMI SCAN: no pthread support, starting nutscan_scan_ipmi...");
-		if (ip_ranges_count) {
-			dev[TYPE_IPMI] = nutscan_scan_ipmi(start_ip, end_ip, &ipmi_sec);
-		} else {
-			/* Probe local device */
-			dev[TYPE_IPMI] = nutscan_scan_ipmi(NULL, NULL, &ipmi_sec);
-		}
+		/* dev[TYPE_IPMI] = nutscan_scan_ipmi(start_ip, end_ip, &ipmi_sec); */
+		run_ipmi(&ipmi_sec);
 #endif /* HAVE_PTHREAD */
 	} else {
 		upsdebugx(1, "IPMI SCAN: not requested or supported, SKIPPED");
@@ -1193,7 +1191,8 @@ display_help:
 		/* nutscan_avail_eaton_serial(?) = 0; */
 #else
 		upsdebugx(1, "SERIAL SCAN: no pthread support, starting nutscan_scan_eaton_serial...");
-		dev[TYPE_EATON_SERIAL] = nutscan_scan_eaton_serial (serial_ports);
+		/* dev[TYPE_EATON_SERIAL] = nutscan_scan_eaton_serial (serial_ports); */
+		run_eaton_serial(serial_ports);
 #endif /* HAVE_PTHREAD */
 	} else {
 		upsdebugx(1, "SERIAL SCAN: not requested or supported, SKIPPED");

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -759,7 +759,7 @@ int main(int argc, char *argv[])
 
 										getnameinfo(ifa->ifa_addr, sizeof(struct sockaddr_in6), addr, sizeof(addr), NULL, 0, NI_NUMERICHOST);
 										getnameinfo(ifa->ifa_netmask, sizeof(struct sockaddr_in6), mask, sizeof(mask), NULL, 0, NI_NUMERICHOST);
-										printf("Interface: %s\tAddress: %s\tMask: %s (len: %i)\tFlags: %08x", ifa->ifa_name, addr, mask, masklen, ifa->ifa_flags);
+										printf("Interface: %s\tAddress: %s\tMask: %s (len: %i)\tFlags: %08" PRIxMAX, ifa->ifa_name, addr, mask, masklen, (uintmax_t)ifa->ifa_flags);
 									} else if (ifa->ifa_addr->sa_family == AF_INET) {
 										struct sockaddr_in *sa = (struct sockaddr_in *)ifa->ifa_addr;
 										struct sockaddr_in *sm = (struct sockaddr_in *)ifa->ifa_netmask;
@@ -772,7 +772,7 @@ int main(int argc, char *argv[])
 											masklen += i & 1;
 											i >>= 1;
 										}
-										printf("Interface: %s\tAddress: %s\tMask: %s (len: %i)\tFlags: %08x", ifa->ifa_name, addr, mask, masklen, ifa->ifa_flags);
+										printf("Interface: %s\tAddress: %s\tMask: %s (len: %i)\tFlags: %08" PRIxMAX, ifa->ifa_name, addr, mask, masklen, (uintmax_t)ifa->ifa_flags);
 /*
 									} else {
 										printf("Addr family: %" PRIuMAX, (intmax_t)ifa->ifa_addr->sa_family);

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -868,6 +868,11 @@ display_help:
 	}
 
 	if (allow_xml && nutscan_avail_xml_http) {
+		/* NOTE: No check for IP address range,
+		 * NetXML default scan is broadcast
+		 * so it just runs (if requested and
+		 * supported).
+		 */
 		upsdebugx(quiet, "Scanning XML/HTTP bus.");
 		xml_sec.usec_timeout = timeout;
 #ifdef HAVE_PTHREAD
@@ -939,6 +944,11 @@ display_help:
 	}
 
 	if (allow_ipmi && nutscan_avail_ipmi) {
+		/* NOTE: No check for IP address range,
+		 * IPMI default scan is local device
+		 * so it just runs (if requested and
+		 * supported).
+		 */
 		upsdebugx(quiet, "Scanning IPMI bus.");
 #ifdef HAVE_PTHREAD
 		upsdebugx(1, "IPMI SCAN: starting pthread_create with run_ipmi...");

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -739,6 +739,7 @@ int main(int argc, char *argv[])
 					if (auto_nets) {
 						fprintf(stderr, "Duplicate request for connected subnet scan ignored\n");
 					} else {
+						/* TODO: Refactor into a method, reduce indentation? */
 						/* Inspired by https://stackoverflow.com/a/63789267/4715872 */
 						struct ifaddrs *ifap;
 
@@ -814,6 +815,11 @@ int main(int argc, char *argv[])
 
 										upsdebugx(5, "Discovering getifaddrs(): %s", msg);
 
+										/* TODO: also rule out "link-local" address ranges
+										 * so we do not issue billions of worthless scans.
+										 * FIXME: IPv6 may also be a problem, see
+										 * https://github.com/networkupstools/nut/issues/2512
+										 */
 										if (!(ifa->ifa_flags & IFF_LOOPBACK)
 										&&   (ifa->ifa_flags & IFF_UP)
 										&&   (ifa->ifa_flags & IFF_RUNNING)

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -726,6 +726,15 @@ int main(int argc, char *argv[])
 				allow_eaton_serial = 1;
 				break;
 			case 'm':
+				if (start_ip || end_ip) {
+					/* Save whatever we have, either
+					 * this one address or an earlier
+					 * known range with its start or end */
+					add_ip_range(start_ip, end_ip);
+					start_ip = NULL;
+					end_ip = NULL;
+				}
+
 				if (!strcmp(optarg, "auto")) {
 					if (auto_nets) {
 						fprintf(stderr, "Duplicate request for connected subnet scan ignored\n");
@@ -809,15 +818,7 @@ int main(int argc, char *argv[])
 						auto_nets = 1;
 					}
 				} else {
-					if (start_ip || end_ip) {
-						/* Save whatever we have, either
-						 * this one address or an earlier
-						 * known range with its start or end */
-						add_ip_range(start_ip, end_ip);
-						start_ip = NULL;
-						end_ip = NULL;
-					}
-
+					/* not `-m auto` => is `-m cidr` */
 					upsdebugx(5, "Processing CIDR net/mask: %s", optarg);
 					nutscan_cidr_to_ip(optarg, &start_ip, &end_ip);
 					upsdebugx(5, "Extracted IP address range from CIDR net/mask: %s => %s", start_ip, end_ip);

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -750,10 +750,13 @@ int main(int argc, char *argv[])
 										char mask[INET6_ADDRSTRLEN];
 										int masklen = 0;
 										uint8_t i, j;
-										struct sockaddr_in6 *sm = (struct sockaddr_in6 *)ifa->ifa_netmask;
+
+										/* Ensure proper alignment */
+										struct sockaddr_in6 sm;
+										memcpy (&sm, ifa->ifa_netmask, sizeof(struct sockaddr_in6));
 
 										for (j = 0; j < 16; j++) {
-											i = sm->sin6_addr.s6_addr[j];
+											i = sm.sin6_addr.s6_addr[j];
 											while (i) {
 												masklen += i & 1;
 												i >>= 1;
@@ -764,13 +767,18 @@ int main(int argc, char *argv[])
 										getnameinfo(ifa->ifa_netmask, sizeof(struct sockaddr_in6), mask, sizeof(mask), NULL, 0, NI_NUMERICHOST);
 										snprintf(msg, sizeof(msg), "Interface: %s\tAddress: %s\tMask: %s (len: %i)\tFlags: %08" PRIxMAX, ifa->ifa_name, addr, mask, masklen, (uintmax_t)ifa->ifa_flags);
 									} else if (ifa->ifa_addr->sa_family == AF_INET) {
-										struct sockaddr_in *sa = (struct sockaddr_in *)ifa->ifa_addr;
-										struct sockaddr_in *sm = (struct sockaddr_in *)ifa->ifa_netmask;
-										char *addr = inet_ntoa(sa->sin_addr);
-										char *mask = inet_ntoa(sm->sin_addr);
+										char *addr, *mask;
 										int masklen = 0;
-										in_addr_t i = sm->sin_addr.s_addr;
+										in_addr_t i;
 
+										/* Ensure proper alignment */
+										struct sockaddr_in sa, sm;
+										memcpy (&sa, ifa->ifa_addr, sizeof(struct sockaddr_in));
+										memcpy (&sm, ifa->ifa_netmask, sizeof(struct sockaddr_in));
+										addr = inet_ntoa(sa.sin_addr);
+										mask = inet_ntoa(sm.sin_addr);
+
+										i = sm.sin_addr.s_addr;
 										while (i) {
 											masklen += i & 1;
 											i >>= 1;

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -800,7 +800,7 @@ int main(int argc, char *argv[])
 										if (ifa->ifa_flags & IFF_BROADCAST)
 											snprintfcat(msg, sizeof(msg), " IFF_BROADCAST(is assigned)");
 
-										upsdebugx(1, "Discovering getifaddrs(): %s", msg);
+										upsdebugx(5, "Discovering getifaddrs(): %s", msg);
 									}	/* else AF_UNIX or a dozen other types we do not care about here */
 								}
 							}

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -734,10 +734,9 @@ int main(int argc, char *argv[])
 						struct ifaddrs *ifap;
 
 						if (getifaddrs(&ifap) < 0) {
-							fprintf(stderr,
+							fatalx(EXIT_FAILURE,
 								"Failed to getifaddrs() for connected subnet scan: %s\n",
 								strerror(errno));
-							exit(EXIT_FAILURE);
 						} else {
 							struct ifaddrs *ifa;
 							char msg[LARGEBUF];

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -59,8 +59,6 @@
 
 #include "nut-scan.h"
 
-#define DEFAULT_TIMEOUT 5
-
 #define ERR_BAD_OPTION	(-1)
 
 static const char optstring[] = "?ht:T:s:e:E:c:l:u:W:X:w:x:p:b:B:d:L:CUSMOAm:QnNPqIVaD";

--- a/tools/nut-scanner/nutscan-device.c
+++ b/tools/nut-scanner/nutscan-device.c
@@ -25,6 +25,7 @@
 #include "config.h"	/* must be the first header */
 
 #include "nutscan-device.h"
+#include "common.h"
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
@@ -174,6 +175,11 @@ nutscan_device_t * nutscan_add_device_to_device(nutscan_device_t * first, nutsca
 {
 	nutscan_device_t * dev1 = NULL;
 	nutscan_device_t * dev2 = NULL;
+
+	if (first == second) {
+		upsdebugx(5, "%s: skip: called to \"add\" same list pointers", __func__);
+		return first;
+	}
 
 	/* Get end of first device */
 	if (first != NULL) {

--- a/tools/nut-scanner/nutscan-ip.c
+++ b/tools/nut-scanner/nutscan-ip.c
@@ -267,6 +267,7 @@ int nutscan_cidr_to_ip(const char * cidr, char ** start_ip, char ** stop_ip)
 	char * mask;
 	char * saveptr = NULL;
 	nutscan_ip_iter_t ip;
+	/* TODO: There can be up to 128-bit CIDR mask for IPv6... */
 	int mask_val;
 	int mask_byte;
 	int ret;
@@ -302,6 +303,7 @@ int nutscan_cidr_to_ip(const char * cidr, char ** start_ip, char ** stop_ip)
 	upsdebugx(5, "%s: parsed cidr=%s into first_ip=%s and mask=%s",
 		__func__, cidr, first_ip, mask);
 
+	/* TODO: check if mask is also an IP address or a bit count */
 	mask_val = atoi(mask);
 	upsdebugx(5, "%s: parsed mask value %d",
 		__func__, mask_val);

--- a/tools/nut-scanner/scan_ipmi.c
+++ b/tools/nut-scanner/scan_ipmi.c
@@ -406,6 +406,8 @@ nutscan_device_t * nutscan_scan_ipmi_device(const char * IPaddr, nutscan_ipmi_t 
 	/* Are we scanning locally, or over the network? */
 	if (IPaddr == NULL)
 	{
+		upsdebugx(2, "Entering %s for local device scan", __func__);
+
 		/* FIXME: we need root right to access local IPMI!
 		if (!ipmi_is_root ()) {
 			fprintf(stderr, "IPMI scan: %s\n", ipmi_ctx_strerror (IPMI_ERR_PERMISSION));
@@ -432,6 +434,8 @@ nutscan_device_t * nutscan_scan_ipmi_device(const char * IPaddr, nutscan_ipmi_t 
 		}
 	}
 	else {
+
+		upsdebugx(2, "Entering %s for %s", __func__, IPaddr);
 
 #if 0
 		if (ipmi_sec->ipmi_version == IPMI_2_0) {
@@ -608,14 +612,20 @@ nutscan_device_t * nutscan_scan_ipmi(const char * start_ip, const char * stop_ip
 		return NULL;
 	}
 
-
 	/* Are we scanning locally, or through the network? */
 	if (start_ip == NULL)
 	{
-		/* Local PSU scan */
+		upsdebugx(1, "%s: Local PSU scan", __func__);
 		current_nut_dev = nutscan_scan_ipmi_device(NULL, NULL);
 	}
 	else {
+		if (start_ip == stop_ip || !stop_ip) {
+			upsdebugx(1, "%s: Scanning remote PSU for single IP address: %s",
+				__func__, start_ip);
+		} else {
+			upsdebugx(1, "%s: Scanning remote PSU for IP address range: %s .. %s",
+				__func__, start_ip, stop_ip);
+		}
 		ip_str = nutscan_ip_iter_init(&ip, start_ip, stop_ip);
 
 		while (ip_str != NULL) {

--- a/tools/nut-scanner/scan_nut.c
+++ b/tools/nut-scanner/scan_nut.c
@@ -156,6 +156,8 @@ static void * list_nut_devices(void * arg)
 	query[0] = "UPS";
 	numq = 1;
 
+	upsdebugx(2, "Entering %s for %s", __func__, target_hostname);
+
 	if ((*nut_upscli_splitaddr)(target_hostname, &hostname, &port) != 0) {
 		free(target_hostname);
 		free(nut_arg);
@@ -299,6 +301,16 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 
 	if (!nutscan_avail_nut) {
 		return NULL;
+	}
+
+	if (!startIP) {
+		upsdebugx(1, "%s: no starting IP address specified", __func__);
+	} else if (startIP == stopIP || !stopIP) {
+		upsdebugx(1, "%s: Scanning \"Old NUT\" bus for single IP address: %s",
+			__func__, startIP);
+	} else {
+		upsdebugx(1, "%s: Scanning \"Old NUT\" bus for IP address range: %s .. %s",
+			__func__, startIP, stopIP);
 	}
 
 #ifndef WIN32

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -1085,6 +1085,16 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 		return NULL;
 	}
 
+	if (!start_ip) {
+		upsdebugx(1, "%s: no starting IP address specified", __func__);
+	} else if (start_ip == stop_ip || !stop_ip) {
+		upsdebugx(1, "%s: Scanning SNMP for single IP address: %s",
+			__func__, start_ip);
+	} else {
+		upsdebugx(1, "%s: Scanning SNMP for IP address range: %s .. %s",
+			__func__, start_ip, stop_ip);
+	}
+
 	g_usec_timeout = usec_timeout;
 
 	/* Force numeric OIDs resolution (ie, do not resolve to textual names)

--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -429,10 +429,11 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 	}
 
 	if (start_ip == NULL) {
-		upsdebugx(1, "Scanning XML/HTTP bus using broadcast.");
+		upsdebugx(1, "%s: Scanning XML/HTTP bus using broadcast.", __func__);
 	} else {
 		if ((start_ip == end_ip) || (end_ip == NULL) || (0 == strncmp(start_ip, end_ip, 128))) {
-			upsdebugx(1, "Scanning XML/HTTP bus for single IP (%s).", start_ip);
+			upsdebugx(1, "%s: Scanning XML/HTTP bus for single IP address: %s",
+				__func__, start_ip);
 		} else {
 			/* Iterate the range of IPs to scan */
 			nutscan_ip_iter_t ip;
@@ -449,7 +450,12 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 # if (defined HAVE_PTHREAD_TRYJOIN) || (defined HAVE_SEMAPHORE)
 			size_t  max_threads_scantype = max_threads_netxml;
 # endif
+#endif
 
+			upsdebugx(1, "%s: Scanning XML/HTTP bus for IP address range: %s .. %s",
+				__func__, start_ip, end_ip);
+
+#ifdef HAVE_PTHREAD
 			pthread_mutex_init(&dev_mutex, NULL);
 
 # ifdef HAVE_SEMAPHORE


### PR DESCRIPTION
Follow-up from PR #2509 for issue #2244 to complete the feature. Separated because of need for longer testing and adaptation to different platforms and certain questions raised in #2509, while that PR has value of its own and can be merged to already allow multiple IP address range scans with one call to the tool.

Closes: #2244