### PR TITLE
Work247-ecomode_addon

### DIFF
--- a/drivers/mge-hid.c
+++ b/drivers/mge-hid.c
@@ -1755,12 +1755,12 @@ static hid_info_t mge_hid2nut[] =
 
 	/* Command to switch ECO Mode */
 	{ "ecomode.disable", 0, 0, "UPS.PowerConverter.Input.[5].Switchable", NULL, "0", HU_TYPE_CMD, NULL },
-	{ "ecomode.enable", 0, 0, "UPS.PowerConverter.Input.[5].Switchable", NULL, "1", HU_TYPE_CMD, NULL },
+	{ "ecomode.enable", 0, 0, "UPS.PowerConverter.Input.[5].Switchable", NULL, "1", HU_TYPE_CMD, eaton_input_eco_mode_check_range },
 	{ "essmode.enable", 0, 0, "UPS.PowerConverter.Input.[5].Switchable", NULL, "2", HU_TYPE_CMD, NULL },
 	{ "essmode.disable", 0, 0, "UPS.PowerConverter.Input.[5].Switchable", NULL, "0", HU_TYPE_CMD, NULL },
 
 	/* Command to switch Automatic Bypass Mode On/Off */
-	{ "bypass.start", 0, 0, "UPS.PowerConverter.Input.[2].SwitchOnControl", NULL, "1", HU_TYPE_CMD, NULL },
+	{ "bypass.start", 0, 0, "UPS.PowerConverter.Input.[2].SwitchOnControl", NULL, "1", HU_TYPE_CMD, eaton_input_bypass_check_range },
 	{ "bypass.stop", 0, 0, "UPS.PowerConverter.Input.[2].SwitchOffControl", NULL, "1", HU_TYPE_CMD, NULL },
 
 	/* end of structure. */

--- a/drivers/mge-hid.c
+++ b/drivers/mge-hid.c
@@ -777,7 +777,7 @@ static const char *eaton_input_eco_mode_check_range(double value)
 static info_lkp_t eaton_input_mode_info[] = {
 	{ 0, "normal", NULL, NULL },
 	{ 1, "ECO", eaton_input_eco_mode_check_range, NULL }, /* NOTE: "ecomode" = checked and working fine */
-	{ 2, "ESS", NULL, NULL }, /* Energy Saver System, makes sense for UPS that implements this mode */
+	{ 2, "ESS", NULL, NULL }, /* Energy Saver System, makes sense for UPS that implements this mode (93PM G2, 9395P) */
 	{ 0, NULL, NULL, NULL }
 };
 
@@ -1755,12 +1755,12 @@ static hid_info_t mge_hid2nut[] =
 
 	/* Command to switch ECO Mode */
 	{ "ecomode.disable", 0, 0, "UPS.PowerConverter.Input.[5].Switchable", NULL, "0", HU_TYPE_CMD, NULL },
-	{ "ecomode.enable", 0, 0, "UPS.PowerConverter.Input.[5].Switchable", NULL, "1", HU_TYPE_CMD, eaton_input_eco_mode_check_range },
+	{ "ecomode.enable", 0, 0, "UPS.PowerConverter.Input.[5].Switchable", NULL, "1", HU_TYPE_CMD, eaton_input_mode_info },
 	{ "essmode.enable", 0, 0, "UPS.PowerConverter.Input.[5].Switchable", NULL, "2", HU_TYPE_CMD, NULL },
 	{ "essmode.disable", 0, 0, "UPS.PowerConverter.Input.[5].Switchable", NULL, "0", HU_TYPE_CMD, NULL },
 
 	/* Command to switch Automatic Bypass Mode On/Off */
-	{ "bypass.start", 0, 0, "UPS.PowerConverter.Input.[2].SwitchOnControl", NULL, "1", HU_TYPE_CMD, eaton_input_bypass_check_range },
+	{ "bypass.start", 0, 0, "UPS.PowerConverter.Input.[2].SwitchOnControl", NULL, "1", HU_TYPE_CMD, eaton_input_bypass_mode_on_info },
 	{ "bypass.stop", 0, 0, "UPS.PowerConverter.Input.[2].SwitchOffControl", NULL, "1", HU_TYPE_CMD, NULL },
 
 	/* end of structure. */


### PR DESCRIPTION
As add-on for https://github.com/networkupstools/nut/pull/2637 ECO/Bypass for Eaton Models
we can leave as is now only check range by r/w values or set also check range for eco/bypass by commands .

Also we can add ESS Mode staff (check range and set ups status) like in ECO mode
if it needed .

But only Eaton Models like `93PM G2` and `9395P` use ESS , not sure if they use NUT :)