### PR TITLE
Port and use a variant of `nut_usb_get_string()` for `nut-scanner`

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -166,9 +166,11 @@ https://github.com/networkupstools/nut/milestone/11
    * Currently this was tested to fix certain device discovery with `usbhid-ups`;
      should also apply out of the box to same discovery logic in `blazer_usb`,
      `nutdrv_qx`, `riello_usb` and `tripplite_usb` drivers.
+   * Also applied to `nut-scanner` and `libnutscan`. [issue #2615]
    * More work may be needed for other USB-capable drivers (`richcomm_usb`,
      `nutdrv_atcl_usb`) and for general code to collect string readings and
-     other data points, and for `nut-scanner`.
+     other data points, and to configure the fallback locale or choose one
+     if several are served by the device. [issues #2613, #2614, #2615]
 
  - Introduced a new driver concept for interaction with OS-reported hardware
    monitoring readings. Currently instantiated as `hwmon_ina219` specifically

--- a/drivers/usb-common.c
+++ b/drivers/usb-common.c
@@ -416,7 +416,10 @@ void warn_if_bad_usb_port_filename(const char *fn) {
  */
 #define MAX_STRING_DESC_TRIES 3
 
-/* API neutral, handles retries */
+/* API neutral, handles retries.
+ * Note for future development: a variant of this code is adapted into
+ * tools/nut-scanner/scan_usb.c - please keep in sync if changing here.
+ */
 static int nut_usb_get_string_descriptor(
 	usb_dev_handle *udev,
 	int StringIdx,
@@ -439,7 +442,10 @@ static int nut_usb_get_string_descriptor(
 	return ret;
 }
 
-/* API neutral, assumes en_US if langid descriptor is broken */
+/* API neutral, assumes en_US if langid descriptor is broken.
+ * Note for future development: a variant of this code is adapted into
+ * tools/nut-scanner/scan_usb.c - please keep in sync if changing here.
+ */
 int nut_usb_get_string(
 	usb_dev_handle *udev,
 	int StringIdx,

--- a/drivers/usb-common.c
+++ b/drivers/usb-common.c
@@ -433,7 +433,7 @@ static int nut_usb_get_string_descriptor(
 			break;
 		} else if (tries) {
 			upsdebugx(1, "%s: string descriptor %d request failed, retrying...", __func__, StringIdx);
-			usleep(50000); /* 50 ms, might help in some cases */
+			usleep(50000);	/* 50 ms, might help in some cases */
 		}
 	}
 	return ret;
@@ -480,13 +480,13 @@ int nut_usb_get_string(
 
 	/* translate simple UTF-16LE to 8-bit */
 	len = ret < (int)buflen ? ret : (int)buflen;
-	len = len / 2 - 1; // 16-bit characters, without header
-	len = len < (int)buflen - 1 ? len : (int)buflen - 1; // reserve for null terminator
+	len = len / 2 - 1;	/* 16-bit characters, without header */
+	len = len < (int)buflen - 1 ? len : (int)buflen - 1;	/* reserve for null terminator */
 	for (i = 0; i < len; i++) {
 		if (buffer[2 + i * 2 + 1] == 0)
 			buf[i] = buffer[2 + i * 2];
 		else
-			buf[i] = '?'; // not decoded
+			buf[i] = '?';	/* not decoded */
 	}
 	buf[i] = '\0';
 

--- a/m4/ax_realpath_lib.m4
+++ b/m4/ax_realpath_lib.m4
@@ -168,13 +168,12 @@ AC_DEFUN([AX_REALPATH_LIB],
             AX_REALPATH([${myLIBPATH}], [myLIBPATH_REAL])
             AC_MSG_RESULT(${myLIBPATH_REAL})
             $2="${myLIBPATH_REAL}"
-            ],[
+        ],[
             AC_MSG_RESULT([not found])
             $2="$3"
-            ])
-        ],
-        [AC_MSG_WARN([Compiler not detected as GCC/CLANG-compatible, skipping REALPATH_LIB($1)])
-         $2="$3"
-        ]
-    )
+        ])
+    ],
+    [AC_MSG_WARN([Compiler not detected as GCC/CLANG-compatible, skipping REALPATH_LIB($1)])
+     $2="$3"
+    ])
 ])

--- a/m4/ax_realpath_lib.m4
+++ b/m4/ax_realpath_lib.m4
@@ -156,16 +156,44 @@ AC_DEFUN([AX_REALPATH_LIB],
         AS_IF([test -n "${myLIBPATH}" && test -s "${myLIBPATH}"], [
             AC_MSG_RESULT([initially '${myLIBPATH}'])
 
-            dnl # Resolving the directory location is a nice bonus
-            dnl # (usually the paths are relative to toolkit and ugly,
-            dnl # though maybe arguably portable with regard to symlinks).
-            dnl # The primary goal is to resolve the actual library file
-            dnl # name like "libnetsnmp.so.1.2.3", so we can preferentially
-            dnl # try to dlopen() it on a system with a packaged footprint
-            dnl # that does not serve short (developer-friendly) links like
-            dnl # "libnetsnmp.so".
-            myLIBPATH_REAL="${myLIBPATH}"
-            AX_REALPATH([${myLIBPATH}], [myLIBPATH_REAL])
+            AC_MSG_CHECKING([whether the file is a "GNU ld script" and not a binary])
+            AS_IF([LANG=C LC_ALL=C file "${myLIBPATH}" | grep -Ei '(ascii|text)' && grep -w GROUP "${myLIBPATH}" >/dev/null], [
+                # dnl e.g. # cat /usr/lib/x86_64-linux-gnu/libusb.so
+                # dnl    /* GNU ld script.  */
+                # dnl    GROUP ( /lib/x86_64-linux-gnu/libusb-0.1.so.4.4.4 )
+                # dnl Note that spaces around parentheses vary, more keywords
+                # dnl may be present in a group (e.g. AS_NEEDED), and comment
+                # dnl strings are inconsistent (useless to match by).
+                AC_MSG_RESULT([yes, iterate further])
+                myLIBPATH_LDSCRIPT="`grep -w GROUP "${myLIBPATH}" | sed 's,^.*GROUP *( *\(/@<:@^ @:>@*\.so@<:@^ @:>@*\)@<:@^0-9a-zA-Z_.-@:>@.*$,\1,'`"
+                AS_IF([test -n "${myLIBPATH_LDSCRIPT}" && test -s "${myLIBPATH_LDSCRIPT}"], [
+                    AC_MSG_NOTICE([will dig into ${myLIBPATH_LDSCRIPT}])
+
+                    dnl # See detailed comments just below
+                    myLIBPATH_REAL="${myLIBPATH_LDSCRIPT}"
+                    AX_REALPATH([${myLIBPATH_LDSCRIPT}], [myLIBPATH_REAL])
+                ], [
+                    AC_MSG_NOTICE([could not determine a further path name, will use what we have])
+
+                    dnl # See detailed comments just below
+                    myLIBPATH_REAL="${myLIBPATH}"
+                    AX_REALPATH([${myLIBPATH}], [myLIBPATH_REAL])
+                ])
+            ],[
+                AC_MSG_RESULT([no, seems like a normal binary])
+
+                dnl # Resolving the directory location is a nice bonus
+                dnl # (usually the paths are relative to toolkit and ugly,
+                dnl # though maybe arguably portable with regard to symlinks).
+                dnl # The primary goal is to resolve the actual library file
+                dnl # name like "libnetsnmp.so.1.2.3", so we can preferentially
+                dnl # try to dlopen() it on a system with a packaged footprint
+                dnl # that does not serve short (developer-friendly) links like
+                dnl # "libnetsnmp.so".
+                myLIBPATH_REAL="${myLIBPATH}"
+                AX_REALPATH([${myLIBPATH}], [myLIBPATH_REAL])
+            ])
+
             AC_MSG_RESULT(${myLIBPATH_REAL})
             $2="${myLIBPATH_REAL}"
         ],[


### PR DESCRIPTION
Partially addresses #2615 (the part for `nut-scanner` scope), follows-up from PR #2604.

Beside porting the method proposed by @tormodvolden in #2604 for `usb-common.c`, there were some other methods used by it that needed porting from libusb headers (inline, not dynamic symbols).

Checked with libusb-0.1 and libusb-1.0 builds on a physical machine, that the resulting `nut-scanner -U` still finds an Eaton USB UPS (although with model not impacted by the issue from #1925 / #2604).

Also found and fixed a problem with stashing of SOPATH and SONAME for libraries seen during build (so `libnutscan` would search for those exact filenames first), as this did not play well with the few "GNU ld script" files instead of binary dynamic libraries, as found on the tested system. Probably can be seen as a fallout of PR #2504 et al for issue #2431.