### PR TITLE
Fix `ChangeLog.html-contentchecked` logic to survive several mentions of date+author; fix host `pkg-config` vs. cross-builds

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -243,6 +243,9 @@ during a NUT build.
    of more complex configurations (e.g. some line patterns that involve too
    many double-quote characters) which are valid for NUT proper. [#657]
 
+ - Cross-builds using only a host implementation of `pkg-config` program
+   should now ignore host `*.pc` files and avoid confusion.
+
  - NUT CI farm build recipes, documentation and some `m4`/`configure.ac`
    sources updated to handle a much larger build scope on MacOS. Also
    migrated the builders to Apple Silicon from x86 (deprecated by CircleCI).

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -229,6 +229,11 @@ check-pdf: $(ASCIIDOC_PDF)
 # and not exactly two mentions, should allow to catch the case
 # of overlapping documents. Checking for the last entry allows
 # to catch incomplete parses, where asciidoc gave up early.
+# NOTE: Technically it may be more than two, if the author and
+# date were used several times in the original ChangeLog file
+# (either with different e-mails, or if different author's work
+# is interleaved during the day, e.g. many PRs merged, and no
+# CHANGELOG_REQUIRE_GROUP_BY_DATE_AUTHOR=true setting was in place.
 # NOTE: No dependencies, avoids (re-)generation and log messages.
 ChangeLog.html-contentchecked:
 	@FAILED=""; \
@@ -237,9 +242,12 @@ ChangeLog.html-contentchecked:
 	    FIRST_ENTRY="`grep -E '^[0-9]' '$(top_builddir)/ChangeLog' | head -1 | sed 's/ *[\"<].*//'`" || FIRST_ENTRY="" ; \
 	    LAST_ENTRY="`grep -E '^[0-9]' '$(top_builddir)/ChangeLog' | tail -1 | sed 's/ *[\"<].*//'`" || LAST_ENTRY="" ; \
 	    if [ -n "$${FIRST_ENTRY}" ] ; then \
+	        O="`grep -cE "^$${FIRST_ENTRY}" '$(top_builddir)/ChangeLog'`" ; \
 	        N="`grep -cE "title.*$${FIRST_ENTRY}" 'ChangeLog.html'`" ; \
-	        if [ 2 != "$${N}" ] ; then \
-	            echo "FAILED ChangeLog.html check: does not contain expected first entry exactly twice (huge doc, must have got aborted mid-way): $${FIRST_ENTRY} (seen $$N times)" >&2 ; \
+	        MIN="`expr $${O} + 1`"     && [ "$${MIN}" -gt 0 ] 2>/dev/null || MIN=1 ; \
+	        MAX="`expr $${O} + $${O}`" && [ "$${MAX}" -gt 2 ] 2>/dev/null || MAX=2 ; \
+	        if [ "$${N}" -lt "$${MIN}" ] || [ "$${N}" -gt "$${MAX}" ]; then \
+	            echo "FAILED ChangeLog.html check: does not contain expected first entry the right amount of times (huge doc, must have got aborted mid-way): $${FIRST_ENTRY} (seen $${N} times, expected between $${MIN} and $${MAX})" >&2 ; \
 	            if [ -z "$$FAILED" ] ; then \
 	                echo "Expected size over 3MB (for common builds):" >&2 ; \
 	                ls -la "ChangeLog.html" '$(top_builddir)/ChangeLog'* >&2 ; \
@@ -248,9 +256,12 @@ ChangeLog.html-contentchecked:
 	        fi ; \
 	    fi; \
 	    if [ -n "$${SECOND_ENTRY}" ] ; then \
+	        O="`grep -cE "^$${SECOND_ENTRY}" '$(top_builddir)/ChangeLog'`" ; \
 	        N="`grep -cE "title.*$${SECOND_ENTRY}" 'ChangeLog.html'`" ; \
-	        if [ 2 != "$${N}" ] ; then \
-	            echo "FAILED ChangeLog.html check: does not contain expected second entry exactly twice (huge doc, must have got aborted mid-way): $${SECOND_ENTRY} (seen $$N times)" >&2 ; \
+	        MIN="`expr $${O} + 1`"     && [ "$${MIN}" -gt 0 ] 2>/dev/null || MIN=1 ; \
+	        MAX="`expr $${O} + $${O}`" && [ "$${MAX}" -gt 2 ] 2>/dev/null || MAX=2 ; \
+	        if [ "$${N}" -lt "$${MIN}" ] || [ "$${N}" -gt "$${MAX}" ]; then \
+	            echo "FAILED ChangeLog.html check: does not contain expected second entry the right amount of times (huge doc, must have got aborted mid-way): $${SECOND_ENTRY} (seen $${N} times, expected between $${MIN} and $${MAX})" >&2 ; \
 	            if [ -z "$$FAILED" ] ; then \
 	                echo "Expected size over 3MB (for common builds):" >&2 ; \
 	                ls -la "ChangeLog.html" '$(top_builddir)/ChangeLog'* >&2 ; \
@@ -259,9 +270,12 @@ ChangeLog.html-contentchecked:
 	        fi ; \
 	    fi; \
 	    if [ -n "$${LAST_ENTRY}" ] ; then \
+	        O="`grep -cE "^$${LAST_ENTRY}" '$(top_builddir)/ChangeLog'`" ; \
 	        N="`grep -cE "title.*$${LAST_ENTRY}" 'ChangeLog.html'`" ; \
-	        if [ 2 != "$${N}" ] ; then \
-	            echo "FAILED ChangeLog.html check: does not contain expected last entry exactly twice (huge doc, must have got aborted mid-way): $${LAST_ENTRY} (seen $$N times)" >&2 ; \
+	        MIN="`expr $${O} + 1`"     && [ "$${MIN}" -gt 0 ] 2>/dev/null || MIN=1 ; \
+	        MAX="`expr $${O} + $${O}`" && [ "$${MAX}" -gt 2 ] 2>/dev/null || MAX=2 ; \
+	        if [ "$${N}" -lt "$${MIN}" ] || [ "$${N}" -gt "$${MAX}" ]; then \
+	            echo "FAILED ChangeLog.html check: does not contain expected last entry the right amount of times (huge doc, must have got aborted mid-way): $${LAST_ENTRY} (seen $${N} times, expected between $${MIN} and $${MAX})" >&2 ; \
 	            if [ -z "$$FAILED" ] ; then \
 	                echo "Expected size over 3MB (for common builds):" >&2 ; \
 	                ls -la "ChangeLog.html" '$(top_builddir)/ChangeLog'* >&2 ; \

--- a/m4/nut_check_libusb.m4
+++ b/m4/nut_check_libusb.m4
@@ -88,9 +88,13 @@ if test -z "${nut_have_libusb_seen}"; then
 		 AS_IF([test x"${LIBUSB_0_1_VERSION}" != xnone], [
 			AS_CASE(["${target_os}"],
 				[*mingw*], [
-					AC_MSG_NOTICE([mingw builds prefer libusb-0.1(-compat) if available])
-					LIBUSB_VERSION="${LIBUSB_0_1_VERSION}"
-					nut_usb_lib="(libusb-0.1)"
+					AS_IF([test x"$build" = x"$host"], [
+						AC_MSG_NOTICE([mingw/MSYS2 native builds prefer libusb-0.1(-compat) over libusb-1.0 if both are available])
+						LIBUSB_VERSION="${LIBUSB_0_1_VERSION}"
+						nut_usb_lib="(libusb-0.1)"
+						],[
+						AC_MSG_NOTICE([mingw cross-builds prefer libusb-1.0 over libusb-0.1(-compat) if both are available])
+						])
 					])
 				]
 			)

--- a/m4/nut_check_pkgconfig.m4
+++ b/m4/nut_check_pkgconfig.m4
@@ -5,7 +5,7 @@ dnl do the checking only once.
 
 AC_DEFUN([NUT_CHECK_PKGCONFIG],
 [
-AS_IF([test -z "${nut_have_pkg_config_seen}"], [
+  AS_IF([test -z "${nut_have_pkg_config_seen}"], [
 	nut_have_pkg_config_seen=yes
 
 	dnl Note that PKG_CONFIG may be a filename, path,
@@ -83,8 +83,15 @@ AS_IF([test -z "${nut_have_pkg_config_seen}"], [
 		 PKG_CONFIG="false"
 		],
 		[AS_IF([test x"$have_PKG_CONFIG_MACROS" = xno],
-			[AC_MSG_WARN([pkg-config macros are needed to look for further dependencies, but in some cases pkg-config program can be used directly])]
-		)]
+			[AC_MSG_WARN([pkg-config macros are needed to look for further dependencies, but in some cases pkg-config program can be used directly])])
+
+		 AC_MSG_CHECKING([for pkg-config envvar PKG_CONFIG_PATH (if passed to configure script)])
+		 AC_MSG_RESULT([${PKG_CONFIG_PATH}])
+
+		 AC_MSG_CHECKING([for pkg-config reported pc_path])
+		 myPKG_CONFIG_PC_PATH="`pkg-config --variable pc_path pkg-config`" || myPKG_CONFIG_PC_PATH=""
+		 AC_MSG_RESULT([${myPKG_CONFIG_PC_PATH}])
+		]
 	)
 
   ]) dnl if nut_have_pkg_config_seen


### PR DESCRIPTION
Some fallout collected and lessons learned from #2536 build failures.