### PR TITLE
drivers/usbhid-ups.c, NEWS.adoc: for devices with VendorID=`0x06da`…

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -91,6 +91,9 @@ https://github.com/networkupstools/nut/milestone/11
  - usbhid-ups updates:
    * Support of the `onlinedischarge_log_throttle_hovercharge` in the NUT
      v2.8.2 release was found to be incomplete. [#2423, follow-up to #2215]
+   * General suggestion from `possibly_supported()` message method for devices
+     with VendorID=`0x06da` (Phoenixtec), seen in some models supported by
+     MGE HID or Liebert HID, updated to suggest trying `nutdrv_qx`. [#334]
    * MGE HID list of `mge_model_names[]` was extended for Eaton 5PX and 5SC
      series (largely guessing, feedback and PRs for adaptation to actual
      string values reported by devices via USB are welcome), so these devices

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -1461,6 +1461,11 @@ void possibly_supported(const char *mfr, HIDDevice_t *arghd)
 "'-x productid=%04x' option. Please report your results to the NUT user's\n"
 "mailing list <nut-upsuser@lists.alioth.debian.org>.\n",
 	mfr, arghd->VendorID, arghd->ProductID, arghd->ProductID);
+
+	if (arghd->VendorID == 0x06da) {
+		upsdebugx(0,
+"Please note that this Vendor ID is also known in devices supported by nutdrv_qx");
+	}
 }
 
 /* Update ups_status to remember this status item. Interpretation is


### PR DESCRIPTION
…(Phoenixtec) suggest trying `nutdrv_qx`

Closes: #334