### PR TITLE
drivers/libusb1.c: fix wrong return value of nut_libusb_get_interrupt()

### DIFF
--- a/drivers/libusb1.c
+++ b/drivers/libusb1.c
@@ -1090,7 +1090,7 @@ static int nut_libusb_get_interrupt(
 		) {
 			return -1;
 		}
-		ret = (usb_ctrl_charbufsize)bufsize;
+		ret = (usb_ctrl_charbufsize)tmpbufsize;
 	}
 
 	return nut_libusb_strerror(ret, __func__);


### PR DESCRIPTION
cf github #2401 

When global var 'interrupt_size' is not set, a transfer size of SMALLBUF (512) is requested when calling libusb_interrupt_transfer(). Our function nut_libusb_get_interrupt() should return the actual transferred size. Otherwise, the caller will attempt to parse any uninitialized data in the buffer after the response.

In libusb0.c this was done correctly by using the return value of usb_interrupt_read(). With libusb1, the transferred size is written to tmpbufsize, and should therefore be used as the return val.

***************

can we trust libusb to not return a value outside the range of `usb_ctrl_charbufsize` ? I did not add a check for this and simply cast the int. [edit - as noted in the review comments, this condition is already checked... 4 lines above)

