### PR TITLE
Fix `nut-scanner` IPv6 support

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -140,6 +140,9 @@ https://github.com/networkupstools/nut/milestone/11
 +
 NOTE: Currently both the long and short names for `libupsclient` should be
 installed.
+   * fixed support for IPv6 addresses (passed in square brackets) for both
+     `-s` start/`-e` end command-line options, and for `-m cidr/mask` option.
+     [issue #2512, PR #2518]
    * newly added support to scan several IP addresses (single or ranges)
      with the same call, by repeating command-line options; also `-m auto{,4,6}`
      can be specified (once) to select IP (all, IPv4, IPv6) address ranges of

--- a/clients/upsclient.c
+++ b/clients/upsclient.c
@@ -1689,6 +1689,16 @@ int upscli_splitaddr(const char *buf, char **hostname, uint16_t *port)
 		return -1;
 	}
 
+	s = strchr(tmp, '@');
+
+	/* someone passed a "@hostname" string? */
+	if (s) {
+		fprintf(stderr, "upscli_splitaddr: wrong call? "
+			"Got upsname@hostname[:port] string where "
+			"only hostname[:port] was expected: %s\n", buf);
+		/* let it pass, but probably fail later */
+	}
+
 	if (*tmp == '[') {
 		if (strchr(tmp, ']') == NULL) {
 			fprintf(stderr, "upscli_splitaddr: missing closing bracket in [domain literal]\n");

--- a/clients/upsclient.c
+++ b/clients/upsclient.c
@@ -1025,7 +1025,7 @@ int upscli_tryconnect(UPSCONN_t *ups, const char *host, uint16_t port, int flags
 	ups->fd = -1;
 
 	if (!host) {
-		upslogx(LOG_WARNING, "%s: Host not found: '%s'", __func__, host);
+		upslogx(LOG_WARNING, "%s: Host not found: '%s'", __func__, NUT_STRARG(host));
 		ups->upserror = UPSCLI_ERR_NOSUCHHOST;
 		return -1;
 	}
@@ -1051,7 +1051,7 @@ int upscli_tryconnect(UPSCONN_t *ups, const char *host, uint16_t port, int flags
 		case EAI_AGAIN:
 			continue;
 		case EAI_NONAME:
-			upslogx(LOG_WARNING, "%s: Host not found: '%s'", __func__, host);
+			upslogx(LOG_WARNING, "%s: Host not found: '%s'", __func__, NUT_STRARG(host));
 			ups->upserror = UPSCLI_ERR_NOSUCHHOST;
 			return -1;
 		case EAI_MEMORY:

--- a/clients/upsclient.c
+++ b/clients/upsclient.c
@@ -1700,6 +1700,10 @@ int upscli_splitaddr(const char *buf, char **hostname, uint16_t *port)
 	}
 
 	if (*tmp == '[') {
+		/* NOTE: Brackets are required for colon-separated IPv6
+		 * addresses, to differentiate from a port number. For
+		 * example, `[1234:5678]:3493` would seem right.
+		 */
 		if (strchr(tmp, ']') == NULL) {
 			fprintf(stderr, "upscli_splitaddr: missing closing bracket in [domain literal]\n");
 			return -1;

--- a/clients/upsclient.c
+++ b/clients/upsclient.c
@@ -3,6 +3,7 @@
    Copyright (C)
 	2002	Russell Kroll <rkroll@exploits.org>
 	2008	Arjen de Korte <adkorte-guest@alioth.debian.org>
+	2020 - 2024	Jim Klimov <jimklimov+nut@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -1024,6 +1025,7 @@ int upscli_tryconnect(UPSCONN_t *ups, const char *host, uint16_t port, int flags
 	ups->fd = -1;
 
 	if (!host) {
+		upslogx(LOG_WARNING, "%s: Host not found: '%s'", __func__, host);
 		ups->upserror = UPSCLI_ERR_NOSUCHHOST;
 		return -1;
 	}
@@ -1049,6 +1051,7 @@ int upscli_tryconnect(UPSCONN_t *ups, const char *host, uint16_t port, int flags
 		case EAI_AGAIN:
 			continue;
 		case EAI_NONAME:
+			upslogx(LOG_WARNING, "%s: Host not found: '%s'", __func__, host);
 			ups->upserror = UPSCLI_ERR_NOSUCHHOST;
 			return -1;
 		case EAI_MEMORY:

--- a/clients/upsclient.c
+++ b/clients/upsclient.c
@@ -1210,7 +1210,7 @@ int upscli_tryconnect(UPSCONN_t *ups, const char *host, uint16_t port, int flags
 		} else if (tryssl && ret == 0) {
 			if (certverify != 0) {
 				upslogx(LOG_NOTICE, "Can not connect to NUT server %s in SSL and "
-				"certificate is needed, disconnect", host);
+					"certificate is needed, disconnect", host);
 				upscli_disconnect(ups);
 				return -1;
 			}

--- a/docs/man/nut-scanner.txt
+++ b/docs/man/nut-scanner.txt
@@ -131,6 +131,8 @@ Requests to scan many single IP addresses will take a while to complete, much
 longer than if they were a single range.  This will be hopefully fixed in later
 releases.
 
+NOTE: Colon-separated IPv6 addresses must be passed in square brackets.
+
 *-t* | *--timeout* 'timeout'::
 Set the network timeout in seconds. Default timeout is 5 seconds.
 

--- a/tools/nut-scanner/Makefile.am
+++ b/tools/nut-scanner/Makefile.am
@@ -94,7 +94,7 @@ libnutscan_la_LDFLAGS += -version-info 2:5:2
 # copies of "nut_debug_level" making fun of our debug-logging attempts.
 # One solution to tackle if needed for those cases would be to make some
 # dynamic/shared libnutcommon (etc.)
-libnutscan_la_LDFLAGS += -export-symbols-regex '^(nutscan_|nut_debug_level|s_upsdebugx|fatalx|xcalloc|snprintfcat|max_threads|curr_threads|nut_report_config_flags|upsdebugx_report_search_paths|nut_prepare_search_paths)'
+libnutscan_la_LDFLAGS += -export-symbols-regex '^(nutscan_|nut_debug_level|s_upsdebug|fatalx|xcalloc|snprintfcat|max_threads|curr_threads|nut_report_config_flags|upsdebugx_report_search_paths|nut_prepare_search_paths)'
 libnutscan_la_CFLAGS = -I$(top_srcdir)/clients -I$(top_srcdir)/include \
 			$(LIBLTDL_CFLAGS) -I$(top_srcdir)/drivers
 

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -713,7 +713,13 @@ int main(int argc, char *argv[])
 					end_ip = NULL;
 				}
 
-				start_ip = strdup(optarg);
+				if (optarg[0] == '[' && optarg[strlen(optarg) - 1] == ']') {
+					start_ip = strdup(optarg + 1);
+					start_ip[strlen(start_ip) - 1] = '\0';
+				} else {
+					start_ip = strdup(optarg);
+				}
+
 				if (end_ip != NULL) {
 					/* Already we know two addresses, save them */
 					add_ip_range(start_ip, end_ip);
@@ -731,7 +737,13 @@ int main(int argc, char *argv[])
 					end_ip = NULL;
 				}
 
-				end_ip = strdup(optarg);
+				if (optarg[0] == '[' && optarg[strlen(optarg) - 1] == ']') {
+					end_ip = strdup(optarg + 1);
+					end_ip[strlen(end_ip) - 1] = '\0';
+				} else {
+					end_ip = strdup(optarg);
+				}
+
 				if (start_ip != NULL) {
 					/* Already we know two addresses, save them */
 					add_ip_range(start_ip, end_ip);

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -1172,7 +1172,10 @@ display_help:
 	}
 
 	upsdebugx(1, "Parallel scan support: max_threads=%" PRIuSIZE, max_threads);
-	sem_init(current_sem, 0, (unsigned int)max_threads);
+	if (sem_init(current_sem, 0, (unsigned int)max_threads)) {
+		/* Show this one to end-users so they know */
+		upsdebug_with_errno(0, "Parallel scan support: sem_init() failed");
+	}
 # endif
 #else
 	upsdebugx(1, "Parallel scan support: !HAVE_PTHREAD");

--- a/tools/nut-scanner/nutscan-init.c
+++ b/tools/nut-scanner/nutscan-init.c
@@ -35,6 +35,7 @@
 #include <string.h>
 #include "nut-scan.h"
 #include "nut_platform.h"
+#include "nut_stdint.h"
 
 #ifdef WIN32
 # define SOEXT ".dll"
@@ -159,7 +160,12 @@ void nutscan_init(void)
 			__func__);
 		max_threads = UINT_MAX - 1;
 	}
-	sem_init(&semaphore, 0, (unsigned int)max_threads);
+
+	upsdebugx(1, "%s: Parallel scan support: max_threads=%" PRIuSIZE,
+		__func__, max_threads);
+	if (sem_init(&semaphore, 0, (unsigned int)max_threads)) {
+		upsdebug_with_errno(4, "%s: Parallel scan support: sem_init() failed", __func__);
+	}
 # endif
 
 # ifdef HAVE_PTHREAD_TRYJOIN

--- a/tools/nut-scanner/nutscan-ip.c
+++ b/tools/nut-scanner/nutscan-ip.c
@@ -282,6 +282,12 @@ int nutscan_cidr_to_ip(const char * cidr, char ** start_ip, char ** stop_ip)
         WSADATA WSAdata;
 #endif
 
+	if (!cidr) {
+		upsdebugx(0, "WARNING: %s: null cidr pointer was provided",
+			__func__);
+		return 0;
+	}
+
 	cidr_tok = strdup(cidr);
 	first_ip = strdup(strtok_r(cidr_tok, "/", &saveptr));
 	if (first_ip == NULL) {

--- a/tools/nut-scanner/nutscan-ip.c
+++ b/tools/nut-scanner/nutscan-ip.c
@@ -176,6 +176,7 @@ char * nutscan_ip_iter_init(nutscan_ip_iter_t * ip, const char * startIP, const 
 		return strdup(host);
 	}
 	else { /* IPv6 */
+		size_t	hlen;
 		for (i = 0; i < 16; i++) {
 			if (ip->start6.s6_addr[i] !=ip->stop6.s6_addr[i]) {
 				if (ip->start6.s6_addr[i] > ip->stop6.s6_addr[i]) {
@@ -185,9 +186,17 @@ char * nutscan_ip_iter_init(nutscan_ip_iter_t * ip, const char * startIP, const 
 			}
 		}
 
-		if (ntop6(&ip->start6, host, sizeof(host)) != 0) {
+		/* IPv6 addresses must be in square brackets,
+		 * for upsclient et al to differentiate them
+		 * from the port number.
+		 */
+		host[0] = '[';
+		if (ntop6(&ip->start6, host + 1, sizeof(host) - 2) != 0) {
 			return NULL;
 		}
+		hlen = strlen(host);
+		host[hlen] = ']';
+		host[hlen + 1] = '\0';
 
 		return strdup(host);
 	}
@@ -217,6 +226,8 @@ char * nutscan_ip_iter_inc(nutscan_ip_iter_t * ip)
 		return strdup(host);
 	}
 	else {
+		size_t	hlen;
+
 		/* Check if this is the last address to scan */
 		if (memcmp(&ip->start6.s6_addr, &ip->stop6.s6_addr,
 				sizeof(ip->start6.s6_addr)) == 0) {
@@ -224,9 +235,18 @@ char * nutscan_ip_iter_inc(nutscan_ip_iter_t * ip)
 		}
 
 		increment_IPv6(&ip->start6);
-		if (ntop6(&ip->start6, host, sizeof(host)) != 0) {
+
+		/* IPv6 addresses must be in square brackets,
+		 * for upsclient et al to differentiate them
+		 * from the port number.
+		 */
+		host[0] = '[';
+		if (ntop6(&ip->start6, host + 1, sizeof(host) - 2) != 0) {
 			return NULL;
 		}
+		hlen = strlen(host);
+		host[hlen] = ']';
+		host[hlen + 1] = '\0';
 
 		return strdup(host);
 	}

--- a/tools/nut-scanner/nutscan-ip.c
+++ b/tools/nut-scanner/nutscan-ip.c
@@ -300,10 +300,18 @@ int nutscan_cidr_to_ip(const char * cidr, char ** start_ip, char ** stop_ip)
 	if (mask == NULL) {
 		upsdebugx(0, "WARNING: %s failed to parse mask from cidr=%s (first_ip=%s)",
 			__func__, cidr, first_ip);
-		free (first_ip);
+		free(first_ip);
 		free(cidr_tok);
 		return 0;
 	}
+
+	if (first_ip[0] == '[' && first_ip[strlen(first_ip) - 1] == ']') {
+		char *s = strdup(first_ip + 1);
+		s[strlen(s) - 1] = '\0';
+		free(first_ip);
+		first_ip = s;
+	}
+
 	upsdebugx(5, "%s: parsed cidr=%s into first_ip=%s and mask=%s",
 		__func__, cidr, first_ip, mask);
 

--- a/tools/nut-scanner/scan_eaton_serial.c
+++ b/tools/nut-scanner/scan_eaton_serial.c
@@ -408,10 +408,15 @@ nutscan_device_t * nutscan_scan_eaton_serial(const char* ports_range)
 	char *current_port_name = NULL;
 	char **serial_ports_list;
 	int  current_port_nb;
+
 #ifdef HAVE_PTHREAD
 # ifdef HAVE_SEMAPHORE
 	sem_t * semaphore = nutscan_semaphore();
-# endif
+	/* TODO? Port semaphore_scantype / max_threads_scantype
+	 *  from sibling sources? We do not have that many serial
+	 *  ports to care much, usually... right?
+	 */
+# endif /* HAVE_SEMAPHORE */
 	pthread_t thread;
 	nutscan_thread_t * thread_array = NULL;
 	size_t thread_count = 0, i;
@@ -484,6 +489,7 @@ nutscan_device_t * nutscan_scan_eaton_serial(const char* ports_range)
 				"(launched overall: %" PRIuSIZE "), "
 				"waiting until some would finish",
 				__func__, curr_threads, thread_count);
+
 			while (curr_threads >= max_threads) {
 				for (i = 0; i < thread_count ; i++) {
 					int ret;
@@ -528,6 +534,7 @@ nutscan_device_t * nutscan_scan_eaton_serial(const char* ports_range)
 			}
 			upsdebugx(2, "%s: proceeding with scan", __func__);
 		}
+
 		/* NOTE: No change to default "pass" in this ifdef:
 		 * if we got to this line, we have a slot to use */
 #  endif /* HAVE_PTHREAD_TRYJOIN */

--- a/tools/nut-scanner/scan_ipmi.c
+++ b/tools/nut-scanner/scan_ipmi.c
@@ -619,6 +619,7 @@ nutscan_device_t * nutscan_scan_ipmi(const char * start_ip, const char * stop_ip
 		current_nut_dev = nutscan_scan_ipmi_device(NULL, NULL);
 	}
 	else {
+		/* TODO: Port HAVE_PTHREAD_TRYJOIN etc. from other files? */
 		if (start_ip == stop_ip || !stop_ip) {
 			upsdebugx(1, "%s: Scanning remote PSU for single IP address: %s",
 				__func__, start_ip);

--- a/tools/nut-scanner/scan_ipmi.c
+++ b/tools/nut-scanner/scan_ipmi.c
@@ -573,6 +573,8 @@ nutscan_device_t * nutscan_scan_ipmi_device(const char * IPaddr, nutscan_ipmi_t 
 			}
 			else {
 				/* FIXME: also check against "localhost" and its IPv{4,6} */
+				/* FIXME: Should the IPv6 address here be bracketed?
+				 *  Does our driver support the notation? */
 				sprintf(port_id, "id%x@%s", ipmi_id, IPaddr);
 			}
 			nut_dev->port = strdup(port_id);

--- a/tools/nut-scanner/scan_nut.c
+++ b/tools/nut-scanner/scan_nut.c
@@ -296,7 +296,11 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 				__func__);
 			max_threads_scantype = UINT_MAX - 1;
 		}
-		sem_init(semaphore_scantype, 0, (unsigned int)max_threads_scantype);
+
+		upsdebugx(4, "%s: sem_init() for %" PRIuSIZE " threads", __func__, max_threads_scantype);
+		if (sem_init(semaphore_scantype, 0, (unsigned int)max_threads_scantype)) {
+			upsdebug_with_errno(4, "%s: sem_init() failed", __func__);
+		}
 	}
 # endif /* HAVE_SEMAPHORE */
 
@@ -356,8 +360,21 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 			sem_wait(semaphore);
 			pass = TRUE;
 		} else {
-			pass = ((max_threads_scantype == 0 || sem_trywait(semaphore_scantype) == 0) &&
-			        sem_trywait(semaphore) == 0);
+			/* If successful (the lock was acquired),
+			 * sem_wait() and sem_trywait() will return 0.
+			 * Otherwise, -1 is returned and errno is set,
+			 * and the state of the semaphore is unchanged.
+			 */
+			int	stwST = sem_trywait(semaphore_scantype), stwS = sem_trywait(semaphore);
+			pass = ((max_threads_scantype == 0 || stwST == 0) && stwS == 0);
+			upsdebugx(4, "%s: max_threads_scantype=%" PRIuSIZE
+				" curr_threads=%" PRIuSIZE
+				" thread_count=%" PRIuSIZE
+				" stwST=%d stwS=%d pass=%d",
+				__func__, max_threads_scantype,
+				curr_threads, thread_count,
+				stwST, stwS, pass
+			);
 		}
 # else
 #  ifdef HAVE_PTHREAD_TRYJOIN
@@ -494,9 +511,10 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 # ifdef HAVE_SEMAPHORE
 			/* Wait for all current scans to complete */
 			if (thread_array != NULL) {
-				upsdebugx (2, "%s: Running too many scanning threads, "
+				upsdebugx (2, "%s: Running too many scanning threads (%"
+					PRIuSIZE "), "
 					"waiting until older ones would finish",
-					__func__);
+					__func__, thread_count);
 				for (i = 0; i < thread_count ; i++) {
 					int ret;
 					if (!thread_array[i].active) {

--- a/tools/nut-scanner/scan_nut.c
+++ b/tools/nut-scanner/scan_nut.c
@@ -247,11 +247,6 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 	int change_action_handler = 0;
 #endif
 	struct scan_nut_arg *nut_arg;
-#ifdef WIN32
-	WSADATA WSAdata;
-	WSAStartup(2,&WSAdata);
-	atexit((void(*)(void))WSACleanup);
-#endif
 
 #ifdef HAVE_PTHREAD
 # ifdef HAVE_SEMAPHORE
@@ -265,7 +260,15 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 # if (defined HAVE_PTHREAD_TRYJOIN) || (defined HAVE_SEMAPHORE)
 	size_t  max_threads_scantype = max_threads_oldnut;
 # endif
+#endif /* HAVE_PTHREAD */
 
+#ifdef WIN32
+	WSADATA WSAdata;
+	WSAStartup(2,&WSAdata);
+	atexit((void(*)(void))WSACleanup);
+#endif
+
+#ifdef HAVE_PTHREAD
 	pthread_mutex_init(&dev_mutex, NULL);
 
 # ifdef HAVE_SEMAPHORE

--- a/tools/nut-scanner/scan_nut.c
+++ b/tools/nut-scanner/scan_nut.c
@@ -377,6 +377,7 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 				"(launched overall: %" PRIuSIZE "), "
 				"waiting until some would finish",
 				__func__, curr_threads, thread_count);
+
 			while (curr_threads >= max_threads
 			   || (curr_threads >= max_threads_scantype && max_threads_scantype > 0)
 			) {
@@ -425,6 +426,7 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 			}
 			upsdebugx(2, "%s: proceeding with scan", __func__);
 		}
+
 		/* NOTE: No change to default "pass" in this ifdef:
 		 * if we got to this line, we have a slot to use */
 #  endif /* HAVE_PTHREAD_TRYJOIN */
@@ -520,7 +522,7 @@ nutscan_device_t * nutscan_scan_nut(const char* startIP, const char* stopIP, con
 			}
 # else
 #  ifdef HAVE_PTHREAD_TRYJOIN
-		/* TODO: Move the wait-loop for TRYJOIN here? */
+			/* TODO: Move the wait-loop for TRYJOIN here? */
 #  endif /* HAVE_PTHREAD_TRYJOIN */
 # endif  /* HAVE_SEMAPHORE */
 #endif   /* HAVE_PTHREAD */

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -1028,6 +1028,7 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 	nutscan_snmp_t * tmp_sec;
 	nutscan_ip_iter_t ip;
 	char * ip_str = NULL;
+
 #ifdef HAVE_PTHREAD
 # ifdef HAVE_SEMAPHORE
 	sem_t * semaphore = nutscan_semaphore();
@@ -1153,6 +1154,7 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 				"(launched overall: %" PRIuSIZE "), "
 				"waiting until some would finish",
 				__func__, curr_threads, thread_count);
+
 			while (curr_threads >= max_threads
 			   || (curr_threads >= max_threads_scantype && max_threads_scantype > 0)
 			) {
@@ -1201,6 +1203,7 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 			}
 			upsdebugx(2, "%s: proceeding with scan", __func__);
 		}
+
 		/* NOTE: No change to default "pass" in this ifdef:
 		 * if we got to this line, we have a slot to use */
 #  endif /* HAVE_PTHREAD_TRYJOIN */
@@ -1279,7 +1282,7 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 			}
 # else
 #  ifdef HAVE_PTHREAD_TRYJOIN
-		/* TODO: Move the wait-loop for TRYJOIN here? */
+			/* TODO: Move the wait-loop for TRYJOIN here? */
 #  endif /* HAVE_PTHREAD_TRYJOIN */
 # endif  /* HAVE_SEMAPHORE */
 #endif   /* HAVE_PTHREAD */

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -1035,20 +1035,21 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 	sem_t   semaphore_scantype_inst;
 	sem_t * semaphore_scantype = &semaphore_scantype_inst;
 # endif /* HAVE_SEMAPHORE */
-
-# ifdef WIN32
-	WSADATA WSAdata;
-	WSAStartup(2,&WSAdata);
-	atexit((void(*)(void))WSACleanup);
-# endif
-
 	pthread_t thread;
 	nutscan_thread_t * thread_array = NULL;
 	size_t thread_count = 0, i;
 # if (defined HAVE_PTHREAD_TRYJOIN) || (defined HAVE_SEMAPHORE)
 	size_t  max_threads_scantype = max_threads_netsnmp;
 # endif
+#endif /* HAVE_PTHREAD */
 
+#ifdef WIN32
+	WSADATA WSAdata;
+	WSAStartup(2,&WSAdata);
+	atexit((void(*)(void))WSACleanup);
+#endif
+
+#ifdef HAVE_PTHREAD
 	pthread_mutex_init(&dev_mutex, NULL);
 
 # ifdef HAVE_SEMAPHORE

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -480,6 +480,8 @@ static void scan_snmp_add_device(nutscan_snmp_t * sec, struct snmp_pdu *response
 	dev = nutscan_new_device();
 	dev->type = TYPE_SNMP;
 	dev->driver = strdup("snmp-ups");
+	/* FIXME: Should the IPv6 address here be bracketed?
+	 *  Does our driver support the notation? */
 	dev->port = strdup(session->peername);
 	if (response != NULL) {
 		buf = malloc (response->variables->val_len + 1);

--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -353,6 +353,8 @@ static void * nutscan_scan_xml_http_generic(void * arg)
 				if (parserFailed == 0) {
 					nut_dev->driver = strdup("netxml-ups");
 					sprintf(buf, "http://%s", string);
+					/* FIXME: Should the IPv6 address here be bracketed?
+					 *  Does our driver support the notation? */
 					nut_dev->port = strdup(buf);
 					upsdebugx(3,
 						"nutscan_scan_xml_http_generic(): "

--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -725,9 +725,10 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 			result = nutscan_rewind_device(dev_ret);
 			dev_ret = NULL;
 			return result;
-		}
+		}	/* end of: scan range, maybe in parallel */
 	}
 
+	/* scan broadcast or single IP */
 	tmp_sec = malloc(sizeof(nutscan_xml_t));
 	if (tmp_sec == NULL) {
 		fprintf(stderr,

--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -616,7 +616,7 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 
 					thread_count++;
 					new_thread_array = realloc(thread_array,
-						thread_count*sizeof(nutscan_thread_t));
+						thread_count * sizeof(nutscan_thread_t));
 					if (new_thread_array == NULL) {
 						upsdebugx(1, "%s: Failed to realloc thread array", __func__);
 						break;

--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -431,35 +431,36 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 	if (start_ip == NULL) {
 		upsdebugx(1, "%s: Scanning XML/HTTP bus using broadcast.", __func__);
 	} else {
+		/* Iterate the one or a range of IPs to scan */
+		nutscan_ip_iter_t ip;
+		char * ip_str = NULL;
+#ifdef HAVE_PTHREAD
+# ifdef HAVE_SEMAPHORE
+		sem_t * semaphore = nutscan_semaphore();
+		sem_t   semaphore_scantype_inst;
+		sem_t * semaphore_scantype = &semaphore_scantype_inst;
+# endif /* HAVE_SEMAPHORE */
+		pthread_t thread;
+		nutscan_thread_t * thread_array = NULL;
+		size_t thread_count = 0, i;
+# if (defined HAVE_PTHREAD_TRYJOIN) || (defined HAVE_SEMAPHORE)
+		size_t  max_threads_scantype = max_threads_netxml;
+# endif
+#endif
+
 		if ((start_ip == end_ip) || (end_ip == NULL) || (0 == strncmp(start_ip, end_ip, 128))) {
 			upsdebugx(1, "%s: Scanning XML/HTTP bus for single IP address: %s",
 				__func__, start_ip);
 		} else {
-			/* Iterate the range of IPs to scan */
-			nutscan_ip_iter_t ip;
-			char * ip_str = NULL;
-#ifdef HAVE_PTHREAD
-# ifdef HAVE_SEMAPHORE
-			sem_t * semaphore = nutscan_semaphore();
-			sem_t   semaphore_scantype_inst;
-			sem_t * semaphore_scantype = &semaphore_scantype_inst;
-# endif /* HAVE_SEMAPHORE */
-			pthread_t thread;
-			nutscan_thread_t * thread_array = NULL;
-			size_t thread_count = 0, i;
-# if (defined HAVE_PTHREAD_TRYJOIN) || (defined HAVE_SEMAPHORE)
-			size_t  max_threads_scantype = max_threads_netxml;
-# endif
-#endif
-
 			upsdebugx(1, "%s: Scanning XML/HTTP bus for IP address range: %s .. %s",
 				__func__, start_ip, end_ip);
+		}
 
 #ifdef HAVE_PTHREAD
-			pthread_mutex_init(&dev_mutex, NULL);
+		pthread_mutex_init(&dev_mutex, NULL);
 
 # ifdef HAVE_SEMAPHORE
-			if (max_threads_scantype > 0) {
+		if (max_threads_scantype > 0) {
 #ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
 #pragma GCC diagnostic push
 #endif
@@ -470,265 +471,266 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunreachable-code"
 #endif
-				/* Different platforms, different sizes, none fits all... */
-				if (SIZE_MAX > UINT_MAX && max_threads_scantype > UINT_MAX) {
+			/* Different platforms, different sizes, none fits all... */
+			if (SIZE_MAX > UINT_MAX && max_threads_scantype > UINT_MAX) {
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif
 #ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
 #pragma GCC diagnostic pop
 #endif
-					upsdebugx(1,
-						"WARNING: %s: Limiting max_threads_scantype to range acceptable for sem_init()",
-						__func__);
-					max_threads_scantype = UINT_MAX - 1;
-				}
-				sem_init(semaphore_scantype, 0, (unsigned int)max_threads_scantype);
+				upsdebugx(1,
+					"WARNING: %s: Limiting max_threads_scantype to range acceptable for sem_init()",
+					__func__);
+				max_threads_scantype = UINT_MAX - 1;
 			}
+			sem_init(semaphore_scantype, 0, (unsigned int)max_threads_scantype);
+		}
 # endif /* HAVE_SEMAPHORE */
 
 #endif /* HAVE_PTHREAD */
 
-			ip_str = nutscan_ip_iter_init(&ip, start_ip, end_ip);
+		ip_str = nutscan_ip_iter_init(&ip, start_ip, end_ip);
 
-			while (ip_str != NULL) {
+		while (ip_str != NULL) {
 #ifdef HAVE_PTHREAD
-				/* NOTE: With many enough targets to scan, this can crash
-				 * by spawning too many children; add a limit and loop to
-				 * "reap" some already done with their work. And probably
-				 * account them in thread_array[] as something to not wait
-				 * for below in pthread_join()...
-				 */
+			/* NOTE: With many enough targets to scan, this can crash
+			 * by spawning too many children; add a limit and loop to
+			 * "reap" some already done with their work. And probably
+			 * account them in thread_array[] as something to not wait
+			 * for below in pthread_join()...
+			 */
 
 # ifdef HAVE_SEMAPHORE
-				/* Just wait for someone to free a semaphored slot,
-				 * if none are available, and then/otherwise grab one
-				 */
-				if (thread_array == NULL) {
-					/* Starting point, or after a wait to complete
-					 * all earlier runners */
-			if (max_threads_scantype > 0)
-				sem_wait(semaphore_scantype);
-					sem_wait(semaphore);
-					pass = TRUE;
-				} else {
-			pass = ((max_threads_scantype == 0 || sem_trywait(semaphore_scantype) == 0) &&
-			        sem_trywait(semaphore) == 0);
-				}
+			/* Just wait for someone to free a semaphored slot,
+			 * if none are available, and then/otherwise grab one
+			 */
+			if (thread_array == NULL) {
+				/* Starting point, or after a wait to complete
+				 * all earlier runners */
+				if (max_threads_scantype > 0)
+					sem_wait(semaphore_scantype);
+						sem_wait(semaphore);
+						pass = TRUE;
+			} else {
+				pass = ((max_threads_scantype == 0 || sem_trywait(semaphore_scantype) == 0) &&
+					sem_trywait(semaphore) == 0);
+			}
 # else
 #  ifdef HAVE_PTHREAD_TRYJOIN
-				/* A somewhat naive and brute-force solution for
-				 * systems without a semaphore.h. This may suffer
-				 * some off-by-one errors, using a few more threads
-				 * than intended (if we race a bit at the wrong time,
-				 * probably up to one per enabled scanner routine).
-				 */
+			/* A somewhat naive and brute-force solution for
+			 * systems without a semaphore.h. This may suffer
+			 * some off-by-one errors, using a few more threads
+			 * than intended (if we race a bit at the wrong time,
+			 * probably up to one per enabled scanner routine).
+			 */
 
-				/* TOTHINK: Should there be a threadcount_mutex when
-				 * we just read the value in if() and while() below?
-				 * At worst we would overflow the limit a bit due to
-				 * other protocol scanners...
-				 */
-		if (curr_threads >= max_threads
-		|| (curr_threads >= max_threads_scantype && max_threads_scantype > 0)
-		) {
-					upsdebugx(2, "%s: already running %" PRIuSIZE " scanning threads "
-						"(launched overall: %" PRIuSIZE "), "
-						"waiting until some would finish",
-						__func__, curr_threads, thread_count);
-			while (curr_threads >= max_threads
-			   || (curr_threads >= max_threads_scantype && max_threads_scantype > 0)
+			/* TOTHINK: Should there be a threadcount_mutex when
+			 * we just read the value in if() and while() below?
+			 * At worst we would overflow the limit a bit due to
+			 * other protocol scanners...
+			 */
+			if (curr_threads >= max_threads
+			|| (curr_threads >= max_threads_scantype && max_threads_scantype > 0)
 			) {
-						for (i = 0; i < thread_count ; i++) {
-							int ret;
+				upsdebugx(2, "%s: already running %" PRIuSIZE " scanning threads "
+					"(launched overall: %" PRIuSIZE "), "
+					"waiting until some would finish",
+					__func__, curr_threads, thread_count);
 
-							if (!thread_array[i].active) continue;
-
-							pthread_mutex_lock(&threadcount_mutex);
-							upsdebugx(3, "%s: Trying to join thread #%i...", __func__, i);
-							ret = pthread_tryjoin_np(thread_array[i].thread, NULL);
-							switch (ret) {
-								case ESRCH:     /* No thread with the ID thread could be found - already "joined"? */
-									upsdebugx(5, "%s: Was thread #%" PRIuSIZE " joined earlier?", __func__, i);
-									break;
-								case 0:         /* thread exited */
-									if (curr_threads > 0) {
-										curr_threads --;
-										upsdebugx(4, "%s: Joined a finished thread #%" PRIuSIZE, __func__, i);
-									} else {
-										/* threadcount_mutex fault? */
-										upsdebugx(0, "WARNING: %s: Accounting of thread count "
-											"says we are already at 0", __func__);
-									}
-									thread_array[i].active = FALSE;
-									break;
-								case EBUSY:     /* actively running */
-									upsdebugx(6, "%s: thread #%" PRIuSIZE " still busy (%i)",
-										__func__, i, ret);
-									break;
-								case EDEADLK:   /* Errors with thread interactions... bail out? */
-								case EINVAL:    /* Errors with thread interactions... bail out? */
-								default:        /* new pthreads abilities? */
-									upsdebugx(5, "%s: thread #%" PRIuSIZE " reported code %i",
-										__func__, i, ret);
-									break;
-							}
-							pthread_mutex_unlock(&threadcount_mutex);
-						}
-
-				if (curr_threads >= max_threads
-				|| (curr_threads >= max_threads_scantype && max_threads_scantype > 0)
+				while (curr_threads >= max_threads
+				   || (curr_threads >= max_threads_scantype && max_threads_scantype > 0)
 				) {
-							usleep (10000); /* microSec's, so 0.01s here */
+					for (i = 0; i < thread_count ; i++) {
+						int ret;
+
+						if (!thread_array[i].active) continue;
+
+						pthread_mutex_lock(&threadcount_mutex);
+						upsdebugx(3, "%s: Trying to join thread #%i...", __func__, i);
+						ret = pthread_tryjoin_np(thread_array[i].thread, NULL);
+						switch (ret) {
+							case ESRCH:     /* No thread with the ID thread could be found - already "joined"? */
+								upsdebugx(5, "%s: Was thread #%" PRIuSIZE " joined earlier?", __func__, i);
+								break;
+							case 0:         /* thread exited */
+								if (curr_threads > 0) {
+									curr_threads --;
+									upsdebugx(4, "%s: Joined a finished thread #%" PRIuSIZE, __func__, i);
+								} else {
+									/* threadcount_mutex fault? */
+									upsdebugx(0, "WARNING: %s: Accounting of thread count "
+										"says we are already at 0", __func__);
+								}
+								thread_array[i].active = FALSE;
+								break;
+							case EBUSY:     /* actively running */
+								upsdebugx(6, "%s: thread #%" PRIuSIZE " still busy (%i)",
+									__func__, i, ret);
+								break;
+							case EDEADLK:   /* Errors with thread interactions... bail out? */
+							case EINVAL:    /* Errors with thread interactions... bail out? */
+							default:        /* new pthreads abilities? */
+								upsdebugx(5, "%s: thread #%" PRIuSIZE " reported code %i",
+									__func__, i, ret);
+								break;
 						}
+						pthread_mutex_unlock(&threadcount_mutex);
 					}
-					upsdebugx(2, "%s: proceeding with scan", __func__);
+
+					if (curr_threads >= max_threads
+					|| (curr_threads >= max_threads_scantype && max_threads_scantype > 0)
+					) {
+							usleep (10000); /* microSec's, so 0.01s here */
+					}
 				}
-				/* NOTE: No change to default "pass" in this ifdef:
-				 * if we got to this line, we have a slot to use */
+				upsdebugx(2, "%s: proceeding with scan", __func__);
+			}
+
+			/* NOTE: No change to default "pass" in this ifdef:
+			 * if we got to this line, we have a slot to use */
 #  endif /* HAVE_PTHREAD_TRYJOIN */
 # endif  /* HAVE_SEMAPHORE */
 #endif   /* HAVE_PTHREAD */
 
-				if (pass) {
-					tmp_sec = malloc(sizeof(nutscan_xml_t));
-					if (tmp_sec == NULL) {
-						fprintf(stderr,
-							"Memory allocation error\n");
-						return NULL;
-					}
-					memcpy(tmp_sec, sec, sizeof(nutscan_xml_t));
-					tmp_sec->peername = ip_str;
-					if (tmp_sec->usec_timeout <= 0) {
-						tmp_sec->usec_timeout = usec_timeout;
-					}
+			if (pass) {
+				tmp_sec = malloc(sizeof(nutscan_xml_t));
+				if (tmp_sec == NULL) {
+					fprintf(stderr,
+						"Memory allocation error\n");
+					return NULL;
+				}
+				memcpy(tmp_sec, sec, sizeof(nutscan_xml_t));
+				tmp_sec->peername = ip_str;
+				if (tmp_sec->usec_timeout <= 0) {
+					tmp_sec->usec_timeout = usec_timeout;
+				}
 
 #ifdef HAVE_PTHREAD
-					if (pthread_create(&thread, NULL, nutscan_scan_xml_http_generic, (void *)tmp_sec) == 0) {
-						nutscan_thread_t	*new_thread_array;
+				if (pthread_create(&thread, NULL, nutscan_scan_xml_http_generic, (void *)tmp_sec) == 0) {
+					nutscan_thread_t	*new_thread_array;
 # ifdef HAVE_PTHREAD_TRYJOIN
-						pthread_mutex_lock(&threadcount_mutex);
-						curr_threads++;
+					pthread_mutex_lock(&threadcount_mutex);
+					curr_threads++;
 # endif /* HAVE_PTHREAD_TRYJOIN */
 
-						thread_count++;
-						new_thread_array = realloc(thread_array,
-							thread_count*sizeof(nutscan_thread_t));
-						if (new_thread_array == NULL) {
-							upsdebugx(1, "%s: Failed to realloc thread array", __func__);
-							break;
-						}
-						else {
-							thread_array = new_thread_array;
-						}
-						thread_array[thread_count - 1].thread = thread;
-						thread_array[thread_count - 1].active = TRUE;
-
-# ifdef HAVE_PTHREAD_TRYJOIN
-							pthread_mutex_unlock(&threadcount_mutex);
-# endif /* HAVE_PTHREAD_TRYJOIN */
+					thread_count++;
+					new_thread_array = realloc(thread_array,
+						thread_count*sizeof(nutscan_thread_t));
+					if (new_thread_array == NULL) {
+						upsdebugx(1, "%s: Failed to realloc thread array", __func__);
+						break;
 					}
+					else {
+						thread_array = new_thread_array;
+					}
+					thread_array[thread_count - 1].thread = thread;
+					thread_array[thread_count - 1].active = TRUE;
+
+# ifdef HAVE_PTHREAD_TRYJOIN
+					pthread_mutex_unlock(&threadcount_mutex);
+# endif /* HAVE_PTHREAD_TRYJOIN */
+				}
 #else /* not HAVE_PTHREAD */
-					nutscan_scan_xml_http_generic((void *)tmp_sec);
+				nutscan_scan_xml_http_generic((void *)tmp_sec);
 #endif /* if HAVE_PTHREAD */
 
-/*					free(ip_str); */ /* One of these free()s seems to cause a double-free instead */
-					ip_str = nutscan_ip_iter_inc(&ip);
-/*					free(tmp_sec); */
-				} else { /* if not pass -- all slots busy */
+/*				free(ip_str); */ /* One of these free()s seems to cause a double-free instead */
+				ip_str = nutscan_ip_iter_inc(&ip);
+/*				free(tmp_sec); */
+			} else { /* if not pass -- all slots busy */
 #ifdef HAVE_PTHREAD
 # ifdef HAVE_SEMAPHORE
-					/* Wait for all current scans to complete */
-					if (thread_array != NULL) {
-				upsdebugx (2, "%s: Running too many scanning threads, "
-					"waiting until older ones would finish",
-					__func__);
-						for (i = 0; i < thread_count ; i++) {
-							int ret;
-							if (!thread_array[i].active) {
-								/* Probably should not get here,
-								 * but handle it just in case */
-								upsdebugx(0, "WARNING: %s: Midway clean-up: did not expect thread %" PRIuSIZE " to be not active",
-									__func__, i);
-								sem_post(semaphore);
-								if (max_threads_scantype > 0)
-									sem_post(semaphore_scantype);
-								continue;
-							}
-							thread_array[i].active = FALSE;
-							ret = pthread_join(thread_array[i].thread, NULL);
-							if (ret != 0) {
-								upsdebugx(0, "WARNING: %s: Midway clean-up: pthread_join() returned code %i",
-									__func__, ret);
-							}
+				/* Wait for all current scans to complete */
+				if (thread_array != NULL) {
+					upsdebugx (2, "%s: Running too many scanning threads, "
+						"waiting until older ones would finish",
+						__func__);
+					for (i = 0; i < thread_count ; i++) {
+						int ret;
+						if (!thread_array[i].active) {
+							/* Probably should not get here,
+							 * but handle it just in case */
+							upsdebugx(0, "WARNING: %s: Midway clean-up: did not expect thread %" PRIuSIZE " to be not active",
+								__func__, i);
 							sem_post(semaphore);
 							if (max_threads_scantype > 0)
 								sem_post(semaphore_scantype);
-							}
-						thread_count = 0;
-						free(thread_array);
-						thread_array = NULL;
+							continue;
+						}
+						thread_array[i].active = FALSE;
+						ret = pthread_join(thread_array[i].thread, NULL);
+						if (ret != 0) {
+							upsdebugx(0, "WARNING: %s: Midway clean-up: pthread_join() returned code %i",
+								__func__, ret);
+						}
+						sem_post(semaphore);
+						if (max_threads_scantype > 0)
+							sem_post(semaphore_scantype);
 					}
+					thread_count = 0;
+					free(thread_array);
+					thread_array = NULL;
+				}
 # else
 #  ifdef HAVE_PTHREAD_TRYJOIN
 				/* TODO: Move the wait-loop for TRYJOIN here? */
 #  endif /* HAVE_PTHREAD_TRYJOIN */
 # endif  /* HAVE_SEMAPHORE */
 #endif   /* HAVE_PTHREAD */
-				} /* if: could we "pass" or not? */
-			} /* while */
+			} /* if: could we "pass" or not? */
+		} /* while */
 
 #ifdef HAVE_PTHREAD
-			if (thread_array != NULL) {
-				upsdebugx(2, "%s: all planned scans launched, waiting for threads to complete", __func__);
-				for (i = 0; i < thread_count; i++) {
-					int ret;
+		if (thread_array != NULL) {
+			upsdebugx(2, "%s: all planned scans launched, waiting for threads to complete", __func__);
+			for (i = 0; i < thread_count; i++) {
+				int ret;
 
-					if (!thread_array[i].active) continue;
+				if (!thread_array[i].active) continue;
 
-					ret = pthread_join(thread_array[i].thread, NULL);
-					if (ret != 0) {
-						upsdebugx(0, "WARNING: %s: Clean-up: pthread_join() returned code %i",
-							__func__, ret);
-					}
-					thread_array[i].active = FALSE;
+				ret = pthread_join(thread_array[i].thread, NULL);
+				if (ret != 0) {
+					upsdebugx(0, "WARNING: %s: Clean-up: pthread_join() returned code %i",
+						__func__, ret);
+				}
+				thread_array[i].active = FALSE;
 # ifdef HAVE_SEMAPHORE
-			sem_post(semaphore);
-			if (max_threads_scantype > 0)
-				sem_post(semaphore_scantype);
+				sem_post(semaphore);
+				if (max_threads_scantype > 0)
+					sem_post(semaphore_scantype);
 # else
 #  ifdef HAVE_PTHREAD_TRYJOIN
-					pthread_mutex_lock(&threadcount_mutex);
-					if (curr_threads > 0) {
-						curr_threads --;
-						upsdebugx(5, "%s: Clean-up: Joined a finished thread #%" PRIuSIZE,
-							__func__, i);
-					} else {
-						upsdebugx(0, "WARNING: %s: Clean-up: Accounting of thread count "
-							"says we are already at 0", __func__);
-					}
-					pthread_mutex_unlock(&threadcount_mutex);
+				pthread_mutex_lock(&threadcount_mutex);
+				if (curr_threads > 0) {
+					curr_threads --;
+					upsdebugx(5, "%s: Clean-up: Joined a finished thread #%" PRIuSIZE,
+						__func__, i);
+				} else {
+					upsdebugx(0, "WARNING: %s: Clean-up: Accounting of thread count "
+						"says we are already at 0", __func__);
+				}
+				pthread_mutex_unlock(&threadcount_mutex);
 #  endif /* HAVE_PTHREAD_TRYJOIN */
 # endif /* HAVE_SEMAPHORE */
-				}
-				free(thread_array);
-				upsdebugx(2, "%s: all threads freed", __func__);
 			}
-			pthread_mutex_destroy(&dev_mutex);
+			free(thread_array);
+			upsdebugx(2, "%s: all threads freed", __func__);
+		}
+		pthread_mutex_destroy(&dev_mutex);
 
 # ifdef HAVE_SEMAPHORE
-	if (max_threads_scantype > 0)
-		sem_destroy(semaphore_scantype);
+		if (max_threads_scantype > 0)
+			sem_destroy(semaphore_scantype);
 # endif /* HAVE_SEMAPHORE */
 #endif /* HAVE_PTHREAD */
 
-			result = nutscan_rewind_device(dev_ret);
-			dev_ret = NULL;
-			return result;
-		}	/* end of: scan range, maybe in parallel */
-	}
+		result = nutscan_rewind_device(dev_ret);
+		dev_ret = NULL;
+		return result;
+	}	/* end of: scan range of 1+ IP address(es), maybe in parallel */
 
-	/* scan broadcast or single IP */
+	/* both start_ip == end_ip == NULL, scan broadcast */
 	tmp_sec = malloc(sizeof(nutscan_xml_t));
 	if (tmp_sec == NULL) {
 		fprintf(stderr,
@@ -740,6 +742,7 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 	if (start_ip == NULL) {
 		tmp_sec->peername = NULL;
 	} else {
+		/* Legacy code path for single-IP scan; should not get here */
 		tmp_sec->peername = strdup(start_ip);
 	}
 

--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -484,7 +484,11 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 					__func__);
 				max_threads_scantype = UINT_MAX - 1;
 			}
-			sem_init(semaphore_scantype, 0, (unsigned int)max_threads_scantype);
+
+			upsdebugx(4, "%s: sem_init() for %" PRIuSIZE " threads", __func__, max_threads_scantype);
+			if (sem_init(semaphore_scantype, 0, (unsigned int)max_threads_scantype)) {
+				upsdebug_with_errno(4, "%s: sem_init() failed", __func__);
+			}
 		}
 # endif /* HAVE_SEMAPHORE */
 
@@ -510,11 +514,24 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 				 * all earlier runners */
 				if (max_threads_scantype > 0)
 					sem_wait(semaphore_scantype);
-						sem_wait(semaphore);
-						pass = TRUE;
+				sem_wait(semaphore);
+				pass = TRUE;
 			} else {
-				pass = ((max_threads_scantype == 0 || sem_trywait(semaphore_scantype) == 0) &&
-					sem_trywait(semaphore) == 0);
+				/* If successful (the lock was acquired),
+				 * sem_wait() and sem_trywait() will return 0.
+				 * Otherwise, -1 is returned and errno is set,
+				 * and the state of the semaphore is unchanged.
+				 */
+				int	stwST = sem_trywait(semaphore_scantype), stwS = sem_trywait(semaphore);
+				pass = ((max_threads_scantype == 0 || stwST == 0) && stwS == 0);
+				upsdebugx(4, "%s: max_threads_scantype=%" PRIuSIZE
+					" curr_threads=%" PRIuSIZE
+					" thread_count=%" PRIuSIZE
+					" stwST=%d stwS=%d pass=%d",
+					__func__, max_threads_scantype,
+					curr_threads, thread_count,
+					stwST, stwS, pass
+				);
 			}
 # else
 #  ifdef HAVE_PTHREAD_TRYJOIN
@@ -643,9 +660,10 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 # ifdef HAVE_SEMAPHORE
 				/* Wait for all current scans to complete */
 				if (thread_array != NULL) {
-					upsdebugx (2, "%s: Running too many scanning threads, "
+					upsdebugx (2, "%s: Running too many scanning threads (%"
+						PRIuSIZE "), "
 						"waiting until older ones would finish",
-						__func__);
+						__func__, thread_count);
 					for (i = 0; i < thread_count ; i++) {
 						int ret;
 						if (!thread_array[i].active) {


### PR DESCRIPTION
Closes: #2512

As found in that issue (in turn stemming from work on PRs for #2244), we had a problem with IPv6 address passing to `nut-scanner`. The culprit was about lack of square brackets (as required by our `upscli_tryconnect()` and `device@host:port` parser methods, to differentiate components of colon-separated IPv6 address from an optional colon-separated port number). Use of square brackets around IP address strings is common practice to suppress DNS resolution or separate host identifiers from port numbers, etc.

On the other hand, `nut-scanner` also rejected addresses wrapped by the brackets, so they could not be passed to the tool.

This PR fixes both the input side (accept and strip brackets from addresses in `-s` and `-e` for start/end of a range, and `-m` for CIDR), and the output side (return IPv6 addresses enclosed in brackets when iterating them for a scan).

* NOTE: Bracketed IPv6 addresses are currently passed to all iteration consumers - so also IPMI, NetXML and SNMP scanners. I do not have actual devices to test against, but at least the calls did not raise any `errno` failures. If this does prove to be a problem, bracketing can be made optional or moved into `scan_nut.c` outright, in future follow-ups. @arnaudquette-eaton : would you have a chance to run some experiments about this?

It also addresses a few points rather related to issue #2511 and adds `NUT_DEBUG_LEVEL` (envvar only) support to `upsc` tool to help troubleshoot the NUT client code.