### PR TITLE
Test for and fix `status_set("ALARM")`; update code and docs on correct Numeric format usage

### DIFF
--- a/docs/nut-names.txt
+++ b/docs/nut-names.txt
@@ -111,6 +111,21 @@ link:http://tools.ietf.org/html/rfc3339[RFC 3339].
 
 Other representations from those specifications are not necessarily supported.
 
+[NOTE]
+======
+Values of certain variables may be propagated from device reports formally
+as opaque strings, which happen to convey a date/time value (commonly the
+device or battery manufacture date, replacement date, last self-test or
+calibration time stamp, device clock, etc.) in some format, not necessarily
+a standard one.
+
+While the drivers may convert them from original vendor-provided markup
+to the standard Time and Date format described above (if the formula is
+known for certain -- e.g. which locale is used by the device, which part
+of that string is the year/month/day, or how to add offset or prefix for
+the year, etc.), they are not generally required to do so.
+======
+
 Variables
 ---------
 

--- a/docs/nut-names.txt
+++ b/docs/nut-names.txt
@@ -87,6 +87,36 @@ and in certain cases detailed below there may be a variable component
 in the practical values (e.g. the `n` in `ambient.n.temperature.alarm`
 variable or `outlet.n.load.off` command names).
 
+Numeric format
+--------------
+
+Depending on the use-case, decimal numbers may be represented as integers
+or as floating-point numbers with a dot character as the separator for the
+fractional part (typically one or two digits long).  Leading zeroes may be
+present. Leading (negative) sign characters are possible, although use-cases
+for them are rare (if any).
+
+Spaces or commas must not be used inside the numeric values.
+
+Scientific notation (with mantissa/exponent) must not be used to represent
+numeric values set into variables, to serve the values as exact as we have
+them and keep the client-side parsing simple and predictable.
+
+For example: "01200.2" and "1200.20" are valid, while "1,200.20" and "1200,20"
+and "1 200.20" and "1.2e4" are invalid.
+
+Programming note: floating-point numbers should be emitted using the `%f`
+format specifier in the C `printf` family of methods and derived methods
+(including NUT `dstate_setinfo()` in the driver code). Specifiers like `%e`
+and `%g` which can emit the scientific notation should be avoided when setting
+variable values (directly in code or when providing format string patterns in
+mapping tables). They may however be used in debug traces, where reasonable.
+
+Note that in some cases (e.g. USB vendor and product identifiers) technically
+numeric values may be reported as hexadecimal and should be treated generally
+as opaque strings (with the consumer ascribing a known meaning to certain
+variable names).
+
 Time and Date format
 --------------------
 

--- a/drivers/clone.c
+++ b/drivers/clone.c
@@ -147,7 +147,7 @@ static int parse_args(size_t numargs, char **arg)
 		if (!strcasecmp(arg[1], "battery.charge")) {
 			battery.charge.act = strtod(arg[2], NULL);
 
-			dstate_setinfo("battery.charge.low", "%g", battery.charge.low);
+			dstate_setinfo("battery.charge.low", "%f", battery.charge.low);
 			dstate_setflags("battery.charge.low", ST_FLAG_RW | ST_FLAG_STRING);
 			dstate_setaux("battery.charge.low", 3);
 		}
@@ -155,7 +155,7 @@ static int parse_args(size_t numargs, char **arg)
 		if (!strcasecmp(arg[1], "battery.runtime")) {
 			battery.runtime.act = strtod(arg[2], NULL);
 
-			dstate_setinfo("battery.runtime.low", "%g", battery.runtime.low);
+			dstate_setinfo("battery.runtime.low", "%f", battery.runtime.low);
 			dstate_setflags("battery.runtime.low", ST_FLAG_RW | ST_FLAG_STRING);
 			dstate_setaux("battery.runtime.low", 4);
 		}
@@ -518,13 +518,13 @@ static int setvar(const char *varname, const char *val)
 {
 	if (!strcasecmp(varname, "battery.charge.low")) {
 		battery.charge.low = strtod(val, NULL);
-		dstate_setinfo("battery.charge.low", "%g", battery.charge.low);
+		dstate_setinfo("battery.charge.low", "%f", battery.charge.low);
 		return STAT_SET_HANDLED;
 	}
 
 	if (!strcasecmp(varname, "battery.runtime.low")) {
 		battery.runtime.low = strtod(val, NULL);
-		dstate_setinfo("battery.runtime.low", "%g", battery.runtime.low);
+		dstate_setinfo("battery.runtime.low", "%f", battery.runtime.low);
 		return STAT_SET_HANDLED;
 	}
 

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -1768,16 +1768,24 @@ void status_commit(void)
 	 * but note that if someone also uses status_set("ALARM") we can end
 	 * up with a "[N/A]" alarm value injected (if no other alarm was set)
 	 * and only add the token here so it remains first.
+	 *
 	 * NOTE: alarm_commit() must be executed before status_commit() for
 	 * this report to work!
 	 * * If a driver only called status_set("ALARM") and did not bother
-	 *   with alarm_commit(), the "ups.alarm" value queries return NULL
-	 *   although the "ups.status" value would report an ALARM token.
+	 *   with alarm_commit(), the "ups.alarm" value queries would have
+	 *   returned NULL if not for the "sloppy driver" fix below, although
+	 *   the "ups.status" value would report an ALARM token.
 	 * * If a driver properly used alarm_init() and alarm_set(), but then
 	 *   called status_commit() before alarm_commit(), the "ups.status"
-	 *   value would not know to report an ALARM token.
+	 *   value would not know to report an ALARM token, as before.
 	 */
-	if (alarm_active || alarm_status) {
+
+	if (!alarm_active && alarm_status && !strcmp(alarm_buf, "[N/A]")) {
+		upsdebugx(2, "%s: Assume sloppy driver coding that ignored alarm methods and used status_set(\"ALARM\") instead: commit the injected N/A ups.alarm value", __func__);
+		alarm_commit();
+	}
+
+	if (alarm_active) {
 		dstate_setinfo("ups.status", "ALARM %s", status_buf);
 	} else {
 		dstate_setinfo("ups.status", "%s", status_buf);

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -1650,7 +1650,7 @@ repeat:
 		return 0;
 
 	offset = s - status_buf;
-#if 0
+#ifdef DEBUG
 	upsdebugx(3, "%s: '%s' in '%s': offset=%" PRIuSIZE" buflen=%" PRIuSIZE" s[buflen]='0x%2X'\n",
 		__func__, buf, status_buf, offset, buflen, s[buflen]);
 #endif
@@ -1670,7 +1670,7 @@ repeat:
 /* add a status element */
 void status_set(const char *buf)
 {
-#if 0
+#ifdef DEBUG
 	upsdebugx(3, "%s: '%s'\n", __func__, buf);
 #endif
 	if (strstr(buf, " ")) {

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -1749,6 +1749,10 @@ void status_commit(void)
 		break;
 	}
 
+	/* NOTE: Not sure if any clients rely on ALARM being first if raised,
+	 * but note that if someone also uses status_set("ALARM") we can end
+	 * up with a duplicate...
+	 */
 	if (alarm_active) {
 		dstate_setinfo("ups.status", "ALARM %s", status_buf);
 	} else {

--- a/drivers/powerp-txt.c
+++ b/drivers/powerp-txt.c
@@ -36,7 +36,7 @@
 
 #include <ctype.h>
 
-#define POWERPANEL_TEXT_VERSION	"Powerpanel-Text 0.61"
+#define POWERPANEL_TEXT_VERSION	"Powerpanel-Text 0.62"
 
 typedef struct {
 	float          i_volt;
@@ -267,13 +267,13 @@ static void powpan_initinfo(void)
 	if (powpan_command("P3\r") > 0) {
 
 		if ((s = strtok(&powpan_answer[1], ",")) != NULL) {
-			dstate_setinfo("battery.voltage.nominal", "%g", strtod(s, NULL));
+			dstate_setinfo("battery.voltage.nominal", "%f", strtod(s, NULL));
 		}
 		if ((s = strtok(NULL, ",")) != NULL) {
 			dstate_setinfo("battery.packs", "%li", strtol(s, NULL, 10));
 		}
 		if ((s = strtok(NULL, ",")) != NULL) {
-			dstate_setinfo("battery.capacity", "%g", strtod(s, NULL));
+			dstate_setinfo("battery.capacity", "%f", strtod(s, NULL));
 		}
 	}
 
@@ -502,7 +502,7 @@ static int powpan_updateinfo(void)
 	if (status.has_b_volt) {
 		dstate_setinfo("battery.voltage", "%.1f", status.b_volt);
 		if (status.b_volt > 20.0 && status.b_volt < 28.0) {
-			dstate_setinfo("battery.voltage.nominal", "%g", 24.0);
+			dstate_setinfo("battery.voltage.nominal", "%f", 24.0);
 		}
 	}
 	if (status.has_o_freq) {

--- a/tests/driver_methods_utest.c
+++ b/tests/driver_methods_utest.c
@@ -189,8 +189,12 @@ int main(int argc, char **argv) {
 	printf(" test for ups.status with explicit ALARM set via status_set() and no extra alarm_set() nor alarm_commit(): '%s'; is ALARM reported?\n", NUT_STRARG(valueStr));
 
 	valueStr = dstate_getinfo("ups.alarm");
-	report_0_means_pass(valueStr != NULL);	/* pass if valueStr is NULL */
+/*
+	report_0_means_pass(valueStr != NULL);	// pass if valueStr is NULL
 	printf(" test for ups.alarm  with explicit ALARM set via status_set() and no extra alarm_set() nor alarm_commit(): '%s'; got no alarms spelled out\n", NUT_STRARG(valueStr));
+*/
+	report_0_means_pass(strcmp(NUT_STRARG(valueStr), "[N/A]"));
+	printf(" test for ups.alarm  with explicit ALARM set via status_set() and no extra alarm_set() nor alarm_commit(): '%s'; got 1 (injected) alarm\n", NUT_STRARG(valueStr));
 
 	/* finish */
 	printf("test_rules completed. Total cases %d, passed %d, failed %d\n",

--- a/tests/driver_methods_utest.c
+++ b/tests/driver_methods_utest.c
@@ -90,7 +90,7 @@ int main(int argc, char **argv) {
 	/* test case #2, build on top of #1 */
 	alarm_init();
 	alarm_set("Test alarm 1");
-	alarm_set("Test alarm 2");
+	alarm_set("[Test alarm 2]");
 	alarm_set("Test alarm 1");
 	alarm_commit();
 	/* Note: normally we re-init and re-set the values */
@@ -102,7 +102,7 @@ int main(int argc, char **argv) {
 	/* test case #3, build on top of #2 */
 	valueStr = dstate_getinfo("ups.alarm");
 	/* NOTE: no dedup here! */
-	report_0_means_pass(strcmp(valueStr, "Test alarm 1 Test alarm 2 Test alarm 1"));
+	report_0_means_pass(strcmp(valueStr, "Test alarm 1 [Test alarm 2] Test alarm 1"));
 	printf(" test for ups.alarm: '%s'; got 3 alarms?\n", NUT_STRARG(valueStr));
 
 	/* test case #4, build on top of #1 and #2 */

--- a/tests/driver_methods_utest.c
+++ b/tests/driver_methods_utest.c
@@ -172,6 +172,26 @@ int main(int argc, char **argv) {
 	report_0_means_pass(strcmp(NUT_STRARG(valueStr), "[N/A]"));
 	printf(" test for ups.alarm  with explicit ALARM set via status_set() and no extra alarm_set(): '%s'; got 1 (injected) alarm\n", NUT_STRARG(valueStr));
 
+	/* test case #11+#12 from scratch */
+	/* flush ups.alarm report */
+	alarm_init();
+	alarm_commit();
+
+	status_init();
+	alarm_init();
+	status_set("OL BOOST");
+	status_set("ALARM");
+	status_set("OB");
+	status_commit();
+
+	valueStr = dstate_getinfo("ups.status");
+	report_0_means_pass(strcmp(valueStr, "ALARM OL BOOST OB"));
+	printf(" test for ups.status with explicit ALARM set via status_set() and no extra alarm_set() nor alarm_commit(): '%s'; is ALARM reported?\n", NUT_STRARG(valueStr));
+
+	valueStr = dstate_getinfo("ups.alarm");
+	report_0_means_pass(valueStr != NULL);	/* pass if valueStr is NULL */
+	printf(" test for ups.alarm  with explicit ALARM set via status_set() and no extra alarm_set() nor alarm_commit(): '%s'; got no alarms spelled out\n", NUT_STRARG(valueStr));
+
 	/* finish */
 	printf("test_rules completed. Total cases %d, passed %d, failed %d\n",
 		cases_passed+cases_failed, cases_passed, cases_failed);

--- a/tests/driver_methods_utest.c
+++ b/tests/driver_methods_utest.c
@@ -130,14 +130,32 @@ int main(int argc, char **argv) {
 	status_commit();
 
 	valueStr = dstate_getinfo("ups.status");
-	report_0_means_pass(strcmp(valueStr, "ALARM OL BOOST ALARM OB"));
-	printf(" test for ups.status with explicit ALARM set via status_set(): '%s'; any duplicate ALARM?\n", NUT_STRARG(valueStr));
+	report_0_means_pass(strcmp(valueStr, "ALARM OL BOOST OB"));
+	printf(" test for ups.status with explicit ALARM set via status_set() and alarm_set() was not used first: '%s'; any duplicate ALARM?\n", NUT_STRARG(valueStr));
+
+	valueStr = dstate_getinfo("ups.alarm");
+	report_0_means_pass(strcmp(valueStr, "[N/A] [Test alarm 2]"));
+	printf(" test for ups.alarm  with explicit ALARM set via status_set() and alarm_set() was not used first: '%s'; got 2 alarms\n", NUT_STRARG(valueStr));
+
+	/* test case #7+#8 from scratch */
+	status_init();
+	alarm_init();
+	status_set("OL BOOST");
+	alarm_set("[Test alarm 2]");
+	status_set("ALARM");
+	status_set("OB");
+	alarm_commit();
+	status_commit();
+
+	valueStr = dstate_getinfo("ups.status");
+	report_0_means_pass(strcmp(valueStr, "ALARM OL BOOST OB"));
+	printf(" test for ups.status with explicit ALARM set via status_set() and alarm_set() was used first: '%s'; any duplicate ALARM?\n", NUT_STRARG(valueStr));
 
 	valueStr = dstate_getinfo("ups.alarm");
 	report_0_means_pass(strcmp(valueStr, "[Test alarm 2]"));
-	printf(" test for ups.alarm with explicit ALARM set via status_set(): '%s'; got 1 alarms\n", NUT_STRARG(valueStr));
+	printf(" test for ups.alarm  with explicit ALARM set via status_set() and alarm_set() was used first: '%s'; got 1 alarm\n", NUT_STRARG(valueStr));
 
-	/* test case #7+#8 from scratch */
+	/* test case #9+#10 from scratch */
 	status_init();
 	alarm_init();
 	status_set("OL BOOST");
@@ -147,13 +165,12 @@ int main(int argc, char **argv) {
 	status_commit();
 
 	valueStr = dstate_getinfo("ups.status");
-	report_0_means_pass(strcmp(valueStr, "OL BOOST ALARM OB"));
+	report_0_means_pass(strcmp(valueStr, "ALARM OL BOOST OB"));
 	printf(" test for ups.status with explicit ALARM set via status_set() and no extra alarm_set(): '%s'; any duplicate ALARM?\n", NUT_STRARG(valueStr));
 
 	valueStr = dstate_getinfo("ups.alarm");
-	/* report_0_means_pass(strcmp(NUT_STRARG(valueStr), "")); */
-	report_0_means_pass(valueStr != NULL);	/* pass if valueStr is NULL */
-	printf(" test for ups.alarm with explicit ALARM set via status_set() and no extra alarm_set(): '%s'; got no alarms\n", NUT_STRARG(valueStr));
+	report_0_means_pass(strcmp(NUT_STRARG(valueStr), "[N/A]"));
+	printf(" test for ups.alarm  with explicit ALARM set via status_set() and no extra alarm_set(): '%s'; got 1 (injected) alarm\n", NUT_STRARG(valueStr));
 
 	/* finish */
 	printf("test_rules completed. Total cases %d, passed %d, failed %d\n",

--- a/tests/driver_methods_utest.c
+++ b/tests/driver_methods_utest.c
@@ -65,6 +65,7 @@ static int report_0_means_pass(int i) {
 	}
 	return i;
 }
+
 int main(int argc, char **argv) {
 	const char	*valueStr = NULL;
 
@@ -115,9 +116,44 @@ int main(int argc, char **argv) {
 	status_set("OOS");
 	status_commit();
 	valueStr = dstate_getinfo("ups.status");
-	nut_debug_level = 0;
 	report_0_means_pass(strcmp(valueStr, "ALARM OL BOOST OB BOO OST OOS"));
 	printf(" test for ups.status: '%s'; any duplicates?\n", NUT_STRARG(valueStr));
+
+	/* test case #5+#6 from scratch */
+	status_init();
+	alarm_init();
+	status_set("OL BOOST");
+	status_set("ALARM");
+	status_set("OB");
+	alarm_set("[Test alarm 2]");
+	alarm_commit();
+	status_commit();
+
+	valueStr = dstate_getinfo("ups.status");
+	report_0_means_pass(strcmp(valueStr, "ALARM OL BOOST ALARM OB"));
+	printf(" test for ups.status with explicit ALARM set via status_set(): '%s'; any duplicate ALARM?\n", NUT_STRARG(valueStr));
+
+	valueStr = dstate_getinfo("ups.alarm");
+	report_0_means_pass(strcmp(valueStr, "[Test alarm 2]"));
+	printf(" test for ups.alarm with explicit ALARM set via status_set(): '%s'; got 1 alarms\n", NUT_STRARG(valueStr));
+
+	/* test case #7+#8 from scratch */
+	status_init();
+	alarm_init();
+	status_set("OL BOOST");
+	status_set("ALARM");
+	status_set("OB");
+	alarm_commit();
+	status_commit();
+
+	valueStr = dstate_getinfo("ups.status");
+	report_0_means_pass(strcmp(valueStr, "OL BOOST ALARM OB"));
+	printf(" test for ups.status with explicit ALARM set via status_set() and no extra alarm_set(): '%s'; any duplicate ALARM?\n", NUT_STRARG(valueStr));
+
+	valueStr = dstate_getinfo("ups.alarm");
+	/* report_0_means_pass(strcmp(NUT_STRARG(valueStr), "")); */
+	report_0_means_pass(valueStr != NULL);	/* pass if valueStr is NULL */
+	printf(" test for ups.alarm with explicit ALARM set via status_set() and no extra alarm_set(): '%s'; got no alarms\n", NUT_STRARG(valueStr));
 
 	/* finish */
 	printf("test_rules completed. Total cases %d, passed %d, failed %d\n",


### PR DESCRIPTION
Work on status vs. alarms follows up from PR #2801 for issue #2708

Formatting spec originated from discussion in #2807