### PR TITLE
drivers/main.c: do not overwrite set allow_killpower flag with defaults

### DIFF
--- a/drivers/main.c
+++ b/drivers/main.c
@@ -2681,7 +2681,9 @@ sockname_ownership_finished:
 			upslogx(LOG_WARNING, "Running as foreground process, not saving a PID file");
 	}
 
-	dstate_setinfo("driver.flag.allow_killpower", "0");
+	if (dstate_getinfo("driver.flag.allow_killpower") == NULL)
+		dstate_setinfo("driver.flag.allow_killpower", "0");
+
 	dstate_setflags("driver.flag.allow_killpower", ST_FLAG_RW | ST_FLAG_NUMBER);
 	dstate_addcmd("driver.killpower");
 

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -2681,6 +2681,7 @@ sockname_ownership_finished:
 			upslogx(LOG_WARNING, "Running as foreground process, not saving a PID file");
 	}
 
+	/* May already be set by parsed configuration flag, only set default if not: */
 	if (dstate_getinfo("driver.flag.allow_killpower") == NULL)
 		dstate_setinfo("driver.flag.allow_killpower", "0");
 


### PR DESCRIPTION
only apply the defaults for `driver.flag.allow_killpower` when `allow_killpower` flag was not already set.
current state applies defaults regardless of this, overwriting a previously set `allow_killpower` flag with `0`.
fixes #2605 , tested and working with APC device using `usbhid-ups` on Slackware 15.0 w/ gcc 11.2.0.