### PR TITLE
Implement `nut-scanner -m auto*` modes on WIN32

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -143,7 +143,7 @@ installed.
    * newly added support to scan several IP addresses (single or ranges)
      with the same call, by repeating command-line options; also `-m auto{,4,6}`
      can be specified (once) to select IP (all, IPv4, IPv6) address ranges of
-     configured local network interfaces (currently not implemented for WIN32).
+     configured local network interfaces.
      An `/ADDRLEN` suffix can be added to the option, to filter out discovered
      subnets with too many bits available for the host address part (avoiding
      millions of scans in the extreme cases).

--- a/common/common.c
+++ b/common/common.c
@@ -3193,24 +3193,33 @@ static char * get_libname_in_dir(const char* base_libname, size_t base_libname_l
 	char *libname_path = NULL, *libname_alias = NULL;
 	char current_test_path[LARGEBUF];
 
+	upsdebugx(3, "%s('%s', %" PRIuSIZE ", '%s', %i): Entering method...",
+		__func__, base_libname, base_libname_length, dirname, index);
+
 	memset(current_test_path, 0, LARGEBUF);
 
 	if ((dp = opendir(dirname)) == NULL) {
 		if (index >= 0) {
-			upsdebugx(5,"NOT looking for lib %s in unreachable directory #%d : %s",
-				base_libname, index, dirname);
+			upsdebugx(5, "%s: NOT looking for lib %s in "
+				"unreachable directory #%d : %s",
+				__func__, base_libname, index, dirname);
 		} else {
-			upsdebugx(5,"NOT looking for lib %s in unreachable directory : %s",
-				base_libname, dirname);
+			upsdebugx(5, "%s: NOT looking for lib %s in "
+				"unreachable directory : %s",
+				__func__, base_libname, dirname);
 		}
 		return NULL;
 	}
 
 	if (index >= 0) {
-		upsdebugx(2,"Looking for lib %s in directory #%d : %s", base_libname, index, dirname);
+		upsdebugx(4, "%s: Looking for lib %s in directory #%d : %s",
+			__func__, base_libname, index, dirname);
 	} else {
-		upsdebugx(2,"Looking for lib %s in directory : %s", base_libname, dirname);
+		upsdebugx(4, "%s: Looking for lib %s in directory : %s",
+			__func__, base_libname, dirname);
 	}
+
+	/* TODO: Try a quick stat() first? */
 	while ((dirp = readdir(dp)) != NULL)
 	{
 #if !HAVE_DECL_REALPATH
@@ -3218,7 +3227,8 @@ static char * get_libname_in_dir(const char* base_libname, size_t base_libname_l
 #endif
 		int compres;
 
-		upsdebugx(5,"Comparing lib %s with dirpath entry %s", base_libname, dirp->d_name);
+		upsdebugx(5, "%s: Comparing lib %s with dirpath entry %s",
+			__func__, base_libname, dirp->d_name);
 		compres = strncmp(dirp->d_name, base_libname, base_libname_length);
 		if (compres == 0) {
 			/* avoid "*.dll.a", ".so.1.2.3" etc. */
@@ -3247,7 +3257,8 @@ static char * get_libname_in_dir(const char* base_libname, size_t base_libname_l
 				for (p = current_test_path; *p != '\0' && (p - current_test_path) < LARGEBUF; p++) {
 					if (*p == '/') *p = '\\';
 				}
-				upsdebugx(3, "%s: WIN32: re-checking with %s", __func__, current_test_path);
+				upsdebugx(4, "%s: WIN32: re-checking with %s",
+					__func__, current_test_path);
 				if (stat(current_test_path, &st) == 0) {
 					if (st.st_size > 0) {
 						libname_path = xstrdup(current_test_path);
@@ -3260,7 +3271,8 @@ static char * get_libname_in_dir(const char* base_libname, size_t base_libname_l
 				 * original dir, and no threading at this moment, to be safe!)
 				 * https://stackoverflow.com/a/66096983/4715872
 				 */
-				upsdebugx(3, "%s: WIN32: re-checking with %s", __func__, current_test_path + 2);
+				upsdebugx(4, "%s: WIN32: re-checking with %s",
+					__func__, current_test_path + 2);
 				if (stat(current_test_path + 2, &st) == 0) {
 					if (st.st_size > 0) {
 						libname_path = xstrdup(current_test_path + 2);
@@ -3270,9 +3282,9 @@ static char * get_libname_in_dir(const char* base_libname, size_t base_libname_l
 # endif /* WIN32 */
 #endif  /* HAVE_DECL_REALPATH */
 
-			upsdebugx(2,"Candidate path for lib %s is %s (realpath %s)",
+			upsdebugx(2, "Candidate path for lib %s is %s (realpath %s)",
 				base_libname, current_test_path,
-				(libname_path!=NULL)?libname_path:"NULL");
+				NUT_STRARG(libname_path));
 			if (libname_path != NULL)
 				break;
 		}
@@ -3304,11 +3316,18 @@ static char * get_libname_in_pathset(const char* base_libname, size_t base_libna
 	char *onedir = NULL;
 	char* pathset_tmp;
 
+	upsdebugx(3, "%s('%s', %" PRIuSIZE ", '%s', %i): Entering method...",
+		__func__, base_libname, base_libname_length,
+		NUT_STRARG(pathset),
+		counter ? *counter : -1);
+
 	if (!pathset || *pathset == '\0')
 		return NULL;
 
 	/* First call to tokenization passes the string, others pass NULL */
 	pathset_tmp = xstrdup(pathset);
+	upsdebugx(4, "%s: Looking for lib %s in a colon-separated path set",
+		__func__, base_libname);
 	while (NULL != (onedir = strtok( (onedir ? NULL : pathset_tmp), ":" ))) {
 		libname_path = get_libname_in_dir(base_libname, base_libname_length, onedir, (*counter)++);
 		if (libname_path != NULL)
@@ -3321,6 +3340,8 @@ static char * get_libname_in_pathset(const char* base_libname, size_t base_libna
 	pathset_tmp = xstrdup(pathset);
 	if (!libname_path) {
 		onedir = NULL; /* probably is NULL already, but better ensure this */
+		upsdebugx(4, "%s: WIN32: Looking for lib %s in a semicolon-separated path set",
+			__func__, base_libname);
 		while (NULL != (onedir = strtok( (onedir ? NULL : pathset_tmp), ";" ))) {
 			libname_path = get_libname_in_dir(base_libname, base_libname_length, onedir, (*counter)++);
 			if (libname_path != NULL)
@@ -3342,16 +3363,21 @@ char * get_libname(const char* base_libname)
 	size_t base_libname_length = strlen(base_libname);
 	struct stat	st;
 
+	upsdebugx(3, "%s('%s'): Entering method...", __func__, base_libname);
+
 	/* First, check for an exact hit by absolute/relative path
 	 * if `base_libname` includes path separator character(s) */
 	if (xbasename(base_libname) != base_libname) {
+		upsdebugx(4, "%s: Looking for lib %s by exact hit...",
+			__func__, base_libname);
 #if HAVE_DECL_REALPATH
 		/* allocates the buffer we free() later */
 		libname_path = realpath(base_libname, NULL);
 		if (libname_path != NULL) {
 			if (stat(libname_path, &st) == 0) {
 				if (st.st_size > 0) {
-					upsdebugx(2, "Looking for lib %s, found by exact hit", base_libname);
+					upsdebugx(2, "Looking for lib %s, found by exact hit",
+						base_libname);
 					goto found;
 				}
 			}
@@ -3366,7 +3392,8 @@ char * get_libname(const char* base_libname)
 		if (stat(base_libname, &st) == 0) {
 			if (st.st_size > 0) {
 				libname_path = xstrdup(base_libname);
-				upsdebugx(2, "Looking for lib %s, found by exact hit", base_libname);
+				upsdebugx(2, "Looking for lib %s, found by exact hit",
+					base_libname);
 				goto found;
 			}
 		}
@@ -3375,25 +3402,36 @@ char * get_libname(const char* base_libname)
 	/* Normally these envvars should not be set, but if the user insists,
 	 * we should prefer the override... */
 #ifdef BUILD_64
+	upsdebugx(4, "%s: Looking for lib %s by path-set LD_LIBRARY_PATH_64...",
+		__func__, base_libname);
 	libname_path = get_libname_in_pathset(base_libname, base_libname_length, getenv("LD_LIBRARY_PATH_64"), &counter);
 	if (libname_path != NULL) {
-		upsdebugx(2, "Looking for lib %s, found in LD_LIBRARY_PATH_64", base_libname);
+		upsdebugx(2, "Looking for lib %s, found in LD_LIBRARY_PATH_64",
+			base_libname);
 		goto found;
 	}
 #else
+	upsdebugx(4, "%s: Looking for lib %s by path-set LD_LIBRARY_PATH_32...",
+		__func__, base_libname);
 	libname_path = get_libname_in_pathset(base_libname, base_libname_length, getenv("LD_LIBRARY_PATH_32"), &counter);
 	if (libname_path != NULL) {
-		upsdebugx(2, "Looking for lib %s, found in LD_LIBRARY_PATH_32", base_libname);
+		upsdebugx(2, "Looking for lib %s, found in LD_LIBRARY_PATH_32",
+			base_libname);
 		goto found;
 	}
 #endif
 
+	upsdebugx(4, "%s: Looking for lib %s by path-set LD_LIBRARY_PATH...",
+		__func__, base_libname);
 	libname_path = get_libname_in_pathset(base_libname, base_libname_length, getenv("LD_LIBRARY_PATH"), &counter);
 	if (libname_path != NULL) {
-		upsdebugx(2, "Looking for lib %s, found in LD_LIBRARY_PATH", base_libname);
+		upsdebugx(2, "Looking for lib %s, found in LD_LIBRARY_PATH",
+			base_libname);
 		goto found;
 	}
 
+	upsdebugx(4, "%s: Looking for lib %s by search_paths[]...",
+		__func__, base_libname);
 	for (index = 0 ; (search_paths[index] != NULL) && (libname_path == NULL) ; index++)
 	{
 		libname_path = get_libname_in_dir(base_libname, base_libname_length, search_paths[index], counter++);
@@ -3408,17 +3446,23 @@ char * get_libname(const char* base_libname)
 	if (!libname_path) {
 		/* First check near the EXE (if executing it from another
 		 * working directory) */
+		upsdebugx(4, "%s: WIN32: Looking for lib %s near EXE...",
+			__func__, base_libname);
 		libname_path = get_libname_in_dir(base_libname, base_libname_length, getfullpath(NULL), counter++);
 	}
 
 # ifdef PATH_LIB
 	if (!libname_path) {
+		upsdebugx(4, "%s: WIN32: Looking for lib %s via PATH_LIB...",
+			__func__, base_libname);
 		libname_path = get_libname_in_dir(base_libname, base_libname_length, getfullpath(PATH_LIB), counter++);
 	}
 # endif
 
 	if (!libname_path) {
 		/* Resolve "lib" dir near the one with current executable ("bin" or "sbin") */
+		upsdebugx(4, "%s: WIN32: Looking for lib %s in a 'lib' dir near EXE...",
+			__func__, base_libname);
 		libname_path = get_libname_in_dir(base_libname, base_libname_length, getfullpath("/../lib"), counter++);
 	}
 #endif  /* WIN32 so far */
@@ -3427,13 +3471,15 @@ char * get_libname(const char* base_libname)
 	/* Windows-specific: DLLs can be provided by common "PATH" envvar,
 	 * at lowest search priority though (after EXE dir, system, etc.) */
 	if (!libname_path) {
-		upsdebugx(2, "Looking for lib %s in PATH", base_libname);
+		upsdebugx(4, "%s: WIN32: Looking for lib %s in PATH",
+			__func__, base_libname);
 		libname_path = get_libname_in_pathset(base_libname, base_libname_length, getenv("PATH"), &counter);
 	}
 #endif  /* WIN32 */
 
 found:
-	upsdebugx(1,"Looking for lib %s, found %s", base_libname, (libname_path!=NULL)?libname_path:"NULL");
+	upsdebugx(1, "Looking for lib %s, found %s",
+		base_libname, NUT_STRARG(libname_path));
 	return libname_path;
 }
 

--- a/configure.ac
+++ b/configure.ac
@@ -1475,11 +1475,12 @@ dnl For `nut-scanner -m auto` modes, see also:
 dnl https://stackoverflow.com/a/41151132/4715872
 dnl https://learn.microsoft.com/en-us/windows/win32/api/iphlpapi/nf-iphlpapi-getadaptersaddresses (since ~Windows Vista)
 dnl https://learn.microsoft.com/en-us/windows/win32/api/iphlpapi/nf-iphlpapi-getadaptersinfo (before Windows XP; not recommended later)
+dnl Must check in global context, to have it not-defined where appropriate too
+NUT_CHECK_HEADER_IPHLPAPI
 AC_CHECK_FUNCS([getifaddrs], [], [
     AS_CASE([${target_os}],
         [*mingw*], [
             dnl Check for GetAdaptersAddresses / GetAdaptersInfo
-            NUT_CHECK_HEADER_IPHLPAPI
             AS_IF([test x"${nut_cv_header_iphlpapi_h}" = xyes], [
 
                 myIPHLPAPI_TEST_HEADERS='

--- a/configure.ac
+++ b/configure.ac
@@ -4943,19 +4943,23 @@ dnl When building ON Windows (mingw/MSYS2, cygwin, etc.) fudge these
 dnl path strings back to what native OS methods would recognize.
 AS_CASE([${target_os}],
     [*mingw*], [
+        AC_MSG_NOTICE([Will try to resolve Windows paths to ABS_TOP_SRCDIR and ABS_TOP_BUILDDIR with cygpath or mingw/msys pwd -W tool (would fail if not a native build)])
+
         dnl Cygwin path resolver
         AC_CHECK_TOOL([CYGPATH], [cygpath], [none])
-        AS_IF([test "x${CYGPATH}" != "xnone"], [
+        AS_IF([test "x${CYGPATH}" != "xnone" && test x"`${CYGPATH}`" != x], [
             tmp="`${CYGPATH} -m "${ABS_TOP_BUILDDIR}" | sed -e 's,/,\\\\\\\\,g'`" && test -n "$tmp" && test -d "$tmp" && ABS_TOP_BUILDDIR="$tmp"
             tmp="`${CYGPATH} -m "${ABS_TOP_SRCDIR}" | sed 's,/,\\\\\\\\,g'`" && test -n "$tmp" && test -d "$tmp" && ABS_TOP_SRCDIR="$tmp"
         ],[
             dnl MSYS pwd with -W option to resolve
             AC_CHECK_TOOL([PWDTOOL], [pwd], [none])
-            AS_IF([test "x${PWDTOOL}" != "xnone"], [
+            AS_IF([test "x${PWDTOOL}" != "xnone" && test x"`${PWDTOOL} -W`" != x], [
                 tmp="`(cd "${ABS_TOP_BUILDDIR}" && ${PWDTOOL} -W) | sed 's,/,\\\\\\\\,g'`" && test -n "$tmp" && test -d "$tmp" && ABS_TOP_BUILDDIR="$tmp"
                 tmp="`(cd "${ABS_TOP_SRCDIR}" && ${PWDTOOL} -W) | sed 's,/,\\\\\\\\,g'`" && test -n "$tmp" && test -d "$tmp" && ABS_TOP_SRCDIR="$tmp"
             ])
         ])
+
+        AC_MSG_NOTICE([FWIW, assuming ABS_TOP_SRCDIR="$ABS_TOP_SRCDIR" and ABS_TOP_BUILDDIR="$ABS_TOP_BUILDDIR"])
 ])
 
 dnl Use these at best for tests (e.g. nutconf), not production code:

--- a/configure.ac
+++ b/configure.ac
@@ -4950,10 +4950,10 @@ AS_CASE([${target_os}],
             tmp="`${CYGPATH} -m "${ABS_TOP_SRCDIR}" | sed 's,/,\\\\\\\\,g'`" && test -n "$tmp" && test -d "$tmp" && ABS_TOP_SRCDIR="$tmp"
         ],[
             dnl MSYS pwd with -W option to resolve
-            AC_CHECK_TOOL([PWD], [pwd], [none])
-            AS_IF([test "x${PWD}" != "xnone"], [
-                tmp="`(cd "${ABS_TOP_BUILDDIR}" && ${PWD} -W) | sed 's,/,\\\\\\\\,g'`" && test -n "$tmp" && test -d "$tmp" && ABS_TOP_BUILDDIR="$tmp"
-                tmp="`(cd "${ABS_TOP_SRCDIR}" && ${PWD} -W) | sed 's,/,\\\\\\\\,g'`" && test -n "$tmp" && test -d "$tmp" && ABS_TOP_SRCDIR="$tmp"
+            AC_CHECK_TOOL([PWDTOOL], [pwd], [none])
+            AS_IF([test "x${PWDTOOL}" != "xnone"], [
+                tmp="`(cd "${ABS_TOP_BUILDDIR}" && ${PWDTOOL} -W) | sed 's,/,\\\\\\\\,g'`" && test -n "$tmp" && test -d "$tmp" && ABS_TOP_BUILDDIR="$tmp"
+                tmp="`(cd "${ABS_TOP_SRCDIR}" && ${PWDTOOL} -W) | sed 's,/,\\\\\\\\,g'`" && test -n "$tmp" && test -d "$tmp" && ABS_TOP_SRCDIR="$tmp"
             ])
         ])
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -1470,6 +1470,140 @@ AS_IF([test x"${ac_cv_struct_pollfd}" = xyes],
     ]
     )
 
+NETLIBS_GETADDRS=""
+dnl For `nut-scanner -m auto` modes, see also:
+dnl https://stackoverflow.com/a/41151132/4715872
+dnl https://learn.microsoft.com/en-us/windows/win32/api/iphlpapi/nf-iphlpapi-getadaptersaddresses (since ~Windows Vista)
+dnl https://learn.microsoft.com/en-us/windows/win32/api/iphlpapi/nf-iphlpapi-getadaptersinfo (before Windows XP; not recommended later)
+AC_CHECK_FUNCS([getifaddrs], [], [
+    AS_CASE([${target_os}],
+        [*mingw*], [
+            dnl Check for GetAdaptersAddresses / GetAdaptersInfo
+            NUT_CHECK_HEADER_IPHLPAPI
+            AS_IF([test x"${nut_cv_header_iphlpapi_h}" = xyes], [
+
+                myIPHLPAPI_TEST_HEADERS='
+#if HAVE_WINDOWS_H
+# undef inline
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
+# include <windows.h>
+# if HAVE_WINSOCK2_H
+#  include <winsock2.h>
+# endif
+# if HAVE_IPHLPAPI_H
+#  include <iphlpapi.h>
+# endif
+#endif
+#include <stdio.h>
+'
+
+                myIPHLPAPI_TEST_GAA='
+/* ULONG GetAdaptersAddresses(ULONG af, ULONG flags, void* rsvd, PIP_ADAPTER_ADDRESSES addrs, PULONG sizeptr); */
+IP_ADAPTER_ADDRESSES buf@<:@8@:>@;
+ULONG bufsz = sizeof(buf);
+printf("%ld ", GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_SKIP_MULTICAST, NULL, buf, &bufsz));
+printf("%ld ", GetAdaptersAddresses(AF_INET, GAA_FLAG_SKIP_DNS_SERVER, NULL, buf, &bufsz));
+printf("%ld ", GetAdaptersAddresses(AF_INET6, GAA_FLAG_SKIP_ANYCAST, NULL, buf, &bufsz))
+/* autoconf adds ";return 0;" */
+'
+
+                AC_CACHE_CHECK([for GetAdaptersAddresses() with IPv4 and IPv6 support],
+                    [ac_cv_func_GetAdaptersAddresses],
+                    [AC_LANG_PUSH([C])
+                    dnl e.g. add "-lws2_32" for mingw builds, maybe "-liphlpapi"
+                    dnl the NETLIBS are set by NUT_CHECK_SOCKETLIB above
+                    SAVED_LIBS="$LIBS"
+                    LIBS="$LIBS $NETLIBS"
+                    AX_RUN_OR_LINK_IFELSE(
+                        [AC_LANG_PROGRAM(
+                            [${myIPHLPAPI_TEST_HEADERS}],
+                            [${myIPHLPAPI_TEST_GAA}])],
+                        [ac_cv_func_GetAdaptersAddresses=yes
+                        ], [
+                            NETLIBS_GETADDRS="-liphlpapi"
+                            LIBS="$LIBS $NETLIBS $NETLIBS_GETADDRS"
+                            AX_RUN_OR_LINK_IFELSE(
+                                [AC_LANG_PROGRAM(
+                                    [${myIPHLPAPI_TEST_HEADERS}],
+                                    [${myIPHLPAPI_TEST_GAA}])],
+                                [
+                                    ac_cv_func_GetAdaptersAddresses=yes
+                                ], [
+                                    ac_cv_func_GetAdaptersAddresses=no
+                                    NETLIBS_GETADDRS=""
+                                ]
+                            )
+                        ]
+                    )
+                    AC_LANG_POP([C])
+                    LIBS="$SAVED_LIBS"
+                ])
+                AS_IF([test x"${ac_cv_func_GetAdaptersAddresses}" = xyes],
+                    [AC_DEFINE([HAVE_GETADAPTERSADDRESSES], 1, [defined if system has the GetAdaptersAddresses() method])],
+                    [dnl AC_MSG_WARN([WIN32 library routine GetAdaptersAddresses() not found])
+                     AS_CASE([${target_os}],
+                         [*mingw*], [AC_MSG_WARN([Windows antivirus might block this test])]
+                         )
+                    ]
+                    )
+
+                myIPHLPAPI_TEST_GAI='
+/* ULONG GetAdaptersInfo(PIP_ADAPTER_INFO addrs, PULONG sizeptr); */
+IP_ADAPTER_INFO buf@<:@8@:>@;
+ULONG bufsz = sizeof(buf);
+printf("%ld ", GetAdaptersInfo(buf, &bufsz))
+/* autoconf adds ";return 0;" */
+'
+
+                AC_CACHE_CHECK([for GetAdaptersInfo() with IPv4 only support],
+                    [ac_cv_func_GetAdaptersInfo],
+                    [AC_LANG_PUSH([C])
+                    dnl e.g. add "-lws2_32" for mingw builds
+                    dnl the NETLIBS are set by NUT_CHECK_SOCKETLIB above
+                    SAVED_LIBS="$LIBS"
+                    LIBS="$LIBS $NETLIBS $NETLIBS_GETADDRS"
+                    AX_RUN_OR_LINK_IFELSE(
+                        [AC_LANG_PROGRAM(
+                            [${myIPHLPAPI_TEST_HEADERS}],
+                            [${myIPHLPAPI_TEST_GAI}])],
+                        [ac_cv_func_GetAdaptersInfo=yes
+                        ], [
+                            NETLIBS_GETADDRS="-liphlpapi"
+                            LIBS="$LIBS $NETLIBS $NETLIBS_GETADDRS"
+                            AX_RUN_OR_LINK_IFELSE(
+                                [AC_LANG_PROGRAM(
+                                    [${myIPHLPAPI_TEST_HEADERS}],
+                                    [${myIPHLPAPI_TEST_GAI}])],
+                                [
+                                    ac_cv_func_GetAdaptersInfo=yes
+                                ], [
+                                    ac_cv_func_GetAdaptersInfo=no
+                                    NETLIBS_GETADDRS=""
+                                ]
+                            )
+                        ]
+                    )
+                    AC_LANG_POP([C])
+                    LIBS="$SAVED_LIBS"
+                ])
+                AS_IF([test x"${ac_cv_func_GetAdaptersInfo}" = xyes],
+                    [AC_DEFINE([HAVE_GETADAPTERSINFO], 1, [defined if system has the GetAdaptersInfo() method])],
+                    [dnl AC_MSG_WARN([WIN32 library routine GetAdaptersInfo() not found])
+                     AS_CASE([${target_os}],
+                         [*mingw*], [AC_MSG_WARN([Windows antivirus might block this test])]
+                         )
+                    ]
+                    )
+
+            ])
+            ]
+    )]
+)
+AC_SUBST([NETLIBS_GETADDRS])
+
+
 dnl ----------------------------------------------------------------------
 dnl Check for Python binary program names per language version
 dnl to embed into scripts and Make rules

--- a/m4/nut_check_headers_windows.m4
+++ b/m4/nut_check_headers_windows.m4
@@ -208,3 +208,41 @@ AC_DEFUN([NUT_CHECK_HEADER_WS2TCPIP], [
   esac
   AM_CONDITIONAL(HAVE_WS2TCPIP_H, test "x$nut_cv_header_ws2tcpip_h" = xyes)
 ])
+
+dnl NUT_CHECK_HEADER_IPHLPAPI
+dnl -------------------------------------------------
+dnl Check for compilable and valid iphlpapi.h header
+
+AC_DEFUN([NUT_CHECK_HEADER_IPHLPAPI], [
+  AC_REQUIRE([NUT_CHECK_HEADER_WINSOCK2])dnl
+  AC_CACHE_CHECK([for iphlpapi.h], [nut_cv_header_iphlpapi_h], [
+    AC_LANG_PUSH([C])
+    AC_COMPILE_IFELSE([
+      AC_LANG_PROGRAM([[
+#undef inline
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#include <winsock2.h>
+#include <iphlpapi.h>
+      ]],[[
+        PIP_ADAPTER_ADDRESSES pAddresses = NULL;
+        IP_ADAPTER_PREFIX *pPrefix = NULL;
+        PIP_ADAPTER_INFO pAdapter = NULL;
+      ]])
+    ],[
+      nut_cv_header_iphlpapi_h="yes"
+    ],[
+      nut_cv_header_iphlpapi_h="no"
+    ])
+    AC_LANG_POP([C])
+  ])
+  AS_CASE([$nut_cv_header_iphlpapi_h],
+    [yes], [
+      AC_DEFINE_UNQUOTED(HAVE_IPHLPAPI_H, 1,
+        [Define to 1 if you have the iphlpapi.h header file.])
+      ]
+  )
+  AM_CONDITIONAL(HAVE_IPHLPAPI_H, test "x$nut_cv_header_iphlpapi_h" = xyes)
+])

--- a/tools/nut-scanner/Makefile.am
+++ b/tools/nut-scanner/Makefile.am
@@ -75,6 +75,8 @@ if HAVE_WINDOWS
   libnutscan_la_LIBADD += $(top_builddir)/common/libnutwincompat.la
   libnutscan_la_LDFLAGS += -no-undefined
 endif HAVE_WINDOWS
+# Technically, we might only have this one set on Windows so far...
+libnutscan_la_LDFLAGS += @NETLIBS_GETADDRS@
 
 #
 # Below we set API versions of public libraries

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -671,6 +671,13 @@ static void handle_arg_cidr(const char *arg_addr, int *auto_nets_ptr)
 					memcpy (&sa, ifa->ifa_addr, sizeof(struct sockaddr_in6));
 					memcpy (&sm, ifa->ifa_netmask, sizeof(struct sockaddr_in6));
 
+					/* FIXME: Here and below, this code
+					 * technically just counts set bits
+					 * and we assume they are a single
+					 * contiguous range in the address
+					 * portion of the IP address for a
+					 * netmask.
+					 */
 					masklen_subnet = 0;
 					for (j = 0; j < 16; j++) {
 						i = sm.sin6_addr.s6_addr[j];

--- a/tools/nut-scanner/nutscan-init.c
+++ b/tools/nut-scanner/nutscan-init.c
@@ -37,6 +37,9 @@
 #include "nut_platform.h"
 
 #ifdef WIN32
+# if defined HAVE_WINSOCK2_H && HAVE_WINSOCK2_H
+#  include <winsock2.h>
+# endif
 # define SOEXT ".dll"
 #else
 # ifdef NUT_PLATFORM_APPLE_OSX
@@ -119,6 +122,13 @@ void do_upsconf_args(char *confupsname, char *var, char *val) {
 void nutscan_init(void)
 {
 	char *libname = NULL;
+
+#ifdef WIN32
+	/* Required ritual before calling any socket functions */
+	WSADATA WSAdata;
+	WSAStartup(2,&WSAdata);
+	atexit((void(*)(void))WSACleanup);
+#endif
 
 	/* Optional filter to not walk things twice */
 	nut_prepare_search_paths();
@@ -567,7 +577,6 @@ void nutscan_init(void)
 /* start of "NUT Simulation" - unconditional */
 /* no need for additional library */
 	nutscan_avail_nut_simulation = 1;
-
 }
 
 void nutscan_free(void)

--- a/tools/nut-scanner/nutscan-ip.c
+++ b/tools/nut-scanner/nutscan-ip.c
@@ -504,9 +504,6 @@ int nutscan_cidr_to_ip(const char * cidr, char ** start_ip, char ** stop_ip)
 
 	*start_ip = NULL;
 	*stop_ip = NULL;
-#ifdef WIN32
-        WSADATA WSAdata;
-#endif
 
 	cidr_tok = strdup(cidr);
 	first_ip = strdup(strtok_r(cidr_tok, "/", &saveptr));
@@ -549,11 +546,6 @@ int nutscan_cidr_to_ip(const char * cidr, char ** start_ip, char ** stop_ip)
 	hints.ai_family = AF_INET;
 
 	ip.type = IPv4;
-
-#ifdef WIN32
-        WSAStartup(2,&WSAdata);
-        atexit((void(*)(void))WSACleanup);
-#endif
 
 	if ((ret = getaddrinfo(first_ip, NULL, &hints, &res)) != 0) {
 		/* EAI_ADDRFAMILY? */

--- a/tools/nut-scanner/scan_nut.c
+++ b/tools/nut-scanner/scan_nut.c
@@ -265,11 +265,6 @@ nutscan_device_t * nutscan_scan_ip_range_nut(nutscan_ip_range_list_t * irl, cons
 	int change_action_handler = 0;
 #endif
 	struct scan_nut_arg *nut_arg;
-#ifdef WIN32
-	WSADATA WSAdata;
-	WSAStartup(2,&WSAdata);
-	atexit((void(*)(void))WSACleanup);
-#endif
 
 #ifdef HAVE_PTHREAD
 # ifdef HAVE_SEMAPHORE

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -1054,12 +1054,6 @@ nutscan_device_t * nutscan_scan_ip_range_snmp(nutscan_ip_range_list_t * irl,
 	sem_t * semaphore_scantype = &semaphore_scantype_inst;
 # endif /* HAVE_SEMAPHORE */
 
-# ifdef WIN32
-	WSADATA WSAdata;
-	WSAStartup(2,&WSAdata);
-	atexit((void(*)(void))WSACleanup);
-# endif
-
 	pthread_t thread;
 	nutscan_thread_t * thread_array = NULL;
 	size_t thread_count = 0, i;

--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -200,16 +200,8 @@ static void * nutscan_scan_xml_http_generic(void * arg)
 	ssize_t recv_size;
 	int i;
 	nutscan_device_t * nut_dev = NULL;
-#ifdef WIN32
-	WSADATA WSAdata;
-#endif
 
 	memset(&sockAddress_udp, 0, sizeof(sockAddress_udp));
-
-#ifdef WIN32
-	WSAStartup(2,&WSAdata);
-	atexit((void(*)(void))WSACleanup);
-#endif
 
 	if (sec != NULL) {
 /*		if (sec->port_http > 0 && sec->port_http <= 65534)


### PR DESCRIPTION
Found two ways to skin the cat. Apparently on older systems (~Vista and before) some structures may be different, something someone would address if encountered.

Checked both APIs in WSL builds, but had problems actually connecting to a NUT data server on another system (when calling NUT programs from WSL and having Windows intercept them to execute). The `upsc.exe` also had such problems; so maybe firewall.

Same binaries executed straight from Windows did walk the data server and discover its devices:
````
C:\Temp\nut_install\bin>./nut-scanner.exe -m auto
Scanning NUT bus (old libupsclient connect method).
Scanning NUT simulation devices.
Failed to open //etc, skip NUT simulation scan
[nutdev-nut1]
        driver = "dummy-ups"
        port = "dummy@xxx.yyy.zzz.99"
[nutdev-nut2]
        driver = "dummy-ups"
        port = "eco650@xxx.yyy.zzz.99"
````

Closes: #2516