### PR TITLE
Address spurious LB+RB log flood on APC BXnnnnMI devices

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -208,6 +208,8 @@ during a NUT build.
      and values (or macros) in the NUT codebase. [issue #1176, issue #31]
    * custom `distcheck-something` targets did not inherit `DISTCHECK_FLAGS`
      properly. [#2541]
+   * added `status_get()` in NUT driver state API, to check if a status
+     token string had been set recently, and to avoid duplicate settings.
 
  - updated `docs/nut-names.txt` with items defined by 42ITy NUT fork. [#2339]
 

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -105,6 +105,9 @@ https://github.com/networkupstools/nut/milestone/11
  - usbhid-ups updates:
    * Support of the `onlinedischarge_log_throttle_hovercharge` in the NUT
      v2.8.2 release was found to be incomplete. [#2423, follow-up to #2215]
+   * Added support for `lbrb_log_delay_sec` setting to delay propagation of
+     `LB` or `LB+RB` state (buggy with APC BXnnnnMI devices circa 2023-2024).
+     [#2347]
    * General suggestion from `possibly_supported()` message method for devices
      with VendorID=`0x06da` (Phoenixtec), seen in some models supported by
      MGE HID or Liebert HID, updated to suggest trying `nutdrv_qx`. [#334]

--- a/docs/man/usbhid-ups.txt
+++ b/docs/man/usbhid-ups.txt
@@ -160,6 +160,20 @@ not forcing it to be fully charged all the time.  As long as the current value
 of `battery.charge` remains at or above this threshold percentage (default 100),
 the `OL+DISCHRG` message logging is not triggered by variations of the charge.
 
+*lbrb_log_delay_sec*='num'::
+Set to delay status-setting (and log messages) about device entering `LB` or
+`LB+RB` state.
++
+Some APC BXnnnnMI device models or firmware versions (reportedly 2023-2024)
+frequently report low battery, replace battery, and all ok within a couple
+of seconds, sometimes but not always preceded by OL+DISCHRG (presumably
+calibration). This setting lets the driver ignore short-lived states and
+only pay attention if they persist longer than this setting (and the device
+power state is `OL`).
+
+*lbrb_log_delay_without_calibrating*::
+Set to apply `lbrb_log_delay_sec` even if device is not calibrating.
+
 *disable_fix_report_desc*::
 Set to disable fix-ups for broken USB encoding, etc. which we apply by default
 on certain models (vendors/products) which were reported as not following the

--- a/docs/new-drivers.txt
+++ b/docs/new-drivers.txt
@@ -214,7 +214,11 @@ UPS status flags like on line (OL) and on battery (OB) live in
 ups.status.  Don't manipulate this by hand.  There are functions which
 will do this for you.
 
-	status_init() -- before doing anything else
+	status_init()   -- before doing anything else (clear internal buffers,
+	                   etc.)
+
+	status_get(val) -- optionally check if a status word had been set
+	                   since the most-recent status_init()
 
 	status_set(val) -- add a status word (OB, OL, etc)
 

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3199 utf-8
+personal_ws-1.1 en 3201 utf-8
 AAC
 AAS
 ABI
@@ -100,6 +100,7 @@ BTS
 BTV
 BUFRD
 BUZ
+BXnnnnMI
 BYP
 BZ
 BZOFF
@@ -2144,6 +2145,7 @@ labcd
 lan
 langid
 lasaine
+lbrb
 ld
 ldd
 le

--- a/drivers/dstate.h
+++ b/drivers/dstate.h
@@ -100,6 +100,10 @@ int dstate_is_stale(void);
 /* clean out the temp space for a new pass */
 void status_init(void);
 
+/* check if a status element has been set, return 0 if not, 1 if yes
+ * (considering a whole-word token in temporary status_buf) */
+int status_get(const char *buf);
+
 /* add a status element */
 void status_set(const char *buf);
 

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -1067,9 +1067,9 @@ void upsdrv_updateinfo(void)
 
 		upsdebugx(1, "Got to reconnect!");
 		if (use_interrupt_pipe == TRUE && interrupt_pipe_EIO_count > 0) {
-			upsdebugx(0, "\nReconnecting. If you saw \"nut_libusb_get_interrupt: Input/Output Error\" "
+			upsdebugx(0, "Reconnecting. If you saw \"nut_libusb_get_interrupt: Input/Output Error\" "
 				"or similar message in the log above, try setting \"pollonly\" flag in \"ups.conf\" "
-				"options section for this driver!\n");
+				"options section for this driver!");
 		}
 
 		if (!reconnect_ups()) {


### PR DESCRIPTION
Closes: #2347

It also adds some visibility around calibration status setting, extends "dstate" API with a `status_get()` method, and this helps avoid setting duplicate states (roughly like "OB LB OB") seen in some drivers earlier.

I hope this toggle allows to fix the problem in the field by optionally delaying spurious status propagation from the driver by `lbrb_log_delay_sec` at most, and if the device is otherwise "online" and is calibrating (unless `lbrb_log_delay_without_calibrating` flag was also set).

The fix goes to some lengths to try detecting the device model during init to default the setting to 3 sec for this line-up, otherwise defaults to 0 (immediate status propagation).