### PR TITLE
Introduce `scripts/systemd/nut-sleep.service` unit

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -158,6 +158,16 @@ https://github.com/networkupstools/nut/milestone/11
    * added an `OBLBDURATION` (seconds) setting to optionally delay raising
      the alarm for immediate shutdown in critical situation. [#321]
 
+ - More systemd integration:
+   * Introduced a `nut-sleep.service` unit which stops `nut.target` when a
+     system sleep was requested, and starts it when the sleep is finished.
+     This helps avoid NUT shutting down a woken-up system just because its
+     power state was critical before the sleep (called as a `SHUTDOWNCMD`
+     implementation by the end-user), and a next-read timestamp was not seen
+     (deemed to be a stale UPS, meaning lost communications during critical
+     state, so must go down ASAP). While not as elegant as native systemd
+     "inhibitor interface" support, this approach does work. [#1833, #1070]
+
  - gamatronic driver revised for safer memory operations; this was reported
    to have fixed a Segmentation Fault seen in earlier NUT releases with
    some of the devices supported by this driver. [#2427]

--- a/scripts/systemd/Makefile.am
+++ b/scripts/systemd/Makefile.am
@@ -14,12 +14,13 @@ systemdsystemunit_DATA = \
         nut-monitor.service \
         nut-server.service  \
         nut-driver.target   \
+        nut-sleep.service   \
         nut.target
 
 systemdtmpfiles_DATA = \
         nut-common-tmpfiles.conf
 
-EXTRA_DIST += nut-driver.target nut.target
+EXTRA_DIST += nut-driver.target nut.target nut-sleep.service
 
 systemdshutdown_SCRIPTS = nutshutdown
 
@@ -29,7 +30,7 @@ sbin_SCRIPTS = ../upsdrvsvcctl/upsdrvsvcctl
 
 else
 EXTRA_DIST += \
-	nut-driver@.service.in nut-monitor.service.in \
+	nut-driver@.service.in nut-monitor.service.in nut-sleep.service \
 	nut-server.service.in nutshutdown.in nut-driver.target nut.target \
 	nut-driver-enumerator.path.in nut-driver-enumerator.service.in \
 	nut-driver-enumerator-daemon-activator.path.in \

--- a/scripts/systemd/nut-driver-enumerator-daemon-activator.service.in
+++ b/scripts/systemd/nut-driver-enumerator-daemon-activator.service.in
@@ -1,5 +1,5 @@
 # Network UPS Tools (NUT) systemd integration
-# Copyright (C) 2011-2023 by NUT contirbutors
+# Copyright (C) 2011-2024 by NUT contirbutors
 # Distributed under the terms of GPLv2+
 # See https://networkupstools.org/
 # and https://github.com/networkupstools/nut/

--- a/scripts/systemd/nut-driver-enumerator-daemon.service.in
+++ b/scripts/systemd/nut-driver-enumerator-daemon.service.in
@@ -1,5 +1,5 @@
 # Network UPS Tools (NUT) systemd integration
-# Copyright (C) 2011-2023 by NUT contirbutors
+# Copyright (C) 2011-2024 by NUT contirbutors
 # Distributed under the terms of GPLv2+
 # See https://networkupstools.org/
 # and https://github.com/networkupstools/nut/

--- a/scripts/systemd/nut-driver-enumerator.path.in
+++ b/scripts/systemd/nut-driver-enumerator.path.in
@@ -1,5 +1,5 @@
 # Network UPS Tools (NUT) systemd integration
-# Copyright (C) 2011-2023 by NUT contirbutors
+# Copyright (C) 2011-2024 by NUT contirbutors
 # Distributed under the terms of GPLv2+
 # See https://networkupstools.org/
 # and https://github.com/networkupstools/nut/

--- a/scripts/systemd/nut-driver-enumerator.service.in
+++ b/scripts/systemd/nut-driver-enumerator.service.in
@@ -1,5 +1,5 @@
 # Network UPS Tools (NUT) systemd integration
-# Copyright (C) 2011-2023 by NUT contirbutors
+# Copyright (C) 2011-2024 by NUT contirbutors
 # Distributed under the terms of GPLv2+
 # See https://networkupstools.org/
 # and https://github.com/networkupstools/nut/

--- a/scripts/systemd/nut-driver.target
+++ b/scripts/systemd/nut-driver.target
@@ -1,5 +1,5 @@
 # Network UPS Tools (NUT) systemd integration
-# Copyright (C) 2011-2023 by NUT contirbutors
+# Copyright (C) 2011-2024 by NUT contirbutors
 # Distributed under the terms of GPLv2+
 # See https://networkupstools.org/
 # and https://github.com/networkupstools/nut/

--- a/scripts/systemd/nut-driver@.service.in
+++ b/scripts/systemd/nut-driver@.service.in
@@ -1,5 +1,5 @@
 # Network UPS Tools (NUT) systemd integration
-# Copyright (C) 2011-2023 by NUT contirbutors
+# Copyright (C) 2011-2024 by NUT contirbutors
 # Distributed under the terms of GPLv2+
 # See https://networkupstools.org/
 # and https://github.com/networkupstools/nut/

--- a/scripts/systemd/nut-monitor.service.in
+++ b/scripts/systemd/nut-monitor.service.in
@@ -1,5 +1,5 @@
 # Network UPS Tools (NUT) systemd integration
-# Copyright (C) 2011-2023 by NUT contirbutors
+# Copyright (C) 2011-2024 by NUT contirbutors
 # Distributed under the terms of GPLv2+
 # See https://networkupstools.org/
 # and https://github.com/networkupstools/nut/

--- a/scripts/systemd/nut-server.service.in
+++ b/scripts/systemd/nut-server.service.in
@@ -1,5 +1,5 @@
 # Network UPS Tools (NUT) systemd integration
-# Copyright (C) 2011-2023 by NUT contirbutors
+# Copyright (C) 2011-2024 by NUT contirbutors
 # Distributed under the terms of GPLv2+
 # See https://networkupstools.org/
 # and https://github.com/networkupstools/nut/

--- a/scripts/systemd/nut-sleep.service
+++ b/scripts/systemd/nut-sleep.service
@@ -1,0 +1,26 @@
+# Network UPS Tools (NUT) systemd integration
+# Copyright (C) 2011-2024 by NUT contirbutors
+# Distributed under the terms of GPLv2+
+# See https://networkupstools.org/
+# and https://github.com/networkupstools/nut/
+
+# A rather blunt solution for system sleeping support, for cases where
+# we can not use a native libssytemd "inhibitor interface". This helps
+# avoid NUT shutting down a woken-up system just because its power state
+# was critical before the sleep, and a next-read timestamp was not seen
+# (deemed to be a stale UPS, meaning lost comms during critical state,
+# so must go down ASAP).
+
+[Unit]
+Description=Network UPS Tools - sleep hook
+Before=sleep.target
+StopWhenUnneeded=yes
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/systemctl stop nut.target
+ExecStop=/usr/bin/systemctl start --no-block nut.target
+
+[Install]
+WantedBy=sleep.target

--- a/scripts/systemd/nut.target
+++ b/scripts/systemd/nut.target
@@ -1,5 +1,5 @@
 # Network UPS Tools (NUT) systemd integration
-# Copyright (C) 2011-2023 by NUT contirbutors
+# Copyright (C) 2011-2024 by NUT contirbutors
 # Distributed under the terms of GPLv2+
 # See https://networkupstools.org/
 # and https://github.com/networkupstools/nut/

--- a/scripts/systemd/nutshutdown.in
+++ b/scripts/systemd/nutshutdown.in
@@ -8,7 +8,7 @@
 # and their configuration files to be present locally and on still-mounted
 # filesystems (may be read-only).
 #
-# Copyright (C) 2011-2023 by NUT contirbutors
+# Copyright (C) 2011-2024 by NUT contirbutors
 # Michal Hlavinka, Laurent Bigonville, Arnaud Quette, Jim Klimov et al.
 #
 # See https://networkupstools.org/


### PR DESCRIPTION
> Introduced a `nut-sleep.service` unit which stops `nut.target` when a system sleep was requested, and starts it when the sleep is finished.
> This helps avoid NUT shutting down a woken-up system just because its power state was critical before the sleep (called as a `SHUTDOWNCMD` implementation by the end-user), and a next-read timestamp was not seen (deemed to be a stale UPS, meaning lost communications during critical state, so must go down ASAP). While not as elegant as native systemd "inhibitor interface" support, this approach does work.

Follows up on issues:
* #1833 - thanks to @Ropid for posting their unit file in a comment, which served as the basis for this PR
* #1070

Also bumps (C) years for unit files in the directory.