### PR TITLE
Fix PEP-0625 naming for PyNUTClient tarball

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -522,6 +522,11 @@ relocated into new `shutdown.default` INSTCMD definitions. [#2670]
    module in the build or execution environment (deprecated in Python 3.11,
    removed since Python 3.13). [#2183]
 
+ - the PyPI distribution of the `PyNUTClient` module tarball should now use a
+   lower-cased file name (and immediate versioned directory name inside) to
+   match the requirements of link:https://peps.python.org/pep-0625/[PEP-0625].
+   The Python module name (and its directory) should remain camel-cased. [#2773]
+
  - enabled installation of built single-file PDF and HTML (including man page
    renditions) under the configured `docdir`. It seems previously they were
    only built (if requested) but not installed via `make`, unlike the common

--- a/UPGRADING.adoc
+++ b/UPGRADING.adoc
@@ -57,6 +57,13 @@ Changes from 2.8.2 to 2.8.3
   depending on `target_cpu` of the build. If you had any scripts relying
   on the older pattern, they may have to be updated.
 
+- the PyPI distribution of the `PyNUTClient` module tarball should now use a
+  lower-cased file name (and immediate versioned directory name inside) to
+  match the requirements of link:https://peps.python.org/pep-0625/[PEP-0625].
+  The Python module name (and its directory) should remain camel-cased.
+  OS distribution package recipes that deliver the module separately (e.g.
+  as part of Python ecosystem rather than NUT) may have to adjust. [#2773]
+
 - Updated man page generation with `configure` script options to specify that
   manual sections on the target platform differ from (Linux-based) defaults
   hard-coded into page sources; this should allow to simplify NUT packaging

--- a/scripts/python/README.adoc
+++ b/scripts/python/README.adoc
@@ -18,8 +18,8 @@ sensitive):
 
     import PyNUT
 
-This module provides a `PyNUTClient` class that can be used to connect and
-get data from an `upsd` data server.
+This module provides a `(PyNUT.)PyNUTClient` class that can be used to connect
+and get data from an `upsd` data server.
 
 To install the `PyNUT` module on Debian/Ubuntu, copy it to:
 `/usr/share/python-support/python-pynut/`
@@ -42,7 +42,7 @@ Historically, the `PyNUTClient` class relied on `telnetlib` module for socket
 communications with the NUT data server, which was provided as part of Python
 core installation with tested 2.6+ and 3.* versions. The module was, however,
 marked deprecated since Python 3.11 and not provided since 3.13. Due to this,
-as a quick stop-gap solution, NUT sources provide `nut_telnetlib.py` - a copy
+as a quick stop-gap solution, NUT sources provide `nut_telnetlib.py` -- a copy
 of the module from Python 3.10 installation, and no longer should require its
 presence in the Python deployment.
 
@@ -55,6 +55,9 @@ app
 
 This directory contains the `NUT-Monitor` UI application, which uses the
 `PyNUT` class, along with its own resources.
+
+NOTE: Do not mistake it for `nut-monitor` service for the `upsmon` client in
+some distributions' NUT packaging.
 
 There are two closely related separate implementations, for Python 2 with GTK2
 and for Python 3 with Qt5. Both can be installed at the same time, if your
@@ -72,5 +75,6 @@ To install it, you will either need to keep the files together, or to install:
 - finally, `nut-monitor-py2gtk2.desktop` and/or `nut-monitor-py3qt5.desktop`
   (optionally symlinked as `nut-monitor.desktop`) to `/usr/share/applications/`
 
-The `PyNUT` module can be kept nearby, or must be installed as a "site" or "vendor"
-provided script into your Python modules location. See the wrapper script for more technical details.
+The `PyNUT` module can be kept nearby, or must be installed as a "site" or
+"vendor" provided script into your Python modules location. See the wrapper
+scripts of the app for more technical details.

--- a/scripts/python/module/Makefile.am
+++ b/scripts/python/module/Makefile.am
@@ -4,6 +4,10 @@
 # Note: this Makefile is focused on PyPI publication
 # The usual autotools stuff including clean-up is in parent dir
 # (to allow easier mixing of the module and app, if/when desired)
+#
+# NOTE: Due to PEP-0625, the versioned tarball and directory names
+# must be normalized to lower-case, as achieved by setup.py(.in).
+# The module name remains camel-cased as it always was.
 
 # Non-maintainers can at most generate the source layout for python setuptools
 # (having only shell scripting as a prerequisite suffices for that)

--- a/scripts/python/module/README.adoc
+++ b/scripts/python/module/README.adoc
@@ -25,6 +25,8 @@ of the original project, allowing to develop other classes nearby later.
 It is published to PyPI repository as
 link:https://pypi.org/project/PyNUTClient/[PyNUTClient]
 and so should be installable with `pip` tooling.
+Note that the file name of the distribution tarball is lower-cased per
+PEP-0625 requirements, while the module name is camel-cased historically.
 
 Currently the module is regularly tested to work with Python interpreter
 versions 2.7, 3.4, 3.5 and 3.7.

--- a/scripts/python/module/setup.py.in
+++ b/scripts/python/module/setup.py.in
@@ -18,6 +18,7 @@ setup(
     name =	"pynutclient",	### "PyNUTClient" lower-cased due to PEP-0625
     version =	'@NUT_SOURCE_GITREV_NUMERIC@',
     author =	"The Network UPS Tools project",
+    license =	"GPL-3.0-or-later",
     license_files =	('LICENSE-GPL3',),
     author_email =	"jimklimov+nut@gmail.com",
     description =	"Python client bindings for NUT",
@@ -39,6 +40,10 @@ setup(
     classifiers = [
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
+        "Intended Audience :: System Administrators",
+        "Topic :: System :: Monitoring",
+        "Topic :: System :: Systems Administration",
+        "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
         "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",

--- a/scripts/python/module/setup.py.in
+++ b/scripts/python/module/setup.py.in
@@ -15,7 +15,7 @@ with codecs.open(os.path.join(here, "README.txt"), encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
 setup(
-    name =	"PyNUTClient",
+    name =	"pynutclient",	### "PyNUTClient" lower-cased due to PEP-0625
     version =	'@NUT_SOURCE_GITREV_NUMERIC@',
     author =	"The Network UPS Tools project",
     license_files =	('LICENSE-GPL3',),


### PR DESCRIPTION
Closes: #2773

Example upload with these changes in place: https://test.pypi.org/project/pynutclient/2.8.2.1915.3/

CC @mtelka