### PR TITLE
drivers/main.c: upsdrv_banner(): keep NUT version near NUT project name…

### DIFF
--- a/drivers/main.c
+++ b/drivers/main.c
@@ -139,9 +139,11 @@ void upsdrv_banner (void)
 {
 	int i;
 
-	printf("Network UPS Tools driver %s - %s %s\n",
+	printf("Network UPS Tools %s - %s%s %s\n",
 		describe_NUT_VERSION_once(),
-		upsdrv_info.name, upsdrv_info.version);
+		upsdrv_info.name,
+		strstr(upsdrv_info.name, "river") ? "" : " driver",
+		upsdrv_info.version);
 
 	/* process sub driver(s) information */
 	for (i = 0; upsdrv_info.subdrv_info[i]; i++) {


### PR DESCRIPTION
…and only mention "driver" if needed (once)

Follow-up to PR #2583

Example change:

* Network UPS Tools driver 2.8.2.1064-1064-g501bbdc62 (development iteration after 2.8.2) - network XML UPS 0.46
* Network UPS Tools 2.8.2.1064-1064-g501bbdc62 (development iteration after 2.8.2) - network XML UPS driver 0.46

or

* Network UPS Tools driver 2.8.2.1064-1064-g501bbdc62 (development iteration after 2.8.2) - Generic HID driver 0.57
* Network UPS Tools 2.8.2.1064-1064-g501bbdc62 (development iteration after 2.8.2) - Generic HID driver 0.57

Compare to older versions' markup where NUT version tailed in the end (generally fixed by PR #2583 due to possible nested parentheses in dev builds):

* Network UPS Tools - Generic HID driver 0.53 (2.8.2)

...and to other non-driver programs now, which generally do print their program name/type after NUT before version:

* Network UPS Tools upsmon 2.8.2.1064-1064-g501bbdc62 (development iteration after 2.8.2)