### PR TITLE
Fix battery runtime calculation for Q2 protocol

### DIFF
--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -275,6 +275,19 @@ int qx_multiply_x1000(item_t *item, char *value, const size_t valuelen) {
 	return 0;
 }
 
+/* Convert minutes to seconds */
+int qx_multiply_m2s(item_t *item, char *value, const size_t valuelen) {
+	float s = 0;
+
+	if (sscanf(item->value, "%f", &s) != 1) {
+		upsdebugx(2, "unparsable ss.ss %s", item->value);
+		return -1;
+	}
+
+	snprintf(value, valuelen, "%.0f", s * 60.0);
+	return 0;
+}
+
 /* Fill batt.volt.act and guesstimate the battery charge
  * if it isn't already available. */
 static int	qx_battery(void)

--- a/drivers/nutdrv_qx.h
+++ b/drivers/nutdrv_qx.h
@@ -192,6 +192,9 @@ int qx_multiply_battvolt(item_t *item, char *value, const size_t valuelen);
 	/* Convert kilo-values to their full representation */
 int qx_multiply_x1000(item_t *item, char *value, const size_t valuelen);
 
+	/* Convert minutes to seconds */
+int qx_multiply_m2s(item_t *item, char *value, const size_t valuelen);
+
 /* Data for processing status values */
 #define	STATUS(x)	((unsigned int)1U<<x)
 

--- a/drivers/nutdrv_qx_q2.c
+++ b/drivers/nutdrv_qx_q2.c
@@ -58,7 +58,7 @@ static item_t	q2_qx2nut[] = {
 	{ "output.L3.load",			0,	NULL,	"Q2\r",	"",	118,	'(',	"",	51,	53,	"%.0f",	0,	NULL,	NULL,	NULL },
 	{ "ups.temperature",		0,	NULL,	"Q2\r",	"",	118,	'(',	"",	66,	69,	"%.1f",	0,	NULL,	NULL,	NULL },
 	{ "battery.voltage",		0,	NULL,	"Q2\r",	"",	118,	'(',	"",	60,	64,	"%.1f",	0,	NULL,	NULL,	qx_multiply_battvolt },
-	{ "battery.runtime",		0,	NULL,	"Q2\r",	"",	118,	'(',	"",	80,	85,	"%.0f",	0,	NULL,	NULL,	NULL },
+	{ "battery.runtime",		0,	NULL,	"Q2\r",	"",	118,	'(',	"",	80,	85,	"%.2f",	0,	NULL,	NULL,	qx_multiply_m2s },
 	{ "battery.charge",			0,	NULL,	"Q2\r",	"",	118,	'(',	"",	87,	89,	"%.0f",	0,	NULL,	NULL,	NULL },
 	{ "experimental.input.topology",	0,	NULL,	"Q2\r",	"",	118,	'(',	"",	115,	115,	"%s",	QX_FLAG_STATIC,		NULL,	NULL,	q2_process_topology_bits },	/* Input transformer topology */
 	{ "experimental.output.topology",	0,	NULL,	"Q2\r",	"",	118,	'(',	"",	116,	116,	"%s",	QX_FLAG_STATIC,		NULL,	NULL,	q2_process_topology_bits },	/* Output transformer topology */


### PR DESCRIPTION
New Q2 and Q6 protocols work like a charm - just tested thoroughly on my Innova RT 3/1 and all looks good! However, I've figured out that my translation/interpretation of original Santak's documentation was wrong at least in one place - Q2 request tells estimated battery runtime in minutes rather than seconds. This PR is for fixing this mistake