### PR TITLE
docs/man/nut_usb_addvars.txt: make a NOTE of LibUSB specific debugging

### DIFF
--- a/docs/man/nut_usb_addvars.txt
+++ b/docs/man/nut_usb_addvars.txt
@@ -124,3 +124,19 @@ number.
 As a rule of thumb for `usb_hid_desc_index` discovery, you can see larger
 `wDescriptorLength` values (roughly 600+ bytes) in reports of `lsusb` or
 similar tools.
+
+[NOTE]
+======
+Run-time troubleshooting of USB-capable NUT drivers can involve not only
+raising the common NUT debug verbosity (e.g. using the `DEBUG_MIN` setting
+in linkman:ups.conf[5] or protocol commands to change the `driver.debug`
+value), but may also benefit from LibUSB specific debugging.
+
+For the latter, currently you would have to export the environment variable
+`LIBUSB_DEBUG` before starting a NUT driver (may be set and "exported" via
+linkman:nut.conf[5]), to a numeric value such as `4` ("All messages are
+emitted"). For more details, including the currently supported values, see:
+
+* https://libusb.sourceforge.io/api-1.0/
+* https://libusb.sourceforge.io/api-1.0/group__libusb__lib.html
+======


### PR DESCRIPTION
First shot at issue #2616, but not "closing" it because a more consistent solution would involve programmatic (run-time) debugging setting for the libusb context instance used, and probably a `driver.debug.libusb` run-time variable. Sometime in the future...
