### PR TITLE
Optionally suggest rpath for NUT libraries for third parties

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -18,6 +18,10 @@ PLANNED: Release notes for NUT 2.8.4 - what's new since 2.8.3
 
 https://github.com/networkupstools/nut/milestone/9
 
+ - `lib/*.pc.in`: propagate `-R/PATH` to NUT library installation location
+   (by default not in system prefix) to help third-party clients link with
+   us automatically. [#2782]
+
  - (expected) Dynamic Mapping Files (DMF) feature supported, to allow
    the driver binaries to be built once and data mappings to be loaded
    and modernized on the fly (porting from 42ITy project)

--- a/configure.ac
+++ b/configure.ac
@@ -5067,6 +5067,7 @@ NUT_REPORT_SETTING_PATH([System exec-library path],
 
 dnl Check if we want to expose non-standard RPATH to third-party consumers
 dnl of libupsclient etc. Keep verbatim dollar-var here, expand in pkg-config!
+dnl NOTE: hardcode_libdir_flag_spec(_CXX) vars come from LT INIT above
 LDFLAGS_NUT_RPATH=''
 LDFLAGS_NUT_RPATH_CXX=''
 AC_MSG_CHECKING([whether to suggest a LDFLAGS_NUT_RPATH in pkg-config et al, and which])
@@ -5075,11 +5076,15 @@ case "${nut_enable_ldflags_nut_rpath}" in
 	auto|yes|"")
 		dnl FIXME: for "auto", detect non-std path,
 		dnl  and set "no" if prefix/libdir is common
-		dnl FIXME: detect supported flags => via hardcode_libdir_flag_spec
 		dnl FIXME: perhaps prefer the new-ELF tricks for "runpath"
 		dnl  (so LD_LIBRARY_PATH can override the built-in suggestion)
 		if test "${nut_enable_ldflags_nut_rpath}" != no ; then
-			LDFLAGS_NUT_RPATH='-R${libdir} -Wl,-rpath,${libdir}'
+			if test x"${hardcode_libdir_flag_spec}" != x ; then
+				LDFLAGS_NUT_RPATH="`libdir='${libdir}'; eval echo "${hardcode_libdir_flag_spec}"`"
+			else
+				AC_MSG_NOTICE([autotools did not report a way to specify rpath for C])
+				dnl # LDFLAGS_NUT_RPATH='-R${libdir} -Wl,-rpath,${libdir}'
+			fi
 		fi
 		;;
 	*) LDFLAGS_NUT_RPATH="${nut_enable_ldflags_nut_rpath}" ;;
@@ -5096,11 +5101,15 @@ case "${nut_enable_ldflags_nut_rpath_cxx}" in
 	auto|yes|"")
 		dnl FIXME: for "auto", detect non-std path,
 		dnl  and set "no" if prefix/libdir is common
-		dnl FIXME: detect supported flags => via hardcode_libdir_flag_spec_CXX
 		dnl FIXME: perhaps prefer the new-ELF tricks for "runpath"
 		dnl  (so LD_LIBRARY_PATH can override the built-in suggestion)
 		if test "${nut_enable_ldflags_nut_rpath_cxx}" != no ; then
-			LDFLAGS_NUT_RPATH_CXX='-R${libdir} -Wl,-rpath,${libdir}'
+			if test x"${hardcode_libdir_flag_spec_CXX}" != x ; then
+				LDFLAGS_NUT_RPATH_CXX="`libdir='${libdir}'; eval echo "${hardcode_libdir_flag_spec_CXX}"`"
+			else
+				AC_MSG_NOTICE([autotools did not report a way to specify rpath for C++])
+				dnl # LDFLAGS_NUT_RPATH_CXX='-R${libdir} -Wl,-rpath,${libdir}'
+			fi
 		fi
 		;;
 	*) LDFLAGS_NUT_RPATH_CXX="${nut_enable_ldflags_nut_rpath_cxx}" ;;
@@ -5241,7 +5250,6 @@ AC_SUBST(NUT_WEBSITE_BASE)
 AC_SUBST(LIBSSL_CFLAGS)
 AC_SUBST(LIBSSL_LIBS)
 AC_SUBST(LIBSSL_LDFLAGS_RPATH)
-AC_SUBST(LIBSSL_LDFLAGS_RPATH_CXX)
 AC_SUBST(LIBSSL_REQUIRES)
 AC_SUBST(LIBGD_CFLAGS)
 AC_SUBST(LIBGD_LDFLAGS)
@@ -5310,6 +5318,7 @@ AC_SUBST(NUT_DATADIR, [`eval echo "${NUT_DATADIR}"`])
 AC_SUBST(NUT_MANDIR, [`eval echo "${NUT_MANDIR}"`])
 AC_SUBST(NUT_LIBEXECDIR, [`eval echo "${LIBEXECDIR}"`])
 AC_SUBST(LDFLAGS_NUT_RPATH)
+AC_SUBST(LDFLAGS_NUT_RPATH_CXX)
 AC_SUBST(DRVPATH)
 AC_SUBST(SBINDIR)
 AC_SUBST(PORT)

--- a/configure.ac
+++ b/configure.ac
@@ -4006,6 +4006,11 @@ else
 fi
 AM_CONDITIONAL(WITH_PKG_CONFIG, test -n "${pkgconfigdir}")
 
+dnl Only check the option here (and show in help near pkg-config)
+dnl See LDFLAGS_NUT_RPATH determination further below
+NUT_ARG_ENABLE([ldflags-nut-rpath],
+    [Suggest linker flags for NUT library consumers to set RPATH for uncommon location],
+    [auto])
 
 dnl Options for Solaris/illumos `make install` and `make package`
 AC_MSG_CHECKING(whether to make Solaris SVR4 packages)
@@ -5052,6 +5057,29 @@ LIBEXECDIR="${conftemp}"
 NUT_REPORT_SETTING_PATH([System exec-library path],
     LIBEXECDIR, "${conftemp}", [Default path for system exec-libraries])
 
+dnl Check if we want to expose non-standard RPATH to third-party consumers
+dnl of libupsclient etc. Keep verbatim dollar-var here, expand in pkg-config!
+AC_MSG_CHECKING([whether to suggest a LDFLAGS_NUT_RPATH in pkg-config et al, and which])
+LDFLAGS_NUT_RPATH=''
+case "${nut_enable_ldflags_nut_rpath}" in
+	no) ;;
+	auto|yes|"")
+		dnl FIXME: for "auto", detect non-std path,
+		dnl  and set "no" if prefix/libdir is common
+		dnl FIXME: detect supported flags
+		dnl FIXME: perhaps prefer the new-ELF tricks for "runpath"
+		dnl  (so LD_LIBRARY_PATH can override the built-in suggestion)
+		if test "${nut_enable_ldflags_nut_rpath}" != no ; then
+			LDFLAGS_NUT_RPATH='-R${libdir} -Wl,-rpath,${libdir}'
+		fi
+		;;
+	*) LDFLAGS_NUT_RPATH="${nut_enable_ldflags_nut_rpath}" ;;
+esac
+
+AS_IF([test x"${LDFLAGS_NUT_RPATH}" = x],
+	[AC_MSG_RESULT([none])],
+	[AC_MSG_RESULT([yes: ${LDFLAGS_NUT_RPATH}])]
+)
 
 dnl checks related to --with-snmp enabled on command-line
 
@@ -5250,6 +5278,7 @@ AC_SUBST(PKGCONFIGDIR)
 AC_SUBST(NUT_DATADIR, [`eval echo "${NUT_DATADIR}"`])
 AC_SUBST(NUT_MANDIR, [`eval echo "${NUT_MANDIR}"`])
 AC_SUBST(NUT_LIBEXECDIR, [`eval echo "${LIBEXECDIR}"`])
+AC_SUBST(LDFLAGS_NUT_RPATH)
 AC_SUBST(DRVPATH)
 AC_SUBST(SBINDIR)
 AC_SUBST(PORT)

--- a/configure.ac
+++ b/configure.ac
@@ -5065,24 +5065,76 @@ LIBEXECDIR="${conftemp}"
 NUT_REPORT_SETTING_PATH([System exec-library path],
     LIBEXECDIR, "${conftemp}", [Default path for system exec-libraries])
 
+AC_MSG_CHECKING([whether NUT libdir='${LIBDIR}' is among common search paths])
+DEFAULT_SEARCH_DIRS="`LANG=C LC_ALL=C ${CC} --print-search-dirs 2>/dev/null | grep libraries: | sed 's,^@<:@^=@:>@*=,,'`" 2>/dev/null || DEFAULT_SEARCH_DIRS=""
+NUT_LIBDIR_IN_DEFAULT_SEARCH_DIRS=""
+NUT_LIBDIR_IN_DEFAULT_SEARCH_DIRS_TEXT=""
+if test x"${DEFAULT_SEARCH_DIRS}" = x ; then
+	NUT_LIBDIR_IN_DEFAULT_SEARCH_DIRS="got empty list"
+	NUT_LIBDIR_IN_DEFAULT_SEARCH_DIRS_TEXT="could not detect default library search paths"
+else
+	AS_CASE(["${target_os}"],
+		[*mingw*], [ dnl # At least tooling on MSYS2 semi-native builds can return
+			dnl # semicolon-separated paths with possibly "C:/mingw..." spelling
+			DEFAULT_SEARCH_DIRS="`echo ":$DEFAULT_SEARCH_DIRS" | sed 's,\(@<:@:;@:>@\)\(@<:@A-Z@:>@\):/,:/\2/,g' | tr ':' '\n' | sed 's,/*$,,'`"
+			],
+			[DEFAULT_SEARCH_DIRS="`echo "$DEFAULT_SEARCH_DIRS" | tr ':' '\n' | sed 's,/*$,,'`"]
+	)
+
+	NUT_LIBDIR_IN_DEFAULT_SEARCH_DIRS="no"
+	NUT_LIBDIR_IN_DEFAULT_SEARCH_DIRS_TEXT="NUT libdir is not among common search paths"
+	dnl # FIXME: ARCH subdirs on some platforms
+
+	dnl # If NUT libdir does not exist, it is not systemic right away
+	if test -d "${LIBDIR}" ; then
+		LIBDIR_REALPATH="`cd "${LIBDIR}" && pwd`" || LIBDIR_REALPATH="${LIBDIR}"
+		LIBDIR_REALPATH="`echo "${LIBDIR_REALPATH}" | sed 's,/*$,,'`"
+		for D in ${DEFAULT_SEARCH_DIRS} ; do
+			if test x"$D" = x"${LIBDIR_REALPATH}" ; then
+				NUT_LIBDIR_IN_DEFAULT_SEARCH_DIRS="yes"
+				NUT_LIBDIR_IN_DEFAULT_SEARCH_DIRS_TEXT="NUT libdir is among common search paths"
+				break
+			else
+				D_REALPATH="`cd "${D}" 2>/dev/null && pwd`" && \
+				if test x"${D_REALPATH}" = x"${LIBDIR_REALPATH}" ; then
+					NUT_LIBDIR_IN_DEFAULT_SEARCH_DIRS="yes"
+					NUT_LIBDIR_IN_DEFAULT_SEARCH_DIRS_TEXT="NUT libdir is among common search paths"
+					break
+				fi
+			fi
+		done
+	fi
+fi
+AC_MSG_RESULT([${NUT_LIBDIR_IN_DEFAULT_SEARCH_DIRS}])
+dnl # if test x"${DEFAULT_SEARCH_DIRS}" != x ; then
+dnl # 	AC_MSG_NOTICE([Checked paths: ${DEFAULT_SEARCH_DIRS}])
+dnl # fi
+
 dnl Check if we want to expose non-standard RPATH to third-party consumers
 dnl of libupsclient etc. Keep verbatim dollar-var here, expand in pkg-config!
 dnl NOTE: hardcode_libdir_flag_spec(_CXX) vars come from LT INIT above
+dnl For "auto", we check for non-std path and set "no" if prefix/libdir *is* common
 LDFLAGS_NUT_RPATH=''
 LDFLAGS_NUT_RPATH_CXX=''
 AC_MSG_CHECKING([whether to suggest a LDFLAGS_NUT_RPATH in pkg-config et al, and which])
+RPATH_CIRCUMSTANCE=''
 case "${nut_enable_ldflags_nut_rpath}" in
 	no) ;;
 	auto|yes|"")
-		dnl FIXME: for "auto", detect non-std path,
-		dnl  and set "no" if prefix/libdir is common
 		dnl FIXME: perhaps prefer the new-ELF tricks for "runpath"
 		dnl  (so LD_LIBRARY_PATH can override the built-in suggestion)
+		if test "${nut_enable_ldflags_nut_rpath}" = auto ; then
+			RPATH_CIRCUMSTANCE="${NUT_LIBDIR_IN_DEFAULT_SEARCH_DIRS_TEXT}"
+			case "${NUT_LIBDIR_IN_DEFAULT_SEARCH_DIRS}" in
+				"got empty list"|no)	;; dnl # keep "auto"
+				yes)	nut_enable_ldflags_nut_rpath=no ;;
+			esac
+		fi
 		if test "${nut_enable_ldflags_nut_rpath}" != no ; then
 			if test x"${hardcode_libdir_flag_spec}" != x ; then
 				LDFLAGS_NUT_RPATH="`libdir='${libdir}'; eval echo "${hardcode_libdir_flag_spec}"`"
 			else
-				AC_MSG_NOTICE([autotools did not report a way to specify rpath for C])
+				RPATH_CIRCUMSTANCE="autotools did not report a way to specify rpath for C"
 				dnl # LDFLAGS_NUT_RPATH='-R${libdir} -Wl,-rpath,${libdir}'
 			fi
 		fi
@@ -5091,23 +5143,35 @@ case "${nut_enable_ldflags_nut_rpath}" in
 esac
 
 AS_IF([test x"${LDFLAGS_NUT_RPATH}" = x],
-	[AC_MSG_RESULT([none])],
-	[AC_MSG_RESULT([yes: ${LDFLAGS_NUT_RPATH}])]
+	[AC_MSG_RESULT([none])
+	 AS_IF([test x"${RPATH_CIRCUMSTANCE}" != x], [
+	    AC_MSG_NOTICE([Reason: ${RPATH_CIRCUMSTANCE}])])
+	],
+	[AC_MSG_RESULT([yes: ${LDFLAGS_NUT_RPATH}])
+	 AS_IF([test x"${RPATH_CIRCUMSTANCE}" != x], [
+	    AC_MSG_NOTICE([Warning: ${RPATH_CIRCUMSTANCE}])])
+	]
 )
 
 AC_MSG_CHECKING([whether to suggest a LDFLAGS_NUT_RPATH_CXX in pkg-config et al, and which])
+RPATH_CIRCUMSTANCE=''
 case "${nut_enable_ldflags_nut_rpath_cxx}" in
 	no) ;;
 	auto|yes|"")
-		dnl FIXME: for "auto", detect non-std path,
-		dnl  and set "no" if prefix/libdir is common
 		dnl FIXME: perhaps prefer the new-ELF tricks for "runpath"
 		dnl  (so LD_LIBRARY_PATH can override the built-in suggestion)
+		if test "${nut_enable_ldflags_nut_rpath_cxx}" = auto ; then
+			RPATH_CIRCUMSTANCE="${NUT_LIBDIR_IN_DEFAULT_SEARCH_DIRS_TEXT}"
+			case "${NUT_LIBDIR_IN_DEFAULT_SEARCH_DIRS}" in
+				"got empty list"|no)	;; dnl # keep "auto"
+				yes)	nut_enable_ldflags_nut_rpath_cxx=no ;;
+			esac
+		fi
 		if test "${nut_enable_ldflags_nut_rpath_cxx}" != no ; then
 			if test x"${hardcode_libdir_flag_spec_CXX}" != x ; then
 				LDFLAGS_NUT_RPATH_CXX="`libdir='${libdir}'; eval echo "${hardcode_libdir_flag_spec_CXX}"`"
 			else
-				AC_MSG_NOTICE([autotools did not report a way to specify rpath for C++])
+				RPATH_CIRCUMSTANCE="autotools did not report a way to specify rpath for C++"
 				dnl # LDFLAGS_NUT_RPATH_CXX='-R${libdir} -Wl,-rpath,${libdir}'
 			fi
 		fi
@@ -5116,8 +5180,14 @@ case "${nut_enable_ldflags_nut_rpath_cxx}" in
 esac
 
 AS_IF([test x"${LDFLAGS_NUT_RPATH_CXX}" = x],
-	[AC_MSG_RESULT([none])],
-	[AC_MSG_RESULT([yes: ${LDFLAGS_NUT_RPATH_CXX}])]
+	[AC_MSG_RESULT([none])
+	 AS_IF([test x"${RPATH_CIRCUMSTANCE}" != x], [
+	    AC_MSG_NOTICE([Reason: ${RPATH_CIRCUMSTANCE}])])
+	],
+	[AC_MSG_RESULT([yes: ${LDFLAGS_NUT_RPATH_CXX}])
+	 AS_IF([test x"${RPATH_CIRCUMSTANCE}" != x], [
+	    AC_MSG_NOTICE([Warning: ${RPATH_CIRCUMSTANCE}])])
+	]
 )
 
 dnl checks related to --with-snmp enabled on command-line

--- a/configure.ac
+++ b/configure.ac
@@ -3667,7 +3667,11 @@ then
     esac
 fi
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
+
+dnl # NOTE: This also initializes `hardcode_libdir_flag_spec` and
+dnl # `hardcode_libdir_flag_spec_CXX` that we use in LDFLAGS_NUT_RPATH
 LT_INIT
+
 AC_SUBST([LIBTOOL_DEPS])
 GCC="$SAVED_GCC"
 CC="$SAVED_CC"
@@ -4009,7 +4013,11 @@ AM_CONDITIONAL(WITH_PKG_CONFIG, test -n "${pkgconfigdir}")
 dnl Only check the option here (and show in help near pkg-config)
 dnl See LDFLAGS_NUT_RPATH determination further below
 NUT_ARG_ENABLE([ldflags-nut-rpath],
-    [Suggest linker flags for NUT library consumers to set RPATH for uncommon location],
+    [Suggest linker flags for NUT C library consumers to set RPATH for uncommon location],
+    [auto])
+
+NUT_ARG_ENABLE([ldflags-nut-rpath-cxx],
+    [Suggest linker flags for NUT C++ library consumers to set RPATH for uncommon location],
     [auto])
 
 dnl Options for Solaris/illumos `make install` and `make package`
@@ -5059,14 +5067,15 @@ NUT_REPORT_SETTING_PATH([System exec-library path],
 
 dnl Check if we want to expose non-standard RPATH to third-party consumers
 dnl of libupsclient etc. Keep verbatim dollar-var here, expand in pkg-config!
-AC_MSG_CHECKING([whether to suggest a LDFLAGS_NUT_RPATH in pkg-config et al, and which])
 LDFLAGS_NUT_RPATH=''
+LDFLAGS_NUT_RPATH_CXX=''
+AC_MSG_CHECKING([whether to suggest a LDFLAGS_NUT_RPATH in pkg-config et al, and which])
 case "${nut_enable_ldflags_nut_rpath}" in
 	no) ;;
 	auto|yes|"")
 		dnl FIXME: for "auto", detect non-std path,
 		dnl  and set "no" if prefix/libdir is common
-		dnl FIXME: detect supported flags
+		dnl FIXME: detect supported flags => via hardcode_libdir_flag_spec
 		dnl FIXME: perhaps prefer the new-ELF tricks for "runpath"
 		dnl  (so LD_LIBRARY_PATH can override the built-in suggestion)
 		if test "${nut_enable_ldflags_nut_rpath}" != no ; then
@@ -5079,6 +5088,27 @@ esac
 AS_IF([test x"${LDFLAGS_NUT_RPATH}" = x],
 	[AC_MSG_RESULT([none])],
 	[AC_MSG_RESULT([yes: ${LDFLAGS_NUT_RPATH}])]
+)
+
+AC_MSG_CHECKING([whether to suggest a LDFLAGS_NUT_RPATH_CXX in pkg-config et al, and which])
+case "${nut_enable_ldflags_nut_rpath_cxx}" in
+	no) ;;
+	auto|yes|"")
+		dnl FIXME: for "auto", detect non-std path,
+		dnl  and set "no" if prefix/libdir is common
+		dnl FIXME: detect supported flags => via hardcode_libdir_flag_spec_CXX
+		dnl FIXME: perhaps prefer the new-ELF tricks for "runpath"
+		dnl  (so LD_LIBRARY_PATH can override the built-in suggestion)
+		if test "${nut_enable_ldflags_nut_rpath_cxx}" != no ; then
+			LDFLAGS_NUT_RPATH_CXX='-R${libdir} -Wl,-rpath,${libdir}'
+		fi
+		;;
+	*) LDFLAGS_NUT_RPATH_CXX="${nut_enable_ldflags_nut_rpath_cxx}" ;;
+esac
+
+AS_IF([test x"${LDFLAGS_NUT_RPATH_CXX}" = x],
+	[AC_MSG_RESULT([none])],
+	[AC_MSG_RESULT([yes: ${LDFLAGS_NUT_RPATH_CXX}])]
 )
 
 dnl checks related to --with-snmp enabled on command-line
@@ -5211,6 +5241,7 @@ AC_SUBST(NUT_WEBSITE_BASE)
 AC_SUBST(LIBSSL_CFLAGS)
 AC_SUBST(LIBSSL_LIBS)
 AC_SUBST(LIBSSL_LDFLAGS_RPATH)
+AC_SUBST(LIBSSL_LDFLAGS_RPATH_CXX)
 AC_SUBST(LIBSSL_REQUIRES)
 AC_SUBST(LIBGD_CFLAGS)
 AC_SUBST(LIBGD_LDFLAGS)

--- a/lib/libnutclient.pc.in
+++ b/lib/libnutclient.pc.in
@@ -9,5 +9,5 @@ nutuser=@RUN_AS_USER@
 Name: libnutclient
 Description: UPS monitoring with Network UPS Tools
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -lnutclient
+Libs: -L${libdir} -R${libdir} -lnutclient
 Cflags: -I${includedir}

--- a/lib/libnutclient.pc.in
+++ b/lib/libnutclient.pc.in
@@ -9,5 +9,5 @@ nutuser=@RUN_AS_USER@
 Name: libnutclient
 Description: UPS monitoring with Network UPS Tools
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} @LDFLAGS_NUT_RPATH@ -lnutclient
+Libs: -L${libdir} @LDFLAGS_NUT_RPATH_CXX@ -lnutclient
 Cflags: -I${includedir}

--- a/lib/libnutclient.pc.in
+++ b/lib/libnutclient.pc.in
@@ -9,5 +9,5 @@ nutuser=@RUN_AS_USER@
 Name: libnutclient
 Description: UPS monitoring with Network UPS Tools
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -R${libdir} -lnutclient
+Libs: -L${libdir} @LDFLAGS_NUT_RPATH@ -lnutclient
 Cflags: -I${includedir}

--- a/lib/libnutclientstub.pc.in
+++ b/lib/libnutclientstub.pc.in
@@ -9,5 +9,5 @@ nutuser=@RUN_AS_USER@
 Name: libnutclientstub
 Description: Stub for UPS monitoring with Network UPS Tools (primarily for C++ tests)
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -R${libdir} -lnutclientstub
+Libs: -L${libdir} @LDFLAGS_NUT_RPATH@ -lnutclientstub
 Cflags: -I${includedir}

--- a/lib/libnutclientstub.pc.in
+++ b/lib/libnutclientstub.pc.in
@@ -9,5 +9,5 @@ nutuser=@RUN_AS_USER@
 Name: libnutclientstub
 Description: Stub for UPS monitoring with Network UPS Tools (primarily for C++ tests)
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -lnutclientstub
+Libs: -L${libdir} -R${libdir} -lnutclientstub
 Cflags: -I${includedir}

--- a/lib/libnutconf.pc.in
+++ b/lib/libnutconf.pc.in
@@ -9,5 +9,5 @@ nutuser=@RUN_AS_USER@
 Name: libnutconf
 Description: Network UPS Tools configuration management
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -R${libdir} -lnutconf
+Libs: -L${libdir} @LDFLAGS_NUT_RPATH@ -lnutconf
 Cflags: -I${includedir}

--- a/lib/libnutconf.pc.in
+++ b/lib/libnutconf.pc.in
@@ -9,5 +9,5 @@ nutuser=@RUN_AS_USER@
 Name: libnutconf
 Description: Network UPS Tools configuration management
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} @LDFLAGS_NUT_RPATH@ -lnutconf
+Libs: -L${libdir} @LDFLAGS_NUT_RPATH_CXX@ -lnutconf
 Cflags: -I${includedir}

--- a/lib/libnutconf.pc.in
+++ b/lib/libnutconf.pc.in
@@ -9,5 +9,5 @@ nutuser=@RUN_AS_USER@
 Name: libnutconf
 Description: Network UPS Tools configuration management
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -lnutconf
+Libs: -L${libdir} -R${libdir} -lnutconf
 Cflags: -I${includedir}

--- a/lib/libnutscan.pc.in
+++ b/lib/libnutscan.pc.in
@@ -9,5 +9,5 @@ nutuser=@RUN_AS_USER@
 Name: libnutscan
 Description: Power devices discovery with Network UPS Tools
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -R${libdir} -lnutscan
+Libs: -L${libdir} @LDFLAGS_NUT_RPATH@ -lnutscan
 Cflags: -I${includedir}

--- a/lib/libnutscan.pc.in
+++ b/lib/libnutscan.pc.in
@@ -9,5 +9,5 @@ nutuser=@RUN_AS_USER@
 Name: libnutscan
 Description: Power devices discovery with Network UPS Tools
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -lnutscan
+Libs: -L${libdir} -R${libdir} -lnutscan
 Cflags: -I${includedir}

--- a/lib/libupsclient-config.in
+++ b/lib/libupsclient-config.in
@@ -3,7 +3,7 @@
 # libupsclient-config: helper script for NUT libupsclient   #
 # **********************************************************#
 # Copyright 2003 - Arnaud Quette                            #
-# Distributed under the GNU GPL v2                          #
+# Distributed under the GNU GPL v2+                         #
 # See the distribution lib/README for usage information     #
 # **********************************************************#
 

--- a/lib/libupsclient-config.in
+++ b/lib/libupsclient-config.in
@@ -15,7 +15,7 @@
 Version="@PACKAGE_VERSION@"
 prefix="@prefix@"
 exec_prefix="@exec_prefix@"
-Libs="-L@libdir@ -lupsclient @LIBSSL_LIBS@"
+Libs="-L@libdir@ @LDFLAGS_NUT_RPATH@ -lupsclient @LIBSSL_LIBS@"
 Cflags="-I@includedir@ @LIBSSL_CFLAGS@"
 ConfigFlags="@CONFIG_FLAGS@"
 

--- a/lib/libupsclient.pc.in
+++ b/lib/libupsclient.pc.in
@@ -9,6 +9,6 @@ nutuser=@RUN_AS_USER@
 Name: libupsclient
 Description: UPS monitoring with Network UPS Tools
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -R${libdir} -lupsclient
+Libs: -L${libdir} @LDFLAGS_NUT_RPATH@ -lupsclient
 Cflags: -I${includedir}
 Requires: @LIBSSL_REQUIRES@

--- a/lib/libupsclient.pc.in
+++ b/lib/libupsclient.pc.in
@@ -9,6 +9,6 @@ nutuser=@RUN_AS_USER@
 Name: libupsclient
 Description: UPS monitoring with Network UPS Tools
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -lupsclient
+Libs: -L${libdir} -R${libdir} -lupsclient
 Cflags: -I${includedir}
 Requires: @LIBSSL_REQUIRES@

--- a/m4/ax_realpath_lib.m4
+++ b/m4/ax_realpath_lib.m4
@@ -111,7 +111,7 @@ AC_DEFUN([AX_REALPATH_LIB],
                                 "${MSYSTEM_PREFIX}/lib" \
                                 "${MINGW_PREFIX}/bin" \
                                 "${MINGW_PREFIX}/lib" \
-                                `${CC} --print-search-dirs 2>/dev/null | grep libraries: | sed 's,^libraries: *=/,/,'` \
+                                `${CC} --print-search-dirs 2>/dev/null | grep libraries: | sed 's,^@<:@^=@:>@*=,:,' | sed 's,\(@<:@:;@:>@\)\(@<:@A-Z@:>@\):/,:/\2/,g' | tr ':' '\n'` \
                             ; do
                                 if test -s "$D/${myLIBPATH}" 2>/dev/null ; then
                                     myLIBPATH="$D/${myLIBPATH}"


### PR DESCRIPTION
Another side of the coin raised by issue #2782 : when we install NUT itself, especially its libraries into uncommon paths like `/usr/local/ups/lib`, third-party progs linked against them can not find them at run-time: the RPATH or RUNPATH has to be embedded (which is what this PR helps with), or LD_LIBRARY_PATH or equivalent frowned-upon tricks should be done.