### PR TITLE
`drivers/libusb{0,1}.c`: Revise "insufficient permissions on everything" messages

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -210,6 +210,10 @@ https://github.com/networkupstools/nut/milestone/11
    or service unit methods or init script), to enable troubleshooting of LibUSB
    itself. [issue #2616]
 
+ - USB drivers should now not log "insufficient permissions on everything" alone
+   when some devices were accessible but just did not match -- clarify that case
+   in the next line, when applicable. [PR #2699]
+
  - Introduced a new driver concept for interaction with OS-reported hardware
    monitoring readings. Currently instantiated as `hwmon_ina219` specifically
    made for Texas Instruments INA219 chip as exposed in the Linux "hwmon"

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -376,6 +376,9 @@ during a NUT build.
  - added `scripts/valgrind` with a helper script and suppression file to
    ignore common third-party problems. [#2511]
 
+ - when drivers dump collected data (during troubleshooting), flush `stdout`
+   buffer immediately for sane logging (especially on Windows). [PR #2699]
+
  - revised `nut.exe` (the NUT for Windows wrapper for all-in-one service)
    to be more helpful with command-line use (report that it failed to start
    as a service, have a help message, pass debug verbosity to launched NUT

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -2088,6 +2088,11 @@ void dstate_dump(void)
 	upsdebugx(3, "Entering %s", __func__);
 
 	node = (const st_tree_t *)dstate_getroot();
+	fflush(stderr);
 
 	dstate_tree_dump(node);
+
+	/* Make sure it lands in one piece and is logged where called */
+	fflush(stdout);
+	fflush(stderr);
 }

--- a/drivers/libusb0.c
+++ b/drivers/libusb0.c
@@ -38,7 +38,7 @@
 #endif
 
 #define USB_DRIVER_NAME		"USB communication driver (libusb 0.1)"
-#define USB_DRIVER_VERSION	"0.48"
+#define USB_DRIVER_VERSION	"0.50"
 
 /* driver description structure */
 upsdrv_info_t comm_upsdrv_info = {
@@ -730,6 +730,7 @@ static int nut_libusb_open(usb_dev_handle **udevp,
 		}
 	}
 
+	/* If we got here, we did not return a successfully chosen device above */
 	*udevp = NULL;
 	upsdebugx(2, "libusb0: No appropriate HID device found");
 	fflush(stdout);
@@ -737,7 +738,7 @@ static int nut_libusb_open(usb_dev_handle **udevp,
 	if (count_open_attempts == 0) {
 		upslogx(LOG_WARNING,
 			"libusb0: Could not open any HID devices: "
-			"no USB buses found");
+			"no USB buses (or devices) found");
 	}
 	else
 	if (count_open_errors > 0
@@ -746,6 +747,13 @@ static int nut_libusb_open(usb_dev_handle **udevp,
 		upslogx(LOG_WARNING,
 			"libusb0: Could not open any HID devices: "
 			"insufficient permissions on everything");
+		if (count_open_attempts > count_open_errors) {
+			upslogx(LOG_WARNING,
+				"libusb0: except %d devices "
+				"tried but not matching the "
+				"requested criteria",
+				count_open_attempts - count_open_errors);
+		}
 	}
 
 	return -1;

--- a/drivers/libusb1.c
+++ b/drivers/libusb1.c
@@ -33,7 +33,7 @@
 #include "nut_stdint.h"
 
 #define USB_DRIVER_NAME		"USB communication driver (libusb 1.0)"
-#define USB_DRIVER_VERSION	"0.49"
+#define USB_DRIVER_VERSION	"0.50"
 
 /* driver description structure */
 upsdrv_info_t comm_upsdrv_info = {
@@ -205,6 +205,7 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 	int i;
 	int count_open_EACCESS = 0;
 	int count_open_errors = 0;
+	int count_open_attempts = 0;
 
 	/* report descriptor */
 	unsigned char	rdbuf[MAX_REPORT_SIZE];
@@ -309,6 +310,7 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 		/* int		if_claimed = 0; */
 		libusb_device	*device = devlist[devnum];
 
+		count_open_attempts++;
 		libusb_get_device_descriptor(device, &dev_desc);
 		upsdebugx(2, "Checking device %" PRIuSIZE " of %" PRIuSIZE " (%04X/%04X)",
 			devnum + 1, devcount,
@@ -813,15 +815,16 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 			nut_libusb_subdriver_defaults(&usb_subdriver);
 	}
 
+	/* If we got here, we did not return a successfully chosen device above */
 	*udevp = NULL;
 	libusb_free_device_list(devlist, 1);
 	upsdebugx(2, "libusb1: No appropriate HID device found");
 	fflush(stdout);
 
-	if (devcount < 1) {
+	if (devcount < 1 || count_open_attempts == 0) {
 		upslogx(LOG_WARNING,
 			"libusb1: Could not open any HID devices: "
-			"no USB buses found");
+			"no USB buses (or devices) found");
 	}
 	else
 	if (count_open_errors > 0
@@ -830,6 +833,13 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 		upslogx(LOG_WARNING,
 			"libusb1: Could not open any HID devices: "
 			"insufficient permissions on everything");
+		if (count_open_attempts > count_open_errors) {
+			upslogx(LOG_WARNING,
+				"libusb1: except %d devices "
+				"tried but not matching the "
+				"requested criteria",
+				count_open_attempts - count_open_errors);
+		}
 	}
 
 	return -1;

--- a/drivers/libusb1.c
+++ b/drivers/libusb1.c
@@ -828,7 +828,7 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 	}
 	else
 	if (count_open_errors > 0
-	||  count_open_errors == count_open_EACCESS
+	&&  count_open_errors == count_open_EACCESS
 	) {
 		upslogx(LOG_WARNING,
 			"libusb1: Could not open any HID devices: "


### PR DESCRIPTION
The original message was misleading in some cases, as seen in https://github.com/networkupstools/nut/issues/2661#issuecomment-2505942832 - a device was accessible and attempted, but did not match. The logged message that the users see without bumping debug is however that nothing was accessible.