### PR TITLE
NUT-Monitor UI and PyNUT: better support for relative path to module, better detect usable interpreter

### DIFF
--- a/scripts/python/app/NUT-Monitor
+++ b/scripts/python/app/NUT-Monitor
@@ -5,7 +5,7 @@
 # a single simple call.
 #
 # Copyright (C):
-#   2022-2023 Jim Klimov <jimklimov+nut@gmail.com>
+#   2022-2024 Jim Klimov <jimklimov+nut@gmail.com>
 #
 # License: GPLv2+
 
@@ -14,27 +14,33 @@
 PREFER_PY2=true
 
 # Detect which variant of NUT-Monitor we can run on the local system:
-[ -s "$0"-py2gtk2 -a -x "$0"-py2gtk2 ] && PYTHON_PY2GTK2="`head -1 "$0"-py2gtk2 | sed 's,^#!,,'`" || PYTHON_PY2GTK2=""
-[ -s "$0"-py3qt5 -a  -x "$0"-py3qt5 ]  && PYTHON_PY3QT5="`head -1 "$0"-py3qt5 | sed 's,^#!,,'`"   || PYTHON_PY3QT5=""
+[ -s "$0"-py2gtk2 -a -x "$0"-py2gtk2 ] && PYTHON_PY2GTK2_SHEBANG="`head -1 "$0"-py2gtk2 | sed 's,^#!,,'`" || PYTHON_PY2GTK2_SHEBANG=""
+[ -s "$0"-py3qt5 -a  -x "$0"-py3qt5 ]  && PYTHON_PY3QT5_SHEBANG="`head -1 "$0"-py3qt5 | sed 's,^#!,,'`"   || PYTHON_PY3QT5_SHEBANG=""
 SCRIPTDIR="`dirname "$0"`" && SCRIPTDIR="`cd "$SCRIPTDIR" && pwd`" || SCRIPTDIR="./"
 
-if [ -n "$PYTHON_PY2GTK2" ] \
-&& (command -v $PYTHON_PY2GTK2) >/dev/null 2>/dev/null \
-&& $PYTHON_PY2GTK2 -c "import re,glob,codecs,gtk,gtk.glade,gobject,ConfigParser" >/dev/null 2>/dev/null \
-; then
-    echo "PYTHON_PY2GTK2 is usable as: $PYTHON_PY2GTK2" >&2
-else
-    PYTHON_PY2GTK2=""
-fi
+PYTHON_PY2GTK2=""
+for P in "$PYTHON2" "$PYTHON_PY2GTK2_SHEBANG" "python2" "python" ; do
+    if [ -n "$P" ] \
+    && (command -v $P) >/dev/null 2>/dev/null \
+    && $P -c "import re,glob,codecs,gtk,gtk.glade,gobject,ConfigParser" >/dev/null 2>/dev/null \
+    ; then
+        PYTHON_PY2GTK2="$P"
+        echo "PYTHON_PY2GTK2 is usable as: $PYTHON_PY2GTK2" >&2
+        break
+    fi
+done
 
-if [ -n "$PYTHON_PY3QT5" ] \
-&& (command -v $PYTHON_PY3QT5) >/dev/null 2>/dev/null \
-&& $PYTHON_PY3QT5 -c "import re,glob,codecs,PyQt5.uic,configparser" >/dev/null 2>/dev/null \
-; then
-    echo "PYTHON_PY3QT5 is usable as: $PYTHON_PY3QT5" >&2
-else
-    PYTHON_PY3QT5=""
-fi
+PYTHON_PY3QT5=""
+for P in "$PYTHON3" "$PYTHON_PY3QT5_SHEBANG" "python3" "python" ; do
+    if [ -n "$P" ] \
+    && (command -v $P) >/dev/null 2>/dev/null \
+    && $P -c "import re,glob,codecs,PyQt5.uic,configparser" >/dev/null 2>/dev/null \
+    ; then
+        PYTHON_PY3QT5="$P"
+        echo "PYTHON_PY3QT5 is usable as: $PYTHON_PY3QT5" >&2
+        break
+    fi
+done
 
 for P in "$PYTHON_PY2GTK2" "$PYTHON_PY3QT5" ; do
     [ -n "$P" ] || continue
@@ -50,16 +56,16 @@ done
 
 if [ -n "$PYTHON_PY2GTK2" ] && [ -n "$PYTHON_PY3QT5" ] ; then
     if $PREFER_PY2 ; then
-        exec "$0"-py2gtk2 "$@"
+        exec $PYTHON_PY2GTK2 "$0"-py2gtk2 "$@"
     else
-        exec "$0"-py3qt5 "$@"
+        exec $PYTHON_PY3QT5 "$0"-py3qt5 "$@"
     fi
 else
     if [ -n "$PYTHON_PY2GTK2" ] ; then
-        exec "$0"-py2gtk2 "$@"
+        exec $PYTHON_PY2GTK2 "$0"-py2gtk2 "$@"
     fi
     if [ -n "$PYTHON_PY3QT5" ] ; then
-        exec "$0"-py3qt5 "$@"
+        exec $PYTHON_PY3QT5 "$0"-py3qt5 "$@"
     fi
 fi
 

--- a/scripts/python/app/NUT-Monitor-py2gtk2.in
+++ b/scripts/python/app/NUT-Monitor-py2gtk2.in
@@ -40,7 +40,30 @@ import optparse
 import ConfigParser
 import locale
 import gettext
-import PyNUT
+
+# Try local development/accompanying packaging first,
+# then system installation
+sys_path_orig = sys.path.copy()
+try:
+	# Try "module" path relative to this program script:
+	mod_path = os.path.sep.join([
+		os.path.dirname(os.path.abspath(os.path.realpath(__file__))),
+		"..", "module"])
+	### sys.stderr.write("[D] mod_path: %s\n" % mod_path)
+	if os.path.isfile(os.path.sep.join([mod_path, "PyNUT.py"])):
+		# Insert into the system path at index 1 to ensure that it
+		# resolves after the main script but before anything else:
+		sys.path.insert(1, mod_path)
+		### sys.stderr.write("[D] sys.path: %s\n" % sys.path)
+
+	# Try our chances with the default or augmented path
+	import PyNUT
+except Exception as ignored:
+	# ModuleNotFoundError, path/parsing, et al
+	# Try our chances with the default path:
+	sys.path = sys_path_orig
+	### sys.stderr.write("[D2] sys.path: %s\n" % sys.path)
+	import PyNUT
 
 
 # Activate threadings on glib

--- a/scripts/python/app/NUT-Monitor-py3qt5.in
+++ b/scripts/python/app/NUT-Monitor-py3qt5.in
@@ -49,7 +49,30 @@ import optparse
 import configparser
 import locale
 import gettext
-import PyNUT
+
+# Try local development/accompanying packaging first,
+# then system installation
+sys_path_orig = sys.path.copy()
+try:
+	# Try "module" path relative to this program script:
+	mod_path = os.path.sep.join([
+		os.path.dirname(os.path.abspath(os.path.realpath(__file__))),
+		"..", "module"])
+	### sys.stderr.write("[D] mod_path: %s\n" % mod_path)
+	if os.path.isfile(os.path.sep.join([mod_path, "PyNUT.py"])):
+		# Insert into the system path at index 1 to ensure that it
+		# resolves after the main script but before anything else:
+		sys.path.insert(1, mod_path)
+		### sys.stderr.write("[D] sys.path: %s\n" % sys.path)
+
+	# Try our chances with the default or augmented path
+	import PyNUT
+except Exception as ignored:
+	# ModuleNotFoundError, path/parsing, et al
+	# Try our chances with the default path:
+	sys.path = sys_path_orig
+	### sys.stderr.write("[D2] sys.path: %s\n" % sys.path)
+	import PyNUT
 
 
 class interface :


### PR DESCRIPTION
Primarily an aid in portability for development (to run directly the UI script like `$PYTHON3 ./NUT-Monitor-py3qt5.in`) and also can help final deployments. Maintains and improves preference for an accompanying version of `PyNUT.py` (over an installed module, if any) if one is in a sibling directory near the application.

Side note: tested with a Linux-configured build directory on Windows, the UI client works and talks to a NUT server on Linux.