### PR TITLE
Teach `upsdrvctl` to list device config names and show run-time `status`, and to optionally hide the start-up banner

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -98,7 +98,7 @@ https://github.com/networkupstools/nut/milestone/11
  - Extended `upsdrvctl` with a `list` operation (or `-l` option) to report
    manageable device configuration names (possible `<ups>` arguments to
    `start`, `stop` etc. operations), or to confirm a single name that it
-   is known. [#2567]
+   is known, and a `status` operation for more information. [#2567]
 
  - riello_ser updates:
    * added `localcalculation` option to compute `battery.runtime` and

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -91,6 +91,10 @@ https://github.com/networkupstools/nut/milestone/11
    command for a protocol equivalent of sending a `SIGTERM`, e.g. when
    a newer instance of the driver program tries to start. [#1903, #2392]
 
+ - A new `NUT_QUIET_INIT_BANNER` envvar (presence or "true" value) can now
+   prevent the tool name and NUT version banner from being unilaterally
+   printed out when NUT programs start. [issues #1789 vs. #316]
+
  - Extended `upsdrvctl` with a `list` operation (or `-l` option) to report
    manageable device configuration names (possible `<ups>` arguments to
    `start`, `stop` etc. operations), or to confirm a single name that it

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -91,6 +91,11 @@ https://github.com/networkupstools/nut/milestone/11
    command for a protocol equivalent of sending a `SIGTERM`, e.g. when
    a newer instance of the driver program tries to start. [#1903, #2392]
 
+ - Extended `upsdrvctl` with a `list` operation (or `-l` option) to report
+   manageable device configuration names (possible `<ups>` arguments to
+   `start`, `stop` etc. operations), or to confirm a single name that it
+   is known. [#2567]
+
  - riello_ser updates:
    * added `localcalculation` option to compute `battery.runtime` and
      `battery.charge` if the device provides bogus values [issue #2390,

--- a/UPGRADING.adoc
+++ b/UPGRADING.adoc
@@ -100,6 +100,16 @@ Changes from 2.8.2 to 2.8.3
   Also the NUT daemons should request to double-check against their
   run-time process name (if it can be detected). [issue #2463]
 
+- More environment variable support was added to NUT programs, primarily
+  aimed at wrappers such as init scripts and service unit definitions,
+  allowing to tweak what (and whether) they write into debug traces, and
+  so "make noise" or "bring invaluable insights" to logs or terminal;
+  they can generally be used for services and init scripts via `nut.conf`:
+  * See `NUT_IGNORE_CHECKPROCNAME` and `NUT_DEBUG_SYSLOG` above. [#1915]
+  * A `NUT_QUIET_INIT_BANNER` envvar (presence or "true" value) prevents
+    tool name and NUT version banner from being printed out when programs
+    start. [issues #1789 vs. #316]
+
 
 Changes from 2.8.1 to 2.8.2
 ---------------------------

--- a/clients/upslog.c
+++ b/clients/upslog.c
@@ -439,7 +439,10 @@ int main(int argc, char **argv)
 	logformat = DEFAULT_LOGFORMAT;
 	user = RUN_AS_USER;
 
-	printf("Network UPS Tools %s %s\n", prog, UPS_VERSION);
+	if (!banner_is_disabled()) {
+		printf("Network UPS Tools %s %s\n", prog, UPS_VERSION);
+		fflush(stdout);
+	}
 
 	while ((i = getopt(argc, argv, "+hs:l:i:f:u:Vp:FBm:")) != -1) {
 		switch(i) {

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -2908,8 +2908,10 @@ int main(int argc, char *argv[])
 	}
 #endif
 
-	printf("Network UPS Tools %s %s\n", prog, UPS_VERSION);
-	fflush(stdout);
+	if (!banner_is_disabled()) {
+		printf("Network UPS Tools %s %s\n", prog, UPS_VERSION);
+		fflush(stdout);
+	}
 
 	/* if no configuration file is specified on the command line, use default */
 	configfile = xmalloc(SMALLBUF);

--- a/common/common.c
+++ b/common/common.c
@@ -189,6 +189,26 @@ int syslog_is_disabled(void)
 	return value;
 }
 
+int banner_is_disabled(void)
+{
+	static int value = -1;
+
+	if (value < 0) {
+		char *s = getenv("NUT_QUIET_INIT_BANNER");
+		/* Envvar present and empty or true-ish means NUT tool name+version
+		 * banners disabled by the setting: default is enabled (inversed per
+		 * method name) */
+		value = 0;
+		if (s) {
+			if (*s == '\0' || !strcasecmp(s, "true") || strcmp(s, "1")) {
+				value = 1;
+			}
+		}
+	}
+
+	return value;
+}
+
 /* enable writing upslog_with_errno() and upslogx() type messages to
    the syslog */
 void syslogbit_set(void)

--- a/conf/nut.conf.sample
+++ b/conf/nut.conf.sample
@@ -98,11 +98,13 @@ MODE=none
 # verbosity passed to NUT daemons. As an environment variable, its priority sits
 # between that of 'DEBUG_MIN' setting of a driver and the command-line options.
 #NUT_DEBUG_LEVEL=0
+#export NUT_DEBUG_LEVEL
 
 # Optionally add current process ID to tags with debug-level identifiers.
 # This may be useful when many NUT daemons write to the same console or log
 # file, such as in containers/plugins for Home Assistant, storage appliances...
 #NUT_DEBUG_PID=true
+#export NUT_DEBUG_PID
 
 # Normally NUT can (attempt to) use the syslog or Event Log (WIN32), but the
 # environment variable 'NUT_DEBUG_SYSLOG' allows to bypass it, and perhaps keep
@@ -113,6 +115,7 @@ MODE=none
 #  `none`    Disabled and background() detaches stderr as usual
 #  `default`/unset/other   Not disabled
 #NUT_DEBUG_SYSLOG=stderr
+#export NUT_DEBUG_SYSLOG
 
 # Normally NUT can (attempt to) verify that the program file name matches the
 # name associated with a running process, when using PID files to send signals.
@@ -122,6 +125,7 @@ MODE=none
 # optionally set in init-scripts or service methods for `upsd`, `upsmon` and
 # NUT drivers/`upsdrvctl`.
 #NUT_IGNORE_CHECKPROCNAME=true
+#export NUT_IGNORE_CHECKPROCNAME
 
 # Optional flag to prevent daemons which can notify service management frameworks
 # (such as systemd) about passing their lifecycle milestones, to not report
@@ -135,6 +139,7 @@ MODE=none
 # platforms without such a framework and not expecting one, although nagging
 # your favourite OS or contributing development to make it better is also a way.
 #NUT_QUIET_INIT_UPSNOTIFY=true
+#export NUT_QUIET_INIT_UPSNOTIFY
 
 ##############################################################################
 # Variables that can be helpful more for tool scripting than service daemons
@@ -145,6 +150,7 @@ MODE=none
 # they have initialized SSL support -- or, loudly, failed to initialize
 # as it was not configured on this system.
 #NUT_QUIET_INIT_SSL=true
+#export NUT_QUIET_INIT_SSL
 
 # Optionally suppress NUT tool name and version banner (normally shown in most
 # NUT programs unilaterally, before processing any CLI options and possibly
@@ -152,3 +158,4 @@ MODE=none
 # NOT recommended for services due to adverse troubleshooting impact, but may
 # be helpful in shell profiles or scripts which process NUT tool outputs.
 #NUT_QUIET_INIT_BANNER=true
+#export NUT_QUIET_INIT_BANNER

--- a/conf/nut.conf.sample
+++ b/conf/nut.conf.sample
@@ -117,3 +117,16 @@ MODE=none
 # optionally set in init-scripts or service methods for `upsd`, `upsmon` and
 # NUT drivers/`upsdrvctl`.
 #NUT_IGNORE_CHECKPROCNAME=true
+
+# Optional flag to prevent daemons which can notify service management frameworks
+# (such as systemd) about passing their lifecycle milestones, to not report
+# loudly if they could NOT do so (e.g. running on a system without a framework,
+# or misconfigured so they could not report and the OS could eventually restart
+# the false-positively identified "unresponsive" service.
+# Currently such reports, done by default, help troubleshoot service start-up
+# and highlight that NUT sources (or package build) did not take advantage of
+# tighter OS service management framework integration (if one exists, so that
+# developers could focus on adding that). Reasons to set this flag could include
+# platforms without such a framework and not expecting one, although nagging
+# your favourite OS or contributing development to make it better is also a way.
+#NUT_QUIET_INIT_UPSNOTIFY=true

--- a/conf/nut.conf.sample
+++ b/conf/nut.conf.sample
@@ -140,3 +140,10 @@ MODE=none
 # they have initialized SSL support -- or, loudly, failed to initialize
 # as it was not configured on this system.
 #NUT_QUIET_INIT_SSL=true
+
+# Optionally suppress NUT tool name and version banner (normally shown in most
+# NUT programs unilaterally, before processing any CLI options and possibly
+# failing due to that).
+# NOT recommended for services due to adverse troubleshooting impact, but may
+# be helpful in shell profiles or scripts which process NUT tool outputs.
+#NUT_QUIET_INIT_BANNER=true

--- a/conf/nut.conf.sample
+++ b/conf/nut.conf.sample
@@ -130,3 +130,13 @@ MODE=none
 # platforms without such a framework and not expecting one, although nagging
 # your favourite OS or contributing development to make it better is also a way.
 #NUT_QUIET_INIT_UPSNOTIFY=true
+
+##############################################################################
+# Variables that can be helpful more for tool scripting than service daemons
+##############################################################################
+
+# Optionally prevent `libupsclient` consumers (notoriously `upsc`, maybe
+# also `dummy-ups` driver or `nut-scanner` tool) from reporting whether
+# they have initialized SSL support -- or, loudly, failed to initialize
+# as it was not configured on this system.
+#NUT_QUIET_INIT_SSL=true

--- a/conf/nut.conf.sample
+++ b/conf/nut.conf.sample
@@ -9,11 +9,16 @@
 #
 # IMPORTANT NOTES:
 #  This file is intended to be sourced by standard POSIX shell scripts
-#  (so there is no guaranteed `export VAR=VAL` syntax) and additionally
-#  by systemd on Linux (no guaranteed expansion of variables).
+#  (so there is no guaranteed `export VAR=VAL` syntax, while you may need
+#  to `export VAR` when sourcing it into init-scripts, for propagation to
+#  NUT programs eventually), and additionally by systemd on Linux (with no
+#  guaranteed expansion of variables -- only verbatim assignments).
+#
 #  You MUST NOT use spaces around the equal sign!
+#
 #  Practical support for this file and its settings currently varies between
 #  various OS packages and NUT sample scripts, but should converge over time.
+#
 #  Contents of this file should be pure ASCII (character codes not in range
 #  would be ignored with a warning message).
 #

--- a/conf/nut.conf.sample
+++ b/conf/nut.conf.sample
@@ -94,6 +94,11 @@ MODE=none
 # between that of 'DEBUG_MIN' setting of a driver and the command-line options.
 #NUT_DEBUG_LEVEL=0
 
+# Optionally add current process ID to tags with debug-level identifiers.
+# This may be useful when many NUT daemons write to the same console or log
+# file, such as in containers/plugins for Home Assistant, storage appliances...
+#NUT_DEBUG_PID=true
+
 # Normally NUT can (attempt to) use the syslog or Event Log (WIN32), but the
 # environment variable 'NUT_DEBUG_SYSLOG' allows to bypass it, and perhaps keep
 # the daemons logging to stderr (useful e.g. in NUT Integration Test suite to

--- a/docs/maintainer-guide.txt
+++ b/docs/maintainer-guide.txt
@@ -228,6 +228,8 @@ MAINTAINER SANDBOX (to be completed and pushed)
 
 * announce on mailing list, IRC, etc.
 
+* update https://en.wikipedia.org/wiki/Network_UPS_Tools
+
 * create a GitHub issue label for the new release, e.g. at
   https://github.com/networkupstools/nut/labels?q=impact :
 ----

--- a/docs/man/nut.conf.txt
+++ b/docs/man/nut.conf.txt
@@ -23,9 +23,22 @@ comments.
 IMPORTANT NOTES
 ---------------
 
-* This file is intended to be sourced by shell scripts.
+* This file is intended to be sourced by shell scripts as well as by
+  service management frameworks like systemd on Linux:
+  - There is no guaranteed `export VAR=VAL` syntax
+  - No guaranteed expansion of variables like `VAR1="$VAR2-something"` --
+    only verbatim assignments
+  - You may need to `export VAR` when sourcing it into init-scripts
+    or other scripts, for eventual propagation of certain settings
+    to NUT programs. Not-exported variables can only be consumed by
+    the script which "sourced" the file (and may choose to `export`
+    them independently).
 
 * You MUST NOT use spaces around the equal sign!
+
+* Practical support for this file and its settings currently varies
+  between different OS packages and NUT sample scripts, but should
+  converge over time.
 
 * Contents of this file should be pure ASCII (character codes
   not in range would be ignored with a warning message).

--- a/docs/man/nut.conf.txt
+++ b/docs/man/nut.conf.txt
@@ -122,6 +122,11 @@ Optional, defaults to `0`. This setting controls the default debugging message
 verbosity passed to NUT daemons. As an environment variable, its priority sits
 between that of 'DEBUG_MIN' setting of a driver and the command-line options.
 
+*NUT_DEBUG_PID*::
+Optionally add current process ID to tags with debug-level identifiers.
+This may be useful when many NUT daemons write to the same console or log
+file, such as in containers/plugins for Home Assistant, storage appliances...
+
 *NUT_DEBUG_SYSLOG*::
 Optional, unset by default.
 Normally NUT can (attempt to) use the syslog or Event Log (WIN32), but the

--- a/docs/man/nut.conf.txt
+++ b/docs/man/nut.conf.txt
@@ -156,6 +156,20 @@ and do not match built-in expectations).
 This environment variable can also be optionally set in init-scripts or
 service methods for `upsd`, `upsmon` and NUT drivers/`upsdrvctl`.
 
+*NUT_QUIET_INIT_UPSNOTIFY*::
+Optional flag to prevent daemons which can notify service management frameworks
+(such as systemd) about passing their lifecycle milestones, to not report
+loudly if they could NOT do so (e.g. running on a system without a framework,
+or misconfigured so they could not report and the OS could eventually restart
+the false-positively identified "unresponsive" service.
++
+Currently such reports, done by default, help troubleshoot service start-up
+and highlight that NUT sources (or package build) did not take advantage of
+tighter OS service management framework integration (if one exists, so that
+developers could focus on adding that). Reasons to set this flag could include
+platforms without such a framework and not expecting one, although nagging
+your favourite OS or contributing development to make it better is also a way.
+
 EXAMPLE
 -------
 

--- a/docs/man/upsdrvctl.txt
+++ b/docs/man/upsdrvctl.txt
@@ -155,8 +155,8 @@ protocol):
                          name corresponds to driver, etc.); `STOPPED` if PID
                          was parsed but not running or has a wrong program
                          name; "N/A" if failed to parse it or no PID file
-        *PF_PID*;;       PID of driver according to PID file (if any), or
-                         `-1` on error
+        *PF_PID*;;       PID of driver according to PID file (if any), or some
+                         negative values upon errors (as defined in `common.c`)
         *S_RESPONSIVE*;; `RESPONSIVE` if `PING`/`PONG` during socket protocol
                          session setup succeeded; `NOT_RESPONSIVE` otherwise
         *S_PID*;;        PID of driver according to `GETPID` active query

--- a/docs/man/upsdrvctl.txt
+++ b/docs/man/upsdrvctl.txt
@@ -11,7 +11,7 @@ SYNOPSIS
 
 *upsdrvctl* -h
 
-*upsdrvctl* ['OPTIONS'] {start | stop | shutdown} ['ups']
+*upsdrvctl* ['OPTIONS'] {start | stop | shutdown | status} ['ups']
 
 *upsdrvctl* ['OPTIONS'] {list | -l} ['ups']
 
@@ -135,6 +135,10 @@ here and managed in other commands).
 NOTE: The tool name and NUT version banner line is also printed to `stdout`
 before any other processing. This can be suppressed by `NUT_QUIET_INIT_BANNER`
 environment variable (exported by caller and empty or "true").
+
+*status*::
+Similar to `list`, but reports more information -- also the driver name, the
+PID if it is running, and result of a signal probe to check it is responding.
 
 *-c* 'command'::
 Send 'command' to the background process as a signal.  Valid commands

--- a/docs/man/upsdrvctl.txt
+++ b/docs/man/upsdrvctl.txt
@@ -133,7 +133,8 @@ readable, or does not define any device sections (whose names are reported
 here and managed in other commands).
 
 NOTE: The tool name and NUT version banner line is also printed to `stdout`
-before any other processing.
+before any other processing. This can be suppressed by `NUT_QUIET_INIT_BANNER`
+environment variable (exported by caller and empty or "true").
 
 *-c* 'command'::
 Send 'command' to the background process as a signal.  Valid commands

--- a/docs/man/upsdrvctl.txt
+++ b/docs/man/upsdrvctl.txt
@@ -13,6 +13,8 @@ SYNOPSIS
 
 *upsdrvctl* ['OPTIONS'] {start | stop | shutdown} ['ups']
 
+*upsdrvctl* ['OPTIONS'] {list | -l} ['ups']
+
 *upsdrvctl* ['OPTIONS'] -c COMMAND ['ups']
 
 DESCRIPTION
@@ -81,6 +83,9 @@ this mode (not saved by default when staying in foreground).
 Drivers will run in the background, regardless of debugging settings,
 as set by *-D* and passed-through by *-d* options.
 
+*-l*::
+Alias for `list` command.
+
 COMMANDS
 --------
 
@@ -117,6 +122,18 @@ to lose power.
 NOTE: refer to linkman:ups.conf[5] for using the *nowait* parameter.
 It can be overridden by `NUT_IGNORE_NOWAIT` environment variable
 (e.g. used to work around certain issues with systemd otherwise).
+
+*list*::
+Without a further argument, report all currently known device configuration
+names to `stdout`, one per line. With an argument, also try to report that
+name, but exit with an error code if that name is not known.
+
+NOTE: The tool would exit with an error if `ups.conf` file is not found,
+readable, or does not define any device sections (whose names are reported
+here and managed in other commands).
+
+NOTE: The tool name and NUT version banner line is also printed to `stdout`
+before any other processing.
 
 *-c* 'command'::
 Send 'command' to the background process as a signal.  Valid commands

--- a/docs/man/upsdrvctl.txt
+++ b/docs/man/upsdrvctl.txt
@@ -142,6 +142,9 @@ PID if it is running, and result of a signal probe to check it is responding.
 
 	UPS2    dummy-ups       RUNNING 31455   RESPONSIVE      31455   "OL BOOST"
 
+Values are TAB-separated. Any complex string values would be encased in
+double-quotes.
+
 Fields reported (`PF_*` = according to PID file, if any; `S_*` = via socket
 protocol):
 
@@ -158,8 +161,6 @@ protocol):
                          session setup succeeded; `NOT_RESPONSIVE` otherwise
         *S_PID*;;        PID of driver according to `GETPID` active query
         *S_STATUS*;;     Value of `ups.status` variable
-
-Any complex string values would be encased in double-quotes.
 
 This mode does not discover drivers that are not in `ups.conf` (e.g. started
 manually for experiments with many `-x` CLI options).

--- a/docs/man/upsdrvctl.txt
+++ b/docs/man/upsdrvctl.txt
@@ -140,6 +140,30 @@ environment variable (exported by caller and empty or "true").
 Similar to `list`, but reports more information -- also the driver name, the
 PID if it is running, and result of a signal probe to check it is responding.
 
+	UPS2    dummy-ups       RUNNING 31455   RESPONSIVE      31455   "OL BOOST"
+
+Fields reported (`PF_*` = according to PID file, if any; `S_*` = via socket
+protocol):
+
+        *UPSNAME*;;      driver section configuration name
+        *UPSDRV*;;       driver program name per `ups.conf`
+        *PF_RUNNING*;;   `RUNNING` if `PF_PID` is valid (PID file existed,
+                         PID was parsed out of it and found running, program
+                         name corresponds to driver, etc.); `STOPPED` if PID
+                         was parsed but not running or has a wrong program
+                         name; "N/A" if failed to parse it or no PID file
+        *PF_PID*;;       PID of driver according to PID file (if any), or
+                         `-1` on error
+        *S_RESPONSIVE*;; `RESPONSIVE` if `PING`/`PONG` during socket protocol
+                         session setup succeeded; `NOT_RESPONSIVE` otherwise
+        *S_PID*;;        PID of driver according to `GETPID` active query
+        *S_STATUS*;;     Value of `ups.status` variable
+
+Any complex string values would be encased in double-quotes.
+
+This mode does not discover drivers that are not in `ups.conf` (e.g. started
+manually for experiments with many `-x` CLI options).
+
 *-c* 'command'::
 Send 'command' to the background process as a signal.  Valid commands
 are:

--- a/docs/man/upsdrvctl.txt
+++ b/docs/man/upsdrvctl.txt
@@ -139,7 +139,14 @@ environment variable (exported by caller and empty or "true").
 *status*::
 Similar to `list`, but reports more information -- also the driver name, the
 PID if it is running, and result of a signal probe to check it is responding.
+The `NUT_QUIET_INIT_BANNER` suppression can be helpful for scripted parsing.
+If there is anything to print (at least one device is known), the first line
+of status report would be the heading with column names:
 
+	:; NUT_QUIET_INIT_BANNER=true upsdrvctl status
+	UPSNAME UPSDRV  PF_RUNNING      PF_PID  S_RESPONSIVE    S_PID   S_STATUS
+	dummy   dummy-ups       N/A     -3      NOT_RESPONSIVE  N/A
+	eco650  usbhid-ups      RUNNING 3559207 RESPONSIVE      3559207 "OL"
 	UPS2    dummy-ups       RUNNING 31455   RESPONSIVE      31455   "OL BOOST"
 
 Values are TAB-separated. Any complex string values would be encased in

--- a/docs/man/upsdrvsvcctl.txt
+++ b/docs/man/upsdrvsvcctl.txt
@@ -127,6 +127,11 @@ by using the 'maxretry' and 'retrydelay' options - see linkman:ups.conf[5].
 *stop*::
 Stop the UPS driver(s).
 
+*status*::
+Query run-time status of all configured devices (or one specified device).
+Currently defers work to linkman:upsdrvctl[8], and does not report service
+unit information.
+
 *upsdrvsvcctl* also supports further operations for troubleshooting the
 mapping of NUT driver section names to the service instance names (which
 may differ due to limitations of various systems).

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3201 utf-8
+personal_ws-1.1 en 3203 utf-8
 AAC
 AAS
 ABI
@@ -262,6 +262,8 @@ DTE
 DTrace
 DUMPALL
 DUMPDONE
+DUMPSTATUS
+DUMPVALUE
 DWAKE
 DWITH
 DX

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3199 utf-8
+personal_ws-1.1 en 3201 utf-8
 AAC
 AAS
 ABI
@@ -392,6 +392,7 @@ GC
 GCCVER
 GES
 GETADDRINFO
+GETPID
 GID
 GND
 GNUmakefile
@@ -1175,6 +1176,7 @@ Stanislav
 StatePath
 Stefano
 Stimits
+StrangeOS
 SuSE
 Suatoni
 Sublicensing

--- a/docs/sock-protocol.txt
+++ b/docs/sock-protocol.txt
@@ -275,6 +275,27 @@ The server can tell when it has a full copy of the data by waiting for
 DUMPDONE.  That special response from the driver is sent once the entire
 set has been transmitted.
 
+DUMPVALUE
+~~~~~~~~~
+
+	DUMPVALUE <varname>
+
+	DUMPVALUE driver.version
+
+Only request the value of specified variable name (and its additional
+metadata in other lines), same as when `DUMPALL` iterates all such names.
+
+The NUT data server or other socket-protocol client should parse the
+response line by line, looking for the SETINFO line to get the value;
+if a DUMPDONE is seen first, the value was not available in the driver.
+
+DUMPSTATUS
+~~~~~~~~~~
+
+	DUMPSTATUS
+
+Effectively an alias to `DUMPVALUE ups.status`.
+
 NOBROADCAST
 ~~~~~~~~~~~
 

--- a/docs/sock-protocol.txt
+++ b/docs/sock-protocol.txt
@@ -130,6 +130,19 @@ DELCMD
 
 	DELCMD load.on
 
+PID
+~~~
+
+	PID <id>
+
+	PID 12345
+
+	PID "StrangeOS process identifier"
+
+Response to `GETPID` query, where we serve platform-specific process
+identifier. On POSIX and many other platforms this would be a numeric
+value, but most generally it should be treated as an opaque string.
+
 DUMPDONE
 ~~~~~~~~
 
@@ -239,6 +252,14 @@ NOTE:
 * "TRACKING <id>" can be provided to track commands execution status, if
 TRACKING was set to ON on upsd. In this case, driver will later return
 the execution status, using TRACKING.
+
+GETPID
+~~~~~~
+
+The server (or sibling driver instances, or `upsdrvctl` tool) can use
+this to request the platform-specific process identifier of the driver
+process. On POSIX and many other platforms this would be a numeric value,
+but most generally it should be treated as an opaque string.
 
 DUMPALL
 ~~~~~~~

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -701,8 +701,12 @@ static int sock_arg(conn_t *conn, size_t numarg, char **arg)
 		return 0;
 	}
 
-	if (!strcasecmp(arg[0], "DUMPALL")) {
+	if (!strcasecmp(arg[0], "GETPID")) {
+		send_to_one(conn, "PID %" PRIiMAX "\n", (intmax_t)getpid());
+		return 1;
+	}
 
+	if (!strcasecmp(arg[0], "DUMPALL")) {
 		/* first thing: the staleness flag (see also below) */
 		if ((stale == 1) && !send_to_one(conn, "DATASTALE\n")) {
 			return 1;

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -1766,7 +1766,9 @@ int main(int argc, char **argv)
 
 	open_syslog(progname);
 
-	upsdrv_banner();
+	if (!banner_is_disabled()) {
+		upsdrv_banner();
+	}
 
 	if (upsdrv_info.status == DRV_EXPERIMENTAL) {
 		printf("Warning: This is an experimental driver.\n");

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -1339,19 +1339,6 @@ int main(int argc, char **argv)
 			nut_debug_level = 2;
 	}
 
-	if (nut_debug_level_passthrough == 0) {
-		upsdebugx(2, "\n"
-			"If you're not a NUT core developer, chances are that you're told to enable debugging\n"
-			"to see why a driver isn't working for you. We're sorry for the confusion, but this is\n"
-			"the 'upsdrvctl' wrapper, not the driver you're interested in.\n\n"
-			"Below you'll find one or more lines starting with 'exec:' followed by an absolute\n"
-			"path to the driver binary and some command line option. This is what the driver\n"
-			"starts and you need to copy and paste that line and append the debug flags to that\n"
-			"line (less the 'exec:' prefix).\n\n"
-			"Alternately, provide an additional '-d' (lower-case) parameter to 'upsdrvctl' to\n"
-			"pass its current debug level to the launched driver, and '-B' keeps it backgrounded.\n");
-	}
-
 	/* Note: argv is incremented above, so [0] is currently the next
 	 * CLI keyword after options */
 	if (!command) {
@@ -1376,6 +1363,19 @@ int main(int argc, char **argv)
 
 	if (!command)
 		fatalx(EXIT_FAILURE, "Error: unrecognized command [%s]", argv[0]);
+
+	if (nut_debug_level_passthrough == 0 && (command == &start_driver || command == &shutdown_driver)) {
+		upsdebugx(2, "\n"
+			"If you're not a NUT core developer, chances are that you're told to enable debugging\n"
+			"to see why a driver isn't working for you. We're sorry for the confusion, but this is\n"
+			"the 'upsdrvctl' wrapper, not the driver you're interested in.\n\n"
+			"Below you'll find one or more lines starting with 'exec:' followed by an absolute\n"
+			"path to the driver binary and some command line option. This is what the driver\n"
+			"starts and you need to copy and paste that line and append the debug flags to that\n"
+			"line (less the 'exec:' prefix).\n\n"
+			"Alternately, provide an additional '-d' (lower-case) parameter to 'upsdrvctl' to\n"
+			"pass its current debug level to the launched driver, and '-B' keeps it backgrounded.\n");
+	}
 
 #ifndef WIN32
 	driverpath = xstrdup(DRVPATH);	/* set default */

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -915,6 +915,12 @@ static void status_driver(const ups_t *ups)
 		}
 	}
 
+	upsdrvquery_close(conn);
+	if (conn) {
+		free(conn);
+		conn = NULL;
+	}
+
 	printf("%s\t%s\t%s\t%" PRIiMAX "\t%s\t%s\t%s\n",
 		ups->upsname, ups->driver,
 		(pidFromFile < 0 ? "N/A" : (cmdret ? "STOPPED" : "RUNNING")),

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -863,7 +863,6 @@ static void status_driver(const ups_t *ups)
 
 			if (upsdrvquery_write(conn, "GETPID\n") >= 0
 			&&  (qretPid = upsdrvquery_read_timeout(conn, tv)) >= 1
-			&&  conn->buf
 			&&  (!strncmp(conn->buf, "PID ", 4))
 			) {
 				size_t	l;
@@ -884,7 +883,6 @@ static void status_driver(const ups_t *ups)
 
 			if (upsdrvquery_write(conn, "DUMPSTATUS\n") >= 0
 			&&  (qretStatus = upsdrvquery_read_timeout(conn, tv)) >= 1
-			&&  conn->buf
 			) {
 				char	*buf;
 

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -817,6 +817,7 @@ static void status_driver(const ups_t *ups)
 	 * the driver name, serial, etc. or even current life-cycle status
 	 * (e.g. valid PID existence, data query via socket protocol...)
 	 */
+	static int	headerShown = 0;
 	char	pidfn[SMALLBUF], bufPid[LARGEBUF], *pidStrFromSocket = NULL, bufStatus[LARGEBUF], *statusStrFromSocket = NULL;
 	int	cmdret = -1, qretPing = -1, qretPid = -1, qretStatus = -1, nsdl = nut_upsdrvquery_debug_level;
 	pid_t	pidFromFile = -1;
@@ -917,6 +918,19 @@ static void status_driver(const ups_t *ups)
 	if (conn) {
 		free(conn);
 		conn = NULL;
+	}
+
+	if (!headerShown) {
+		printf("%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			"UPSNAME",
+			"UPSDRV",
+			"PF_RUNNING",
+			"PF_PID",
+			"S_RESPONSIVE",
+			"S_PID",
+			"S_STATUS"
+			);
+		headerShown = 1;
 	}
 
 	printf("%s\t%s\t%s\t%" PRIiMAX "\t%s\t%s\t%s\n",

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -1088,10 +1088,10 @@ static void send_one_driver(void (*command_func)(const ups_t *), const char *arg
 /* walk UPS table and send command to all UPSes according to sdorder */
 static void send_all_drivers(void (*command_func)(const ups_t *))
 {
-	ups_t	*ups;
+	ups_t	*ups = upstable;
 	int	i;
 
-	if (!upstable)
+	if (!ups)
 		fatalx(EXIT_FAILURE, "Error: no UPS definitions found in ups.conf");
 
 	exec_error = 0;
@@ -1108,7 +1108,7 @@ static void send_all_drivers(void (*command_func)(const ups_t *))
 	}
 
 	if (command_func != &shutdown_driver) {
-		ups = upstable;
+		/* e.g. start_driver or stop_driver */
 
 		/* Only warn when relevant - got more than one device to start */
 		if (command_func == &start_driver
@@ -1142,8 +1142,6 @@ static void send_all_drivers(void (*command_func)(const ups_t *))
 
 	/* Orderly processing of shutdowns */
 	for (i = 0; i <= maxsdorder; i++) {
-		ups = upstable;
-
 		while (ups) {
 			if (ups->sdorder == i)
 				command_func(ups);

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -1193,7 +1193,7 @@ static void exit_cleanup(void)
 int main(int argc, char **argv)
 {
 	int	i, lastarg = 0;
-	char	*prog;
+	char	*prog, *command_name = NULL;
 
 	printf("Network UPS Tools - UPS driver controller %s\n",
 		UPS_VERSION);
@@ -1245,6 +1245,7 @@ int main(int argc, char **argv)
 						"sent with option -%c. Try -h for help.", i);
 				}
 				command = &signal_driver;
+				command_name = "signal";
 
 				if (!strncmp(optarg, "reload-or-error", strlen(optarg))) {
 					signal_flag = SIGCMD_RELOAD_OR_ERROR;
@@ -1299,6 +1300,7 @@ int main(int argc, char **argv)
 				break;
 			case 'l':
 				command = &list_driver;
+				command_name = "list";
 				break;
 			case 'h':
 			default:
@@ -1350,15 +1352,19 @@ int main(int argc, char **argv)
 	if (!command) {
 		if (!strcmp(argv[0], "start")) {
 			command = &start_driver;
+			command_name = argv[0];
 		} else
 		if (!strcmp(argv[0], "stop")) {
 			command = &stop_driver;
+			command_name = argv[0];
 		} else
 		if (!strcmp(argv[0], "shutdown")) {
 			command = &shutdown_driver;
+			command_name = argv[0];
 		} else
 		if (!strcmp(argv[0], "list")) {
 			command = &list_driver;
+			command_name = argv[0];
 		}
 		lastarg = 1;
 	}
@@ -1386,13 +1392,13 @@ int main(int argc, char **argv)
 		}
 
 		upsdebugx(1, "upsdrvctl commanding all drivers (%d found): %s",
-			upscount, (pt_cmd ? pt_cmd : NUT_STRARG(argv[lastarg])));
+			upscount, (pt_cmd ? pt_cmd : NUT_STRARG(command_name)));
 		send_all_drivers(command);
 	} else
 	if (argc == (lastarg + 1)) {
 		upscount = 1;
 		upsdebugx(1, "upsdrvctl commanding one driver (%s): %s",
-			argv[lastarg], (pt_cmd ? pt_cmd : NUT_STRARG(argv[lastarg - 1])));
+			argv[lastarg], (pt_cmd ? pt_cmd : NUT_STRARG(command_name)));
 		send_one_driver(command, argv[lastarg]);
 	} else {
 		fatalx(EXIT_FAILURE, "Error: extra arguments left on command line\n"

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -819,7 +819,7 @@ static void status_driver(const ups_t *ups)
 	 */
 	static int	headerShown = 0;
 	char	pidfn[SMALLBUF], bufPid[LARGEBUF], *pidStrFromSocket = NULL, bufStatus[LARGEBUF], *statusStrFromSocket = NULL;
-	int	cmdret = -1, qretPing = -1, qretPid = -1, qretStatus = -1, nsdl = nut_upsdrvquery_debug_level;
+	int	cmdret = -1, qretPing = -1, qretPid = -1, qretStatus = -1, nudl = nut_upsdrvquery_debug_level, nsdl = nut_sendsignal_debug_level;
 	pid_t	pidFromFile = -1;
 	struct timeval	tv;
 	udq_pipe_conn_t	*conn;
@@ -842,7 +842,10 @@ static void status_driver(const ups_t *ups)
 	cmdret = sendsignal(pidfn, 0, 1);
 #endif
 
+	/* Hush the fopen(socketfile) in upsdrvquery_connect_drvname_upsname() */
+	nut_upsdrvquery_debug_level = 0;
 	conn = upsdrvquery_connect_drvname_upsname(ups->driver, ups->upsname);
+	nut_upsdrvquery_debug_level = nudl;
 
 	if (conn && VALID_FD(conn->sockfd)) {
 		/* Post the query and wait for reply */
@@ -942,7 +945,7 @@ static void status_driver(const ups_t *ups)
 		((qretStatus == STAT_INSTCMD_HANDLED) ? NUT_STRARG(statusStrFromSocket) : "")
 		);
 
-	nut_upsdrvquery_debug_level = nsdl;
+	nut_sendsignal_debug_level = nsdl;
 }
 
 static void start_driver(const ups_t *ups)

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -191,6 +191,9 @@ static void signal_driver_cmd(const ups_t *ups,
 )
 {
 #ifndef WIN32
+/* TODO: implement WIN32: https://github.com/networkupstools/nut/issues/1916
+ * Currently the codepath is not implemented below
+ */
 	char	pidfn[SMALLBUF];
 #endif
 	int	ret;

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -1195,9 +1195,11 @@ int main(int argc, char **argv)
 	int	i, lastarg = 0;
 	char	*prog, *command_name = NULL;
 
-	printf("Network UPS Tools - UPS driver controller %s\n",
-		UPS_VERSION);
-	fflush(stdout);
+	if (!banner_is_disabled()) {
+		printf("Network UPS Tools - UPS driver controller %s\n",
+			UPS_VERSION);
+		fflush(stdout);
+	}
 
 	prog = argv[0];
 	while ((i = getopt(argc, argv, "+htu:r:DdFBVc:l")) != -1) {

--- a/drivers/upsdrvquery.c
+++ b/drivers/upsdrvquery.c
@@ -158,22 +158,22 @@ udq_pipe_conn_t *upsdrvquery_connect(const char *sockfn) {
 }
 
 udq_pipe_conn_t *upsdrvquery_connect_drvname_upsname(const char *drvname, const char *upsname) {
-	char	pidfn[SMALLBUF];
+	char	sockname[SMALLBUF];
 #ifndef WIN32
 	struct stat     fs;
-	snprintf(pidfn, sizeof(pidfn), "%s/%s-%s",
+	snprintf(sockname, sizeof(sockname), "%s/%s-%s",
 		dflt_statepath(), drvname, upsname);
-	check_unix_socket_filename(pidfn);
-	if (stat(pidfn, &fs)) {
+	check_unix_socket_filename(sockname);
+	if (stat(sockname, &fs)) {
 		if (nut_debug_level > 0 || nut_upsdrvquery_debug_level >= NUT_UPSDRVQUERY_DEBUG_LEVEL_CONNECT)
-			upslog_with_errno(LOG_ERR, "Can't open %s", pidfn);
+			upslog_with_errno(LOG_ERR, "Can't open %s", sockname);
 		return NULL;
 	}
 #else
-	snprintf(pidfn, sizeof(pidfn), "\\\\.\\pipe\\%s-%s", drvname, upsname);
+	snprintf(sockname, sizeof(sockname), "\\\\.\\pipe\\%s-%s", drvname, upsname);
 #endif  /* WIN32 */
 
-	return upsdrvquery_connect(pidfn);
+	return upsdrvquery_connect(sockname);
 }
 
 void upsdrvquery_close(udq_pipe_conn_t *conn) {

--- a/include/common.h
+++ b/include/common.h
@@ -295,15 +295,22 @@ pid_t get_max_pid_t(void);
  * -1 for error, or zero for a successfully sent signal */
 int sendsignalpid(pid_t pid, int sig, const char *progname, int check_current_progname);
 
-/* open <pidfn>, get the pid, then send it <sig>
+/* open <pidfn> and get the pid
+ * returns zero or more for successfully retrieved value,
+ * negative for errors:
+ * -3   PID file not found
+ * -2   PID file not parsable
+ */
+pid_t parsepidfile(const char *pidfn);
+
+#ifndef WIN32
+/* use parsepidfile() to get the pid, then send it <sig>
  * returns zero for successfully sent signal,
  * negative for errors:
  * -3   PID file not found
  * -2   PID file not parsable
  * -1   Error sending signal
- */
-#ifndef WIN32
-/* open <pidfn>, get the pid, then send it <sig>
+ *
  * if executable process with that pid has suitable progname
  * (specified or that of the current process, depending on args:
  * most daemons request to check_current_progname for their other

--- a/include/common.h
+++ b/include/common.h
@@ -200,6 +200,10 @@ extern const char *UPS_VERSION;
 /** @brief Default timeout (in seconds) for retrieving the result of a `TRACKING`-enabled operation (e.g. `INSTCMD`, `SET VAR`). */
 #define DEFAULT_TRACKING_TIMEOUT	10
 
+/* Based on NUT_QUIET_INIT_BANNER envvar (present and empty or "true")
+ * hide the NUT tool name+version banners; show them by default */
+int banner_is_disabled(void);
+
 /* Normally we can (attempt to) use the syslog or Event Log (WIN32),
  * but environment variable NUT_DEBUG_SYSLOG allows to bypass it, and
  * perhaps keep daemons logging to stderr (e.g. in NUT Integration Test

--- a/scripts/upsdrvsvcctl/upsdrvsvcctl.in
+++ b/scripts/upsdrvsvcctl/upsdrvsvcctl.in
@@ -1,6 +1,7 @@
 #!/bin/sh
 #
 # Copyright (C) 2016-2018 Eaton
+# Copyright (C) 2020-2024 Jim Klimov <jimklimov+nut@gmail.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -91,10 +92,21 @@ usage: $0 [OPTIONS] list [<ups>]
                 	to list the mapping of service instances to device sections
   list <ups>    	(optionally return the service instance name for one device)
 
+usage: $0 [OPTIONS] status [<ups>]
+  status        	report run-time status for each driver in ups.conf
+  status <ups>  	(optionally return the status info only for one device)
+                	Fields: UPSNAME UPSDRV PF_RUNNING PF_PID S_RESPONSIVE S_PID S_STATUS
+                	(PF_* = according to PID file, if any; S_* = via socket protocol)
 usage: $0 [OPTIONS] show-config [<ups>]
   show-config <ups>	output config section from ups.conf for device <ups>
   show-config   	...or all devices if no <ups> argument was passed
 EOF
+
+# TODO:
+#  status        	call $ENUMERATOR
+#                	to list the mapping of service instances to device sections
+#                	and report run-time status for each one
+
 }
 
 ACTION=""
@@ -131,6 +143,13 @@ while [ $# -gt 0 ]; do
             else
                 eval $ENUMERATOR --show-all-configs ; exit $?
             fi
+            ;;
+        status)
+            # TODO: Add info about service units
+            echo "NOTE: Action '$1' is not implemented via services currently, will call upsdrvctl" >&2
+            RES=0
+            @SBINDIR@/upsdrvctl status $2 || RES=$?
+            exit $RES
             ;;
         start|stop)
             ACTION="$1"

--- a/server/netget.c
+++ b/server/netget.c
@@ -167,13 +167,39 @@ static void get_type(nut_ctype_t *client, const char *upsname, const char *var)
 
 static void get_var_server(nut_ctype_t *client, const char *upsname, const char *var)
 {
+#ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+#pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+#pragma GCC diagnostic ignored "-Wunreachable-code"
+#endif
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunreachable-code"
+#endif
+	int	pkgurlHasNutOrg = PACKAGE_URL ? (strstr(PACKAGE_URL, "networkupstools.org") != NULL) : 0;
+
 	if (!strcasecmp(var, "server.info")) {
+		/* NOTE: Some compilers deduce that macro-based decisions about
+		 * NUT_VERSION_IS_RELEASE make one of codepaths unreachable in
+		 * a particular build. So we pragmatically handwave this away.
+		 */
 		sendback(client, "VAR %s server.info "
 			"\"Network UPS Tools upsd %s - "
-			"https://www.networkupstools.org/\"\n",
-			upsname, UPS_VERSION);
+			"%s%s%s\"\n",
+			upsname, UPS_VERSION,
+			PACKAGE_URL ? PACKAGE_URL : "",
+			(PACKAGE_URL && !pkgurlHasNutOrg) ? " or " : "",
+			pkgurlHasNutOrg ? "" : "https://www.networkupstools.org/"
+			);
 		return;
 	}
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+#ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+#pragma GCC diagnostic pop
+#endif
 
 	if (!strcasecmp(var, "server.version")) {
 		sendback(client, "VAR %s server.version \"%s\"\n",

--- a/server/netmisc.c
+++ b/server/netmisc.c
@@ -31,14 +31,46 @@
 
 void net_ver(nut_ctype_t *client, size_t numarg, const char **arg)
 {
+	int	pkgurlHasNutOrg = 0;
 	NUT_UNUSED_VARIABLE(arg);
+
 	if (numarg != 0) {
 		send_err(client, NUT_ERR_INVALID_ARGUMENT);
 		return;
 	}
 
-	sendback(client, "Network UPS Tools upsd %s - https://www.networkupstools.org/\n",
-		UPS_VERSION);
+#ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+#pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+#pragma GCC diagnostic ignored "-Wunreachable-code"
+#endif
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunreachable-code"
+#endif
+	if (PACKAGE_URL && strstr(PACKAGE_URL, "networkupstools.org")) {
+		pkgurlHasNutOrg = 1;
+	} else {
+		upsdebugx(1, "%s: WARNING: PACKAGE_URL of this build does not point to networkupstools.org!", __func__);
+	}
+
+	/* NOTE: Some compilers deduce that macro-based decisions about
+	 * NUT_VERSION_IS_RELEASE make one of codepaths unreachable in
+	 * a particular build. So we pragmatically handwave this away.
+	 */
+	sendback(client, "Network UPS Tools upsd %s - %s%s%s\n",
+		UPS_VERSION,
+		PACKAGE_URL ? PACKAGE_URL : "",
+		(PACKAGE_URL && !pkgurlHasNutOrg) ? " or " : "",
+		pkgurlHasNutOrg ? "" : "https://www.networkupstools.org/"
+		);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+#ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+#pragma GCC diagnostic pop
+#endif
 }
 
 void net_netver(nut_ctype_t *client, size_t numarg, const char **arg)

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -1935,8 +1935,10 @@ int main(int argc, char **argv)
 	/* set up some things for later */
 	snprintf(pidfn, sizeof(pidfn), "%s/%s.pid", altpidpath(), progname);
 
-	printf("Network UPS Tools %s %s\n", progname, UPS_VERSION);
-	fflush(stdout);
+	if (!banner_is_disabled()) {
+		printf("Network UPS Tools %s %s\n", progname, UPS_VERSION);
+		fflush(stdout);
+	}
 
 	while ((i = getopt(argc, argv, "+h46p:qr:i:fu:Vc:P:DFB")) != -1) {
 		switch (i) {

--- a/tools/gitlog2version.sh
+++ b/tools/gitlog2version.sh
@@ -259,3 +259,8 @@ fi
 
 report_debug
 report_output
+
+# Set exit code based on availability of default version info data point
+# Not empty means good
+# TOTHINK: consider the stdout of report_output() instead?
+[ x"${DESC50}" != x ]

--- a/tools/gitlog2version.sh
+++ b/tools/gitlog2version.sh
@@ -101,7 +101,7 @@ fi
 [ -n "${NUT_VERSION_DEFAULT-}" ] || NUT_VERSION_DEFAULT='2.8.2.1'
 
 # Default website paths, extended for historic sub-sites for a release
-[ -n "${NUT_WEBSITE-}" ] || NUT_WEBSITE="https://networkupstools.org/"
+[ -n "${NUT_WEBSITE-}" ] || NUT_WEBSITE="https://www.networkupstools.org/"
 
 # Must be "true" or "false" exactly, interpreted as such below:
 [ x"${NUT_VERSION_PREFER_GIT-}" = xfalse ] || { [ -e "${abs_top_srcdir}/.git" ] && NUT_VERSION_PREFER_GIT=true || NUT_VERSION_PREFER_GIT=false ; }

--- a/tools/gitlog2version.sh
+++ b/tools/gitlog2version.sh
@@ -130,7 +130,7 @@ getver_git() {
     || DESC="`git describe $ALL_TAGS_ARG $ALWAYS_DESC_ARG | grep -Ev '(rc|-signed|alpha|beta|Windows|IPM)' | grep -E 'v[0-9]*.[0-9]*.[0-9]'`"
     # Old stripper (also for possible refspec parts like "tags/"):
     #   echo "${DESC}" | sed -e 's/^v\([0-9]\)/\1/' -e 's,^.*/,,'
-    if [ x"${DESC}" = x ] ; then echo "$0: FAILED to 'git describe' this codebase" >&2 ; return ; fi
+    if [ x"${DESC}" = x ] ; then echo "$0: FAILED to 'git describe' this codebase" >&2 ; return 1 ; fi
 
     # How much of the known trunk history is in current HEAD?
     # e.g. all of it when we are on that branch or PR made from its tip,
@@ -138,7 +138,7 @@ getver_git() {
     # at the tagged commit (it is the merge base for itself and any of
     # its descendants):
     BASE="`git merge-base HEAD "${NUT_VERSION_GIT_TRUNK}"`" || BASE=""
-    if [ x"${BASE}" = x ] ; then echo "$0: FAILED to get a git merge-base of this codebase vs. '${NUT_VERSION_GIT_TRUNK}'" >&2 ; DESC=""; return ; fi
+    if [ x"${BASE}" = x ] ; then echo "$0: FAILED to get a git merge-base of this codebase vs. '${NUT_VERSION_GIT_TRUNK}'" >&2 ; DESC=""; return  1; fi
 
     # Nearest (annotated by default) tag preceding the HEAD in history:
     TAG="`echo "${DESC}" | sed 's/-[0-9][0-9]*-g[0-9a-fA-F][0-9a-fA-F]*$//'`"

--- a/tools/gitlog2version.sh
+++ b/tools/gitlog2version.sh
@@ -111,13 +111,6 @@ getver_git() {
     # or "upstream/master", etc.) for resulting version discovery to make sense.
     [ x"${NUT_VERSION_GIT_TRUNK-}" != x ] || NUT_VERSION_GIT_TRUNK=master
 
-    # How much of the known trunk history is in current HEAD?
-    # e.g. all of it when we are on that branch or PR made from its tip,
-    # some of it if looking at a historic snapshot, or nothing if looking
-    # at the tagged commit (it is the merge base for itself and any of
-    # its descendants):
-    BASE="`git merge-base HEAD "${NUT_VERSION_GIT_TRUNK}"`"
-
     # By default, only annotated tags are considered
     ALL_TAGS_ARG=""
     if [ x"${NUT_VERSION_GIT_ALL_TAGS-}" = xtrue ] ; then ALL_TAGS_ARG="--tags" ; fi
@@ -138,6 +131,14 @@ getver_git() {
     # Old stripper (also for possible refspec parts like "tags/"):
     #   echo "${DESC}" | sed -e 's/^v\([0-9]\)/\1/' -e 's,^.*/,,'
     if [ x"${DESC}" = x ] ; then echo "$0: FAILED to 'git describe' this codebase" >&2 ; return ; fi
+
+    # How much of the known trunk history is in current HEAD?
+    # e.g. all of it when we are on that branch or PR made from its tip,
+    # some of it if looking at a historic snapshot, or nothing if looking
+    # at the tagged commit (it is the merge base for itself and any of
+    # its descendants):
+    BASE="`git merge-base HEAD "${NUT_VERSION_GIT_TRUNK}"`" || BASE=""
+    if [ x"${BASE}" = x ] ; then echo "$0: FAILED to get a git merge-base of this codebase vs. '${NUT_VERSION_GIT_TRUNK}'" >&2 ; DESC=""; return ; fi
 
     # Nearest (annotated by default) tag preceding the HEAD in history:
     TAG="`echo "${DESC}" | sed 's/-[0-9][0-9]*-g[0-9a-fA-F][0-9a-fA-F]*$//'`"

--- a/tools/gitlog2version.sh
+++ b/tools/gitlog2version.sh
@@ -249,7 +249,7 @@ report_output() {
 DESC=""
 if $NUT_VERSION_PREFER_GIT ; then
     if (command -v git && git rev-parse --show-toplevel) >/dev/null 2>/dev/null ; then
-        getver_git || DESC=""
+        getver_git || { echo "$0: Fall back to pre-set default version information" >&2 ; DESC=""; }
     fi
 fi
 


### PR DESCRIPTION
Also update some docs for recently added tweaking envvars, and use `PACKAGE_URL` value in networked queries (`upsd` `GET` and `GET VAR <upsname> server.info`).

Touches on several issues/PRs:
* #2567
* #1789
* #316
* #1949
* #2118
* #2136
* #1662

UPDATE: With `status` (also in `upsdrvsvcctl`, albeit rudimentary -- just calling `upsdrvctl` but not drilling into service unit info) it actually...
Closes: #2567

