### PR TITLE
Fix `generic_gpio_libgpiod` driver builds with libgpio 2.x API changes

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -216,6 +216,11 @@ Overall, NUT CI farm build times got 25%+ shorter (which is important as
    * extended Voltronic protocol to support longer numbers as remaining
      `battery.runtime` value. [#2765]
 
+ - GPIO drivers:
+   * extending to support library API of not only libgpiod v1.x releases,
+     but also v2.x; introduced a NUT `WITH_LIBGPIO_VERSION` C macro (in
+     `config.h`) to differentiate the library variants. [issue #2833]
+
  - bicker_ser: added new driver for Bicker 12/24Vdc UPS via RS-232 serial
    communication protocol, which supports any UPS shipped with the PSZ-1053
    extension module. [PR #2448]

--- a/configure.ac
+++ b/configure.ac
@@ -1902,6 +1902,8 @@ AC_ARG_WITH(drivers,
 		if test -z "${with_gpio}"; then
 			dnl NOTE: Currently we only support a Linux libgpiod
 			dnl backend for GPIO; eventually there could be more.
+			dnl Also note that since March 2023 the very different
+			dnl libgpiod v2.x is out (requires kernel 5.17.4+)
 			case ${target_os} in
 				linux*) with_gpio="auto";; dnl # TODO: Detect 2018+ distros?
 				*) with_gpio="auto";;
@@ -2117,6 +2119,8 @@ AC_ARG_WITH(all,
 		if test -z "${with_gpio}"; then
 			dnl NOTE: Currently we only support a Linux libgpiod
 			dnl backend for GPIO; eventually there could be more.
+			dnl Also note that since March 2023 the very different
+			dnl libgpiod v2.x is out (requires kernel 5.17.4+)
 			with_gpio="${withval}"
 			case ${target_os} in
 				linux*) ;;
@@ -2595,7 +2599,8 @@ if test "${nut_with_gpio}" != "no"; then
    nut_with_gpio="${nut_have_gpio}"
 fi
 
-NUT_REPORT_DRIVER([build GPIO driver], [${nut_with_gpio}], [${nut_gpio_lib}],
+dnl NOTE: m4 scriptlet also defines WITH_LIBGPIO_VERSION like 0x00020000 in config.h
+NUT_REPORT_DRIVER([build GPIO driver (library v${GPIO_VERSION})], [${nut_with_gpio}], [${nut_gpio_lib}],
 					[WITH_GPIO], [Define to enable GPIO support])
 
 dnl ----------------------------------------------------------------------

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3323 utf-8
+personal_ws-1.1 en 3324 utf-8
 AAC
 AAS
 ABI
@@ -595,6 +595,7 @@ LEDs
 LGTM
 LH
 LIBGD
+LIBGPIO
 LIBNEON
 LIBNETSNMP
 LIBOPENSSL

--- a/drivers/generic_gpio_libgpiod.c
+++ b/drivers/generic_gpio_libgpiod.c
@@ -1,7 +1,7 @@
 /*  generic_gpio_libgpiod.c - gpiod based NUT driver code for GPIO attached UPS devices
  *
  *  Copyright (C)
- *	2023       	Modris Berzonis <modrisb@apollo.lv>
+ *	2023 - 2025		Modris Berzonis <modrisb@apollo.lv>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -31,7 +31,7 @@
 #endif
 
 #define DRIVER_NAME	"GPIO UPS driver (API " WITH_LIBGPIO_VERSION_STR ")"
-#define DRIVER_VERSION	"1.02"
+#define DRIVER_VERSION	"1.03"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -81,6 +81,7 @@ static void reserve_lines_libgpiod(struct gpioups_t *gpioupsfdlocal, int inner) 
 	upsdebugx(5, "reserve_lines_libgpiod runOptions 0x%x, inner %d", gpioupsfdlocal->runOptions, inner);
 
 	if(((gpioupsfdlocal->runOptions&ROPT_REQRES) != 0) == inner) {
+#if WITH_LIBGPIO_VERSION < 0x00020000
 		struct gpiod_line_request_config config;
 		int gpioRc;
 		config.consumer=upsdrv_info.name;
@@ -103,6 +104,14 @@ static void reserve_lines_libgpiod(struct gpioups_t *gpioupsfdlocal, int inner) 
 			config.request_type,
 			gpioRc
 		);
+#else	/* #if WITH_LIBGPIO_VERSION >= 0x00020000 */
+		if(!libgpiod_data->request) {
+			libgpiod_data->request = gpiod_chip_request_lines(libgpiod_data->gpioChipHandle, libgpiod_data->config, libgpiod_data->lineConfig);
+		}
+		if(!libgpiod_data->request) {
+			fatalx(LOG_ERR,	"Failed to create line request");
+		}
+#endif	/* WITH_LIBGPIO_VERSION */
 	}
 }
 
@@ -114,7 +123,20 @@ void gpio_open(struct gpioups_t *gpioupsfdlocal) {
 	struct libgpiod_data_t *libgpiod_data = xcalloc(1, sizeof(struct libgpiod_data_t));
 	gpioupsfdlocal->lib_data = libgpiod_data;
 
+#if WITH_LIBGPIO_VERSION < 0x00020000
 	libgpiod_data->gpioChipHandle = gpiod_chip_open_by_name(gpioupsfdlocal->chipName);
+#else	/* #if WITH_LIBGPIO_VERSION >= 0x00020000 */
+	if(!strchr(gpioupsfdlocal->chipName, '/')) {
+		char *pathName = xcalloc(strlen(gpioupsfdlocal->chipName)+6, sizeof(char));
+		strcpy(pathName, "/dev/");
+		strcat(pathName, gpioupsfdlocal->chipName);
+		libgpiod_data->gpioChipHandle = gpiod_chip_open(pathName);
+		free(pathName);
+	} else {
+		libgpiod_data->gpioChipHandle = gpiod_chip_open(gpioupsfdlocal->chipName);
+	}
+#endif	/* WITH_LIBGPIO_VERSION */
+
 	if(!libgpiod_data->gpioChipHandle)
 		fatal_with_errno(
 			LOG_ERR,
@@ -123,8 +145,17 @@ void gpio_open(struct gpioups_t *gpioupsfdlocal) {
 		);
 	else {
 		int gpioRc;
+
+#if WITH_LIBGPIO_VERSION < 0x00020000
 		upslogx(LOG_NOTICE, "GPIO chip [%s] opened", gpioupsfdlocal->chipName);
 		gpioupsfdlocal->chipLinesCount = gpiod_chip_num_lines(libgpiod_data->gpioChipHandle);
+#else	/* #if WITH_LIBGPIO_VERSION >= 0x00020000 */
+		upslogx(LOG_NOTICE, "GPIO chip [%s] opened, api version 2", gpioupsfdlocal->chipName);
+		struct gpiod_chip_info *chipInfo = gpiod_chip_get_info(libgpiod_data->gpioChipHandle);
+		gpioupsfdlocal->chipLinesCount = gpiod_chip_info_get_num_lines(chipInfo);
+		gpiod_chip_info_free(chipInfo);
+#endif	/* WITH_LIBGPIO_VERSION */
+
 		upslogx(LOG_NOTICE, "Find %d lines on GPIO chip [%s]", gpioupsfdlocal->chipLinesCount, gpioupsfdlocal->chipName);
 		if(gpioupsfdlocal->chipLinesCount<gpioupsfdlocal->upsMaxLine) {
 			gpiod_chip_close(libgpiod_data->gpioChipHandle);
@@ -135,6 +166,8 @@ void gpio_open(struct gpioups_t *gpioupsfdlocal) {
 				gpioupsfdlocal->upsMaxLine
 			);
 		}
+
+#if WITH_LIBGPIO_VERSION < 0x00020000
 		gpiod_line_bulk_init(&libgpiod_data->gpioLines);
 		gpiod_line_bulk_init(&libgpiod_data->gpioEventLines);
 		gpioRc = gpiod_chip_get_lines(
@@ -143,6 +176,30 @@ void gpio_open(struct gpioups_t *gpioupsfdlocal) {
 			gpioupsfdlocal->upsLinesCount,
 			&libgpiod_data->gpioLines
 		);
+#else	/* #if WITH_LIBGPIO_VERSION >= 0x00020000 */
+		libgpiod_data->values = xcalloc(gpioupsfdlocal->upsLinesCount, sizeof(*libgpiod_data->values));
+		struct gpiod_line_settings *lineSettings = gpiod_line_settings_new();
+		libgpiod_data->lineConfig = gpiod_line_config_new();
+		libgpiod_data->config = gpiod_request_config_new();
+		if(!lineSettings || !libgpiod_data->lineConfig || !libgpiod_data->config) {
+			fatalx(LOG_ERR,	"Failed to allocate configuration structures - out of memory");
+		}
+		gpioRc = gpiod_line_settings_set_direction(lineSettings, GPIOD_LINE_DIRECTION_INPUT);
+		if(gpioRc) {
+			fatal_with_errno(LOG_ERR, "Failed to set lines to GPIOD_LINE_DIRECTION_INPUT");
+		}
+		gpioRc = gpiod_line_settings_set_edge_detection(lineSettings, GPIOD_LINE_EDGE_BOTH);
+		if(gpioRc) {
+			fatal_with_errno(LOG_ERR, "Failed to set lines to GPIOD_LINE_EDGE_BOTH");
+		}
+		gpioRc = gpiod_line_config_add_line_settings(libgpiod_data->lineConfig, (unsigned int *)gpioupsfdlocal->upsLines,
+							  gpioupsfdlocal->upsLinesCount, lineSettings);
+		if(gpioRc) {
+			fatalx(LOG_ERR,	"Failed to attach line settings to line configuration");
+		}
+		gpiod_request_config_set_consumer(libgpiod_data->config, upsdrv_info.name);
+		gpiod_line_settings_free(lineSettings);
+#endif
 		if(gpioRc)
 			fatal_with_errno(
 				LOG_ERR,
@@ -151,6 +208,15 @@ void gpio_open(struct gpioups_t *gpioupsfdlocal) {
 			);
 		upsdebugx(5, "GPIO gpiod_chip_get_lines return code %d", gpioRc);
 		reserve_lines_libgpiod(gpioupsfdlocal, 0);
+
+#if WITH_LIBGPIO_VERSION >= 0x00020000
+	gpioRc=gpiod_line_request_get_values(libgpiod_data->request, gpioupsfdlocal->upsLinesStates);
+	if(gpioRc==0) {
+		for(int i=0; i < gpioupsfdlocal->upsLinesCount; i++) {
+			gpioupsfdlocal->upsLinesStates[i] = libgpiod_data->values[i];
+		}
+	}
+#endif	/* WITH_LIBGPIO_VERSION */
 	}
 }
 
@@ -161,6 +227,13 @@ void gpio_close(struct gpioups_t *gpioupsfdlocal) {
 	if(gpioupsfdlocal) {
 		struct libgpiod_data_t *libgpiod_data = (struct libgpiod_data_t *)(gpioupsfdlocal->lib_data);
 		if(libgpiod_data) {
+#if WITH_LIBGPIO_VERSION >= 0x00020000
+			if(libgpiod_data->values) {
+				free(libgpiod_data->values);
+			}
+			gpiod_line_config_free(libgpiod_data->lineConfig);
+			gpiod_request_config_free(libgpiod_data->config);
+#endif	/* WITH_LIBGPIO_VERSION */
 			if(libgpiod_data->gpioChipHandle) {
 				gpiod_chip_close(libgpiod_data->gpioChipHandle);
 			}
@@ -179,7 +252,9 @@ void gpio_get_lines_states(struct gpioups_t *gpioupsfdlocal) {
 	struct libgpiod_data_t *libgpiod_data = (struct libgpiod_data_t *)(gpioupsfdlocal->lib_data);
 
 	reserve_lines_libgpiod(gpioupsfdlocal, 1);
+
 	if(gpioupsfdlocal->runOptions&ROPT_EVMODE) {
+#if WITH_LIBGPIO_VERSION < 0x00020000
 		struct timespec timeoutLong = {1,0};
 		struct gpiod_line_event event;
 		int monRes;
@@ -228,15 +303,32 @@ void gpio_get_lines_states(struct gpioups_t *gpioupsfdlocal) {
 				);
 			}
 		}
+#else	/* #if WITH_LIBGPIO_VERSION >= 0x00020000 */
+		int64_t poll_timeout = 1000000000;	//	in nanoseconds
+		if(gpioupsfdlocal->initial) {
+			poll_timeout = 35000000000;
+		} else {
+			gpioupsfdlocal->initial = 1;
+		}
+		gpioRc = gpiod_line_request_wait_edge_events(libgpiod_data->request, poll_timeout);
+#endif	/* WITH_LIBGPIO_VERSION */
 	}
 	for(i=0; i < gpioupsfdlocal->upsLinesCount; i++) {
 		gpioupsfdlocal->upsLinesStates[i] = -1;
 	}
+#if WITH_LIBGPIO_VERSION < 0x00020000
 	gpioRc=gpiod_line_get_value_bulk(
 		&libgpiod_data->gpioLines,
 		gpioupsfdlocal->upsLinesStates
 	);
-
+#else	/* #if WITH_LIBGPIO_VERSION >= 0x00020000 */
+	gpioRc=gpiod_line_request_get_values(libgpiod_data->request, libgpiod_data->values);
+	if(gpioRc==0) {
+		for(i=0; i < gpioupsfdlocal->upsLinesCount; i++) {
+			gpioupsfdlocal->upsLinesStates[i] = libgpiod_data->values[i];
+		}
+	}
+#endif	/* WITH_LIBGPIO_VERSION */
 	if (gpioRc < 0)
 		fatal_with_errno(LOG_ERR, "GPIO line status read call failed");
 
@@ -254,6 +346,11 @@ void gpio_get_lines_states(struct gpioups_t *gpioupsfdlocal) {
 	}
 
 	if(gpioupsfdlocal->runOptions&ROPT_REQRES) {
+#if WITH_LIBGPIO_VERSION < 0x00020000
 		gpiod_line_release_bulk(&libgpiod_data->gpioLines);
+#else	/* #if WITH_LIBGPIO_VERSION >= 0x00020000 */
+		gpiod_line_request_release(libgpiod_data->request);
+		libgpiod_data->request = NULL;
+#endif	/* WITH_LIBGPIO_VERSION */
 	}
 }

--- a/drivers/generic_gpio_libgpiod.c
+++ b/drivers/generic_gpio_libgpiod.c
@@ -26,6 +26,10 @@
 #include "generic_gpio_common.h"
 #include "generic_gpio_libgpiod.h"
 
+#if !(defined WITH_LIBGPIO_VERSION) || !(defined WITH_LIBGPIO_VERSION_STR) || (WITH_LIBGPIO_VERSION == 0)
+# error "This driver can not be built, requires a known API WITH_LIBGPIO_VERSION to build against"
+#endif
+
 #define DRIVER_NAME	"GPIO UPS driver (API " WITH_LIBGPIO_VERSION_STR ")"
 #define DRIVER_VERSION	"1.02"
 

--- a/drivers/generic_gpio_libgpiod.c
+++ b/drivers/generic_gpio_libgpiod.c
@@ -26,7 +26,7 @@
 #include "generic_gpio_common.h"
 #include "generic_gpio_libgpiod.h"
 
-#define DRIVER_NAME	"GPIO UPS driver"
+#define DRIVER_NAME	"GPIO UPS driver (API " WITH_LIBGPIO_VERSION_STR ")"
 #define DRIVER_VERSION	"1.02"
 
 /* driver description structure */

--- a/drivers/generic_gpio_libgpiod.h
+++ b/drivers/generic_gpio_libgpiod.h
@@ -1,7 +1,7 @@
 /*  generic_gpio_libgpiod.h - gpiod based NUT driver definitions for GPIO attached UPS devices
  *
  *  Copyright (C)
- *	2023       	Modris Berzonis <modrisb@apollo.lv>
+ *	2023 - 2025		Modris Berzonis <modrisb@apollo.lv>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -24,11 +24,19 @@
 #define GENERIC_GPIO_LIBGPIOD_H_SEEN 1
 
 #include <gpiod.h>
+#include <poll.h>
 
 typedef struct libgpiod_data_t {
 	struct gpiod_chip	*gpioChipHandle;	/* libgpiod chip handle when opened */
+#if WITH_LIBGPIO_VERSION < 0x00020000
 	struct gpiod_line_bulk	gpioLines;	/* libgpiod lines to monitor */
 	struct gpiod_line_bulk	gpioEventLines;	/* libgpiod lines for event monitoring */
+#else	/* #if WITH_LIBGPIO_VERSION >= 0x00020000 */
+	struct gpiod_line_config *lineConfig;
+	struct gpiod_request_config *config;
+	struct gpiod_line_request *request;
+	enum gpiod_line_value *values;
+#endif	/* WITH_LIBGPIO_VERSION */
 } libgpiod_data;
 
 #endif	/* GENERIC_GPIO_LIBGPIOD_H_SEEN */

--- a/m4/nut_check_libgpiod.m4
+++ b/m4/nut_check_libgpiod.m4
@@ -107,14 +107,21 @@ if test -z "${nut_have_gpio_seen}"; then
 
 		dnl Normally this would be in library headers, but they do not seem forthcoming
 		AS_CASE([${GPIO_VERSION}],
-			[2.*], [AC_DEFINE(WITH_LIBGPIO_VERSION, 0x00020000, [Define libgpio C API version generation])],
-			[1.*], [AC_DEFINE(WITH_LIBGPIO_VERSION, 0x00010000, [Define libgpio C API version generation])]
+			[2.*], [
+				AC_DEFINE(WITH_LIBGPIO_VERSION, 0x00020000, [Define libgpio C API version generation])
+				AC_DEFINE_UNQUOTED(WITH_LIBGPIO_VERSION_STR, ["0x00020000"], [Define libgpio C API version generation as string])
+				],
+			[1.*], [
+				AC_DEFINE(WITH_LIBGPIO_VERSION, 0x00010000, [Define libgpio C API version generation])
+				AC_DEFINE_UNQUOTED(WITH_LIBGPIO_VERSION_STR, ["0x00010000"], [Define libgpio C API version generation as string])
+				]
 		)
 	else
 		dnl FIXME: Report "none" here?
 		nut_gpio_lib=""
 
 		AC_DEFINE(WITH_LIBGPIO_VERSION, 0x00000000, [Define libgpio C API version generation])
+		AC_DEFINE_UNQUOTED(WITH_LIBGPIO_VERSION_STR, ["0x00000000"], [Define libgpio C API version generation as string])
 	fi
 
 	unset CFLAGS

--- a/m4/nut_check_libgpiod.m4
+++ b/m4/nut_check_libgpiod.m4
@@ -84,14 +84,37 @@ if test -z "${nut_have_gpio_seen}"; then
 	CFLAGS="${CFLAGS_ORIG} ${depCFLAGS}"
 	LIBS="${LIBS_ORIG} ${depLIBS}"
 	AC_CHECK_HEADERS(gpiod.h, [nut_have_gpio=yes], [nut_have_gpio=no], [AC_INCLUDES_DEFAULT])
-	AC_CHECK_FUNCS(gpiod_chip_open_by_name gpiod_chip_close, [nut_gpio_lib="libgpiod"], [nut_have_gpio=no])
+	AS_IF([text x"${nut_have_gpio}" = xyes], [AC_CHECK_FUNCS(gpiod_chip_close, [], [nut_have_gpio=no])])
+	AS_IF([text x"${nut_have_gpio}" = xyes], [
+		AS_CASE(["${GPIO_VERSION}"],
+			[2.*], [AC_CHECK_FUNCS(gpiod_chip_open, [nut_gpio_lib="libgpiod"], [nut_have_gpio=no])],
+			[1.*], [AC_CHECK_FUNCS(gpiod_chip_open_by_name, [nut_gpio_lib="libgpiod"], [nut_have_gpio=no])],
+				[AC_CHECK_FUNCS(gpiod_chip_open_by_name, [
+					nut_gpio_lib="libgpiod"
+					AS_IF([test x"${GPIO_VERSION}" = xnone], [GPIO_VERSION="1.x"])
+				 ], [
+					AC_CHECK_FUNCS(gpiod_chip_open, [
+						nut_gpio_lib="libgpiod"
+						AS_IF([test x"${GPIO_VERSION}" = xnone], [GPIO_VERSION="2.x"])
+					])]
+				 )]
+		)
+	])
 
 	if test "${nut_have_gpio}" = "yes"; then
 		LIBGPIO_CFLAGS="${depCFLAGS}"
 		LIBGPIO_LIBS="${depLIBS}"
+
+		dnl Normally this would be in library headers, but they do not seem forthcoming
+		AS_CASE([${GPIO_VERSION}],
+			[2.*], [AC_DEFINE(WITH_LIBGPIO_VERSION, 0x00020000, [Define libgpio C API version generation])],
+			[1.*], [AC_DEFINE(WITH_LIBGPIO_VERSION, 0x00010000, [Define libgpio C API version generation])]
+		)
 	else
 		dnl FIXME: Report "none" here?
 		nut_gpio_lib=""
+
+		AC_DEFINE(WITH_LIBGPIO_VERSION, 0x00000000, [Define libgpio C API version generation])
 	fi
 
 	unset CFLAGS

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -109,8 +109,8 @@ generic_gpio_common.c: $(top_srcdir)/drivers/generic_gpio_common.c
 
 gpiotest_SOURCES = generic_gpio_utest.c generic_gpio_liblocal.c
 nodist_gpiotest_SOURCES = generic_gpio_libgpiod.c generic_gpio_common.c
-gpiotest_LDADD = $(top_builddir)/drivers/libdummy_mockdrv.la
-gpiotest_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/tests -DDRIVERS_MAIN_WITHOUT_MAIN=1
+gpiotest_LDADD = $(top_builddir)/drivers/libdummy_mockdrv.la $(LIBGPIO_LDFLAGS)
+gpiotest_CFLAGS = $(LIBGPIO_CFLAGS) $(AM_CFLAGS) -I$(top_srcdir)/tests -DDRIVERS_MAIN_WITHOUT_MAIN=1
 else !WITH_GPIO
 EXTRA_DIST += generic_gpio_utest.c generic_gpio_liblocal.c
 endif !WITH_GPIO

--- a/tests/generic_gpio_liblocal.c
+++ b/tests/generic_gpio_liblocal.c
@@ -1,7 +1,7 @@
-/*  generic_gpio_libglocal.c - gpio device emulation library for GPIO attached UPS devices
+/*  tests/generic_gpio_libglocal.c - gpio device emulation library for GPIO attached UPS devices
  *
  *  Copyright (C)
- *	2023       	Modris Berzonis <modrisb@apollo.lv>
+ *	2023 - 2025		Modris Berzonis <modrisb@apollo.lv>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -27,6 +27,19 @@
 
 static char  chipName[NUT_GPIO_CHIPNAMEBUF];
 static unsigned int num_lines=0;
+
+static int gStatus = 0;
+static int errReqFor_line_get_value_bulk=0;
+
+void setNextLinesReadToFail(void) {
+	errReqFor_line_get_value_bulk=1;
+}
+
+void gpiod_chip_close(struct gpiod_chip *chip) {
+	NUT_UNUSED_VARIABLE(chip);
+}
+
+#if WITH_LIBGPIO_VERSION < 0x00020000
 
 struct gpiod_chip *gpiod_chip_open_by_name(const char *name) {
 	strcpy(chipName, name);
@@ -63,13 +76,6 @@ int gpiod_line_request_bulk(struct gpiod_line_bulk *bulk,
 	NUT_UNUSED_VARIABLE(config);
 	NUT_UNUSED_VARIABLE(default_vals);
 	return 0;
-}
-
-static int gStatus = 0;
-static int errReqFor_line_get_value_bulk=0;
-
-void setNextLinesReadToFail(void) {
-	errReqFor_line_get_value_bulk=1;
 }
 
 int gpiod_line_get_value_bulk(struct gpiod_line_bulk *bulk,
@@ -120,10 +126,6 @@ int gpiod_line_event_wait_bulk(struct gpiod_line_bulk *bulk,
 	return 0;
 }
 
-void gpiod_chip_close(struct gpiod_chip *chip) {
-	NUT_UNUSED_VARIABLE(chip);
-}
-
 int gpiod_line_event_read(struct gpiod_line *line,
 			  struct gpiod_line_event *event) {
 	NUT_UNUSED_VARIABLE(line);
@@ -139,3 +141,145 @@ unsigned int gpiod_line_offset(struct gpiod_line *line) {
 void gpiod_line_release_bulk(struct gpiod_line_bulk *bulk) {
 	NUT_UNUSED_VARIABLE(bulk);
 }
+
+#else	/* #if WITH_LIBGPIO_VERSION >= 0x00020000 */
+
+struct gpiod_line_request *
+gpiod_chip_request_lines(struct gpiod_chip *chip,
+			 struct gpiod_request_config *req_cfg,
+			 struct gpiod_line_config *line_cfg) {
+	NUT_UNUSED_VARIABLE(chip);
+	NUT_UNUSED_VARIABLE(req_cfg);
+	NUT_UNUSED_VARIABLE(line_cfg);
+	return (struct gpiod_line_request *)1;
+}
+
+struct gpiod_chip *gpiod_chip_open(const char *path) {
+	strcpy(chipName, path);
+	if(!strstr(path, "gpiochip1"))
+		return (struct gpiod_chip *)1;
+	else {
+		errno = EACCES;
+		return NULL;
+	}
+}
+
+struct gpiod_chip_info *gpiod_chip_get_info(struct gpiod_chip *chip) {
+	NUT_UNUSED_VARIABLE(chip);
+	return (struct gpiod_chip_info *)1;
+}
+
+size_t gpiod_chip_info_get_num_lines(struct gpiod_chip_info *info) {
+	NUT_UNUSED_VARIABLE(info);
+	if(strstr(chipName, "gpiochip2"))
+		return 2;
+	return 32;
+}
+
+void gpiod_chip_info_free(struct gpiod_chip_info *info) {
+	NUT_UNUSED_VARIABLE(info);
+}
+
+struct gpiod_line_settings *gpiod_line_settings_new(void) {
+	return (struct gpiod_line_settings *)1;
+}
+
+int gpiod_line_settings_set_direction(struct gpiod_line_settings *settings,
+				      enum gpiod_line_direction direction) {
+	NUT_UNUSED_VARIABLE(settings);
+	NUT_UNUSED_VARIABLE(direction);
+	return 0;
+}
+
+int gpiod_line_settings_set_edge_detection(struct gpiod_line_settings *settings,
+					   enum gpiod_line_edge edge) {
+	NUT_UNUSED_VARIABLE(settings);
+	NUT_UNUSED_VARIABLE(edge);
+	return 0;
+}
+
+struct gpiod_line_config *gpiod_line_config_new(void) {
+	return (struct gpiod_line_config *)1;
+}
+
+int gpiod_line_config_add_line_settings(struct gpiod_line_config *config,
+					const unsigned int *offsets,
+					size_t num_offsets,
+					struct gpiod_line_settings *settings) {
+	NUT_UNUSED_VARIABLE(config);
+	NUT_UNUSED_VARIABLE(offsets);
+	NUT_UNUSED_VARIABLE(num_offsets);
+	NUT_UNUSED_VARIABLE(settings);
+	return 0;
+}
+
+struct gpiod_request_config *gpiod_request_config_new(void) {
+	return (struct gpiod_request_config *)1;
+}
+
+void gpiod_request_config_set_consumer(struct gpiod_request_config *config,
+				       const char *consumer) {
+	NUT_UNUSED_VARIABLE(config);
+	NUT_UNUSED_VARIABLE(consumer);
+}
+
+int gpiod_line_request_get_values(struct gpiod_line_request *request,
+				  enum gpiod_line_value *values) {
+	NUT_UNUSED_VARIABLE(request);
+	unsigned int	i;
+	int	pinPos = 1;
+
+	if(errReqFor_line_get_value_bulk) {
+		errReqFor_line_get_value_bulk=0;
+		errno = EPERM;
+		return -1;
+	}
+	for(i=0; i<num_lines; i++) {
+		values[i]=(gStatus&pinPos)!=0;
+		pinPos=pinPos<<1;
+	}
+
+	gStatus++;
+	return 0;
+}
+
+void gpiod_line_settings_free(struct gpiod_line_settings *settings) {
+	NUT_UNUSED_VARIABLE(settings);
+}
+
+void gpiod_line_config_free(struct gpiod_line_config *config) {
+	NUT_UNUSED_VARIABLE(config);
+}
+
+void gpiod_request_config_free(struct gpiod_request_config *config) {
+	NUT_UNUSED_VARIABLE(config);
+}
+
+int gpiod_line_request_wait_edge_events(struct gpiod_line_request *request,
+					int64_t timeout_ns) {
+	NUT_UNUSED_VARIABLE(request);
+	NUT_UNUSED_VARIABLE(timeout_ns);
+	switch(gStatus%3) {
+		case 0:
+			sleep(2);
+			break;
+
+		case 1:
+			sleep(4);
+			break;
+
+		case 2:
+			sleep(6);
+			break;
+
+		/* Static analysis wants this, we should never get here though, not with %3 above */
+		default:
+			fatalx(EXIT_FAILURE, "%s: Hit impossible default case", __func__);
+	}
+	return 0;
+}
+
+void gpiod_line_request_release(struct gpiod_line_request *request) {
+	NUT_UNUSED_VARIABLE(request);
+}
+#endif	/* WITH_LIBGPIO_VERSION */

--- a/tests/generic_gpio_liblocal.c
+++ b/tests/generic_gpio_liblocal.c
@@ -25,6 +25,10 @@
 #include <errno.h>
 #include "generic_gpio_utest.h"
 
+#if !(defined WITH_LIBGPIO_VERSION) || !(defined WITH_LIBGPIO_VERSION_STR) || (WITH_LIBGPIO_VERSION == 0)
+# error "This driver can not be built, requires a known API WITH_LIBGPIO_VERSION to build against"
+#endif
+
 static char  chipName[NUT_GPIO_CHIPNAMEBUF];
 static unsigned int num_lines=0;
 

--- a/tests/generic_gpio_utest.c
+++ b/tests/generic_gpio_utest.c
@@ -1,7 +1,7 @@
-/*  generic_gpio_utest.c - gpio NUT driver code test tool
+/*  tests/generic_gpio_utest.c - gpio NUT driver code test tool
  *
  *  Copyright (C)
- *	2023       	Modris Berzonis <modrisb@apollo.lv>
+ *	2023 - 2025		Modris Berzonis <modrisb@apollo.lv>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -143,6 +143,8 @@ int main(int argc, char **argv) {
 	char testDescFileNameBuf[LARGEBUF];
 	char *testDescFileName = "generic_gpio_test.txt";
 	unsigned int i;
+	unsigned long version = WITH_LIBGPIO_VERSION;
+	printf("Tests running for libgpiod library version %lu\n", version);
 
 	test_with_exit=0;
 


### PR DESCRIPTION
Closes: #2833

API of the library has massively changed between 1.6.x available in older distros, and 2.x in newer ones (and matching Linux kernel functionality changed a lot as well). The driver was not buildable in newer/upcoming distribution releases because of that.

Great thanks to @modrisb for initial driver development, and for this subsequent fix (on short notice at that). And to @tomeko12 for raising the alarm :)

For my part, it should now be easy to identify which API (1 or 2) the program got built against:
```
### configure log: * build GPIO driver (library v2.3):     yes libgpiod
:; ./drivers/generic_gpio_libgpiod -V
Network UPS Tools 2.8.2.2324.5-2329-g03947d319 (development iteration after 2.8.2) - GPIO UPS driver (API 0x00020000) 1.03

### configure log: * build GPIO driver (library v1.6.3):   yes libgpiod
:; ./drivers/generic_gpio_libgpiod -V
Network UPS Tools 2.8.2.2327.5-2332-g4940ab008 (development iteration after 2.8.2) - GPIO UPS driver (API 0x00010000) 1.03
```

NOTE: Currently the API is not elaborated in detail by `m4/nut_check_libgpiod.m4` and effectively just says 1 or 2 (extensibly as a 32-bit int define `WITH_LIBGPIO_VERSION`, so we can add minor/patch layers if wanted). Note that the `GPIOD_VERSION` used by the script comes from `pkg-config` and may reflect the library API version placed into the `*.pc` metadata, rather than a source/package version.

A custom build of the library to test NUT builds against is detailed at https://github.com/networkupstools/nut/issues/2833#issuecomment-2700238503 and trivial to complete.