### PR TITLE
Fix: Prevent UPS Lockup on '0 HID Objects' by Reconnecting on Stale Data

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -146,6 +146,10 @@ https://github.com/networkupstools/nut/milestone/11
  - usbhid-ups updates:
    * Support of the `onlinedischarge_log_throttle_hovercharge` in the NUT
      v2.8.2 release was found to be incomplete. [#2423, follow-up to #2215]
+   * Prevent UPS Lockup on "0 HID Objects" by reconnecting on stale data.
+     Note that while some devices just report information upon subsequent
+     poll, others (APC BXnnnnMI) were seen to lock up until full connection
+     restart. [#2671]
    * Added support for `lbrb_log_delay_sec=N` setting to delay propagation of
      `LB` or `LB+RB` state (buggy with APC BXnnnnMI devices circa 2023-2024).
      This may work better with flags like `onlinedischarge_calibration` and

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -1088,6 +1088,7 @@ void upsdrv_makevartable(void)
 }
 
 #define	MAX_EVENT_NUM	32
+#define NO_EVENTS	0
 
 void upsdrv_updateinfo(void)
 {
@@ -1144,6 +1145,7 @@ void upsdrv_updateinfo(void)
 #if WITH_LIBUSB_0_1 /* limit to libusb 0.1 implementation */
 		case -EPERM:		/* Operation not permitted */
 #endif
+		case NO_EVENTS:              /* No HID Events */
 		case LIBUSB_ERROR_NO_DEVICE: /* No such device */
 		case LIBUSB_ERROR_ACCESS:    /* Permission denied */
 #if WITH_LIBUSB_0_1         /* limit to libusb 0.1 implementation */


### PR DESCRIPTION
This PR addresses an issue where the UPS would stop responding and become "stuck" with a status of "0 HID objects" requiring a driver restart to recover.

Related to #2644

It might be worth looking more into why this happens in the first place. In my opinion, this is just a workaround for the real issue, or maybe there’s actually a firmware bug in the APC BX###M series.