### PR TITLE
CI: Fix configure.ac and Makefiles to deliver libnutconf (optionally)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -152,7 +152,7 @@ EXTRA_DIST += autogen.sh
 
 if KEEP_NUT_REPORT
 nodist_data_DATA = config.nut_report_feature.log
-endif
+endif KEEP_NUT_REPORT
 
 # Not too different from automake generated recursive rules at first sight,
 # but here we do not loop all subdirs sequentially - instead, a sub-make
@@ -736,9 +736,9 @@ ChangeLog: dummy-stamp
 
 if WITH_PDF_NONASCII_TITLES
 WITH_PDF_NONASCII_TITLES_ENVVAR = WITH_PDF_NONASCII_TITLES=yes
-else
+else !WITH_PDF_NONASCII_TITLES
 WITH_PDF_NONASCII_TITLES_ENVVAR = WITH_PDF_NONASCII_TITLES=no
-endif
+endif !WITH_PDF_NONASCII_TITLES
 
 # Be sure to not confuse with a DIST'ed file (and so try to overwrite it);
 # do however avoid re-generating it if already made on a previous pass and
@@ -900,39 +900,39 @@ install-data-hook:
 
 if HAVE_SYSTEMD
 HAVE_SYSTEMD = true
-else
+else !HAVE_SYSTEMD
 HAVE_SYSTEMD = false
-endif
+endif !HAVE_SYSTEMD
 
 if WITH_SYSTEMD_TMPFILES
 WITH_SYSTEMD_TMPFILES = true
-else
+else !WITH_SYSTEMD_TMPFILES
 WITH_SYSTEMD_TMPFILES = false
-endif
+endif !WITH_SYSTEMD_TMPFILES
 
 if WITH_SYSTEMD_PRESET
 WITH_SYSTEMD_PRESET = true
-else
+else !WITH_SYSTEMD_PRESET
 WITH_SYSTEMD_PRESET = false
-endif
+endif !WITH_SYSTEMD_PRESET
 
 if WITH_CGI
 WITH_CGI = true
-else
+else !WITH_CGI
 WITH_CGI = false
-endif
+endif !WITH_CGI
 
 if WITH_SOLARIS_SMF
 WITH_SOLARIS_SMF = true
-else
+else !WITH_SOLARIS_SMF
 WITH_SOLARIS_SMF = false
-endif
+endif !WITH_SOLARIS_SMF
 
 if WITH_SOLARIS_INIT
 WITH_SOLARIS_INIT = true
-else
+else !WITH_SOLARIS_INIT
 WITH_SOLARIS_INIT = false
-endif
+endif !WITH_SOLARIS_INIT
 
 # TODO: Actually move this into scripts like Solaris/postinstall
 # using OS-specific `useradd`/`groupadd`, etc.
@@ -1212,13 +1212,13 @@ install-win-bundle-thirdparty:
 	 | grep -vE "^($${relbindir}|$${relsbindir}|$${reldriverexecdir}|$${relcgiexecdir}|$${rellibexecdir})" \
 	 | ( RES=0 ; while IFS= read LINE ; do echo "$$LINE" ; RES=1; done; exit $$RES )
 
-else
+else !HAVE_WINDOWS
 install-win-bundle:
 	@echo "SKIP: '$@' not enabled for current build configuration"
 
 install-win-bundle-thirdparty:
 	@echo "SKIP: '$@' not enabled for current build configuration"
-endif
+endif !HAVE_WINDOWS
 
 print-MAINTAINERCLEANFILES print-REALCLEANFILES:
 	@echo $(MAINTAINERCLEANFILES)

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -110,6 +110,33 @@ https://github.com/networkupstools/nut/milestone/11
      references in their command-line usage help, method `suggest_doc_links()`
      was introduced for this purpose. [issue #722, PR #2733]
 
+ - A technologically and practically interesting revamp of NUT mesh of
+   link:https://www.gnu.org/software/automake/[automake] (`Makefile.am`)
+   recipes was completed, allowing for a more parallelizable build routine
+   on multi-CPU machines -- utilizing more cores and completing in less
+   "wall-clock" time that the standard `SUBDIRS` driven approach -- when
+   running `make -j (N)` from the project root directory to build everything
+   enabled by the `configure` script.
++
+This was tested with several (GNU, BSD, Sun) implementations of the
+   "make" program on the few dozen platforms that NUT CI farm tests on.
+   Notably, GNU make 4.x and newer seems to process parallel high-level
+   goals and sub-`make` runs better than the competition (including GNU
+   make 3.x).
++
+It is not a radical rewrite like some other research suggested, and so retains
+   the general structure and certain benefits and flexibility of that standard
+   `automake` approach, including developer build workflows with a bespoke
+   `Makefile` in every significant directory.  This also retains (and builds
+   upon) the benefits of older work done in NUT, for builds in one directory
+   to depend on libraries and other artifacts built (once) in another.
++
+Overall, NUT CI farm build times got 25%+ shorter (which is important as
+   some scenarios had hit the 1-hour timeout imposed by providers of free
+   CI hosting coupled with the weak machines provided in their free layer),
+   and we suppose this is an interesting case for other projects to draw
+   inspiration from for their recipe refactoring. [PR #2825]
+
  - the `upsnotify()` common code introduced in recent NUT releases (integrating
    with service management frameworks, etc.) was a bit cryptic when it reported
    a *failure to notify* (e.g. when not running as a service currently), fixed

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -1251,8 +1251,8 @@ consider_cleanup_shortcut() {
         fi
     fi
 
-    # When itertating configure.ac or m4 sources, we can end up with an
-    # existing but useless scropt file - nuke it and restart from scratch!
+    # When iterating configure.ac or m4 sources, we can end up with an
+    # existing but useless script file - nuke it and restart from scratch!
     if [ -s "${CI_BUILDDIR}"/configure ] ; then
         if ! sh -n "${CI_BUILDDIR}"/configure 2>/dev/null ; then
             echo "=== Starting initial clean-up (from old build products): TAKING SHORTCUT because current configure script syntax is broken"

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -1351,7 +1351,7 @@ if [ -z "$BUILD_TYPE" ] ; then
 
         win32|cross-windows-mingw32) BUILD_TYPE="cross-windows-mingw32" ; shift ;;
 
-        win|cross-windows-mingw) BUILD_TYPE="cross-windows-mingw" ; shift ;;
+        win|windows|cross-windows-mingw) BUILD_TYPE="cross-windows-mingw" ; shift ;;
 
         spellcheck|spellcheck-interactive)
             # Note: this is a little hack to reduce typing

--- a/clients/Makefile.am
+++ b/clients/Makefile.am
@@ -26,12 +26,12 @@ $(top_builddir)/common/libparseconf.la: dummy
 LDADD_FULL = $(top_builddir)/common/libcommon.la libupsclient.la $(NETLIBS)
 if WITH_SSL
   LDADD_FULL += $(LIBSSL_LIBS) $(LIBSSL_LDFLAGS_RPATH)
-endif
+endif WITH_SSL
 
 LDADD_CLIENT = $(top_builddir)/common/libcommonclient.la libupsclient.la $(NETLIBS)
 if WITH_SSL
   LDADD_CLIENT += $(LIBSSL_LIBS) $(LIBSSL_LDFLAGS_RPATH)
-endif
+endif WITH_SSL
 
 # by default, link programs in this directory with
 # the more compact libcommonclient.a bundle
@@ -43,23 +43,23 @@ LDADD = $(LDADD_CLIENT)
 AM_CFLAGS = -I$(top_srcdir)/include
 if WITH_SSL
   AM_CFLAGS += $(LIBSSL_CFLAGS)
-endif
+endif WITH_SSL
 if WITH_CGI
   AM_CFLAGS += $(LIBGD_CFLAGS)
-endif
+endif WITH_CGI
 
 bin_PROGRAMS = upsc upslog upsrw upscmd
 dist_bin_SCRIPTS = upssched-cmd
 sbin_PROGRAMS = upsmon upssched
 if HAVE_WINDOWS_SOCKETS
   sbin_PROGRAMS += message
-endif
+endif HAVE_WINDOWS_SOCKETS
 
 lib_LTLIBRARIES = libupsclient.la
 if HAVE_CXX11
   lib_LTLIBRARIES += libnutclient.la
   lib_LTLIBRARIES += libnutclientstub.la
-endif
+endif HAVE_CXX11
 
 # Optionally deliverable as part of NUT public API:
 if WITH_DEV
@@ -73,7 +73,7 @@ endif WITH_DEV
 
 if WITH_CGI
  cgiexec_PROGRAMS = upsstats.cgi upsimage.cgi upsset.cgi
-endif
+endif WITH_CGI
 
 upsc_SOURCES = upsc.c upsclient.h
 upscmd_SOURCES = upscmd.c upsclient.h
@@ -84,7 +84,7 @@ upsmon_SOURCES = upsmon.c upsmon.h upsclient.h
 upsmon_LDADD = $(LDADD_FULL)
 if HAVE_WINDOWS_SOCKETS
 message_SOURCES = message.c
-endif
+endif HAVE_WINDOWS_SOCKETS
 
 upssched_SOURCES = upssched.c upssched.h
 upssched_LDADD = $(top_builddir)/common/libcommonclient.la $(top_builddir)/common/libparseconf.la $(NETLIBS)
@@ -101,10 +101,10 @@ libupsclient_la_SOURCES = upsclient.c upsclient.h
 libupsclient_la_LIBADD = $(top_builddir)/common/libcommonclient.la
 if HAVE_WINDOWS_SOCKETS
   libupsclient_la_LIBADD += -lws2_32
-endif
+endif HAVE_WINDOWS_SOCKETS
 if WITH_SSL
   libupsclient_la_LIBADD += $(LIBSSL_LDFLAGS_RPATH) $(LIBSSL_LIBS)
-endif
+endif WITH_SSL
 
 # Below we set API versions of public libraries
 # http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
@@ -117,7 +117,7 @@ libupsclient_la_LDFLAGS += -export-symbols-regex ^upscli_
 if HAVE_WINDOWS
   # Many versions of MingW seem to fail to build non-static DLL without this
   libupsclient_la_LDFLAGS += -no-undefined
-endif
+endif HAVE_WINDOWS
 
 # ./clients/libupsclient.la samples (partial!) on...
 # Linux:
@@ -154,10 +154,10 @@ libnutclient_la_LIBADD = $(top_builddir)/common/libcommonclient.la
 if HAVE_WINDOWS
   # Many versions of MingW seem to fail to build non-static DLL without this
   libnutclient_la_LDFLAGS += -no-undefined
-endif
-else
+endif HAVE_WINDOWS
+else !HAVE_CXX11
 EXTRA_DIST += nutclient.h nutclient.cpp
-endif
+endif !HAVE_CXX11
 
 if HAVE_CXX11
 # libnutclientstub version information and build
@@ -167,10 +167,10 @@ libnutclientstub_la_LIBADD = libnutclient.la
 if HAVE_WINDOWS
   # Many versions of MingW seem to fail to build non-static DLL without this
   libnutclientstub_la_LDFLAGS += -no-undefined
-endif
-else
+endif HAVE_WINDOWS
+else !HAVE_CXX11
 EXTRA_DIST += nutclientmem.h nutclientmem.cpp
-endif
+endif !HAVE_CXX11
 
 dummy:
 

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -136,8 +136,16 @@ libcommon_la_CFLAGS = $(AM_CFLAGS)
 libcommonclient_la_CFLAGS = $(AM_CFLAGS)
 
 if WITH_NUTCONF
+  # libnutconf version information and build
+  # currently considered a highly experimental and so unstable API at least
+  # (at least, headers contain a lot of data/code, not sure they should)
+  libnutconf_la_LDFLAGS = -version-info 0:1:0
   libnutconf_la_CXXFLAGS = $(AM_CXXFLAGS)
   libnutconf_la_LIBADD = @LTLIBOBJS@ @NETLIBS@ libcommonclient.la
+if HAVE_WINDOWS
+  # Many versions of MingW seem to fail to build non-static DLL without this
+  libnutconf_la_LDFLAGS += -no-undefined
+endif HAVE_WINDOWS
   libnutconf_la_SOURCES = nutconf.cpp nutstream.cpp nutwriter.cpp nutipc.cpp \
 	../include/nutconf.hpp ../include/nutipc.hpp \
 	../include/nutstream.hpp ../include/nutwriter.hpp

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -16,10 +16,11 @@ EXTRA_DIST =
 CLEANFILES =
 
 noinst_LTLIBRARIES = libparseconf.la libcommon.la libcommonclient.la
+lib_LTLIBRARIES =
 if WITH_NUTCONF
-  # We define the recipe below in any case, but only activate it by default
-  # if the build configuration tells us to:
-  noinst_LTLIBRARIES += libnutconf.la
+# We define the recipe below in any case, but only activate it by default
+# if the build configuration tells us to:
+  lib_LTLIBRARIES += libnutconf.la
 endif WITH_NUTCONF
 
 libparseconf_la_SOURCES = parseconf.c

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -155,7 +155,8 @@ if HAVE_WINDOWS
 endif HAVE_WINDOWS
 endif WITH_DEV_LIBNUTCONF
   libnutconf_la_CXXFLAGS = $(AM_CXXFLAGS)
-  libnutconf_la_LIBADD = @LTLIBOBJS@ @NETLIBS@ libcommonclient.la
+  # NOTE: No @LTLIBOBJS@ here, because libcommonclient.la includes them (if any)
+  libnutconf_la_LIBADD = @NETLIBS@ libcommonclient.la
   libnutconf_la_SOURCES = nutconf.cpp nutstream.cpp nutwriter.cpp nutipc.cpp \
 	../include/nutconf.hpp ../include/nutipc.hpp \
 	../include/nutstream.hpp ../include/nutwriter.hpp

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -17,11 +17,19 @@ CLEANFILES =
 
 noinst_LTLIBRARIES = libparseconf.la libcommon.la libcommonclient.la
 lib_LTLIBRARIES =
-if WITH_NUTCONF
+
 # We define the recipe below in any case, but only activate it by default
 # if the build configuration tells us to:
+if WITH_DEV_LIBNUTCONF
+# We want it built and delivered (standalone or with tool)
   lib_LTLIBRARIES += libnutconf.la
+else !WITH_DEV_LIBNUTCONF
+if WITH_NUTCONF
+# We only want the tool, make a private build
+  noinst_LTLIBRARIES += libnutconf.la
+# else do not build at all, e.g. do not have C++ support
 endif WITH_NUTCONF
+endif !WITH_DEV_LIBNUTCONF
 
 libparseconf_la_SOURCES = parseconf.c
 
@@ -135,23 +143,25 @@ libcommonclient_la_LIBADD = libparseconf.la @LTLIBOBJS@ @NETLIBS@ @BSDKVMPROCLIB
 libcommon_la_CFLAGS = $(AM_CFLAGS)
 libcommonclient_la_CFLAGS = $(AM_CFLAGS)
 
-if WITH_NUTCONF
+if WITH_LIBNUTCONF
+if WITH_DEV_LIBNUTCONF
   # libnutconf version information and build
   # currently considered a highly experimental and so unstable API at least
   # (at least, headers contain a lot of data/code, not sure they should)
   libnutconf_la_LDFLAGS = -version-info 0:1:0
-  libnutconf_la_CXXFLAGS = $(AM_CXXFLAGS)
-  libnutconf_la_LIBADD = @LTLIBOBJS@ @NETLIBS@ libcommonclient.la
 if HAVE_WINDOWS
   # Many versions of MingW seem to fail to build non-static DLL without this
   libnutconf_la_LDFLAGS += -no-undefined
 endif HAVE_WINDOWS
+endif WITH_DEV_LIBNUTCONF
+  libnutconf_la_CXXFLAGS = $(AM_CXXFLAGS)
+  libnutconf_la_LIBADD = @LTLIBOBJS@ @NETLIBS@ libcommonclient.la
   libnutconf_la_SOURCES = nutconf.cpp nutstream.cpp nutwriter.cpp nutipc.cpp \
 	../include/nutconf.hpp ../include/nutipc.hpp \
 	../include/nutstream.hpp ../include/nutwriter.hpp
-else !WITH_NUTCONF
+else !WITH_LIBNUTCONF
   EXTRA_DIST += nutconf.cpp nutstream.cpp nutwriter.cpp nutipc.cpp
-endif !WITH_NUTCONF
+endif !WITH_LIBNUTCONF
 
 if HAVE_LIBREGEX
   libcommon_la_CFLAGS += $(LIBREGEX_CFLAGS)

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -25,8 +25,6 @@ endif WITH_NUTCONF
 
 libparseconf_la_SOURCES = parseconf.c
 
-libnutconf_la_SOURCES = nutconf.cpp nutstream.cpp nutwriter.cpp nutipc.cpp
-
 # do not hard depend on '../include/nut_version.h', since it blocks
 # 'dist', and is only required for actual build, in which case
 # BUILT_SOURCES (in ../include) will ensure nut_version.h will
@@ -140,7 +138,12 @@ libcommonclient_la_CFLAGS = $(AM_CFLAGS)
 if WITH_NUTCONF
   libnutconf_la_CXXFLAGS = $(AM_CXXFLAGS)
   libnutconf_la_LIBADD = @LTLIBOBJS@ @NETLIBS@ libcommonclient.la
-endif WITH_NUTCONF
+  libnutconf_la_SOURCES = nutconf.cpp nutstream.cpp nutwriter.cpp nutipc.cpp \
+	../include/nutconf.hpp ../include/nutipc.hpp \
+	../include/nutstream.hpp ../include/nutwriter.hpp
+else !WITH_NUTCONF
+  EXTRA_DIST += nutconf.cpp nutstream.cpp nutwriter.cpp nutipc.cpp
+endif !WITH_NUTCONF
 
 if HAVE_LIBREGEX
   libcommon_la_CFLAGS += $(LIBREGEX_CFLAGS)

--- a/common/setenv.c
+++ b/common/setenv.c
@@ -26,4 +26,4 @@ int nut_setenv(const char *name, const char *value, int overwrite)
 	rv = putenv(buffer); /* man putenv, do not free(buffer) */
 	return (rv);
 }
-#endif
+#endif	/* !HAVE_SETENV */

--- a/configure.ac
+++ b/configure.ac
@@ -2098,7 +2098,7 @@ dnl check for --with-all (or --without-all, or --with-all=auto) flag
 
 AC_MSG_CHECKING(for --with-all)
 AC_ARG_WITH(all,
-	AS_HELP_STRING([--with-all], [enable serial, usb, snmp, neon, ipmi, powerman, modbus, gpio (currently on Linux released after ~2018), linux_i2c (on Linux), macosx-ups (on MacOS), cgi, dev, avahi, nut-scanner, nutconf, pynut]),
+	AS_HELP_STRING([--with-all], [enable serial, usb, snmp, neon, ipmi, powerman, modbus, gpio (currently on Linux released after ~2018), linux_i2c (on Linux), macosx-ups (on MacOS), cgi, dev, avahi, nut-scanner, nutconf, dev-libnutconf, pynut]),
 [
 	if test -n "${withval}"; then
 		dnl Note: we allow "no" as a positive value, because
@@ -2143,6 +2143,7 @@ AC_ARG_WITH(all,
 		if test -z "${with_avahi}"; then with_avahi="${withval}"; fi
 		if test -z "${with_nut_scanner}"; then with_nut_scanner="${withval}"; fi
 		if test -z "${with_nutconf}"; then with_nutconf="${withval}"; fi
+		if test -z "${with_dev_libnutconf}"; then with_dev_libnutconf="${withval}"; fi
 
 		if test -n "${PYTHON}${PYTHON2}${PYTHON3}" -a x"${withval}" = xyes \
 		|| test x"${withval}" != xyes \
@@ -2172,9 +2173,14 @@ dnl they are listed near the top by "./configure --help"; however,
 dnl note that options with further investigation methods are listed
 dnl a bit below to be grouped with their additional with/enable help.
 
+dnl Depends on C++ support being available and enabled
 NUT_ARG_WITH([nutconf], [build and install the nutconf tool (experimental, has compiler/coverage warnings)], [auto])
 
 NUT_ARG_WITH([dev], [build and install the development files], [no])
+
+dnl Depends on C++ support being available and enabled
+dnl Does not depend on nutconf or dev explicitly (but warns about inconsistencies)
+NUT_ARG_WITH([dev-libnutconf], [deliver the C++ library behind the nutconf tool and its headers (experimental)], [no])
 
 dnl Activate WITH_UNMAPPED_DATA_POINTS for troubleshooting and evolution?
 dnl Note that production drivers must conform to docs/nut-names.txt
@@ -4492,6 +4498,39 @@ AM_CONDITIONAL(WITH_NUTCONF, test "${nut_with_nutconf}" = "yes")
 NUT_REPORT_PROGRAM([build and install the nutconf tool (experimental, may lack support for recent NUT options)],
 					[${nut_with_nutconf}], [],
 					[WITH_NUTCONF], [Define to enable nutconf tool support])
+
+dnl ----------------------------------------------------------------------
+
+dnl Depends on C++, potentially nutconf and dev...
+dnl If not enabled for delivery, the library is built as internal detail
+dnl of the tool (if that is enabled)
+AC_MSG_CHECKING([whether we can and want to deliver the libnutconf library and headers])
+
+AS_CASE(["${nut_with_dev_libnutconf}"],
+		["auto"], [AS_IF([test x"${have_cxx11}" = xyes], [nut_with_dev_libnutconf="yes"], [nut_with_dev_libnutconf="no"])],
+		["yes"], [AS_IF([test x"${have_cxx11}" = xyes], [], [AC_MSG_ERROR([explicit --with-dev-libnutconf=yes can not be satisfied: C++11 support not enabled])])],
+		["no"], [nut_with_dev_libnutconf=no]
+	)
+AC_MSG_RESULT(${nut_with_dev_libnutconf})
+
+AM_CONDITIONAL(WITH_DEV_LIBNUTCONF, test "${nut_with_dev_libnutconf}" = "yes")
+NUT_REPORT_PROGRAM([build and install the deliver the libnutconf library and headers (experimental)],
+					[${nut_with_dev_libnutconf}], [],
+					[WITH_DEV_LIBNUTCONF], [Define to enable delivery of libnutconf developer files])
+
+AS_IF([test x"$nut_with_dev_libnutconf" = x"yes" -a x"${nut_with_dev}" != x"yes"], [
+	AC_MSG_WARN([You are effectively building --with-dev-libnutconf --without-dev, so would only get this library and headers but maybe not others it might need])
+])
+AS_IF([test x"$nut_with_dev_libnutconf" = x"yes" -a x"${nut_with_nutconf}" != x"yes"], [
+	AC_MSG_NOTICE([You are effectively building --with-dev-libnutconf --without-nutconf, so would only get the library and headers but not the tool])
+])
+AS_IF([test x"$nut_with_dev_libnutconf" != x"yes" -a x"${nut_with_nutconf}" = x"yes"], [
+	AC_MSG_NOTICE([You are effectively building --without-dev-libnutconf --with-nutconf, so would only get the tool (library and headers are just its internal detail during build)])
+])
+
+dnl At least the lib and/or the tool delivery are enabled, generate the
+dnl automake rules to build the library (privately or publicly, that depends):
+AM_CONDITIONAL(WITH_LIBNUTCONF, [test x"${nut_with_dev_libnutconf}" = x"yes" -o x"${nut_with_nutconf}" = x"yes"])
 
 dnl ----------------------------------------------------------------------
 

--- a/configure.ac
+++ b/configure.ac
@@ -5731,6 +5731,7 @@ AC_CONFIG_FILES([
  include/Makefile
  lib/libupsclient.pc
  lib/libnutclient.pc
+ lib/libnutconf.pc
  lib/libnutclientstub.pc
  lib/libnutscan.pc
  lib/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -2143,7 +2143,22 @@ AC_ARG_WITH(all,
 		if test -z "${with_avahi}"; then with_avahi="${withval}"; fi
 		if test -z "${with_nut_scanner}"; then with_nut_scanner="${withval}"; fi
 		if test -z "${with_nutconf}"; then with_nutconf="${withval}"; fi
-		if test -z "${with_dev_libnutconf}"; then with_dev_libnutconf="${withval}"; fi
+
+		dnl dev-libnutconf is experimental, and relies on
+		dnl functional C++11 that we only check for later;
+		dnl at best, we can follow main nutconf request
+		dnl (explicit from caller, or set a few lines above)
+		if test -z "${with_dev_libnutconf}" ; then
+			if test "${withval}" = no ; then
+				with_dev_libnutconf="no"
+			else
+				case "${with_dev}${with_nutconf}" in
+					*no*) with_dev_libnutconf="no" ;;
+					*auto*) with_dev_libnutconf="auto" ;;
+					yesyes) with_dev_libnutconf="yes" ;;
+				esac
+			fi
+		fi
 
 		if test -n "${PYTHON}${PYTHON2}${PYTHON3}" -a x"${withval}" = xyes \
 		|| test x"${withval}" != xyes \

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -207,16 +207,16 @@ html-chunked: $(ASCIIDOC_HTML_CHUNKED)
 htmldoc_DATA =
 if WITH_HTML_SINGLE
 htmldoc_DATA += $(ASCIIDOC_HTML_SINGLE)
-endif
+endif WITH_HTML_SINGLE
 # FIXME: Install tools refuse to work with directories in this context
 # and html-chunked documentation has a separate tree per document.
 # Maybe an "(un)install-data-local" or "install-data-hook" for this?
 #if WITH_HTML_CHUNKED
 #htmldoc_DATA += $(ASCIIDOC_HTML_CHUNKED)
-#endif
+#endif WITH_HTML_CHUNKED
 if WITH_PDFS
 pdf_DATA = $(ASCIIDOC_PDFS)
-endif
+endif WITH_PDFS
 
 # the "for" loops might better use $^ but it might be not portable
 check-pdf: .check-pdf

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -501,15 +501,25 @@ static libraries.
 
 Build and install the nutconf library and header files, to build further
 projects against NUT (especially those that need to set it up).  This is
-currently not tied into either `--with-dev` nor `--with-nutconf`, because
-the tool and library are experimental and the API may undergo significant
-changes in the coming years.
-+
+currently not automatically tied into either `--with-dev` nor `--with-nutconf`
+(note below on `--with-all`), because the tool and library are experimental
+and the API may yet undergo significant changes in the coming years.
+
 It is more recommended to use the CLI tool as a presumably more stable API
 for third-party integrations, than the library directly.
-+
-This would be (optionally) enabled by `--with-all(=auto)` request, though.
-+
+
+This feature may however be enabled or disabled implicitly, using
+`--with-all(=yes/no/auto)` request, based on a combination of
+`--with-nutconf` and `--with-dev` options:
+
+* if `--without-all`, default to set `--with-dev-libnutconf=no`; otherwise...
+* if either `--without-dev` or `--without-nutconf`,
+  default to set `--with-dev-libnutconf=no`; otherwise...
+* if either `--without-dev=auto` and/or `--without-nutconf=auto`,
+  default to set `--with-dev-libnutconf=auto`; otherwise...
+* if both `--with-dev` and `--with-nutconf`,
+  default to set `--with-dev-libnutconf=yes`.
+
 Requires C++11 support to be enabled (available in compiler, not neutered
 by explicit selection of an older standard).
 

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -470,6 +470,20 @@ Development files
 Build and install the upsclient and nutclient library and header files, to
 build further projects against NUT (such as wmNUT client and many others).
 
+Also delivers `libnutscan` library and header files, if `--with-nut-scanner`
+is enabled.
+
+	--with-dev-libnutconf (default: no)
+
+Build and install the nutconf library and header files, to build further
+projects against NUT (especially those that need to set it up).  This is
+currently not tied into either `--with-dev` nor `--with-nutconf`, because
+the tool and library are experimental and the API may undergo significant
+changes in the coming years.  It is more recommended to use the CLI tool
+for third-party integrations, than the library.
++
+This would be (optionally) enabled by `--with-all(=auto)` request, though.
+
 Options for developers
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -503,10 +503,15 @@ Build and install the nutconf library and header files, to build further
 projects against NUT (especially those that need to set it up).  This is
 currently not tied into either `--with-dev` nor `--with-nutconf`, because
 the tool and library are experimental and the API may undergo significant
-changes in the coming years.  It is more recommended to use the CLI tool
-for third-party integrations, than the library.
+changes in the coming years.
++
+It is more recommended to use the CLI tool as a presumably more stable API
+for third-party integrations, than the library directly.
 +
 This would be (optionally) enabled by `--with-all(=auto)` request, though.
++
+Requires C++11 support to be enabled (available in compiler, not neutered
+by explicit selection of an older standard).
 
 Options for developers
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -494,7 +494,7 @@ build further projects against NUT (such as wmNUT client and many others).
 Also delivers `libnutscan` library and header files, if `--with-nut-scanner`
 is enabled.
 
-	--with-dev-libnutconf (default: no)
+	--with-dev-libnutconf (yes/no/auto, default: no)
 
 Build and install the nutconf library and header files, to build further
 projects against NUT (especially those that need to set it up).  This is

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -250,6 +250,30 @@ CGI configuration files. This is not enabled by default, as they
 are only useful on web servers. See link:data/html/README[] for additional
 information on how to set up CGI programs.
 
+NUT Scanner tool
+~~~~~~~~~~~~~~~~
+
+	--with-nut-scanner (default: auto)
+
+Build and install the optional linkman:nut-scanner[8] tool to discover some
+types of UPS or ePDU devices on locally or remotely connected media (such as
+Serial, USB, SNMP, IPMI, NetXML), as well as NUT data servers (by Avahi/mDNS
+broadcasts or "old" NUT port polling) and simulation device configurations
+that can be relayed by a local linkman:dummy-ups[8] driver instance.
+
+Many of the features depend on third-party libraries that are loosely linked
+at run-time using libltdl, and due to that, the build, delivery and use of the
+tool does not depend on *all* of them being available in the final deployment.
+
+NUT Configuration tool
+~~~~~~~~~~~~~~~~~~~~~~
+
+	--with-nutconf (default: auto)
+
+Build and install the optional linkman:nutconf[8] tool to create and manipulate
+NUT configuration files.  It also optionally supports device scanning, using
+the linkman:nutscan[3] library (if built), to suggest configuration of devices.
+
 Pretty documentation and man pages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -494,6 +494,9 @@ build further projects against NUT (such as wmNUT client and many others).
 Also delivers `libnutscan` library and header files, if `--with-nut-scanner`
 is enabled.
 
+Disabled development file delivery, in particular, disables installation of
+static libraries.
+
 	--with-dev-libnutconf (yes/no/auto, default: no)
 
 Build and install the nutconf library and header files, to build further

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -3,6 +3,27 @@ Configure options
 =================
 endif::website[]
 
+As many other projects relying on GNU autotools for build recipe automation,
+NUT sources deliver a `configure` script which is used to set up numerous
+nuances relevant for your build of the project.  Most of the configuration
+requirements are passed by `--with-something` or `--enable-something` options
+(allegedly, not always used consistently with autotools naming recommendations),
+and with environment variables like `CFLAGS` typically also passed as command
+line options.
+
+Default syntax of `--with-something` or `--enable-something` assumes a boolean
+approach, so the option as such conveys a `yes` string value, and aliases
+`--without-something` or `--disable-something` are handled automatically as
+a `no` string value, for the option named `something`.
+
+In many cases, these options are used to pass non-boolean configuration of the
+option in question, commonly a path, program name, compiler flags to use along
+with a particular dependency, user name or type of documentation to build, etc.
+
+A special case here concerns options that accept an `auto` value, where the
+`configure` script would opine to request a final `yes` or `no`, depending on
+other circumstances of the build environment and requested configuration.
+
 [NOTE]
 ======
 When building NUT from Git sources rather than the distribution tarballs,

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3322 utf-8
+personal_ws-1.1 en 3323 utf-8
 AAC
 AAS
 ABI
@@ -2264,6 +2264,7 @@ libnut
 libnutclient
 libnutclientstub
 libnutclientsub
+libnutconf
 libnutconfig
 libnutscan
 libpcre

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3319 utf-8
+personal_ws-1.1 en 3322 utf-8
 AAC
 AAS
 ABI
@@ -1137,6 +1137,7 @@ STIME
 STO
 STP
 STRARG
+SUBDIRS
 SUNWlibusbugen
 SUNWugen
 SUNWusb
@@ -2589,6 +2590,7 @@ ovmf
 pF
 pacman
 pacstrap
+parallelizable
 parallelized
 param
 parsable
@@ -3258,6 +3260,7 @@ wix
 wmNUT
 wmnut
 workflow
+workflows
 workspace
 workspaceFolder
 workspaces

--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -31,25 +31,25 @@ LDADD = $(LDADD_DRIVERS_SERIAL)
 AM_CFLAGS = -I$(top_srcdir)/include
 if WITH_USB
   AM_CFLAGS += $(LIBUSB_CFLAGS)
-endif
+endif WITH_USB
 if WITH_NEON
   AM_CFLAGS += $(LIBNEON_CFLAGS)
-endif
+endif WITH_NEON
 if WITH_LIBPOWERMAN
   AM_CFLAGS += $(LIBPOWERMAN_CFLAGS)
-endif
+endif WITH_LIBPOWERMAN
 if WITH_IPMI
   AM_CFLAGS += $(LIBIPMI_CFLAGS)
-endif
+endif WITH_IPMI
 if WITH_GPIO
   AM_CFLAGS += $(LIBGPIO_CFLAGS)
-endif
+endif WITH_GPIO
 if WITH_MODBUS
   AM_CFLAGS += $(LIBMODBUS_CFLAGS)
-endif
+endif WITH_MODBUS
 if HAVE_LIBREGEX
   AM_CFLAGS += $(LIBREGEX_CFLAGS)
-endif
+endif HAVE_LIBREGEX
 
 # Allow top-level Makefile override NUTSW_DRIVERLIST_DUMMY_UPS="dummy" to run
 # a build scenario without this driver (it is in a different dependency)
@@ -94,45 +94,45 @@ EXTRA_PROGRAMS += $(GPIO_DRIVERLIST)
 # construct the list of drivers to build
 if SOME_DRIVERS
  driverexec_PROGRAMS = $(DRIVER_BUILD_LIST)
-else
+else !SOME_DRIVERS
  driverexec_PROGRAMS = $(NUTSW_DRIVERLIST)
 if WITH_SERIAL
   driverexec_PROGRAMS += $(SERIAL_DRIVERLIST) $(SERIAL_USB_DRIVERLIST)
-else
+else !WITH_SERIAL
 if WITH_USB
   driverexec_PROGRAMS += $(SERIAL_USB_DRIVERLIST)
-endif
-endif
+endif WITH_USB
+endif !WITH_SERIAL
 if WITH_SNMP
   driverexec_PROGRAMS += $(SNMP_DRIVERLIST)
-endif
+endif WITH_SNMP
 if WITH_USB
    driverexec_PROGRAMS += $(USB_LIBUSB_DRIVERLIST)
-endif
+endif WITH_USB
 if WITH_NEON
    driverexec_PROGRAMS += $(NEONXML_DRIVERLIST)
-endif
+endif WITH_NEON
 if WITH_LIBPOWERMAN
    driverexec_PROGRAMS += $(POWERMAN_DRIVERLIST)
-endif
+endif WITH_LIBPOWERMAN
 if WITH_IPMI
    driverexec_PROGRAMS += $(IPMI_DRIVERLIST)
-endif
+endif WITH_IPMI
 if WITH_GPIO
    driverexec_PROGRAMS += $(GPIO_DRIVERLIST)
-endif
+endif WITH_GPIO
 if WITH_MACOSX
    driverexec_PROGRAMS += $(MACOSX_DRIVERLIST)
-endif
+endif WITH_MACOSX
 if WITH_LINUX_I2C
    driverexec_PROGRAMS += $(LINUX_I2C_DRIVERLIST)
-endif
+endif WITH_LINUX_I2C
 if WITH_MODBUS
   driverexec_PROGRAMS += $(MODBUS_DRIVERLIST)
-endif
+endif WITH_MODBUS
 else
    driverexec_PROGRAMS += skel
-endif
+endif !SOME_DRIVERS
 
 # always build upsdrvctl
 sbin_PROGRAMS = upsdrvctl
@@ -214,7 +214,7 @@ if WITH_SSL
   dummy_ups_CFLAGS += $(LIBSSL_CFLAGS)
   dummy_ups_LDADD += $(LIBSSL_LIBS)
   dummy_ups_LDFLAGS += $(LIBSSL_LDFLAGS_RPATH)
-endif
+endif WITH_SSL
 
 # Clone drivers (in NUTSW_DRIVERLIST)
 clone_SOURCES = clone.c
@@ -233,10 +233,10 @@ skel_LDADD = $(LDADD_DRIVERS)
 # USB
 if WITH_LIBUSB_0_1
 LIBUSB_IMPL = libusb0.c
-endif
+endif WITH_LIBUSB_0_1
 if WITH_LIBUSB_1_0
 LIBUSB_IMPL = libusb1.c
-endif
+endif WITH_LIBUSB_1_0
 USBHID_UPS_SUBDRIVERS = apc-hid.c arduino-hid.c belkin-hid.c cps-hid.c explore-hid.c \
  liebert-hid.c mge-hid.c powercom-hid.c tripplite-hid.c idowell-hid.c \
  openups-hid.c powervar-hid.c delta_ups-hid.c ever-hid.c legrand-hid.c salicru-hid.c
@@ -311,7 +311,7 @@ if WITH_SSL
   netxml_ups_CFLAGS += $(LIBSSL_CFLAGS)
   netxml_ups_LDADD += $(LIBSSL_LIBS)
   netxml_ups_LDFLAGS += $(LIBSSL_LDFLAGS_RPATH)
-endif
+endif WITH_SSL
 
 # Powerman
 powerman_pdu_SOURCES = powerman-pdu.c
@@ -321,7 +321,7 @@ powerman_pdu_LDADD = $(LDADD) $(LIBPOWERMAN_LIBS)
 nut_ipmipsu_SOURCES = nut-ipmipsu.c
 if WITH_FREEIPMI
   nut_ipmipsu_SOURCES += nut-libfreeipmi.c
-endif
+endif WITH_FREEIPMI
 # FIXME: Hacky hot-fix for build agents of varying OS generations:
 # Different versions of IPMI libs requested 'unsigned int *' or 'int *' args:
 #nut_ipmipsu_CFLAGS = $(AM_CFLAGS) -Wno-pointer-sign
@@ -348,7 +348,7 @@ apc_modbus_LDADD = $(LDADD_DRIVERS) $(LIBMODBUS_LIBS)
 if WITH_MODBUS_USB
   apc_modbus_SOURCES += $(LIBUSB_IMPL) hidparser.c usb-common.c
   apc_modbus_LDADD += $(LIBUSB_LIBS)
-endif
+endif WITH_MODBUS_USB
 
 # Huawei UPS2000 driver
 # (this is both a Modbus and a serial driver)
@@ -379,12 +379,12 @@ nutdrv_qx_CFLAGS = $(AM_CFLAGS)
 if WITH_SERIAL
 nutdrv_qx_CFLAGS += -DQX_SERIAL
 nutdrv_qx_LDADD += libdummy_serial.la $(SERLIBS)
-endif
+endif WITH_SERIAL
 if WITH_USB
 nutdrv_qx_CFLAGS += -DQX_USB
 nutdrv_qx_SOURCES += $(LIBUSB_IMPL) usb-common.c
 nutdrv_qx_LDADD += $(LIBUSB_LIBS)
-endif
+endif WITH_USB
 NUTDRV_QX_SUBDRIVERS = nutdrv_qx_bestups.c nutdrv_qx_blazer-common.c	\
  nutdrv_qx_innovart31.c	\
  nutdrv_qx_masterguard.c	\

--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -130,8 +130,6 @@ endif WITH_LINUX_I2C
 if WITH_MODBUS
   driverexec_PROGRAMS += $(MODBUS_DRIVERLIST)
 endif WITH_MODBUS
-else
-   driverexec_PROGRAMS += skel
 endif !SOME_DRIVERS
 
 # always build upsdrvctl

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -19,11 +19,11 @@ dist_noinst_HEADERS = \
 # Optionally deliverable as part of NUT public API:
 if WITH_DEV
 include_HEADERS += parseconf.h
-if WITH_NUTCONF
+if WITH_DEV_LIBNUTCONF
 include_HEADERS += nutstream.hpp nutwriter.hpp nutipc.hpp nutconf.hpp
-else !WITH_NUTCONF
+else !WITH_DEV_LIBNUTCONF
 dist_noinst_HEADERS += nutstream.hpp nutwriter.hpp nutipc.hpp nutconf.hpp
-endif !WITH_NUTCONF
+endif !WITH_DEV_LIBNUTCONF
 else !WITH_DEV
 dist_noinst_HEADERS += parseconf.h
 dist_noinst_HEADERS += nutstream.hpp nutwriter.hpp nutipc.hpp nutconf.hpp

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -9,19 +9,25 @@
 @NUT_AM_MAKE_CAN_EXPORT@@NUT_AM_EXPORT_CCACHE_PATH@export CCACHE_PATH=@CCACHE_PATH@
 @NUT_AM_MAKE_CAN_EXPORT@@NUT_AM_EXPORT_CCACHE_PATH@export PATH=@PATH_DURING_CONFIGURE@
 
+include_HEADERS =
 dist_noinst_HEADERS = \
     attribute.h common.h extstate.h proto.h			\
     state.h str.h timehead.h upsconf.h				\
     nut_bool.h nut_float.h nut_stdint.h nut_platform.h		\
-    nutstream.hpp nutwriter.hpp nutipc.hpp nutconf.hpp		\
     wincompat.h
 
 # Optionally deliverable as part of NUT public API:
 if WITH_DEV
-include_HEADERS = parseconf.h
-else
+include_HEADERS += parseconf.h
+if WITH_NUTCONF
+include_HEADERS += nutstream.hpp nutwriter.hpp nutipc.hpp nutconf.hpp
+else !WITH_NUTCONF
+dist_noinst_HEADERS += nutstream.hpp nutwriter.hpp nutipc.hpp nutconf.hpp
+endif !WITH_NUTCONF
+else !WITH_DEV
 dist_noinst_HEADERS += parseconf.h
-endif
+dist_noinst_HEADERS += nutstream.hpp nutwriter.hpp nutipc.hpp nutconf.hpp
+endif !WITH_DEV
 
 # http://www.gnu.org/software/automake/manual/automake.html#Clean
 BUILT_SOURCES = nut_version.h

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,5 +1,6 @@
 /libnutclient.pc
 /libnutclientstub.pc
+/libnutconf.pc
 /libnutscan.pc
 /libupsclient-config
 /libupsclient.pc

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -13,14 +13,16 @@
 @NUT_AM_MAKE_CAN_EXPORT@@NUT_AM_EXPORT_CCACHE_PATH@export CCACHE_PATH=@CCACHE_PATH@
 @NUT_AM_MAKE_CAN_EXPORT@@NUT_AM_EXPORT_CCACHE_PATH@export PATH=@PATH_DURING_CONFIGURE@
 
+# Note: do not need to EXTRA_DIST the *.in files since they are listed
+# in configure.ac for template conversion and automake knows about them.
 EXTRA_DIST = README.adoc
 
 if WITH_DEV
 if WITH_PKG_CONFIG
  pkgconfig_DATA = libupsclient.pc libnutscan.pc libnutclient.pc libnutclientstub.pc
-if WITH_NUTCONF
+if WITH_DEV_LIBNUTCONF
  pkgconfig_DATA += libnutconf.pc
-endif WITH_NUTCONF
+endif WITH_DEV_LIBNUTCONF
 else !WITH_PKG_CONFIG
  bin_SCRIPTS = libupsclient-config
 endif !WITH_PKG_CONFIG

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -18,6 +18,9 @@ EXTRA_DIST = README.adoc
 if WITH_DEV
 if WITH_PKG_CONFIG
  pkgconfig_DATA = libupsclient.pc libnutscan.pc libnutclient.pc libnutclientstub.pc
+if WITH_NUTCONF
+ pkgconfig_DATA += libnutconf.pc
+endif WITH_NUTCONF
 else !WITH_PKG_CONFIG
  bin_SCRIPTS = libupsclient-config
 endif !WITH_PKG_CONFIG

--- a/lib/libnutconf.pc.in
+++ b/lib/libnutconf.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libnutconf
+Description: Network UPS Tools configuration management
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lnutconf
+Cflags: -I${includedir}

--- a/scripts/Windows/build-mingw-nut.sh
+++ b/scripts/Windows/build-mingw-nut.sh
@@ -216,7 +216,8 @@ do_build_mingw_nut() {
 		|| echo "NOTE: FAILED to process OPTIONAL cgi-bin directory; was NUT CGI enabled?" >&2
 	fi
 
-	echo "$0: install phase complete ($?)" >&2
+	# If we had fatal errors above, we exited there - so here we are SUCCESSful
+	echo "$0: SUCCESS: install phase complete ($?)" >&2
 	cd ..
 }
 

--- a/server/Makefile.am
+++ b/server/Makefile.am
@@ -35,12 +35,12 @@ upsd_LDFLAGS = $(AM_LDFLAGS)
 if WITH_WRAP
   upsd_CFLAGS += $(LIBWRAP_CFLAGS)
   upsd_LDADD += $(LIBWRAP_LIBS)
-endif
+endif WITH_WRAP
 if WITH_SSL
   upsd_CFLAGS += $(LIBSSL_CFLAGS)
   upsd_LDADD += $(LIBSSL_LIBS)
   upsd_LDFLAGS += $(LIBSSL_LDFLAGS_RPATH)
-endif
+endif WITH_SSL
 
 # Developer, troubleshooting, or odd automation aid tool:
 if HAVE_WINDOWS
@@ -52,7 +52,7 @@ endif !HAVE_WINDOWS
 if WITH_DEV
 # Have it installed properly
 libexec_PROGRAMS = sockdebug
-endif
+endif WITH_DEV
 
 dummy:
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -133,7 +133,7 @@ $(top_builddir)/common/libcommon.la: dummy
 ### Optional tests which can not be built everywhere
 # List of src files for CppUnit tests
 CPPUNITTESTSRC = example.cpp nutclienttest.cpp
-# These are an optional part of cppunittest, if building WITH_NUTCONF
+# These are an optional part of cppunittest, if building WITH_LIBNUTCONF
 CPPUNITTESTSRC_NUTCONF = nutconf_parser_ut.cpp nutstream_ut.cpp nutconf_ut.cpp nutipc_ut.cpp
 # The test driver which orchestrates running those tests above
 CPPUNITTESTERSRC = cpputest.cpp
@@ -161,10 +161,10 @@ cppunittest_SOURCES = $(CPPUNITTESTSRC) $(CPPUNITTESTERSRC)
 
 # Currently nutconf and related codebase causes woes for static analysis
 # so we do not build it unless explicitly asked to.
-if WITH_NUTCONF
+if WITH_LIBNUTCONF
 cppunittest_SOURCES += $(CPPUNITTESTSRC_NUTCONF)
 cppunittest_LDADD += $(top_builddir)/common/libnutconf.la
-endif WITH_NUTCONF
+endif WITH_LIBNUTCONF
 
 cppnit_CXXFLAGS = $(AM_CXXFLAGS) $(CPPUNIT_CFLAGS) $(CPPUNIT_CXXFLAGS) $(CPPUNIT_NUT_CXXFLAGS) $(CXXFLAGS)
 cppnit_LDFLAGS = $(CPPUNIT_LDFLAGS) $(CPPUNIT_LIBS)


### PR DESCRIPTION
This PR follows up from #2825 to complete a feature originally tried there but excised due to added complexity/instability of original PoC builds. Also updates bits of documentation and general Makefile markup here and there, and presumably fixes a presumably broken delivery of some source files into "dist" archives in certain build circumstances.

The `libnutconf` library was until now treated in recipes as an internal detail of the `nutconf` tool, added to main codebase in PR #2283 and refined later on. However for third-party integrations it may be (or not be) interesting to experiment with use of the library as such, rather than calling the command-line tool (which allegedly provides a more stable API for integrations). IMHO there's too much placed into the header files for it to be stable, and some lower-level concepts were evolving since the branch merge into master.

To allow for such experiments, this PR introduces `configure --with-dev-libnutconf` to enable delivery of a (shared) library file and corresponding C++ headers.

UPDATE: This was originally "orthogonal to either `--with-nutconf` or `--with-dev` being enabled or disabled", but now is tied to those values IF `--with-all=(auto|yes|no)` is used and no explicit `--with-dev-libnutconf` value is requested. The updated decision logic is also documented in `docs/configure.txt`.

CC @arnaudquette-eaton if this can help in e.g. SmartNUT. Not sure how stable or unstable this API would end up being, but at least the PR makes it easier to try.

Feel free to CC @emilienkia-eaton @ericclappier-eaton and other initial authors/contributors to see how their baby grew :)