### PR TITLE
use novendor param as flag for don't read vendro name, need for dexp ups

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -213,6 +213,8 @@ Overall, NUT CI farm build times got 25%+ shorter (which is important as
      on Innova devices, but other models than RT 3/1. [#2798]
    * introduced a `gtec` subdriver and protocol, tested over USB with a
      Gtec ZP120N device. [#2818]
+   * fixed `hunnox_protocol()` to honour the optional `novendor` setting for
+     devices that are confused by such query, e.g. DEXP LCD EURO 1200VA. [#2839]
    * extended Voltronic protocol to support longer numbers as remaining
      `battery.runtime` value. [#2765]
 

--- a/UPGRADING.adoc
+++ b/UPGRADING.adoc
@@ -117,6 +117,11 @@ Changes from 2.8.2 to 2.8.3
   other devices using that MIB (negatively, if the older mappings were
   indeed correct for any practical cases, and were not a typo). [#2803]
 
+- `nutdrv_qx` fixed `hunnox_protocol()` to honour the optional `novendor`
+  setting for devices that are confused by such query (e.g. DEXP LCD EURO
+  1200VA); it may be remotely possible that some other devices could begin
+  to misbehave due to this fix -- please let us know then. [#2839]
+
 - mge-utalk driver will no longer set non-standard status values `COMMFAULT`
   and `ALARM` (for a specific status bit); instead, it will set modern
   `ups.alarm` with values `COMMFAULT` and/or `DEVICEALARM` (and raise

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -329,6 +329,7 @@
 "Deltec"	"ups"	"4"	"PRM 450/700/1000/1500"	""	"upscode2"
 
 "DEXP"	"ups"	"2"	"MIX 850VA"	"USB"	"blazer_usb langid_fix=0x0409 runtimecal=240,100,720,50 default.battery.voltage.high=2.27 default.battery.voltage.low=1.72"	# https://github.com/networkupstools/nut/issues/721
+"DEXP"	"ups"	"2"	"LCD EURO 1200VA"	"USB"	"driver=nutdrv_qx port=auto vendorid=0001 productid=0000 product=MEC0003 langid_fix=0x0409 protocol=hunnox subdriver=hunnox novendor norating noscanlangid default.battery.voltage.high=28,6 default.battery.voltage.low=21,4"	
 
 "Digital Loggers"	"pdu"	"1"	"LPC, EPCR2, DIN"	"8 outlets"	"powerman-pdu (experimental)"
 

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -329,7 +329,7 @@
 "Deltec"	"ups"	"4"	"PRM 450/700/1000/1500"	""	"upscode2"
 
 "DEXP"	"ups"	"2"	"MIX 850VA"	"USB"	"blazer_usb langid_fix=0x0409 runtimecal=240,100,720,50 default.battery.voltage.high=2.27 default.battery.voltage.low=1.72"	# https://github.com/networkupstools/nut/issues/721
-"DEXP"	"ups"	"2"	"LCD EURO 1200VA"	"USB"	"driver=nutdrv_qx port=auto vendorid=0001 productid=0000 product=MEC0003 langid_fix=0x0409 protocol=hunnox subdriver=hunnox novendor norating noscanlangid default.battery.voltage.high=28,6 default.battery.voltage.low=21,4"	
+"DEXP"	"ups"	"2"	"LCD EURO 1200VA"	"USB"	"driver=nutdrv_qx port=auto vendorid=0001 productid=0000 product=MEC0003 langid_fix=0x0409 protocol=hunnox subdriver=hunnox novendor norating noscanlangid default.battery.voltage.high=28.6 default.battery.voltage.low=21.4"	# https://github.com/networkupstools/nut/pull/2839
 
 "Digital Loggers"	"pdu"	"1"	"LPC, EPCR2, DIN"	"8 outlets"	"powerman-pdu (experimental)"
 

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3323 utf-8
+personal_ws-1.1 en 3324 utf-8
 AAC
 AAS
 ABI
@@ -245,6 +245,7 @@ DES
 DESTDIR
 DEVICEALARM
 DEVNAME
+DEXP
 DF
 DHEA
 DIGYS

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -993,7 +993,7 @@ static int 	hunnox_protocol(int asking_for)
 			}
 			break;
 		case 3:
-			if (asking_for != 0x0c) {
+			if (asking_for != 0x0c && !testvar("novendor")) {
 				upsdebugx(3, "asking for: %02X", (unsigned int)0x0c);
 				usb_get_string(udev, 0x0c,
 					langid_fix_local, (usb_ctrl_charbuf)buf, 102);


### PR DESCRIPTION
As I found, in **hunnox_protocol** on step 3 and `asking_for = x0c` it tried to read some string (vendor data by protocol), but ups didn't provide this data and because empty value on next step it cause crash of ups logic and it are stops response.
As I found, it should be solved by use **novendor**, that was used in **blazer_usb**, I added use it in **nutdrv_qx**, but not sure if it will not broke other working setup. Please suggest better solution for it.