### PR TITLE
Windows cross build documentation

### DIFF
--- a/drivers/cps-hid.c
+++ b/drivers/cps-hid.c
@@ -388,11 +388,16 @@ static int cps_fix_report_desc(HIDDevice_t *pDev, HIDDesc_t *pDesc_arg) {
 						"LogMin: %ld LogMax: %ld",
 						input_logmin, input_logmax);
 
-					pData->LogMin = CPS_VOLTAGE_LOGMIN;
-					pData->LogMax = CPS_VOLTAGE_LOGMAX;
-					upsdebugx(3, "Fixing Report Descriptor: "
-						"set Input Voltage LogMin = %d, LogMax = %d",
-						CPS_VOLTAGE_LOGMIN, CPS_VOLTAGE_LOGMAX);
+					/* TOTHINK: Should this be still about
+					 * the *HIGH* Voltage Transfer? Or LOW?
+					 */
+					if (hvt_logmin == input_logmin && hvt_logmax == input_logmax) {
+						pData->LogMin = CPS_VOLTAGE_LOGMIN;
+						pData->LogMax = CPS_VOLTAGE_LOGMAX;
+						upsdebugx(3, "Fixing Report Descriptor: "
+							"set Input Voltage LogMin = %d, LogMax = %d",
+							CPS_VOLTAGE_LOGMIN, CPS_VOLTAGE_LOGMAX);
+					}
 				}
 
 				retval = 1;

--- a/scripts/Windows/README.adoc
+++ b/scripts/Windows/README.adoc
@@ -177,6 +177,12 @@ NOTE: Instructions below use `sudo` to specify operations you may need to run
 with privilege elevation (assuming installation into a `PREFIX=/usr/$ARCH`);
 the majority of operations can be done (recommended) as an unprivileged user.
 
+NOTE: The instrunctions reported below can be saved as shell sctipts and execued with the following command (otherwise the change directory commands are not permanent):
+
+------
+. ./scriptname.sh
+------
+
 pthread library
 ^^^^^^^^^^^^^^^
 

--- a/scripts/Windows/README.adoc
+++ b/scripts/Windows/README.adoc
@@ -404,6 +404,10 @@ Needed for libneon.
 	:; cd "$WSDIR"
 	:; tar xzf "$DLDIR"/libxml2-v2.9.14.tar.gz
 	:; cd libxml2-v2.9.14
+	:; libtoolize
+	:; aclocal
+	:; autoheader
+	:; autoupdate
 	:; ./autogen.sh --prefix="$PREFIX" $HOST_FLAG --without-python
 	:; make
 	:; sudo make install

--- a/scripts/Windows/README.adoc
+++ b/scripts/Windows/README.adoc
@@ -279,6 +279,8 @@ libusb
 	:; cd "$WSDIR"
 	:; unzip "$DLDIR"/libusb-compat-0.1-master.zip
 	:; cd libusb-compat-0.1-master
+	:; export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig
+	:; export PATH=$PREFIX/bin/:$PATH
 	:; ./bootstrap.sh
 	:; ./configure --prefix="$PREFIX" $HOST_FLAG
 	:; make

--- a/scripts/Windows/README.adoc
+++ b/scripts/Windows/README.adoc
@@ -284,6 +284,15 @@ libusb
 	:; make
 	:; sudo make install
 
+[NOTE]
+======
+If it complains about
+`libtoolize or glibtoolize was not found! Please install libtool.`
+please edit export the bin folder under PREFIX path:
+
+	:; export PATH=$PREFIX/bin:$PATH
+
+======
 
 zlib
 ^^^^

--- a/scripts/Windows/README.adoc
+++ b/scripts/Windows/README.adoc
@@ -289,16 +289,6 @@ libusb
 [NOTE]
 ======
 If it complains about
-`libtoolize or glibtoolize was not found! Please install libtool.`
-please export the bin folder under PREFIX path:
-
-	:; export PATH=$PREFIX/bin:$PATH
-
-======
-
-[NOTE]
-======
-If it complains about
 `syntax error near unexpected toket 'LIBUSB_1_0,'
  'PKG_CHECK_MODULES(LIBUSB_1_0, libusb-1.0 >= 0.9.1)'`
 please install pkgconf:

--- a/scripts/Windows/README.adoc
+++ b/scripts/Windows/README.adoc
@@ -532,6 +532,7 @@ such context, this must be something about STDCALL and/or "extern C"...
 	:; cd "$WSDIR"
 	:; tar xzf "$DLDIR"/libgd-2.3.3.tar.gz
 	:; cd libgd-2.3.3
+	:; export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig
 	:; ./configure --prefix="$PREFIX" $HOST_FLAG \
 	    --with-png --with-freetype \
 	    --without-tiff --without-jpeg --without-xpm \

--- a/scripts/Windows/README.adoc
+++ b/scripts/Windows/README.adoc
@@ -770,11 +770,11 @@ or, depending on the build environment(s) you have prepared,
 This is also automated for common NUT CI build script, calling it like this:
 ------
 # Try to guess bitness based on ARCH or CFLAGS:
-BUILD_TYPE=cross-windows-mingw ./ci_build.sh
+BUILD_TYPE=cross-windows-mingw ./ci_build.sh --prefix=$PREFIX $HOST_FLAG
 
 # Or specifically:
-BUILD_TYPE=cross-windows-mingw-32 ./ci_build.sh
-BUILD_TYPE=cross-windows-mingw-64 ./ci_build.sh
+BUILD_TYPE=cross-windows-mingw-32 ./ci_build.sh --prefix=$PREFIX $HOST_FLAG
+BUILD_TYPE=cross-windows-mingw-64 ./ci_build.sh --prefix=$PREFIX $HOST_FLAG
 ------
 ======
 

--- a/scripts/Windows/README.adoc
+++ b/scripts/Windows/README.adoc
@@ -288,9 +288,20 @@ libusb
 ======
 If it complains about
 `libtoolize or glibtoolize was not found! Please install libtool.`
-please edit export the bin folder under PREFIX path:
+please export the bin folder under PREFIX path:
 
 	:; export PATH=$PREFIX/bin:$PATH
+
+======
+
+[NOTE]
+======
+If it complains about
+`syntax error near unexpected toket 'LIBUSB_1_0,'
+ 'PKG_CHECK_MODULES(LIBUSB_1_0, libusb-1.0 >= 0.9.1)'`
+please install pkgconf:
+
+	:; sudo apt-get install pkgconf
 
 ======
 

--- a/scripts/Windows/README.adoc
+++ b/scripts/Windows/README.adoc
@@ -177,8 +177,8 @@ NOTE: Instructions below use `sudo` to specify operations you may need to run
 with privilege elevation (assuming installation into a `PREFIX=/usr/$ARCH`);
 the majority of operations can be done (recommended) as an unprivileged user.
 
-NOTE: The instrunctions reported below can be saved as shell sctipts and execued with the following command (otherwise the change directory commands are not permanent):
-
+NOTE: The instrunctions reported below can be saved as shell sctipts and execued
+with the following command (otherwise the change directory commands are not permanent):
 ------
 . ./scriptname.sh
 ------

--- a/scripts/Windows/README.adoc
+++ b/scripts/Windows/README.adoc
@@ -449,7 +449,7 @@ and/or of the system antivirus interaction?..
 
 [NOTE]
 ======
-If the build is failing on VirtualBox VM please make sure to have installed the VirtualBox Guest Additions.
+If the build is failing on Virtual Box VM please make sure to have installed the Virtual Box Guest Additions.
 ======
 
 /////////////////////////////////////////////////////////////////////////////

--- a/scripts/Windows/README.adoc
+++ b/scripts/Windows/README.adoc
@@ -609,16 +609,14 @@ the Makefiles for current `install` target definition to run its job without
 `install-docs` part (example posted below).
 
 	#:; ( cd "$DLDIR" && git clone -b fix-mingw-cross https://github.com/jimklimov/neon neon-git )
-	:; ( cd "$DLDIR" && git clone https://github.com/notroj/neon neon-git )
-	:; ( cd "$DLDIR/neon-git" && ./autogen.sh )
 	:; cd "$WSDIR"
-	:; rm -rf neon-git ; mkdir neon-git
-	:; cd neon-git
-	:; "$DLDIR"/neon-git/configure --prefix="$PREFIX" $HOST_FLAG \
-	    --enable-shared --with-ssl=openssl
+	:; git clone https://github.com/notroj/neon
+	:; cd "$WSDIR/neon"
+	:; export PATH=$PREFIX/bin:$PATH
+	:; ./autogen.sh
+	:; ./configure --prefix="$PREFIX" $HOST_FLAG --enable-shared --with-ssl=openssl
 	:; make all docs
-	:; sudo make install \
-	   || sudo make install-lib install-headers install-config install-nls ###install-docs
+	:; sudo make install || sudo make install-lib install-headers install-config install-nls ###install-docs
 
 
 /////////////////////////////////////////////////////////////////////////////

--- a/scripts/Windows/README.adoc
+++ b/scripts/Windows/README.adoc
@@ -457,6 +457,10 @@ and/or of the system antivirus interaction?..
 	:; make
 	:; sudo make install
 
+[NOTE]
+======
+If the build is failing on VirtualBox VM please make sure to have installed the VirtualBox Guest Additions.
+======
 
 /////////////////////////////////////////////////////////////////////////////
 WIP - fontconfig not usable yet due to ICU failing to cross-build

--- a/scripts/Windows/README.adoc
+++ b/scripts/Windows/README.adoc
@@ -179,9 +179,7 @@ the majority of operations can be done (recommended) as an unprivileged user.
 
 NOTE: The instrunctions reported below can be saved as shell sctipts and execued
 with the following command (otherwise the change directory commands are not permanent):
-------
-. ./scriptname.sh
-------
+`. ./scriptname.sh`
 
 pthread library
 ^^^^^^^^^^^^^^^

--- a/scripts/Windows/README.adoc
+++ b/scripts/Windows/README.adoc
@@ -226,9 +226,12 @@ presumed inconsequential. You can try a not-"inlined" build instead.
 
 Finally, install the resulting files into locations under `PREFIX`:
 
-	:; sudo cp *.dll ${PREFIX}/pthreads/lib/
-	:; sudo cp *.a ${PREFIX}/lib/
-	:; sudo cp pthread.h sched.h semaphore.h ${PREFIX}/pthreads/include
+	:; sudo mkdir -p $PREFIX/pthreads/lib/
+	:; sudo cp *.dll $PREFIX/pthreads/lib/
+	:; sudo mkdir -p $PREFIX/lib/
+	:; sudo cp *.a $PREFIX/lib/
+	:; sudo mkdir -p $PREFIX/pthreads/include/
+	:; sudo cp pthread.h sched.h semaphore.h $PREFIX/pthreads/include
 
 
 MinGW regex library


### PR DESCRIPTION
Updated documentation for cross compilation of nut project with windows target. 

The steps have been tested on Ubuntu 22.04 virtual machine (VirtualBox) but the binaries have not been tested yet.