### PR TITLE
Support for Liebert GXE 1-3KVA series

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -22,6 +22,7 @@ https://github.com/networkupstools/nut/milestone/9
    the driver binaries to be built once and data mappings to be loaded
    and modernized on the fly [Ported from 42ITy project]
 
+ - (expected) Added support for Liebert GXE Series UPS. [#2629]
 
 PLANNED: Release notes for NUT 2.8.3 - what's new since 2.8.2
 -------------------------------------------------------------

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -22,8 +22,6 @@ https://github.com/networkupstools/nut/milestone/9
    the driver binaries to be built once and data mappings to be loaded
    and modernized on the fly [Ported from 42ITy project]
 
- - (expected) Added support for Liebert GXE Series UPS. [#2629]
-
 PLANNED: Release notes for NUT 2.8.3 - what's new since 2.8.2
 -------------------------------------------------------------
 
@@ -133,6 +131,9 @@ https://github.com/networkupstools/nut/milestone/11
  - bicker_ser: added new driver for Bicker 12/24Vdc UPS via RS-232 serial
    communication protocol, which supports any UPS shipped with the PSZ-1053
    extension module. [PR #2448]
+
+ - liebert-gxe: added new driver with support for Liebert GXE Series UPS
+   (serial or USB posing as a serial port). [#2629]
 
  - usbhid-ups updates:
    * Support of the `onlinedischarge_log_throttle_hovercharge` in the NUT

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -656,6 +656,7 @@
 
 "Liebert"	"ups"	"2"	"ITON 600VA"	""	"blazer_ser"
 "Liebert"	"ups"	"5"	"UPStation GXT2"	"contact-closure cable"	"liebert"
+"Liebert"	"ups"	"4"	"GXE 1-3kVA"   		"Serial"	"liebert-gxe (experimental)"
 "Liebert"	"ups"	"1"	"GXT2-3000RT230"	""	"liebert-esp2 (experimental)"
 "Liebert"	"ups"	"3"	"PowerSure Personal XT"	"USB"	"usbhid-ups"
 "Liebert"	"ups"	"3"	"PowerSure PSA"	"USB"	"usbhid-ups"

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -497,6 +497,7 @@ SRC_SERIAL_PAGES = \
 	isbmex.txt	\
 	ivtscd.txt	\
 	liebert.txt	\
+	liebert-gxe.txt	\
 	liebert-esp2.txt	\
 	masterguard.txt	\
 	metasys.txt	\
@@ -545,6 +546,7 @@ MAN_SERIAL_PAGES = \
 	isbmex.8	\
 	ivtscd.8	\
 	liebert.8	\
+	liebert-gxe.8	\
 	liebert-esp2.8	\
 	masterguard.8	\
 	metasys.8	\
@@ -596,6 +598,7 @@ HTML_SERIAL_MANS = \
 	isbmex.html	\
 	ivtscd.html	\
 	liebert.html	\
+	liebert-gxe.html\
 	liebert-esp2.html	\
 	masterguard.html	\
 	metasys.html	\

--- a/docs/man/liebert-gxe.txt
+++ b/docs/man/liebert-gxe.txt
@@ -36,7 +36,7 @@ EXTRA ARGUMENTS
 This driver supports the following optional settings in linkman:ups.conf[5]:
 
 *addr=*'num'::
-Set the address of the UPS - 01 (default) ~ 99.
+Set the address of the UPS -- 01 (default) ~ 99.
 
 *retry=*'num'::
 Set the max times of read failures. (UPS sometimes ignores the incoming

--- a/docs/man/liebert-gxe.txt
+++ b/docs/man/liebert-gxe.txt
@@ -1,0 +1,59 @@
+LIEBERT-GXE(8)
+===============
+
+NAME
+----
+
+liebert-gxe - Driver for Liebert GXE series UPS, using the YDN23 serial protocol
+
+SYNOPSIS
+--------
+
+*liebert-gxe* -h
+
+*liebert-gxe* -a 'UPS_NAME' ['OPTIONS']
+
+NOTE: This man page only documents the hardware-specific features of the
+liebert-gxe driver.  For information about the core driver, see
+linkman:nutupsdrv[8].
+
+SUPPORTED HARDWARE
+------------------
+
+Tested to work on the following units:
+
+* Liebert GXE 01k00TS1101C00
+
+This is an experimental driver.  You have been warned.
+
+EXTRA ARGUMENTS
+---------------
+
+This driver supports the following optional settings in linkman:ups.conf[5]:
+
+*addr=*'num'::
+Set the address of the UPS - 01 (default) ~ 99.
+
+*retry=*'num'::
+Set the max times of read failures. (UPS sometimes ignores the incoming
+command and causes driver stales. The driver will ignore *retry* failures if
+occurred in a row. However, this does increase the latency if a real stale
+happened. Default to 3)
+
+AUTHORS
+-------
+
+* Gong Zhile <goodspeed at mailo.cat>
+
+SEE ALSO
+--------
+
+The core driver:
+~~~~~~~~~~~~~~~~
+
+linkman:nutupsdrv[8]
+
+Internet resources:
+~~~~~~~~~~~~~~~~~~~
+
+The NUT (Network UPS Tools) home page: https://www.networkupstools.org/

--- a/docs/man/liebert-gxe.txt
+++ b/docs/man/liebert-gxe.txt
@@ -23,6 +23,10 @@ SUPPORTED HARDWARE
 Tested to work on the following units:
 
 * Liebert GXE 01k00TS1101C00
++
+NOTE: This UPS has an RS-232 port and a USB port. The USB port has an
+ACM interface which functions as a serial port for the host operating
+system. Both ports can be used managing the device.
 
 This is an experimental driver.  You have been warned.
 

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3215 utf-8
+personal_ws-1.1 en 3220 utf-8
 AAC
 AAS
 ABI
@@ -1391,6 +1391,7 @@ Xfer
 Xlinker
 Xpert
 Xups
+YDN
 YQ
 YV
 YY
@@ -1407,6 +1408,7 @@ Zaika
 Zampieri
 Zawadzki
 ZeroMQ
+Zhile
 abandonware
 abcd
 ablerex
@@ -1967,6 +1969,7 @@ gmake
 gmtime
 gnuplot
 gnutls
+goodspeed
 google
 goto
 gotos
@@ -1984,6 +1987,7 @@ guesstimation
 guez
 gufw
 gui
+gxe
 gz
 gzip
 hal
@@ -2280,6 +2284,7 @@ mDNS
 mS
 macaddr
 macosx
+mailo
 mailx
 mainFrame
 maintainer's

--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -54,7 +54,7 @@ endif
 NUTSW_DRIVERLIST = dummy-ups clone clone-outlet apcupsd-ups skel
 SERIAL_DRIVERLIST = al175 bcmxcp belkin belkinunv bestfcom	\
  bestfortress bestuferrups bestups etapro everups 	\
- gamatronic genericups isbmex liebert liebert-esp2 masterguard metasys	\
+ gamatronic genericups isbmex liebert liebert-esp2 liebert-gxe masterguard metasys	\
  mge-utalk microdowell microsol-apc mge-shut oneac optiups powercom rhino 	\
  safenet nutdrv_siemens-sitop solis tripplite tripplitesu upscode2 victronups powerpanel \
  blazer_ser ivtscd apcsmart apcsmart-old riello_ser sms_ser bicker_ser
@@ -157,6 +157,7 @@ isbmex_LDADD = $(LDADD) -lm
 ivtscd_SOURCES = ivtscd.c
 liebert_SOURCES = liebert.c
 liebert_esp2_SOURCES = liebert-esp2.c
+liebert_gxe_SOURCES = liebert-gxe.c
 masterguard_SOURCES = masterguard.c
 metasys_SOURCES = metasys.c
 metasys_LDADD = $(LDADD) -lm
@@ -399,7 +400,7 @@ dist_noinst_HEADERS = \
  xppc-mib.h huawei-mib.h eaton-ats16-nmc-mib.h eaton-ats16-nm2-mib.h apc-ats-mib.h raritan-px2-mib.h eaton-ats30-mib.h \
  apc-pdu-mib.h apc-epdu-mib.h ever-hid.h eaton-pdu-genesis2-mib.h eaton-pdu-marlin-mib.h eaton-pdu-marlin-helpers.h \
  eaton-pdu-pulizzi-mib.h eaton-pdu-revelation-mib.h emerson-avocent-pdu-mib.h eaton-ups-pwnm2-mib.h eaton-ups-pxg-mib.h legrand-hid.h \
- hpe-pdu-mib.h hpe-pdu3-cis-mib.h powervar-hid.h delta_ups-hid.h generic_modbus.h salicru-hid.h adelsystem_cbi.h eaton-pdu-nlogic-mib.h
+ hpe-pdu-mib.h hpe-pdu3-cis-mib.h powervar-hid.h delta_ups-hid.h generic_modbus.h salicru-hid.h adelsystem_cbi.h eaton-pdu-nlogic-mib.h ydn23.h
 
 # Define a dummy library so that Automake builds rules for the
 # corresponding object files.  This library is not actually built,

--- a/drivers/liebert-gxe.c
+++ b/drivers/liebert-gxe.c
@@ -405,13 +405,35 @@ void upsdrv_updateinfo(void)
 		upslogx(LOG_DEBUG, "Polling SYSPARAM data");
 		upsdrv_updateinfo_sysparam();
 		break;
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT
+# pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+# pragma GCC diagnostic ignored "-Wunreachable-code"
+#endif
+/* Older CLANG (e.g. clang-3.4) seems to not support the GCC pragmas above */
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunreachable-code"
+# pragma clang diagnostic ignored "-Wcovered-switch-default"
+#endif
 	default:
+		/* Must not occur. */
 		upslogx(LOG_WARNING,
 			"Unknown State Reached, "
 			"Fallback to ANALOG data");
 		poll_state = GXE_ANALOG;
 		upsdrv_updateinfo();
 		break;
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic pop
+#endif
 	}
 }
 

--- a/drivers/liebert-gxe.c
+++ b/drivers/liebert-gxe.c
@@ -455,7 +455,7 @@ void upsdrv_initinfo(void)
 	}
 
 	if (ret <= 0)
-		fatal_with_errno(EXIT_FAILURE, "gxe: failed reading response");
+		fatal_with_errno(EXIT_FAILURE, "liebert-gxe: failed reading response");
 
 	/* UPS Name, 10 bytes */
 	ydn23_substr_from_hex(databuf, 11, YDN23_FRAME_REG(recvframe, 0), 20);
@@ -503,7 +503,7 @@ void upsdrv_initups(void)
 
 void upsdrv_shutdown(void)
 {
-	upslogx(LOG_INFO, "GXE UPS can't fully shutdown, NOOP");
+	upslogx(LOG_INFO, "Liebert GXE UPS can't fully shutdown, NOOP");
 }
 
 void upsdrv_cleanup(void)

--- a/drivers/liebert-gxe.c
+++ b/drivers/liebert-gxe.c
@@ -1,0 +1,490 @@
+/* liebert-gxe.c - support for Liebert GXE Series UPS models via serial.
+
+   Copyright (C) 2024  Gong Zhile <goodspeed@mailo.cat>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
+#include "config.h"
+#include "main.h"
+#include "attribute.h"
+#include "serial.h"
+#include "ydn23.h"
+
+#define DRIVER_NAME	"Liebert GXE Series UPS driver"
+#define DRIVER_VERSION	"0.01"
+
+#define PROBE_RETRIES   3
+#define DEFAULT_STALE_RETRIES	3
+
+#define DATAFLAG_WARN_MASK (1)
+#define DATAFLAG_ONOFF_MASK (1 << 4)
+
+static char *devaddr = NULL;
+
+static int stale_retries = DEFAULT_STALE_RETRIES;
+static int stale_retry = DEFAULT_STALE_RETRIES;
+
+#define TRY_STALE()							\
+	if ((stale_retry--) > 0)					\
+		dstate_dataok();					\
+	else								\
+		dstate_datastale();					\
+
+#define ARRAY_SIZE(x) ((sizeof x) / (sizeof *x))
+static const char *gxe_warns[] = {
+	NULL,			/* DATAFLAG */
+	"Inverter Out-of-Sync",
+	"Unhealthy Main Circuit",
+	"Rectifier Failure",
+	"Inverter Failure",
+	"Unhealthy Bypass",
+	"Unhealthy Battery Voltage",
+	NULL,			/* USER_DEFINED */
+	NULL,			/* USER_DEFINED */
+	"Power Module Overheated",
+	"Unhealthy Fan",
+	"Netural Input Missing",
+	"Master Line Abnormally Turned-off",
+	"Charger Failure",
+	"Battery Discharge Declined",
+	"Backup Power Supply Failure",
+	"Ouput Overloaded",
+	"Ouput Shorted",
+	"Overload Timed-out",
+	"Unhealthy Parallel Machine Current",
+	"Parallel Machine Connection Failure",
+	"Parallel Machine Address Error",
+	"Unhealthy Internal Communication",
+	"System Overloaded",
+	"Battery Installed Backwards",
+	"Battery Not Found",
+};
+
+/* Instcmd & Driver Init: SYSPARAM -OK-> WARNING -OK-> ONOFF -OK-> ANALOG */
+/* If the dataflag set for WARNING/ONOFF, set next state respectively. */
+static enum gxe_poll_state {
+	GXE_ONOFF,
+	GXE_ANALOG,
+	GXE_WARNING,
+	/* Scheduled System Parameters, Trigged by Instcmd */
+	GXE_SYSPARAM,
+} poll_state;
+
+upsdrv_info_t upsdrv_info = {
+	DRIVER_NAME,
+	DRIVER_VERSION,
+	"Gong Zhile <goodspeed@mailo.cat>",
+	DRV_EXPERIMENTAL,
+	{ NULL }
+};
+
+static int instcmd(const char *cmdname, const char *extra)
+{
+	enum YDN23_COMMAND_ID cmd = YDN23_REMOTE_COMMAND;
+	struct ydn23_frame sendframe, recvframe;
+	int retry, ret, len = 4;
+	char *data = NULL;
+
+	if (!strcasecmp(cmdname, "test.battery.start"))
+		data = "1002";
+	else if (!strcasecmp(cmdname, "test.battery.stop"))
+		data = "1003";
+	else if (!strcasecmp(cmdname, "load.on"))
+		data = "2001";
+	else if (!strcasecmp(cmdname, "load.off"))
+		data = "2003";
+	else {
+		upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+		return STAT_INSTCMD_UNKNOWN;
+	}
+
+	ydn23_frame_init(&sendframe, cmd, devaddr, "21", data, len);
+	for (retry = 0; retry < PROBE_RETRIES; retry++) {
+		ret = ydn23_frame_send(upsfd, &sendframe);
+		if (ret <= 0) continue;
+
+		ret = ydn23_frame_read(upsfd, &recvframe, 2, 0);
+		if (ret > 0) {
+			poll_state = GXE_SYSPARAM;
+			return STAT_INSTCMD_HANDLED;
+		}
+	}
+
+	upslogx(LOG_WARNING, "instcmd: remote failed response, try again");
+	return STAT_INSTCMD_FAILED;
+}
+
+static void upsdrv_updateinfo_onoff(void)
+{
+	int retry, ret = -1, dflag, pwrval, rectval;
+	struct ydn23_frame sendframe, frame;
+
+	ydn23_frame_init(&sendframe, YDN23_GET_ONOFF_DATA,
+			 "21", devaddr, NULL, 0);
+
+	for (retry = 0; retry < PROBE_RETRIES; retry++) {
+		ret = ydn23_frame_send(upsfd, &sendframe);
+		if (ret <= 0) continue;
+		ret = ydn23_frame_read(upsfd, &frame, 2, 0);
+		if (ret > 0)
+			break;
+	}
+
+	if (ret <= 0) {
+		upslogx(LOG_WARNING, "failed reading ONOFF data, retry");
+		TRY_STALE()
+		return;
+	}
+
+	stale_retry = stale_retries;
+	poll_state = GXE_ANALOG;
+
+	/* DATAFLAG */
+	dflag = ydn23_val_from_hex(YDN23_FRAME_REG(frame, 0), 2);
+	if (dflag & DATAFLAG_ONOFF_MASK)
+		poll_state = GXE_ONOFF;
+	if (dflag & DATAFLAG_WARN_MASK)
+		poll_state = GXE_WARNING;
+
+	status_init();
+
+	/* Field 1, Power Supply (01=UPS, 02=Bypass) */
+	pwrval = ydn23_val_from_hex(YDN23_FRAME_REG(frame, 1), 2);
+	/* Field 3, Rectifier Power Supply (E0=None, E1=CITYPWR, E2=BAT) */
+	rectval = ydn23_val_from_hex(YDN23_FRAME_REG(frame, 3), 2);
+
+	if (pwrval == 0x01 && rectval == 0xe2)
+		status_set("OB");
+	else if (pwrval == 0x01)
+		status_set("OL");
+	else if (pwrval == 0x02)
+		status_set("OL BYPASS");
+	else upslogx(LOG_WARNING, "unknown ups state: %x %x", pwrval, rectval);
+
+	status_commit();
+
+	/* Field 4, Battery Status */
+	switch(ydn23_val_from_hex(YDN23_FRAME_REG(frame, 4), 2)) {
+	case 0xe0:
+		dstate_setinfo("battery.charger.status", "resting");
+		break;
+	case 0xe1:
+	case 0xe2:
+		dstate_setinfo("battery.charger.status", "charging");
+		break;
+	case 0xe3:
+		dstate_setinfo("battery.charger.status", "discharging");
+		break;
+	default:
+		upslogx(LOG_WARNING, "unknown battery status, ignored");
+		break;
+	}
+
+	/* Field 5, Battery Test State */
+	switch(ydn23_val_from_hex(YDN23_FRAME_REG(frame, 5), 2)) {
+	case 0xe0:
+		dstate_setinfo("ups.test.result", "In progress");
+		break;
+	case 0xe1:
+		dstate_setinfo("ups.test.result", "Idle");
+		break;
+	default:
+		upslogx(LOG_WARNING, "unknown battery test state, ignored");
+		break;
+	}
+
+	dstate_dataok();
+}
+
+static void upsdrv_updateinfo_analog(void)
+{
+	struct ydn23_frame sendframe, frame;
+	int retry, ret = -1, dflag, volt;
+
+	ydn23_frame_init(&sendframe, YDN23_GET_ANALOG_DATA_D,
+			 "21", devaddr, NULL, 0);
+
+	for (retry = 0; retry < PROBE_RETRIES; retry++) {
+		ret = ydn23_frame_send(upsfd, &sendframe);
+		if (ret <= 0) continue;
+		ret = ydn23_frame_read(upsfd, &frame, 2, 0);
+		if (ret > 0)
+			break;
+	}
+
+	if (ret <= 0) {
+		upslogx(LOG_WARNING, "failed reading ANALOG data, retry");
+		TRY_STALE()
+		return;
+	}
+
+	stale_retry = stale_retries;
+
+	/* DATAFLAG, NOT RELIABLE SOMEHOW */
+	dflag = ydn23_val_from_hex(frame.INFO, 2);
+	if (dflag & DATAFLAG_ONOFF_MASK)
+		poll_state = GXE_ONOFF;
+	if (dflag & DATAFLAG_WARN_MASK)
+		poll_state = GXE_WARNING;
+
+	/* Field 1, AC_IN VOLTAGE */
+	volt = ydn23_val_from_hex(YDN23_FRAME_REG(frame, 1), 4)/100;
+
+	if (volt == 0 && status_get("OL")) {
+		/* Oh no, power failed still online? */
+		status_init();
+		status_set("OB");
+		status_commit();
+		poll_state = GXE_WARNING;
+	}
+
+	if (volt > 0 && status_get("OB")) {
+		/* Hum, power recovered still on battery? */
+		status_init();
+		status_set("OL");
+		status_commit();
+		poll_state = GXE_WARNING;
+	}
+
+	dstate_setinfo("input.voltage", "%.02f",
+		       ydn23_val_from_hex(YDN23_FRAME_REG(frame, 1), 4)/100.0f);
+	/* Field 4, AC_OUT VOLTAGE */
+	dstate_setinfo("output.voltage", "%.02f",
+		       ydn23_val_from_hex(YDN23_FRAME_REG(frame, 7), 4)/100.0f);
+	/* Field 7, AC_OUT CURRENT */
+	dstate_setinfo("output.current", "%.02f",
+		       ydn23_val_from_hex(YDN23_FRAME_REG(frame, 13), 4)/100.0f);
+	/* Field 10, DC VOLTAGE */
+	dstate_setinfo("battery.voltage", "%.02f",
+		       ydn23_val_from_hex(YDN23_FRAME_REG(frame, 19), 4)/100.0f);
+	/* Field 11, AC_OUT FREQUENCY */
+	dstate_setinfo("output.frequency", "%.02f",
+		       ydn23_val_from_hex(YDN23_FRAME_REG(frame, 21), 4)/100.0f);
+	/* Field 15, AC_IN FREQUENCY */
+	dstate_setinfo("input.frequency", "%.02f",
+		       ydn23_val_from_hex(YDN23_FRAME_REG(frame, 27), 4)/100.0f);
+	/* Field 18, AC_OUT REALPOWER, kW */
+	dstate_setinfo("ups.realpower", "%d",
+		       ydn23_val_from_hex(YDN23_FRAME_REG(frame, 33), 4)*10);
+	/* Field 19, AC_OUT POWER, kVA */
+	dstate_setinfo("ups.power", "%d",
+		       ydn23_val_from_hex(YDN23_FRAME_REG(frame, 35), 4)*10);
+	/* Field 22, BATTERY BACKUP TIME, Min */
+	dstate_setinfo("battery.runtime.low", "%.2f",
+		       ydn23_val_from_hex(YDN23_FRAME_REG(frame, 41), 4)/100.0f*60.0f);
+
+	dstate_dataok();
+}
+
+static void upsdrv_updateinfo_sysparam(void)
+{
+	struct ydn23_frame sendframe, frame;
+	int retry, ret = -1;
+
+	ydn23_frame_init(&sendframe, YDN23_GET_SYS_PARAM_D,
+			 "21", devaddr, NULL, 0);
+
+	for (retry = 0; retry < PROBE_RETRIES; retry++) {
+		ret = ydn23_frame_send(upsfd, &sendframe);
+		if (ret <= 0) continue;
+		ret = ydn23_frame_read(upsfd, &frame, 2, 0);
+		if (ret > 0)
+			break;
+	}
+
+	if (ret <= 0) {
+		upslogx(LOG_WARNING, "failed reading SYSPARAM data, retry");
+		TRY_STALE()
+		return;
+	}
+
+	stale_retry = stale_retries;
+	poll_state = GXE_WARNING;
+
+	/* Field 6, Nominal Voltage */
+	dstate_setinfo("output.voltage.nominal", "%d",
+		       ydn23_val_from_hex(YDN23_FRAME_REG(frame, 9), 4));
+	/* Field 7, Nominal Frequency */
+	dstate_setinfo("output.frequency.nominal", "%d",
+		       ydn23_val_from_hex(YDN23_FRAME_REG(frame, 11), 4));
+	/* Field 10, Bypass Working Voltage Max, ALWAYS 115% */
+	if (ydn23_val_from_hex(YDN23_FRAME_REG(frame, 17), 4) == 1)
+		dstate_setinfo("input.transfer.bypass.high", "%f",
+			       ydn23_val_from_hex(YDN23_FRAME_REG(frame, 9), 4)*1.15f);
+	/* Field 11, Bypass Working Voltage Min, Volt */
+	if (ydn23_val_from_hex(YDN23_FRAME_REG(frame, 19), 4) == 1)
+		dstate_setinfo("input.transfer.bypass.low", "%d", 120);
+	/* Field 21, Battery Test Interval, per 3 mons */
+	dstate_setinfo("ups.test.interval", "%lu",
+		       (long) ydn23_val_from_hex(YDN23_FRAME_REG(frame, 39), 4)*3*108000);
+
+	dstate_dataok();
+}
+
+static void upsdrv_updateinfo_warning(void)
+{
+	struct ydn23_frame sendframe, frame;
+	int retry, ret = -1, val;
+	size_t i;
+
+	ydn23_frame_init(&sendframe, YDN23_GET_WARNING_DATA,
+			 "21", devaddr, NULL, 0);
+
+	for (retry = 0; retry < PROBE_RETRIES; retry++) {
+		ret = ydn23_frame_send(upsfd, &sendframe);
+		if (ret <= 0) continue;
+		ret = ydn23_frame_read(upsfd, &frame, 2, 0);
+		if (ret > 0)
+			break;
+	}
+
+	if (ret <= 0) {
+		upslogx(LOG_WARNING, "failed reading WARNING data, retry");
+		TRY_STALE()
+		return;
+	}
+
+	stale_retry = stale_retries;
+	poll_state = GXE_ONOFF;
+
+	alarm_init();
+	for (i = 0; i < ARRAY_SIZE(gxe_warns); i++) {
+		if (!gxe_warns[i])
+			continue;
+		val = ydn23_val_from_hex(YDN23_FRAME_REG(frame, 1+i), 2);
+		switch(val)  {
+		case 0x00:
+		case 0x0e:
+		case 0xe0:
+			break;
+		case 0x01:
+		case 0x02:
+		case 0x03:
+		case 0xf0:
+			alarm_set(gxe_warns[i]);
+			break;
+		default:
+			upslogx(LOG_WARNING, "unexpected warning val %x", val);
+			break;
+		}
+	}
+	alarm_commit();
+
+	dstate_dataok();
+}
+
+void upsdrv_updateinfo(void)
+{
+	switch(poll_state) {
+	case GXE_ANALOG:
+		upslogx(LOG_DEBUG, "Polling ANALOG data");
+		upsdrv_updateinfo_analog();
+		break;
+	case GXE_ONOFF:
+		upslogx(LOG_DEBUG, "Polling ONOFF data");
+		upsdrv_updateinfo_onoff();
+		break;
+	case GXE_WARNING:
+		upslogx(LOG_DEBUG, "Polling WARNING data");
+		upsdrv_updateinfo_warning();
+		break;
+	case GXE_SYSPARAM:
+		upslogx(LOG_DEBUG, "Polling SYSPARAM data");
+		upsdrv_updateinfo_sysparam();
+		break;
+	default:
+		upslogx(LOG_WARNING,
+			"Unknown State Reached, "
+			"Fallback to ANALOG data");
+		poll_state = GXE_ANALOG;
+		upsdrv_updateinfo();
+		break;
+	}
+}
+
+void upsdrv_initinfo(void)
+{
+	struct ydn23_frame sendframe, recvframe;
+	char databuf[11];
+	int retry, ret = -1;
+
+	ydn23_frame_init(&sendframe, YDN23_GET_VENDOR_INFO,
+			 "21", devaddr, NULL, 0);
+
+	for (retry = 0; retry < PROBE_RETRIES; retry++) {
+		ret = ydn23_frame_send(upsfd, &sendframe);
+		if (ret <= 0) continue;
+		ret = ydn23_frame_read(upsfd, &recvframe, 2, 0);
+		if (ret > 0)
+			break;
+	}
+
+	if (ret <= 0)
+		fatal_with_errno(EXIT_FAILURE, "gxe: failed reading response");
+
+	/* UPS Name, 10 bytes */
+	ydn23_substr_from_hex(databuf, 11, YDN23_FRAME_REG(recvframe, 0), 20);
+	dstate_setinfo("ups.mfr", "EmersonNetworkPower");
+	dstate_setinfo("ups.model", "%s", databuf);
+
+	dstate_setinfo("ups.id", "%s", devaddr);
+
+	dstate_addcmd("test.battery.start");
+	dstate_addcmd("test.battery.stop");
+	dstate_addcmd("load.off");
+	dstate_addcmd("load.on");
+
+	upsh.instcmd = instcmd;
+
+	poll_state = GXE_SYSPARAM;
+}
+
+void upsdrv_help(void)
+{
+}
+
+void upsdrv_makevartable(void)
+{
+	addvar(VAR_VALUE, "addr", "Override default UPS address");
+	addvar(VAR_VALUE, "retry", "Override default retry");
+}
+
+void upsdrv_initups(void)
+{
+	upsfd = ser_open(device_path);
+
+	devaddr = "01";		/* Default Address is 0x01 */
+	if (testvar("addr"))
+		devaddr = getval("addr");
+
+	if (testvar("retry"))
+		stale_retries = atoi(getval("retry"));
+
+	stale_retry = stale_retries;
+	poll_interval = 5;
+
+	usleep(100000);
+}
+
+void upsdrv_shutdown(void)
+{
+	upslogx(LOG_INFO, "GXE UPS can't fully shutdown, NOOP");
+}
+
+void upsdrv_cleanup(void)
+{
+	ser_close(upsfd, device_path);
+}

--- a/drivers/ydn23.h
+++ b/drivers/ydn23.h
@@ -1,0 +1,344 @@
+/* ydn23.h - helper functions for YDN23 (YD/T1363) serial protocol.
+
+   Copyright (C) 2024  Gong Zhile <goodspeed@mailo.cat>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
+/* BACKGROUND: YDN23 (YD/T1363) is a serial protocol standarized by China
+   Communications Standards Association. The biggest adpoter is Emerson Network
+   Power. And, in fact, Emerson Network Power did involve in the drafting.
+   
+   The protocol is identified as `Dian4 Zong3 Xie2 Yi4' in Chinese and rarely
+   referred as `YDN23' or `YD/T1363' in English documents. The standard is
+   written in Chinese, identified as YD/T 1363.3-2014 (also YD∕T 1363.3-2023),
+   with the English title being `Specification of supervision system for power,
+   air condition and envirnoment -- Part 3: Intelligent equipment communication
+   power'.
+*/
+
+/* TESTING: search indicates several Vertiv (Formly, Emerson) devices are
+   using this protocol.
+
+   A UPS can by probed with the command (GET_DEV_ADDR):
+
+     # cat /dev/ttyX & printf "~21012A500000FDA4\x0D" > /dev/ttyX
+
+   Response (Whitespaces are only for formating):
+
+     ~ 21 01 2A 00 0000 [] FDA9 [\x0D]
+     ^ ^  ^  ^  ^  ^    ^  ^    ^
+     | |  |  |  |  |    |  |    | EOI
+     | |  |  |  |  |    |  | CHKSUM
+     | |  |  |  |  |    | INFO (No Data)
+     | |  |  |  |  | LENGTH (No Data)
+     | |  |  |  | RTN/CID2 (Return Value = 0x00, OK)
+     | |  |  | CID1 (Device Type = 0x2A, UPS)
+     | |  | ADR (Device Address = 0x01)
+     | | VER (Protocol Version = 0x21)
+     | SOI
+
+   `liebert-gxe' is the driver implimented for Liebert GXE Series UPS. The
+   standard defined UPS data frames and registers and it's similar to the
+   protocol manual of Liebert GXE Series UPS. If the above test works, you can
+   try `liebert-gxe' driver. Good Luck ;-)
+*/
+
+#ifndef YDN23_H_SEEN
+#define YDN23_H_SEEN 1
+
+#include "serial.h"
+
+#ifndef htole16
+#ifdef WORDS_BIGENDIAN
+#define htole16(x) ((((x) >> 8) | ((x) << 8)))
+#else  /* WORDS_BIGENDIAN */
+#define htole16(x) (x)
+#endif	/* WORDS_BIGENDIAN */
+#endif	/* htole16 */
+
+/* X_F: Float-point Data, X_D: Fixed-point Data */
+enum YDN23_COMMAND_ID {
+	YDN23_CMD_FIRST = 0,
+	YDN23_GET_ANALOG_DATA_F,
+	YDN23_GET_ANALOG_DATA_D,
+	YDN23_GET_ONOFF_DATA,
+	YDN23_GET_WARNING_DATA,
+	YDN23_REMOTE_COMMAND,
+	YDN23_GET_SYS_PARAM_F,
+	YDN23_GET_SYS_PARAM_D,
+	YDN23_SET_SYS_PARAM_F,
+	YDN23_SET_SYS_PARAM_D,
+	YDN23_GET_SYS_HIST_F,
+	YDN23_GET_SYS_HIST_D,
+	YDN23_GET_WARN_HIST,
+	YDN23_GET_TIME,
+	YDN23_SET_TIME,
+	YDN23_GET_PROTO_VER,
+	YDN23_GET_DEV_ADDR,
+	YDN23_GET_VENDOR_INFO,
+	YDN23_CMD_LAST,
+};
+
+/* YDN23 Protocol frame has two command ID.
+   CID1: Device Type (2A for UPS)
+   CID2: Action	(41~51 Standarized, 80~EF Customized)
+*/
+
+static const char YDN23_COMMANDS[YDN23_CMD_LAST][4] = {
+	{'0','0','0','0'},	/* RESERVED */
+	{'2','A','4','1'},	/* YDN23_GET_ANALOG_DATA_F */
+	{'2','A','4','2'},	/* YDN23_GET_ANALOG_DATA_D */
+	{'2','A','4','3'},	/* YDN23_GET_ONOFF_DATA */
+	{'2','A','4','4'},	/* YDN23_GET_WARNING_DATA */
+	{'2','A','4','5'},	/* YDN23_REMOTE_COMMAND */
+	{'2','A','4','6'},	/* YDN23_GET_SYS_PARAM_F */
+	{'2','A','4','7'},	/* YDN23_GET_SYS_PARAM_D */
+	{'2','A','4','8'},	/* YDN23_SET_SYS_PARAM_F */
+	{'2','A','4','9'},	/* YDN23_SET_SYS_PARAM_D */
+	{'2','A','4','A'},	/* YDN23_GET_SYS_HIST_F */
+	{'2','A','4','B'},	/* YDN23_GET_SYS_HIST_D */
+	{'2','A','4','C'},	/* YDN23_GET_WARN_HIST */
+	{'2','A','4','D'},	/* YDN23_GET_TIME */
+	{'2','A','4','E'},	/* YDN23_SET_TIME */
+	{'2','A','4','F'},	/* YDN23_GET_PROTO_VER */
+	{'2','A','5','0'},	/* YDN23_GET_DEV_ADDR */
+	{'2','A','5','1'},	/* YDN23_GET_VENDOR_INFO */
+};
+
+#ifndef YDN23_FRAME_INFO_SIZE
+#define YDN23_FRAME_INFO_SIZE 128
+#endif	/* YDN23_FRAME_INFO_SIZE */
+
+static const char *YDN23_RTN_VALS[] = {
+	"OK",
+	"Bad VER",
+	"Bad CHKSUM",
+	"Bad LCHKSUM",
+	"Invalid CID2",
+	"Bad Command Format",
+	"Bad Data",
+};
+
+#define YDN23_RTN_TO_STR(rtn)							\
+  (((size_t) rtn) < sizeof(YDN23_RTN_VALS)/sizeof(*YDN23_RTN_VALS) ? YDN23_RTN_VALS[(rtn)] : "Unknown RTN")
+
+#pragma pack(push, 1)
+struct ydn23_frame {
+	char SOI;		/* Start of Infomation, 0x7e */
+	char VER[2];		/* Protocol Version */
+	char ADR[2];		/* Device Address */
+	char CID[4];		/* Command ID 1&2 */
+	char LEN[4];		/* Message Length, LCHKSUM &LENID */
+	char INFO[YDN23_FRAME_INFO_SIZE]; /* Command Info, Data Info */
+	char CHKSUM[4];			  /* Checksum */
+	char EOI;			  /* End of Infomation, 0x0d */
+
+	size_t infolen;
+};
+#pragma pack(pop)
+
+static inline void ydn23_lchecksum(uint16_t dlen, char *out)
+{
+	uint8_t lenchk = 0;
+	uint16_t lelen = htole16(dlen);
+	/* GCC complains uint16_t fits 7-bytes buffer, store here. */
+	char fbuf[7];
+
+	/* Sum all four 4 bits */
+	lenchk += lelen & 0x000f;
+	lenchk += lelen & 0x00f0;
+	lenchk += lelen & 0x0f00;
+	lenchk += lelen & 0xf000;
+
+	lenchk %= 16;
+	lenchk = ~lenchk + 1;
+
+	snprintf(fbuf, 7, "%04X", (uint16_t) (lelen | lenchk << 12));
+	memcpy(out, fbuf, 5);
+}
+
+static inline void ydn23_checksum(const char *buf, size_t len, char* out)
+{
+	size_t i;
+	uint32_t sum = 0;
+	/* GCC complains uint16_t fits 7-bytes buffer, store here. */
+	char fbuf[7];
+
+	for (i = 0; i < len; i++)
+		sum += buf[i];
+	sum %= 65536;
+
+	snprintf(fbuf, 7, "%04X", (uint16_t) ~sum + 1);
+	memcpy(out, fbuf, 5);
+}
+
+#define YDN23_FRAME_CLEAR(framep) memset((framep), 0, sizeof(struct ydn23_frame))
+
+/* Get the address to a register in the frame. Since all the binary data will
+   be presented in INFO as hexidecimal string, the macro multiplies actual reg
+   address by 2 to get the address in INFO. However, *_from_hex functions still
+   take the hexidecimal string length (e.g. 1 byte reg = 2 bytes hex, dlen = 2).
+*/
+#define YDN23_FRAME_REG(frame, reg) ((frame).INFO + 2 * reg)
+
+static inline int ydn23_val_from_hex(char *buf, size_t dlen)
+{
+	char valbuf[16];
+
+	if (dlen > 15)
+		return 0;
+
+	memcpy(valbuf, buf, dlen);
+	valbuf[dlen] = '\0';
+	return strtol(valbuf, NULL, 16);
+}
+
+static inline void ydn23_substr_from_hex(char *substr, size_t len,
+					 char *dbuf, size_t dlen)
+{
+	int val;
+	size_t i;
+	for (i = 0; i < dlen; i += 2) {
+		val = ydn23_val_from_hex(dbuf+i, 2);
+		if (val == 0x20) {
+			substr[i/2] = '\0';
+			return;
+		}
+		if (i/2 > len-1)
+			break;
+		substr[i/2] = val;
+	}
+	substr[i/2] = '\0';
+	upslogx(LOG_DEBUG, "ydn23_substr_from_hex: %s", substr);
+}
+
+static inline void ydn23_frame_init(struct ydn23_frame *frame,
+				    enum YDN23_COMMAND_ID cmdi,
+				    const char *ver,
+				    const char *addr,
+				    const char *dptr,
+				    size_t dlen)
+{
+	if (dlen > YDN23_FRAME_INFO_SIZE) {
+		upslogx(LOG_WARNING,
+			"frame not big enough, required %d got %zu, truncated",
+			YDN23_FRAME_INFO_SIZE, dlen);
+		dlen = YDN23_FRAME_INFO_SIZE;
+	}
+
+	frame->infolen = dlen;
+	memset(frame->INFO, 0, sizeof(frame->INFO));
+
+	frame->SOI = 0x7e;
+	memcpy(frame->VER, ver, sizeof(frame->VER));
+	memcpy(frame->ADR, addr, sizeof(frame->ADR));
+	memcpy(frame->CID, YDN23_COMMANDS[cmdi], sizeof(frame->CID));
+	ydn23_lchecksum(dlen, frame->LEN);
+	memcpy(frame->INFO, dptr, dlen);
+	ydn23_checksum(frame->VER, frame->CHKSUM - frame->VER, frame->CHKSUM);
+	frame->EOI = 0x0d;
+
+	upsdebug_hex(6, "ydn23_frame_init", frame, sizeof(*frame));
+}
+
+static inline int ydn23_frame_send(TYPE_FD_SER fd, struct ydn23_frame *frame)
+{
+	int ret;
+
+	ser_flush_io(fd);
+
+	ret = ser_send_buf(fd, frame, frame->INFO - &frame->SOI);
+	if (ret <= 0) {
+		upslogx(LOG_WARNING, "ydn23_frame_send: %s",
+			ret ? strerror(errno) : "timeout");
+		return ret;
+	}
+
+	if (frame->infolen) {
+		ret = ser_send_buf(fd, frame->INFO, frame->infolen);
+		if (ret <= 0) {
+			upslogx(LOG_WARNING, "ydn23_frame_send: %s",
+				ret ? strerror(errno) : "timeout");
+			return ret;
+		}
+	}
+
+	ret = ser_send_buf(fd, frame->CHKSUM,
+			   ((char *) &frame->infolen) - frame->CHKSUM);
+	if (ret <= 0) {
+		upslogx(LOG_WARNING, "ydn23_frame_send: %s", ret ? strerror(errno) : "timeout");
+		return ret;
+	}
+
+	return ret;
+}
+
+static inline int ydn23_frame_read(TYPE_FD_SER fd, struct ydn23_frame *frame,
+				   time_t d_sec, useconds_t d_usec)
+{
+	char clearlen[5];
+	int ret, rtn;
+
+	clearlen[4] = '\0';
+	YDN23_FRAME_CLEAR(frame);
+
+	ret = ser_get_buf(fd, frame, sizeof(*frame), d_sec, d_usec);
+	if (ret <= 0) {
+		upslogx(LOG_WARNING, "ydn23_frame_read: %s", ret ? strerror(errno) : "timeout");
+		return -1;
+	}
+	upsdebug_hex(5, "ydn23_frame_read(raw)", frame, sizeof(*frame));
+
+	if (frame->SOI != 0x7e) {
+		upslogx(LOG_WARNING, "ydn23_frame_read: bad SOI, frame dropped");
+		return -1;
+	}
+
+	if ((rtn = ydn23_val_from_hex(frame->CID + 2, 2))) {
+		upslogx(LOG_WARNING,
+			"ydn23_frame_read: bad RTN (%s), frame dropped",
+			YDN23_RTN_TO_STR(rtn));
+		return -1;
+	}
+
+	memcpy(clearlen, frame->LEN, sizeof(frame->LEN));
+	frame->infolen = ydn23_val_from_hex(clearlen+1, 4); /* Exclude LENID */
+
+	if (frame->infolen > YDN23_FRAME_INFO_SIZE) {
+		upslogx(LOG_WARNING,
+			"ydn23_frame_read: bad LEN (%zx), frame dropped",
+			frame->infolen);
+		return -1;
+	}
+
+	memcpy(frame->CHKSUM, frame->INFO + frame->infolen,
+	       ((char *) &frame->infolen) - frame->CHKSUM);
+	memset(frame->INFO + frame->infolen, 0,
+	       ((char *) &frame->infolen) - frame->CHKSUM);
+
+	ydn23_checksum(frame->VER, frame->CHKSUM - frame->VER, clearlen);
+	if (memcmp(clearlen, frame->CHKSUM, sizeof(frame->CHKSUM))) {
+		upslogx(LOG_WARNING,
+			"ydn23_frame_read: bad CHKSUM (%c%c%c%c, %s), frame dropped",
+			frame->CHKSUM[0], frame->CHKSUM[1], frame->CHKSUM[2], frame->CHKSUM[3], clearlen);
+		return -1;
+	}
+
+	upsdebug_hex(5, "ydn23_frame_read(cooked)", frame, sizeof(*frame));
+	return ret;
+}
+
+#endif	/* YDN23_H_SEEN */


### PR DESCRIPTION
Product Breif: https://www.vertiv.com/4a3d25/globalassets/products/critical-power/uninterruptible-power-supplies-ups/vertiv-liebert-gxe-1000-3000va-racktower-230v-single-phase-ups/vertiv-liebert-gxe-datasheet-en-emea---mka4l0ukvlg.pdf

This UPS has a RS232 port and a USB port. The USB port has an ACM interface which functions as a serial port. Both ports can be used managing the device.

<!-- Comment:
* Please revise the docs/developers.txt for coding style suggestions and
  other considerations applicable to NUT codebase contributions, as well
  as for which text documents to update. See also docs/developer-guide.txt
  for general points on NUT architecture and design.

* Please note that we require "Signed-Off-By" tags in each Git Commit
  message, to conform to the common DCO (Developer Certificate of Origin)
  as posted in LICENSE-DCO at root of NUT codebase as well as published
  at https://developercertificate.org/

* The checklist below is more of a reminder of steps to take and "dangers"
  to look out for. PRs to update this template are also welcome :)

* Local build iterations can be augmented with the ci_build.sh script.
-->

## General points

- [ ] Described the changes in the PR submission or a separate issue, e.g.
  known published or discovered protocols, applicable hardware (expected
  compatible and actually tested/developed against), limitations, etc.

- [ ] There may be multiple commits in the PR, aligned and commented with
  a functional change. Notably, coding style changes better belong in a
  separate PR, but certainly in a dedicated commit to simplify reviews
  of "real" changes in the other commits. Similarly for typo fixes in
  comments or text documents.

- [ ] Please star NUT on GitHub, this helps with sponsorships! ;)

## Frequent "underwater rocks" for driver addition/update PRs

- [ ] Revised existing driver families and added a sub-driver if applicable
  (`nutdrv_qx`, `usbhid-ups`...) or added a brand new driver in the other
  case.

- [ ] Did not extend obsoleted drivers with new hardware support features
  (notably `blazer` and other single-device family drivers for Qx protocols,
  except the new `nutdrv_qx` which should cover them all).

- [ ] For updated existing device drivers, bumped the `DRIVER_VERSION` macro
  or its equivalent.

<!-- Comment:
  Some sub-drivers have `SUBDRIVER_VERSION` or customized names like
  e.g. `MEGATEC_VERSION` in `drivers/nutdrv_qx_megatec.c`
-->

- [ ] For USB devices (HID or not), revised that the driver uses unique
  VID/PID combinations, or raised discussions when this is not the case
  (several vendors do use same interface chips for unrelated protocols).

- [ ] For new USB devices, built and committed the changes for the
  `scripts/upower/95-upower-hid.hwdb` file

- [ ] Proposed NUT data mapping is aligned with existing `docs/nut-names.txt`
  file. If the device exposes useful data points not listed in the file, the
  `experimental.*` namespace can be used as documented there, and discussion
  should be raised on the NUT Developers mailing list to standardize the new
  concept.

- [ ] Updated `data/driver.list.in` if applicable (new tested device info)
<!-- Comment:
Also note below, a point about PR posting for NUT DDL
-->

## Frequent "underwater rocks" for general C code PRs

- [ ] Did not "blindly assume" default integer type sizes and value ranges,
  structure layout and alignment in memory, endianness (layout of bytes and
  bits in memory for multi-byte numeric types), or use of generic `int` where
  language or libraries dictate the use of `size_t` (or `ssize_t` sometimes).

<!-- Comment:
* NOTE: Casting and/or pragmas (support detected at compile time,
  see `m4/ax_c_pragmas.m4`) to silence warnings may be acceptable,
  but only if coupled with range checks or similar actions.
-->

- [ ] Progress and errors are handled with `upsdebugx()`, `upslogx()`,
  `fatalx()` and related methods, not with direct `printf()` or `exit()`.
  Similarly, NUT helpers are used for error-checked memory allocation and
  string operations (except where customized error handling is needed,
  such as unlocking device ports, etc.)

- [ ] Coding style (including whitespace for indentations) follows precedent
  in the code of the file, and examples/guide in `docs/developers.txt` file.

- [ ] For newly added files, the `Makefile.am` recipes were updated and the
  `make distcheck` target passes.

## General documentation updates

- [ ] Updated `docs/acknowledgements.txt` (for vendor-backed device support)

- [ ] Added or updated manual page information in `docs/man/*.txt` files
  and corresponding recipe lists in `docs/man/Makefile.am` for new pages

- [ ] Passed `make spellcheck`, updated spell-checking dictionary in the
  `docs/nut.dict` file if needed (did not remove any words -- the `make`
  rule printout in case of changes suggests how to maintain it).

## Additional work may be needed after posting this PR

- [ ] Propose a PR for NUT DDL with detailed device data dumps from tests
  against real hardware (the more models, the better).

- [ ] Address NUT CI farm build failures for the PR: testing on numerous
  platforms and toolkits can expose issues not seen on just one system.

<!-- Comment:
* One frequent "offence" is the appearance of unexpected (not git-ignored)
  or modification during build of files tracked in Git.

* Another frequent issue is not tracking newly introduced file names in
  `EXTRA_DIST` of the `Makefile.am` (and for `*.in` templates -- of rules
  in the `configure.ac` script) so the `make distcheck` fails.

* Avoid using GNU-specific constructs in the `Makefile.am`, even if that
  means cumbersome ways to build a target. This should not happen in mere
  driver updates, however.

* Also some third-party libraries or OS headers and method argument types
  and counts can differ -- necessitating m4 code for `configure` script
  probing, and `ifdef`, `typedef`, etc. in C code to adapt to the build
  environment (precedents available in NUT codebase). In extreme cases,
  you may need to spin up a VM or container to reproduce those issues
  and iterate on a fix locally; see `docs/config-prereqs.txt` and
  `docs/ci-farm-lxc-setup.txt` for notes taken during preparation of
  the multi-platform NUT CI farm.
-->

- [ ] Revise suggestions from LGTM.COM analysis about "new issues" with
  the changed codebase.

<!-- Comment:
  Take them with a grain of salt, especially with regard to things like
  architecture-dependent range checks, but many of the complaints from
  the tool are indeed useful.
-->
