### PR TITLE
netvision-mib: sync netvision_output_info with SOCOMECUPS-MIB.txt

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -285,6 +285,8 @@ https://github.com/networkupstools/nut/milestone/11
      serving same basic data points as were available in `baytech-mib.c`,
      but checking for a different model OID subtree and different OIDs for
      the device model information. [#2779]
+   * fixed `netvision-mib`: sync `netvision_output_info` with currently
+     available `SOCOMECUPS-MIB.txt`. [#2803]
 
  - Introduced a new driver concept for interaction with OS-reported hardware
    monitoring readings. Currently instantiated as `hwmon_ina219` specifically

--- a/UPGRADING.adoc
+++ b/UPGRADING.adoc
@@ -112,6 +112,11 @@ Changes from 2.8.2 to 2.8.3
   and `ondelay` to 120 seconds, in accordance with man page suggestions;
   users with custom settings not divisible by 60 will be loudly warned. [#1394]
 
+- `snmp-ups` subdriver `netvision-mib`: synchronized `netvision_output_info`
+  with the currently available `SOCOMECUPS-MIB.txt`; this can impact some
+  other devices using that MIB (negatively, if the older mappings were
+  indeed correct for any practical cases, and were not a typo). [#2803]
+
 - Added support for `lbrb_log_delay_sec=N` setting to delay propagation of
   `LB` or `LB+RB` state (buggy with APC BXnnnnMI devices/firmwares issued
   circa 2023-2024 which flood the logs with spurious LOWBATT and REPLACEBATT

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3287 utf-8
+personal_ws-1.1 en 3288 utf-8
 AAC
 AAS
 ABI
@@ -1103,6 +1103,7 @@ SNR
 SOCK
 SOCKADDR
 SOCKLEN
+SOCOMECUPS
 SOFF
 SOLA
 SOMECO

--- a/drivers/netvision-mib.c
+++ b/drivers/netvision-mib.c
@@ -25,7 +25,7 @@
 
 #include "netvision-mib.h"
 
-#define NETVISION_MIB_VERSION			"0.44"
+#define NETVISION_MIB_VERSION			"0.45"
 
 #define NETVISION_SYSOID				".1.3.6.1.4.1.4555.1.1.1"
 
@@ -108,13 +108,13 @@ static info_lkp_t netvision_onbatt_info[] = {
 static info_lkp_t netvision_output_info[] = {
 	info_lkp_default(1, ""),	/* output source unknown   */
 	info_lkp_default(2, ""),	/* output source inverter  */
-	info_lkp_default(3, "OL"),	/* output source mains  */
-	info_lkp_default(4, ""),	/* output source ecomode  */
-	info_lkp_default(5, "OL BYPASS"), /* output source bypass */
-	info_lkp_default(6, "OFF"),	/* output source standby */
+	info_lkp_default(3, "OL"),	/* output source mains     */
+	info_lkp_default(4, ""),	/* output source ecomode   */
+	info_lkp_default(5, "OL BYPASS"), /* output source bypass  */
+	info_lkp_default(6, "OFF"),	/* output source standby   */
 	info_lkp_default(7, "OL BYPASS"), /* output source maintenance bypass */
-	info_lkp_default(8, "OFF"),	/* output source off */
-	info_lkp_default(9, ""),	/* output source normal */
+	info_lkp_default(8, "OFF"),	/* output source off       */
+	info_lkp_default(9, ""),	/* output source normal    */
 	info_lkp_sentinel
 };
 

--- a/drivers/netvision-mib.c
+++ b/drivers/netvision-mib.c
@@ -100,16 +100,21 @@ static info_lkp_t netvision_onbatt_info[] = {
 #define NETVISION_OID_CONTROL_STATUS 	     ".1.3.6.1.4.1.4555.1.1.1.1.8.1"
 #define NETVISION_OID_CONTROL_SHUTDOWN_DELAY ".1.3.6.1.4.1.4555.1.1.1.1.8.2"
 
+/*
+ * some of the output sources below are set to empty string; because we
+ * don't know from here if we are online or on batteries.
+ * In this case upsAlarmOnBattery will set the appropriate status.
+ */
 static info_lkp_t netvision_output_info[] = {
-	info_lkp_default(1, ""),	/* output source other   */
-	info_lkp_default(2, ""),	/* output source none    */
-	info_lkp_default(3, "OL"),	/* output source normal  */
-	info_lkp_default(4, "OL BYPASS"),	/* output source bypass  */
-	info_lkp_default(5, "OB"),	/* output source battery */
-	info_lkp_default(6, "OL BOOST"),	/* output source booster */
-	info_lkp_default(7, "OL TRIM"),	/* output source reducer */
-	info_lkp_default(8, "OL"),	/* output source standby */
-	info_lkp_default(9, ""),	/* output source ecomode */
+	info_lkp_default(1, ""),	/* output source unknown   */
+	info_lkp_default(2, ""),	/* output source inverter  */
+	info_lkp_default(3, "OL"),	/* output source mains  */
+	info_lkp_default(4, ""),	/* output source ecomode  */
+	info_lkp_default(5, "OL BYPASS"), /* output source bypass */
+	info_lkp_default(6, "OFF"),	/* output source standby */
+	info_lkp_default(7, "OL BYPASS"), /* output source maintenance bypass */
+	info_lkp_default(8, "OFF"),	/* output source off */
+	info_lkp_default(9, ""),	/* output source normal */
 	info_lkp_sentinel
 };
 

--- a/drivers/netvision-mib.c
+++ b/drivers/netvision-mib.c
@@ -106,6 +106,22 @@ static info_lkp_t netvision_onbatt_info[] = {
  * In this case upsAlarmOnBattery will set the appropriate status.
  */
 static info_lkp_t netvision_output_info[] = {
+#if 0
+	/* For reference: from the times before Git until SVN, this mapping
+	 * was defined as stashed away in this block of code. It was wrong
+	 * at least for MASTERYS 3/3 SYSTEM 60 kVA UPS devices described in
+	 * pull request https://github.com/networkupstools/nut/pull/2803
+	 */
+	info_lkp_default(1, ""),	/* output source other   */
+	info_lkp_default(2, ""),	/* output source none    */
+	info_lkp_default(3, "OL"),	/* output source normal  */
+	info_lkp_default(4, "OL BYPASS"),	/* output source bypass  */
+	info_lkp_default(5, "OB"),	/* output source battery */
+	info_lkp_default(6, "OL BOOST"),	/* output source booster */
+	info_lkp_default(7, "OL TRIM"),	/* output source reducer */
+	info_lkp_default(8, "OL"),	/* output source standby */
+	info_lkp_default(9, ""),	/* output source ecomode */
+#else
 	info_lkp_default(1, ""),	/* output source unknown   */
 	info_lkp_default(2, ""),	/* output source inverter  */
 	info_lkp_default(3, "OL"),	/* output source mains     */
@@ -115,6 +131,7 @@ static info_lkp_t netvision_output_info[] = {
 	info_lkp_default(7, "OL BYPASS"), /* output source maintenance bypass */
 	info_lkp_default(8, "OFF"),	/* output source off       */
 	info_lkp_default(9, ""),	/* output source normal    */
+#endif
 	info_lkp_sentinel
 };
 


### PR DESCRIPTION
Hello
We have servers powered from two MASTERYS 3/3 SYSTEM 60 kVA UPSes, with some of them with redondant power supplies from both UPSes.

After a power failure, the batteries went low and the UPSes cut outputs. Everything worked as expected for hosts with a single
power source, but not for those with redondant power. After the first UPS went down, upsmon started reporting this UPS
as being at the same time OL and OB (and not LB any more):
Feb 11 08:52:27 localhost upsmon[2175]: UPS ups-1@localhost battery is low
Feb 11 08:56:23 localhost upsmon[2175]: Giving up on the primary for UPS [ups-1@localhost] after 241 sec since last comms
Feb 11 08:56:28 localhost upsmon[2175]: Giving up on the primary for UPS [ups-1@localhost] after 246 sec since last comms
Feb 11 08:56:33 localhost upsmon[2175]: Giving up on the primary for UPS [ups-1@localhost] after 251 sec since last comms
Feb 11 08:56:38 localhost upsmon[2175]: Giving up on the primary for UPS [ups-1@localhost] after 256 sec since last comms
Feb 11 08:56:43 localhost upsmon[2175]: Giving up on the primary for UPS [ups-1@localhost] after 261 sec since last comms
Feb 11 08:56:48 localhost upsmon[2175]: UPS ups-1@localhost on line power
Feb 11 08:56:48 localhost upsmon[2175]: UPS ups-1@localhost on battery
Feb 11 08:56:53 localhost upsmon[2175]: UPS ups-1@localhost on line power
Feb 11 08:56:53 localhost upsmon[2175]: UPS ups-1@localhost on battery
Feb 11 08:56:58 localhost upsmon[2175]: UPS ups-1@localhost on line power
Feb 11 08:56:58 localhost upsmon[2175]: UPS ups-1@localhost on battery
(and so on until the second UPS ran out of battery)
At this point nagios reported the UPS as:
[1739260700] SERVICE ALERT: localhost;nut-ups-1;WARNING;HARD;4;UPS WARNING - Status=OnlineOn Battery, Boosting, Discharging Batt=47.0% Left=592.0min
while the UPS output was, in fact, off.
The result is that when ups-2 ran out of batteries, upsmon considered that ups-1 was still alive and didn't shutdown servers
with dual power source.

The MIB I have for this UPS (which match the only one publically available I found) shows for upsOutputSource:
     SYNTAX     INTEGER {
           unknown(1),
           onInverter(2),
           onMains(3),
           ecoMode(4),
           onBypass(5),
           standby(6),
           onMaintenanceBypass(7),
           upsOff(8),
           normalMode(9)
     }

This dissagrees with netvision_output_info[] in drivers/netvision-mib.c

Our zabbix server recorded the raw SNMP values during the incident. The values were:
NETVISION_OID_BATTERYSTATUS:
2 (normal) -> 5 (discharing) -> 3 (low) / the UPS turned output off/ -> 5
upsAlarmOnBattery:
0 / main power shutdown / -> 1 (until blackout in the server room at last, probably until main power came back)
NETVISION_OID_OUTPUT_SOURCE:
2 -> / the UPS turned output off/ ->6

This matches the MIB fragment above, and also explains why NUT reported OL BOOST while the UPS was off.

This patch gets netvision_output_info[] in sync with information available, and also probably fixes the issue we noticed. I'm now running with this patch installed, but this is hard to test for me, as I won't cause another server room blackout only to test this.

Do you know where the actual values for netvision_output_info[] comes from ? I wonder we there could be UPSes with the same MIB but sighly different values for upsOutputSource.