### PR TITLE
CI: pass NIT on android

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -62,6 +62,8 @@ https://github.com/networkupstools/nut/milestone/11
      regression. [issue #1904, issue #2484]
    * Fallback `localtime_r()` and `gmtime_r()` for some platform builds where
      a `*_s()` variant was available was not handled correctly. [PR #2583]
+   * A recently introduced `allow_killpower` did not actually work as an
+     `ups.conf` flag (only as a protocol command). [issue #2605, PR #2606]
 
  - development iterations of NUT should now identify with not only the semantic
    version of a preceding release, but with git-derived information about the

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -138,13 +138,6 @@ isBusy_NUT_PORT() {
     && log_debug "isBusy_NUT_PORT() found that NUT_PORT=${NUT_PORT} is busy per lsof" \
     && return
 
-    # Not busy... or no tools to confirm?
-    if (command -v netstat || command -v sockstat || command -v ss || command -v lsof) 2>/dev/null >/dev/null ; then
-        # at least one tool is present, so not busy
-        log_debug "isBusy_NUT_PORT() found that NUT_PORT=${NUT_PORT} is not busy per netstat, sockstat, ss or lsof"
-        return 1
-    fi
-
     # If the current shell interpreter is bash, it can do a bit of networking:
     if [ -n "${BASH_VERSION-}" ]; then
         # NOTE: Probing host names we use in upsd.conf
@@ -164,6 +157,13 @@ isBusy_NUT_PORT() {
             return 1
         ) && return 0
         log_warn "isBusy_NUT_PORT() tried with BASH-specific query, and port does not seem busy (or something else errored out)"
+    fi
+
+    # Not busy... or no tools to confirm? (or no perms, or no lsof plugin)?
+    if (command -v netstat || command -v sockstat || command -v ss || command -v lsof) 2>/dev/null >/dev/null ; then
+        # at least one tool is present, so not busy
+        log_debug "isBusy_NUT_PORT() found that NUT_PORT=${NUT_PORT} is not busy per netstat, sockstat, ss or lsof"
+        return 1
     fi
 
     # Assume not busy to not preclude testing in 100% of the cases

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -36,6 +36,19 @@
 #
 # License: GPLv2+
 
+if [ -z "${BASH_VERSION-}" ] \
+&& (command -v bash) \
+&& [ x"${DEBUG_NONBASH-}" != xtrue ] \
+; then
+    # FIXME: detect and pass -x/-v options?
+    echo "WARNING: Re-execing in BASH (export DEBUG_NONBASH=true to avoid)" >&2
+    exec bash $0 "$@"
+fi
+
+if [ -n "${BASH_VERSION-}" ]; then
+    eval `echo "set -o pipefail"`
+fi
+
 TZ=UTC
 LANG=C
 LC_ALL=C

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -110,7 +110,7 @@ isBusy_NUT_PORT() {
     [ -n "${NUT_PORT}" ] || return
 
     log_debug "isBusy_NUT_PORT() Trying to report if NUT_PORT=${NUT_PORT} is used"
-    if [ -e /proc/net/tcp ] || [ -e /proc/net/tcp6 ]; then
+    if [ -r /proc/net/tcp ] || [ -r /proc/net/tcp6 ]; then
         # Assume Linux - hex-encoded
         # IPv4:
         #   sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -61,6 +61,8 @@ export NUT_QUIET_INIT_NDE_WARNING
 ARG_FG="-F"
 if [ x"${NUT_FOREGROUND_WITH_PID-}" = xtrue ] ; then ARG_FG="-FF" ; fi
 
+TABCHAR="`printf '\t'`"
+
 log_separator() {
     echo "" >&2
     echo "================================" >&2
@@ -128,7 +130,7 @@ isBusy_NUT_PORT() {
         return 1
     fi
 
-    (netstat -an || sockstat -l || ss -tn || ss -n) 2>/dev/null | grep -E "[:.]${NUT_PORT}(\t| |\$)" > /dev/null \
+    (netstat -an || sockstat -l || ss -tn || ss -n) 2>/dev/null | grep -E "[:.]${NUT_PORT}(${TABCHAR}| |\$)" > /dev/null \
     && log_debug "isBusy_NUT_PORT() found that NUT_PORT=${NUT_PORT} is busy per netstat, sockstat or ss" \
     && return
 


### PR DESCRIPTION
While on the road, it is fun to build and test NUT in the TermUX (Debian-like userland) app on a phone.

But there are some caveats to pass the `make check-NIT` due to (in-)visibility of open ports...