### PR TITLE
Issue 2708 2686 2184

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -84,6 +84,10 @@ https://github.com/networkupstools/nut/milestone/11
    * In `cps_fix_report_desc()` we intended to fix-up input and output voltages
      in certain cases against high voltage transfer, we only fixed-up one of
      them. [#1245]
+   * `upsd` should now handle `TRACKING` value of `STAT_CONVERSION_FAILED`
+     introduced in NUT v2.8.2 for the socket protocol (between driver and
+     data server), by returning "ERR INVALID-ARGUMENT", so there is no change
+     for the network protocol definition. [#2182]
 
  - SEMVER, know thyself!
    * Development iterations of NUT should now identify with not only the

--- a/docs/man/upscli_strerror.txt
+++ b/docs/man/upscli_strerror.txt
@@ -35,4 +35,4 @@ SEE ALSO
 linkman:upscli_fd[3], linkman:upscli_get[3],
 linkman:upscli_readline[3], linkman:upscli_sendline[3],
 linkman:upscli_ssl[3],
-linkman:upscli_strerror[3], linkman:upscli_upserror[3]
+linkman:upscli_upserror[3]

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -818,7 +818,7 @@ static int sock_arg(conn_t *conn, size_t numarg, char **arg)
 		char *cmdparam = NULL;
 		char *cmdid = NULL;
 
-		/* Check if <cmdparam> and TRACKING were provided */
+		/* Check if <cmdparam> and/or TRACKING were provided */
 		if (numarg == 3) {
 			cmdparam = arg[2];
 		} else if (numarg == 4 && !strcasecmp(arg[2], "TRACKING")) {
@@ -872,6 +872,17 @@ static int sock_arg(conn_t *conn, size_t numarg, char **arg)
 				NUT_STRARG(cmdname));
 		}
 
+		/* Send back execution result (here, STAT_INSTCMD_UNKNOWN)
+		 * if TRACKING was requested.
+		 * Note that in practice we should not get here often: if the
+		 * instcmd was not registered, it may be rejected earlier in
+		 * call stack, or returned by a driver's handler (for unknown
+		 * commands) just a bit above.
+		 */
+		if (cmdid)
+			send_tracking(conn, cmdid, ret);
+
+		/* The command was handled, status is a separate consideration */
 		return 1;
 	}
 

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -29,7 +29,7 @@
  */
 
 #define DRIVER_NAME	"Generic HID driver"
-#define DRIVER_VERSION	"0.61"
+#define DRIVER_VERSION	"0.62"
 
 #define HU_VAR_WAITBEFORERECONNECT "waitbeforereconnect"
 
@@ -914,6 +914,10 @@ int instcmd(const char *cmdname, const char *extradata)
 
 	/* If extradata is empty, use the default value from the HID-to-NUT table */
 	val = extradata ? extradata : hidups_item->dfl;
+	if (!val) {
+		upsdebugx(2, "instcmd: %s requires an explicit parameter\n", cmdname);
+		return STAT_INSTCMD_CONVERSION_FAILED;
+	}
 
 	/* Lookup the new value if needed */
 	if (hidups_item->hid2info != NULL) {

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -1320,6 +1320,7 @@ char *tracking_get(const char *id)
 		case STAT_UNKNOWN:
 			return "ERR UNKNOWN";
 		case STAT_INVALID:
+		case STAT_CONVERSION_FAILED:
 			return "ERR INVALID-ARGUMENT";
 		case STAT_FAILED:
 			return "ERR FAILED";

--- a/server/upsd.h
+++ b/server/upsd.h
@@ -82,7 +82,8 @@ enum {
    STAT_HANDLED = 0,	/* completed successfully (NUT_SUCCESS or "OK") */
    STAT_UNKNOWN,	/* unspecified error (NUT_ERR_UNKNOWN) */
    STAT_INVALID,	/* invalid command/setvar (NUT_ERR_INVALID_ARGUMENT) */
-   STAT_FAILED		/* command/setvar failed (NUT_ERR_INSTCMD_FAILED / NUT_ERR_SET_FAILED) */
+   STAT_FAILED,		/* command/setvar failed (NUT_ERR_INSTCMD_FAILED / NUT_ERR_SET_FAILED) */
+   STAT_CONVERSION_FAILED	/* STAT_INSTCMD_CONVERSION_FAILED / STAT_SET_CONVERSION_FAILED in drivers/upshandler.h => "ERR INVALID-ARGUMENT" same as STAT_INVALID */
 };
 
 /* Commands and settings status tracking functions */


### PR DESCRIPTION
Some older tech debt found during work on solution for #2708 and planned follow-up to #2850 in particular:

* `drivers/dstate.c`: `sock_arg()`: if INSTCMD returns STAT_INSTCMD_UNKNOWN, let it be known to the TRACKING clients 
  * Follow-up to #656, #659, #660, #673 et al
  * The situation seemed unlikely (unsupported commands would be filtered out earlier), but still untidy. The code structure with "try shared instcmd, try driver instcmd, return" was there from 2005 or before; the (pedantically incomplete) ability to actually report the status was added in v2.8.0, in 2019 or so (when TRACKING mode is enabled for the query).
* `server/upsd.{c,h}`: handle TRACKING value for STAT_CONVERSION_FAILED
  * Follow-up from #2184 (v2.8.2)
  * We could report a numeric status (on socket protocol between driver and data server) not understood by the latter, so it would be an `ERR UNKNOWN` rather than `ERR INVALID-ARGUMENT` which applies more closely (at least from variants already defined in the NUT networking protocol)
* `drivers/usbhid-ups.c`: anticipate NULL `hidups_item->dfl` for commands; return STAT_INSTCMD_CONVERSION_FAILED if neither caller nor default parameter was available
  * for older code - avoid NPE in subsequent use of `val` with drivers that might put a `NULL` value in that `dfl` field for `HU_TYPE_CMD` entries (none seen in-tree so far)
  * for future code - prepare for use-cases that require a caller-provided argument (intentionally setting no defaults) for an INSTCMD, this is a direction where PR #2850 (or its follow-ups) may be going