### PR TITLE
drivers/mge-hid.c, NEWS.adoc: try to recognize Eaton 9E model and info

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -108,7 +108,7 @@ https://github.com/networkupstools/nut/milestone/11
    * General suggestion from `possibly_supported()` message method for devices
      with VendorID=`0x06da` (Phoenixtec), seen in some models supported by
      MGE HID or Liebert HID, updated to suggest trying `nutdrv_qx`. [#334]
-   * MGE HID list of `mge_model_names[]` was extended for Eaton 5PX and 5SC
+   * MGE HID list of `mge_model_names[]` was extended for Eaton 9E, 5PX and 5SC
      series (largely guessing, feedback and PRs for adaptation to actual
      string values reported by devices via USB are welcome), so these devices
      would now report `battery.voltage` and `battery.voltage.nominal`. [#2380]

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -362,6 +362,7 @@
 "Eaton"	"ups"	"5"	"5S"	"USB port"	"usbhid-ups"
 "Eaton"	"ups"	"5"	"5SC"	"USB port"	"usbhid-ups"
 "Eaton"	"ups"	"5"	"5P"	"USB port"	"usbhid-ups"
+"Eaton"	"ups"	"5"	"9E"	"USB port"	"usbhid-ups"
 "Eaton"	"ups"	"5"	"9SX"	"USB port"	"usbhid-ups"
 "Eaton"	"ups"	"5"	"9PX"	"USB port"	"usbhid-ups"
 "Eaton"	"ups"	"5"	"9PX Split Phase 6/8/10 kVA"	"USB port"	"usbhid-ups"

--- a/drivers/mge-hid.c
+++ b/drivers/mge-hid.c
@@ -1152,15 +1152,21 @@ static models_name_t mge_model_names [] =
 	 * https://github.com/networkupstools/nut/issues/2380
 	 * https://github.com/networkupstools/nut/issues/2492
 	 */
+	{ "Eaton 9E", "1000",  EATON_9E, "9E1000" },
+	{ "Eaton 9E", "1000i", EATON_9E, "9E1000i" },
+	{ "Eaton 9E", "1000ir", EATON_9E, "9E1000ir" },
 	{ "Eaton 9E", "2000",  EATON_9E, "9E2000" },
 	{ "Eaton 9E", "2000i", EATON_9E, "9E2000i" },
+	{ "Eaton 9E", "2000ir", EATON_9E, "9E2000ir" },
 	{ "Eaton 9E", "3000",  EATON_9E, "9E3000" },
 	{ "Eaton 9E", "3000i", EATON_9E, "9E3000i" },
+	{ "Eaton 9E", "3000ir", EATON_9E, "9E3000ir" },
 
 	/* https://github.com/networkupstools/nut/issues/1925#issuecomment-1609262963
 	 * if we failed to get iManufacturer, iProduct and iSerialNumber but saw
 	 * the UPS.Flow.[4].ConfigApparentPower (the "2000" or "3000" part here)
 	 */
+	{ "unknown",  "1000",  EATON_9E, "9E1000i (presumed)" },
 	{ "unknown",  "2000",  EATON_9E, "9E2000i (presumed)" },
 	{ "unknown",  "3000",  EATON_9E, "9E3000i (presumed)" },
 

--- a/drivers/mge-hid.c
+++ b/drivers/mge-hid.c
@@ -1154,13 +1154,18 @@ static models_name_t mge_model_names [] =
 	 */
 	{ "Eaton 9E", "1000",  EATON_9E, "9E1000" },
 	{ "Eaton 9E", "1000i", EATON_9E, "9E1000i" },
+	{ "Eaton 9E", "1000iau", EATON_9E, "9E1000iau" },
 	{ "Eaton 9E", "1000ir", EATON_9E, "9E1000ir" },
 	{ "Eaton 9E", "2000",  EATON_9E, "9E2000" },
 	{ "Eaton 9E", "2000i", EATON_9E, "9E2000i" },
+	{ "Eaton 9E", "2000iau", EATON_9E, "9E2000iau" },
 	{ "Eaton 9E", "2000ir", EATON_9E, "9E2000ir" },
 	{ "Eaton 9E", "3000",  EATON_9E, "9E3000" },
 	{ "Eaton 9E", "3000i", EATON_9E, "9E3000i" },
+	{ "Eaton 9E", "3000iau", EATON_9E, "9E3000iau" },
 	{ "Eaton 9E", "3000ir", EATON_9E, "9E3000ir" },
+	{ "Eaton 9E", "3000ixl", EATON_9E, "9E3000ixl" },
+	{ "Eaton 9E", "3000ixlau", EATON_9E, "9E3000ixlau" },
 
 	/* https://github.com/networkupstools/nut/issues/1925#issuecomment-1609262963
 	 * if we failed to get iManufacturer, iProduct and iSerialNumber but saw

--- a/drivers/mge-hid.c
+++ b/drivers/mge-hid.c
@@ -1152,11 +1152,17 @@ static models_name_t mge_model_names [] =
 	 * https://github.com/networkupstools/nut/issues/2380
 	 * https://github.com/networkupstools/nut/issues/2492
 	 */
-	{ "unknown",  "2000",  EATON_9E, "9E2000 (presumed)" },	/* https://github.com/networkupstools/nut/issues/1925#issuecomment-1609262963 */
 	{ "Eaton 9E", "2000",  EATON_9E, "9E2000" },
 	{ "Eaton 9E", "2000i", EATON_9E, "9E2000i" },
 	{ "Eaton 9E", "3000",  EATON_9E, "9E3000" },
 	{ "Eaton 9E", "3000i", EATON_9E, "9E3000i" },
+
+	/* https://github.com/networkupstools/nut/issues/1925#issuecomment-1609262963
+	 * if we failed to get iManufacturer, iProduct and iSerialNumber but saw
+	 * the UPS.Flow.[4].ConfigApparentPower (the "2000" or "3000" part here)
+	 */
+	{ "unknown",  "2000",  EATON_9E, "9E2000i (presumed)" },
+	{ "unknown",  "3000",  EATON_9E, "9E3000i (presumed)" },
 
 	/* Pulsar M models */
 	{ "PULSAR M", "2200", MGE_PULSAR_M_2200, NULL },

--- a/drivers/mge-hid.c
+++ b/drivers/mge-hid.c
@@ -50,7 +50,7 @@
 # endif
 #endif
 
-#define MGE_HID_VERSION		"MGE HID 1.47"
+#define MGE_HID_VERSION		"MGE HID 1.48"
 
 /* (prev. MGE Office Protection Systems, prev. MGE UPS SYSTEMS) */
 /* Eaton */
@@ -131,7 +131,8 @@ typedef enum {
 		MGE_PULSAR_M_2200,
 		MGE_PULSAR_M_3000,
 		MGE_PULSAR_M_3000_XL,
-	EATON_5P = 0x500			/* Eaton 5P / 5PX / 5SC series */
+	EATON_5P = 0x500,			/* Eaton 5P / 5PX / 5SC series */
+	EATON_9E = 0x900			/* Eaton 9E entry-level series */
 } models_type_t;
 
 /* Default to line-interactive or online (ie, not offline).
@@ -489,6 +490,7 @@ static const char *mge_battery_voltage_nominal_fun(double value)
 
 	case MGE_PULSAR_M:
 	case EATON_5P:
+	case EATON_9E:	/* Presumably per https://github.com/networkupstools/nut/issues/1925#issuecomment-1562342854 */
 		break;
 
 	default:
@@ -514,6 +516,7 @@ static const char *mge_battery_voltage_fun(double value)
 	case MGE_EVOLUTION:
 	case MGE_PULSAR_M:
 	case EATON_5P:
+	case EATON_9E:	/* Presumably per https://github.com/networkupstools/nut/issues/1925#issuecomment-1562342854 */
 		break;
 
 	default:
@@ -1143,6 +1146,17 @@ static models_name_t mge_model_names [] =
 	{ "Eaton 5SC", "1500", EATON_5P, NULL },
 	{ "Eaton 5SC", "2200", EATON_5P, NULL },
 	{ "Eaton 5SC", "3000", EATON_5P, NULL },
+
+	/* Eaton 9E entry-level series per discussions in
+	 * https://github.com/networkupstools/nut/issues/1925
+	 * https://github.com/networkupstools/nut/issues/2380
+	 * https://github.com/networkupstools/nut/issues/2492
+	 */
+	{ "unknown",  "2000",  EATON_9E, "9E2000 (presumed)" },	/* https://github.com/networkupstools/nut/issues/1925#issuecomment-1609262963 */
+	{ "Eaton 9E", "2000",  EATON_9E, "9E2000" },
+	{ "Eaton 9E", "2000i", EATON_9E, "9E2000i" },
+	{ "Eaton 9E", "3000",  EATON_9E, "9E3000" },
+	{ "Eaton 9E", "3000i", EATON_9E, "9E3000i" },
 
 	/* Pulsar M models */
 	{ "PULSAR M", "2200", MGE_PULSAR_M_2200, NULL },


### PR DESCRIPTION
Also handle "unknown 2000" assuming it is a mis-read "Eaton 9E 2000(i?)" which refused to tell libusb its vendor/product/serial strings. Although note that if we were not able to read basic identification data, chances of really interacting with the device are... sketchy.

This may be the answer to such issues as #1925, #2380 (re-opened), #2492

To recap, reported issues were (at least):
* "unknown 2000" as the `device.model` and `ups.model`
* missing serial number info
* ...which may be due to inability to get identification data from `nut_libusb_open()`, even when NUT runs as `root` (but maybe is somehow restricted being in a container?)
* ...which is discovered by `lsusb` on the same box, by `udevadm info`, and by `apcupsd` it seems
* `battery.type` is present but has no value
* not sure if it is only seen on Unraid?
* not getting battery.voltage per https://github.com/networkupstools/nut/issues/2380#issuecomment-2177855078 and https://github.com/networkupstools/nut/issues/2380#issuecomment-2178670566 (originally discussed for 5P/5S series)

The PR is more or less a guess-work based on earlier comments from @arnaudquette-eaton in those issue discussions.

CC @masterwishx @loso2255 @lemeshovich : would you be able to try a custom build of NUT following https://github.com/networkupstools/nut/wiki/Building-NUT-for-in%E2%80%90place-upgrades-or-non%E2%80%90disruptive-tests to see if it handles the devices better? A couple of things I'd be interested in is if it can recognize the device properly (as "9E2000" or "9E2000i", not "9E2000 (presumed)"), and if it serves the `battery.voltage` (current and nominal).

For the git checkout, use this PR's source branch:
````
:; git clone https://github.com/jimklimov/nut -b usb-eaton-ids nut
:; cd nut
...
````