### PR TITLE
Fix (re-)detection of libmodbus RTU USB support with static libmodbus builds

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -378,6 +378,11 @@ during a NUT build.
    and it defaults to `true` allowing for better ordered documents at the cost
    of some memory during document generation. [#2510]
 
+ - lines in first section of NUT configuration report (can optionally remain as
+   `config.nut_report_feature.log` and be installed into shared documentation
+   of a NUT package) are now better grouped as miscellaneous features and
+   detection results, then drivers and programs/tools. [#2676]
+
  - added a `common/Makefile.am` build product for a new internal library
    `libcommonstr.la` which allows a smaller selection of helper methods
    for tools like `nut-scanner` which do not need the full `libcommon.la`

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -395,6 +395,16 @@ during a NUT build.
  - build of `snmp-ups` and `netxml-ups` drivers now explicitly brings linker
    dependency on chosen SSL libraries. [#2479]
 
+ - introduced `configure --with-modbus+usb` option to require an USB-capable
+   libmodbus, and defaulted a couple of specific situations as if this was
+   required (implicitly): `configure --with-modbus --with-usb`
+   and either `--with-drivers=*apc_modbus*`
+   or `--with-modbus-includes=... --with-modbus-libs=...`
+   as a way to avoid surprises with custom NUT builds aiming to have an
+   USB-capable `apc_modbus` driver (currently this requires a custom-built
+   libmodbus). Also fixed (re-)detection of libmodbus RTU USB support with
+   static libmodbus builds. [#2666]
+
  - brought keyword dictionaries of `nutconf` and `augeas` NUT configuration
    file parsers up to date; restored automated checks for `augeas` lenses.
    [issue #657, issue #2294]

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -397,8 +397,8 @@ during a NUT build.
 
  - introduced `configure --with-modbus+usb` option to require an USB-capable
    libmodbus, and defaulted a couple of specific situations as if this was
-   required (implicitly): `configure --with-modbus --with-usb`
-   and either `--with-drivers=*apc_modbus*`
+   required (implicitly): `configure --with-modbus --with-usb` and
+   either `--with-drivers=*apc_modbus*` (actually implies `--with-modbus`)
    or `--with-modbus-includes=... --with-modbus-libs=...`
    as a way to avoid surprises with custom NUT builds aiming to have an
    USB-capable `apc_modbus` driver (currently this requires a custom-built

--- a/UPGRADING.adoc
+++ b/UPGRADING.adoc
@@ -137,8 +137,8 @@ Changes from 2.8.2 to 2.8.3
 - A `configure` script option to build `--with-modbus+usb` was added to
   let the caller insist on the use of USB-capable libmodbus (or fail the
   NUT build attempt). Certain build arguments can default this option to
-  become enabled (implicitly): `configure --with-modbus --with-usb`
-  and either `--with-drivers=*apc_modbus*`
+  become enabled (implicitly): `configure --with-modbus --with-usb` and
+  either `--with-drivers=*apc_modbus*` (actually implies `--with-modbus`)
   or `--with-modbus-includes=... --with-modbus-libs=...`
   as a way to avoid surprises with custom NUT builds aiming to have an
   USB-capable `apc_modbus` driver (currently this requires a custom-built

--- a/UPGRADING.adoc
+++ b/UPGRADING.adoc
@@ -134,6 +134,16 @@ Changes from 2.8.2 to 2.8.3
     tool name and NUT version banner from being printed out when programs
     start. [issues #1789 vs. #316]
 
+- A `configure` script option to build `--with-modbus+usb` was added to
+  let the caller insist on the use of USB-capable libmodbus (or fail the
+  NUT build attempt). Certain build arguments can default this option to
+  become enabled (implicitly): `configure --with-modbus --with-usb`
+  and either `--with-drivers=*apc_modbus*`
+  or `--with-modbus-includes=... --with-modbus-libs=...`
+  as a way to avoid surprises with custom NUT builds aiming to have an
+  USB-capable `apc_modbus` driver (currently this requires a custom-built
+  libmodbus, can be a static build to avoid conflicts with OS). [#2666]
+
 - A `configure` script option to `--enable-NUT_STRARG-always` was added
   to enable the `NUT_STRARG` macro (to handle `NULL` string printing)
   even if system libraries seem to safely support this behavior natively.

--- a/configure.ac
+++ b/configure.ac
@@ -2344,6 +2344,13 @@ fi
 NUT_REPORT_DRIVER([build Modbus driver], [${nut_with_modbus}], [],
 					[WITH_MODBUS], [Define to enable Modbus support])
 
+AS_IF([test "${nut_with_modbus}" != "no"], [
+	dnl Only display this detail when building modbus at all
+	dnl Config definition NUT_MODBUS_HAS_USB is set in the
+	dnl detection method (if nut_have_libmodbus_usb=="yes")
+	NUT_REPORT_DRV([build Modbus driver with RTU USB support], [${nut_have_libmodbus_usb}])
+])
+
 dnl ----------------------------------------------------------------------
 dnl Check for with-ipmi, and --with-freeipmi (or --with-openipmi)
 dnl Only one can be enabled at a time, with a preference for FreeIPMI

--- a/configure.ac
+++ b/configure.ac
@@ -2269,7 +2269,7 @@ getspeed(&baudrate);
         [AC_MSG_RESULT([no])])
 ])
 
-NUT_REPORT_FEATURE([build serial drivers], [${nut_with_serial}], [],
+NUT_REPORT_DRIVER([build serial drivers], [${nut_with_serial}], [],
 					[WITH_SERIAL], [Define to enable serial support])
 
 dnl ----------------------------------------------------------------------
@@ -2279,7 +2279,7 @@ dnl Note: there is no libusb-config script (and variable) for libusb-1.0
 AM_CONDITIONAL(WITH_LIBUSB_1_0, test "${nut_usb_lib}" = "(libusb-1.0)")
 AM_CONDITIONAL(WITH_LIBUSB_0_1, test "${nut_usb_lib}" = "(libusb-0.1)" -o "${nut_usb_lib}" = "(libusb-0.1-config)")
 
-NUT_REPORT_FEATURE([build USB drivers], [${nut_with_usb}], [${nut_usb_lib}],
+NUT_REPORT_DRIVER([build USB drivers], [${nut_with_usb}], [${nut_usb_lib}],
 					[WITH_USB], [Define to enable USB support])
 
 dnl ----------------------------------------------------------------------
@@ -2294,7 +2294,7 @@ if test "${nut_with_neon}" != "no"; then
    nut_with_neon="${nut_have_neon}"
 fi
 
-NUT_REPORT_FEATURE([build neon based XML driver], [${nut_with_neon}], [],
+NUT_REPORT_DRIVER([build neon based XML driver], [${nut_with_neon}], [],
 					[WITH_NEON], [Define to enable Neon HTTP support])
 AM_CONDITIONAL([HAVE_NEON], [test "${nut_have_neon}" = "yes"])
 
@@ -2326,7 +2326,7 @@ if test "${nut_with_powerman}" != "no"; then
    nut_with_powerman="${nut_have_libpowerman}"
 fi
 
-NUT_REPORT_FEATURE([build Powerman PDU client driver], [${nut_with_powerman}], [],
+NUT_REPORT_DRIVER([build Powerman PDU client driver], [${nut_with_powerman}], [],
 					[WITH_LIBPOWERMAN], [Define to enable Powerman PDU support])
 
 dnl ----------------------------------------------------------------------
@@ -2341,8 +2341,9 @@ if test "${nut_with_modbus}" != "no"; then
    nut_with_modbus="${nut_have_libmodbus}"
 fi
 
-NUT_REPORT_FEATURE([build Modbus driver], [${nut_with_modbus}], [],
-                                       [WITH_MODBUS], [Define to enable Modbus support])
+NUT_REPORT_DRIVER([build Modbus driver], [${nut_with_modbus}], [],
+					[WITH_MODBUS], [Define to enable Modbus support])
+
 dnl ----------------------------------------------------------------------
 dnl Check for with-ipmi, and --with-freeipmi (or --with-openipmi)
 dnl Only one can be enabled at a time, with a preference for FreeIPMI
@@ -2398,7 +2399,7 @@ if test "${nut_with_ipmi}" != "no"; then
 fi
 
 
-NUT_REPORT_FEATURE([build IPMI driver], [${nut_with_ipmi}], [${nut_ipmi_lib}],
+NUT_REPORT_DRIVER([build IPMI driver], [${nut_with_ipmi}], [${nut_ipmi_lib}],
 					[WITH_IPMI], [Define to enable IPMI support])
 
 dnl Note: we still have to manually enable complementary AC_DEFINEs (see above)
@@ -2418,7 +2419,7 @@ if test "${nut_with_gpio}" != "no"; then
    nut_with_gpio="${nut_have_gpio}"
 fi
 
-NUT_REPORT_FEATURE([build GPIO driver], [${nut_with_gpio}], [${nut_gpio_lib}],
+NUT_REPORT_DRIVER([build GPIO driver], [${nut_with_gpio}], [${nut_gpio_lib}],
 					[WITH_GPIO], [Define to enable GPIO support])
 
 dnl ----------------------------------------------------------------------
@@ -2438,7 +2439,7 @@ if test "${nut_with_macosx_ups}" != no; then
    fi
 fi
 
-NUT_REPORT_FEATURE([build Mac OS X meta-driver],
+NUT_REPORT_DRIVER([build Mac OS X meta-driver],
 			[${nut_with_macosx_ups}], [${nut_macosx_ups_lib}],
 			[WITH_MACOSX], [Define to enable Mac OS X meta-driver])
 
@@ -2510,7 +2511,7 @@ if test "${nut_with_linux_i2c}" != no; then
             ;;
     esac
 fi
-NUT_REPORT_FEATURE(
+NUT_REPORT_DRIVER(
     [build i2c based drivers],
     [${nut_with_linux_i2c}],
     [],
@@ -2587,7 +2588,7 @@ if test x"${nut_with_nut_scanner}" = x"auto"; then
     nut_with_nut_scanner="${nut_with_libltdl}"
 fi
 
-NUT_REPORT_FEATURE([build nut-scanner], [${nut_with_nut_scanner}], [],
+NUT_REPORT_PROGRAM([build nut-scanner], [${nut_with_nut_scanner}], [],
 					[WITH_NUT_SCANNER], [Define to enable nut-scanner tool support])
 
 dnl ----------------------------------------------------------------------
@@ -2609,7 +2610,7 @@ if test "${nut_with_cgi}" != "no"; then
    nut_with_cgi="${nut_have_libgd}"
 fi
 
-NUT_REPORT_FEATURE([build CGI programs], [${nut_with_cgi}], [],
+NUT_REPORT_PROGRAM([build CGI programs], [${nut_with_cgi}], [],
 					[WITH_CGI], [Define to enable CGI (HTTP) support])
 
 
@@ -2919,10 +2920,10 @@ if test "${nut_with_pynut}" = force ; then
     fi
 fi
 
-NUT_REPORT_FEATURE([install NUT-Monitor desktop application], [${nut_with_nut_monitor}], [],
+NUT_REPORT_PROGRAM([install NUT-Monitor desktop application], [${nut_with_nut_monitor}], [],
 					[WITH_NUT_MONITOR], [Define to enable NUT-Monitor desktop application installation])
 
-NUT_REPORT_FEATURE([install PyNUT binding module], [${nut_with_pynut}], [],
+NUT_REPORT_PROGRAM([install PyNUT binding module], [${nut_with_pynut}], [],
 					[WITH_PYNUT], [Define to enable PyNUT module installation])
 
 dnl One or both of these may be installed:
@@ -4276,7 +4277,7 @@ AS_CASE(["${nut_with_nutconf}"],
 AC_MSG_RESULT(${nut_with_nutconf})
 
 AM_CONDITIONAL(WITH_NUTCONF, test "${nut_with_nutconf}" = "yes")
-NUT_REPORT_FEATURE([build and install the nutconf tool (experimental, may lack support for recent NUT options)],
+NUT_REPORT_PROGRAM([build and install the nutconf tool (experimental, may lack support for recent NUT options)],
 					[${nut_with_nutconf}], [],
 					[WITH_NUTCONF], [Define to enable nutconf tool support])
 
@@ -4649,9 +4650,9 @@ else
    nut_have_libnetsnmp_static="no"
 fi
 
-NUT_REPORT_FEATURE([build SNMP drivers], [${nut_with_snmp}], [],
+NUT_REPORT_DRIVER([build SNMP drivers], [${nut_with_snmp}], [],
 					[WITH_SNMP], [Define to enable SNMP support])
-NUT_REPORT_FEATURE([build SNMP drivers with statically linked lib(net)snmp], [${nut_have_libnetsnmp_static}], [],
+NUT_REPORT_DRIVER([build SNMP drivers with statically linked lib(net)snmp], [${nut_have_libnetsnmp_static}], [],
 					[WITH_SNMP_STATIC], [Define to use SNMP support with a statically linked libnetsnmp])
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -2334,21 +2334,21 @@ dnl checks related to --with-modbus
 
 dnl ${nut_with_modbus}: any value except "yes" or "no" is treated as "auto".
 if test "${nut_with_modbus}" = "yes" -a "${nut_have_libmodbus}" != "yes"; then
-   AC_MSG_ERROR([modbus library not found, required for Modbus driver])
+   AC_MSG_ERROR([modbus library not found, required for Modbus drivers])
 fi
 
 if test "${nut_with_modbus}" != "no"; then
    nut_with_modbus="${nut_have_libmodbus}"
 fi
 
-NUT_REPORT_DRIVER([build Modbus driver], [${nut_with_modbus}], [],
+NUT_REPORT_DRIVER([build Modbus drivers], [${nut_with_modbus}], [],
 					[WITH_MODBUS], [Define to enable Modbus support])
 
 AS_IF([test "${nut_with_modbus}" != "no"], [
 	dnl Only display this detail when building modbus at all
 	dnl Config definition NUT_MODBUS_HAS_USB is set in the
 	dnl detection method (if nut_have_libmodbus_usb=="yes")
-	NUT_REPORT_DRV([build Modbus driver with RTU USB support], [${nut_have_libmodbus_usb}])
+	NUT_REPORT_DRV([build Modbus drivers with RTU USB support], [${nut_have_libmodbus_usb}])
 ])
 
 dnl ----------------------------------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -1731,6 +1731,55 @@ dnl to embed into scripts and Make rules
 NUT_CHECK_PYTHON_DEFAULT
 
 dnl ----------------------------------------------------------------------
+dnl Check for "require Modbus with USB support" situation before we mangle
+dnl caller-provided with_* values below (by --with-drivers and --with-all)
+
+nut_with_modbus_and_usb=auto
+AC_ARG_WITH(modbus+usb,
+	AS_HELP_STRING([--with-modbus+usb],
+	[Require Modbus with USB support (auto)]),
+[
+	case "${withval}" in
+	no)
+		dnl # AC_MSG_ERROR(invalid option --without-modbus+usb - see docs/configure.txt)
+		AC_MSG_NOTICE([Treating --without-modbus+usb as not-requiring that used libmodbus supports RTU USB])
+		nut_with_modbus_and_usb="no"
+		;;
+	auto)
+		nut_with_modbus_and_usb="auto"
+		;;
+	yes|'')
+		if test -z "${with_usb}"; then with_usb="${withval}"; fi
+		if test -z "${with_modbus}"; then with_modbus="${withval}"; fi
+		nut_with_modbus_and_usb="yes"
+		;;
+	*)
+		AC_MSG_ERROR(invalid option --with-modbus+usb='${withval}' - see docs/configure.txt)
+		;;
+	esac
+], [
+	dnl Explicit request to build apc_modbus with both modbus and usb
+	dnl support specified on command line implies we want them present
+	dnl together too by default
+	dnl FIXME: Extend to checking --with-drivers including apc_modbus?
+	if test x"${with_usb}" = xyes -a x"${with_modbus}" = xyes; then
+		case x"${with_driver}" in
+			*apc_modbus*)
+				nut_with_modbus_and_usb="yes"
+				AC_MSG_WARN([Treating explicit requests to build apc_modbus with both modbus and usb as building --with-modbus+usb=yes])
+				;;
+			*)
+				if test x"${with_modbus_includes}" != x -a x"${with_modbus_libs}" != x ; then
+					nut_with_modbus_and_usb="yes"
+					AC_MSG_WARN([Treating explicit requests to build NUT with both modbus (with custom includes and libs) and usb as building --with-modbus+usb=yes])
+				fi
+				;;
+		esac
+	fi
+])
+
+
+dnl ----------------------------------------------------------------------
 dnl check for --with-drivers=all (or --with-drivers=name[,name...]) flag
 dnl Note: a few drivers are NUT software constructs (NUTSW_DRIVERLIST)
 dnl e.g. dummy-ups, clone and clone-outlet; they do not have a separate
@@ -2335,6 +2384,10 @@ dnl checks related to --with-modbus
 dnl ${nut_with_modbus}: any value except "yes" or "no" is treated as "auto".
 if test "${nut_with_modbus}" = "yes" -a "${nut_have_libmodbus}" != "yes"; then
    AC_MSG_ERROR([modbus library not found, required for Modbus drivers])
+fi
+
+if test "${nut_with_modbus_and_usb}" = "yes" -a "${nut_have_libmodbus_usb}" != "yes"; then
+   AC_MSG_ERROR([modbus library variant with RTU USB support not found, required for USB-capable Modbus drivers])
 fi
 
 if test "${nut_with_modbus}" != "no"; then

--- a/configure.ac
+++ b/configure.ac
@@ -1761,21 +1761,26 @@ AC_ARG_WITH(modbus+usb,
 	dnl Explicit request to build apc_modbus with both modbus and usb
 	dnl support specified on command line implies we want them present
 	dnl together too by default
-	dnl FIXME: Extend to checking --with-drivers including apc_modbus?
-	if test x"${with_usb}" = xyes -a x"${with_modbus}" = xyes; then
-		case x"${with_driver}" in
-			*apc_modbus*)
+	dnl FIXME: Extend to --with-drivers=all or that would not be
+	dnl  a least-surprise breakage for packagers?
+	case x"${with_drivers}" in
+		*apc_modbus*)
+			dnl Note: defaulting of with_modbus=yes will be handled
+			dnl below by --with-drivers
+			if test x"${with_usb}" = xyes ; then
 				nut_with_modbus_and_usb="yes"
-				AC_MSG_WARN([Treating explicit requests to build apc_modbus with both modbus and usb as building --with-modbus+usb=yes])
-				;;
-			*)
-				if test x"${with_modbus_includes}" != x -a x"${with_modbus_libs}" != x ; then
-					nut_with_modbus_and_usb="yes"
-					AC_MSG_WARN([Treating explicit requests to build NUT with both modbus (with custom includes and libs) and usb as building --with-modbus+usb=yes])
-				fi
-				;;
-		esac
-	fi
+				AC_MSG_WARN([Treating explicit requests to build apc_modbus and toe libusb as building --with-modbus+usb=yes])
+			fi
+			;;
+		*)
+			if test x"${with_usb}" = xyes -a x"${with_modbus}" = xyes \
+			     -a x"${with_modbus_includes}" != x -a x"${with_modbus_libs}" != x \
+			; then
+				nut_with_modbus_and_usb="yes"
+				AC_MSG_WARN([Treating explicit requests to build NUT with both modbus (with custom includes and libs) and usb as building --with-modbus+usb=yes])
+			fi
+			;;
+	esac
 ])
 
 

--- a/docs/config-prereqs.txt
+++ b/docs/config-prereqs.txt
@@ -140,7 +140,8 @@ For development on the road (or a native ARM build) you can use the
 link:https://termux.dev/en/[Termux] project on Android. It provides
 a sufficiently Debian-like operating environment for all intents and
 purposes, but you may have to use their `pkg` wrapper instead of `apt`
-tooling directly.
+tooling directly, and `ldd` may be in a package separate from `binutils`,
+but otherwise the Debian/Ubuntu oriented lists of packages below apply.
 
 You would need at least a couple of gigabytes available on the internal
 phone storage though, especially if using `ccache` or setting up cross
@@ -156,7 +157,7 @@ metadata about recently published package revisions:
 :; apt-get install \
     ccache time \
     git perl curl \
-    make autoconf automake libltdl-dev libtool \
+    make autoconf automake libltdl-dev libtool binutils \
     valgrind \
     cppcheck \
     pkg-config \

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -189,6 +189,21 @@ Build and install modbus (Serial, TCP) drivers (default: auto-detect)
 
 Note that you need to install libmodbus development package or files.
 
+	--with-modbus+usb
+
+Require a variant of libmodbus with RTU USB support. This feature is
+currently not available in upstream project or OS distribution packages,
+so your NUT build environment should provide a prerequisite build of
+https://github.com/networkupstools/libmodbus/tree/rtu_usb (may be a
+static library build, used from a temporary installation prefix location,
+to avoid potential conflicts with the OS packaged shared library).
+
+At the time of this writing, such constraint can be desirable for the
+linkman:apc_modbus[8] driver which supports different communication media.
+
+For more details please see
+https://github.com/networkupstools/nut/wiki/APC-UPS-with-Modbus-protocol
+
 Manual selection of drivers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/drivers/apc_modbus.c
+++ b/drivers/apc_modbus.c
@@ -33,7 +33,11 @@
 
 #include <modbus.h>
 
-#define DRIVER_NAME "NUT APC Modbus driver"
+#if defined NUT_MODBUS_HAS_USB
+# define DRIVER_NAME "NUT APC Modbus driver with USB support"
+#else
+# define DRIVER_NAME "NUT APC Modbus driver without USB support"
+#endif
 #define DRIVER_VERSION "0.10"
 
 #if defined NUT_MODBUS_HAS_USB

--- a/drivers/apc_modbus.c
+++ b/drivers/apc_modbus.c
@@ -1579,8 +1579,10 @@ void upsdrv_makevartable(void)
 #endif /* defined NUT_MODBUS_HAS_USB */
 
 #if defined NUT_MODBUS_HAS_USB
+	upsdebugx(1, "This build of the driver is USB-capable; also Serial and TCP Modbus RTU are supported");
 	addvar(VAR_VALUE, "porttype", "Modbus port type (serial, tcp, usb, default=usb)");
 #else
+	upsdebugx(1, "This build of the driver is not USB-capable, only Serial and TCP Modbus RTU are supported");
 	addvar(VAR_VALUE, "porttype", "Modbus port type (serial, tcp, default=serial)");
 #endif /* defined NUT_MODBUS_HAS_USB */
 	addvar(VAR_VALUE, "slaveid", "Modbus slave id (default=1)");

--- a/m4/nut_check_libmodbus.m4
+++ b/m4/nut_check_libmodbus.m4
@@ -79,10 +79,23 @@ if test -z "${nut_have_libmodbus_seen}"; then
 	AC_CHECK_FUNCS(modbus_set_response_timeout, [], [nut_have_libmodbus=no])
 
 	AC_CHECK_FUNCS(modbus_new_rtu_usb, [nut_have_libmodbus_usb=yes], [
-		AS_IF([test x"${nut_with_usb}" = xyes && test x"${nut_with_modbus}" = xyes && test x"${nut_have_libmodbus}" = xyes ], [
-			AC_MSG_WARN([Both --with-modbus and --with-usb were requested, and a libmodbus was found, but it seems to not support USB. You may require a custom build per https://github.com/networkupstools/nut/wiki/APC-UPS-with-Modbus-protocol])
-		])
 		nut_have_libmodbus_usb=no
+		AS_IF([test x"${nut_with_usb}" != xno && test x"${nut_with_modbus}" != xno && test x"${nut_have_libmodbus}" = xyes ], [
+			dnl Retry with LibUSB dependency settings if we
+			dnl know we are not opposed to pulling it in.
+			dnl Static libmodbus builds do not refer to
+			dnl (shared) libusb for example.
+			NUT_CHECK_LIBUSB
+			AC_MSG_NOTICE([Retry detection of libmodbus USB support])
+			CFLAGS="$CFLAGS $LIBUSB_CFLAGS"
+			LIBS="$LIBS $LIBUSB_LIBS"
+			unset ac_cv_func_modbus_new_rtu_usb
+			AC_CHECK_FUNCS(modbus_new_rtu_usb, [nut_have_libmodbus_usb=yes], [
+				AS_IF([test x"${nut_with_usb}" = xyes && test x"${nut_with_modbus}" = xyes && test x"${nut_have_libmodbus}" = xyes ], [
+					AC_MSG_WARN([Both --with-modbus and --with-usb were requested, and a libmodbus was found, but it seems to not support USB. You may require a custom build per https://github.com/networkupstools/nut/wiki/APC-UPS-with-Modbus-protocol])
+				])
+			])
+		])
 	])
 
 	dnl modbus_set_byte_timeout() and modbus_set_response_timeout()

--- a/m4/nut_report_feature.m4
+++ b/m4/nut_report_feature.m4
@@ -13,16 +13,20 @@ AC_DEFUN([NUT_REPORT_FILE],
     AS_IF([test x"${nut_report_feature_flag$3}" = x], [
         nut_report_feature_flag$3="1"
         ac_clean_files="${ac_clean_files} config.nut_report_feature.log.$3"
-        if test x1 = "x$3" ; then
+        case x"$3" in
+        x1a)
             echo "$4"
             echo "$4" | sed 's/./=/g'
             echo ""
-        else
+            ;;
+        x1*) ;;
+        *)
             echo ""
             echo "$4"
             echo "$4" | sed 's/./-/g'
             echo ""
-        fi > "config.nut_report_feature.log.$3"
+            ;;
+        esac > "config.nut_report_feature.log.$3"
     ])
     printf "* %s:\t%s\n" "$1" "$2" >> "config.nut_report_feature.log.$3"
 ])
@@ -31,7 +35,23 @@ AC_DEFUN([NUT_REPORT],
 [
     dnl arg#1 = description (summary)
     dnl arg#2 = value
-    NUT_REPORT_FILE([$1], [$2], [1], "NUT Configuration summary:")
+    NUT_REPORT_FILE([$1], [$2], [1a], "NUT Configuration summary:")
+])
+
+AC_DEFUN([NUT_REPORT_DRV],
+[
+    dnl arg#1 = description (summary)
+    dnl arg#2 = value
+    dnl Title irrelevant here, should not show
+    NUT_REPORT_FILE([$1], [$2], [1b], "NUT Configuration summary:")
+])
+
+AC_DEFUN([NUT_REPORT_PRG],
+[
+    dnl arg#1 = description (summary)
+    dnl arg#2 = value
+    dnl Title irrelevant here, should not show
+    NUT_REPORT_FILE([$1], [$2], [1c], "NUT Configuration summary:")
 ])
 
 AC_DEFUN([NUT_REPORT_PATH],
@@ -46,6 +66,42 @@ AC_DEFUN([NUT_REPORT_PATH_INTEGRATIONS],
     dnl arg#1 = description (summary)
     dnl arg#2 = value
     NUT_REPORT_FILE([$1], [$2], [3], "NUT Paths for third-party integrations:")
+])
+
+AC_DEFUN([NUT_REPORT_DRIVER],
+[
+    dnl NOTE: Same as feature, just grouped into "1b" file to display after features
+    dnl arg#1 = summary/config.log description
+    dnl arg#2 = test flag ("yes" or not)
+    dnl arg#3 = value
+    dnl arg#4 = autoconf varname
+    dnl arg#5 = longer description (autoconf comment)
+    AC_MSG_CHECKING([whether to $1])
+    AC_MSG_RESULT([$2 $3])
+    NUT_REPORT_DRV([$1], [$2 $3])
+
+    AM_CONDITIONAL([$4], test "$2" = "yes")
+    AS_IF([test x"$2" = x"yes"], [
+        AC_DEFINE_UNQUOTED($4, 1, $5)
+    ])
+])
+
+AC_DEFUN([NUT_REPORT_PROGRAM],
+[
+    dnl NOTE: Same as feature, just grouped into "1c" file to display last
+    dnl arg#1 = summary/config.log description
+    dnl arg#2 = test flag ("yes" or not)
+    dnl arg#3 = value
+    dnl arg#4 = autoconf varname
+    dnl arg#5 = longer description (autoconf comment)
+    AC_MSG_CHECKING([whether to $1])
+    AC_MSG_RESULT([$2 $3])
+    NUT_REPORT_PRG([$1], [$2 $3])
+
+    AM_CONDITIONAL([$4], test "$2" = "yes")
+    AS_IF([test x"$2" = x"yes"], [
+        AC_DEFINE_UNQUOTED($4, 1, $5)
+    ])
 ])
 
 AC_DEFUN([NUT_REPORT_FEATURE],


### PR DESCRIPTION
...and allow users to require `configure --with-modbus+usb` to avoid surprises with a wrong choice of the library.

Should help with investigation for #2666 and fixes a bug detected in that discussion.

Also revise configuration script report.

Closes: #2676

Example runs with failsafe firing (where the OS has a packaged standard shared libmodbus; a custom static build with USB support is installed into `--prefix=/tmp`)

NEGATIVE CASES

* Use new options and cause use of OS-provided library (by default):
````
:: ./autogen.sh && ./configure --with-modbus+usb
````
* Legacy common case: explicitly request `apc_modbus` and `libusb` among `configure` options (and still use OS-provided library):
````
:; ./configure --with-drivers=apc_modbus --with-usb
````
* Legacy common case: explicitly request `libmodbus` and `libusb`, but passing `--with-modbus-includes` and/or `--with-modbus-libs` for a build that is not USB-capable (done here via bad location of `--with-modbus-libs`):
````
:; ./configure --with-modbus --with-usb --with-modbus-includes=-I/tmp/include/modbus --with-modbus-libs="-L/tmp/libxxx -lmodbus"
````

These all end with:
```
...
checking for modbus.h... yes
checking for modbus_new_rtu... yes
checking for modbus_new_tcp... yes
checking for modbus_set_byte_timeout... yes
checking for modbus_set_response_timeout... yes
checking for modbus_new_rtu_usb... no
configure: Retry detection of libmodbus USB support
checking for modbus_new_rtu_usb... no
configure: WARNING: Both --with-modbus and --with-usb were requested, and a libmodbus was found, but it seems to not support USB. You may require a custom build per https://github.com/networkupstools/nut/wiki/APC-UPS-with-Modbus-protocol
...
configure: error: modbus library variant with RTU USB support not found, required for USB-capable Modbus drivers
````


POSITIVE CASES

* Legacy common case: explicitly request `libmodbus` and `libusb`, explicitly passing correct `--with-modbus-includes` and `--with-modbus-libs` for a build that is USB-capable:
````
:; ./configure --with-modbus --with-usb --with-modbus-includes=-I/tmp/include/modbus --with-modbus-libs="-L/tmp/lib -lmodbus"
````
* Request the `apc_modbus` driver AND `libusb`, explicitly passing correct `--with-modbus-includes` and `--with-modbus-libs` for a build that is USB-capable:
````
:; ./configure --with-drivers=apc_modbus --with-usb --with-modbus-includes=-I/tmp/include/modbus --with-modbus-libs="-L/tmp/lib -lmodbus"
````
* Use new option and pass correct `--with-modbus-includes` and `--with-modbus-libs` for a build that is USB-capable:
````
:: ./configure --with-modbus+usb --with-modbus-includes=-I/tmp/include/modbus --with-modbus-libs="-L/tmp/lib -lmodbus"
```

These all end with:
```
...
checking for libmodbus version via pkg-config... 3.1.6 found
checking for libmodbus cflags... -I/tmp/include/modbus
checking for libmodbus ldflags... -L/tmp/lib -lmodbus
checking for modbus.h... yes
checking for modbus_new_rtu... yes
checking for modbus_new_tcp... yes
checking for modbus_set_byte_timeout... yes
checking for modbus_set_response_timeout... yes
checking for modbus_new_rtu_usb... no
configure: Retry detection of libmodbus USB support
checking for modbus_new_rtu_usb... yes
checking types of arguments for modbus_set_byte_timeout... sec_usec_uint32_cast_timeval_fields
Found types to use for modbus_set_byte_timeout: sec_usec_uint32_cast_timeval_fields
...
* build Modbus drivers: yes
* build Modbus drivers with RTU USB support:    yes
````

The resulting driver build reports its USB-capability early in debug log now (see second `[D1]` line) as well as via `DRIVER_NAME` seen in banner and protocol (`upsc` etc.):
````
:; ./drivers/apc_modbus -D -V
Network UPS Tools 2.8.2.1179.10-1189-geb99e125f (development iteration after 2.8.2) - NUT APC Modbus driver with USB support 0.10
   0.000000     [D1] Using USB implementation: libusb-1.0.25 (API: 0x1000109)
   0.000040     [D1] This build of the driver is USB-capable; also Serial and TCP Modbus RTU are supported
   0.000055     [D1] Network UPS Tools version 2.8.2.1179.10-1189-geb99e125f (development iteration after 2.8.2) built with gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0 and configured with flags: --with-modbus+usb --without-docs --with-modbus-includes=-I/tmp/include/modbus --with-modbus-libs='-L/tmp/lib -lmodbus'
   0.000088     [D1] upsnotify: notify about state 4 with libsystemd: was requested, but not running as a service unit now, will not spam more about it
   0.000117     [D1] upsnotify: failed to notify about state 4: no notification tech defined, will not spam more about it
````

NEUTRAL CASES

The `apc_modbus` driver is build using OS packaged libmodbus, without USB support, without aborting NUT build (common packaging).

* Explicitly requesting the `apc_modbus` driver but not explicitly requesting `libusb`:
````
:; ./configure --with-drivers=apc_modbus
...
* build Modbus drivers: yes
* build Modbus drivers with RTU USB support:    no
...

:; ./drivers/apc_modbus -D -V
Network UPS Tools 2.8.2.1179.10-1189-geb99e125f (development iteration after 2.8.2) - NUT APC Modbus driver without USB support 0.10
   0.000000     [D1] This build of the driver is not USB-capable, only Serial and TCP Modbus RTU are supported
   0.000030     [D1] Network UPS Tools version 2.8.2.1179.10-1189-geb99e125f (development iteration after 2.8.2) built with gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0 and configured with flags: --with-drivers=apc_modbus --without-docs
   0.000061     [D1] upsnotify: notify about state 4 with libsystemd: was requested, but not running as a service unit now, will not spam more about it
   0.000098     [D1] upsnotify: failed to notify about state 4: no notification tech defined, will not spam more about it
````
* Default build requesting everything (but not specific combos explicitly expected by fallbacks tested above):
````
:; ./configure --with-all
````
* Even a build with `libusb` and `libmodbus` but without custom options for the latter (nor the specific driver):
````
:; ./configure --without-docs --with-usb --with-modbus
````