### PR TITLE
Assorted codebase cleanup while preparing work for issue #2523

### DIFF
--- a/UPGRADING.adoc
+++ b/UPGRADING.adoc
@@ -43,8 +43,8 @@ Changes from 2.8.2 to 2.8.3
 
 - Numerous changes to `nut-scanner` and symbols that its `libnutscan.so`
   delivers have caused a library version bump.  New methods have been added
-  and one structure (`nutscan_ipmi_t`) updated in a (hopefully) backwards
-  compatible manner. [PR #2523, issue #2244 and numerous PRs for it]
+  in a (hopefully) backwards compatible manner. [issue #2244 and numerous
+  PRs for it]
 
 - Internal API change for `sendsignalpid()` and `sendsignalfn()` methods,
   which can impact NUT forks which build using `libcommon.la` and similar

--- a/UPGRADING.adoc
+++ b/UPGRADING.adoc
@@ -41,6 +41,11 @@ Changes from 2.8.2 to 2.8.3
   symlinks). Packaging recipes can likely be simplified now: some distros
   certainly did patch NUT source to similar effect). [#2431]
 
+- Numerous changes to `nut-scanner` and symbols that its `libnutscan.so`
+  delivers have caused a library version bump.  New methods have been added
+  and one structure (`nutscan_ipmi_t`) updated in a (hopefully) backwards
+  compatible manner. [PR #2523, issue #2244 and numerous PRs for it]
+
 - Internal API change for `sendsignalpid()` and `sendsignalfn()` methods,
   which can impact NUT forks which build using `libcommon.la` and similar
   libraries.  Added new last argument with `const char *progname` (may be

--- a/clients/upsclient.h
+++ b/clients/upsclient.h
@@ -54,7 +54,7 @@
 #endif
 
 #if defined HAVE_SYS_TYPES_H
-  #include <sys/types.h>
+# include <sys/types.h>
 #endif
 
 #ifdef __cplusplus

--- a/drivers/nut-libfreeipmi.c
+++ b/drivers/nut-libfreeipmi.c
@@ -48,7 +48,7 @@
 #include <freeipmi/freeipmi.h>
 #include <ipmi_monitoring.h>
 #if HAVE_FREEIPMI_MONITORING
-#include <ipmi_monitoring_bitmasks.h>
+# include <ipmi_monitoring_bitmasks.h>
 #endif
 #include "nut-ipmi.h"
 #include "nut_stdint.h"
@@ -69,41 +69,41 @@ static ipmi_monitoring_ctx_t mon_ctx = NULL;
 #ifdef HAVE_FREEIPMI_11X_12X
   static ipmi_sdr_ctx_t sdr_ctx = NULL;
   static ipmi_fru_ctx_t fru_ctx = NULL;
-  #define SDR_PARSE_CTX sdr_ctx
-  #define NUT_IPMI_SDR_CACHE_DEFAULTS                              IPMI_SDR_CACHE_CREATE_FLAGS_DEFAULT
+#  define SDR_PARSE_CTX sdr_ctx
+#  define NUT_IPMI_SDR_CACHE_DEFAULTS                              IPMI_SDR_CACHE_CREATE_FLAGS_DEFAULT
 #else
   static ipmi_sdr_cache_ctx_t sdr_ctx = NULL;
   static ipmi_sdr_parse_ctx_t sdr_parse_ctx = NULL;
-  #define SDR_PARSE_CTX sdr_parse_ctx
+#  define SDR_PARSE_CTX sdr_parse_ctx
   static ipmi_fru_parse_ctx_t fru_ctx = NULL;
   /* Functions remapping */
-  #define ipmi_sdr_ctx_create                           ipmi_sdr_cache_ctx_create
-  #define ipmi_sdr_ctx_destroy                          ipmi_sdr_cache_ctx_destroy
-  #define ipmi_sdr_ctx_errnum                           ipmi_sdr_cache_ctx_errnum
-  #define ipmi_sdr_ctx_errormsg                         ipmi_sdr_cache_ctx_errormsg
-  #define ipmi_fru_ctx_create                           ipmi_fru_parse_ctx_create
-  #define ipmi_fru_ctx_destroy                          ipmi_fru_parse_ctx_destroy
-  #define ipmi_fru_ctx_set_flags                        ipmi_fru_parse_ctx_set_flags
-  #define ipmi_fru_ctx_strerror                         ipmi_fru_parse_ctx_strerror
-  #define ipmi_fru_ctx_errnum                           ipmi_fru_parse_ctx_errnum
-  #define ipmi_fru_open_device_id                       ipmi_fru_parse_open_device_id
-  #define ipmi_fru_close_device_id                      ipmi_fru_parse_close_device_id
-  #define ipmi_fru_ctx_errormsg                         ipmi_fru_parse_ctx_errormsg
-  #define ipmi_fru_read_data_area                       ipmi_fru_parse_read_data_area
-  #define ipmi_fru_next                                 ipmi_fru_parse_next
-  #define ipmi_fru_type_length_field_to_string          ipmi_fru_parse_type_length_field_to_string
-  #define ipmi_fru_multirecord_power_supply_information ipmi_fru_parse_multirecord_power_supply_information
-  #define ipmi_fru_board_info_area                      ipmi_fru_parse_board_info_area
-  #define ipmi_fru_field_t                              ipmi_fru_parse_field_t
+#  define ipmi_sdr_ctx_create                           ipmi_sdr_cache_ctx_create
+#  define ipmi_sdr_ctx_destroy                          ipmi_sdr_cache_ctx_destroy
+#  define ipmi_sdr_ctx_errnum                           ipmi_sdr_cache_ctx_errnum
+#  define ipmi_sdr_ctx_errormsg                         ipmi_sdr_cache_ctx_errormsg
+#  define ipmi_fru_ctx_create                           ipmi_fru_parse_ctx_create
+#  define ipmi_fru_ctx_destroy                          ipmi_fru_parse_ctx_destroy
+#  define ipmi_fru_ctx_set_flags                        ipmi_fru_parse_ctx_set_flags
+#  define ipmi_fru_ctx_strerror                         ipmi_fru_parse_ctx_strerror
+#  define ipmi_fru_ctx_errnum                           ipmi_fru_parse_ctx_errnum
+#  define ipmi_fru_open_device_id                       ipmi_fru_parse_open_device_id
+#  define ipmi_fru_close_device_id                      ipmi_fru_parse_close_device_id
+#  define ipmi_fru_ctx_errormsg                         ipmi_fru_parse_ctx_errormsg
+#  define ipmi_fru_read_data_area                       ipmi_fru_parse_read_data_area
+#  define ipmi_fru_next                                 ipmi_fru_parse_next
+#  define ipmi_fru_type_length_field_to_string          ipmi_fru_parse_type_length_field_to_string
+#  define ipmi_fru_multirecord_power_supply_information ipmi_fru_parse_multirecord_power_supply_information
+#  define ipmi_fru_board_info_area                      ipmi_fru_parse_board_info_area
+#  define ipmi_fru_field_t                              ipmi_fru_parse_field_t
   /* Constants */
-  #define IPMI_SDR_MAX_RECORD_LENGTH                               IPMI_SDR_CACHE_MAX_SDR_RECORD_LENGTH
-  #define IPMI_SDR_ERR_CACHE_READ_CACHE_DOES_NOT_EXIST             IPMI_SDR_CACHE_ERR_CACHE_READ_CACHE_DOES_NOT_EXIST
-  #define IPMI_FRU_AREA_SIZE_MAX                                   IPMI_FRU_PARSE_AREA_SIZE_MAX
-  #define IPMI_FRU_FLAGS_SKIP_CHECKSUM_CHECKS                      IPMI_FRU_PARSE_FLAGS_SKIP_CHECKSUM_CHECKS
-  #define IPMI_FRU_AREA_TYPE_BOARD_INFO_AREA                       IPMI_FRU_PARSE_AREA_TYPE_BOARD_INFO_AREA
-  #define IPMI_FRU_AREA_TYPE_MULTIRECORD_POWER_SUPPLY_INFORMATION  IPMI_FRU_PARSE_AREA_TYPE_MULTIRECORD_POWER_SUPPLY_INFORMATION
-  #define IPMI_FRU_AREA_STRING_MAX                                 IPMI_FRU_PARSE_AREA_STRING_MAX
-  #define NUT_IPMI_SDR_CACHE_DEFAULTS                              IPMI_SDR_CACHE_CREATE_FLAGS_DEFAULT, IPMI_SDR_CACHE_VALIDATION_FLAGS_DEFAULT
+#  define IPMI_SDR_MAX_RECORD_LENGTH                               IPMI_SDR_CACHE_MAX_SDR_RECORD_LENGTH
+#  define IPMI_SDR_ERR_CACHE_READ_CACHE_DOES_NOT_EXIST             IPMI_SDR_CACHE_ERR_CACHE_READ_CACHE_DOES_NOT_EXIST
+#  define IPMI_FRU_AREA_SIZE_MAX                                   IPMI_FRU_PARSE_AREA_SIZE_MAX
+#  define IPMI_FRU_FLAGS_SKIP_CHECKSUM_CHECKS                      IPMI_FRU_PARSE_FLAGS_SKIP_CHECKSUM_CHECKS
+#  define IPMI_FRU_AREA_TYPE_BOARD_INFO_AREA                       IPMI_FRU_PARSE_AREA_TYPE_BOARD_INFO_AREA
+#  define IPMI_FRU_AREA_TYPE_MULTIRECORD_POWER_SUPPLY_INFORMATION  IPMI_FRU_PARSE_AREA_TYPE_MULTIRECORD_POWER_SUPPLY_INFORMATION
+#  define IPMI_FRU_AREA_STRING_MAX                                 IPMI_FRU_PARSE_AREA_STRING_MAX
+#  define NUT_IPMI_SDR_CACHE_DEFAULTS                              IPMI_SDR_CACHE_CREATE_FLAGS_DEFAULT, IPMI_SDR_CACHE_VALIDATION_FLAGS_DEFAULT
 #endif /* HAVE_FREEIPMI_11X_12X */
 
 /* FIXME: freeipmi auto selects a cache based on the hostname you are

--- a/drivers/nut-libfreeipmi.c
+++ b/drivers/nut-libfreeipmi.c
@@ -310,22 +310,23 @@ static const char* libfreeipmi_getfield (uint8_t language_code,
 	if (strbuflen)
 		return strbuf;
 
-  return NULL;
+	return NULL;
 }
 
 /* Get voltage value from the IPMI voltage code */
 static float libfreeipmi_get_voltage (uint8_t voltage_code)
 {
-  if (voltage_code == IPMI_FRU_VOLTAGE_12V)
-    return 12;
-  else if (voltage_code == IPMI_FRU_VOLTAGE_MINUS12V)
-    return -12;
-  else if (voltage_code == IPMI_FRU_VOLTAGE_5V)
-    return 5;
-  else if (voltage_code == IPMI_FRU_VOLTAGE_3_3V)
-    return 3.3;
-  else
-    return 0;
+	/* FIXME: switch/case? */
+	if (voltage_code == IPMI_FRU_VOLTAGE_12V)
+		return 12;
+	else if (voltage_code == IPMI_FRU_VOLTAGE_MINUS12V)
+		return -12;
+	else if (voltage_code == IPMI_FRU_VOLTAGE_5V)
+		return 5;
+	else if (voltage_code == IPMI_FRU_VOLTAGE_3_3V)
+		return 3.3;
+	else
+		return 0;
 }
 
 /* Cleanup IPMI contexts */

--- a/drivers/usb-common.c
+++ b/drivers/usb-common.c
@@ -100,13 +100,13 @@ static int match_function_exact(USBDevice_t *hd, void *privdata)
 	}
 #endif
 #if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
-  #ifdef DEBUG_EXACT_MATCH_BUSPORT
+# ifdef DEBUG_EXACT_MATCH_BUSPORT
 	if (strcmp_null(hd->BusPort, data->BusPort) != 0) {
 		upsdebugx(2, "%s: failed match of %s: %s != %s",
 		    __func__, "BusPort", hd->BusPort, data->BusPort);
 		return 0;
 	}
-  #endif
+# endif
 #endif
 #ifdef DEBUG_EXACT_MATCH_DEVICE
 	if (strcmp_null(hd->Device, data->Device) != 0) {

--- a/drivers/usb-common.h
+++ b/drivers/usb-common.h
@@ -113,79 +113,79 @@
  * any use-case.
  */
  typedef uint8_t usb_ctrl_requesttype;
- #define USB_CTRL_REQUESTTYPE_MIN	0
- #define USB_CTRL_REQUESTTYPE_MAX	UINT8_MAX
+# define USB_CTRL_REQUESTTYPE_MIN	0
+# define USB_CTRL_REQUESTTYPE_MAX	UINT8_MAX
 
  typedef uint8_t usb_ctrl_request;
- #define USB_CTRL_REQUEST_MIN	0
- #define USB_CTRL_REQUEST_MAX	UINT8_MAX
+# define USB_CTRL_REQUEST_MIN	0
+# define USB_CTRL_REQUEST_MAX	UINT8_MAX
 
  typedef unsigned char usb_ctrl_endpoint;
- #define USB_CTRL_ENDPOINT_MIN	0
- #define USB_CTRL_ENDPOINT_MAX	UCHAR_MAX
+# define USB_CTRL_ENDPOINT_MIN	0
+# define USB_CTRL_ENDPOINT_MAX	UCHAR_MAX
 
  typedef uint16_t usb_ctrl_msgvalue;
- #define USB_CTRL_MSGVALUE_MIN	0
- #define USB_CTRL_MSGVALUE_MAX	UINT16_MAX
+# define USB_CTRL_MSGVALUE_MIN	0
+# define USB_CTRL_MSGVALUE_MAX	UINT16_MAX
 
  typedef uint8_t usb_ctrl_cfgindex;
- #define USB_CTRL_CFGINDEX_MIN	0
- #define USB_CTRL_CFGINDEX_MAX	UINT8_MAX
+# define USB_CTRL_CFGINDEX_MIN	0
+# define USB_CTRL_CFGINDEX_MAX	UINT8_MAX
 
  typedef uint16_t usb_ctrl_repindex;
- #define USB_CTRL_REPINDEX_MIN	0
- #define USB_CTRL_REPINDEX_MAX	UINT16_MAX
+# define USB_CTRL_REPINDEX_MIN	0
+# define USB_CTRL_REPINDEX_MAX	UINT16_MAX
 
  typedef uint8_t usb_ctrl_strindex;
- #define USB_CTRL_STRINDEX_MIN	0
- #define USB_CTRL_STRINDEX_MAX	UINT8_MAX
+# define USB_CTRL_STRINDEX_MIN	0
+# define USB_CTRL_STRINDEX_MAX	UINT8_MAX
 
  typedef uint8_t usb_ctrl_descindex;
- #define USB_CTRL_DESCINDEX_MIN	0
- #define USB_CTRL_DESCINDEX_MAX	UINT8_MAX
+# define USB_CTRL_DESCINDEX_MIN	0
+# define USB_CTRL_DESCINDEX_MAX	UINT8_MAX
 
  typedef unsigned char* usb_ctrl_charbuf;
  typedef unsigned char usb_ctrl_char;
- #define USB_CTRL_CHAR_MIN	0
- #define USB_CTRL_CHAR_MAX	UCHAR_MAX
+# define USB_CTRL_CHAR_MIN	0
+# define USB_CTRL_CHAR_MAX	UCHAR_MAX
 
  /* Here MIN/MAX should not matter much, type mostly used for casting */
  typedef uint16_t usb_ctrl_charbufsize;
- #define USB_CTRL_CHARBUFSIZE_MIN	0
- #define USB_CTRL_CHARBUFSIZE_MAX	UINT16_MAX
- #define PRI_NUT_USB_CTRL_CHARBUFSIZE PRIu16
+# define USB_CTRL_CHARBUFSIZE_MIN	0
+# define USB_CTRL_CHARBUFSIZE_MAX	UINT16_MAX
+# define PRI_NUT_USB_CTRL_CHARBUFSIZE PRIu16
 
  typedef unsigned int usb_ctrl_timeout_msec;	/* in milliseconds */
 	/* Note: there does not seem to be a standard type
 	 * for milliseconds, like there is an useconds_t */
- #define USB_CTRL_TIMEOUTMSEC_MIN	0
- #define USB_CTRL_TIMEOUTMSEC_MAX	UINT_MAX
+# define USB_CTRL_TIMEOUTMSEC_MIN	0
+# define USB_CTRL_TIMEOUTMSEC_MAX	UINT_MAX
 
  /* defines */
- #define USB_CLASS_PER_INTERFACE	LIBUSB_CLASS_PER_INTERFACE
- #define USB_DT_STRING				LIBUSB_DT_STRING
- #define USB_ENDPOINT_IN			LIBUSB_ENDPOINT_IN
- #define USB_ENDPOINT_OUT			LIBUSB_ENDPOINT_OUT
- #define USB_RECIP_ENDPOINT			LIBUSB_RECIPIENT_ENDPOINT
- #define USB_RECIP_INTERFACE		LIBUSB_RECIPIENT_INTERFACE
- #define USB_REQ_SET_DESCRIPTOR		LIBUSB_REQUEST_SET_DESCRIPTOR
- #define USB_TYPE_CLASS				LIBUSB_REQUEST_TYPE_CLASS
- #define USB_TYPE_VENDOR			LIBUSB_REQUEST_TYPE_VENDOR
+# define USB_CLASS_PER_INTERFACE	LIBUSB_CLASS_PER_INTERFACE
+# define USB_DT_STRING				LIBUSB_DT_STRING
+# define USB_ENDPOINT_IN			LIBUSB_ENDPOINT_IN
+# define USB_ENDPOINT_OUT			LIBUSB_ENDPOINT_OUT
+# define USB_RECIP_ENDPOINT			LIBUSB_RECIPIENT_ENDPOINT
+# define USB_RECIP_INTERFACE		LIBUSB_RECIPIENT_INTERFACE
+# define USB_REQ_SET_DESCRIPTOR		LIBUSB_REQUEST_SET_DESCRIPTOR
+# define USB_TYPE_CLASS				LIBUSB_REQUEST_TYPE_CLASS
+# define USB_TYPE_VENDOR			LIBUSB_REQUEST_TYPE_VENDOR
 
 /* Codebase updated to use LIBUSB_* tokens:
- #define ERROR_ACCESS		LIBUSB_ERROR_ACCESS
- #define ERROR_BUSY			LIBUSB_ERROR_BUSY
- #define ERROR_IO			LIBUSB_ERROR_IO
- #define ERROR_NO_DEVICE	LIBUSB_ERROR_NO_DEVICE
- #define ERROR_NOT_FOUND	LIBUSB_ERROR_NOT_FOUND
- #define ERROR_OVERFLOW		LIBUSB_ERROR_OVERFLOW
- #define ERROR_PIPE			LIBUSB_ERROR_PIPE
- #define ERROR_TIMEOUT		LIBUSB_ERROR_TIMEOUT
- #define ERROR_NO_MEM   LIBUSB_ERROR_NO_MEM
- #define ERROR_INVALID_PARAM  LIBUSB_ERROR_INVALID_PARAM
- #define ERROR_INTERRUPTED    LIBUSB_ERROR_INTERRUPTED
- #define ERROR_NOT_SUPPORTED  LIBUSB_ERROR_NOT_SUPPORTED
- #define ERROR_OTHER          LIBUSB_ERROR_OTHER
+# define ERROR_ACCESS		LIBUSB_ERROR_ACCESS
+# define ERROR_BUSY			LIBUSB_ERROR_BUSY
+# define ERROR_IO			LIBUSB_ERROR_IO
+# define ERROR_NO_DEVICE	LIBUSB_ERROR_NO_DEVICE
+# define ERROR_NOT_FOUND	LIBUSB_ERROR_NOT_FOUND
+# define ERROR_OVERFLOW		LIBUSB_ERROR_OVERFLOW
+# define ERROR_PIPE			LIBUSB_ERROR_PIPE
+# define ERROR_TIMEOUT		LIBUSB_ERROR_TIMEOUT
+# define ERROR_NO_MEM   LIBUSB_ERROR_NO_MEM
+# define ERROR_INVALID_PARAM  LIBUSB_ERROR_INVALID_PARAM
+# define ERROR_INTERRUPTED    LIBUSB_ERROR_INTERRUPTED
+# define ERROR_NOT_SUPPORTED  LIBUSB_ERROR_NOT_SUPPORTED
+# define ERROR_OTHER          LIBUSB_ERROR_OTHER
 */
 
  /* Functions, including range-checks to convert data types of the two APIs.
@@ -373,16 +373,16 @@
 #endif
 
  /* Functions for which simple mappings seem to suffice (no build warnings emitted): */
- #define usb_claim_interface	libusb_claim_interface
- #define usb_clear_halt			libusb_clear_halt
- #define usb_close				libusb_close
- #define usb_set_configuration	libusb_set_configuration
- #define usb_release_interface	libusb_release_interface
- #define usb_reset				libusb_reset_device
+# define usb_claim_interface	libusb_claim_interface
+# define usb_clear_halt			libusb_clear_halt
+# define usb_close				libusb_close
+# define usb_set_configuration	libusb_set_configuration
+# define usb_release_interface	libusb_release_interface
+# define usb_reset				libusb_reset_device
 
  /* FIXME: some original libusb1.c code cast the (int) argument
   * as (enum libusb_error) - should we force that in the macro? */
- #define nut_usb_strerror(a)	libusb_strerror(a)
+# define nut_usb_strerror(a)	libusb_strerror(a)
 #endif  /* WITH_LIBUSB_1_0 */
 
 /* Note: Checked above that in practice we handle some one libusb API */
@@ -406,70 +406,70 @@
  /* no typedef for usb_dev_handle - part of libusb-0.1 API names */
 
  typedef int usb_ctrl_requesttype;
- #define USB_CTRL_REQUESTTYPE_MIN	INT_MIN
- #define USB_CTRL_REQUESTTYPE_MAX	INT_MAX
+# define USB_CTRL_REQUESTTYPE_MIN	INT_MIN
+# define USB_CTRL_REQUESTTYPE_MAX	INT_MAX
 
  typedef int usb_ctrl_request;
- #define USB_CTRL_REQUEST_MIN	INT_MIN
- #define USB_CTRL_REQUEST_MAX	INT_MAX
+# define USB_CTRL_REQUEST_MIN	INT_MIN
+# define USB_CTRL_REQUEST_MAX	INT_MAX
 
  typedef int usb_ctrl_endpoint;
- #define USB_CTRL_ENDPOINT_MIN	INT_MIN
- #define USB_CTRL_ENDPOINT_MAX	INT_MAX
+# define USB_CTRL_ENDPOINT_MIN	INT_MIN
+# define USB_CTRL_ENDPOINT_MAX	INT_MAX
 
  typedef int usb_ctrl_msgvalue;
- #define USB_CTRL_MSGVALUE_MIN	INT_MIN
- #define USB_CTRL_MSGVALUE_MAX	INT_MAX
+# define USB_CTRL_MSGVALUE_MIN	INT_MIN
+# define USB_CTRL_MSGVALUE_MAX	INT_MAX
 
  typedef uint8_t usb_ctrl_cfgindex;
- #define USB_CTRL_CFGINDEX_MIN	0
- #define USB_CTRL_CFGINDEX_MAX	UINT8_MAX
+# define USB_CTRL_CFGINDEX_MIN	0
+# define USB_CTRL_CFGINDEX_MAX	UINT8_MAX
 
  typedef int usb_ctrl_repindex;
- #define USB_CTRL_REPINDEX_MIN	INT_MIN
- #define USB_CTRL_REPINDEX_MAX	INT_MAX
+# define USB_CTRL_REPINDEX_MIN	INT_MIN
+# define USB_CTRL_REPINDEX_MAX	INT_MAX
 
  typedef int usb_ctrl_strindex;
- #define USB_CTRL_STRINDEX_MIN	INT_MIN
- #define USB_CTRL_STRINDEX_MAX	INT_MAX
+# define USB_CTRL_STRINDEX_MIN	INT_MIN
+# define USB_CTRL_STRINDEX_MAX	INT_MAX
 
  typedef int usb_ctrl_descindex;
- #define USB_CTRL_DESCINDEX_MIN	INT_MIN
- #define USB_CTRL_DESCINDEX_MAX	INT_MAX
+# define USB_CTRL_DESCINDEX_MIN	INT_MIN
+# define USB_CTRL_DESCINDEX_MAX	INT_MAX
 
  /* Here MIN/MAX should not matter much, type mostly used for casting */
  typedef char* usb_ctrl_charbuf;
  typedef char usb_ctrl_char;
- #define USB_CTRL_CHAR_MIN	CHAR_MIN
- #define USB_CTRL_CHAR_MAX	CHAR_MAX
+# define USB_CTRL_CHAR_MIN	CHAR_MIN
+# define USB_CTRL_CHAR_MAX	CHAR_MAX
 
  typedef int usb_ctrl_charbufsize;
- #define USB_CTRL_CHARBUFSIZE_MIN	INT_MIN
- #define USB_CTRL_CHARBUFSIZE_MAX	INT_MAX
+# define USB_CTRL_CHARBUFSIZE_MIN	INT_MIN
+# define USB_CTRL_CHARBUFSIZE_MAX	INT_MAX
  /* There is no PRIi :) So we define directly by spec */
- #define PRI_NUT_USB_CTRL_CHARBUFSIZE "i"
+# define PRI_NUT_USB_CTRL_CHARBUFSIZE "i"
 
  typedef int usb_ctrl_timeout_msec;	/* in milliseconds */
- #define USB_CTRL_TIMEOUTMSEC_MIN	INT_MIN
- #define USB_CTRL_TIMEOUTMSEC_MAX	INT_MAX
+# define USB_CTRL_TIMEOUTMSEC_MIN	INT_MIN
+# define USB_CTRL_TIMEOUTMSEC_MAX	INT_MAX
 
  /* defines */
- #define LIBUSB_ERROR_ACCESS		-EACCES
- #define LIBUSB_ERROR_BUSY			-EBUSY
- #define LIBUSB_ERROR_IO			-EIO
- #define LIBUSB_ERROR_NO_DEVICE	-ENODEV
- #define LIBUSB_ERROR_NOT_FOUND	-ENOENT
- #define LIBUSB_ERROR_OVERFLOW		-EOVERFLOW
- #define LIBUSB_ERROR_PIPE			-EPIPE
- #define LIBUSB_ERROR_TIMEOUT		-ETIMEDOUT
- #define LIBUSB_ERROR_NO_MEM		-ENOMEM
- #define LIBUSB_ERROR_INVALID_PARAM		-EINVAL
- #define LIBUSB_ERROR_INTERRUPTED		-EINTR
- #define LIBUSB_ERROR_NOT_SUPPORTED	-ENOSYS
- #define LIBUSB_ERROR_OTHER		-ERANGE
+# define LIBUSB_ERROR_ACCESS		-EACCES
+# define LIBUSB_ERROR_BUSY			-EBUSY
+# define LIBUSB_ERROR_IO			-EIO
+# define LIBUSB_ERROR_NO_DEVICE	-ENODEV
+# define LIBUSB_ERROR_NOT_FOUND	-ENOENT
+# define LIBUSB_ERROR_OVERFLOW		-EOVERFLOW
+# define LIBUSB_ERROR_PIPE			-EPIPE
+# define LIBUSB_ERROR_TIMEOUT		-ETIMEDOUT
+# define LIBUSB_ERROR_NO_MEM		-ENOMEM
+# define LIBUSB_ERROR_INVALID_PARAM		-EINVAL
+# define LIBUSB_ERROR_INTERRUPTED		-EINTR
+# define LIBUSB_ERROR_NOT_SUPPORTED	-ENOSYS
+# define LIBUSB_ERROR_OTHER		-ERANGE
 
  /* Functions for which simple mappings seem to suffice (no build warnings emitted): */
- #define nut_usb_strerror(a)	usb_strerror()
+# define nut_usb_strerror(a)	usb_strerror()
 #endif  /* WITH_LIBUSB_0_1 */
 
 /* USB standard timeout [ms] */

--- a/tools/nut-scanner/nut-scan.h
+++ b/tools/nut-scanner/nut-scan.h
@@ -124,15 +124,15 @@ typedef struct nutscan_ipmi {
 
 /* IPMI auth defines, simply using FreeIPMI defines */
 #ifndef IPMI_AUTHENTICATION_TYPE_NONE
-  #define IPMI_AUTHENTICATION_TYPE_NONE                  0x00
-  #define IPMI_AUTHENTICATION_TYPE_MD2                   0x01
-  #define IPMI_AUTHENTICATION_TYPE_MD5                   0x02
-  #define IPMI_AUTHENTICATION_TYPE_STRAIGHT_PASSWORD_KEY 0x04
-  #define IPMI_AUTHENTICATION_TYPE_OEM_PROP              0x05
-  #define IPMI_AUTHENTICATION_TYPE_RMCPPLUS              0x06
+# define IPMI_AUTHENTICATION_TYPE_NONE                  0x00
+# define IPMI_AUTHENTICATION_TYPE_MD2                   0x01
+# define IPMI_AUTHENTICATION_TYPE_MD5                   0x02
+# define IPMI_AUTHENTICATION_TYPE_STRAIGHT_PASSWORD_KEY 0x04
+# define IPMI_AUTHENTICATION_TYPE_OEM_PROP              0x05
+# define IPMI_AUTHENTICATION_TYPE_RMCPPLUS              0x06
 #endif /* IPMI_AUTHENTICATION_TYPE_NONE */
 #ifndef IPMI_PRIVILEGE_LEVEL_ADMIN
-  #define IPMI_PRIVILEGE_LEVEL_ADMIN                     0x04
+# define IPMI_PRIVILEGE_LEVEL_ADMIN                     0x04
 #endif /* IPMI_PRIVILEGE_LEVEL_ADMIN */
 
 #define IPMI_1_5		1

--- a/tools/nut-scanner/nutscan-device.c
+++ b/tools/nut-scanner/nutscan-device.c
@@ -1,6 +1,7 @@
 /*
- *  Copyright (C) 2011 - 2024 Arnaud Quette (Design and part of implementation)
+ *  Copyright (C) 2011-2024 Arnaud Quette (Design and part of implementation)
  *  Copyright (C) 2011 - EATON
+ *  Copyright (C) 2020-2024 - Jim Klimov <jimklimov+nut@gmail.com> - support and modernization of codebase
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/tools/nut-scanner/nutscan-device.h
+++ b/tools/nut-scanner/nutscan-device.h
@@ -1,6 +1,7 @@
 /*
- *  Copyright (C) 2011 - 2024 Arnaud Quette (Design and part of implementation)
+ *  Copyright (C) 2011-2024 Arnaud Quette (Design and part of implementation)
  *  Copyright (C) 2011 - EATON
+ *  Copyright (C) 2020-2024 - Jim Klimov <jimklimov+nut@gmail.com> - support and modernization of codebase
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/tools/nut-scanner/nutscan-display.c
+++ b/tools/nut-scanner/nutscan-display.c
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 2011 - EATON
- *  2023 - Jim Klimov <jimklimov+nut@gmail.com>
+ *  Copyright (C) 2020-2024 - Jim Klimov <jimklimov+nut@gmail.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/tools/nut-scanner/nutscan-init.c
+++ b/tools/nut-scanner/nutscan-init.c
@@ -2,7 +2,7 @@
  *  Copyright (C) 2011 - 2024 Arnaud Quette (Design and part of implementation)
  *  Copyright (C) 2011 - 2021 EATON
  *  Copyright (C) 2016 - 2021 Jim Klimov <EvgenyKlimov@eaton.com>
- *  Copyright (C) 2022 - 2024 Jim Klimov <jimklimov+nut@gmail.com>
+ *  Copyright (C) 2021 - 2024 Jim Klimov <jimklimov+nut@gmail.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/tools/nut-scanner/nutscan-ip.h
+++ b/tools/nut-scanner/nutscan-ip.h
@@ -1,5 +1,6 @@
 /*
  *  Copyright (C) 2011 - EATON
+ *  Copyright (C) 2020-2024 - Jim Klimov <jimklimov+nut@gmail.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/tools/nut-scanner/scan_avahi.c
+++ b/tools/nut-scanner/scan_avahi.c
@@ -1,6 +1,7 @@
 /*
- *  Copyright (C) 2011 - 2024 Arnaud Quette (Design and part of implementation)
+ *  Copyright (C) 2011-2024 Arnaud Quette (Design and part of implementation)
  *  Copyright (C) 2011 - EATON
+ *  Copyright (C) 2020-2024 - Jim Klimov <jimklimov+nut@gmail.com> - support and modernization of codebase
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/tools/nut-scanner/scan_eaton_serial.c
+++ b/tools/nut-scanner/scan_eaton_serial.c
@@ -30,7 +30,7 @@
 
 /* Need this on AIX when using xlc to get alloca */
 #ifdef _AIX
-#pragma alloca
+# pragma alloca
 #endif /* _AIX */
 
 #include <fcntl.h>

--- a/tools/nut-scanner/scan_eaton_serial.c
+++ b/tools/nut-scanner/scan_eaton_serial.c
@@ -1,6 +1,7 @@
 /*
  *  Copyright (C) 2012 - EATON
  *  Copyright (C) 2016-2021 - EATON - Various threads-related improvements
+ *  Copyright (C) 2020-2024 - Jim Klimov <jimklimov+nut@gmail.com> - support and modernization of codebase
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/tools/nut-scanner/scan_ipmi.c
+++ b/tools/nut-scanner/scan_ipmi.c
@@ -28,10 +28,11 @@
 #include "nut-scan.h"
 
 #ifdef WITH_IPMI
+
 #include "upsclient.h"
 #include <freeipmi/freeipmi.h>
-#include <stdio.h>
 #include <string.h>
+#include <stdio.h>
 #include <ltdl.h>
 
 #define NUT_IPMI_DRV_NAME	"nut-ipmipsu"
@@ -47,31 +48,31 @@ static const char *dl_error = NULL;
 
 #ifdef HAVE_FREEIPMI_11X_12X
   /* Functions symbols remapping */
-  #define IPMI_FRU_CLOSE_DEVICE_ID                     "ipmi_fru_close_device_id"
-  #define IPMI_FRU_CTX_DESTROY                         "ipmi_fru_ctx_destroy"
-  #define IPMI_FRU_CTX_CREATE                          "ipmi_fru_ctx_create"
-  #define IPMI_FRU_CTX_SET_FLAGS                       "ipmi_fru_ctx_set_flags"
-  #define IPMI_FRU_OPEN_DEVICE_ID                      "ipmi_fru_open_device_id"
-  #define IPMI_FRU_CTX_ERRORMSG                        "ipmi_fru_ctx_errormsg"
-  #define IPMI_FRU_READ_DATA_AREA                      "ipmi_fru_read_data_area"
-  #define IPMI_FRU_PARSE_NEXT                          "ipmi_fru_next"
+#  define IPMI_FRU_CLOSE_DEVICE_ID                     "ipmi_fru_close_device_id"
+#  define IPMI_FRU_CTX_DESTROY                         "ipmi_fru_ctx_destroy"
+#  define IPMI_FRU_CTX_CREATE                          "ipmi_fru_ctx_create"
+#  define IPMI_FRU_CTX_SET_FLAGS                       "ipmi_fru_ctx_set_flags"
+#  define IPMI_FRU_OPEN_DEVICE_ID                      "ipmi_fru_open_device_id"
+#  define IPMI_FRU_CTX_ERRORMSG                        "ipmi_fru_ctx_errormsg"
+#  define IPMI_FRU_READ_DATA_AREA                      "ipmi_fru_read_data_area"
+#  define IPMI_FRU_PARSE_NEXT                          "ipmi_fru_next"
   typedef ipmi_fru_ctx_t ipmi_fru_parse_ctx_t;
   typedef ipmi_sdr_ctx_t ipmi_sdr_cache_ctx_t;
   /* Functions remapping */
   static void (*nut_ipmi_sdr_ctx_destroy) (ipmi_sdr_ctx_t ctx);
 #else /* HAVE_FREEIPMI_11X_12X */
-  #define IPMI_FRU_AREA_SIZE_MAX                                   IPMI_FRU_PARSE_AREA_SIZE_MAX
-  #define IPMI_FRU_FLAGS_SKIP_CHECKSUM_CHECKS                      IPMI_FRU_PARSE_FLAGS_SKIP_CHECKSUM_CHECKS
-  #define IPMI_FRU_AREA_TYPE_MULTIRECORD_POWER_SUPPLY_INFORMATION  IPMI_FRU_PARSE_AREA_TYPE_MULTIRECORD_POWER_SUPPLY_INFORMATION
+#  define IPMI_FRU_AREA_SIZE_MAX                                   IPMI_FRU_PARSE_AREA_SIZE_MAX
+#  define IPMI_FRU_FLAGS_SKIP_CHECKSUM_CHECKS                      IPMI_FRU_PARSE_FLAGS_SKIP_CHECKSUM_CHECKS
+#  define IPMI_FRU_AREA_TYPE_MULTIRECORD_POWER_SUPPLY_INFORMATION  IPMI_FRU_PARSE_AREA_TYPE_MULTIRECORD_POWER_SUPPLY_INFORMATION
   /* Functions symbols remapping */
-  #define IPMI_FRU_CLOSE_DEVICE_ID                     "ipmi_fru_parse_close_device_id"
-  #define IPMI_FRU_CTX_DESTROY                         "ipmi_fru_parse_ctx_destroy"
-  #define IPMI_FRU_CTX_CREATE                          "ipmi_fru_parse_ctx_create"
-  #define IPMI_FRU_CTX_SET_FLAGS                       "ipmi_fru_parse_ctx_set_flags"
-  #define IPMI_FRU_OPEN_DEVICE_ID                      "ipmi_fru_parse_open_device_id"
-  #define IPMI_FRU_CTX_ERRORMSG                        "ipmi_fru_parse_ctx_errormsg"
-  #define IPMI_FRU_READ_DATA_AREA                      "ipmi_fru_parse_read_data_area"
-  #define IPMI_FRU_PARSE_NEXT                          "ipmi_fru_parse_next"
+#  define IPMI_FRU_CLOSE_DEVICE_ID                     "ipmi_fru_parse_close_device_id"
+#  define IPMI_FRU_CTX_DESTROY                         "ipmi_fru_parse_ctx_destroy"
+#  define IPMI_FRU_CTX_CREATE                          "ipmi_fru_parse_ctx_create"
+#  define IPMI_FRU_CTX_SET_FLAGS                       "ipmi_fru_parse_ctx_set_flags"
+#  define IPMI_FRU_OPEN_DEVICE_ID                      "ipmi_fru_parse_open_device_id"
+#  define IPMI_FRU_CTX_ERRORMSG                        "ipmi_fru_parse_ctx_errormsg"
+#  define IPMI_FRU_READ_DATA_AREA                      "ipmi_fru_parse_read_data_area"
+#  define IPMI_FRU_PARSE_NEXT                          "ipmi_fru_parse_next"
   /* Functions remapping */
   static void (*nut_ipmi_sdr_cache_ctx_destroy) (ipmi_sdr_cache_ctx_t ctx);
   static void (*nut_ipmi_sdr_parse_ctx_destroy) (ipmi_sdr_parse_ctx_t ctx);

--- a/tools/nut-scanner/scan_ipmi.c
+++ b/tools/nut-scanner/scan_ipmi.c
@@ -1,6 +1,8 @@
 /*
  *  Copyright (C)
  *    2011 - 2012  Arnaud Quette <arnaud.quette@free.fr>
+ *    2016 - 2021  EATON - Various threads-related improvements
+ *    2020 - 2024  Jim Klimov <jimklimov+nut@gmail.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/tools/nut-scanner/scan_nut.c
+++ b/tools/nut-scanner/scan_nut.c
@@ -47,6 +47,8 @@ static int (*nut_upscli_list_next)(UPSCONN_t *ups, size_t numq,
 			const char **query, size_t *numa, char ***answer);
 static int (*nut_upscli_disconnect)(UPSCONN_t *ups);
 
+/* This variable collects device(s) from a sequential or parallel scan,
+ * is returned to caller, and cleared to allow subsequent independent scans */
 static nutscan_device_t * dev_ret = NULL;
 #ifdef HAVE_PTHREAD
 static pthread_mutex_t dev_mutex;
@@ -551,6 +553,8 @@ nutscan_device_t * nutscan_scan_ip_range_nut(nutscan_ip_range_list_t * irl, cons
 #else  /* not HAVE_PTHREAD */
 			list_nut_devices(nut_arg);
 #endif /* if HAVE_PTHREAD */
+
+			/* Prepare the next iteration */
 			free(ip_str);
 			ip_str = nutscan_ip_ranges_iter_inc(&ip);
 		} else { /* if not pass -- all slots busy */

--- a/tools/nut-scanner/scan_nut.c
+++ b/tools/nut-scanner/scan_nut.c
@@ -2,6 +2,7 @@
  *  Copyright (C) 2011 - 2023 Arnaud Quette (Design and part of implementation)
  *  Copyright (C) 2011 - EATON
  *  Copyright (C) 2016-2021 - EATON - Various threads-related improvements
+ *  Copyright (C) 2020-2024 - Jim Klimov <jimklimov+nut@gmail.com> - support and modernization of codebase
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -32,9 +32,9 @@
 #ifdef WITH_SNMP
 
 #ifndef WIN32
-#include <sys/socket.h>
+# include <sys/socket.h>
 #else
-#undef _WIN32_WINNT
+# undef _WIN32_WINNT
 #endif
 
 #include <stdio.h>
@@ -44,23 +44,23 @@
 /* workaround for buggy Net-SNMP config
  * from drivers/snmp-ups.h */
 #ifdef PACKAGE_BUGREPORT
-#undef PACKAGE_BUGREPORT
+# undef PACKAGE_BUGREPORT
 #endif
 
 #ifdef PACKAGE_NAME
-#undef PACKAGE_NAME
+# undef PACKAGE_NAME
 #endif
 
 #ifdef PACKAGE_VERSION
-#undef PACKAGE_VERSION
+# undef PACKAGE_VERSION
 #endif
 
 #ifdef PACKAGE_STRING
-#undef PACKAGE_STRING
+# undef PACKAGE_STRING
 #endif
 
 #ifdef PACKAGE_TARNAME
-#undef PACKAGE_TARNAME
+# undef PACKAGE_TARNAME
 #endif
 
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNUSED_PARAMETER)
@@ -88,11 +88,11 @@
 
 /* Address API change */
 #if ( ! NUT_HAVE_LIBNETSNMP_usmAESPrivProtocol ) && ( ! defined usmAESPrivProtocol )
-#define USMAESPRIVPROTOCOL "usmAES128PrivProtocol"
-#define USMAESPRIVPROTOCOL_PTR usmAES128PrivProtocol
+# define USMAESPRIVPROTOCOL "usmAES128PrivProtocol"
+# define USMAESPRIVPROTOCOL_PTR usmAES128PrivProtocol
 #else
-#define USMAESPRIVPROTOCOL "usmAESPrivProtocol"
-#define USMAESPRIVPROTOCOL_PTR usmAESPrivProtocol
+# define USMAESPRIVPROTOCOL "usmAESPrivProtocol"
+# define USMAESPRIVPROTOCOL_PTR usmAESPrivProtocol
 #endif
 
 #define SysOID ".1.3.6.1.2.1.1.2.0"

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -97,18 +97,20 @@
 
 #define SysOID ".1.3.6.1.2.1.1.2.0"
 
+/* This variable collects device(s) from a sequential or parallel scan,
+ * is returned to caller, and cleared to allow subsequent independent scans */
+static nutscan_device_t * dev_ret = NULL;
+#ifdef HAVE_PTHREAD
+static pthread_mutex_t dev_mutex;
+#endif
+static useconds_t g_usec_timeout ;
+
 /* use explicit booleans */
 #ifndef FALSE
 typedef enum ebool { FALSE = 0, TRUE } bool_t;
 #else
 typedef int bool_t;
 #endif
-
-static nutscan_device_t * dev_ret = NULL;
-#ifdef HAVE_PTHREAD
-static pthread_mutex_t dev_mutex;
-#endif
-static useconds_t g_usec_timeout ;
 
 #ifndef WITH_SNMP_STATIC
 /* dynamic link library stuff */
@@ -1290,6 +1292,8 @@ nutscan_device_t * nutscan_scan_ip_range_snmp(nutscan_ip_range_list_t * irl,
 #else   /* not HAVE_PTHREAD */
 			try_SysOID((void *)tmp_sec);
 #endif  /* if HAVE_PTHREAD */
+
+			/* Prepare the next iteration */
 /*			free(ip_str); */ /* Do not free() here - seems to cause a double-free instead */
 			ip_str = nutscan_ip_ranges_iter_inc(&ip);
 /*			free(tmp_sec); */

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -1,6 +1,7 @@
 /*
  *  Copyright (C) 2011 - EATON
  *  Copyright (C) 2016-2021 - EATON - Various threads-related improvements
+ *  Copyright (C) 2020-2024 - Jim Klimov <jimklimov+nut@gmail.com> - support and modernization of codebase
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -1400,6 +1400,7 @@ nutscan_device_t * nutscan_scan_snmp(const char * start_ip, const char * stop_ip
 	NUT_UNUSED_VARIABLE(stop_ip);
 	NUT_UNUSED_VARIABLE(usec_timeout);
 	NUT_UNUSED_VARIABLE(sec);
+
 	return NULL;
 }
 
@@ -1410,6 +1411,7 @@ nutscan_device_t * nutscan_scan_ip_range_snmp(nutscan_ip_range_list_t * irl,
 	NUT_UNUSED_VARIABLE(irl);
 	NUT_UNUSED_VARIABLE(usec_timeout);
 	NUT_UNUSED_VARIABLE(sec);
+
 	return NULL;
 }
 

--- a/tools/nut-scanner/scan_usb.c
+++ b/tools/nut-scanner/scan_usb.c
@@ -27,6 +27,7 @@
 #include "nut-scan.h"
 
 #ifdef WITH_USB
+
 #include "upsclient.h"
 #include "nutscan-usb.h"
 #include <stdio.h>
@@ -43,10 +44,10 @@ static int (*nut_usb_get_string_simple)(libusb_device_handle *dev, int index,
 
 /* Compatibility layer between libusb 0.1 and 1.0 */
 #if WITH_LIBUSB_1_0
- #define USB_INIT_SYMBOL "libusb_init"
- #define USB_OPEN_SYMBOL "libusb_open"
- #define USB_CLOSE_SYMBOL "libusb_close"
- #define USB_STRERROR_SYMBOL "libusb_strerror"
+# define USB_INIT_SYMBOL "libusb_init"
+# define USB_OPEN_SYMBOL "libusb_open"
+# define USB_CLOSE_SYMBOL "libusb_close"
+# define USB_STRERROR_SYMBOL "libusb_strerror"
  static int (*nut_usb_open)(libusb_device *dev, libusb_device_handle **handle);
  static int (*nut_usb_init)(libusb_context **ctx);
  static void (*nut_usb_exit)(libusb_context *ctx);
@@ -59,10 +60,10 @@ static int (*nut_usb_get_string_simple)(libusb_device_handle *dev, int index,
  static int (*nut_usb_get_device_descriptor)(libusb_device *dev,
 	struct libusb_device_descriptor *desc);
 #else /* => WITH_LIBUSB_0_1 */
- #define USB_INIT_SYMBOL "usb_init"
- #define USB_OPEN_SYMBOL "usb_open"
- #define USB_CLOSE_SYMBOL "usb_close"
- #define USB_STRERROR_SYMBOL "usb_strerror"
+# define USB_INIT_SYMBOL "usb_init"
+# define USB_OPEN_SYMBOL "usb_open"
+# define USB_CLOSE_SYMBOL "usb_close"
+# define USB_STRERROR_SYMBOL "usb_strerror"
  static libusb_device_handle * (*nut_usb_open)(struct usb_device *dev);
  static void (*nut_usb_init)(void);
  static int (*nut_usb_find_busses)(void);

--- a/tools/nut-scanner/scan_usb.c
+++ b/tools/nut-scanner/scan_usb.c
@@ -1,5 +1,6 @@
 /*
  *  Copyright (C) 2011-2016 - EATON
+ *  Copyright (C) 2020-2024 - Jim Klimov <jimklimov+nut@gmail.com> - support and modernization of codebase
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -31,24 +31,25 @@
 #include "nut_stdint.h"
 
 #ifdef WITH_NEON
+
 #ifndef WIN32
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <netdb.h>
-#include <arpa/inet.h>
-#include <netinet/in.h>
-#include <sys/select.h>
-#define SOCK_OPT_CAST
+# include <sys/types.h>
+# include <sys/socket.h>
+# include <netdb.h>
+# include <arpa/inet.h>
+# include <netinet/in.h>
+# include <sys/select.h>
+# define SOCK_OPT_CAST
 #else
-#define SOCK_OPT_CAST (char*)
+# define SOCK_OPT_CAST (char*)
 /* Those 2 files for support of getaddrinfo, getnameinfo and freeaddrinfo
    on Windows 2000 and older versions */
-#include <ws2tcpip.h>
-#include <wspiapi.h>
+# include <ws2tcpip.h>
+# include <wspiapi.h>
 # if ! HAVE_INET_PTON
 #  include "wincompat.h"	/* fallback inet_ntop where needed */
 # endif
-#endif
+#endif	/* WIN32 */
 
 #include <string.h>
 #include <stdio.h>

--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -70,6 +70,8 @@ static int (*nut_ne_xml_failed)(ne_xml_parser *p);
 static ne_xml_parser * (*nut_ne_xml_create)(void);
 static int (*nut_ne_xml_parse)(ne_xml_parser *p, const char *block, size_t len);
 
+/* This variable collects device(s) from a sequential or parallel scan,
+ * is returned to caller, and cleared to allow subsequent independent scans */
 static nutscan_device_t * dev_ret = NULL;
 #ifdef HAVE_PTHREAD
 static pthread_mutex_t dev_mutex;
@@ -451,6 +453,7 @@ nutscan_device_t * nutscan_scan_ip_range_xml_http(nutscan_ip_range_list_t * irl,
 	 || irl->ip_ranges->start_ip == NULL || irl->ip_ranges->end_ip == NULL
 	) {
 		upsdebugx(1, "%s: Scanning XML/HTTP bus using broadcast.", __func__);
+		/* Fall through to after the if/else clause */
 	} else {
 		/* Iterate the one or a range of IPs to scan */
 		nutscan_ip_range_list_iter_t ip;
@@ -676,6 +679,7 @@ nutscan_device_t * nutscan_scan_ip_range_xml_http(nutscan_ip_range_list_t * irl,
 				nutscan_scan_xml_http_generic((void *)tmp_sec);
 #endif /* if HAVE_PTHREAD */
 
+				/* Prepare the next iteration */
 /*				free(ip_str); */ /* One of these free()s seems to cause a double-free instead */
 				ip_str = nutscan_ip_ranges_iter_inc(&ip);
 /*				free(tmp_sec); */

--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -2,6 +2,7 @@
  *  Copyright (C) 2011 - EATON
  *  Copyright (C) 2016 - EATON - IP addressed XML scan
  *  Copyright (C) 2016-2021 - EATON - Various threads-related improvements
+ *  Copyright (C) 2020-2024 - Jim Klimov <jimklimov+nut@gmail.com> - support and modernization of codebase
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -813,6 +813,7 @@ nutscan_device_t * nutscan_scan_xml_http_range(const char * start_ip, const char
 	NUT_UNUSED_VARIABLE(end_ip);
 	NUT_UNUSED_VARIABLE(usec_timeout);
 	NUT_UNUSED_VARIABLE(sec);
+
 	return NULL;
 }
 
@@ -822,6 +823,7 @@ nutscan_device_t * nutscan_scan_ip_range_xml_http(nutscan_ip_range_list_t * irl,
 	NUT_UNUSED_VARIABLE(irl);
 	NUT_UNUSED_VARIABLE(usec_timeout);
 	NUT_UNUSED_VARIABLE(sec);
+
 	return NULL;
 }
 


### PR DESCRIPTION
Stressed in `UPGRADING.adoc` that we updated `libnutscan` version due to new methods and a structure change (latter pending), so new exported symbols.

Fixed code style for nested preprocessor code vs. pedantic preprocessor implementations, and to satisfy related recent updates to NUT developer style guide.

A few small changes to comments and code layout here and there.