### PR TITLE
add-missing-vars-desc

### DIFF
--- a/data/cmdvartab
+++ b/data/cmdvartab
@@ -42,6 +42,7 @@ VARDESC ups.type "UPS type"
 VARDESC ups.start.auto "UPS starts when mains is (re)applied"
 VARDESC ups.start.battery "Allow to start UPS from battery"
 VARDESC ups.start.reboot "UPS reboots when power returns during shutdown delay"
+VARDESC ups.shutdown "Enable or disable UPS shutdown ability (poweroff)"
 
 VARDESC input.voltage "Input voltage (V)"
 VARDESC input.voltage.extended "Extended input voltage range"
@@ -197,8 +198,18 @@ VARDESC outlet.2.autoswitch.charge.low "Remaining battery level to power off thi
 VARDESC outlet.2.delay.shutdown "Interval to wait before shutting down this outlet (seconds)"
 VARDESC outlet.2.delay.start "Interval to wait before restarting this outlet (seconds)"
 
-VARDESC device.part "Device Part Number"
-VARDESC device.mfr "Device Manufacturer"
+VARDESC device.part "Device part number"
+VARDESC device.mfr "Device manufacturer"
+VARDESC device.model "Device model"
+VARDESC device.serial "Device serial number"
+VARDESC device.type "Device type"
+VARDESC device.description "Device description"
+VARDESC device.contact "Device administrator name"
+VARDESC device.location "Device physical location"
+VARDESC device.macaddr "Physical network address of the device"
+VARDESC device.uptime "Device uptime in seconds"
+VARDESC device.count "Total number of daisychained devices"
+VARDESC device.usb.version "Device USB version"
 
 VARDESC server.info "Server information"
 VARDESC server.version "Server version"
@@ -211,6 +222,7 @@ VARDESC driver.flag.allow_killpower "Safety flip-switch to allow the driver daem
 VARDESC driver.version "Driver version - NUT release"
 VARDESC driver.version.internal "Internal driver version"
 VARDESC driver.version.usb "USB library version"
+VARDESC driver.state "Current state in driver's lifecycle"
 
 # FIXME: driver.parameter and driver.flag can have many possible members
 #

--- a/data/cmdvartab
+++ b/data/cmdvartab
@@ -133,7 +133,7 @@ VARDESC battery.energysave.load "Switch off UPS if on battery and load level low
 VARDESC battery.energysave.delay "Delay before switch off UPS if on battery and load level low (min)"
 VARDESC battery.energysave.realpower "Switch off UPS if on battery and load level lower (Watts)"
 VARDESC battery.charger.status "Battery charger status"
-VARDESC battery.charger.type "ABM charger type"
+VARDESC battery.charger.type "Type of battery charger"
 
 VARDESC ambient.temperature "Ambient temperature (degrees C)"
 VARDESC ambient.temperature.alarm "Ambient temperature alarm is active"

--- a/data/cmdvartab
+++ b/data/cmdvartab
@@ -74,6 +74,8 @@ VARDESC input.transfer.bypass.outlimits "Rule for auto transfer on Bypass when o
 VARDESC input.bypass.switchable "Input auto transfer on Bypass when overload or out of tolerance (enabled or disabled)"
 VARDESC input.bypass.switch.on "Put the UPS in Bypass mode"
 VARDESC input.bypass.switch.off "Take the UPS out of Bypass mode"
+VARDESC input.bypass.voltage "Input bypass voltage (V)"
+VARDESC input.bypass.frequency "Input bypass frequency (Hz)"
 VARDESC input.sensitivity "Input power sensitivity"
 VARDESC input.quality "Input power quality"
 VARDESC input.current "Input current (A)"
@@ -131,6 +133,7 @@ VARDESC battery.energysave.load "Switch off UPS if on battery and load level low
 VARDESC battery.energysave.delay "Delay before switch off UPS if on battery and load level low (min)"
 VARDESC battery.energysave.realpower "Switch off UPS if on battery and load level lower (Watts)"
 VARDESC battery.charger.status "Battery charger status"
+VARDESC battery.charger.type "ABM charger type"
 
 VARDESC ambient.temperature "Ambient temperature (degrees C)"
 VARDESC ambient.temperature.alarm "Ambient temperature alarm is active"
@@ -195,6 +198,7 @@ VARDESC outlet.2.delay.shutdown "Interval to wait before shutting down this outl
 VARDESC outlet.2.delay.start "Interval to wait before restarting this outlet (seconds)"
 
 VARDESC device.part "Device Part Number"
+VARDESC device.mfr "Device Manufacturer"
 
 VARDESC server.info "Server information"
 VARDESC server.version "Server version"

--- a/data/cmdvartab
+++ b/data/cmdvartab
@@ -224,7 +224,7 @@ VARDESC driver.version "Driver version - NUT release"
 VARDESC driver.version.internal "Internal driver version"
 VARDESC driver.version.usb "USB library version"
 VARDESC driver.version.data "Version of the internal data mapping, for generic drivers"
-VARDESC driver.state "Current state in driver's lifecycle"
+VARDESC driver.state "Current state in driver's lifecycle" 
 
 # FIXME: driver.parameter and driver.flag can have many possible members
 #

--- a/data/cmdvartab
+++ b/data/cmdvartab
@@ -224,7 +224,7 @@ VARDESC driver.version "Driver version - NUT release"
 VARDESC driver.version.internal "Internal driver version"
 VARDESC driver.version.usb "USB library version"
 VARDESC driver.version.data "Version of the internal data mapping, for generic drivers"
-VARDESC driver.state "Current state in driver's lifecycle" 
+VARDESC driver.state "Current state in driver's lifecycle"
 
 # FIXME: driver.parameter and driver.flag can have many possible members
 #

--- a/data/cmdvartab
+++ b/data/cmdvartab
@@ -187,6 +187,7 @@ VARDESC outlet.1.ecocontrol "Master Outlet used to automatically power off the s
 VARDESC outlet.1.autoswitch.charge.low "Remaining battery level to power off this outlet (percent)"
 VARDESC outlet.1.delay.shutdown "Interval to wait before shutting down this outlet (seconds)"
 VARDESC outlet.1.delay.start "Interval to wait before restarting this outlet (seconds)"
+VARDESC outlet.1.designator "Outlet designator"
 VARDESC outlet.2.id "Outlet system identifier"
 VARDESC outlet.2.desc "Outlet description"
 VARDESC outlet.2.switch "Outlet switch control"
@@ -222,6 +223,7 @@ VARDESC driver.flag.allow_killpower "Safety flip-switch to allow the driver daem
 VARDESC driver.version "Driver version - NUT release"
 VARDESC driver.version.internal "Internal driver version"
 VARDESC driver.version.usb "USB library version"
+VARDESC driver.version.data "Version of the internal data mapping, for generic drivers"
 VARDESC driver.state "Current state in driver's lifecycle"
 
 # FIXME: driver.parameter and driver.flag can have many possible members

--- a/docs/nut-names.txt
+++ b/docs/nut-names.txt
@@ -320,6 +320,8 @@ input: Incoming line/power information
 								                                  | enabled
 | input.bypass.switch.on      | Put the UPS in Bypass mode        | on
 | input.bypass.switch.off     | Take the UPS out of Bypass mode   | disabled
+| input.bypass.voltage        | Input bypass voltage (V)          | 233
+| input.bypass.frequency      | Input bypass frequency (Hz)       | 50
 | input.load                  | Load on (ePDU) input (percent
                                 of full)                          | 25
 | input.realpower             | Current sum value of all (ePDU)
@@ -534,6 +536,7 @@ battery: Any battery details
                                  to "Warning" state (percent)        | 50
 | battery.charger.status       | Status of the battery charger
                                  (see the note below)                | charging
+| battery.charger.type         | ABM charger type                    | ABM
 | battery.voltage              | Battery voltage (V)                 | 24.84
 | battery.voltage.cell.max     | Maximum battery voltage seen of the
                                  Li-ion cell (V)                     | 3.44

--- a/docs/nut-names.txt
+++ b/docs/nut-names.txt
@@ -722,6 +722,7 @@ of the user manual.
 | outlet.n.ecocontrol            | Master Outlet used to
                                    automatically power off the
                                    slave outlets               | The outlet is not ECO controlled
+| outlet.n.designator            | Outlet designator           | AC OUTPUT
 | outlet.n.autoswitch.charge.low | Remaining battery level to
                                    power off this outlet
                                    (percent)                   | 80

--- a/docs/nut-names.txt
+++ b/docs/nut-names.txt
@@ -536,7 +536,7 @@ battery: Any battery details
                                  to "Warning" state (percent)        | 50
 | battery.charger.status       | Status of the battery charger
                                  (see the note below)                | charging
-| battery.charger.type         | ABM charger type                    | ABM
+| battery.charger.type         | Type of battery charger             | ABM
 | battery.voltage              | Battery voltage (V)                 | 24.84
 | battery.voltage.cell.max     | Maximum battery voltage seen of the
                                  Li-ion cell (V)                     | 3.44

--- a/docs/nut-names.txt
+++ b/docs/nut-names.txt
@@ -134,6 +134,7 @@ during a transition period. The ups.* data will then be removed.
 | device.macaddr      | Physical network address of the device     | 68:b5:99:f5:89:27
 | device.uptime       | Device uptime in seconds                   | 1782
 | device.count        | Total number of daisychained devices       | 1
+| device.usb.version  | Device USB version                         | 01.29
 |====================================================================================
 
 [NOTE]

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3263 utf-8
+personal_ws-1.1 en 3264 utf-8
 AAC
 AAS
 ABI
@@ -1786,6 +1786,7 @@ desc
 deschis
 descr
 desde
+designator
 dev
 devctl
 devd


### PR DESCRIPTION
Adding some missing description for cmdvartab and nut-names.txt.

After @desertwitch (nut plugin for Unraid developer) kindly added new future (show description form cmdvartab on hover for nut variables) asked by me, found some of them missing description. 