### PR TITLE
drivers/libusb{0,1}.c: reset driver parameters while enumerating

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -175,6 +175,10 @@ https://github.com/networkupstools/nut/milestone/11
      `nutdrv_atcl_usb`) and for general code to collect string readings and
      other data points, and for `nut-scanner`.
 
+ - USB drivers should now be more likely to succeed with iterative detection
+   of an UPS interface on a composite USB device or when looking at devices
+   with non-default interface/endpoint/config numbers. [PR #2611]
+
  - Introduced a new driver concept for interaction with OS-reported hardware
    monitoring readings. Currently instantiated as `hwmon_ina219` specifically
    made for Texas Instruments INA219 chip as exposed in the Linux "hwmon"

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -149,6 +149,11 @@ https://github.com/networkupstools/nut/milestone/11
      by default: `powercom_sdcmd_byte_order_fallback`. [PR #2480]
    * `cps-hid` subdriver now supports more variables, as available on e.g.
      CP1350EPFCLCD model. [PR #2540]
+   * USB parameters (per `usb_communication_subdriver_t`) are now set back to
+     their default values during enumeration after probing each subdriver.
+     Having an unrelated device connected with a VID:PID matching the
+     `arduino-hid` subdriver prevented use of an actual `usb-hid` device due to
+     changes made to this struct during probe. [#2611]
 
  - bicker_ser: added new driver for Bicker 12/24Vdc UPS via RS-232 serial
    communication protocol, which supports any UPS shipped with the PSZ-1053

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3214 utf-8
+personal_ws-1.1 en 3215 utf-8
 AAC
 AAS
 ABI

--- a/drivers/libusb0.c
+++ b/drivers/libusb0.c
@@ -186,6 +186,20 @@ static int nut_libusb_set_altinterface(usb_dev_handle *udev)
 	return ret;
 }
 
+static void nut_usb_subdriver_defaults(usb_communication_subdriver_t *subdriver)
+{
+	if (!getval("usb_config_index"))
+		subdriver->usb_config_index = LIBUSB_DEFAULT_CONF_INDEX;
+	if (!getval("usb_hid_rep_index"))
+		subdriver->hid_rep_index = LIBUSB_DEFAULT_INTERFACE;
+	if (!getval("usb_hid_desc_index"))
+		subdriver->hid_desc_index = LIBUSB_DEFAULT_DESC_INDEX;
+	if (!getval("usb_hid_ep_in"))
+		subdriver->hid_ep_in = LIBUSB_DEFAULT_HID_EP_IN;
+	if (!getval("usb_hid_ep_out"))
+		subdriver->hid_ep_out = LIBUSB_DEFAULT_HID_EP_OUT;
+}
+
 #define usb_control_msg         typesafe_control_msg
 
 /* On success, fill in the curDevice structure and return the report
@@ -711,6 +725,8 @@ static int nut_libusb_open(usb_dev_handle **udevp,
 			/* if (if_claimed)
 				usb_release_interface(udev, 0); */
 			usb_close(udev);
+			/* reset any parameters modified by unmatched drivers back to defaults */
+			nut_usb_subdriver_defaults(&usb_subdriver);
 		}
 	}
 

--- a/drivers/libusb0.c
+++ b/drivers/libusb0.c
@@ -186,7 +186,7 @@ static int nut_libusb_set_altinterface(usb_dev_handle *udev)
 	return ret;
 }
 
-static void nut_usb_subdriver_defaults(usb_communication_subdriver_t *subdriver)
+static void nut_libusb_subdriver_defaults(usb_communication_subdriver_t *subdriver)
 {
 	if (!getval("usb_config_index"))
 		subdriver->usb_config_index = LIBUSB_DEFAULT_CONF_INDEX;
@@ -726,7 +726,7 @@ static int nut_libusb_open(usb_dev_handle **udevp,
 				usb_release_interface(udev, 0); */
 			usb_close(udev);
 			/* reset any parameters modified by unmatched drivers back to defaults */
-			nut_usb_subdriver_defaults(&usb_subdriver);
+			nut_libusb_subdriver_defaults(&usb_subdriver);
 		}
 	}
 

--- a/drivers/libusb1.c
+++ b/drivers/libusb1.c
@@ -152,7 +152,7 @@ static int nut_libusb_set_altinterface(libusb_device_handle *udev)
 	return ret;
 }
 
-static void nut_usb_subdriver_defaults(usb_communication_subdriver_t *subdriver)
+static void nut_libusb_subdriver_defaults(usb_communication_subdriver_t *subdriver)
 {
 	if (!getval("usb_config_index"))
 		subdriver->usb_config_index = LIBUSB_DEFAULT_CONF_INDEX;
@@ -810,7 +810,7 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 				libusb_release_interface(udev, usb_subdriver.hid_rep_index); */
 			libusb_close(udev);
 			/* reset any parameters modified by unmatched drivers back to defaults */
-			nut_usb_subdriver_defaults(&usb_subdriver);
+			nut_libusb_subdriver_defaults(&usb_subdriver);
 	}
 
 	*udevp = NULL;

--- a/drivers/libusb1.c
+++ b/drivers/libusb1.c
@@ -152,6 +152,20 @@ static int nut_libusb_set_altinterface(libusb_device_handle *udev)
 	return ret;
 }
 
+static void nut_usb_subdriver_defaults(usb_communication_subdriver_t *subdriver)
+{
+	if (!getval("usb_config_index"))
+		subdriver->usb_config_index = LIBUSB_DEFAULT_CONF_INDEX;
+	if (!getval("usb_hid_rep_index"))
+		subdriver->hid_rep_index = LIBUSB_DEFAULT_INTERFACE;
+	if (!getval("usb_hid_desc_index"))
+		subdriver->hid_desc_index = LIBUSB_DEFAULT_DESC_INDEX;
+	if (!getval("usb_hid_ep_in"))
+		subdriver->hid_ep_in = LIBUSB_DEFAULT_HID_EP_IN;
+	if (!getval("usb_hid_ep_out"))
+		subdriver->hid_ep_out = LIBUSB_DEFAULT_HID_EP_OUT;
+}
+
 /* On success, fill in the curDevice structure and return the report
  * descriptor length. On failure, return -1.
  * Note: When callback is not NULL, the report descriptor will be
@@ -795,6 +809,8 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 			/* if (if_claimed)
 				libusb_release_interface(udev, usb_subdriver.hid_rep_index); */
 			libusb_close(udev);
+			/* reset any parameters modified by unmatched drivers back to defaults */
+			nut_usb_subdriver_defaults(&usb_subdriver);
 	}
 
 	*udevp = NULL;


### PR DESCRIPTION
With an Arduino Leonardo compatible board attached alongside a CyberPower CP1500PFCLCD, usbhid-ups would incorrectly conclude that there was no kernel driver attached to the UPS and then fail subsequent steps accordingly.

The cause is the global usb_communication_subdriver_t struct; when a subdriver (e.g. arduino-hid) sets different values during the enumeration loop, they're not set back to defaults afterwards, causing issues with other subdrivers (e.g. cps-hid).

So, if a subdriver doesn't match, set a selection of fields back to their default values using the newly added nut_usb_subdriver_defaults() before the next attempt.

<!-- Comment:
* Please revise the docs/developers.txt for coding style suggestions and
  other considerations applicable to NUT codebase contributions, as well
  as for which text documents to update. See also docs/developer-guide.txt
  for general points on NUT architecture and design.

* Please note that we require "Signed-Off-By" tags in each Git Commit
  message, to conform to the common DCO (Developer Certificate of Origin)
  as posted in LICENSE-DCO at root of NUT codebase as well as published
  at https://developercertificate.org/

* The checklist below is more of a reminder of steps to take and "dangers"
  to look out for. PRs to update this template are also welcome :)

* Local build iterations can be augmented with the ci_build.sh script.
-->

## General points

- [x] Described the changes in the PR submission or a separate issue, e.g.
  known published or discovered protocols, applicable hardware (expected
  compatible and actually tested/developed against), limitations, etc.

- [ ] There may be multiple commits in the PR, aligned and commented with
  a functional change. Notably, coding style changes better belong in a
  separate PR, but certainly in a dedicated commit to simplify reviews
  of "real" changes in the other commits. Similarly for typo fixes in
  comments or text documents.

- [x] Please star NUT on GitHub, this helps with sponsorships! ;)

## Frequent "underwater rocks" for driver addition/update PRs

- [ ] Revised existing driver families and added a sub-driver if applicable
  (`nutdrv_qx`, `usbhid-ups`...) or added a brand new driver in the other
  case.

- [x] Did not extend obsoleted drivers with new hardware support features
  (notably `blazer` and other single-device family drivers for Qx protocols,
  except the new `nutdrv_qx` which should cover them all).

- [ ] For updated existing device drivers, bumped the `DRIVER_VERSION` macro
  or its equivalent.

<!-- Comment:
  Some sub-drivers have `SUBDRIVER_VERSION` or customized names like
  e.g. `MEGATEC_VERSION` in `drivers/nutdrv_qx_megatec.c`
-->

- [ ] For USB devices (HID or not), revised that the driver uses unique
  VID/PID combinations, or raised discussions when this is not the case
  (several vendors do use same interface chips for unrelated protocols).

- [ ] For new USB devices, built and committed the changes for the
  `scripts/upower/95-upower-hid.hwdb` file

- [ ] Proposed NUT data mapping is aligned with existing `docs/nut-names.txt`
  file. If the device exposes useful data points not listed in the file, the
  `experimental.*` namespace can be used as documented there, and discussion
  should be raised on the NUT Developers mailing list to standardize the new
  concept.

- [ ] Updated `data/driver.list.in` if applicable (new tested device info)
<!-- Comment:
Also note below, a point about PR posting for NUT DDL
-->

## Frequent "underwater rocks" for general C code PRs

- [x] Did not "blindly assume" default integer type sizes and value ranges,
  structure layout and alignment in memory, endianness (layout of bytes and
  bits in memory for multi-byte numeric types), or use of generic `int` where
  language or libraries dictate the use of `size_t` (or `ssize_t` sometimes).

<!-- Comment:
* NOTE: Casting and/or pragmas (support detected at compile time,
  see `m4/ax_c_pragmas.m4`) to silence warnings may be acceptable,
  but only if coupled with range checks or similar actions.
-->

- [ ] Progress and errors are handled with `upsdebugx()`, `upslogx()`,
  `fatalx()` and related methods, not with direct `printf()` or `exit()`.
  Similarly, NUT helpers are used for error-checked memory allocation and
  string operations (except where customized error handling is needed,
  such as unlocking device ports, etc.)

- [x] Coding style (including whitespace for indentations) follows precedent
  in the code of the file, and examples/guide in `docs/developers.txt` file.

- [ ] For newly added files, the `Makefile.am` recipes were updated and the
  `make distcheck` target passes.

## General documentation updates

- [ ] Updated `docs/acknowledgements.txt` (for vendor-backed device support)

- [ ] Added or updated manual page information in `docs/man/*.txt` files
  and corresponding recipe lists in `docs/man/Makefile.am` for new pages

- [x] Passed `make spellcheck`, updated spell-checking dictionary in the
  `docs/nut.dict` file if needed (did not remove any words -- the `make`
  rule printout in case of changes suggests how to maintain it).

## Additional work may be needed after posting this PR

- [ ] Propose a PR for NUT DDL with detailed device data dumps from tests
  against real hardware (the more models, the better).

- [ ] Address NUT CI farm build failures for the PR: testing on numerous
  platforms and toolkits can expose issues not seen on just one system.

<!-- Comment:
* One frequent "offence" is the appearance of unexpected (not git-ignored)
  or modification during build of files tracked in Git.

* Another frequent issue is not tracking newly introduced file names in
  `EXTRA_DIST` of the `Makefile.am` (and for `*.in` templates -- of rules
  in the `configure.ac` script) so the `make distcheck` fails.

* Avoid using GNU-specific constructs in the `Makefile.am`, even if that
  means cumbersome ways to build a target. This should not happen in mere
  driver updates, however.

* Also some third-party libraries or OS headers and method argument types
  and counts can differ -- necessitating m4 code for `configure` script
  probing, and `ifdef`, `typedef`, etc. in C code to adapt to the build
  environment (precedents available in NUT codebase). In extreme cases,
  you may need to spin up a VM or container to reproduce those issues
  and iterate on a fix locally; see `docs/config-prereqs.txt` and
  `docs/ci-farm-lxc-setup.txt` for notes taken during preparation of
  the multi-platform NUT CI farm.
-->

- [ ] Revise suggestions from LGTM.COM analysis about "new issues" with
  the changed codebase.

<!-- Comment:
  Take them with a grain of salt, especially with regard to things like
  architecture-dependent range checks, but many of the complaints from
  the tool are indeed useful.
-->
