### PR TITLE
Refactor `status_set()` et al and update a test, optimize `upsmon` a bit, retouch docs

### DIFF
--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -1088,14 +1088,14 @@ static int get_var(utype_t *ups, const char *var, char *buf, size_t bufsize)
 		query[1] = ups->upsname;
 		numq = 2;
 	}
-
+	else
 	if (!strcmp(var, "status")) {
 		query[0] = "VAR";
 		query[1] = ups->upsname;
 		query[2] = "ups.status";
 		numq = 3;
 	}
-
+	else
 	if (!strcmp(var, "alarm")) {
 		/* Opaque string */
 		query[0] = "VAR";

--- a/docs/nut-names.txt
+++ b/docs/nut-names.txt
@@ -636,7 +636,8 @@ battery: Any battery details
                                  and load level lower (Watts)        | 10
 |===============================================================================
 
-NOTE:
+[NOTE]
+======
 `battery.charger.status` replaces the historic flags `CHRG` and `DISCHRG`
 that were exposed through `ups.status`.
 The `battery.charger.status` can have one of the following values:
@@ -646,6 +647,7 @@ The `battery.charger.status` can have one of the following values:
 - `floating`: battery has completed its charge cycle,
    and waiting to go to resting mode,
 - `resting`: the battery is fully charged, and not charging nor discharging.
+======
 
 NOTE: When possible, time-stamps and dates should be expressed as detailed
 above in the Time and Date format chapter.

--- a/docs/nut-names.txt
+++ b/docs/nut-names.txt
@@ -179,7 +179,7 @@ during a transition period. The `ups.*` data will then be removed.
 | device.macaddr      | Physical network address of the device     | 68:b5:99:f5:89:27
 | device.uptime       | Device uptime in seconds                   | 1782
 | device.count        | Total number of daisychained devices       | 1
-| device.usb.version  | Device USB version                         | 01.29
+| device.usb.version  | Device (firmware-reported) USB version     | 01.29
 |====================================================================================
 
 [NOTE]

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -4,7 +4,7 @@
 	2003		Russell Kroll <rkroll@exploits.org>
 	2008		Arjen de Korte <adkorte-guest@alioth.debian.org>
 	2012-2017	Arnaud Quette <arnaud.quette@free.fr>
-	2020-2024	Jim Klimov <jimklimov+nut@gmail.com>
+	2020-2025	Jim Klimov <jimklimov+nut@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -1636,80 +1636,23 @@ void status_init(void)
  * (considering a whole-word token in temporary status_buf) */
 int status_get(const char *buf)
 {
-	char	*s = NULL;
-	size_t	offset = 0, buflen = 0;
-
-	if (!buf || !*buf || !*status_buf)
-		return 0;
-
-	s = strstr(status_buf, buf);
-	buflen = strlen(buf);
-
-repeat:
-	/* not found or hit end of line */
-	if (!s || !*s)
-		return 0;
-
-	offset = s - status_buf;
-#ifdef DEBUG
-	upsdebugx(3, "%s: '%s' in '%s': offset=%" PRIuSIZE" buflen=%" PRIuSIZE" s[buflen]='0x%2X'\n",
-		__func__, buf, status_buf, offset, buflen, s[buflen]);
-#endif
-	if (offset == 0 || status_buf[offset - 1] == ' ') {
-		/* We have hit the start of token */
-		if (s[buflen] == '\0' || s[buflen] == ' ') {
-			/* And we have hit the end of token */
-			return 1;
-		}
-	}
-
-	/* buf was a substring of some other token */
-	s = strstr(s + 1, buf);
-	goto repeat;
+	return str_contains_token(status_buf, buf);
 }
 
 /* add a status element */
-void status_set(const char *buf)
+static int status_set_callback(char *tgt, size_t tgtsize, const char *token)
 {
-#ifdef DEBUG
-	upsdebugx(3, "%s: '%s'\n", __func__, buf);
-#endif
-	if (strstr(buf, " ")) {
-		/* Recurse adding each sub-status one by one (avoid duplicates)
-		 * We frown upon adding "A FEW TOKENS" at once, but in e.g.
-		 * snmp-ups subdrivers with a mapping table this is not easily
-		 * avoidable...
-		 */
-		char	*tmp = xstrdup(buf), *p = tmp, *s = tmp;
-		while (*p) {
-			if (*p == ' ') {
-				*p = '\0';
-				if (s != p) {
-					/* Only recurse to set non-trivial tokens */
-					status_set(s);
-				}
-				p++;
-				s = p;	/* Start of new word... or a consecutive space to ignore on next cycle */
-			} else {
-				p++;
-			}
-		}
-
-		if (s != p) {
-			/* Last valid token did end with (*p=='\0') */
-			status_set(s);
-		}
-
-		free(tmp);
-		return;
+	if (tgt != status_buf || tgtsize != sizeof(status_buf)) {
+		upsdebugx(2, "%s: called for wrong use-case", __func__);
+		return 0;
 	}
 
-	if (ignorelb && !strcasecmp(buf, "LB")) {
+	if (ignorelb && !strcasecmp(token, "LB")) {
 		upsdebugx(2, "%s: ignoring LB flag from device", __func__);
-		return;
+		return 0;
 	}
 
-	if (!strcasecmp(buf, "ALARM")) {
+	if (!strcasecmp(token, "ALARM")) {
 		/* Drivers really should not raise alarms this way,
 		 * but for the sake of third-party forks, we handle
 		 * the possibility...
@@ -1720,20 +1663,19 @@ void status_set(const char *buf)
 			alarm_set("[N/A]");
 		}
 		alarm_status++;
-		return;
+		return 0;
 	}
 
-	if (status_get(buf)) {
-		upsdebugx(2, "%s: status was already set: %s", __func__, buf);
-		return;
-	}
+	/* Proceed adding the token */
+	return 1;
+}
 
-	/* separate with a space if multiple elements are present */
-	if (strlen(status_buf) > 0) {
-		snprintfcat(status_buf, sizeof(status_buf), " %s", buf);
-	} else {
-		snprintfcat(status_buf, sizeof(status_buf), "%s", buf);
-	}
+void status_set(const char *buf)
+{
+#ifdef DEBUG
+	upsdebugx(3, "%s: '%s'\n", __func__, buf);
+#endif
+	str_add_unique_token(status_buf, sizeof(status_buf), buf, status_set_callback, NULL);
 }
 
 /* write the status_buf into the externally visible dstate storage */
@@ -1815,6 +1757,11 @@ void alarm_init(void)
 #endif
 void alarm_set(const char *buf)
 {
+	/* NOTE: Differs from status_set() since we can add whole sentences
+	 *  here, not just unique tokens. Drivers are encouraged to wrap such
+	 *  sentences into brackets, especially when many alarms raised at once
+	 *  are anticipated, for readability.
+	 */
 	int ret;
 	if (strlen(alarm_buf) < 1 || (alarm_status && !strcmp(alarm_buf, "[N/A]"))) {
 		ret = snprintf(alarm_buf, sizeof(alarm_buf), "%s", buf);

--- a/include/common.h
+++ b/include/common.h
@@ -1,7 +1,7 @@
 /* common.h - prototypes for the common useful functions
 
    Copyright (C) 2000  Russell Kroll <rkroll@exploits.org>
-   Copyright (C) 2021-2024  Jim Klimov <jimklimov+nut@gmail.com>
+   Copyright (C) 2021-2025  Jim Klimov <jimklimov+nut@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -314,6 +314,34 @@ int sendsignal(const char *progname, const char * sig, int check_current_prognam
 
 int snprintfcat(char *dst, size_t size, const char *fmt, ...)
 	__attribute__ ((__format__ (__printf__, 3, 4)));
+
+/*****************************************************************************
+ * String methods for space-separated token lists, used originally in dstate *
+ *****************************************************************************/
+
+/* Return non-zero if "string" contains "token" (case-sensitive),
+ * either surrounded by space character(s) or start/end of "string",
+ * or 0 if that token is not there, or if either string is NULL or empty.
+ */
+int	str_contains_token(const char *string, const char *token);
+
+/* Add "token" to end of string "tgt", if it is not yet there
+ * (prefix it with a space character if "tgt" is not empty).
+ * Return 0 if already there, 1 if token was added successfully,
+ * -1 if we needed to add it but it did not fit under the tgtsize limit,
+ * -2 if either string was NULL or "token" was empty.
+ * NOTE: If token contains space(s) inside, recurse to treat it
+ * as several tokens to add independently.
+ * Optionally calls "callback_always" (if not NULL) after checking
+ * for spaces (and maybe recursing) and before checking if the token
+ * is already there, and/or "callback_unique" (if not NULL) after
+ * checking for uniqueness and going to add a newly seen token.
+ * If such callback returns 0, abort the addition of token and return -3.
+ */
+int	str_add_unique_token(char *tgt, size_t tgtsize, const char *token,
+			    int (*callback_always)(char *, size_t, const char *),
+			    int (*callback_unique)(char *, size_t, const char *)
+);
 
 /* Report maximum platform value for the pid_t */
 pid_t get_max_pid_t(void);

--- a/tests/driver_methods_utest.c
+++ b/tests/driver_methods_utest.c
@@ -182,10 +182,11 @@ int main(int argc, char **argv) {
 	status_set("OL BOOST");
 	status_set("ALARM");
 	status_set("OB");
+	status_set("LB");	/* Should be honoured */
 	status_commit();
 
 	valueStr = dstate_getinfo("ups.status");
-	report_0_means_pass(strcmp(valueStr, "ALARM OL BOOST OB"));
+	report_0_means_pass(strcmp(valueStr, "ALARM OL BOOST OB LB"));
 	printf(" test for ups.status with explicit ALARM set via status_set() and no extra alarm_set() nor alarm_commit(): '%s'; is ALARM reported?\n", NUT_STRARG(valueStr));
 
 	valueStr = dstate_getinfo("ups.alarm");
@@ -201,12 +202,15 @@ int main(int argc, char **argv) {
 	alarm_init();
 	alarm_commit();
 
+	dstate_setinfo("driver.flag.ignorelb", "enabled");
+
 	status_init();
 	alarm_init();
 	status_set("OL BOOST");
 	alarm_set("[N/A]");
 	alarm_set("[Test alarm 2]");
 	status_set("OB");
+	status_set("LB");	/* Should be ignored */
 	alarm_commit();
 	status_commit();
 


### PR DESCRIPTION
Assorted features and fixes inspired by #2708 discussion, to avoid cluttering the main PR's review scope.

Notably, the refactoring of `status_set()` allows other PRs to manage multiple-unique-token data similar to `ups.status` (as proposed for those "ECO" related changes), potentially not only in drivers.