### PR TITLE
Updated Phoenix Contact modbus driver for newer models

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -279,6 +279,9 @@ https://github.com/networkupstools/nut/milestone/11
    to have fixed a Segmentation Fault seen in earlier NUT releases with
    some of the devices supported by this driver. [#2427]
 
+ - phoenixcontact_modbus driver: Introduced Phoenix Contact QUINT4-UPS/24DC
+   management (only new modbus addresses). [#2689]
+
  - upsd:
    * `upsd_cleanup()` is now traced, to more easily see that the daemon is
      exiting (and/or start-up has aborted due to configuration or run-time
@@ -449,8 +452,6 @@ during a NUT build.
 
  - Introduced a simple experiment to expose NUT client readings as filesystem
    objects via FUSE, in `scripts/fuse/execfuse-nut` now. [#2591]
-
- - Introduced Phoenix Contact QUINT4-UPS/24DC management (only new modbus addresses). [#2689]
 
 
 Release notes for NUT 2.8.2 - what's new since 2.8.1

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -450,6 +450,8 @@ during a NUT build.
  - Introduced a simple experiment to expose NUT client readings as filesystem
    objects via FUSE, in `scripts/fuse/execfuse-nut` now. [#2591]
 
+ - Introduced Phoenix Contact QUINT4-UPS/24DC management (only new modbus addresses). [#2689]
+
 
 Release notes for NUT 2.8.2 - what's new since 2.8.1
 ----------------------------------------------------

--- a/drivers/phoenixcontact_modbus.c
+++ b/drivers/phoenixcontact_modbus.c
@@ -20,6 +20,34 @@
  *
  */
 
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT
+# pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+# pragma GCC diagnostic ignored "-Wunreachable-code"
+#endif
+/* Older CLANG (e.g. clang-3.4) seems to not support the GCC pragmas above */
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunreachable-code"
+# pragma clang diagnostic ignored "-Wcovered-switch-default"
+#endif
+                /* All enum cases defined as of the time of coding
+                 * have been covered above. Handle later definitions,
+                 * memory corruptions and buggy inputs below...
+                 */
+                default:
+                        fatalx(EXIT_FAILURE, "no suitable definition found!");
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic pop
+#endif
+
 #include "main.h"
 #include <modbus.h>
 

--- a/drivers/phoenixcontact_modbus.c
+++ b/drivers/phoenixcontact_modbus.c
@@ -149,7 +149,6 @@ void upsdrv_updateinfo(void)
 		break;
 	default:
 		fatalx(EXIT_FAILURE, "Uknown UPS firmware version.");
-		break;
 	}	
 
 	status_init();
@@ -177,7 +176,6 @@ void upsdrv_updateinfo(void)
 		break;
 	default:
 		fatalx(EXIT_FAILURE, "Uknown UPS firmware version.");
-		break;
 	}
 
 	dstate_setinfo("output.voltage", "%d", (int) (tab_reg[0] / 1000));
@@ -192,7 +190,6 @@ void upsdrv_updateinfo(void)
 		break;
 	default:
 		fatalx(EXIT_FAILURE, "Uknown UPS firmware version.");
-		break;
 	}
 
 	dstate_setinfo("battery.charge", "%d", tab_reg[0]);
@@ -222,7 +219,6 @@ void upsdrv_updateinfo(void)
 		break;
 	default:
 		fatalx(EXIT_FAILURE, "Uknown UPS firmware version.");
-		break;
 	}
 
 	dstate_setinfo("battery.voltage", "%f", (double) (tab_reg[0]) / 1000.0);
@@ -305,7 +301,6 @@ void upsdrv_updateinfo(void)
 		break;
 	default:
 		fatalx(EXIT_FAILURE, "Uknown UPS firmware version.");
-		break;
 	}
 
 	if (errcount == 0) {

--- a/drivers/phoenixcontact_modbus.c
+++ b/drivers/phoenixcontact_modbus.c
@@ -135,7 +135,6 @@ void upsdrv_updateinfo(void)
 	switch (UPSModel)
 	{
 	case QUINT4_UPS:
-
 		mrir(modbus_ctx, 0x2000, 1, &actual_code_functions);
 
 		tab_reg[0] = CHECK_BIT(actual_code_functions, 2); /* Battery mode is the 2nd bit of the register 0x2000 */
@@ -146,10 +145,10 @@ void upsdrv_updateinfo(void)
 		tab_reg[1] = CHECK_BIT(actual_alarms1, 2); /* Battery discharged is the 2nd bit of the register 0x3001 */
 		break;
 	case QUINT_UPS:
-
 		mrir(modbus_ctx, 29697, 3, tab_reg); /* LB is actually called "shutdown event" on this ups */
 		break;
 	default:
+		fatalx(EXIT_FAILURE, "Uknown UPS firmware version.");
 		break;
 	}	
 
@@ -171,14 +170,13 @@ void upsdrv_updateinfo(void)
 	switch (UPSModel)
 	{
 	case QUINT4_UPS:
-
 		mrir(modbus_ctx, 0x2006, 1, tab_reg);
 		break;
 	case QUINT_UPS:
-
 		mrir(modbus_ctx, 29745, 1, tab_reg);
 		break;
 	default:
+		fatalx(EXIT_FAILURE, "Uknown UPS firmware version.");
 		break;
 	}
 
@@ -187,14 +185,13 @@ void upsdrv_updateinfo(void)
 	switch (UPSModel)
 	{
 	case QUINT4_UPS:
-
 		mrir(modbus_ctx, 0x200F, 1, tab_reg);
 		break;
 	case QUINT_UPS:
-
 		mrir(modbus_ctx, 29749, 5, tab_reg);
 		break;
 	default:
+		fatalx(EXIT_FAILURE, "Uknown UPS firmware version.");
 		break;
 	}
 
@@ -204,7 +201,6 @@ void upsdrv_updateinfo(void)
 	switch (UPSModel)
 	{
 	case QUINT4_UPS:
-
 		mrir(modbus_ctx, 0x200A, 1, &battery_voltage);
 		tab_reg[0] = battery_voltage;
 
@@ -222,10 +218,10 @@ void upsdrv_updateinfo(void)
 
 		break;
 	case QUINT_UPS:
-
 		mrir(modbus_ctx, 29792, 10, tab_reg);
 		break;
 	default:
+		fatalx(EXIT_FAILURE, "Uknown UPS firmware version.");
 		break;
 	}
 
@@ -242,7 +238,6 @@ void upsdrv_updateinfo(void)
 	switch (UPSModel)
 	{
 	case QUINT4_UPS:
-
 		tab_reg[0] = 0;
 		actual_alarms = 0;
 		actual_alarms1 = 0;
@@ -282,7 +277,6 @@ void upsdrv_updateinfo(void)
 
 		break;
 	case QUINT_UPS:
-
 		mrir(modbus_ctx, 29840, 1, tab_reg);
 
 		if (CHECK_BIT(tab_reg[0], 4) && CHECK_BIT(tab_reg[0], 5))
@@ -310,6 +304,7 @@ void upsdrv_updateinfo(void)
 			alarm_set("Low Battery (Service)");
 		break;
 	default:
+		fatalx(EXIT_FAILURE, "Uknown UPS firmware version.");
 		break;
 	}
 

--- a/drivers/phoenixcontact_modbus.c
+++ b/drivers/phoenixcontact_modbus.c
@@ -32,7 +32,7 @@
 typedef enum
 {
 	QUINT_UPS,
-	QUINT4_UPS;
+	QUINT4_UPS
 } models;
 
 /* Variables */

--- a/drivers/phoenixcontact_modbus.c
+++ b/drivers/phoenixcontact_modbus.c
@@ -64,12 +64,12 @@ void upsdrv_initinfo(void)
 	if (FWVersion == 544)
 	{
 		UPSModel = QUINT_UPS;
-		dstate_setinfo("device.model", "QUINT-UPS/24DC OLD");
+		dstate_setinfo("device.model", "QUINT-UPS/24DC");
 	}
 	else if (FWVersion == 305)
 	{
 		UPSModel = QUINT4_UPS;
-		dstate_setinfo("device.model", "QUINT-UPS/24DC NEW");
+		dstate_setinfo("device.model", "QUINT4-UPS/24DC");
 	}
 
 	dstate_setinfo("ups.firmware", "%d", FWVersion);

--- a/drivers/phoenixcontact_modbus.c
+++ b/drivers/phoenixcontact_modbus.c
@@ -87,7 +87,6 @@ void upsdrv_updateinfo(void)
 	uint16_t actual_code_functions;
 	uint16_t actual_alarms = 0;
 	uint16_t actual_alarms1 = 0;
-	uint32_t alarms_word;
 	uint16_t battery_voltage;
 	uint16_t battery_temperature;
 	uint16_t battery_runtime;
@@ -209,38 +208,37 @@ void upsdrv_updateinfo(void)
 		actual_alarms = 0;
 		actual_alarms1 = 0;
 
-		alarms_word = 0;
+		mrir(modbus_ctx, 0x3000, 1, &actual_alarms);
+		mrir(modbus_ctx, 0x3000, 1, &actual_alarms1);
 
-		mrir(modbus_ctx, 0x3000, 2, &alarms_word);
-
-		if (CHECK_BIT(alarms_word, 10) && CHECK_BIT(alarms_word, 10))
+		if (CHECK_BIT(actual_alarms, 9) && CHECK_BIT(actual_alarms, 9))
 			alarm_set("End of life (Resistance)");
 
-		if (CHECK_BIT(alarms_word, 16))
+		if (CHECK_BIT(actual_alarms1, 0))
 			alarm_set("End of life (Time)");
 
-		if (CHECK_BIT(alarms_word, 10))
+		if (CHECK_BIT(actual_alarms, 10))
 			alarm_set("End of life (Voltage)");
 
-		if (CHECK_BIT(alarms_word, 3))
+		if (CHECK_BIT(actual_alarms, 3))
 			alarm_set("No Battery");
 
-		if (CHECK_BIT(alarms_word, 5))
+		if (CHECK_BIT(actual_alarms, 5))
 			alarm_set("Inconsistent technology");
 
-		if (CHECK_BIT(alarms_word, 24))
+		if (CHECK_BIT(actual_alarms1, 8))
 			alarm_set("Overload Cutoff");
 
-		if (CHECK_BIT(alarms_word, 19))
+		if (CHECK_BIT(actual_alarms1, 3))
 			alarm_set("Low Battery (Voltage)");
 
-		if (CHECK_BIT(alarms_word, 20))
+		if (CHECK_BIT(actual_alarms1, 4))
 			alarm_set("Low Battery (Charge)");
 
-		if (CHECK_BIT(alarms_word, 21))
+		if (CHECK_BIT(actual_alarms1, 5))
 			alarm_set("Low Battery (Time)");
 
-		if (CHECK_BIT(alarms_word, 30))
+		if (CHECK_BIT(actual_alarms1, 14))
 			alarm_set("Low Battery (Service)");
 
 		break;

--- a/drivers/phoenixcontact_modbus.c
+++ b/drivers/phoenixcontact_modbus.c
@@ -38,9 +38,11 @@
                 /* All enum cases defined as of the time of coding
                  * have been covered above. Handle later definitions,
                  * memory corruptions and buggy inputs below...
+				 *
+				 * default:
+                 * 		fatalx(EXIT_FAILURE, "no suitable definition found!");
                  */
-                default:
-                        fatalx(EXIT_FAILURE, "no suitable definition found!");
+                
 #ifdef __clang__
 # pragma clang diagnostic pop
 #endif

--- a/drivers/phoenixcontact_modbus.c
+++ b/drivers/phoenixcontact_modbus.c
@@ -20,36 +20,6 @@
  *
  */
 
-#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
-# pragma GCC diagnostic push
-#endif
-#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT
-# pragma GCC diagnostic ignored "-Wcovered-switch-default"
-#endif
-#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
-# pragma GCC diagnostic ignored "-Wunreachable-code"
-#endif
-/* Older CLANG (e.g. clang-3.4) seems to not support the GCC pragmas above */
-#ifdef __clang__
-# pragma clang diagnostic push
-# pragma clang diagnostic ignored "-Wunreachable-code"
-# pragma clang diagnostic ignored "-Wcovered-switch-default"
-#endif
-                /* All enum cases defined as of the time of coding
-                 * have been covered above. Handle later definitions,
-                 * memory corruptions and buggy inputs below...
-				 *
-				 * default:
-                 * 		fatalx(EXIT_FAILURE, "no suitable definition found!");
-                 */
-                
-#ifdef __clang__
-# pragma clang diagnostic pop
-#endif
-#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
-# pragma GCC diagnostic pop
-#endif
-
 #include "main.h"
 #include <modbus.h>
 
@@ -147,9 +117,35 @@ void upsdrv_updateinfo(void)
 	case QUINT_UPS:
 		mrir(modbus_ctx, 29697, 3, tab_reg); /* LB is actually called "shutdown event" on this ups */
 		break;
+
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT
+# pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+# pragma GCC diagnostic ignored "-Wunreachable-code"
+#endif
+/* Older CLANG (e.g. clang-3.4) seems to not support the GCC pragmas above */
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunreachable-code"
+# pragma clang diagnostic ignored "-Wcovered-switch-default"
+#endif
+                /* All enum cases defined as of the time of coding
+                 * have been covered above. Handle later definitions,
+                 * memory corruptions and buggy inputs below...
+		 */
 	default:
 		fatalx(EXIT_FAILURE, "Uknown UPS firmware version.");
-	}	
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic pop
+#endif
+	}
 
 	status_init();
 
@@ -174,8 +170,34 @@ void upsdrv_updateinfo(void)
 	case QUINT_UPS:
 		mrir(modbus_ctx, 29745, 1, tab_reg);
 		break;
+
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT
+# pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+# pragma GCC diagnostic ignored "-Wunreachable-code"
+#endif
+/* Older CLANG (e.g. clang-3.4) seems to not support the GCC pragmas above */
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunreachable-code"
+# pragma clang diagnostic ignored "-Wcovered-switch-default"
+#endif
+                /* All enum cases defined as of the time of coding
+                 * have been covered above. Handle later definitions,
+                 * memory corruptions and buggy inputs below...
+		 */
 	default:
 		fatalx(EXIT_FAILURE, "Uknown UPS firmware version.");
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic pop
+#endif
 	}
 
 	dstate_setinfo("output.voltage", "%d", (int) (tab_reg[0] / 1000));
@@ -188,8 +210,34 @@ void upsdrv_updateinfo(void)
 	case QUINT_UPS:
 		mrir(modbus_ctx, 29749, 5, tab_reg);
 		break;
+
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT
+# pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+# pragma GCC diagnostic ignored "-Wunreachable-code"
+#endif
+/* Older CLANG (e.g. clang-3.4) seems to not support the GCC pragmas above */
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunreachable-code"
+# pragma clang diagnostic ignored "-Wcovered-switch-default"
+#endif
+                /* All enum cases defined as of the time of coding
+                 * have been covered above. Handle later definitions,
+                 * memory corruptions and buggy inputs below...
+		 */
 	default:
 		fatalx(EXIT_FAILURE, "Uknown UPS firmware version.");
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic pop
+#endif
 	}
 
 	dstate_setinfo("battery.charge", "%d", tab_reg[0]);
@@ -217,8 +265,34 @@ void upsdrv_updateinfo(void)
 	case QUINT_UPS:
 		mrir(modbus_ctx, 29792, 10, tab_reg);
 		break;
+
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT
+# pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+# pragma GCC diagnostic ignored "-Wunreachable-code"
+#endif
+/* Older CLANG (e.g. clang-3.4) seems to not support the GCC pragmas above */
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunreachable-code"
+# pragma clang diagnostic ignored "-Wcovered-switch-default"
+#endif
+                /* All enum cases defined as of the time of coding
+                 * have been covered above. Handle later definitions,
+                 * memory corruptions and buggy inputs below...
+		 */
 	default:
 		fatalx(EXIT_FAILURE, "Uknown UPS firmware version.");
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic pop
+#endif
 	}
 
 	dstate_setinfo("battery.voltage", "%f", (double) (tab_reg[0]) / 1000.0);
@@ -299,8 +373,34 @@ void upsdrv_updateinfo(void)
 		if (CHECK_BIT(tab_reg[0], 16))
 			alarm_set("Low Battery (Service)");
 		break;
+
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT
+# pragma GCC diagnostic ignored "-Wcovered-switch-default"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE
+# pragma GCC diagnostic ignored "-Wunreachable-code"
+#endif
+/* Older CLANG (e.g. clang-3.4) seems to not support the GCC pragmas above */
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunreachable-code"
+# pragma clang diagnostic ignored "-Wcovered-switch-default"
+#endif
+                /* All enum cases defined as of the time of coding
+                 * have been covered above. Handle later definitions,
+                 * memory corruptions and buggy inputs below...
+		 */
 	default:
 		fatalx(EXIT_FAILURE, "Uknown UPS firmware version.");
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_COVERED_SWITCH_DEFAULT) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) )
+# pragma GCC diagnostic pop
+#endif
 	}
 
 	if (errcount == 0) {

--- a/drivers/phoenixcontact_modbus.c
+++ b/drivers/phoenixcontact_modbus.c
@@ -119,8 +119,6 @@ void upsdrv_updateinfo(void)
 
 		mrir(modbus_ctx, 29697, 3, tab_reg); /* LB is actually called "shutdown event" on this ups */
 		break;
-	default:
-		break;
 	}	
 
 	status_init();
@@ -148,8 +146,6 @@ void upsdrv_updateinfo(void)
 
 		mrir(modbus_ctx, 29745, 1, tab_reg);
 		break;
-	default:
-		break;
 	}
 
 	dstate_setinfo("output.voltage", "%d", (int) (tab_reg[0] / 1000));
@@ -163,8 +159,6 @@ void upsdrv_updateinfo(void)
 	case QUINT_UPS:
 
 		mrir(modbus_ctx, 29749, 5, tab_reg);
-		break;
-	default:
 		break;
 	}
 
@@ -194,8 +188,6 @@ void upsdrv_updateinfo(void)
 	case QUINT_UPS:
 
 		mrir(modbus_ctx, 29792, 10, tab_reg);
-		break;
-	default:
 		break;
 	}
 
@@ -278,8 +270,6 @@ void upsdrv_updateinfo(void)
 			alarm_set("Low Battery (Time)");
 		if (CHECK_BIT(tab_reg[0], 16))
 			alarm_set("Low Battery (Service)");
-		break;
-	default:
 		break;
 	}
 

--- a/drivers/phoenixcontact_modbus.c
+++ b/drivers/phoenixcontact_modbus.c
@@ -149,6 +149,8 @@ void upsdrv_updateinfo(void)
 
 		mrir(modbus_ctx, 29697, 3, tab_reg); /* LB is actually called "shutdown event" on this ups */
 		break;
+	default:
+		break;
 	}	
 
 	status_init();
@@ -176,6 +178,8 @@ void upsdrv_updateinfo(void)
 
 		mrir(modbus_ctx, 29745, 1, tab_reg);
 		break;
+	default:
+		break;
 	}
 
 	dstate_setinfo("output.voltage", "%d", (int) (tab_reg[0] / 1000));
@@ -189,6 +193,8 @@ void upsdrv_updateinfo(void)
 	case QUINT_UPS:
 
 		mrir(modbus_ctx, 29749, 5, tab_reg);
+		break;
+	default:
 		break;
 	}
 
@@ -218,6 +224,8 @@ void upsdrv_updateinfo(void)
 	case QUINT_UPS:
 
 		mrir(modbus_ctx, 29792, 10, tab_reg);
+		break;
+	default:
 		break;
 	}
 
@@ -300,6 +308,8 @@ void upsdrv_updateinfo(void)
 			alarm_set("Low Battery (Time)");
 		if (CHECK_BIT(tab_reg[0], 16))
 			alarm_set("Low Battery (Service)");
+		break;
+	default:
 		break;
 	}
 

--- a/drivers/phoenixcontact_modbus.c
+++ b/drivers/phoenixcontact_modbus.c
@@ -29,8 +29,11 @@
 #define CHECK_BIT(var,pos) ((var) & (1<<(pos)))
 #define MODBUS_SLAVE_ID 192
 
-#define QUINT_UPS 0
-#define QUINT4_UPS 1
+typedef enum
+{
+	QUINT_UPS,
+	QUINT4_UPS;
+} models;
 
 /* Variables */
 static modbus_t *modbus_ctx = NULL;
@@ -38,7 +41,15 @@ static int errcount = 0;
 
 static int mrir(modbus_t * arg_ctx, int addr, int nb, uint16_t * dest);
 
-static uint16_t UPSModel;
+static models UPSModel;
+
+/*
+	For the QUINT ups (first implementation of the driver) the modbus addresses
+	are reported in dec format,for the QUINT4 ups they are reported in hex format.
+	The difference is caused from the way they are reported in the datasheet,
+	keeping them in the same format as the datasheet make more simple the maintenence 
+	of the driver avoiding conversions while coding.
+*/
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/phoenixcontact_modbus.c
+++ b/drivers/phoenixcontact_modbus.c
@@ -24,16 +24,21 @@
 #include <modbus.h>
 
 #define DRIVER_NAME	"NUT PhoenixContact Modbus driver"
-#define DRIVER_VERSION	"0.04"
+#define DRIVER_VERSION	"0.05"
 
 #define CHECK_BIT(var,pos) ((var) & (1<<(pos)))
 #define MODBUS_SLAVE_ID 192
+
+#define OLD_UPS 0
+#define NEW_UPS 1
 
 /* Variables */
 static modbus_t *modbus_ctx = NULL;
 static int errcount = 0;
 
 static int mrir(modbus_t * arg_ctx, int addr, int nb, uint16_t * dest);
+
+uint16_t UPSModel;
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -49,21 +54,58 @@ void upsdrv_initinfo(void)
 	upsdebugx(2, "upsdrv_initinfo");
 
 	dstate_setinfo("device.mfr", "Phoenix Contact");
-	dstate_setinfo("device.model", "QUINT-UPS/24DC");
-
+	
 	/* upsh.instcmd = instcmd; */
 	/* upsh.setvar = setvar; */
+
+	uint16_t FWVersion;
+
+	mrir(modbus_ctx, 0x0004, 1, &FWVersion);
+
+	if (FWVersion == 544)
+	{
+		UPSModel = OLD_UPS;
+		dstate_setinfo("device.model", "QUINT-UPS/24DC OLD");
+	}
+	else if (FWVersion == 305)
+	{
+		UPSModel = NEW_UPS;
+		dstate_setinfo("device.model", "QUINT-UPS/24DC NEW");
+	}
 }
 
 void upsdrv_updateinfo(void)
 {
 	uint16_t tab_reg[64];
-
+	
 	errcount = 0;
 
 	upsdebugx(2, "upsdrv_updateinfo");
 
-	mrir(modbus_ctx, 29697, 3, tab_reg);
+	uint16_t actual_code_functions;
+	uint16_t actual_alarms = 0;
+	uint16_t actual_alarms1 = 0;
+
+	switch (UPSModel)
+	{
+	case NEW_UPS:
+		
+		mrir(modbus_ctx, 0x2000, 1, &actual_code_functions);
+
+		tab_reg[0] = CHECK_BIT(actual_code_functions, 2); //battery mode is the 2nd bit of the register 0x2000
+		tab_reg[2] = CHECK_BIT(actual_code_functions, 5); //battery charging is the 5th bit of the register 0x2000
+				
+		mrir(modbus_ctx, 0x3001, 1, &actual_alarms1);
+
+		tab_reg[1] = CHECK_BIT(actual_alarms1, 2); //battery discharged is the 2nd bit of the register 0x3001
+		break;
+	case OLD_UPS:
+
+		mrir(modbus_ctx, 29697, 3, tab_reg); /* LB is actually called "shutdown event" on this ups */
+		break;
+	default:
+		break;
+	}	
 
 	status_init();
 
@@ -77,17 +119,76 @@ void upsdrv_updateinfo(void)
 	}
 
 	if (tab_reg[1]) {
-		status_set("LB");	/* LB is actually called "shutdown event" on this ups */
+		status_set("LB");	
 	}
 
-	mrir(modbus_ctx, 29745, 1, tab_reg);
+	switch (UPSModel)
+	{
+	case NEW_UPS:
+
+		mrir(modbus_ctx, 0x2006, 1, tab_reg);
+		break;
+	case OLD_UPS:
+
+		mrir(modbus_ctx, 29745, 1, tab_reg);
+		break;
+	default:
+		break;
+	}
+	
 	dstate_setinfo("output.voltage", "%d", (int) (tab_reg[0] / 1000));
 
-	mrir(modbus_ctx, 29749, 5, tab_reg);
+	switch (UPSModel)
+	{
+	case NEW_UPS:
+
+		mrir(modbus_ctx, 0x200F, 1, tab_reg);
+		break;
+	case OLD_UPS:
+
+		mrir(modbus_ctx, 29749, 5, tab_reg);
+		break;
+	default:
+		break;
+	}
+		
 	dstate_setinfo("battery.charge", "%d", tab_reg[0]);
 	/* dstate_setinfo("battery.runtime",tab_reg[1]*60); */ /* also reported on this address, but less accurately */
 
-	mrir(modbus_ctx, 29792, 10, tab_reg);
+	uint16_t battery_voltage;
+	uint16_t battery_temperature;
+	uint16_t battery_runtime;
+	uint16_t battery_capacity;
+	uint16_t output_current;
+
+	switch (UPSModel)
+	{
+	case NEW_UPS:
+				
+		mrir(modbus_ctx, 0x200A, 1, &battery_voltage);
+		tab_reg[0] = battery_voltage;
+				
+		mrir(modbus_ctx, 0x200D, 1, &battery_temperature);
+		tab_reg[1] = battery_temperature;
+				
+		mrir(modbus_ctx, 0x2010, 1, &battery_runtime);
+		tab_reg[3] = battery_runtime;
+
+		mrir(modbus_ctx, 0x4211, 1, &battery_capacity);
+		tab_reg[8] = battery_capacity;
+
+		mrir(modbus_ctx, 0x2007, 1, &output_current);
+		tab_reg[6] = output_current;
+
+		break;
+	case OLD_UPS:
+
+		mrir(modbus_ctx, 29792, 10, tab_reg);
+		break;
+	default:
+		break;
+	}
+	
 	dstate_setinfo("battery.voltage", "%f", (double) (tab_reg[0]) / 1000.0);
 	dstate_setinfo("battery.temperature", "%d", tab_reg[1] - 273);
 	dstate_setinfo("battery.runtime", "%d", tab_reg[3]);
@@ -95,31 +196,86 @@ void upsdrv_updateinfo(void)
 	dstate_setinfo("output.current", "%f", (double) (tab_reg[6]) / 1000.0);
 
 	/* ALARMS */
-	mrir(modbus_ctx, 29840, 1, tab_reg);
+	
 	alarm_init();
-	if (CHECK_BIT(tab_reg[0], 4) && CHECK_BIT(tab_reg[0], 5))
-		alarm_set("End of life (Resistance)");
-	if (CHECK_BIT(tab_reg[0], 6))
-		alarm_set("End of life (Time)");
-	if (CHECK_BIT(tab_reg[0], 7))
-		alarm_set("End of life (Voltage)");
-	if (CHECK_BIT(tab_reg[0], 9))
-		alarm_set("No Battery");
-	if (CHECK_BIT(tab_reg[0], 10))
-		alarm_set("Inconsistent technology");
-	if (CHECK_BIT(tab_reg[0], 11))
-		alarm_set("Overload Cutoff");
-	/* We don't use those low-battery indicators below.
-	 * No info or configuration exists for those alarm low-bat
-	 */
-	if (CHECK_BIT(tab_reg[0], 12))
-		alarm_set("Low Battery (Voltage)");
-	if (CHECK_BIT(tab_reg[0], 13))
-		alarm_set("Low Battery (Charge)");
-	if (CHECK_BIT(tab_reg[0], 14))
-		alarm_set("Low Battery (Time)");
-	if (CHECK_BIT(tab_reg[0], 16))
-		alarm_set("Low Battery (Service)");
+
+	uint32_t alarms_word;
+
+	switch (UPSModel)
+	{
+	case NEW_UPS:
+
+		tab_reg[0] = 0;
+		actual_alarms = 0;
+		actual_alarms1 = 0;
+
+		alarms_word = 0;
+
+		mrir(modbus_ctx, 0x3000, 2, &alarms_word);
+
+		if (CHECK_BIT(alarms_word, 10) && CHECK_BIT(alarms_word, 10))
+			alarm_set("End of life (Resistance)");
+
+		if (CHECK_BIT(alarms_word, 16))
+			alarm_set("End of life (Time)");
+
+		if (CHECK_BIT(alarms_word, 10))
+			alarm_set("End of life (Voltage)");
+
+		if (CHECK_BIT(alarms_word, 3))
+			alarm_set("No Battery");
+
+		if (CHECK_BIT(alarms_word, 5))
+			alarm_set("Inconsistent technology");
+
+		if (CHECK_BIT(alarms_word, 24))
+			alarm_set("Overload Cutoff");
+
+		if (CHECK_BIT(alarms_word, 19))
+			alarm_set("Low Battery (Voltage)");
+
+		if (CHECK_BIT(alarms_word, 20))
+			alarm_set("Low Battery (Charge)");
+
+		if (CHECK_BIT(alarms_word, 21))
+			alarm_set("Low Battery (Time)");
+
+		if (CHECK_BIT(alarms_word, 30))
+			alarm_set("Low Battery (Service)");
+
+		break;
+	case OLD_UPS:
+
+		mrir(modbus_ctx, 29840, 1, tab_reg);
+
+		
+		if (CHECK_BIT(tab_reg[0], 4) && CHECK_BIT(tab_reg[0], 5))
+			alarm_set("End of life (Resistance)");
+		if (CHECK_BIT(tab_reg[0], 6))
+			alarm_set("End of life (Time)");
+		if (CHECK_BIT(tab_reg[0], 7))
+			alarm_set("End of life (Voltage)");
+		if (CHECK_BIT(tab_reg[0], 9))
+			alarm_set("No Battery");
+		if (CHECK_BIT(tab_reg[0], 10))
+			alarm_set("Inconsistent technology");
+		if (CHECK_BIT(tab_reg[0], 11))
+			alarm_set("Overload Cutoff");
+		/* We don't use those low-battery indicators below.
+		 * No info or configuration exists for those alarm low-bat
+		 */
+		if (CHECK_BIT(tab_reg[0], 12))
+			alarm_set("Low Battery (Voltage)");
+		if (CHECK_BIT(tab_reg[0], 13))
+			alarm_set("Low Battery (Charge)");
+		if (CHECK_BIT(tab_reg[0], 14))
+			alarm_set("Low Battery (Time)");
+		if (CHECK_BIT(tab_reg[0], 16))
+			alarm_set("Low Battery (Service)");
+		break;
+	default:
+		break;
+	}
 
 	if (errcount == 0) {
 		alarm_commit();
@@ -151,17 +307,17 @@ void upsdrv_initups(void)
 {
 	int r;
 	upsdebugx(2, "upsdrv_initups");
-
+	
 	modbus_ctx = modbus_new_rtu(device_path, 115200, 'E', 8, 1);
 	if (modbus_ctx == NULL)
 		fatalx(EXIT_FAILURE, "Unable to create the libmodbus context");
-
+	
 	r = modbus_set_slave(modbus_ctx, MODBUS_SLAVE_ID);	/* slave ID */
 	if (r < 0) {
 		modbus_free(modbus_ctx);
 		fatalx(EXIT_FAILURE, "Invalid modbus slave ID %d",MODBUS_SLAVE_ID);
 	}
-
+	
 	if (modbus_connect(modbus_ctx) == -1) {
 		modbus_free(modbus_ctx);
 		fatalx(EXIT_FAILURE, "modbus_connect: unable to connect: %s", modbus_strerror(errno));

--- a/drivers/phoenixcontact_modbus.c
+++ b/drivers/phoenixcontact_modbus.c
@@ -38,7 +38,7 @@ static int errcount = 0;
 
 static int mrir(modbus_t * arg_ctx, int addr, int nb, uint16_t * dest);
 
-uint16_t UPSModel;
+static uint16_t UPSModel;
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -51,14 +51,13 @@ upsdrv_info_t upsdrv_info = {
 
 void upsdrv_initinfo(void)
 {
+	uint16_t FWVersion;
 	upsdebugx(2, "upsdrv_initinfo");
 
 	dstate_setinfo("device.mfr", "Phoenix Contact");
 
 	/* upsh.instcmd = instcmd; */
-	/* upsh.setvar = setvar; */
-
-	uint16_t FWVersion;
+	/* upsh.setvar = setvar; */	
 
 	mrir(modbus_ctx, 0x0004, 1, &FWVersion);
 
@@ -79,11 +78,6 @@ void upsdrv_initinfo(void)
 void upsdrv_updateinfo(void)
 {
 	uint16_t tab_reg[64];
-
-	errcount = 0;
-
-	upsdebugx(2, "upsdrv_updateinfo");
-
 	uint16_t actual_code_functions;
 	uint16_t actual_alarms = 0;
 	uint16_t actual_alarms1 = 0;
@@ -92,6 +86,10 @@ void upsdrv_updateinfo(void)
 	uint16_t battery_runtime;
 	uint16_t battery_capacity;
 	uint16_t output_current;
+
+	errcount = 0;
+
+	upsdebugx(2, "upsdrv_updateinfo");
 
 	switch (UPSModel)
 	{


### PR DESCRIPTION
Updated Phoenix Contact modbus driver for newer models which are using different modbus addresses. Choice is made basing on the UPS firmware version and the model information have been changed in order to have a quick feedback over the new/old model detection.