### PR TITLE
usbhid-ups: added support for 0x09d6:0x0001 (KSTAR) UPSes using MGE HID

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -189,6 +189,8 @@ https://github.com/networkupstools/nut/milestone/11
      would now report `battery.voltage` and `battery.voltage.nominal`. [#2380]
    * Added `ups.beeper.status` support for Masterpower MF-UPS650VA using the
      MGE HID subdriver. [#2662]
+   * Added support for `0x09D6:0x0001` devices using the MGE HID subdriver
+     assuming devices made by KSTAR (alternately using MGE vendor ID). [#2661]
    * `powercom-hid` subdriver sent UPS shutdown commands in wrong byte order,
      at least for devices currently in the field. A toggle was added to set
      the old behavior (if some devices do need it), while a fix is applied

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -687,6 +687,8 @@
 
 "Masterguard"	"ups"	"1"	"(various)"	""	"masterguard"
 
+"MasterPower"	"ups"	"3"	"MF-UPS650VA"	"USB"	"usbhid-ups"	# https://github.com/networkupstools/nut/issues/2661 - Note there are two VendorID:ProductID for KSTAR making this device
+
 "Maxxtro"	"ups"	"2"	"UPS 600 VA"	"serial port"	"blazer_ser"
 
 "Mecer"	"ups"	"2"	"ME-1000-WTU"	"USB"	"nutdrv_qx"	# http://www.comx-computers.co.za/download/mecer/ME-1000-WTU.pdf
@@ -886,6 +888,7 @@
 "Microline"	"ups"	"2"	"C-Lion Innova Combo 10K/20K (3/1)"	"USB"	"blazer_usb"
 
 "Micropower"	"ups"	"2"	"LCD 1000"	"USB"	"blazer_usb"
+#"Micropower"	"ups"	"3"	"0x09d6:0x0001"	"USB"	"usbhid-ups"	# assuming, per https://github.com/networkupstools/nut/issues/2661 and https://alioth-lists.debian.net/pipermail/nut-upsuser/2023-April/013224.html
 
 "Microsol"	"ups"	"4"	"Solis 1.0"	"1000VA"	"solis"
 "Microsol"	"ups"	"4"	"Solis 1.5"	"1500VA"	"solis"

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3269 utf-8
+personal_ws-1.1 en 3270 utf-8
 AAC
 AAS
 ABI
@@ -553,6 +553,7 @@ KOLFF
 KRT
 KRTL
 KRTS
+KSTAR
 KTTS
 Kain
 Kaminski

--- a/drivers/mge-hid.c
+++ b/drivers/mge-hid.c
@@ -50,7 +50,7 @@
 # endif
 #endif
 
-#define MGE_HID_VERSION		"MGE HID 1.51"
+#define MGE_HID_VERSION		"MGE HID 1.52"
 
 /* (prev. MGE Office Protection Systems, prev. MGE UPS SYSTEMS) */
 /* Eaton */
@@ -75,6 +75,9 @@
 
 /* IBM */
 #define IBM_VENDORID		0x04b3
+
+/* KSTAR under Berkeley Varitronics Systems ID */
+#define KSTAR_VENDORID		0x09d6
 
 #if !((defined SHUT_MODE) && SHUT_MODE)
 #include "usb-common.h"
@@ -105,6 +108,10 @@ static usb_device_id_t mge_usb_device_table[] = {
 
 	/* 6000 VA LCD 4U Rack UPS; 5396-1Kx */
 	{ USB_DEVICE(IBM_VENDORID, 0x0001), NULL },
+
+	/* MasterPower MF-UPS650VA under KSTAR vendorid (can also be under MGE)
+	 * MicroPower models were also reported */
+	{ USB_DEVICE(KSTAR_VENDORID, 0x0001), NULL },
 
 	/* Terminating entry */
 	{ 0, 0, NULL }

--- a/drivers/mge-hid.c
+++ b/drivers/mge-hid.c
@@ -2227,6 +2227,15 @@ static int mge_claim(HIDDevice_t *hd) {
 				/* Let liebert-hid grab this */
 				return 0;
 
+			case KSTAR_VENDORID:
+				if (hd->Vendor && strstr(hd->Vendor, "KSTAR")) {
+					return 1;
+				}
+
+				/* So far we only heard of KSTAR using this ID
+				 * in some models (or MGE 0x0463 originally) */
+				return 0;
+
 			default: /* Valid for Eaton */
 				/* by default, reject, unless the productid option is given */
 				if (getval("productid")) {
@@ -2249,6 +2258,15 @@ static int mge_claim(HIDDevice_t *hd) {
 				}
 
 				/* Let liebert-hid grab this */
+				return 0;
+
+			case KSTAR_VENDORID:
+				if (hd->Vendor && strstr(hd->Vendor, "KSTAR")) {
+					return 1;
+				}
+
+				/* So far we only heard of KSTAR using this ID
+				 * in some models (or MGE 0x0463 originally) */
 				return 0;
 
 			default:

--- a/scripts/upower/95-upower-hid.hwdb
+++ b/scripts/upower/95-upower-hid.hwdb
@@ -141,6 +141,11 @@ usb:v09AEp4008*
  UPOWER_BATTERY_TYPE=ups
  UPOWER_VENDOR=TrippLite
 
+# KSTAR under Berkeley Varitronics Systems ID
+usb:v09D6p0001*
+ UPOWER_BATTERY_TYPE=ups
+ UPOWER_VENDOR=KSTAR under Berkeley Varitronics Systems ID
+
 # PowerCOM
 usb:v0D9Fp0001*
 usb:v0D9Fp0004*


### PR DESCRIPTION
Closes: #2661

Note: previously same model names also manufactured by KSTAR were using MGE USB VendorID (0x0463).

Also note that per #230 some devices with this ID could use Megatec Qx protocol family instead.