### PR TITLE
Update mge-hid.c: Added ups.beeper.status support for Masterpower MF-UPS650VA

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -157,6 +157,8 @@ https://github.com/networkupstools/nut/milestone/11
      series (largely guessing, feedback and PRs for adaptation to actual
      string values reported by devices via USB are welcome), so these devices
      would now report `battery.voltage` and `battery.voltage.nominal`. [#2380]
+   * Added `ups.beeper.status` support for Masterpower MF-UPS650VA using the
+     MGE HID subdriver. [#2662]
    * `powercom-hid` subdriver sent UPS shutdown commands in wrong byte order,
      at least for devices currently in the field. A toggle was added to set
      the old behavior (if some devices do need it), while a fix is applied

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3220 utf-8
+personal_ws-1.1 en 3224 utf-8
 AAC
 AAS
 ABI
@@ -640,6 +640,7 @@ MDigest
 MEC
 MEGATAEC
 MERCHANTABILITY
+MF
 MH
 MIBs
 MIMode
@@ -677,6 +678,7 @@ Martinezgarza
 Martín
 Marzouk
 Massimo
+Masterpower
 Matthijs
 MaxLinear
 McKinnon

--- a/drivers/mge-hid.c
+++ b/drivers/mge-hid.c
@@ -1304,6 +1304,7 @@ static hid_info_t mge_hid2nut[] =
 	 * Only the first valid one will be used */
 	{ "ups.beeper.status", 0 ,0, "UPS.BatterySystem.Battery.AudibleAlarmControl", NULL, "%s", HU_FLAG_SEMI_STATIC, beeper_info },
 	{ "ups.beeper.status", 0 ,0, "UPS.PowerSummary.AudibleAlarmControl", NULL, "%s", HU_FLAG_SEMI_STATIC, beeper_info },
+	{ "ups.beeper.status", 0 ,0, "UPS.AudibleAlarmControl", NULL, "%s", HU_FLAG_SEMI_STATIC, beeper_info },   //yonesmit - support for Masterpower MF-UPS650VA
 	{ "ups.temperature", 0, 0, "UPS.PowerSummary.Temperature", NULL, "%s", 0, kelvin_celsius_conversion },
 	{ "ups.power", 0, 0, "UPS.PowerConverter.Output.ApparentPower", NULL, "%.0f", 0, NULL },
 	{ "ups.L1.power", 0, 0, "UPS.PowerConverter.Output.Phase.[1].ApparentPower", NULL, "%.0f", 0, NULL },
@@ -1524,6 +1525,8 @@ static hid_info_t mge_hid2nut[] =
 	{ "beeper.disable", 0, 0, "UPS.PowerSummary.AudibleAlarmControl", NULL, "1", HU_TYPE_CMD, NULL },
 	{ "beeper.enable", 0, 0, "UPS.BatterySystem.Battery.AudibleAlarmControl", NULL, "2", HU_TYPE_CMD, NULL },
 	{ "beeper.enable", 0, 0, "UPS.PowerSummary.AudibleAlarmControl", NULL, "2", HU_TYPE_CMD, NULL },
+	{ "beeper.disable", 0, 0, "UPS.AudibleAlarmControl", NULL, "1", HU_TYPE_CMD, NULL }, //yonesmit - support for Masterpower MF-UPS650VA
+	{ "beeper.enable", 0, 0, "UPS.AudibleAlarmControl", NULL, "2", HU_TYPE_CMD, NULL },  //yonesmit - support for Masterpower MF-UPS650VA
 
 	/* Command for the outlet collection */
 	{ "outlet.1.load.off", 0, 0, "UPS.OutletSystem.Outlet.[2].DelayBeforeShutdown", NULL, "0", HU_TYPE_CMD, NULL },

--- a/drivers/mge-hid.c
+++ b/drivers/mge-hid.c
@@ -50,7 +50,7 @@
 # endif
 #endif
 
-#define MGE_HID_VERSION		"MGE HID 1.49"
+#define MGE_HID_VERSION		"MGE HID 1.50"
 
 /* (prev. MGE Office Protection Systems, prev. MGE UPS SYSTEMS) */
 /* Eaton */


### PR DESCRIPTION
As explained here:
https://github.com/networkupstools/nut/issues/2661#issue-2593677212
This is a request to add suport for ups.beeper.status feature for Masterpower MF-UPS650VA
The only change is to find it in a different path from the already two paths supported.

Thanks
Best Regards,
yonesmit
