### PR TITLE
CI: Sanity-check generated `ChangeLog.html` with more attention to detail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ Makefile.in
 /ltmain.sh
 /missing
 /test-driver
+*-contentchecked
 *-spellchecked
 *-prepped
 *.usage-report

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -211,20 +211,23 @@ check-html-single: $(ASCIIDOC_HTML_SINGLE)
 	                FIRST_ENTRY="`grep -E '^[0-9]' "$(top_builddir)/ChangeLog" | head -1 | sed 's/ *["<].*//'`" || FIRST_ENTRY="" ; \
 	                LAST_ENTRY="`grep -E '^[0-9]' "$(top_builddir)/ChangeLog" | tail -1 | sed 's/ *["<].*//'`" || LAST_ENTRY="" ; \
 	                if [ -n "$${FIRST_ENTRY}" ] ; then \
-	                    if [ 2 != "`grep -cE "title.*$${FIRST_ENTRY}" "$$F"`" ] ; then \
-	                        echo "FAILED $$F check: does not contain expected first entry exactly twice (huge doc, must have got aborted mid-way): $${FIRST_ENTRY}" >&2 ; \
+	                    N="`grep -cE "title.*$${FIRST_ENTRY}" "$$F"`" ; \
+	                    if [ 2 != "$${N}" ] ; then \
+	                        echo "FAILED $$F check: does not contain expected first entry exactly twice (huge doc, must have got aborted mid-way): $${FIRST_ENTRY} (seen $$N times)" >&2 ; \
 	                        FAILED="$$FAILED $$F" ; \
 	                    fi ; \
 	                fi; \
 	                if [ -n "$${SECOND_ENTRY}" ] ; then \
-	                    if [ 2 != "`grep -cE "title.*$${SECOND_ENTRY}" "$$F"`" ] ; then \
-	                        echo "FAILED $$F check: does not contain expected second entry exactly twice (huge doc, must have got aborted mid-way): $${SECOND_ENTRY}" >&2 ; \
+	                    N="`grep -cE "title.*$${SECOND_ENTRY}" "$$F"`" ; \
+	                    if [ 2 != "$${N}" ] ; then \
+	                        echo "FAILED $$F check: does not contain expected second entry exactly twice (huge doc, must have got aborted mid-way): $${SECOND_ENTRY} (seen $$N times)" >&2 ; \
 	                        FAILED="$$FAILED $$F" ; \
 	                    fi ; \
 	                fi; \
 	                if [ -n "$${LAST_ENTRY}" ] ; then \
-	                    if [ 2 != "`grep -cE "title.*$${LAST_ENTRY}" "$$F"`" ] ; then \
-	                        echo "FAILED $$F check: does not contain expected last entry exactly twice (huge doc, must have got aborted mid-way): $${LAST_ENTRY}" >&2 ; \
+	                    N="`grep -cE "title.*$${LAST_ENTRY}" "$$F"`" ; \
+	                    if [ 2 != "$${N}" ] ; then \
+	                        echo "FAILED $$F check: does not contain expected last entry exactly twice (huge doc, must have got aborted mid-way): $${LAST_ENTRY} (seen $$N times)" >&2 ; \
 	                        FAILED="$$FAILED $$F" ; \
 	                    fi ; \
 	                fi; \

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -498,6 +498,7 @@ DOCBUILD_END = { \
 	            $(MAKE) $(AM_MAKEFLAGS) "`basename '$(@F)'`"-contentchecked || RES=$$? ; \
 	            if [ "$$RES" != 0 ] ; then \
 	                echo "  DOC-HTML Generating $@ (retry once)" >&2; \
+	                rm -f "$@"; \
 	                A2X_OUTDIR="tmp/html-single.$(@F).$$$$-retry" ; \
 	                $(DOCBUILD_BEGIN) ; RES=0; rm -f "`basename '$(@F)'`"-contentchecked || true ; \
 	                $(A2X) $(A2X_COMMON_OPTS) --attribute=xhtml11_format --format=xhtml --xsl-file=$(srcdir)/xhtml.xsl "$(<D)/`basename '$(<F)' -prepped`" || RES=$$? ; \

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -216,45 +216,48 @@ check-pdf: $(ASCIIDOC_PDF)
 # and not exactly two mentions, should allow to catch the case
 # of overlapping documents. Checking for the last entry allows
 # to catch incomplete parses, where asciidoc gave up early.
-ChangeLog.html-contentchecked: ChangeLog.html
+# NOTE: No dependencies, avoids (re-)generation and log messages.
+ChangeLog.html-contentchecked:
 	@FAILED=""; \
-	 if [ -s '$(top_builddir)/ChangeLog' ] ; then \
+	 if [ -s '$(top_builddir)/ChangeLog' ] && [ -s ChangeLog.html ] ; then \
 	    SECOND_ENTRY="`grep -E '^[0-9]' '$(top_builddir)/ChangeLog' | head -2 | tail -1 | sed 's/ *[\"<].*//'`" || SECOND_ENTRY="" ; \
 	    FIRST_ENTRY="`grep -E '^[0-9]' '$(top_builddir)/ChangeLog' | head -1 | sed 's/ *[\"<].*//'`" || FIRST_ENTRY="" ; \
 	    LAST_ENTRY="`grep -E '^[0-9]' '$(top_builddir)/ChangeLog' | tail -1 | sed 's/ *[\"<].*//'`" || LAST_ENTRY="" ; \
 	    if [ -n "$${FIRST_ENTRY}" ] ; then \
-	        N="`grep -cE "title.*$${FIRST_ENTRY}" '$(?)'`" ; \
+	        N="`grep -cE "title.*$${FIRST_ENTRY}" 'ChangeLog.html'`" ; \
 	        if [ 2 != "$${N}" ] ; then \
-	            echo "FAILED $(?) check: does not contain expected first entry exactly twice (huge doc, must have got aborted mid-way): $${FIRST_ENTRY} (seen $$N times)" >&2 ; \
+	            echo "FAILED ChangeLog.html check: does not contain expected first entry exactly twice (huge doc, must have got aborted mid-way): $${FIRST_ENTRY} (seen $$N times)" >&2 ; \
 	            if [ -z "$$FAILED" ] ; then \
 	                echo "Expected size over 3MB (for common builds):" >&2 ; \
-	                ls -la "$(?)" '$(top_builddir)/ChangeLog'* >&2 ; \
-	                FAILED="$(?)" ; \
+	                ls -la "ChangeLog.html" '$(top_builddir)/ChangeLog'* >&2 ; \
+	                FAILED="ChangeLog.html" ; \
 	            fi ; \
 	        fi ; \
 	    fi; \
 	    if [ -n "$${SECOND_ENTRY}" ] ; then \
-	        N="`grep -cE "title.*$${SECOND_ENTRY}" '$(?)'`" ; \
+	        N="`grep -cE "title.*$${SECOND_ENTRY}" 'ChangeLog.html'`" ; \
 	        if [ 2 != "$${N}" ] ; then \
-	            echo "FAILED $(?) check: does not contain expected second entry exactly twice (huge doc, must have got aborted mid-way): $${SECOND_ENTRY} (seen $$N times)" >&2 ; \
+	            echo "FAILED ChangeLog.html check: does not contain expected second entry exactly twice (huge doc, must have got aborted mid-way): $${SECOND_ENTRY} (seen $$N times)" >&2 ; \
 	            if [ -z "$$FAILED" ] ; then \
 	                echo "Expected size over 3MB (for common builds):" >&2 ; \
-	                ls -la "$(?)" '$(top_builddir)/ChangeLog'* >&2 ; \
-	                FAILED="$(?)" ; \
+	                ls -la "ChangeLog.html" '$(top_builddir)/ChangeLog'* >&2 ; \
+	                FAILED="ChangeLog.html" ; \
 	            fi ; \
 	        fi ; \
 	    fi; \
 	    if [ -n "$${LAST_ENTRY}" ] ; then \
-	        N="`grep -cE "title.*$${LAST_ENTRY}" '$(?)'`" ; \
+	        N="`grep -cE "title.*$${LAST_ENTRY}" 'ChangeLog.html'`" ; \
 	        if [ 2 != "$${N}" ] ; then \
-	            echo "FAILED $(?) check: does not contain expected last entry exactly twice (huge doc, must have got aborted mid-way): $${LAST_ENTRY} (seen $$N times)" >&2 ; \
+	            echo "FAILED ChangeLog.html check: does not contain expected last entry exactly twice (huge doc, must have got aborted mid-way): $${LAST_ENTRY} (seen $$N times)" >&2 ; \
 	            if [ -z "$$FAILED" ] ; then \
 	                echo "Expected size over 3MB (for common builds):" >&2 ; \
-	                ls -la "$(?)" '$(top_builddir)/ChangeLog'* >&2 ; \
-	                FAILED="$(?)" ; \
+	                ls -la "ChangeLog.html" '$(top_builddir)/ChangeLog'* >&2 ; \
+	                FAILED="ChangeLog.html" ; \
 	            fi ; \
 	        fi ; \
 	    fi; \
+	 else \
+	    echo "SKIPPED $@ because input files were not available" >&2 ; \
 	 fi
 
 check-html-single: $(ASCIIDOC_HTML_SINGLE)

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -214,21 +214,33 @@ check-html-single: $(ASCIIDOC_HTML_SINGLE)
 	                    N="`grep -cE "title.*$${FIRST_ENTRY}" "$$F"`" ; \
 	                    if [ 2 != "$${N}" ] ; then \
 	                        echo "FAILED $$F check: does not contain expected first entry exactly twice (huge doc, must have got aborted mid-way): $${FIRST_ENTRY} (seen $$N times)" >&2 ; \
-	                        FAILED="$$FAILED $$F" ; \
+	                        if ! echo "$$FAILED" | grep -w "$$F" >/dev/null ; then \
+	                            echo "Expected size over 3MB (for common builds):" >&2 ; \
+	                            ls -la "$$F" "$(top_builddir)/ChangeLog"* >&2 ; \
+	                            FAILED="$$FAILED $$F" ; \
+	                        fi ; \
 	                    fi ; \
 	                fi; \
 	                if [ -n "$${SECOND_ENTRY}" ] ; then \
 	                    N="`grep -cE "title.*$${SECOND_ENTRY}" "$$F"`" ; \
 	                    if [ 2 != "$${N}" ] ; then \
 	                        echo "FAILED $$F check: does not contain expected second entry exactly twice (huge doc, must have got aborted mid-way): $${SECOND_ENTRY} (seen $$N times)" >&2 ; \
-	                        FAILED="$$FAILED $$F" ; \
+	                        if ! echo "$$FAILED" | grep -w "$$F" >/dev/null ; then \
+	                            echo "Expected size over 3MB (for common builds):" >&2 ; \
+	                            ls -la "$$F" "$(top_builddir)/ChangeLog"* >&2 ; \
+	                            FAILED="$$FAILED $$F" ; \
+	                        fi ; \
 	                    fi ; \
 	                fi; \
 	                if [ -n "$${LAST_ENTRY}" ] ; then \
 	                    N="`grep -cE "title.*$${LAST_ENTRY}" "$$F"`" ; \
 	                    if [ 2 != "$${N}" ] ; then \
 	                        echo "FAILED $$F check: does not contain expected last entry exactly twice (huge doc, must have got aborted mid-way): $${LAST_ENTRY} (seen $$N times)" >&2 ; \
-	                        FAILED="$$FAILED $$F" ; \
+	                        if ! echo "$$FAILED" | grep -w "$$F" >/dev/null ; then \
+	                            echo "Expected size over 3MB (for common builds):" >&2 ; \
+	                            ls -la "$$F" "$(top_builddir)/ChangeLog"* >&2 ; \
+	                            FAILED="$$FAILED $$F" ; \
+	                        fi ; \
 	                    fi ; \
 	                fi; \
 	            fi ;; \

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -819,7 +819,7 @@ $(abs_top_builddir)/docs/.prep-src-docs: $(PREP_SRC)
 	        D="`dirname "$$F"`" ; \
 	        $(MKDIR_P) "$${linkroot}/$$D" || { rm -f "$@.working" ; exit 1 ; } ; \
 	        if ! test -s "$${linkroot}/$$F" && test -s "$${linksrcroot}/$$F" ; then \
-	            echo "  LN     '$${linksrcroot}/$$F' => '$${linkroot}/$$F' (PWD = '`pwd`')" >&2 ; \
+	            echo "  LN     '$${linksrcroot}/$$F' => '$${linkroot}/$$F' (PWD = '`pwd`')" ; \
 	            ln -fs "$${linksrcroot}/$$F" "$${linkroot}/$$F" || { rm -f "$@.working" ; exit 1 ; } ; \
 	            COUNT="`expr $$COUNT + 1`" ; \
 	        fi ; \

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -494,7 +494,7 @@ DOCBUILD_END = { \
 	    *ChangeLog*) if [ -s '$(top_builddir)/ChangeLog' ] ; then \
 	            $(MAKE) $(AM_MAKEFLAGS) "`basename '$(@F)'`"-contentchecked || RES=$$? ; \
 	            if [ "$$RES" != 0 ] ; then \
-	                echo "  DOC-HTML Generating $@ (retry once)"; \
+	                echo "  DOC-HTML Generating $@ (retry once)" >&2; \
 	                A2X_OUTDIR="tmp/html-single.$(@F).$$$$-retry" ; \
 	                $(DOCBUILD_BEGIN) ; RES=0; rm -f "`basename '$(@F)'`"-contentchecked || true ; \
 	                $(A2X) $(A2X_COMMON_OPTS) --attribute=xhtml11_format --format=xhtml --xsl-file=$(srcdir)/xhtml.xsl "$(<D)/`basename '$(<F)' -prepped`" || RES=$$? ; \

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -201,53 +201,59 @@ check-pdf: $(ASCIIDOC_PDF)
 # and not exactly two mentions, should allow to catch the case
 # of overlapping documents. Checking for the last entry allows
 # to catch incomplete parses, where asciidoc gave up early.
+ChangeLog.html-contentchecked: ChangeLog.html
+	@FAILED=""; \
+	 if [ -s "$(top_builddir)/ChangeLog" ] ; then \
+	    SECOND_ENTRY="`grep -E '^[0-9]' "$(top_builddir)/ChangeLog" | head -2 | tail -1 | sed 's/ *["<].*//'`" || SECOND_ENTRY="" ; \
+	    FIRST_ENTRY="`grep -E '^[0-9]' "$(top_builddir)/ChangeLog" | head -1 | sed 's/ *["<].*//'`" || FIRST_ENTRY="" ; \
+	    LAST_ENTRY="`grep -E '^[0-9]' "$(top_builddir)/ChangeLog" | tail -1 | sed 's/ *["<].*//'`" || LAST_ENTRY="" ; \
+	    if [ -n "$${FIRST_ENTRY}" ] ; then \
+	        N="`grep -cE "title.*$${FIRST_ENTRY}" "$?"`" ; \
+	        if [ 2 != "$${N}" ] ; then \
+	            echo "FAILED $(?) check: does not contain expected first entry exactly twice (huge doc, must have got aborted mid-way): $${FIRST_ENTRY} (seen $$N times)" >&2 ; \
+	            if [ -z "$$FAILED" ] ; then \
+	                echo "Expected size over 3MB (for common builds):" >&2 ; \
+	                ls -la "$(?)" "$(top_builddir)/ChangeLog"* >&2 ; \
+	                FAILED="$(?)" ; \
+	            fi ; \
+	        fi ; \
+	    fi; \
+	    if [ -n "$${SECOND_ENTRY}" ] ; then \
+	        N="`grep -cE "title.*$${SECOND_ENTRY}" "$(?)"`" ; \
+	        if [ 2 != "$${N}" ] ; then \
+	            echo "FAILED $(?) check: does not contain expected second entry exactly twice (huge doc, must have got aborted mid-way): $${SECOND_ENTRY} (seen $$N times)" >&2 ; \
+	            if [ -z "$$FAILED" ] ; then \
+	                echo "Expected size over 3MB (for common builds):" >&2 ; \
+	                ls -la "$(?)" "$(top_builddir)/ChangeLog"* >&2 ; \
+	                FAILED="$(?)" ; \
+	            fi ; \
+	        fi ; \
+	    fi; \
+	    if [ -n "$${LAST_ENTRY}" ] ; then \
+	        N="`grep -cE "title.*$${LAST_ENTRY}" "$(?)"`" ; \
+	        if [ 2 != "$${N}" ] ; then \
+	            echo "FAILED $(?) check: does not contain expected last entry exactly twice (huge doc, must have got aborted mid-way): $${LAST_ENTRY} (seen $$N times)" >&2 ; \
+	            if [ -z "$$FAILED" ] ; then \
+	                echo "Expected size over 3MB (for common builds):" >&2 ; \
+	                ls -la "$(?)" "$(top_builddir)/ChangeLog"* >&2 ; \
+	                FAILED="$(?)" ; \
+	            fi ; \
+	        fi ; \
+	    fi; \
+	 fi
+
 check-html-single: $(ASCIIDOC_HTML_SINGLE)
-	@FAILED=""; LANG=C; LC_ALL=C; export LANG; export LC_ALL; \
-	for F in $(ASCIIDOC_HTML_SINGLE) ; do \
+	+@FAILED=""; LANG=C; LC_ALL=C; export LANG; export LC_ALL; \
+	 for F in $(ASCIIDOC_HTML_SINGLE) ; do \
 	    test -s "$$F" && { file "$$F" | $(EGREP) -i '(XML|HTML.*document)' > /dev/null ; } || FAILED="$$FAILED $$F" ; \
 	    case "$$F" in \
 	        *ChangeLog*) if [ -s "$(top_builddir)/ChangeLog" ] ; then \
-	                SECOND_ENTRY="`grep -E '^[0-9]' "$(top_builddir)/ChangeLog" | head -2 | tail -1 | sed 's/ *["<].*//'`" || SECOND_ENTRY="" ; \
-	                FIRST_ENTRY="`grep -E '^[0-9]' "$(top_builddir)/ChangeLog" | head -1 | sed 's/ *["<].*//'`" || FIRST_ENTRY="" ; \
-	                LAST_ENTRY="`grep -E '^[0-9]' "$(top_builddir)/ChangeLog" | tail -1 | sed 's/ *["<].*//'`" || LAST_ENTRY="" ; \
-	                if [ -n "$${FIRST_ENTRY}" ] ; then \
-	                    N="`grep -cE "title.*$${FIRST_ENTRY}" "$$F"`" ; \
-	                    if [ 2 != "$${N}" ] ; then \
-	                        echo "FAILED $$F check: does not contain expected first entry exactly twice (huge doc, must have got aborted mid-way): $${FIRST_ENTRY} (seen $$N times)" >&2 ; \
-	                        if ! echo "$$FAILED" | grep -w "$$F" >/dev/null ; then \
-	                            echo "Expected size over 3MB (for common builds):" >&2 ; \
-	                            ls -la "$$F" "$(top_builddir)/ChangeLog"* >&2 ; \
-	                            FAILED="$$FAILED $$F" ; \
-	                        fi ; \
-	                    fi ; \
-	                fi; \
-	                if [ -n "$${SECOND_ENTRY}" ] ; then \
-	                    N="`grep -cE "title.*$${SECOND_ENTRY}" "$$F"`" ; \
-	                    if [ 2 != "$${N}" ] ; then \
-	                        echo "FAILED $$F check: does not contain expected second entry exactly twice (huge doc, must have got aborted mid-way): $${SECOND_ENTRY} (seen $$N times)" >&2 ; \
-	                        if ! echo "$$FAILED" | grep -w "$$F" >/dev/null ; then \
-	                            echo "Expected size over 3MB (for common builds):" >&2 ; \
-	                            ls -la "$$F" "$(top_builddir)/ChangeLog"* >&2 ; \
-	                            FAILED="$$FAILED $$F" ; \
-	                        fi ; \
-	                    fi ; \
-	                fi; \
-	                if [ -n "$${LAST_ENTRY}" ] ; then \
-	                    N="`grep -cE "title.*$${LAST_ENTRY}" "$$F"`" ; \
-	                    if [ 2 != "$${N}" ] ; then \
-	                        echo "FAILED $$F check: does not contain expected last entry exactly twice (huge doc, must have got aborted mid-way): $${LAST_ENTRY} (seen $$N times)" >&2 ; \
-	                        if ! echo "$$FAILED" | grep -w "$$F" >/dev/null ; then \
-	                            echo "Expected size over 3MB (for common builds):" >&2 ; \
-	                            ls -la "$$F" "$(top_builddir)/ChangeLog"* >&2 ; \
-	                            FAILED="$$FAILED $$F" ; \
-	                        fi ; \
-	                    fi ; \
-	                fi; \
+	                $(MAKE) $(AM_MAKEFLAGS) "`basename "$$F"`"-contentchecked || FAILED="$$FAILED $$F" ; \
 	            fi ;; \
 	    esac ; \
-	done; if test -n "$$FAILED" ; then \
+	 done; if test -n "$$FAILED" ; then \
 	    echo "FAILED HTML-single sanity check for:$$FAILED" >&2 ; file $$FAILED >&2 ; exit 1; \
-	fi; echo "PASSED HTML-single sanity check"; exit 0
+	 fi; echo "PASSED HTML-single sanity check"; exit 0
 
 check-html-chunked: $(ASCIIDOC_HTML_CHUNKED)
 	@FAILED=""; LANG=C; LC_ALL=C; export LANG; export LC_ALL; \
@@ -273,7 +279,7 @@ check-man all-man man-man all-html html-man:
 man:
 	+cd $(abs_top_builddir)/docs/man/ && $(MAKE) $(AM_MAKEFLAGS) -f Makefile all
 
-CLEANFILES = *.xml *.html *.pdf *-spellchecked docbook-xsl.css docinfo.xml.in.tmp
+CLEANFILES = *.xml *.html *.pdf *-spellchecked *-contentchecked docbook-xsl.css docinfo.xml.in.tmp
 CLEANFILES += $(top_builddir)/INSTALL.nut $(top_builddir)/UPGRADING $(top_builddir)/NEWS $(top_builddir)/ChangeLog.adoc $(top_builddir)/README
 CLEANFILES += $(top_builddir)/*.adoc-parsed *.adoc-parsed
 

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -185,10 +185,51 @@ check-pdf: $(ASCIIDOC_PDF)
 	    echo "FAILED PDF sanity check for:$$FAILED" >&2 ; file $$FAILED >&2 ; exit 1; \
 	fi; echo "PASSED PDF sanity check"; exit 0
 
+# Regarding ChangeLog check: sometimes asciidoc gives up early
+# (we have megabytes of text and thousands of sections here).
+# In some cases, the intermediate XML is broken and a2x=>xmllint
+# notices it. In others, it is truncated at just the right place
+# structurally and leads to a short HTML with only part of the
+# expected contents. We should no longer have several processes
+# trying to create the files involved (or rather do so atomically
+# and rename into final path, in case we still have competition
+# here); earlier when several generators appended to the same
+# file we could have several copies overlaid, with one of the
+# document's copies starting mid-sentence of another.
+# The two expected mentions are in the table of contents and
+# in the eventual section. Checking for first/second entries,
+# and not exactly two mentions, should allow to catch the case
+# of overlapping documents. Checking for the last entry allows
+# to catch incomplete parses, where asciidoc gave up early.
 check-html-single: $(ASCIIDOC_HTML_SINGLE)
 	@FAILED=""; LANG=C; LC_ALL=C; export LANG; export LC_ALL; \
 	for F in $(ASCIIDOC_HTML_SINGLE) ; do \
 	    test -s "$$F" && { file "$$F" | $(EGREP) -i '(XML|HTML.*document)' > /dev/null ; } || FAILED="$$FAILED $$F" ; \
+	    case "$$F" in \
+	        *ChangeLog*) if [ -s "$(top_builddir)/ChangeLog" ] ; then \
+	                SECOND_ENTRY="`grep -E '^[0-9]' "$(top_builddir)/ChangeLog" | head -2 | tail -1 | sed 's/ *["<].*//'`" || SECOND_ENTRY="" ; \
+	                FIRST_ENTRY="`grep -E '^[0-9]' "$(top_builddir)/ChangeLog" | head -1 | sed 's/ *["<].*//'`" || FIRST_ENTRY="" ; \
+	                LAST_ENTRY="`grep -E '^[0-9]' "$(top_builddir)/ChangeLog" | tail -1 | sed 's/ *["<].*//'`" || LAST_ENTRY="" ; \
+	                if [ -n "$${FIRST_ENTRY}" ] ; then \
+	                    if [ 2 != "`grep -cE "title.*$${FIRST_ENTRY}" "$$F"`" ] ; then \
+	                        echo "FAILED $$F check: does not contain expected first entry exactly twice (huge doc, must have got aborted mid-way): $${FIRST_ENTRY}" >&2 ; \
+	                        FAILED="$$FAILED $$F" ; \
+	                    fi ; \
+	                fi; \
+	                if [ -n "$${SECOND_ENTRY}" ] ; then \
+	                    if [ 2 != "`grep -cE "title.*$${SECOND_ENTRY}" "$$F"`" ] ; then \
+	                        echo "FAILED $$F check: does not contain expected second entry exactly twice (huge doc, must have got aborted mid-way): $${SECOND_ENTRY}" >&2 ; \
+	                        FAILED="$$FAILED $$F" ; \
+	                    fi ; \
+	                fi; \
+	                if [ -n "$${LAST_ENTRY}" ] ; then \
+	                    if [ 2 != "`grep -cE "title.*$${LAST_ENTRY}" "$$F"`" ] ; then \
+	                        echo "FAILED $$F check: does not contain expected last entry exactly twice (huge doc, must have got aborted mid-way): $${LAST_ENTRY}" >&2 ; \
+	                        FAILED="$$FAILED $$F" ; \
+	                    fi ; \
+	                fi; \
+	            fi ;; \
+	    esac ; \
 	done; if test -n "$$FAILED" ; then \
 	    echo "FAILED HTML-single sanity check for:$$FAILED" >&2 ; file $$FAILED >&2 ; exit 1; \
 	fi; echo "PASSED HTML-single sanity check"; exit 0

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -470,11 +470,25 @@ DOCBUILD_END = { \
 
 *.html: common.xsl xhtml.xsl
 .txt-prepped.html:
-	@A2X_OUTDIR="tmp/html-single.$(@F).$$$$" ; \
+	+@A2X_OUTDIR="tmp/html-single.$(@F).$$$$" ; \
 	 echo "  DOC-HTML Generating $@"; \
 	 $(DOCBUILD_BEGIN) ; RES=0; \
 	 $(A2X) $(A2X_COMMON_OPTS) --attribute=xhtml11_format --format=xhtml --xsl-file=$(srcdir)/xhtml.xsl "$(<D)/`basename "$(<F)" -prepped`" || RES=$$? ; \
-	 $(DOCBUILD_END) ; exit $$RES
+	 $(DOCBUILD_END) ; \
+	 case "$(@F)" in \
+	    *ChangeLog*) if [ -s "$(top_builddir)/ChangeLog" ] ; then \
+	            $(MAKE) $(AM_MAKEFLAGS) "`basename "$(@F)"`"-contentchecked || RES=$$? ; \
+	            if [ "$$RES" != 0 ] ; then \
+	                echo "  DOC-HTML Generating $@ (retry once)"; \
+	                A2X_OUTDIR="tmp/html-single.$(@F).$$$$-retry" ; \
+	                $(DOCBUILD_BEGIN) ; RES=0; rm -f "`basename "$(@F)"`"-contentchecked || true ; \
+	                $(A2X) $(A2X_COMMON_OPTS) --attribute=xhtml11_format --format=xhtml --xsl-file=$(srcdir)/xhtml.xsl "$(<D)/`basename "$(<F)" -prepped`" || RES=$$? ; \
+	                $(DOCBUILD_END) ; \
+	                $(MAKE) $(AM_MAKEFLAGS) "`basename "$(@F)"`"-contentchecked || RES=$$? ; \
+	            fi ; \
+	        fi ;; \
+	 esac ; \
+	 exit $$RES
 
 *.chunked: common.xsl chunked.xsl
 .txt-prepped.chunked:

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -1,5 +1,20 @@
 # Network UPS Tools: main docs
 
+# FIXME: There is a lot of shell-scripting below which gets processed by
+# whatever system shell there is. While bash handles expressions like
+#   VAL="`cmd "some params"`"
+# in a way that "some params" are a single token passed to "cmd" as an
+# argument, and the stdout of such command execution is collected into a
+# single-token string as "VAL" (even if with white-spaces). Some other
+# shells, e.g. "ksh" seems to actively dislike unbalanced double-quotes
+# inside the backticks (e.g. matched in some grep/sed regexes below),
+# although generally the approach works for such "VAL" assignments too.
+# Note that the newer "$(...)" syntax is not portable, older shells
+# have no idea about it, and it is cumbersome with `make` substitution.
+# Keep a lookout with multi-platform NUT CI jobs, and try to use single
+# quotes where possible (e.g. where pre-expanded `make` variables are
+# involved - so shell should not process them again anyway).
+
 MAINTAINERCLEANFILES = Makefile.in .dirstamp
 EXTRA_DIST =
 
@@ -203,39 +218,39 @@ check-pdf: $(ASCIIDOC_PDF)
 # to catch incomplete parses, where asciidoc gave up early.
 ChangeLog.html-contentchecked: ChangeLog.html
 	@FAILED=""; \
-	 if [ -s "$(top_builddir)/ChangeLog" ] ; then \
-	    SECOND_ENTRY="`grep -E '^[0-9]' "$(top_builddir)/ChangeLog" | head -2 | tail -1 | sed 's/ *["<].*//'`" || SECOND_ENTRY="" ; \
-	    FIRST_ENTRY="`grep -E '^[0-9]' "$(top_builddir)/ChangeLog" | head -1 | sed 's/ *["<].*//'`" || FIRST_ENTRY="" ; \
-	    LAST_ENTRY="`grep -E '^[0-9]' "$(top_builddir)/ChangeLog" | tail -1 | sed 's/ *["<].*//'`" || LAST_ENTRY="" ; \
+	 if [ -s '$(top_builddir)/ChangeLog' ] ; then \
+	    SECOND_ENTRY="`grep -E '^[0-9]' '$(top_builddir)/ChangeLog' | head -2 | tail -1 | sed 's/ *[\"<].*//'`" || SECOND_ENTRY="" ; \
+	    FIRST_ENTRY="`grep -E '^[0-9]' '$(top_builddir)/ChangeLog' | head -1 | sed 's/ *[\"<].*//'`" || FIRST_ENTRY="" ; \
+	    LAST_ENTRY="`grep -E '^[0-9]' '$(top_builddir)/ChangeLog' | tail -1 | sed 's/ *[\"<].*//'`" || LAST_ENTRY="" ; \
 	    if [ -n "$${FIRST_ENTRY}" ] ; then \
-	        N="`grep -cE "title.*$${FIRST_ENTRY}" "$?"`" ; \
+	        N="`grep -cE "title.*$${FIRST_ENTRY}" '$(?)'`" ; \
 	        if [ 2 != "$${N}" ] ; then \
 	            echo "FAILED $(?) check: does not contain expected first entry exactly twice (huge doc, must have got aborted mid-way): $${FIRST_ENTRY} (seen $$N times)" >&2 ; \
 	            if [ -z "$$FAILED" ] ; then \
 	                echo "Expected size over 3MB (for common builds):" >&2 ; \
-	                ls -la "$(?)" "$(top_builddir)/ChangeLog"* >&2 ; \
+	                ls -la "$(?)" '$(top_builddir)/ChangeLog'* >&2 ; \
 	                FAILED="$(?)" ; \
 	            fi ; \
 	        fi ; \
 	    fi; \
 	    if [ -n "$${SECOND_ENTRY}" ] ; then \
-	        N="`grep -cE "title.*$${SECOND_ENTRY}" "$(?)"`" ; \
+	        N="`grep -cE "title.*$${SECOND_ENTRY}" '$(?)'`" ; \
 	        if [ 2 != "$${N}" ] ; then \
 	            echo "FAILED $(?) check: does not contain expected second entry exactly twice (huge doc, must have got aborted mid-way): $${SECOND_ENTRY} (seen $$N times)" >&2 ; \
 	            if [ -z "$$FAILED" ] ; then \
 	                echo "Expected size over 3MB (for common builds):" >&2 ; \
-	                ls -la "$(?)" "$(top_builddir)/ChangeLog"* >&2 ; \
+	                ls -la "$(?)" '$(top_builddir)/ChangeLog'* >&2 ; \
 	                FAILED="$(?)" ; \
 	            fi ; \
 	        fi ; \
 	    fi; \
 	    if [ -n "$${LAST_ENTRY}" ] ; then \
-	        N="`grep -cE "title.*$${LAST_ENTRY}" "$(?)"`" ; \
+	        N="`grep -cE "title.*$${LAST_ENTRY}" '$(?)'`" ; \
 	        if [ 2 != "$${N}" ] ; then \
 	            echo "FAILED $(?) check: does not contain expected last entry exactly twice (huge doc, must have got aborted mid-way): $${LAST_ENTRY} (seen $$N times)" >&2 ; \
 	            if [ -z "$$FAILED" ] ; then \
 	                echo "Expected size over 3MB (for common builds):" >&2 ; \
-	                ls -la "$(?)" "$(top_builddir)/ChangeLog"* >&2 ; \
+	                ls -la "$(?)" '$(top_builddir)/ChangeLog'* >&2 ; \
 	                FAILED="$(?)" ; \
 	            fi ; \
 	        fi ; \
@@ -247,7 +262,7 @@ check-html-single: $(ASCIIDOC_HTML_SINGLE)
 	 for F in $(ASCIIDOC_HTML_SINGLE) ; do \
 	    test -s "$$F" && { file "$$F" | $(EGREP) -i '(XML|HTML.*document)' > /dev/null ; } || FAILED="$$FAILED $$F" ; \
 	    case "$$F" in \
-	        *ChangeLog*) if [ -s "$(top_builddir)/ChangeLog" ] ; then \
+	        *ChangeLog*) if [ -s '$(top_builddir)/ChangeLog' ] ; then \
 	                $(MAKE) $(AM_MAKEFLAGS) "`basename "$$F"`"-contentchecked || FAILED="$$FAILED $$F" ; \
 	            fi ;; \
 	    esac ; \
@@ -473,18 +488,18 @@ DOCBUILD_END = { \
 	+@A2X_OUTDIR="tmp/html-single.$(@F).$$$$" ; \
 	 echo "  DOC-HTML Generating $@"; \
 	 $(DOCBUILD_BEGIN) ; RES=0; \
-	 $(A2X) $(A2X_COMMON_OPTS) --attribute=xhtml11_format --format=xhtml --xsl-file=$(srcdir)/xhtml.xsl "$(<D)/`basename "$(<F)" -prepped`" || RES=$$? ; \
+	 $(A2X) $(A2X_COMMON_OPTS) --attribute=xhtml11_format --format=xhtml --xsl-file=$(srcdir)/xhtml.xsl "$(<D)/`basename '$(<F)' -prepped`" || RES=$$? ; \
 	 $(DOCBUILD_END) ; \
 	 case "$(@F)" in \
-	    *ChangeLog*) if [ -s "$(top_builddir)/ChangeLog" ] ; then \
-	            $(MAKE) $(AM_MAKEFLAGS) "`basename "$(@F)"`"-contentchecked || RES=$$? ; \
+	    *ChangeLog*) if [ -s '$(top_builddir)/ChangeLog' ] ; then \
+	            $(MAKE) $(AM_MAKEFLAGS) "`basename '$(@F)'`"-contentchecked || RES=$$? ; \
 	            if [ "$$RES" != 0 ] ; then \
 	                echo "  DOC-HTML Generating $@ (retry once)"; \
 	                A2X_OUTDIR="tmp/html-single.$(@F).$$$$-retry" ; \
-	                $(DOCBUILD_BEGIN) ; RES=0; rm -f "`basename "$(@F)"`"-contentchecked || true ; \
-	                $(A2X) $(A2X_COMMON_OPTS) --attribute=xhtml11_format --format=xhtml --xsl-file=$(srcdir)/xhtml.xsl "$(<D)/`basename "$(<F)" -prepped`" || RES=$$? ; \
+	                $(DOCBUILD_BEGIN) ; RES=0; rm -f "`basename '$(@F)'`"-contentchecked || true ; \
+	                $(A2X) $(A2X_COMMON_OPTS) --attribute=xhtml11_format --format=xhtml --xsl-file=$(srcdir)/xhtml.xsl "$(<D)/`basename '$(<F)' -prepped`" || RES=$$? ; \
 	                $(DOCBUILD_END) ; \
-	                $(MAKE) $(AM_MAKEFLAGS) "`basename "$(@F)"`"-contentchecked || RES=$$? ; \
+	                $(MAKE) $(AM_MAKEFLAGS) "`basename '$(@F)'`"-contentchecked || RES=$$? ; \
 	            fi ; \
 	        fi ;; \
 	 esac ; \
@@ -495,7 +510,7 @@ DOCBUILD_END = { \
 	@A2X_OUTDIR="tmp/html-chunked.$(@F).$$$$" ; \
 	 echo "  DOC-HTML-CHUNKED Generating $@"; \
 	 $(DOCBUILD_BEGIN) ; RES=0; \
-	 $(A2X) $(A2X_COMMON_OPTS) --attribute=chunked_format --format=chunked --xsl-file=$(srcdir)/chunked.xsl "$(<D)/`basename "$(<F)" -prepped`" || RES=$$? ; \
+	 $(A2X) $(A2X_COMMON_OPTS) --attribute=chunked_format --format=chunked --xsl-file=$(srcdir)/chunked.xsl "$(<D)/`basename '$(<F)' -prepped`" || RES=$$? ; \
 	 $(DOCBUILD_END) ; exit $$RES
 
 # Note: non-HTML a2x modes may ignore the destination directory
@@ -504,7 +519,7 @@ DOCBUILD_END = { \
 	@A2X_OUTDIR="tmp/pdf.$(@F).$$$$" ; \
 	 echo "  DOC-PDF  Generating $@"; \
 	 $(DOCBUILD_BEGIN) ; RES=0; \
-	 $(A2X) $(A2X_COMMON_OPTS) --attribute=pdf_format --format=pdf -a docinfo1 "$(<D)/`basename "$(<F)" -prepped`" || RES=$$? ; \
+	 $(A2X) $(A2X_COMMON_OPTS) --attribute=pdf_format --format=pdf -a docinfo1 "$(<D)/`basename '$(<F)' -prepped`" || RES=$$? ; \
 	 $(DOCBUILD_END) ; exit $$RES
 
 # Used below for spellcheck and for .prep-src-docs
@@ -595,12 +610,12 @@ $(SPELLCHECK_BUILDDIR)/$(SPELLCHECK_SRC_ONE)-spellchecked: $(SPELLCHECK_SRCDIR)/
 		/*) ;; \
 		*/*)	if [ x"$${REPORT_SRCDIR}" = x ] ; then \
 				echo EMPTY >$(SPELLCHECK_RECIPE_DEBUG_STREAM) ; \
-				REPORT_SRCDIR="`dirname "$(SPELLCHECK_SRC_ONE)"`"; \
+				REPORT_SRCDIR="`dirname '$(SPELLCHECK_SRC_ONE)'`"; \
 			else \
-				echo "APPEND: SPELLCHECK_SRCDIR='$(SPELLCHECK_SRCDIR)' SPELLCHECK_SRC_ONE='$(SPELLCHECK_SRC_ONE)' dirname='`dirname "$(SPELLCHECK_SRC_ONE)"`'" >$(SPELLCHECK_RECIPE_DEBUG_STREAM) ; \
-				REPORT_SRCDIR="$${REPORT_SRCDIR}/`dirname "$(SPELLCHECK_SRC_ONE)"`"; \
+				echo "APPEND: SPELLCHECK_SRCDIR='$(SPELLCHECK_SRCDIR)' SPELLCHECK_SRC_ONE='$(SPELLCHECK_SRC_ONE)' dirname='`dirname '$(SPELLCHECK_SRC_ONE)'`'" >$(SPELLCHECK_RECIPE_DEBUG_STREAM) ; \
+				REPORT_SRCDIR="$${REPORT_SRCDIR}/`dirname '$(SPELLCHECK_SRC_ONE)'`"; \
 			fi ; \
-			REPORT_SRC_ONE="`basename "$(SPELLCHECK_SRC_ONE)"`"; \
+			REPORT_SRC_ONE="`basename '$(SPELLCHECK_SRC_ONE)'`"; \
 			;; \
 		*) ;; \
 	 esac; \
@@ -616,7 +631,7 @@ $(SPELLCHECK_BUILDDIR)/$(SPELLCHECK_SRC_ONE)-spellchecked: $(SPELLCHECK_SRCDIR)/
 		*)  REPORT_SRCDIR="$${REPORT_SRCDIR}/" ;; \
 	 esac ; \
 	 echo "  ASPELL   Spell checking on $${REPORT_PREFIX}$${REPORT_SRCDIR}$${REPORT_SRC_ONE}"; \
-	 OUT="`(sed 's,^\(.*\)$$, \1,' | $(ASPELL) -a $(ASPELL_NUT_TEXMODE_ARGS) $(ASPELL_NUT_COMMON_ARGS) 2>&1) < "$(SPELLCHECK_SRCDIR)/$(SPELLCHECK_SRC_ONE)"`" \
+	 OUT="`(sed 's,^\(.*\)$$, \1,' | $(ASPELL) -a $(ASPELL_NUT_TEXMODE_ARGS) $(ASPELL_NUT_COMMON_ARGS) 2>&1) < '$(SPELLCHECK_SRCDIR)/$(SPELLCHECK_SRC_ONE)'`" \
 		&& { if test -n "$$OUT" ; then OUT="`echo "$$OUT" | $(EGREP) -b -v '$(ASPELL_OUT_NOTERRORS)' `" ; fi; \
 		     test -z "$$OUT" ; } \
 		|| { RES=$$? ; \
@@ -673,7 +688,7 @@ spellcheck-sortdict: $(abs_builddir)/$(NUT_SPELL_DICT).sorted
 $(abs_builddir)/$(NUT_SPELL_DICT).sorted: $(abs_srcdir)/$(NUT_SPELL_DICT)
 	@cp -pf $(abs_srcdir)/$(NUT_SPELL_DICT) $(abs_builddir)/$(NUT_SPELL_DICT).bak-pre-sorting
 	@LANG=$(ASPELL_ENV_LANG); LC_ALL=$(ASPELL_ENV_LANG); export LANG; export LC_ALL; ( \
-	    WORDLIST="`tail -n +2 < "$?" | sort | uniq`"; \
+	    WORDLIST="`tail -n +2 < '$(?)' | sort | uniq`"; \
 	    WORDCOUNT="`echo "$$WORDLIST" | wc -l`"; \
 	    head -1 < "$?" | while read P L C E ; do echo "$$P $$L $$WORDCOUNT $$E"; break; done ; \
 	    echo "$$WORDLIST"; \
@@ -767,7 +782,7 @@ $(abs_top_builddir)/docs/.prep-src-docs: $(PREP_SRC)
 	    COUNT=0; \
 	    for F in $(PREP_SRC) ; do \
 	        case "$$F" in \
-	            /*) F="`echo "$$F" | sed "s#^$(abs_top_srcdir)/*#./#"`"; \
+	            /*) F="`echo "$$F" | sed 's#^$(abs_top_srcdir)/*#./#'`"; \
 	                if test x"$${linkroot}" = x"$(abs_builddir)" ; then \
 	                    linkroot="$(abs_top_builddir)" ; \
 	                    cd "$(abs_top_builddir)" ; \
@@ -793,7 +808,7 @@ $(abs_top_builddir)/docs/.prep-src-docs: $(PREP_SRC)
 	    linksrcroot="$(abs_srcdir)" ; \
 	    for F in `echo $(PREP_SRC) | tr ' ' '\n' | sort -n | uniq` ; do \
 	        case "$$F" in \
-	            /*) F="`echo "$$F" | sed "s#^$(abs_top_srcdir)/*#./#"`"; \
+	            /*) F="`echo "$$F" | sed 's#^$(abs_top_srcdir)/*#./#'`"; \
 	                if test x"$${linkroot}" = x"$(abs_builddir)" ; then \
 	                    linkroot="$(abs_top_builddir)" ; \
 	                    linksrcroot="$(abs_top_srcdir)" ; \
@@ -822,7 +837,7 @@ clean-local:
 	$(AM_V_at)rm -rf *.chunked *.bak tmp
 	$(AM_V_at)for F in $(PREP_SRC) ; do \
 	        case "$$F" in \
-	            /*) F="`echo "$$F" | sed "s#^$(abs_top_srcdir)/*#./#"`"; cd "$(abs_top_builddir)" ;; \
+	            /*) F="`echo "$$F" | sed 's#^$(abs_top_srcdir)/*#./#'`"; cd "$(abs_top_builddir)" ;; \
 	        esac ; \
 	        if test x"$(abs_srcdir)" != x"$(abs_builddir)" ; then \
 	            if test -L "$$F" || test -h "$$F" ; then \

--- a/scripts/Windows/build-mingw-nut.sh
+++ b/scripts/Windows/build-mingw-nut.sh
@@ -168,7 +168,7 @@ if [ "$cmd" == "all64" ] || [ "$cmd" == "b64" ] || [ "$cmd" == "all32" ] || [ "$
 		# on a modern Windows one could go to their installed "sbin" to
 		#   mklink .\libupsclient-3.dll ..\bin\libupsclient-3.dll
 		(cd "$INSTALL_DIR/bin" && ln libupsclient*.dll ../sbin/)
-		(cd "$INSTALL_DIR/cgi-bin" && ln ../bin/libupsclient*.dll ./) \
+		(cd "$INSTALL_DIR/cgi-bin" 2>/dev/null && ln ../bin/libupsclient*.dll ./) \
 		|| echo "NOTE: FAILED to process OPTIONAL cgi-bin directory; was NUT CGI enabled?" >&2
 
 		echo "NOTE: Adding third-party dependency libraries for each installed program" >&2
@@ -188,7 +188,7 @@ if [ "$cmd" == "all64" ] || [ "$cmd" == "b64" ] || [ "$cmd" == "all32" ] || [ "$
 		(cd "$INSTALL_DIR/sbin" && { DESTDIR="$INSTALL_DIR" dllldddir . | while read D ; do ln -f ../bin/"`basename "$D"`" ./ ; done ; } ) || true
 
 		# Hardlink libraries for cgi-bin if present:
-		(cd "$INSTALL_DIR/cgi-bin" && { DESTDIR="$INSTALL_DIR" dllldddir . | while read D ; do ln -f ../bin/"`basename "$D"`" ./ ; done ; } ) \
+		(cd "$INSTALL_DIR/cgi-bin" 2>/dev/null && { DESTDIR="$INSTALL_DIR" dllldddir . | while read D ; do ln -f ../bin/"`basename "$D"`" ./ ; done ; } ) \
 		|| echo "NOTE: FAILED to process OPTIONAL cgi-bin directory; was NUT CGI enabled?" >&2
 	fi
 

--- a/scripts/Windows/build-mingw-nut.sh
+++ b/scripts/Windows/build-mingw-nut.sh
@@ -143,6 +143,7 @@ if [ "$cmd" == "all64" ] || [ "$cmd" == "b64" ] || [ "$cmd" == "all32" ] || [ "$
 	make 1>/dev/null || exit
 	make doc 1>/dev/null || exit
 	make -k man-man html-man 1>/dev/null || true
+	(cd docs && make check) 1>/dev/null || exit
 	echo "$0: build phase complete ($?)" >&2
 
 	if [ "x$INSTALL_WIN_BUNDLE" = xtrue ] ; then

--- a/scripts/Windows/build-mingw-nut.sh
+++ b/scripts/Windows/build-mingw-nut.sh
@@ -117,6 +117,7 @@ if [ "$cmd" == "all64" ] || [ "$cmd" == "b64" ] || [ "$cmd" == "all32" ] || [ "$
 	# Note: installation prefix here is "/" and desired INSTALL_DIR
 	# location is passed to `make install` as DESTDIR below.
 	# FIXME: Implement support for --without-pkg-config in m4 and use it
+	RES_CFG=0
 	$CONFIGURE_SCRIPT $HOST_FLAG $BUILD_FLAG --prefix=/ \
 	    $KEEP_NUT_REPORT_FEATURE_FLAG \
 	    PKG_CONFIG_PATH="${ARCH_PREFIX}/lib/pkgconfig" \
@@ -126,9 +127,19 @@ if [ "$cmd" == "all64" ] || [ "$cmd" == "b64" ] || [ "$cmd" == "all32" ] || [ "$
 	    --with-pynut=app \
 	    --with-augeas-lenses-dir=/augeas-lenses \
 	    --enable-Werror \
-	|| exit
-	echo "$0: configure phase complete ($?)" >&2
+	|| RES_CFG=$?
+	echo "$0: configure phase complete ($RES_CFG)" >&2
+	[ x"$RES_CFG" = x0 ] || exit $RES_CFG
 
+	echo "Configuration finished, starting make" >&2
+	if [ -n "$PARMAKE_FLAGS" ]; then
+		echo "For parallel builds, '$PARMAKE_FLAGS' options would be used" >&2
+	fi
+	if [ -n "$MAKEFLAGS" ]; then
+		echo "Generally, MAKEFLAGS='$MAKEFLAGS' options would be passed" >&2
+	fi
+
+	# FIXME: parameterize ${MAKE} ?
 	make 1>/dev/null || exit
 	make doc 1>/dev/null || exit
 	make -k man-man html-man 1>/dev/null || true


### PR DESCRIPTION
Outcome of part of investigation for issue #2510

Apparently we can end up with valid-looking but contentually wrong documents. Possibly `asciidoc` or `a2x` gives up generating the XML intermediate file (the prepared asciidoc text source is huge, several megabytes and thousands of sections) and we get just a beginning part of the change log, or we still have some clashes from parallel runs corrupting each other's files (should have been solved earlier in the year, but...)

Anyhow, we can try to catch and prevent delivery of generated pretty documents (starting with the simplest case of single HTML) which do not mention first, second and last section titles present in the `ChangeLog` (generated from git) exactly twice (table of contents and section itself).