### PR TITLE
Fix Appveyor CI builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,6 +34,11 @@ install:
   - cmd: |
         REM Do not give pacman cause for complaints:
         C:\msys64\usr\bin\bash -lc "mkdir -p /var/cache/pacman/pkg; ls -la /"
+        REM FIXME: Since Jan 2025, normal update below fails with the message:
+        REM   installing mingw-w64-i686-gdb (16.1-1) breaks dependency
+        REM   'mingw-w64-i686-gdb=15.2' required by mingw-w64-i686-gdb-multiarch
+        REM Currently we sweep it away by removing the conflicting package:
+        C:\msys64\usr\bin\bash -lc "date -u; pacman --noconfirm -R mingw-w64-i686-gdb-multiarch || true"
   - cmd: |
         REM Core update (in case any core packages are outdated):
         C:\msys64\usr\bin\bash -lc "date -u; pacman --noconfirm -Syuu"

--- a/scripts/Windows/build-mingw-prereqs.sh
+++ b/scripts/Windows/build-mingw-prereqs.sh
@@ -47,7 +47,7 @@ prepareEnv() {
 
 		# Assumes Ubuntu/Debian with mingw prepared, per README
 		HOST_FLAG="--host=$ARCH"
-        PREFIX="/usr/$ARCH"
+		PREFIX="/usr/$ARCH"
 
 		export ARCH PREFIX
 
@@ -86,7 +86,7 @@ provide_netsnmp() (
 		# Quickly install if prebuilt
 		if [ -d "${WSDIR}/${DEP_DIRNAME}/.inst" ]; then (
 			cd "${WSDIR}/${DEP_DIRNAME}/.inst" || exit
-			(command -v rsync) && $SUDO rsync -avPHK ./ / && exit
+			(command -v rsync) && $SUDO rsync -cavPHK ./ / && exit
 			$SUDO cp -pr ./ / && exit
 			exit 1
 			) && return 0
@@ -94,6 +94,8 @@ provide_netsnmp() (
 
 		# no stashed .inst; any Makefile at least?
 		if [ -s "${WSDIR}/${DEP_DIRNAME}/Makefile" ]; then ( cd "${WSDIR}/${DEP_DIRNAME}" && $SUDO $MAKE install ) && return ; fi
+
+		# Not pre-built, fall through
 	fi
 
 	# (Re-)make and install from scratch

--- a/scripts/Windows/build-mingw-prereqs.sh
+++ b/scripts/Windows/build-mingw-prereqs.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# Copyright (C) 2022-2023 by Jim Klimov <jimklimov+nut@gmail.com>
-# Licensed same as NUT
+# Copyright (C) 2022-2025 by Jim Klimov <jimklimov+nut@gmail.com>
+# Licensed GPLv2+, same as NUT
 #
 # Helper automating the nuances from NUT::scripts/Windows/README.adoc
 # to provide prerequisites needed in semi-native or cross-builds.

--- a/scripts/Windows/build-mingw-prereqs.sh
+++ b/scripts/Windows/build-mingw-prereqs.sh
@@ -14,10 +14,15 @@
 prepareEnv() {
 	[ -n "${MAKE-}" ] || {
 		(command -v gmake) 2>/dev/null >/dev/null \
-		&& MAKE="gmake -j 8" \
-		|| MAKE="make -j 8"
+		&& MAKE="gmake" \
+		|| MAKE="make"
 	}
 	export MAKE
+
+	[ -n "${MAKEFLAGS-}" ] || {
+		MAKEFLAGS="-j 8"
+		export MAKEFLAGS
+	}
 
 	if [ -z "${SUDO-}" ] ; then
 		SUDO=" " # avoid reeval

--- a/scripts/Windows/build-mingw-prereqs.sh
+++ b/scripts/Windows/build-mingw-prereqs.sh
@@ -12,7 +12,11 @@
 # TODO: Support `make uninstall` attempts for older versions?..
 
 prepareEnv() {
-	[ -n "${MAKE-}" ] || MAKE="make -j 8"
+	[ -n "${MAKE-}" ] || {
+		(command -v gmake) 2>/dev/null >/dev/null \
+		&& MAKE="gmake -j 8" \
+		|| MAKE="make -j 8"
+	}
 	export MAKE
 
 	if [ -z "${SUDO-}" ] ; then


### PR DESCRIPTION
The MSYS2 repo seems confused about versions of GDB it can install right now, and we do not really care about it there, so pre-remove it for now.