### PR TITLE
Report full path to driver socket (when we listen or fail to connect)

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -137,6 +137,12 @@ https://github.com/networkupstools/nut/milestone/11
    prevent the tool name and NUT version banner from being unilaterally
    printed out when NUT programs start. [issues #1789 vs. #316; #2573]
 
+ - Drivers would now report the socket they are listening on, and server
+   would report full path to the driver socket it tries to connect to.
+   A new `NUT_QUIET_INIT_LISTENER` envvar (presence or "true" value) can
+   prevent the socket name from being unilaterally printed out when NUT
+   drivers start. [#2764]
+
  - The `upsdrvctl` should now warn if executed on systems where NUT was
    built with support for service management frameworks like systemd or SMF,
    so nut-driver service units prepared by `nut-driver-enumerator` would

--- a/clients/cgilib.c
+++ b/clients/cgilib.c
@@ -162,7 +162,7 @@ static void cgilib_err(const char *errmsg)
 
 int checkhost(const char *host, char **desc)
 {
-	char	fn[SMALLBUF];
+	char	fn[NUT_PATH_MAX];
 	PCONF_CTX_t	ctx;
 
 	if (!host)

--- a/clients/upssched.c
+++ b/clients/upssched.c
@@ -1439,7 +1439,7 @@ static void upssched_err(const char *errmsg)
 
 static void checkconf(void)
 {
-	char	fn[SMALLBUF];
+	char	fn[NUT_PATH_MAX];
 	PCONF_CTX_t	ctx;
 	int	numerrors = 0;
 

--- a/clients/upssched.c
+++ b/clients/upssched.c
@@ -970,14 +970,14 @@ static void start_daemon(TYPE_FD lockfd)
 	DWORD timeout_ms;
 	HANDLE rfds[32];
 
-	char module[MAX_PATH];
+	char module[NUT_PATH_MAX];
 	STARTUPINFO sinfo;
 	PROCESS_INFORMATION pinfo;
-	if( !GetModuleFileName(NULL,module,MAX_PATH) ) {
+	if (!GetModuleFileName(NULL, module, NUT_PATH_MAX)) {
 		fatal_with_errno(EXIT_FAILURE, "Can't retrieve module name");
 	}
 	memset(&sinfo,0,sizeof(sinfo));
-	if(!CreateProcess(module, NULL, NULL,NULL,FALSE,0,NULL,NULL,&sinfo,&pinfo)) {
+	if (!CreateProcess(module, NULL, NULL, NULL, FALSE, 0, NULL, NULL, &sinfo, &pinfo)) {
 		fatal_with_errno(EXIT_FAILURE, "Can't create child process");
 	}
 	pipefd = open_sock();

--- a/clients/upsset.c
+++ b/clients/upsset.c
@@ -194,7 +194,7 @@ static void upsset_hosts_err(const char *errmsg)
 /* this defaults to wherever we are now, ups and function-wise */
 static void do_pickups(const char *currfunc)
 {
-	char	hostfn[SMALLBUF];
+	char	hostfn[NUT_PATH_MAX];
 	PCONF_CTX_t	ctx;
 
 	snprintf(hostfn, sizeof(hostfn), "%s/hosts.conf", confpath());
@@ -1020,7 +1020,7 @@ static void upsset_conf_err(const char *errmsg)
 /* see if the user has confirmed their cgi directory's secure state */
 static void check_conf(void)
 {
-	char	fn[SMALLBUF];
+	char	fn[NUT_PATH_MAX];
 	PCONF_CTX_t	ctx;
 
 	snprintf(fn, sizeof(fn), "%s/upsset.conf", confpath());

--- a/clients/upsstats.c
+++ b/clients/upsstats.c
@@ -846,7 +846,7 @@ static void parse_line(const char *buf)
 
 static void display_template(const char *tfn)
 {
-	char	fn[SMALLBUF], buf[LARGEBUF];
+	char	fn[NUT_PATH_MAX], buf[LARGEBUF];
 
 	snprintf(fn, sizeof(fn), "%s/%s", confpath(), tfn);
 
@@ -965,7 +965,7 @@ static void upsstats_hosts_err(const char *errmsg)
 
 static void load_hosts_conf(void)
 {
-	char	fn[SMALLBUF];
+	char	fn[NUT_PATH_MAX];
 	PCONF_CTX_t	ctx;
 
 	snprintf(fn, sizeof(fn), "%s/hosts.conf", CONFPATH);

--- a/common/common.c
+++ b/common/common.c
@@ -2061,7 +2061,7 @@ int snprintfcat(char *dst, size_t size, const char *fmt, ...)
 #ifndef WIN32
 int sendsignal(const char *progname, int sig, int check_current_progname)
 {
-	char	fn[SMALLBUF];
+	char	fn[NUT_PATH_MAX];
 
 	snprintf(fn, sizeof(fn), "%s/%s.pid", rootpidpath(), progname);
 
@@ -3880,12 +3880,12 @@ static char * get_libname_in_dir(const char* base_libname, size_t base_libname_l
 	DIR *dp;
 	struct dirent *dirp;
 	char *libname_path = NULL, *libname_alias = NULL;
-	char current_test_path[LARGEBUF];
+	char current_test_path[NUT_PATH_MAX];
 
 	upsdebugx(3, "%s('%s', %" PRIuSIZE ", '%s', %i): Entering method...",
 		__func__, base_libname, base_libname_length, dirname, index);
 
-	memset(current_test_path, 0, LARGEBUF);
+	memset(current_test_path, 0, sizeof(current_test_path));
 
 	if ((dp = opendir(dirname)) == NULL) {
 		if (index >= 0) {
@@ -3928,7 +3928,7 @@ static char * get_libname_in_dir(const char* base_libname, size_t base_libname_l
 				continue;
 			}
 
-			snprintf(current_test_path, LARGEBUF, "%s/%s", dirname, dirp->d_name);
+			snprintf(current_test_path, sizeof(current_test_path), "%s/%s", dirname, dirp->d_name);
 #if HAVE_DECL_REALPATH
 			libname_path = realpath(current_test_path, NULL);
 #else

--- a/common/common.c
+++ b/common/common.c
@@ -1661,7 +1661,7 @@ finish:
    depending on the .exe path */
 char * getfullpath(char * relative_path)
 {
-	char buf[MAX_PATH];
+	char buf[NUT_PATH_MAX];
 	if ( GetModuleFileName(NULL, buf, sizeof(buf)) == 0 ) {
 		return NULL;
 	}
@@ -1682,7 +1682,7 @@ char * getfullpath(char * relative_path)
 void writepid(const char *name)
 {
 #ifndef WIN32
-	char	fn[SMALLBUF];
+	char	fn[NUT_PATH_MAX];
 	FILE	*pidf;
 	mode_t	mask;
 

--- a/common/common.c
+++ b/common/common.c
@@ -1012,11 +1012,7 @@ char * getprocname(pid_t pid)
 	 */
 	char	*procname = NULL;
 	size_t	procnamelen = 0;
-#ifdef UNIX_PATH_MAX
-	char	pathname[UNIX_PATH_MAX];
-#else
-	char	pathname[PATH_MAX];
-#endif
+	char	pathname[NUT_PATH_MAX];
 	struct stat	st;
 
 #ifdef WIN32
@@ -1473,11 +1469,7 @@ int compareprocname(pid_t pid, const char *procname, const char *progname)
 	size_t	procbasenamelen = 0, progbasenamelen = 0;
 	/* Track where the last dot is in the basename; 0 means none */
 	size_t	procbasenamedot = 0, progbasenamedot = 0;
-#ifdef UNIX_PATH_MAX
-	char	procbasename[UNIX_PATH_MAX], progbasename[UNIX_PATH_MAX];
-#else
-	char	procbasename[PATH_MAX], progbasename[PATH_MAX];
-#endif
+	char	procbasename[NUT_PATH_MAX], progbasename[NUT_PATH_MAX];
 
 	if (checkprocname_ignored(__func__)) {
 		ret = -3;
@@ -3088,11 +3080,7 @@ const char * rootpidpath(void)
 /* Die with a standard message if socket filename is too long */
 void check_unix_socket_filename(const char *fn) {
 	size_t len = strlen(fn);
-#ifdef UNIX_PATH_MAX
-	size_t max = UNIX_PATH_MAX;
-#else
-	size_t max = PATH_MAX;
-#endif
+	size_t max = NUT_PATH_MAX;
 #ifndef WIN32
 	struct sockaddr_un	ssaddr;
 	max = sizeof(ssaddr.sun_path);
@@ -3108,6 +3096,8 @@ void check_unix_socket_filename(const char *fn) {
 	 * varying 104-108 bytes (UNIX_PATH_MAX)
 	 * as opposed to PATH_MAX or MAXPATHLEN
 	 * typically of a kilobyte range.
+	 * We define NUT_PATH_MAX as the greatest
+	 * value of them all.
 	 */
 	fatalx(EXIT_FAILURE,
 		"Can't create a unix domain socket: pathname '%s' "

--- a/common/nutstream.cpp
+++ b/common/nutstream.cpp
@@ -242,7 +242,7 @@ static const char* getTmpDirPath() {
 
 #ifdef WIN32
 	/* Suggestions from https://sourceforge.net/p/mingw/bugs/666/ */
-	static char pathbuf[MAX_PATH];
+	static char pathbuf[NUT_PATH_MAX];
 	int i;
 #endif
 
@@ -255,7 +255,7 @@ static const char* getTmpDirPath() {
 
 #ifdef WIN32
 	i = GetTempPathA(sizeof(pathbuf), pathbuf);
-	if ((i > 0) && (i < MAX_PATH) && checkExistsWritableDir(pathbuf))
+	if ((i > 0) && (i < NUT_PATH_MAX) && checkExistsWritableDir(pathbuf))
 		return (const char *)pathbuf;
 #endif
 
@@ -328,7 +328,7 @@ NutFile::NutFile(anonymous_t):
 	/* Suggestions from https://sourceforge.net/p/mingw/bugs/666/ because
 	 * msvcrt tmpfile() uses C: root dir and lacks permissions to actually
 	 * use it, and mingw tends to call that OS method so far */
-	char filename[MAX_PATH];
+	char filename[NUT_PATH_MAX];
 	memset(filename, 0, sizeof(filename));
 
 	GetTempFileNameA(m_tmp_dir.c_str(), "nuttemp", 0, filename);

--- a/common/upsconf.c
+++ b/common/upsconf.c
@@ -75,7 +75,7 @@ static void upsconf_err(const char *errmsg)
  */
 int read_upsconf(int fatal_errors)
 {
-	char	fn[SMALLBUF];
+	char	fn[NUT_PATH_MAX];
 	PCONF_CTX_t	ctx;
 
 	ups_section = NULL;

--- a/common/wincompat.c
+++ b/common/wincompat.c
@@ -498,11 +498,11 @@ static const char	*named_pipe_name=NULL;
 void pipe_create(const char * pipe_name)
 {
 	BOOL ret;
-	char pipe_full_name[SMALLBUF];
+	char pipe_full_name[NUT_PATH_MAX];
 
 	/* save pipe name for further use in pipe_connect */
-	if( pipe_name == NULL ) {
-		if( named_pipe_name == NULL ) {
+	if (pipe_name == NULL) {
+		if (named_pipe_name == NULL) {
 			return;
 		}
 	}

--- a/conf/nut.conf.sample
+++ b/conf/nut.conf.sample
@@ -159,3 +159,7 @@ MODE=none
 # be helpful in shell profiles or scripts which process NUT tool outputs.
 #NUT_QUIET_INIT_BANNER=true
 #export NUT_QUIET_INIT_BANNER
+
+# Optionally suppress reporting of sockets the driver programs listen at.
+#NUT_QUIET_INIT_LISTENER=true
+#export NUT_QUIET_INIT_LISTENER

--- a/configure.ac
+++ b/configure.ac
@@ -210,6 +210,21 @@ CFLAGS=${CFLAGS-"-O"}
 dnl # Not so far a legacy, added for consistency in 2024 :)
 CXXFLAGS=${CXXFLAGS-"-O"}
 
+dnl Check for various integer types
+AC_TYPE_SSIZE_T
+AC_TYPE_INTMAX_T
+AC_TYPE_INT8_T
+AC_TYPE_INT16_T
+AC_TYPE_INT32_T
+AC_TYPE_INT64_T
+
+AC_TYPE_SIZE_T
+AC_TYPE_UINTMAX_T
+AC_TYPE_UINT8_T
+AC_TYPE_UINT16_T
+AC_TYPE_UINT32_T
+AC_TYPE_UINT64_T
+
 dnl +-------------------------------------------------------------------
 
 dnl Use "./configure --enable-maintainer-mode" to keep Makefile.in and Makefile

--- a/drivers/clone-outlet.c
+++ b/drivers/clone-outlet.c
@@ -253,7 +253,7 @@ static TYPE_FD sstate_connect(void)
 
 	/* continued below... */
 #else /* WIN32 */
-	char		pipename[SMALLBUF];
+	char		pipename[NUT_PATH_MAX];
 	BOOL		result = FALSE;
 
 	snprintf(pipename, sizeof(pipename), "\\\\.\\pipe\\%s/%s", dflt_statepath(), device_path);

--- a/drivers/clone.c
+++ b/drivers/clone.c
@@ -268,7 +268,7 @@ static TYPE_FD sstate_connect(void)
 
 	/* continued below... */
 #else /* WIN32 */
-	char		pipename[SMALLBUF];
+	char		pipename[NUT_PATH_MAX];
 	BOOL		result = FALSE;
 
 	snprintf(pipename, sizeof(pipename), "\\\\.\\pipe\\%s/%s", dflt_statepath(), device_path);

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -166,7 +166,8 @@ static TYPE_FD sock_open(const char *fn)
 		fatal_with_errno(EXIT_FAILURE, "listen(%d, %d) failed", fd, DS_LISTEN_BACKLOG);
 	}
 
-	upslogx(LOG_INFO, "Listening on socket %s", sockfn);
+	if (!getenv("NUT_QUIET_INIT_LISTENER"))
+		upslogx(LOG_INFO, "Listening on socket %s", sockfn);
 
 #else /* WIN32 */
 
@@ -201,7 +202,8 @@ static TYPE_FD sock_open(const char *fn)
 	/* Wait for a connection */
 	ConnectNamedPipe(fd, &connect_overlapped);
 
-	upslogx(LOG_INFO, "Listening on named pipe %s", fn);
+	if (!getenv("NUT_QUIET_INIT_LISTENER"))
+		upslogx(LOG_INFO, "Listening on named pipe %s", fn);
 
 #endif
 

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -166,6 +166,8 @@ static TYPE_FD sock_open(const char *fn)
 		fatal_with_errno(EXIT_FAILURE, "listen(%d, %d) failed", fd, DS_LISTEN_BACKLOG);
 	}
 
+	upslogx(LOG_INFO, "Listening on socket %s", sockfn);
+
 #else /* WIN32 */
 
 	fd = CreateNamedPipe(
@@ -198,6 +200,9 @@ static TYPE_FD sock_open(const char *fn)
 
 	/* Wait for a connection */
 	ConnectNamedPipe(fd,&connect_overlapped);
+
+	upslogx(LOG_INFO, "Listening on named pipe %s", fn);
+
 #endif
 
 	return fd;

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -189,17 +189,17 @@ static TYPE_FD sock_open(const char *fn)
 	}
 
 	/* Prepare an async wait on a connection on the pipe */
-	memset(&connect_overlapped,0,sizeof(connect_overlapped));
+	memset(&connect_overlapped, 0, sizeof(connect_overlapped));
 	connect_overlapped.hEvent = CreateEvent(NULL, /*Security*/
 			FALSE, /* auto-reset*/
 			FALSE, /* inital state = non signaled*/
 			NULL /* no name*/);
-	if(connect_overlapped.hEvent == NULL ) {
+	if (connect_overlapped.hEvent == NULL) {
 		fatal_with_errno(EXIT_FAILURE, "Can't create event");
 	}
 
 	/* Wait for a connection */
-	ConnectNamedPipe(fd,&connect_overlapped);
+	ConnectNamedPipe(fd, &connect_overlapped);
 
 	upslogx(LOG_INFO, "Listening on named pipe %s", fn);
 
@@ -215,7 +215,7 @@ static void sock_disconnect(conn_t *conn)
 	close(conn->fd);
 #else
 	/* FIXME not sure if this is the right way to close a connection */
-	if( conn->read_overlapped.hEvent != INVALID_HANDLE_VALUE) {
+	if (conn->read_overlapped.hEvent != INVALID_HANDLE_VALUE) {
 		CloseHandle(conn->read_overlapped.hEvent);
 		conn->read_overlapped.hEvent = INVALID_HANDLE_VALUE;
 	}

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -1081,7 +1081,7 @@ static void sock_close(void)
 
 char * dstate_init(const char *prog, const char *devname)
 {
-	char	sockname[SMALLBUF];
+	char	sockname[NUT_PATH_MAX];
 
 #ifndef WIN32
 	/* do this here for now */

--- a/drivers/dummy-ups.c
+++ b/drivers/dummy-ups.c
@@ -280,7 +280,7 @@ void upsdrv_updateinfo(void)
 			/* less stress on the sys */
 			if (ctx == NULL && next_update == -1) {
 				struct stat	fs;
-				char fn[SMALLBUF];
+				char fn[NUT_PATH_MAX];
 
 				prepare_filepath(fn, sizeof(fn));
 
@@ -446,7 +446,7 @@ void upsdrv_initups(void)
 	}
 	else
 	{
-		char fn[SMALLBUF];
+		char fn[NUT_PATH_MAX];
 		mode = MODE_NONE;
 
 		if (val) {
@@ -747,7 +747,7 @@ static void upsconf_err(const char *errmsg)
  */
 static int parse_data_file(TYPE_FD arg_upsfd)
 {
-	char	fn[SMALLBUF];
+	char	fn[NUT_PATH_MAX];
 	char	*ptr, var_value[MAX_STRING_SIZE];
 	size_t	value_args = 0, counter;
 	time_t	now;

--- a/drivers/hwmon_ina219.c
+++ b/drivers/hwmon_ina219.c
@@ -50,7 +50,7 @@ upsdrv_info_t upsdrv_info = {
 /**
  * @brief Path usually pointing to /sys/class/hwmon/hwmonX.
  */
-static char ina219_base_path[PATH_MAX];
+static char ina219_base_path[NUT_PATH_MAX];
 
 /**
  * @brief Threshold for detection of LB status.
@@ -128,7 +128,7 @@ static int file_read_number(const char *path, int *value)
 
 static int detect_ina219(const char *ina219_dir)
 {
-	char namepath[PATH_MAX];
+	char namepath[NUT_PATH_MAX];
 
 	upsdebugx(3, "checking %s", ina219_dir);
 
@@ -166,7 +166,7 @@ static int scan_hwmon_ina219(const char *sysfs_hwmon_dir)
 	}
 
 	while ((entry = readdir(sysfs)) != NULL) {
-		char hwmon_dir[PATH_MAX];
+		char hwmon_dir[NUT_PATH_MAX];
 
 		if (entry->d_type != DT_DIR && entry->d_type != DT_LNK) {
 			upsdebugx(3, "path %s/%s is not directory/symlink", sysfs_hwmon_dir,
@@ -204,10 +204,10 @@ static int update_intvar(
 	const char *name,
 	int *value)
 {
-	char path[PATH_MAX];
+	char path[NUT_PATH_MAX];
 	int ret;
 
-	if (snprintf(path, sizeof(path), "%s/%s", base_path, name) >= PATH_MAX) {
+	if (snprintf(path, sizeof(path), "%s/%s", base_path, name) >= NUT_PATH_MAX) {
 		errno = ENAMETOOLONG;
 		upslog_with_errno(LOG_ERR, "snprintf(%s/%s) has failed", base_path, name);
 		return -ENAMETOOLONG;

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -2007,7 +2007,7 @@ int main(int argc, char **argv)
 
 	const char	* drv_name = NULL;
 	char	* dot = NULL;
-	char	name[SMALLBUF];
+	char	name[NUT_PATH_MAX];
 #endif
 
 	const char optstring[] = "+a:s:kDFBd:hx:Lqr:u:g:Vi:c:"
@@ -2595,7 +2595,7 @@ int main(int argc, char **argv)
 	 * deliberately.
 	 */
 	if (cmd || foreground == 0 || foreground == 2 || do_forceshutdown) {
-		char	pidfnbuf[SMALLBUF];
+		char	pidfnbuf[NUT_PATH_MAX];
 
 		snprintf(pidfnbuf, sizeof(pidfnbuf), "%s/%s-%s.pid", altpidpath(), progname, upsname);
 
@@ -3002,7 +3002,7 @@ sockname_ownership_finished:
 		 */
 		case 2:
 			if (!pidfn) {
-				char	pidfnbuf[SMALLBUF];
+				char	pidfnbuf[NUT_PATH_MAX];
 				snprintf(pidfnbuf, sizeof(pidfnbuf), "%s/%s-%s.pid", altpidpath(), progname, upsname);
 				pidfn = xstrdup(pidfnbuf);
 			}

--- a/drivers/nhs_ser.c
+++ b/drivers/nhs_ser.c
@@ -224,7 +224,7 @@ static unsigned int	max_checktime = 6000000;	/* max wait time: 6 seconds */
 static unsigned int	send_extended = 0;
 static int		bwritten = 0;
 static unsigned char	datapacket[DATAPACKETSIZE];
-static char		porta[PATH_MAX] = DEFAULTPORT;
+static char		porta[NUT_PATH_MAX] = DEFAULTPORT;
 static int		baudrate = DEFAULTBAUD;
 static float		minpower = 0;
 static float		maxpower = 0;

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -4181,7 +4181,7 @@ static void mibconf_err(const char *errmsg)
 /* load *mib.conf into an snmp_info_t structure */
 void read_mibconf(char *mib)
 {
-	char	fn[SMALLBUF];
+	char	fn[NUT_PATH_MAX];
 	PCONF_CTX_t	ctx;
 	int	numerrors = 0;
 

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -194,7 +194,7 @@ static void signal_driver_cmd(const ups_t *ups,
 /* TODO: implement WIN32: https://github.com/networkupstools/nut/issues/1916
  * Currently the codepath is not implemented below
  */
-	char	pidfn[SMALLBUF];
+	char	pidfn[NUT_PATH_MAX];
 #endif
 	int	ret;
 
@@ -338,7 +338,7 @@ static void signal_driver(const ups_t *ups) {
 /* handle sending the signal */
 static void stop_driver(const ups_t *ups)
 {
-	char	pidfn[SMALLBUF];
+	char	pidfn[NUT_PATH_MAX];
 	int	ret, i;
 
 	upsdebugx(1, "Stopping UPS: %s", ups->upsname);
@@ -819,7 +819,7 @@ static void status_driver(const ups_t *ups)
 	 */
 	static int	headerShown = 0;
 #ifndef WIN32
-	char	pidfn[SMALLBUF];
+	char	pidfn[NUT_PATH_MAX];
 	int	cmdret = -1;
 #endif
 	char	bufPid[LARGEBUF], *pidStrFromSocket = NULL,
@@ -1023,7 +1023,7 @@ static void status_driver(const ups_t *ups)
 static void start_driver(const ups_t *ups)
 {
 	char	*argv[10];
-	char	dfn[SMALLBUF], dbg[SMALLBUF];
+	char	dfn[NUT_PATH_MAX], dbg[SMALLBUF];
 	int	ret, arg = 0;
 	int	initial_exec_error = exec_error, initial_exec_timeout = exec_timeout, drv_maxretry = maxretry;
 	struct stat	fs;
@@ -1248,7 +1248,7 @@ static void help(const char *arg_progname)
 static void shutdown_driver(const ups_t *ups)
 {
 	char	*argv[9];
-	char	dfn[SMALLBUF];
+	char	dfn[NUT_PATH_MAX];
 	int	arg = 0;
 
 	upsdebugx(1, "Shutdown UPS: %s", ups->upsname);

--- a/drivers/upsdrvquery.c
+++ b/drivers/upsdrvquery.c
@@ -158,7 +158,7 @@ udq_pipe_conn_t *upsdrvquery_connect(const char *sockfn) {
 }
 
 udq_pipe_conn_t *upsdrvquery_connect_drvname_upsname(const char *drvname, const char *upsname) {
-	char	sockname[SMALLBUF];
+	char	sockname[NUT_PATH_MAX];
 #ifndef WIN32
 	struct stat     fs;
 	snprintf(sockname, sizeof(sockname), "%s/%s-%s",

--- a/drivers/upsdrvquery.h
+++ b/drivers/upsdrvquery.h
@@ -32,7 +32,7 @@ typedef struct udq_pipe_conn_s {
 	int		newread;	/* Set to 1 to start a new ReadFile, forget old buf */
 #endif	/* WIN32 */
 	char		buf[LARGEBUF];
-	char		sockfn[LARGEBUF];
+	char		sockfn[NUT_PATH_MAX];
 } udq_pipe_conn_t;
 
 udq_pipe_conn_t *upsdrvquery_connect(const char *sockfn);

--- a/include/common.h
+++ b/include/common.h
@@ -544,6 +544,25 @@ char * get_libname(const char* base_libname);
 /** @brief (Minimum) Size that a string must have to hold a UUID4 (i.e. UUID4 length + the terminating null character). */
 #define UUID4_LEN	37
 
+#define NUT_PATH_MAX	SMALLBUF
+#if (defined(PATH_MAX)) && PATH_MAX > NUT_PATH_MAX
+# undef NUT_PATH_MAX
+# define NUT_PATH_MAX	PATH_MAX
+#endif
+#if (defined(MAX_PATH)) && MAX_PATH > NUT_PATH_MAX
+/* PATH_MAX is the POSIX equivalent for Microsoft's MAX_PATH */
+# undef NUT_PATH_MAX
+# define NUT_PATH_MAX	MAX_PATH
+#endif
+#if (defined(UNIX_PATH_MAX)) && UNIX_PATH_MAX > NUT_PATH_MAX
+# undef NUT_PATH_MAX
+# define NUT_PATH_MAX	UNIX_PATH_MAX
+#endif
+#if (defined(MAXPATHLEN)) && MAXPATHLEN > NUT_PATH_MAX
+# undef NUT_PATH_MAX
+# define NUT_PATH_MAX	MAXPATHLEN
+#endif
+
 /* Provide declarations for getopt() global variables */
 
 #ifdef NEED_GETOPT_H

--- a/include/wincompat.h
+++ b/include/wincompat.h
@@ -350,11 +350,4 @@ speed_t cfgetospeed(const struct termios *t);
 #define TIOCM_RI	TIOCM_RNG /* at least that's the definition in Linux */
 #define TIOCM_CD	MS_RLSD_ON /*0x0080*/
 
-#if !defined(PATH_MAX) && defined(MAX_PATH)
-/* PATH_MAX is the POSIX equivalent for Microsoft's MAX_PATH
- * both should be defined in (mingw) limits.h
- */
-# define PATH_MAX MAX_PATH
-#endif
-
 #endif /* NUT_WINCOMPAT_H */

--- a/scripts/Windows/wininit.c
+++ b/scripts/Windows/wininit.c
@@ -145,7 +145,7 @@ static const char * makearg_debug(void)
 /* return PID of created process or 0 on failure */
 static DWORD run_drivers(void)
 {
-	char command[MAX_PATH];
+	char command[NUT_PATH_MAX];
 	char *path;
 
 	path = getfullpath(PATH_BIN);
@@ -162,7 +162,7 @@ static DWORD run_drivers(void)
 /* return PID of created process or 0 on failure */
 static DWORD stop_drivers(void)
 {
-	char command[MAX_PATH];
+	char command[NUT_PATH_MAX];
 	char *path;
 
 	path = getfullpath(PATH_BIN);
@@ -179,7 +179,7 @@ static DWORD stop_drivers(void)
 /* return PID of created process or 0 on failure */
 static void run_upsd(void)
 {
-	char command[MAX_PATH];
+	char command[NUT_PATH_MAX];
 	char *path;
 
 	path = getfullpath(PATH_SBIN);
@@ -201,7 +201,7 @@ static void stop_upsd(void)
 /* return PID of created process or 0 on failure */
 static void run_upsmon(void)
 {
-	char command[MAX_PATH];
+	char command[NUT_PATH_MAX];
 	char *path;
 
 	path = getfullpath(PATH_SBIN);
@@ -223,7 +223,7 @@ static void stop_upsmon(void)
 /* Return 0 if powerdown flag is set */
 static DWORD test_powerdownflag(void)
 {
-	char command[MAX_PATH];
+	char command[NUT_PATH_MAX];
 	char *path;
 	STARTUPINFO StartupInfo;
 	PROCESS_INFORMATION ProcessInformation;
@@ -279,7 +279,7 @@ static DWORD test_powerdownflag(void)
 
 static DWORD shutdown_ups(void)
 {
-	char command[MAX_PATH];
+	char command[NUT_PATH_MAX];
 	char *path;
 
 	path = getfullpath(PATH_BIN);
@@ -373,9 +373,9 @@ static int SvcInstall(const char * SvcName, const char * args)
 {
 	SC_HANDLE SCManager;
 	SC_HANDLE Service;
-	TCHAR Path[MAX_PATH];
+	TCHAR Path[NUT_PATH_MAX];
 
-	if (!GetModuleFileName(NULL, Path, MAX_PATH)) {
+	if (!GetModuleFileName(NULL, Path, NUT_PATH_MAX)) {
 		printf("Cannot install service (%d)\n", (int)GetLastError());
 		return EXIT_FAILURE;
 	}

--- a/scripts/Windows/wininit.c
+++ b/scripts/Windows/wininit.c
@@ -296,10 +296,10 @@ static DWORD shutdown_ups(void)
 /* return 0 on failure */
 static int parse_nutconf(BOOL start_flag)
 {
-	char	fn[SMALLBUF];
+	char	fn[NUT_PATH_MAX];
 	FILE	*nutf;
 	char	buf[SMALLBUF];
-	char	fullname[SMALLBUF];
+	char	fullname[NUT_PATH_MAX];
 
 	snprintf(fn, sizeof(fn), "%s/nut.conf", confpath());
 

--- a/server/conf.c
+++ b/server/conf.c
@@ -357,7 +357,7 @@ static void upsd_conf_err(const char *errmsg)
 
 void load_upsdconf(int reloading)
 {
-	char	fn[SMALLBUF];
+	char	fn[NUT_PATH_MAX];
 	PCONF_CTX_t	ctx;
 	int	numerrors = 0;
 
@@ -497,7 +497,7 @@ void do_upsconf_args(char *upsname, char *var, char *val)
 void upsconf_add(int reloading)
 {
 	ups_t	*tmp = upstable, *next;
-	char	statefn[SMALLBUF];
+	char	statefn[NUT_PATH_MAX];
 
 	if (!tmp) {
 		upslogx(LOG_WARNING, "Warning: no UPS definitions in ups.conf");
@@ -599,7 +599,7 @@ static void delete_ups(upstype_t *target)
 /* see if we can open a file */
 static int check_file(const char *fn)
 {
-	char	chkfn[SMALLBUF];
+	char	chkfn[NUT_PATH_MAX];
 	FILE	*f;
 
 	snprintf(chkfn, sizeof(chkfn), "%s/%s", confpath(), fn);

--- a/server/desc.c
+++ b/server/desc.c
@@ -95,7 +95,7 @@ static void desc_file_err(const char *errmsg)
 
 void desc_load(void)
 {
-	char	fn[SMALLBUF];
+	char	fn[NUT_PATH_MAX];
 	PCONF_CTX_t	ctx;
 
 	snprintf(fn, sizeof(fn), "%s/cmdvartab", datapath);

--- a/server/pipedebug.c
+++ b/server/pipedebug.c
@@ -40,7 +40,7 @@ static void pipe_arg(int numarg, char **arg)
 static HANDLE pipe_connect(const char *pipefn)
 {
 	HANDLE	fd;
-	char	pipename[SMALLBUF];
+	char	pipename[NUT_PATH_MAX];
 	BOOL	result = FALSE;
 
 	snprintf(pipename, sizeof(pipename), "\\\\.\\pipe\\%s", pipefn);

--- a/server/sstate.c
+++ b/server/sstate.c
@@ -224,7 +224,7 @@ TYPE_FD sstate_connect(upstype_t *ups)
 			upsdebugx(2, "%s: failed to connect() UNIX socket %s (%s)",
 				__func__, NUT_STRARG(ups->fn), sa.sun_path);
 		} else {
-			char	cwd[PATH_MAX+1];
+			char	cwd[NUT_PATH_MAX+1];
 			upsdebugx(2, "%s: failed to connect() UNIX socket %s (%s/%s)",
 				__func__, NUT_STRARG(ups->fn),
 				getcwd(cwd, sizeof(cwd)), sa.sun_path);
@@ -241,7 +241,7 @@ TYPE_FD sstate_connect(upstype_t *ups)
 			upslog_with_errno(LOG_ERR, "Can't connect to UPS [%s] (%s)",
 				ups->name, ups->fn);
 		} else {
-			char	cwd[PATH_MAX+1];
+			char	cwd[NUT_PATH_MAX+1];
 			upslog_with_errno(LOG_ERR, "Can't connect to UPS [%s] (%s/%s)",
 				ups->name, getcwd(cwd, sizeof(cwd)), ups->fn);
 		}

--- a/server/sstate.c
+++ b/server/sstate.c
@@ -275,7 +275,7 @@ TYPE_FD sstate_connect(upstype_t *ups)
 	}
 
 #else
-	char pipename[SMALLBUF];
+	char pipename[NUT_PATH_MAX];
 	const char	*dumpcmd = "DUMPALL\n";
 	BOOL  result = FALSE;
 	DWORD bytesWritten;

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -157,7 +157,7 @@ static HANDLE		mutex = INVALID_HANDLE_VALUE;
 static handler_t	*handler = NULL;
 
 	/* pid file */
-static char	pidfn[SMALLBUF];
+static char	pidfn[NUT_PATH_MAX];
 
 	/* set by signal handlers */
 static int	reload_flag = 0, exit_flag = 0;

--- a/server/upstype.h
+++ b/server/upstype.h
@@ -34,7 +34,7 @@ extern "C" {
 /* structure for the linked list of each UPS that we track */
 typedef struct upstype_s {
 	char			*name;
-	char			*fn;
+	char			*fn;	/* base filename of UPS socket (or part of pipe name in WIN32) as "drivername-upsname" */
 	char			*desc;
 	TYPE_FD			sock_fd;
 #ifdef WIN32

--- a/server/user.c
+++ b/server/user.c
@@ -468,7 +468,7 @@ static void upsd_user_err(const char *errmsg)
 
 void user_load(void)
 {
-	char	fn[SMALLBUF];
+	char	fn[NUT_PATH_MAX];
 	PCONF_CTX_t	ctx;
 
 	curr_user = NULL;


### PR DESCRIPTION
Follows up from #2764 discussion.

Also reshuffle path-related char arrays to use a common `NUT_PATH_MAX` large enough for different platforms.
Note that internally data server and driver programs generally deal with short base filenames of the sockets (e.g. in `ups->fn` values), assuming that they `chdir` into the state path first. When people build custom NUT and mix some things from that build and others from packaging, they are at risk of using different state paths in different programs (e.g. `/var/state/ups` and `(/var)/run/nut`) and this change should help discover and rectify this in troubleshooting, or rule it out as not the problem in a discussed case.

Examples of output from `make check-NIT-sandbox-devel`:
* `upsd` starting, not seeing UPSes:
````
Sun Jan 19 10:15:55 UTC 2025 [DEBUG] [sandbox] Tried to start UPSD as PID 953682
Network UPS Tools upsd 2.8.2.1902-1902-gd1fb34894 (development iteration after 2.8.2)
listening on localhost port 12345
not listening on 127.0.0.1 port 12345
listening on ::1 port 12345
Can't connect to UPS [UPS2] (/home/jim/nut/tests/NIT/tmp/run/dummy-ups-UPS2): No such file or directory
Can't connect to UPS [UPS1] (/home/jim/nut/tests/NIT/tmp/run/dummy-ups-UPS1): No such file or directory
Can't connect to UPS [dummy] (/home/jim/nut/tests/NIT/tmp/run/dummy-ups-dummy): No such file or directory
Found 3 UPS defined in ups.conf
/usr/local/ups/share/cmdvartab not found - disabling descriptions
````
* Drivers started a bit later:
````
Network UPS Tools 2.8.2.1902-1902-gd1fb34894 (development iteration after 2.8.2) - Device simulation and repeater driver 0.20
Network UPS Tools 2.8.2.1902-1902-gd1fb34894 (development iteration after 2.8.2) - Device simulation and repeater driver 0.20
Network UPS Tools 2.8.2.1902-1902-gd1fb34894 (development iteration after 2.8.2) - Device simulation and repeater driver 0.20
Listening on socket /home/jim/nut/tests/NIT/tmp/run/dummy-ups-dummy
Running as foreground process, but saving a PID file anyway
Listening on socket /home/jim/nut/tests/NIT/tmp/run/dummy-ups-UPS1
Running as foreground process, but saving a PID file anyway
Listening on socket /home/jim/nut/tests/NIT/tmp/run/dummy-ups-UPS2
Running as foreground process, but saving a PID file anyway
sock_connect: enabling asynchronous mode (auto)
sock_connect: enabling asynchronous mode (auto)
sock_connect: enabling asynchronous mode (auto)
````
* ...and `upsd` sees them:
````
Connected to UPS [dummy]: dummy-ups-dummy
Connected to UPS [UPS1]: dummy-ups-UPS1
Connected to UPS [UPS2]: dummy-ups-UPS2
````
* driver killed off later, while `upsd` is running:
````
  13.069585     [D2:953915] mainloop: polling 6 filedescriptors
Signal 15: exiting
13.603506   [D2:953915] mainloop: polling 6 filedescriptors
  13.603652     [D1:953915] mainloop: UPS [UPS1] is not currently connected, trying to reconnect
  13.603679     [D2:953915] sstate_connect: preparing UNIX socket dummy-ups-UPS1
  13.603708     [D2:953915] sstate_connect: failed to connect() UNIX socket dummy-ups-UPS1 (/home/jim/nut/tests/NIT/tmp/run/dummy-ups-UPS1)
  13.603738     Can't connect to UPS [UPS1] (/home/jim/nut/tests/NIT/tmp/run/dummy-ups-UPS1): No such file or directory
  13.603762     [D1:953915] mainloop: UPS [UPS1] is still not connected (FD -1)
  13.603767     [D2:953915] mainloop: polling 5 filedescriptors
...
````
* restarted the missing driver:
````
...
  45.372413     [D1:954304] mainloop: UPS [UPS1] is not currently connected, trying to reconnect
  45.372460     [D2:954304] sstate_connect: preparing UNIX socket dummy-ups-UPS1
  45.372486     [D2:954304] sstate_connect: failed to connect() UNIX socket dummy-ups-UPS1 (/home/jim/nut/tests/NIT/tmp/run/dummy-ups-UPS1)
  45.372521     [D1:954304] mainloop: UPS [UPS1] is still not connected (FD -1)
  45.372544     [D2:954304] mainloop: polling 5 filedescriptors
   1.004226     [D1:954347] entering parse_data_file()
   1.004309     [D1:954347] leaving (paused)...
   1.004438     Listening on socket /home/jim/nut/tests/NIT/tmp/run/dummy-ups-UPS1
   1.004579     [D2:954347] dstate_init: sock /home/jim/nut/tests/NIT/tmp/run/dummy-ups-UPS1 open on fd 4
   1.004638     Running as foreground process, not saving a PID file
   1.004710     [D1:954347] Driver initialization completed, beginning regular infinite loop
   1.004771     [D1:954347] upsnotify: notify about state NOTIFY_STATE_READY_WITH_PID with libsystemd: was requested, but not running as a service unit now, will not spam more about it
   1.004780     [D1:954347] upsnotify: failed to notify about state NOTIFY_STATE_READY_WITH_PID: no notification tech defined, will not spam more about it
   1.004787     [D1:954347] upsnotify: logged the systemd watchdog situation once, will not spam more about it
   1.004798     [D1:954347] upsdrv_updateinfo...
  46.373262     [D1:954304] mainloop: UPS [UPS1] is not currently connected, trying to reconnect
  46.373311     [D2:954304] sstate_connect: preparing UNIX socket dummy-ups-UPS1
  46.373354     Connected to UPS [UPS1]: dummy-ups-UPS1
  46.373382     [D1:954304] mainloop: UPS [UPS1] is now connected as FD 8
  46.373388     [D2:954304] mainloop: polling 5 filedescriptors
  46.482778     [D2:954304] write: [destfd=7] [len=26] [VAR dummy ups.status "OB"]
  46.482819     [D2:954304] mainloop: polling 6 filedescriptors
   2.004960     [D1:954347] entering parse_data_file()
   2.005027     [D1:954347] leaving (paused)...
   2.005086     sock_connect: enabling asynchronous mode (auto)
   2.005128     [D3:954347] sock_connect: new connection on fd 5
   2.005165     [D2:954347] send_to_one: sending SETINFO battery.charge "90"
   2.005208     [D2:954347] send_to_one: sending SETFLAGS battery.charge RW
   2.005247     [D2:954347] send_to_one: sending SETINFO battery.charge.low "30"
  46.852973     [D2:954304] mainloop: polling 6 filedescriptors
...
````
* Final exit of `upsd` with one driver not connected (invalid FD, killed off again):
````
...
 473.982332   mainloop: Interrupted system call
 473.982380     Signal 2: exiting
 473.982390     [D1:953915] upsd_cleanup: starting the end-game
 473.982445     [D1:953915] driver_free: forgetting UPS [dummy] (FD 5)
 473.982491     [D1:953915] driver_free: forgetting UPS [UPS1] (FD -1)
 473.982516     [D1:953915] driver_free: forgetting UPS [UPS2] (FD 6)
 473.982569     [D1:953915] upsd_cleanup: finished
````
