### PR TITLE
Fix NUT for Windows build

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -499,6 +499,12 @@ relocated into new `shutdown.default` INSTCMD definitions. [#2670]
    as a service, have a help message, pass debug verbosity to launched NUT
    programs...) and add a man page for it. [issue #2432, PR #2446]
 
+ - the `scripts/Windows/build-mingw-nut.sh` helper script was extended to
+   use `nut_build_${ARCH}` and `nut_install_${ARCH}` directories by default,
+   with the older `nut_build` and `nut_install` short names becoming just a
+   symbolic link to the latest executed build: this should help compare the
+   differences of 32/64-bit builds, without them stepping on each other's toes.
+
  - the `PyNUTClient` module should no longer rely on presence of a `telnetlib`
    module in the build or execution environment (deprecated in Python 3.11,
    removed since Python 3.13). [#2183]

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3277 utf-8
+personal_ws-1.1 en 3278 utf-8
 AAC
 AAS
 ABI
@@ -2550,6 +2550,7 @@ optiups
 oq
 os
 ostream
+other's
 otheruser
 outliers
 ovmf

--- a/m4/nut_check_libnetsnmp.m4
+++ b/m4/nut_check_libnetsnmp.m4
@@ -165,6 +165,7 @@ if test -z "${nut_have_libnetsnmp_seen}"; then
 					dnl # arguments when building "if WITH_SNMP_STATIC" recipe blocks!
 					dnl # For a practical example, see tools/nut-scanner/Makefile.am.
 					depLIBS="`echo " $depLIBS" | sed 's/ -l/ -Wl,-l/g'`"
+					LIBS="${LIBS_ORIG} ${depLIBS}"
 					AS_UNSET([ac_cv_func_init_snmp])
 					AC_CHECK_FUNCS(init_snmp, [
 						nut_have_libnetsnmp=yes

--- a/scripts/Windows/.gitignore
+++ b/scripts/Windows/.gitignore
@@ -3,5 +3,7 @@
 winevent.h
 winevent.rc
 MSG00409.bin
-/nut_build/
-/nut_install/
+/nut_build_*/
+/nut_install_*/
+/nut_build
+/nut_install

--- a/scripts/Windows/README.adoc
+++ b/scripts/Windows/README.adoc
@@ -808,13 +808,13 @@ release would fare, starting from a git checkout, use this:
 	    (cd scripts/Windows/ && SOURCEMODE=dist ./build-mingw-nut.sh all64)
 
 If everything goes fine, you will find a NUT installation tree in 'nut_install'
-sub-directory. Note the script accepts some parameters e.g. for 32/64 bit build
-targets.
+sub-directory (technically, a symbolic link to `nut_install_${ARCH}` directory).
+Note the script accepts some parameters e.g. for 32/64 bit build targets.
 
 NOTE: For other ways of building and packaging, it might make sense for
-a packaged delivery to also `make install DESTDIR=.../nut_install` from
-the sources of dependency projects built above, or at least to copy the
-built `*.dll` files from `${PREFIX}/bin` to `nut_install/bin`. For those
-dependencies that are listed above, the script does this best-effort
-activity (does not fail if some are missing, but running the programs
-can fail later).
+a packaged delivery to also `make install DESTDIR=.../nut_install_${ARCH}`
+from the sources of dependency projects built above, or at least to copy
+the built `*.dll` files from `${PREFIX}/bin` to `nut_install_${ARCH}/bin`.
+For those dependencies that are listed above, the script does this best-effort
+activity (does not fail if some are missing, but running the programs can fail
+later).

--- a/scripts/Windows/README.adoc
+++ b/scripts/Windows/README.adoc
@@ -11,11 +11,12 @@ so pull requests are welcome to tie up some loose ends (add more prerequisites,
 test and fix programs, re-enable some code just commented away by `ifdef`'s...)
 
 NOTE: It is possible to prepare a Windows machine with tools and prerequisites
-for building NUT natively, as detailed in `docs/config-prereqs.txt` and easily
-handled by NUT common `ci_build.sh` script. Most prerequisites are already
-packaged in that environment, but notably net-snmp is missing -- but can be
-built from source following this document. Possibly, the instructions below
-would converge there over time to keep it simple.
+for building NUT natively, using the MSYS2 environment, as detailed in the
+`docs/config-prereqs.txt` file, and easily handled by NUT common `ci_build.sh`
+script with default parameters. Most prerequisites are already packaged in that
+environment, but notably net-snmp is missing -- however it can be built from
+source following this document. Possibly, the instructions below would converge
+in that document over time to keep it simple.
 
 For additional reference about prerequisite preparation and further ideas for
 the NUT for Windows effort, please see detailed report in the mailing list:

--- a/scripts/Windows/README.adoc
+++ b/scripts/Windows/README.adoc
@@ -618,6 +618,21 @@ the Makefiles for current `install` target definition to run its job without
 	   || sudo make install-lib install-headers install-config install-nls ###install-docs
 
 
+cppunit
+^^^^^^^
+
+Needed for C++ unit tests (optional, and may be pointless in cross-builds
+where you can not also run the tested binaries built for another platform):
+
+	:; ( cd "$DLDIR" && wget -c http://dev-www.libreoffice.org/src/cppunit-1.15.1.tar.gz )
+	:; cd "$WSDIR"
+	:; tar xzf "$DLDIR"/cppunit-1.15.1.tar.gz
+	:; cd cppunit-1.15.1
+	:; ./configure --prefix="$PREFIX" $HOST_FLAG
+	:; make all
+	:; sudo make install
+
+
 /////////////////////////////////////////////////////////////////////////////
 // for avahi
 

--- a/scripts/Windows/build-mingw-nut.sh
+++ b/scripts/Windows/build-mingw-nut.sh
@@ -12,16 +12,6 @@ SCRIPTDIR="`cd "$SCRIPTDIR" && pwd`"
 
 DLLLDD_SOURCED=true . "${SCRIPTDIR}/dllldd.sh"
 
-# default to update source then build
-
-# These paths are somewhat related:
-[ -n "${WINDIR-}" ] || WINDIR="$(pwd)"
-[ -n "${TOP_DIR-}" ] || TOP_DIR="$WINDIR/../.."
-
-# These may be located elsewhere:
-[ -n "${BUILD_DIR-}" ] || BUILD_DIR="$WINDIR/nut_build"
-[ -n "${INSTALL_DIR-}" ] || INSTALL_DIR="$WINDIR/nut_install"
-
 # This should match the tarball and directory name,
 # if a stable version is used:
 [ -n "$VER_OPT" ] || VER_OPT=2.8.2
@@ -32,13 +22,49 @@ DEBUG=true
 # those DLLs should correspond to same architecture selection
 cmd=all32
 if [ -n "$1" ] ; then
-	cmd=$1
+	cmd="$1"
 fi
 
+if [ "$cmd" == "all64" ] || [ "$cmd" == "b64" ] || [ "$cmd" == "all32" ] || [ "$cmd" == "b32" ] ; then
+	ARCH="x86_64-w64-mingw32"
+	if [ "$cmd" == "all32" ] || [ "$cmd" == "b32" ] ; then
+		ARCH="i686-w64-mingw32"
+	fi
+else
+	echo "Usage:"
+	echo "		$0 [all64 | b64 | all32 | b32]"
+	echo "		Default: 'all32'"
+	echo "Optionally export SOURCEMODE=[stable|dist|out-of-tree]"
+	case "${cmd}" in
+		-h|--help|help) exit 0 ;;
+		*) exit 1 ;;
+	esac
+fi
+
+# These paths are somewhat related:
+[ -n "${WINDIR-}" ] || WINDIR="$(pwd)"
+[ -n "${TOP_DIR-}" ] || TOP_DIR="$WINDIR/../.."
+
+# These may be located elsewhere:
+[ -n "${BUILD_DIR-}" ] || BUILD_DIR="$WINDIR/nut_build_${ARCH}"
+[ -n "${INSTALL_DIR-}" ] || INSTALL_DIR="$WINDIR/nut_install_${ARCH}"
+
+# Convenience symlink to find the latest completed build workspace and
+# installed results; not used by the script other than updating the symlink:
+[ -n "${BUILD_DIR_SYMLINK-}" ] || BUILD_DIR_SYMLINK="$WINDIR/nut_build"
+[ -n "${INSTALL_DIR_SYMLINK-}" ] || INSTALL_DIR_SYMLINK="$WINDIR/nut_install"
+
+rm -rf "$BUILD_DIR" "$INSTALL_DIR" "$BUILD_DIR_SYMLINK" "$INSTALL_DIR_SYMLINK"
+if [ x"$BUILD_DIR" != x"$BUILD_DIR_SYMLINK" ] ; then
+	ln -fsr "$BUILD_DIR" "$BUILD_DIR_SYMLINK"
+fi
+if [ x"$INSTALL_DIR" != x"$INSTALL_DIR_SYMLINK" ] ; then
+	ln -fsr "$INSTALL_DIR" "$INSTALL_DIR_SYMLINK"
+fi
+
+CONFIGURE_SCRIPT="./configure"
 [ -n "$SOURCEMODE" ] || SOURCEMODE="out-of-tree"
 
-rm -rf "$BUILD_DIR" "$INSTALL_DIR"
-CONFIGURE_SCRIPT="./configure"
 case "$SOURCEMODE" in
 stable)
 # FIXME
@@ -57,7 +83,7 @@ dist)
 	rm -f nut-?.?.?*.tar.gz
 	[ -s Makefile ] || { ./autogen.sh && ./configure; }
 	make dist
-	SRC_ARCHIVE=$(ls -1 nut-?.?.?*.tar.gz | sort -n | tail -1)
+	SRC_ARCHIVE="$(ls -1 nut-?.?.?*.tar.gz | sort -n | tail -1)"
 	cd scripts/Windows
 	tar -xzf "../../$SRC_ARCHIVE"
 	mv nut-?.?.?* "$BUILD_DIR"
@@ -76,18 +102,13 @@ out-of-tree)
 	;;
 esac
 
-cd "$BUILD_DIR" || exit
-
 if [ -z "$INSTALL_WIN_BUNDLE" ]; then
 	echo "NOTE: You might want to export INSTALL_WIN_BUNDLE=true to use main NUT Makefile"
 	echo "recipe for DLL co-bundling (default: false to use logic maintained in $0"
 fi >&2
 
-if [ "$cmd" == "all64" ] || [ "$cmd" == "b64" ] || [ "$cmd" == "all32" ] || [ "$cmd" == "b32" ] ; then
-	ARCH="x86_64-w64-mingw32"
-	if [ "$cmd" == "all32" ] || [ "$cmd" == "b32" ] ; then
-		ARCH="i686-w64-mingw32"
-	fi
+do_build_mingw_nut() {
+	cd "$BUILD_DIR" || exit
 
 	HOST_FLAG="--host=$ARCH"
 	# --build needs to be specified, beside of --host, to avoid Warning
@@ -197,9 +218,6 @@ if [ "$cmd" == "all64" ] || [ "$cmd" == "b64" ] || [ "$cmd" == "all32" ] || [ "$
 
 	echo "$0: install phase complete ($?)" >&2
 	cd ..
-else
-	echo "Usage:"
-	echo "		$0 [all64 | b64 | all32 | b32]"
-	echo "		Default: 'all32'"
-	echo "Optionally export SOURCEMODE=[stable|dist|out-of-tree]"
-fi
+}
+
+do_build_mingw_nut


### PR DESCRIPTION
* Added docs on custom-building cppunit (questionable usefulness though specifically for Windows cross-builds from Linux, but can help other platforms where it is lacking from packaging)
* Found that earlier work broke discovery of libnetsnmp (where static variant was needed) with mingw
* Extended build and install areas to be named with their `$ARCH` in mind, so 32/64-bit builds are easier to compare during investigations