### PR TITLE
Fix compilation on newer gcc-13.x and clang-18, fix `nut-scanner` offering config values not applicable for some USB drivers

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -221,6 +221,10 @@ during a NUT build.
      properly. [#2541]
    * local socket/pipe protocol introduced a `LOGOUT` command for cleaner
      disconnection handling. [#2572]
+   * codebase adapted to the liking of `clang-18` and newer revisions of
+     `gcc-13`+ whose static analyzers on NUT CI farm complained about some
+     imperfections after adding newer OS revisions to the population of
+     build agents. [#2585, #2588]
 
  - updated `docs/nut-names.txt` with items defined by 42ITy NUT fork. [#2339]
 

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -189,6 +189,9 @@ during a NUT build.
      all supported buses with `-m auto` takes unbearably long. [#2523]
    * bumped version of `libnutscan` to 2.6.0, it now includes a few more
      methods and symbols from `libcommon`. [issue #2244, PR #2509]
+   * do not actively suggest `vendor(id)`, `product(id)`, and `serial` options
+     for `bcmxcp_usb`, `richcomm_usb` and `nutdrv_atcl_usb` drivers for now
+     [#1763, #1764, #1768, #2580]
 
  - common code:
    * introduced a `NUT_DEBUG_SYSLOG` environment variable to tweak activation

--- a/UPGRADING.adoc
+++ b/UPGRADING.adoc
@@ -110,6 +110,12 @@ Changes from 2.8.2 to 2.8.3
     tool name and NUT version banner from being printed out when programs
     start. [issues #1789 vs. #316]
 
+- A `configure` script option to `--enable-NUT_STRARG-always` was added
+  to enable the `NUT_STRARG` macro (to handle `NULL` string printing)
+  even if system libraries seem to safely support this behavior natively.
+  This should primarily help against overly zealous static analysis tools
+  in recent compiler generations. [#2585]
+
 
 Changes from 2.8.1 to 2.8.2
 ---------------------------

--- a/clients/nutclient.cpp
+++ b/clients/nutclient.cpp
@@ -1367,6 +1367,31 @@ std::vector<std::string> TcpClient::explode(const std::string& str, size_t begin
 			}
 			state = QUOTED_STRING;
 			break;
+
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT
+# pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+# pragma GCC diagnostic ignored "-Wunreachable-code"
+#endif
+/* Older CLANG (e.g. clang-3.4) seems to not support the GCC pragmas above */
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunreachable-code"
+# pragma clang diagnostic ignored "-Wcovered-switch-default"
+#endif
+		default:
+			/* Must not occur. */
+			break;
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic pop
+#endif
 		}
 	}
 

--- a/clients/upsclient.c
+++ b/clients/upsclient.c
@@ -620,6 +620,9 @@ const char *upscli_strerror(UPSCONN_t *ups)
 			upscli_errlist[ups->upserror].str,
 			ups->pc_ctx.errmsg);
 		return ups->errbuf;
+
+	default:
+		break;
 	}
 
 #ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_NONLITERAL
@@ -1059,6 +1062,8 @@ int upscli_tryconnect(UPSCONN_t *ups, const char *host, uint16_t port, int flags
 			return -1;
 		case EAI_SYSTEM:
 			ups->syserrno = errno;
+			break;
+		default:
 			break;
 		}
 

--- a/clients/upslog.c
+++ b/clients/upslog.c
@@ -523,6 +523,12 @@ int main(int argc, char **argv)
 			case 'B':
 				foreground = 0;
 				break;
+
+			default:
+				fatalx(EXIT_FAILURE,
+					"Error: unknown option -%c. Try -h for help.",
+					(char)i);
+
 		}
 	}
 

--- a/clients/upssched.c
+++ b/clients/upssched.c
@@ -286,6 +286,9 @@ static void us_serialize(int op)
 			ret = read(pipefd[0], &ch, 1);
 			close(pipefd[0]);
 			break;
+
+		default:
+			break;
 	}
 }
 #endif
@@ -1531,6 +1534,11 @@ int main(int argc, char **argv)
 				/* just show the optional CONFIG_FLAGS banner */
 				nut_report_config_flags();
 				exit(EXIT_SUCCESS);
+
+			default:
+				fatalx(EXIT_FAILURE,
+					"Error: unknown option -%c. Try -h for help.",
+					(char)i);
 		}
 	}
 

--- a/common/common.c
+++ b/common/common.c
@@ -1407,6 +1407,9 @@ int sendsignalpid(pid_t pid, int sig, const char *progname, int check_current_pr
 							(uintmax_t)pid);
 					}
 					break;
+
+				default:
+					break;
 			}
 		}
 

--- a/common/nutconf.cpp
+++ b/common/nutconf.cpp
@@ -439,6 +439,30 @@ std::list<NutParser::Token> NutParser::parseLine()
 			case Token::TOKEN_NONE:
 			case Token::TOKEN_EOL:
 				return res;
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT
+# pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+# pragma GCC diagnostic ignored "-Wunreachable-code"
+#endif
+/* Older CLANG (e.g. clang-3.4) seems to not support the GCC pragmas above */
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunreachable-code"
+# pragma clang diagnostic ignored "-Wcovered-switch-default"
+#endif
+			default:
+				/* Must not occur. */
+				break;
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic pop
+#endif
 		}
 	}
 }
@@ -703,6 +727,9 @@ void NutConfigParser::parseConfig()
 						break;
 				}
 				break;
+
+			default:
+				break;
 		}
 	}
 
@@ -727,6 +754,8 @@ void NutConfigParser::parseConfig()
 			break;
 		case CPS_DEFAULT:
 			/* TOTHINK: no-op? */
+			break;
+		default:
 			break;
 	}
 #ifdef __clang__

--- a/common/nutstream.cpp
+++ b/common/nutstream.cpp
@@ -432,6 +432,31 @@ const char * NutFile::strAccessMode(access_t mode)
 		case APPEND_ONLY:
 			mode_str = append_only;
 			break;
+
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT
+# pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+# pragma GCC diagnostic ignored "-Wunreachable-code"
+#endif
+/* Older CLANG (e.g. clang-3.4) seems to not support the GCC pragmas above */
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunreachable-code"
+# pragma clang diagnostic ignored "-Wcovered-switch-default"
+#endif
+		default:
+			/* Must not occur. */
+			break;
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic pop
+#endif
 	}
 
 	assert(nullptr != mode_str);
@@ -1049,6 +1074,8 @@ bool NutSocket::accept(
 		case ENFILE:		// Open file descriptors per-system limit was reached
 		case EPROTO:		// Protocol error
 			return false;
+		default:
+			break;
 	}
 
 	std::stringstream e;

--- a/common/nutwriter.cpp
+++ b/common/nutwriter.cpp
@@ -289,6 +289,31 @@ NutWriter::status_t NutConfConfigWriter::writeConfig(const NutConfiguration & co
 			case NutConfiguration::MODE_MANUAL:
 				mode_str = "manual";
 				break;
+
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT
+# pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+# pragma GCC diagnostic ignored "-Wunreachable-code"
+#endif
+/* Older CLANG (e.g. clang-3.4) seems to not support the GCC pragmas above */
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunreachable-code"
+# pragma clang diagnostic ignored "-Wcovered-switch-default"
+#endif
+			default:
+				/* Must not occur. */
+				break;
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic pop
+#endif
 		}
 
 		status = writeDirective("MODE=" + mode_str);

--- a/common/parseconf.c
+++ b/common/parseconf.c
@@ -485,6 +485,9 @@ static void parse_char(PCONF_CTX_t *ctx)
 		case STATE_COLLECTLITERAL:
 			ctx->state = collectliteral(ctx);
 			break;
+
+		default:
+			break;
 	}	/* switch */
 }
 

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -437,12 +437,14 @@ which generated them from data walks, but developers did not rename yet
 to NUT mappings conforming to `docs/nut-names.txt` standards. Production
 driver builds must not include any non-standard names.
 
-	--enable-NUT_STRARG-always (default: no)
+	--enable-NUT_STRARG-always (default: auto)
 
 Enable the `NUT_STRARG` macro (to handle `NULL` string printing) even
-if the system libraries seem to safely support this behavior natively.
+if the system libraries seem to safely support this behavior natively?
 This flag should primarily help against overly zealous static analysis
-tools in recent compiler generations.
+tools in recent compiler generations.  The `auto` value enables the flag
+for certain compiler versions known to complain about some of our use
+cases -- even though those seem to be false positives.
 
 
 I want it all!

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -437,6 +437,14 @@ which generated them from data walks, but developers did not rename yet
 to NUT mappings conforming to `docs/nut-names.txt` standards. Production
 driver builds must not include any non-standard names.
 
+	--enable-NUT_STRARG-always (default: no)
+
+Enable the `NUT_STRARG` macro (to handle `NULL` string printing) even
+if the system libraries seem to safely support this behavior natively.
+This flag should primarily help against overly zealous static analysis
+tools in recent compiler generations.
+
+
 I want it all!
 ~~~~~~~~~~~~~~
 

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3204 utf-8
+personal_ws-1.1 en 3205 utf-8
 AAC
 AAS
 ABI
@@ -1106,6 +1106,7 @@ STI
 STIME
 STO
 STP
+STRARG
 SUNWlibusbugen
 SUNWugen
 SUNWusb

--- a/drivers/apc_modbus.c
+++ b/drivers/apc_modbus.c
@@ -363,6 +363,30 @@ static int _apc_modbus_to_double(const apc_modbus_value_t *value, double *output
 			break;
 		case APC_VT_STRING:
 			return 0;
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT
+# pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+# pragma GCC diagnostic ignored "-Wunreachable-code"
+#endif
+/* Older CLANG (e.g. clang-3.4) seems to not support the GCC pragmas above */
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunreachable-code"
+# pragma clang diagnostic ignored "-Wcovered-switch-default"
+#endif
+		default:
+			/* Must not occur. */
+			break;
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic pop
+#endif
 	}
 
 	return 1;
@@ -1050,6 +1074,31 @@ static int _apc_modbus_update_value(apc_modbus_register_t *regs_info, const uint
 	case APC_VT_UINT:
 		_apc_modbus_to_uint64(regs, regs_info->modbus_len, &value.data.uint_value);
 		break;
+
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT
+# pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+# pragma GCC diagnostic ignored "-Wunreachable-code"
+#endif
+/* Older CLANG (e.g. clang-3.4) seems to not support the GCC pragmas above */
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunreachable-code"
+# pragma clang diagnostic ignored "-Wcovered-switch-default"
+#endif
+	default:
+		/* Must not occur. */
+		break;
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic pop
+#endif
 	}
 
 	if (regs_info->value_converter != NULL && regs_info->value_converter->apc_to_nut != NULL) {
@@ -1078,6 +1127,31 @@ static int _apc_modbus_update_value(apc_modbus_register_t *regs_info, const uint
 		case APC_VT_UINT:
 			dstate_setinfo(regs_info->nut_variable_name, regs_info->value_format, value.data.uint_value);
 			break;
+
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT
+# pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+# pragma GCC diagnostic ignored "-Wunreachable-code"
+#endif
+/* Older CLANG (e.g. clang-3.4) seems to not support the GCC pragmas above */
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunreachable-code"
+# pragma clang diagnostic ignored "-Wcovered-switch-default"
+#endif
+		default:
+			/* Must not occur. */
+			break;
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic pop
+#endif
 		}
 #ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_NONLITERAL
 #pragma GCC diagnostic pop
@@ -1205,6 +1279,31 @@ static int _apc_modbus_setvar(const char *nut_varname, const char *str_value)
 		case APC_VT_UINT:
 			r = _apc_modbus_from_uint64_string(str_value, reg_value, apc_value->modbus_len);
 			break;
+
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT
+# pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+# pragma GCC diagnostic ignored "-Wunreachable-code"
+#endif
+/* Older CLANG (e.g. clang-3.4) seems to not support the GCC pragmas above */
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunreachable-code"
+# pragma clang diagnostic ignored "-Wcovered-switch-default"
+#endif
+		default:
+			/* Must not occur. */
+			break;
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic pop
+#endif
 		}
 
 		if (!r) {

--- a/drivers/apcsmart-old.c
+++ b/drivers/apcsmart-old.c
@@ -118,6 +118,9 @@ static const char *convert_data(apc_vartab_t *cmd_entry, const char *upsval)
 				case 'S': return "simulated power failure or UPS test";
 				default: return upsval;
 			}
+
+		default:
+			break;
 	}
 
 	upslogx(LOG_NOTICE, "Unable to handle conversion of %s", cmd_entry->name);

--- a/drivers/apcsmart.c
+++ b/drivers/apcsmart.c
@@ -196,6 +196,9 @@ static const char *convert_data(apc_vartab_t *vt, const char *upsval)
 					  strcpy(temp, upsval);
 					  return temp;
 			}
+
+		default:
+			break;
 	}
 
 	/* this should never happen */

--- a/drivers/bcmxcp.c
+++ b/drivers/bcmxcp.c
@@ -2218,6 +2218,10 @@ void upsdrv_help(void)
 /* list flags and values that you want to receive via -x */
 void upsdrv_makevartable(void)
 {
+	/* NOTE: The USB variant of this driver currently does not
+	 * involve nut_usb_addvars() method like others do. When
+	 * fixing, see also tools/nut-scanner/scan_usb.c "exceptions".
+	 */
 	addvar(VAR_VALUE, "shutdown_delay", "Specify shutdown delay (seconds)");
 	addvar(VAR_VALUE, "baud_rate", "Specify communication speed (ex: 9600)");
 }

--- a/drivers/bcmxcp.c
+++ b/drivers/bcmxcp.c
@@ -1158,6 +1158,8 @@ void init_ext_vars(void)
 						dstate_setaux("battery.packs", 1);
 						break;
 
+			default:
+						break;
 		}
 	}
 }
@@ -2096,6 +2098,8 @@ static int instcmd(const char *cmdname, const char *extra)
 				cbuf[2] = 0x2;
 				break;                  /*mute beeper*/
 				}
+			default:
+				break;
 		}
 		cbuf[3] = 0x0;          /*padding*/
 

--- a/drivers/belkin-hid.c
+++ b/drivers/belkin-hid.c
@@ -665,6 +665,9 @@ static int belkin_claim(HIDDevice_t *hd)
 			}
 			possibly_supported("Liebert", hd);
 			return 0;
+
+		default:
+			break;
 		}
 		return 0;
 

--- a/drivers/bestups.c
+++ b/drivers/bestups.c
@@ -209,6 +209,9 @@ static void ups_ident(void)
 		case 5:
 			highvolt = atof(ptr);
 			break;
+
+		default:
+			break;
 		}
 
 		ptr = strtok(NULL, ",");

--- a/drivers/blazer_usb.c
+++ b/drivers/blazer_usb.c
@@ -138,6 +138,9 @@ static int phoenix_command(const char *cmd, char *buf, size_t buflen)
 
 		case LIBUSB_ERROR_TIMEOUT: /** Operation or Connection timed out */
 			break;
+
+		default:
+			break;
 		}
 
 		if (ret < 0) {

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -106,6 +106,9 @@ static void sock_fail(const char *fn)
 		printf(" - rm %s\n\n", dflt_statepath());
 		printf(" - mkdir %s\n", dflt_statepath());
 		break;
+
+	default:
+		break;
 	}
 
 	/*

--- a/drivers/etapro.c
+++ b/drivers/etapro.c
@@ -106,6 +106,8 @@ etapro_get_response(const char *resp_type)
 	case 'T':
 		dstate_setinfo("ups.mfr.date", "%s", cp + 2);
 		return 0;
+	default:
+		break;
 	}
 	/* Handle all other responses as hexadecimal numbers.  */
 	val = 0;

--- a/drivers/hidparser.c
+++ b/drivers/hidparser.c
@@ -350,6 +350,9 @@ static int HIDParse(HIDParser_t *pParser, HIDData_t *pData)
 			/* can't handle long items, but should at least skip them */
 			pParser->Pos += (uint8_t)(pParser->Value & 0xff);
 			break;
+
+		default:
+			break;
 		}
 	} /* while ((Found < 0) && (pParser->Pos < pParser->ReportDescSize)) */
 

--- a/drivers/huawei-ups2000.c
+++ b/drivers/huawei-ups2000.c
@@ -1035,6 +1035,9 @@ static int ups2000_update_alarm(void)
 				case ALARM_CLEAR_DEPENDING:
 					upslogx(loglevel, "This alarm is auto or manual cleared "
 							  "depending on the specific problem.");
+					break;
+				default:
+					break;
 				}
 
 				ups2000_alarm[i].active = 1;

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -555,6 +555,9 @@ finish:
 
 		case  0:	/* value may not be (re-)applied, but it may not have been required */
 			break;
+
+		default:
+			break;
 	}
 
 	upsdebugx(6, "%s: verdict for (re)loading var=%s value: %d",
@@ -647,6 +650,9 @@ finish:
 			break;
 
 		case  0:	/* value may not be (re-)applied, but it may not have been required */
+			break;
+
+		default:
 			break;
 	}
 
@@ -1701,6 +1707,8 @@ int main(int argc, char **argv)
 			case 'd':
 				dump_data = atoi(optarg);
 				break;
+			default:
+				break;
 		}
 	}
 	/* Reset the index, read argv[1] next time (loop below)
@@ -1965,7 +1973,8 @@ int main(int argc, char **argv)
 				exit(EXIT_SUCCESS);
 			default:
 				fatalx(EXIT_FAILURE,
-					"Error: unknown option -%c. Try -h for help.", i);
+					"Error: unknown option -%c. Try -h for help.",
+					(char)i);
 		}
 	}
 

--- a/drivers/mge-hid.c
+++ b/drivers/mge-hid.c
@@ -1669,6 +1669,9 @@ static int mge_claim(HIDDevice_t *hd) {
 
 				/* Let liebert-hid grab this */
 				return 0;
+
+			default:
+				break;
 		}
 
 		return 1;

--- a/drivers/mge-xml.c
+++ b/drivers/mge-xml.c
@@ -510,6 +510,8 @@ static const char *mge_beeper_info(const char *arg_val)
 		return "enabled";
 	case 3:
 		return "muted";
+	default:
+		break;
 	}
 	return NULL;
 }
@@ -528,6 +530,8 @@ static const char *mge_upstype_conversion(const char *arg_val)
 		return "online - parallel with hot standy";
 	case 5:
 		return "online - hot standby redundancy";
+	default:
+		break;
 	}
 	return NULL;
 }
@@ -542,6 +546,8 @@ static const char *mge_sensitivity_info(const char *arg_val)
 		return "high";
 	case 2:
 		return "low";
+	default:
+		break;
 	}
 	return NULL;
 }
@@ -566,6 +572,8 @@ static const char *mge_test_result_info(const char *arg_val)
 		return "no test initiated";
 	case 7:
 		return "test scheduled";
+	default:
+		break;
 	}
 	return NULL;
 }
@@ -1416,6 +1424,10 @@ static int mge_xml_startelm_cb(void *userdata, int parent, const char *nspace, c
 			state = XC_BROADCAST;
 			break;
 		}
+		break;
+
+	default:
+		break;
 	}
 
 	upsdebugx(3, "%s: name <%s> (parent = %d, state = %d)", __func__, name, parent, state);
@@ -1444,6 +1456,9 @@ static int mge_xml_cdata_cb(void *userdata, int state, const char *cdata, size_t
 	case SU_OBJECT:
 	case GO_OBJECT:
 		snprintfcat(val, sizeof(val), "%.*s", (int)len, cdata);
+		break;
+
+	default:
 		break;
 	}
 
@@ -1516,6 +1531,9 @@ static int mge_xml_endelm_cb(void *userdata, int state, const char *nspace, cons
 		dstate_detect_phasecount("output.", 1,
 			&inited_phaseinfo_out, &num_outphases, 0);
 
+		break;
+
+	default:
 		break;
 	}
 

--- a/drivers/netxml-ups.c
+++ b/drivers/netxml-ups.c
@@ -1149,13 +1149,36 @@ static void object_entry_destroy(object_query_t *handle, object_entry_t *entry) 
 	switch (handle->type) {
 		case SET_OBJECT_REQUEST:
 			set_object_req_destroy(&entry->payld.req);
-
 			break;
 
 		case SET_OBJECT_RESPONSE:
 			set_object_resp_destroy(&entry->payld.resp);
-
 			break;
+
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT
+# pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+# pragma GCC diagnostic ignored "-Wunreachable-code"
+#endif
+/* Older CLANG (e.g. clang-3.4) seems to not support the GCC pragmas above */
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunreachable-code"
+# pragma clang diagnostic ignored "-Wcovered-switch-default"
+#endif
+		default:
+			/* Must not occur. */
+			break;
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic pop
+#endif
 	}
 
 	/* Destroy entry */
@@ -1809,13 +1832,36 @@ static object_query_t *set_object(object_query_t *req) {
 	switch (req->mode) {
 		case RAW_POST:
 			resp = set_object_raw(req);
-
 			break;
 
 		case FORM_POST:
 			resp = set_object_form(req);
-
 			break;
+
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT
+# pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+# pragma GCC diagnostic ignored "-Wunreachable-code"
+#endif
+/* Older CLANG (e.g. clang-3.4) seems to not support the GCC pragmas above */
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunreachable-code"
+# pragma clang diagnostic ignored "-Wcovered-switch-default"
+#endif
+		default:
+			/* Must not occur. */
+			break;
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic pop
+#endif
 	}
 
 	return resp;

--- a/drivers/nut-libfreeipmi.c
+++ b/drivers/nut-libfreeipmi.c
@@ -1069,6 +1069,8 @@ int nut_ipmi_get_sensors_status(IPMIDevice_t *ipmi_dev)
 					str_count++;
 				}
 				break;
+			default:
+				break;
 		}
 	}
 
@@ -1091,6 +1093,8 @@ int nut_ipmi_get_sensors_status(IPMIDevice_t *ipmi_dev)
 			case PSU_POWER_FAILURE:
 				status_set("OFF");
 				retval = 0;
+				break;
+			default:
 				break;
 		}
 

--- a/drivers/nutdrv_atcl_usb.c
+++ b/drivers/nutdrv_atcl_usb.c
@@ -440,6 +440,9 @@ static int usb_device_open(usb_dev_handle **handlep, USBDevice_t *device, USBDev
 				case -2:
 					upsdebugx(4, "matcher: unspecified error");
 					goto next_device;
+
+				default:
+					break;
 				}
 			}
 #ifdef HAVE_LIBUSB_SET_AUTO_DETACH_KERNEL_DRIVER

--- a/drivers/nutdrv_atcl_usb.c
+++ b/drivers/nutdrv_atcl_usb.c
@@ -689,6 +689,7 @@ void upsdrv_makevartable(void)
 {
 	/* NOTE: This driver uses a very custom device matching method,
 	 * so does not involve nut_usb_addvars() method like others do.
+	 * When fixing, see also tools/nut-scanner/scan_usb.c "exceptions".
 	 */
 	addvar(VAR_VALUE, "vendor", "USB vendor string (or NULL if none)");
 }

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -757,6 +757,9 @@ static int	phoenix_command(const char *cmd, char *buf, size_t buflen)
 
 		case LIBUSB_ERROR_TIMEOUT:	/* Connection timed out */
 			break;
+
+		default:
+			break;
 		}
 
 		if (ret < 0) {

--- a/drivers/nutdrv_qx_masterguard.c
+++ b/drivers/nutdrv_qx_masterguard.c
@@ -619,6 +619,8 @@ static int masterguard_setvar(item_t *item, char *value, const size_t valuelen) 
 		case 's':
 			snprintf(value, valuelen, item->command, s);
 			break;
+		default:
+			break;
 	}
 #ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_NONLITERAL
 #pragma GCC diagnostic pop

--- a/drivers/openups-hid.c
+++ b/drivers/openups-hid.c
@@ -63,6 +63,8 @@ static void *get_voltage_multiplier(USBDevice_t *device)
 			ccharge_scale = 0.1; /* unverified */
 			cdischarge_scale = 0.1; /* unverified */
 			break;
+		default:
+			break;
 	}
 
 	upsdebugx(1, "vin_scale = %g; vout_scale = %g\n", vin_scale, vout_scale);

--- a/drivers/powercom.c
+++ b/drivers/powercom.c
@@ -669,6 +669,7 @@ static float load_level(void)
 				case 1000:
 				case 1500:
 				case 2000: return raw_data[UPS_LOAD]*110.0/load1000i[voltage];
+				default: break;
 			}
 		}
 	} else if (!strcmp(types[type].name, "KIN")) {

--- a/drivers/rhino.c
+++ b/drivers/rhino.c
@@ -464,6 +464,9 @@ CommReceive(const unsigned char *bufptr, ssize_t size)
 			break;
 		}
 
+		default:
+			break;
+
 	}
 
 	Waiting = 0;

--- a/drivers/richcomm_usb.c
+++ b/drivers/richcomm_usb.c
@@ -746,6 +746,7 @@ void upsdrv_makevartable(void)
 {
 	/* allow -x vendor=X, vendorid=X, product=X, productid=X, serial=X */
 	/* TODO: Uncomment while addressing https://github.com/networkupstools/nut/issues/1768
-	nut_usb_addvars();
+	 * When fixing, see also tools/nut-scanner/scan_usb.c "exceptions".
+	 * nut_usb_addvars();
 	*/
 }

--- a/drivers/richcomm_usb.c
+++ b/drivers/richcomm_usb.c
@@ -490,6 +490,9 @@ static int usb_device_open(usb_dev_handle **handlep, USBDevice_t *device, USBDev
 				case -2:
 					upsdebugx(4, "matcher: unspecified error");
 					goto next_device;
+
+				default:
+					break;
 				}
 			}
 #ifdef HAVE_LIBUSB_SET_AUTO_DETACH_KERNEL_DRIVER

--- a/drivers/riello.c
+++ b/drivers/riello.c
@@ -86,6 +86,8 @@ uint16_t riello_calc_CRC(uint8_t type, uint8_t *buff, uint16_t size, uint8_t che
 					CRC_Word += buff[i];
 			}
 			break;
+		default:
+			break;
 	}
 	return(CRC_Word);
 }
@@ -125,6 +127,8 @@ uint8_t riello_test_crc(uint8_t type, uint8_t *buff, uint16_t size, uint8_t chec
 			suma += (buff[size-2]-0x30);
 			if (suma != CRC_Word)
 				return(1);
+			break;
+		default:
 			break;
 	}
 	return(0);
@@ -944,6 +948,8 @@ uint8_t riello_header(uint8_t type, uint8_t a, uint8_t* length)
 			if ((buf_ptr_length==0) && (LAST_DATA[5]>0x20) && (LAST_DATA[4]==0x2))
 				return(1);
 			break;
+		default:
+			break;
 	}
 	return(0);
 }
@@ -963,6 +969,8 @@ uint8_t riello_tail(uint8_t type, uint8_t length)
 			if (LAST_DATA[5] == 0x03)
 				return(1);
 			break;
+		default:
+			break;
 	}
 	return(0);
 }
@@ -973,6 +981,8 @@ uint8_t riello_test_nak(uint8_t type, uint8_t* buffer)
 		case DEV_RIELLOGPSER:
 			if (buffer[3] == 0x15)
 				return(1);
+			break;
+		default:
 			break;
 	}
 	return(0);

--- a/drivers/solis.c
+++ b/drivers/solis.c
@@ -799,8 +799,10 @@ static void get_base_info(void) {
 		Model = "Solis 3.0";
 		break;
 	case 16:
-	  Model = "Microsol Back-Ups BZ1200-BR";
-	  break;
+		Model = "Microsol Back-Ups BZ1200-BR";
+		break;
+	default:
+		break;
 	}
 
 	/* if( isprogram ) */

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -1493,6 +1493,8 @@ void upsdrv_updateinfo(void)
 				case '0':
 					dstate_setinfo("input.frequency.nominal", "%d", 50);
 					break;
+				default:
+					break;
 			}
 		}
 

--- a/include/str.h
+++ b/include/str.h
@@ -32,7 +32,7 @@ extern "C" {
 /* Some compilers and/or C libraries do not handle printf("%s", NULL) correctly */
 #ifndef NUT_STRARG
 # if (defined REQUIRE_NUT_STRARG) && (REQUIRE_NUT_STRARG == 0)
-#  define NUT_STRARG(x) x
+#  define NUT_STRARG(x) (x)
 # else
 /* Is required, or not defined => err on safe side */
 #  define NUT_STRARG(x) (x?x:"(null)")

--- a/m4/ax_c_pragmas.m4
+++ b/m4/ax_c_pragmas.m4
@@ -1194,7 +1194,11 @@ return 0;
   )
   unset myWARN_CFLAGS
 
-  AS_IF([test "$ax_cv__printf_string_null" = "yes"],[
+  NUT_ARG_ENABLE([NUT_STRARG-always],
+    [Enable NUT_STRARG macro to handle NULL string printing even if system libraries seem to support it natively],
+    [no])
+
+  AS_IF([test "$ax_cv__printf_string_null" = "yes" && test x"$nut_enable_NUT_STRARG_always" != xyes],[
     AM_CONDITIONAL([REQUIRE_NUT_STRARG], [false])
     AC_DEFINE([REQUIRE_NUT_STRARG], [0],
       [Define to 0 if your libc can printf("%s", NULL) sanely, or to 1 if your libc requires workarounds to print NULL values.])

--- a/m4/ax_c_pragmas.m4
+++ b/m4/ax_c_pragmas.m4
@@ -1202,8 +1202,7 @@ return 0;
   dnl alleged formatting string overflow (seems like a false
   dnl positive in that case). Require the full macro there
   dnl by default.
-  AC_MSG_NOTICE([CC_VERSION='$CC_VERSION'])
-  set -x
+  dnl AC_MSG_NOTICE([CC_VERSION='$CC_VERSION'])
   AS_IF([test x"$nut_enable_NUT_STRARG_always" = xauto], [
     nut_enable_NUT_STRARG_always=no
     AS_IF([test "${CLANGCC}" = "yes"], [
@@ -1232,8 +1231,6 @@ dnl        )
       [Define to 0 if your libc can printf("%s", NULL) sanely, or to 1 if your libc requires workarounds to print NULL values.])
     AC_MSG_WARN([Your C library requires workarounds to print NULL values; if something crashes with a segmentation fault (especially during verbose debug) - that may be why])
   ])
-
-set +x
 
   AC_LANG_POP([C])
 fi

--- a/m4/ax_c_pragmas.m4
+++ b/m4/ax_c_pragmas.m4
@@ -1196,7 +1196,29 @@ return 0;
 
   NUT_ARG_ENABLE([NUT_STRARG-always],
     [Enable NUT_STRARG macro to handle NULL string printing even if system libraries seem to support it natively],
-    [no])
+    [auto])
+
+  dnl gcc-13.2.0 and gcc-13.3.0 were seen to complain about
+  dnl alleged formatting string overflow (seems like a false
+  dnl positive in that case). Require the full macro there
+  dnl by default.
+  AS_IF([test x"$nut_enable_NUT_STRARG_always" = xauto], [
+    nut_enable_NUT_STRARG_always=no
+    AS_IF([test "${CLANGCC}" = "yes"], [
+        true dnl no-op at the moment
+dnl        AS_CASE(["$CC_VERSION"],
+dnl            [*" "18.*], [nut_enable_NUT_STRARG_always=yes]
+dnl        )
+        ],[
+        AS_IF([test "${GCC}" = "yes"], [
+            AS_CASE(["$CC_VERSION"],
+                [*" "13.*], [nut_enable_NUT_STRARG_always=yes]
+            )
+        ])
+    ])
+    AS_IF([test x"$nut_enable_NUT_STRARG_always" = xyes],
+        [AC_MSG_NOTICE([Automatically enabled NUT_STRARG-always due to compiler version used])])
+  ])
 
   AS_IF([test "$ax_cv__printf_string_null" = "yes" && test x"$nut_enable_NUT_STRARG_always" != xyes],[
     AM_CONDITIONAL([REQUIRE_NUT_STRARG], [false])

--- a/m4/ax_c_pragmas.m4
+++ b/m4/ax_c_pragmas.m4
@@ -1202,6 +1202,8 @@ return 0;
   dnl alleged formatting string overflow (seems like a false
   dnl positive in that case). Require the full macro there
   dnl by default.
+  AC_MSG_NOTICE([CC_VERSION='$CC_VERSION'])
+  set -x
   AS_IF([test x"$nut_enable_NUT_STRARG_always" = xauto], [
     nut_enable_NUT_STRARG_always=no
     AS_IF([test "${CLANGCC}" = "yes"], [
@@ -1230,6 +1232,8 @@ dnl        )
       [Define to 0 if your libc can printf("%s", NULL) sanely, or to 1 if your libc requires workarounds to print NULL values.])
     AC_MSG_WARN([Your C library requires workarounds to print NULL values; if something crashes with a segmentation fault (especially during verbose debug) - that may be why])
   ])
+
+set +x
 
   AC_LANG_POP([C])
 fi

--- a/server/netssl.c
+++ b/server/netssl.c
@@ -346,6 +346,8 @@ void net_starttls(nut_ctype_t *client, size_t numarg, const char **arg)
 		upslog_with_errno(LOG_ERR, "Unknown return value from SSL_accept");
 		ssl_error(client->ssl, ret);
 		break;
+	default:
+		break;
 	}
 
 #elif defined(WITH_NSS) /* WITH_OPENSSL */

--- a/server/sockdebug.c
+++ b/server/sockdebug.c
@@ -123,6 +123,9 @@ static void read_sock(int fd)
 			case -1:
 				printf("Parse error: [%s]\n", sock_ctx.errmsg);
 				break;
+
+			default:
+				break;
 		}
 	}
 }

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -1323,6 +1323,8 @@ char *tracking_get(const char *id)
 			return "ERR INVALID-ARGUMENT";
 		case STAT_FAILED:
 			return "ERR FAILED";
+		default:
+			break;
 		}
 	}
 

--- a/tools/nut-scanner/scan_avahi.c
+++ b/tools/nut-scanner/scan_avahi.c
@@ -414,7 +414,7 @@ static void resolve_callback(
 				(*nut_avahi_strerror)((*nut_avahi_client_errno)((*nut_avahi_service_resolver_get_client)(r))));
 			break;
 
-		case AVAHI_RESOLVER_FOUND: {
+		case AVAHI_RESOLVER_FOUND: { /* scoping */
 			char a[AVAHI_ADDRESS_STR_MAX], *t;
 
 /*			upsdebugx(1, "%s: Service '%s' of type '%s' in domain '%s':", __func__, name, type, domain); */
@@ -444,7 +444,33 @@ static void resolve_callback(
 */
 			update_device(host_name, a, port, t, address->proto);
 			(*nut_avahi_free)(t);
-		}
+			}
+			break;
+
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT
+# pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+# pragma GCC diagnostic ignored "-Wunreachable-code"
+#endif
+/* Older CLANG (e.g. clang-3.4) seems to not support the GCC pragmas above */
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunreachable-code"
+# pragma clang diagnostic ignored "-Wcovered-switch-default"
+#endif
+		default:
+			/* Must not occur. */
+			break;
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic pop
+#endif
 	}
 
 	(*nut_avahi_service_resolver_free)(r);
@@ -518,6 +544,31 @@ static void browse_callback(
 		fallthrough_AVAHI_BROWSER_CACHE_EXHAUSTED:
 /*			upsdebugx(1, "%s: (Browser) %s", __func__, event == AVAHI_BROWSER_CACHE_EXHAUSTED ? "CACHE_EXHAUSTED" : "ALL_FOR_NOW"); */
 			break;
+
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT
+# pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+# pragma GCC diagnostic ignored "-Wunreachable-code"
+#endif
+/* Older CLANG (e.g. clang-3.4) seems to not support the GCC pragmas above */
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunreachable-code"
+# pragma clang diagnostic ignored "-Wcovered-switch-default"
+#endif
+		default:
+			/* Must not occur. */
+			break;
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic pop
+#endif
 	}
 }
 

--- a/tools/nut-scanner/scan_usb.c
+++ b/tools/nut-scanner/scan_usb.c
@@ -602,36 +602,87 @@ nutscan_device_t * nutscan_scan_usb(nutscan_usb_t * scanopts)
 				}
 				nut_dev->port = strdup("auto");
 
-				sprintf(string, "%04X", VendorID);
-				nutscan_add_option_to_device(nut_dev,
-					"vendorid",
-					string);
-
-				sprintf(string, "%04X", ProductID);
-				nutscan_add_option_to_device(nut_dev,
-					"productid",
-					string);
-
-				if (device_name) {
+				/* FIXME: https://github.com/networkupstools/nut/pull/1763
+				 * and linked issues: some drivers do not use
+				 * the common nut_usb_addvars() method, and
+				 * do not otherwise support these options:
+				 */
+				if (strncmp(driver_name, "bcmxcp_usb", 10)
+				 && strncmp(driver_name, "richcomm_usb", 12)
+				 && strncmp(driver_name, "nutdrv_atcl_usb", 15)
+				) {
+					sprintf(string, "%04X", VendorID);
 					nutscan_add_option_to_device(nut_dev,
-						"product",
-						device_name);
-					free(device_name);
-					device_name = NULL;
-				}
+						"vendorid",
+						string);
 
-				if (serialnumber) {
+					sprintf(string, "%04X", ProductID);
 					nutscan_add_option_to_device(nut_dev,
-						"serial",
-						serialnumber);
-					free(serialnumber);
-					serialnumber = NULL;
+						"productid",
+						string);
+
+					if (device_name) {
+						nutscan_add_option_to_device(nut_dev,
+							"product",
+							device_name);
+						free(device_name);
+						device_name = NULL;
+					}
+
+					if (serialnumber) {
+						nutscan_add_option_to_device(nut_dev,
+							"serial",
+							serialnumber);
+						free(serialnumber);
+						serialnumber = NULL;
+					}
+				} else {
+					sprintf(string, "%04X", VendorID);
+					nutscan_add_commented_option_to_device(nut_dev,
+						"vendorid",
+						string,
+						"");
+
+					sprintf(string, "%04X", ProductID);
+					nutscan_add_commented_option_to_device(nut_dev,
+						"productid",
+						string,
+						"");
+
+					if (device_name) {
+						nutscan_add_commented_option_to_device(nut_dev,
+							"product",
+							device_name,
+							"");
+						free(device_name);
+						device_name = NULL;
+					}
+
+					if (serialnumber) {
+						nutscan_add_commented_option_to_device(nut_dev,
+							"serial",
+							serialnumber,
+							"");
+						free(serialnumber);
+						serialnumber = NULL;
+					}
 				}
 
 				if (vendor_name) {
-					nutscan_add_option_to_device(nut_dev,
-						"vendor",
-						vendor_name);
+					/* NOTE: nutdrv_atcl_usb recognizes
+					 * "vendor" but not other opts */
+					if (strncmp(driver_name, "bcmxcp_usb", 10)
+					 && strncmp(driver_name, "richcomm_usb", 12)
+					) {
+						nutscan_add_option_to_device(nut_dev,
+							"vendor",
+							vendor_name);
+					} else {
+						nutscan_add_commented_option_to_device(nut_dev,
+							"vendor",
+							vendor_name,
+							"");
+					}
 					free(vendor_name);
 					vendor_name = NULL;
 				}


### PR DESCRIPTION
Touches on a number of issues:

#1763
#1764 
#1768 
Closes: #2580
Closes: #2585
Closes: #2588