### PR TITLE
Follow-up to `upsdrvctl status` on Windows, add `LOGOUT` to local socket protocol

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -217,6 +217,8 @@ during a NUT build.
      and values (or macros) in the NUT codebase. [issue #1176, issue #31]
    * custom `distcheck-something` targets did not inherit `DISTCHECK_FLAGS`
      properly. [#2541]
+   * local socket/pipe protocol introduced a `LOGOUT` command for cleaner
+     disconnection handling. [#2572]
 
  - updated `docs/nut-names.txt` with items defined by 42ITy NUT fork. [#2339]
 

--- a/common/common.c
+++ b/common/common.c
@@ -1412,8 +1412,10 @@ pid_t parsepid(const char *buf)
 	pid_t	pid = -1;
 	intmax_t	_pid;
 
+	errno = 0;
 	if (!buf) {
 		upsdebugx(6, "%s: called with NULL input", __func__);
+		errno = EINVAL;
 		return pid;
 	}
 
@@ -1422,6 +1424,8 @@ pid_t parsepid(const char *buf)
 	if (_pid <= get_max_pid_t()) {
 		pid = (pid_t)_pid;
 	} else {
+		errno = ERANGE;
+
 		if (nut_debug_level > 0 || nut_sendsignal_debug_level > 0)
 			upslogx(LOG_NOTICE,
 				"Received a pid number too big for a pid_t: %"

--- a/docs/man/upsdrvctl.txt
+++ b/docs/man/upsdrvctl.txt
@@ -149,30 +149,38 @@ If there is anything to print (at least one device is known), the first line
 of status report would be the heading with column names:
 
 	:; NUT_QUIET_INIT_BANNER=true upsdrvctl status
-	UPSNAME UPSDRV  PF_RUNNING      PF_PID  S_RESPONSIVE    S_PID   S_STATUS
-	dummy   dummy-ups       N/A     -3      NOT_RESPONSIVE  N/A
-	eco650  usbhid-ups      RUNNING 3559207 RESPONSIVE      3559207 "OL"
-	UPS2    dummy-ups       RUNNING 31455   RESPONSIVE      31455   "OL BOOST"
+	UPSNAME              UPSDRV  RUNNING PF_PID  S_RESPONSIVE    S_PID   S_STATUS
+	dummy             dummy-ups  N/A     -3      NOT_RESPONSIVE  N/A
+	eco650           usbhid-ups  RUNNING 3559207 RESPONSIVE      3559207 "OL"
+	UPS2              dummy-ups  RUNNING 31455   RESPONSIVE      31455   "OL BOOST"
 
-Values are TAB-separated. Any complex string values would be encased in
-double-quotes.
+Values are TAB-separated, but UPSNAME and UPSDRV may be padded by spaces
+on the right and on the left respectively. Any complex string values would
+be encased in double-quotes.
 
 Fields reported (`PF_*` = according to PID file, if any; `S_*` = via socket
 protocol):
 
         *UPSNAME*;;      driver section configuration name
         *UPSDRV*;;       driver program name per `ups.conf`
-        *PF_RUNNING*;;   `RUNNING` if `PF_PID` is valid (PID file existed,
-                         PID was parsed out of it and found running, program
-                         name corresponds to driver, etc.); `STOPPED` if PID
-                         was parsed but not running or has a wrong program
-                         name; "N/A" if failed to parse it or no PID file
+        *RUNNING*;;      `RUNNING` if `PF_PID` or `S_PID` is valid,
+                         `STOPPED` if at least one PID value was parsed but
+                         none was found running with a correct program name;
+                         `N/A` if no PID file/socket reply or failed to parse.
+                         First the PID file is consulted, but it may be absent
+                         either due to command-line parameters of daemons, or
+                         due to platform (WIN32). If no PID value was found and
+                         confirmed this way, we fall back to checking the PID
+                         reported via protocol (if available and different).
         *PF_PID*;;       PID of driver according to PID file (if any), or some
                          negative values upon errors (as defined in `common.c`)
+                         including an absent PID file, invalid contents, or
+                         unsupported platform for this mechanism (e.g. WIN32)
         *S_RESPONSIVE*;; `RESPONSIVE` if `PING`/`PONG` during socket protocol
                          session setup succeeded; `NOT_RESPONSIVE` otherwise
-        *S_PID*;;        PID of driver according to `GETPID` active query
-        *S_STATUS*;;     Value of `ups.status` variable
+        *S_PID*;;        PID of driver according to `GETPID` active query,
+                         or `N/A` if the query failed
+        *S_STATUS*;;     Quoted value of `ups.status` variable
 
 This mode does not discover drivers that are not in `ups.conf` (e.g. started
 manually for experiments with many `-x` CLI options).

--- a/docs/man/upsdrvctl.txt
+++ b/docs/man/upsdrvctl.txt
@@ -134,7 +134,12 @@ here and managed in other commands).
 
 NOTE: The tool name and NUT version banner line is also printed to `stdout`
 before any other processing. This can be suppressed by `NUT_QUIET_INIT_BANNER`
-environment variable (exported by caller and empty or "true").
+environment variable (exported by caller and empty or "true"):
+
+	:; NUT_QUIET_INIT_BANNER=true upsdrvctl list
+	dummy
+	UPS1
+	UPS2
 
 *status*::
 Similar to `list`, but reports more information -- also the driver name, the

--- a/docs/man/upsdrvsvcctl.txt
+++ b/docs/man/upsdrvsvcctl.txt
@@ -11,7 +11,7 @@ SYNOPSIS
 
 *upsdrvsvcctl* -h
 
-*upsdrvsvcctl* ['OPTIONS'] {start | stop } ['ups']
+*upsdrvsvcctl* ['OPTIONS'] {start | stop | status} ['ups']
 
 DESCRIPTION
 -----------
@@ -135,8 +135,11 @@ Stop the UPS driver(s).
 
 *status*::
 Query run-time status of all configured devices (or one specified device).
-Currently defers work to linkman:upsdrvctl[8], and does not report service
-unit information.
+Currently defers work to linkman:upsdrvctl[8], to list known device
+configurations and their driver daemon details (PID, responsiveness,
+`ups.status`) and to linkman:nut-driver-enumerator[8] to map device
+names to service unit instances to report their names and states in
+the service management framework.
 
 *upsdrvsvcctl* also supports further operations for troubleshooting the
 mapping of NUT driver section names to the service instance names (which

--- a/docs/man/upsdrvsvcctl.txt
+++ b/docs/man/upsdrvsvcctl.txt
@@ -61,7 +61,13 @@ OPTIONS
 -------
 
 *-h*::
-Display the help text.
+Display the help text, including the built-in version of the script.
+
+*-V*::
+Display the version of NUT binaries (calling *upsdrvctl -V*), which
+normally should not differ much from the built-in version of the script
+shown in help. But with custom builds everything is possible, so it may
+be useful to know.
 
 *-t*::
 Enable testing mode. Testing mode makes upsdrvsvcctl display the actions

--- a/docs/sock-protocol.txt
+++ b/docs/sock-protocol.txt
@@ -162,6 +162,14 @@ This is sent in response to a PING from the server.  It is only used as
 a sanity check to make sure that the driver has not gotten stuck
 somewhere.
 
+OK
+~~
+
+	OK Goodbye
+
+This is sent in response to a LOGOUT from the server (or more likely from
+a sibling driver or `upsdrvctl` program).
+
 DATAOK
 ~~~~~~
 
@@ -311,6 +319,17 @@ enables that -- unless disabled by providing an optional zero or negative
 numeric argument. Note that initial default is to receive everything, so
 this command may be useful for connections that disabled broadcasts at
 some point.
+
+LOGOUT
+~~~~~~
+
+Primarily used by communications between driver processes and/or `upsdrvctl`,
+this command allows clients to gracefully close connection to the NUT driver
+which acts as the server on the socket/pipe, avoiding noisy logs about sudden
+disconnection.
+
+	LOGOUT
+	OK Goodbye
 
 Design notes
 ------------

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -203,6 +203,7 @@ static TYPE_FD sock_open(const char *fn)
 static void sock_disconnect(conn_t *conn)
 {
 #ifndef WIN32
+	upsdebugx(3, "%s: disconnecting socket %d", __func__, (int)conn->fd);
 	close(conn->fd);
 #else
 	/* FIXME not sure if this is the right way to close a connection */
@@ -210,11 +211,14 @@ static void sock_disconnect(conn_t *conn)
 		CloseHandle(conn->read_overlapped.hEvent);
 		conn->read_overlapped.hEvent = INVALID_HANDLE_VALUE;
 	}
+	upsdebugx(3, "%s: disconnecting named pipe handle %p", __func__, conn->fd);
 	DisconnectNamedPipe(conn->fd);
 #endif
 
+	upsdebugx(5, "%s: finishing parsing context", __func__);
 	pconf_finish(&conn->ctx);
 
+	upsdebugx(5, "%s: relinking the chain of connections", __func__);
 	if (conn->prev) {
 		conn->prev->next = conn->next;
 	} else {
@@ -227,6 +231,7 @@ static void sock_disconnect(conn_t *conn)
 		/* conntail = conn->prev; */
 	}
 
+	upsdebugx(5, "%s: freeing the conn object", __func__);
 	free(conn);
 }
 
@@ -701,6 +706,21 @@ static int sock_arg(conn_t *conn, size_t numarg, char **arg)
 		return 0;
 	}
 
+	if (!strcasecmp(arg[0], "LOGOUT")) {
+		send_to_one(conn, "OK Goodbye\n");
+#ifndef WIN32
+		upsdebugx(2, "%s: received LOGOUT on socket %d, disconnecting", __func__, (int)conn->fd);
+#else
+		upsdebugx(2, "%s: received LOGOUT on handle %p, disconnecting", __func__, conn->fd);
+#endif
+		/* Let the system flush the reply somehow (or the other
+		 * side to just see it) before we drop the pipe */
+		usleep(1000000);
+		sock_disconnect(conn);
+		upsdebugx(4, "%s: LOGOUT processing finished", __func__);
+		return 2;
+	}
+
 	if (!strcasecmp(arg[0], "GETPID")) {
 		send_to_one(conn, "PID %" PRIiMAX "\n", (intmax_t)getpid());
 		return 1;
@@ -901,6 +921,7 @@ static int sock_arg(conn_t *conn, size_t numarg, char **arg)
 static void sock_read(conn_t *conn)
 {
 	ssize_t	ret, i;
+	int	ret_arg = -1;
 
 #ifndef WIN32
 	char	buf[SMALLBUF];
@@ -979,7 +1000,8 @@ static void sock_read(conn_t *conn)
 			continue;
 
 		case 1: /* try to use it, and complain about unknown commands */
-			if (!sock_arg(conn, conn->ctx.numargs, conn->ctx.arglist)) {
+			ret_arg = sock_arg(conn, conn->ctx.numargs, conn->ctx.arglist);
+			if (!ret_arg) {
 				size_t	arg;
 
 				upslogx(LOG_INFO, "Unknown command on socket: ");
@@ -987,7 +1009,12 @@ static void sock_read(conn_t *conn)
 				for (arg = 0; arg < conn->ctx.numargs && arg < INT_MAX; arg++) {
 					upslogx(LOG_INFO, "arg %d: %s", (int)arg, conn->ctx.arglist[arg]);
 				}
+			} else if (ret_arg == 2) {
+				/* closed by LOGOUT processing, conn is free()'d */
+				upsdebugx(1, "%s: returning early, socket is not valid anymore", __func__);
+				return;
 			}
+
 			continue;
 
 		default: /* nothing parsed */
@@ -1154,6 +1181,8 @@ int dstate_poll_fds(struct timeval timeout, TYPE_FD arg_extrafd)
 
 		if (FD_ISSET(conn->fd, &rfds)) {
 			sock_read(conn);
+			/* Note: do not use "conn" after loop,
+			 * it may be freed by LOGOUT */
 		}
 	}
 
@@ -1235,6 +1264,8 @@ int dstate_poll_fds(struct timeval timeout, TYPE_FD arg_extrafd)
 	else {
 		if (conn != NULL) {
 			sock_read(conn);
+			/* Note: do not use "conn" after this,
+			 * it may be freed by LOGOUT */
 		}
 	}
 

--- a/drivers/dstate.h
+++ b/drivers/dstate.h
@@ -54,6 +54,7 @@ typedef struct conn_s {
 	struct conn_s	*next;
 	int	nobroadcast;	/* connections can request to ignore send_to_all() updates */
 	int	readzero;	/* how many times in a row we had zero bytes read; see DSTATE_CONN_READZERO_THROTTLE_USEC and DSTATE_CONN_READZERO_THROTTLE_MAX */
+	int	closing;	/* raised during LOGOUT processing, to close the socket when time is right */
 } conn_t;
 
 /* sleep after read()ing zero bytes */

--- a/drivers/upsdrvquery.c
+++ b/drivers/upsdrvquery.c
@@ -180,6 +180,20 @@ void upsdrvquery_close(udq_pipe_conn_t *conn) {
 	if (!conn)
 		return;
 
+	if (VALID_FD(conn->sockfd)) {
+		int	nudl = nut_upsdrvquery_debug_level;
+		ssize_t ret;
+		upsdebugx(5, "%s: closing driver socket, try to say goodbye", __func__);
+		ret = upsdrvquery_write(conn, "LOGOUT\n");
+		if (7 <= ret) {
+			upsdebugx(5, "%s: okay", __func__);
+			usleep(1000000);
+		} else {
+			upsdebugx(5, "%s: must have been closed on the other side", __func__);
+		}
+		nut_upsdrvquery_debug_level = nudl;
+	}
+
 #ifndef WIN32
 	if (VALID_FD(conn->sockfd))
 		close(conn->sockfd);

--- a/scripts/upsdrvsvcctl/upsdrvsvcctl.in
+++ b/scripts/upsdrvsvcctl/upsdrvsvcctl.in
@@ -44,6 +44,7 @@ case "$SERVICE_FRAMEWORK" in
     *)  echo "Unrecognized SERVICE_FRAMEWORK: $SERVICE_FRAMEWORK" >&2 ; exit ;;
 esac
 UPSDRVCTL='@SBINDIR@/upsdrvctl'
+PACKAGE_VERSION='@PACKAGE_VERSION@'
 
 usage() {
     # Note: version header differs from UPS_VERSION in binaries that
@@ -58,6 +59,8 @@ usage: $0 [OPTIONS] (start | stop | shutdown) [<ups>]
 
 Options:
   -h            	display this help
+  -V            	display upsdrvctl binary program version (should
+                	not differ from script version above, but...)
   -t            	testing mode - prints actions without doing them
   -D            	raise debugging level
   --timeout-cmd <prog>	service management calls will be time-limited
@@ -190,6 +193,7 @@ while [ $# -gt 0 ]; do
             ;;
         -t) DRYRUN="echo" ;;
         -h) usage; exit 0 ;;
+        -V) "${UPSDRVCTL}" -V ; exit ;;
         -D) DEBUG="`expr $DEBUG + 1`" ;;
         -r|-u) echo "Option '$1 $2' is not implemented via services currently" >&2 ; shift;;
         *)  echo "Unrecognized argument: $1" >&2 ; exit ;;

--- a/scripts/upsdrvsvcctl/upsdrvsvcctl.in
+++ b/scripts/upsdrvsvcctl/upsdrvsvcctl.in
@@ -43,7 +43,7 @@ case "$SERVICE_FRAMEWORK" in
         ;;
     *)  echo "Unrecognized SERVICE_FRAMEWORK: $SERVICE_FRAMEWORK" >&2 ; exit ;;
 esac
-
+UPSDRVCTL='@SBINDIR@/upsdrvctl'
 
 usage() {
     # Note: version header differs from UPS_VERSION in binaries that
@@ -148,7 +148,7 @@ while [ $# -gt 0 ]; do
             # TODO: Add info about service units
             echo "NOTE: Action '$1' is not implemented via services currently, will call upsdrvctl" >&2
             RES=0
-            @SBINDIR@/upsdrvctl status $2 || RES=$?
+            "${UPSDRVCTL}" status $2 || RES=$?
             exit $RES
             ;;
         start|stop)
@@ -163,7 +163,7 @@ while [ $# -gt 0 ]; do
             echo "Stopping the driver service instance(s) to release exclusive resources, if any..." >&2
             RES=0
             $0 stop $2
-            @SBINDIR@/upsdrvctl shutdown $2 || RES=$?
+            "${UPSDRVCTL}" shutdown $2 || RES=$?
             echo "Starting the driver service instance(s) so they can reconnect when the UPS returns..." >&2
             $0 start $2
             exit $RES

--- a/scripts/upsdrvsvcctl/upsdrvsvcctl.in
+++ b/scripts/upsdrvsvcctl/upsdrvsvcctl.in
@@ -33,12 +33,17 @@ fi
 VERB=""
 CMD=""
 CMDARG=""
+# Note: some frameworks separate the commands for acting and for reporting
+CMDREPORT=""
+CMDREPORTARG=""
 ENUMERATOR=""
 case "$SERVICE_FRAMEWORK" in
     smf) CMD="/usr/sbin/svcadm"
+        CMDREPORT="/usr/bin/svcs"
         ENUMERATOR="@NUT_LIBEXECDIR@/nut-driver-enumerator.sh"
         ;;
     systemd) CMD="/bin/systemctl"
+        CMDREPORT="${CMD}"
         ENUMERATOR="@NUT_LIBEXECDIR@/nut-driver-enumerator.sh"
         ;;
     *)  echo "Unrecognized SERVICE_FRAMEWORK: $SERVICE_FRAMEWORK" >&2 ; exit ;;
@@ -97,19 +102,18 @@ usage: $0 [OPTIONS] list [<ups>]
 
 usage: $0 [OPTIONS] status [<ups>]
   status        	report run-time status for each driver in ups.conf
+                	and call $ENUMERATOR
+                	to list the mapping of service instances to device sections
+                	and report run-time status for each one that was matched
   status <ups>  	(optionally return the status info only for one device)
-                	Fields: UPSNAME UPSDRV PF_RUNNING PF_PID S_RESPONSIVE S_PID S_STATUS
-                	(PF_* = according to PID file, if any; S_* = via socket protocol)
+                	Fields: SVC_NAME SVC_STATE UPSNAME UPSDRV RUNNING PF_PID S_RESPONSIVE S_PID S_STATUS
+                	(SVC_* according to service management framework; and
+                	PF_* = according to PID file, if any; S_* = via socket
+                	protocol -- as defined by upsdrvctl)
 usage: $0 [OPTIONS] show-config [<ups>]
   show-config <ups>	output config section from ups.conf for device <ups>
   show-config   	...or all devices if no <ups> argument was passed
 EOF
-
-# TODO:
-#  status        	call $ENUMERATOR
-#                	to list the mapping of service instances to device sections
-#                	and report run-time status for each one
-
 }
 
 ACTION=""
@@ -148,10 +152,81 @@ while [ $# -gt 0 ]; do
             fi
             ;;
         status)
-            # TODO: Add info about service units
-            echo "NOTE: Action '$1' is not implemented via services currently, will call upsdrvctl" >&2
             RES=0
-            "${UPSDRVCTL}" status $2 || RES=$?
+            STATUSES="`NUT_QUIET_INIT_BANNER=true "${UPSDRVCTL}" status $2`" || RES=$?
+            if [ x"${STATUSES}" = x ]; then
+                exit $RES
+            fi
+
+            SVCINSTS="`$0 list $2`" || RES=$?
+            # Use a common approach below, even if we only got one instance name from list()
+            if [ -n "$2" ] && [ -n "${SVCINSTS}" ] ; then SVCINSTS="${SVCINSTS}	$2" ; fi
+
+            case "$SERVICE_FRAMEWORK" in
+                smf) SVC_STATE_WIDTH="11" ;;
+                systemd) SVC_STATE_WIDTH="23" ;;
+            esac
+
+            echo "$STATUSES" | ( COUNT=0; while IFS='' read LINE ; do
+                COUNT="`expr $COUNT + 1`"
+                if [ "$COUNT" = 1 ] ; then
+                    # Header line
+                    printf '%-30s\t%'"${SVC_STATE_WIDTH}"'s\t%s\n' "SVC_NAME" "SVC_STATE" "$LINE"
+                    continue
+                fi
+                DEV_NAME="`echo "$LINE" | awk '{print $1}'`"
+                SVC_NAME="`echo "$SVCINSTS" | awk '($NF == "'"${DEV_NAME}"'") {print $1}'`" && [ -n "$SVC_NAME" ] || SVC_NAME="N/A"
+                if [ x"$SVC_NAME" = "N/A" ]; then
+                    SVC_STATE="N/A"
+                else
+                    case "$SERVICE_FRAMEWORK" in
+                        smf) SVC_STATE="`$CMDREPORT -Hostate ${SVC_NAME} 2>/dev/null`" \
+                            && [ -n "$SVC_STATE" ] && [ 1 = `echo "$SVC_STATE" | wc -l` ] \
+                            || SVC_STATE="N/A"
+                            ;;
+                        systemd) SVC_STATE=""
+                            CMDRES=0
+                            OUT="`$CMDREPORT is-enabled "${SVC_NAME}" 2>/dev/null`" || CMDRES=$?
+                            if [ x"$OUT" != x ] ; then SVC_STATE="${OUT}" ; else
+                                [ 0 = "$CMDRES" ] && SVC_STATE="enabled" || SVC_STATE="disabled"
+                            fi
+                            # At this point we should have some value, so others below
+                            # may be or not be suffixed with a comma.
+
+                            # The masked unit state has no separate query in some (all?)
+                            # systemd versions and can be reported as part of the above
+                            CMDRES=0
+                            OUT="`$CMDREPORT is-masked "${SVC_NAME}" 2>/dev/null`" || CMDRES=$?
+                            if [ x"$OUT" != x ] ; then
+                                if [ x"${SVC_STATE}" != xmasked ] && [ x"${SVC_STATE}" != x"${OUT}" ] ; then
+                                    SVC_STATE="${SVC_STATE},${OUT}"
+                                fi
+                            else
+                                [ 0 = "$CMDRES" ] && SVC_STATE="${SVC_STATE},masked" || true
+                            fi
+
+                            CMDRES=0
+                            OUT="`$CMDREPORT is-active "${SVC_NAME}" 2>/dev/null`" || CMDRES=$?
+                            if [ x"$OUT" != x ] ; then
+                                SVC_STATE="${SVC_STATE},${OUT}"
+                            else
+                                [ 0 = "$CMDRES" ] && SVC_STATE="${SVC_STATE},active" || true
+                            fi
+
+                            CMDRES=0
+                            OUT="`$CMDREPORT is-failed "${SVC_NAME}" 2>/dev/null`" || CMDRES=$?
+                            if [ x"$OUT" != x ] ; then
+                                if [ x"${OUT}" != xactive ] && [ x"${OUT}" != xinactive ] ; then
+                                    SVC_STATE="${SVC_STATE},${OUT}"
+                                fi
+                            else
+                                [ 0 = "$CMDRES" ] && SVC_STATE="${SVC_STATE},failed" || true
+                            fi
+                            ;;
+                    esac
+                fi
+                printf '%-30s\t%'"${SVC_STATE_WIDTH}"'s\t%s\n' "$SVC_NAME" "$SVC_STATE" "$LINE"
+            done )
             exit $RES
             ;;
         start|stop)

--- a/scripts/upsdrvsvcctl/upsdrvsvcctl.in
+++ b/scripts/upsdrvsvcctl/upsdrvsvcctl.in
@@ -36,19 +36,18 @@ CMDARG=""
 # Note: some frameworks separate the commands for acting and for reporting
 CMDREPORT=""
 CMDREPORTARG=""
-ENUMERATOR=""
 case "$SERVICE_FRAMEWORK" in
     smf) CMD="/usr/sbin/svcadm"
         CMDREPORT="/usr/bin/svcs"
-        ENUMERATOR="@NUT_LIBEXECDIR@/nut-driver-enumerator.sh"
+        [ -n "${ENUMERATOR-}" ] && export ENUMERATOR || ENUMERATOR="@NUT_LIBEXECDIR@/nut-driver-enumerator.sh"
         ;;
     systemd) CMD="/bin/systemctl"
         CMDREPORT="${CMD}"
-        ENUMERATOR="@NUT_LIBEXECDIR@/nut-driver-enumerator.sh"
+        [ -n "${ENUMERATOR-}" ] && export ENUMERATOR || ENUMERATOR="@NUT_LIBEXECDIR@/nut-driver-enumerator.sh"
         ;;
     *)  echo "Unrecognized SERVICE_FRAMEWORK: $SERVICE_FRAMEWORK" >&2 ; exit ;;
 esac
-UPSDRVCTL='@SBINDIR@/upsdrvctl'
+[ -n "${UPSDRVCTL-}" ] && export UPSDRVCTL || UPSDRVCTL='@SBINDIR@/upsdrvctl'
 PACKAGE_VERSION='@PACKAGE_VERSION@'
 
 usage() {

--- a/scripts/upsdrvsvcctl/upsdrvsvcctl.in
+++ b/scripts/upsdrvsvcctl/upsdrvsvcctl.in
@@ -161,16 +161,18 @@ while [ $# -gt 0 ]; do
             # Use a common approach below, even if we only got one instance name from list()
             if [ -n "$2" ] && [ -n "${SVCINSTS}" ] ; then SVCINSTS="${SVCINSTS}	$2" ; fi
 
+            # Accomodate svc:/system/power/nut-driver:dummy (SMF)
+            # or         nut-driver@dummy.service           (systemd)
             case "$SERVICE_FRAMEWORK" in
-                smf) SVC_STATE_WIDTH="11" ;;
-                systemd) SVC_STATE_WIDTH="23" ;;
+                smf) SVC_NAME_WIDTH="39" ; SVC_STATE_WIDTH="11" ;;
+                systemd) SVC_NAME_WIDTH="30" ; SVC_STATE_WIDTH="23" ;;
             esac
 
             echo "$STATUSES" | ( COUNT=0; while IFS='' read LINE ; do
                 COUNT="`expr $COUNT + 1`"
                 if [ "$COUNT" = 1 ] ; then
                     # Header line
-                    printf '%-30s\t%'"${SVC_STATE_WIDTH}"'s\t%s\n' "SVC_NAME" "SVC_STATE" "$LINE"
+                    printf '%-'"${SVC_NAME_WIDTH}"'s\t%'"${SVC_STATE_WIDTH}"'s\t%s\n' "SVC_NAME" "SVC_STATE" "$LINE"
                     continue
                 fi
                 DEV_NAME="`echo "$LINE" | awk '{print $1}'`"
@@ -224,7 +226,7 @@ while [ $# -gt 0 ]; do
                             ;;
                     esac
                 fi
-                printf '%-30s\t%'"${SVC_STATE_WIDTH}"'s\t%s\n' "$SVC_NAME" "$SVC_STATE" "$LINE"
+                printf '%-'"${SVC_NAME_WIDTH}"'s\t%'"${SVC_STATE_WIDTH}"'s\t%s\n' "$SVC_NAME" "$SVC_STATE" "$LINE"
             done )
             exit $RES
             ;;

--- a/server/netmisc.c
+++ b/server/netmisc.c
@@ -92,8 +92,9 @@ void net_help(nut_ctype_t *client, size_t numarg, const char **arg)
 		return;
 	}
 
-	sendback(client, "Commands: HELP VER GET LIST SET INSTCMD LOGIN LOGOUT"
-		" USERNAME PASSWORD STARTTLS\n");
+	sendback(client, "Commands: HELP VER PROTVER GET LIST SET INSTCMD"
+		" LOGIN LOGOUT USERNAME PASSWORD STARTTLS\n");
+	/* Not exposed: PRIMARY/MASTER FSD */
 }
 
 void net_fsd(nut_ctype_t *client, size_t numarg, const char **arg)

--- a/tools/gitlog2version.sh
+++ b/tools/gitlog2version.sh
@@ -111,8 +111,11 @@ getver_git() {
     # or "upstream/master", etc.) for resulting version discovery to make sense.
     if [ x"${NUT_VERSION_GIT_TRUNK-}" = x ] ; then
         # Find the newest info, it may be in a fetched branch
-        # not yet checked out locally (or long not updated)
-        for T in master `git branch -a 2>/dev/null | grep -E '^ *remotes/[^ ]*/master$'` origin/master upstream/master ; do
+        # not yet checked out locally (or long not updated).
+        # Currently we repeat the likely branch names in the
+        # end, so that if they exist and are still newest -
+        # those are the names to report.
+        for T in master `git branch -a 2>/dev/null | grep -E '^ *remotes/[^ ]*/master$'` origin/master upstream/master master ; do
             git log -1 "$T" 2>/dev/null >/dev/null || continue
             if [ x"${NUT_VERSION_GIT_TRUNK-}" = x ] ; then
                 NUT_VERSION_GIT_TRUNK="$T"


### PR DESCRIPTION
Address lack of signals, properly close connections, add `LOGOUT` to dstate (local socket protocol).

Follows up primarily from issue #2567 / PR #2568 but also touches on some other recent work like #1949 

UPDATE: Also completes `upsdrvsvcctl status`, tested with Debian Linux systemd and OpenIndiana SMF