### PR TITLE
common/common.c, include/common.h: follow-up for `upsnotify()`

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -90,7 +90,7 @@ https://github.com/networkupstools/nut/milestone/11
    with service management frameworks, etc.) was a bit cryptic when it reported
    a *failure to notify* (e.g. when not running as a service currently), fixed
    now to report human-friendly text instead of internal enum codes. Follow-up
-   to [PR #1590, PR #2136]
+   to [issue #1590, PR #1777, PR #2136]
 
  - drivers, `upsd`, `upsmon`: reduce "scary noise" about failure to `fopen()`
    the PID file (which most of the time means that no previous instance of

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -86,6 +86,12 @@ https://github.com/networkupstools/nut/milestone/11
    current version information would be embedded into "dist" archives as a
    `VERSION_DEFAULT` file. [#1949]
 
+ - the `upsnotify()` common code introduced in recent NUT releases (integrating
+   with service management frameworks, etc.) was a bit cryptic when it reported
+   a *failure to notify* (e.g. when not running as a service currently), fixed
+   now to report human-friendly text instead of internal enum codes. Follow-up
+   to [PR #1590, PR #2136]
+
  - drivers, `upsd`, `upsmon`: reduce "scary noise" about failure to `fopen()`
    the PID file (which most of the time means that no previous instance of
    the daemon was running to potentially conflict with), especially useless

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3237 utf-8
+personal_ws-1.1 en 3244 utf-8
 AAC
 AAS
 ABI
@@ -3087,6 +3087,7 @@ upslogx
 upsmon
 upsmon's
 upsname
+upsnotify
 upsonbatt
 upspass
 upspasswd

--- a/include/common.h
+++ b/include/common.h
@@ -402,6 +402,7 @@ typedef enum eupsnotify_state {
 	NOTIFY_STATE_STATUS,	/* Send a text message per "fmt" below */
 	NOTIFY_STATE_WATCHDOG	/* Ping the framework that we are still alive */
 } upsnotify_state_t;
+const char *str_upsnotify_state(upsnotify_state_t state);
 /* Note: here fmt may be null, then the STATUS message would not be sent/added */
 int upsnotify(upsnotify_state_t state, const char *fmt, ...)
 	__attribute__ ((__format__ (__printf__, 2, 3)));


### PR DESCRIPTION
Follow-up for PRs #1590, #2136

* introduce `str_upsnotify_state()` for meaningful debug log messages;
* suggest to `export NUT_QUIET_INIT_UPSNOTIFY=true` where we "will not spam more about it" for systems that do not currently expect to have notification support or need
