### PR TITLE
Neuter our `PACKAGE_URL` in SNMP code builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -259,6 +259,17 @@ VERSION_DEFAULT: dummy-stamp
 CLEANFILES += VERSION_DEFAULT.tmp
 EXTRA_DIST += VERSION_DEFAULT
 
+# Best-effort delivery for (overly?) customized distros, e.g. via
+#   echo NUT_VERSION_FORCED_SEMVER=1.1.1 > VERSION_FORCED_SEMVER
+dist-hook:
+	for D in "$(abs_top_srcdir)" "$(abs_top_builddir)" ; do \
+	    for F in VERSION_FORCED VERSION_FORCED_SEMVER ; do \
+	        if [ -s "$$D/$$F" ] ; then \
+	            cat "$$D/$$F" > "$(top_distdir)/$$F" || true ; \
+	        fi ; \
+	    done ; \
+	done
+
 # This target adds syntax-checking for committed shell script files,
 # to avoid surprises and delays in finding fatal typos after packaging
 ###

--- a/docs/maintainer-guide.txt
+++ b/docs/maintainer-guide.txt
@@ -153,9 +153,9 @@ MAINTAINER SANDBOX (to be completed and pushed)
    make -j 8 spellcheck && \
    make -j 8 distcheck
 ----
-* create a GPG-signed tag v<incremented version> (ex: v2.8.0):
+* create an annotated GPG-signed tag v<incremented version> (ex: `v2.8.0`):
 ----
-:; git tag -sm 'Release NUT v2.8.0' v2.8.0
+:; git tag -asm 'Release NUT v2.8.0' v2.8.0
 ----
 ** in case of second thoughts, `git tag -d v2.8.0` and retry later
 ** try to avoid adding signed tags later (ex. v2.8.0-signed) to avoid the

--- a/docs/maintainer-guide.txt
+++ b/docs/maintainer-guide.txt
@@ -118,7 +118,11 @@ MAINTAINER SANDBOX (to be completed and pushed)
 * commit these finishing touches
 
 * bump the release identification:
-** update version to <exact incremented version> (ex: 2.8.0) in `configure.ac`
+** update the fallback `NUT_DEFAULT_VERSION` in `tools/gitlog2version.sh` to
+   <exact incremented version> (ex: `2.8.0`)
+*** Experiment if still needed: update version to <exact incremented version>
+    (ex: 2.8.0) in `configure.ac`, or if the script bump above + git tagging
+    would suffice:
 ----
 :; git commit -sm 'configure.ac: update AC_INIT for NUT v2.8.0 release`
 ----
@@ -166,7 +170,10 @@ MAINTAINER SANDBOX (to be completed and pushed)
   then) to store the source tarball, checksum and signature files
 
 * post-release update of the "in-development" codebase:
-** maybe update nut/configure.ac version to <incremented version>.1 (ex: 2.8.0.1)
+** update the fallback `NUT_DEFAULT_VERSION` in `tools/gitlog2version.sh` to
+   <incremented version>.1 (ex: `2.8.0.1`)
+*** maybe update nut/configure.ac version to <incremented version>.1
+    (ex: `2.8.0.1`):
 ----
 :; git commit -sm 'configure.ac: bump AC_INIT to development version 2.8.0.1'
 ----

--- a/drivers/snmp-ups.h
+++ b/drivers/snmp-ups.h
@@ -84,6 +84,10 @@
 #undef PACKAGE_TARNAME
 #endif
 
+#ifdef PACKAGE_URL
+#undef PACKAGE_URL
+#endif
+
 #ifdef HAVE_DMALLOC_H
 #undef HAVE_DMALLOC_H
 #endif

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -67,6 +67,10 @@ int nutscan_unload_snmp_library(void);
 # undef PACKAGE_TARNAME
 #endif
 
+#ifdef PACKAGE_URL
+# undef PACKAGE_URL
+#endif
+
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNUSED_PARAMETER)
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wunused-parameter"


### PR DESCRIPTION
Follow-up to PR #2554 for issue #1949. Headers from libnetsnmp declare their autoconf macro values directly, conflicting with ones we define ourselves for NUT, so historically we `undef`ed them before SNMP code builds. Now that we deliver `PACKAGE_URL`, gotta handle it similarly.