### PR TITLE
Optimize parallel spellcheck some more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,8 +53,8 @@ Makefile.in
 /ltmain.sh
 /missing
 /test-driver
-*-contentchecked
-*-spellchecked
+*-contentchecked*
+*-spellchecked*
 *-prepped
 *.usage-report
 *.adoc-parsed

--- a/Makefile.am
+++ b/Makefile.am
@@ -623,13 +623,27 @@ $(SPELLCHECK_DIRS_LAST): prep-src-docs/docs/man prep-src-docs/docs $(SPELLCHECK_
 	  $(SUBDIR_TGT_RULE)
 
 # We want to check all files even if some have errors, so sub-make with "-k":
-spellcheck:
-	+@$(MAKE) $(AM_MAKEFLAGS) SUBDIR_MAKE_VERBOSE=0 -ks $(SPELLCHECK_DIRS)
-
 # Tricky TGT to pass sort-of-same rules (and dir list) as spellcheck,
 # but using the correct make target for this goal:
-spellcheck-interactive:
-	+@$(MAKE) $(AM_MAKEFLAGS) SUBDIR_MAKE_VERBOSE=0 TGT='$@' -ks $(SPELLCHECK_DIRS)
+spellcheck spellcheck-interactive:
+	+@if [ x"$(NUT_MAKE_SKIP_FANOUT)" = xtrue ] ; then \
+		if [ x"$(SUBDIR_MAKE_VERBOSE)" = x1 ] ; then \
+			echo "  SUBDIR-MAKE       $@: skip optimization for parallel make - NUT_MAKE_SKIP_FANOUT is set" ; \
+		fi ; \
+		RES=0 ; \
+		(cd $(builddir)/docs && $(MAKE) $(AM_MAKEFLAGS) -s $(abs_top_builddir)/docs/.prep-src-docs) || RES=$$? ; \
+		(cd $(builddir)/docs/man && $(MAKE) $(AM_MAKEFLAGS) -s $(abs_top_builddir)/docs/man/.prep-src-docs) || RES=$$? ; \
+		for D in $(SPELLCHECK_DIRS_MOST) ; do \
+			D="`echo "$$D" | sed 's,^spellcheck/,,'`" ; \
+			(cd "$(builddir)/$$D" && $(MAKE) $(AM_MAKEFLAGS) -s $@) || RES=$$? ; \
+		done ; \
+		for D in $(SPELLCHECK_DIRS_LAST) ; do \
+			D="`echo "$$D" | sed 's,^spellcheck/,,'`" ; \
+			(cd "$(builddir)/$$D" && $(MAKE) $(AM_MAKEFLAGS) SPELLCHECK_REPORT_MAYBE_UPDATED_DICT=yes -s $@) || RES=$$? ; \
+		done ; \
+		exit $$RES ; \
+	  fi ; \
+	  $(MAKE) $(AM_MAKEFLAGS) SUBDIR_MAKE_VERBOSE=0 TGT='$@' -ks $(SPELLCHECK_DIRS)
 
 # Auto-parallel recipe (if current 'make' implementation supports the "-j N"
 # syntax; the optional MAXPARMAKES may be set in NUT CI farm style builds):

--- a/Makefile.am
+++ b/Makefile.am
@@ -591,7 +591,42 @@ distclean-local:
 # Only require SPELLCHECK_REPORT_MAYBE_UPDATED_DICT=yes for the last entry
 # (reduce noise for spellcheck-interactive)
 # Maint: grep -l 'SPELLCHECK_' `git grep -lw spellcheck '*.am'`
-spellcheck spellcheck-interactive:
+SPELLCHECK_DIRS_MOST = \
+	spellcheck/docs \
+	spellcheck/docs/man \
+	spellcheck/conf \
+	spellcheck/data \
+	spellcheck/data/html \
+	spellcheck/scripts \
+	spellcheck/scripts/Solaris \
+	spellcheck/scripts/Windows \
+	spellcheck/scripts/devd \
+	spellcheck/scripts/external_apis \
+	spellcheck/scripts/hotplug \
+	spellcheck/scripts/installer \
+	spellcheck/scripts/python \
+	spellcheck/scripts/systemd \
+	spellcheck/scripts/udev \
+	spellcheck/scripts/upsdrvsvcctl
+
+# Same but with an info notice, so runs alone last
+SPELLCHECK_DIRS_LAST = spellcheck/tests/NIT
+
+SPELLCHECK_DIRS = $(SPELLCHECK_DIRS_MOST) $(SPELLCHECK_DIRS_LAST)
+
+$(SPELLCHECK_DIRS_MOST): prep-src-docs/docs/man prep-src-docs/docs
+	+@$(SUBDIR_TGT_RULE)
+
+$(SPELLCHECK_DIRS_LAST): prep-src-docs/docs/man prep-src-docs/docs $(SPELLCHECK_DIRS_MOST)
+	+@SUBDIR_TGT_MAKEFLAGS="SPELLCHECK_REPORT_MAYBE_UPDATED_DICT=yes"; \
+	  export SUBDIR_TGT_MAKEFLAGS ; \
+	  $(SUBDIR_TGT_RULE)
+
+# We want to check all files even if some have errors, so sub-make with "-k":
+spellcheck:
+	+@$(MAKE) $(AM_MAKEFLAGS) SUBDIR_MAKE_VERBOSE=0 -ks $(SPELLCHECK_DIRS)
+
+spellcheck-interactive:
 	+@RES=0; \
 	(cd $(builddir)/docs && $(MAKE) $(AM_MAKEFLAGS) -s $(abs_top_builddir)/docs/.prep-src-docs) || RES=$$? ; \
 	(cd $(builddir)/docs/man && $(MAKE) $(AM_MAKEFLAGS) -s $(abs_top_builddir)/docs/man/.prep-src-docs) || RES=$$? ; \

--- a/Makefile.am
+++ b/Makefile.am
@@ -601,9 +601,14 @@ spellcheck spellcheck-interactive:
 	(cd $(builddir)/tests/NIT && $(MAKE) $(AM_MAKEFLAGS) SPELLCHECK_REPORT_MAYBE_UPDATED_DICT=yes -s $@) || RES=$$? ; \
 	exit $$RES
 
+# Auto-parallel recipe (if current 'make' implementation supports the "-j N" syntax):
+spellcheck-quick:
+	+@case " $(MAKEFLAGS) $(AM_MAKEFLAGS)" in *"j"*) $(MAKE) $(AM_MAKEFLAGS) -ks spellcheck && exit ;; *) $(MAKE) $(AM_MAKEFLAGS) -ks -j 8 spellcheck && exit ;; esac
+
+# Run auto-parallel recipe, and if something fails - re-run interactively:
 spellcheck-interactive-quick:
-	+@case " $(MAKEFLAGS) $(AM_MAKEFLAGS)" in *"j"*) $(MAKE) $(AM_MAKEFLAGS) -ks spellcheck && exit ;; *) $(MAKE) $(AM_MAKEFLAGS) -ks -j 8 spellcheck && exit ;; esac \
-	 || make spellcheck-interactive
+	+@$(MAKE) $(AM_MAKEFLAGS) -ks spellcheck-quick \
+	 || $(MAKE) $(AM_MAKEFLAGS) spellcheck-interactive
 
 # Note: the "all-docs" and "check-docs" targets may require tools not
 # found by `configure` script (and so avoided by conventional recipes)

--- a/Makefile.am
+++ b/Makefile.am
@@ -645,9 +645,9 @@ spellcheck spellcheck-interactive:
 		done ; \
 		exit $$RES ; \
 	  fi ; \
-	  $(MAKE) $(AM_MAKEFLAGS) SUBDIR_MAKE_VERBOSE=1 TGT='$@' -ks $(SPELLCHECK_DIRS) && exit ; \
+	  $(MAKE) $(AM_MAKEFLAGS) TGT='$@' -ks $(SPELLCHECK_DIRS) && exit ; \
 	  echo "WARNING: FAILED fanned-out attempt in $@, retrying with NUT_MAKE_SKIP_FANOUT" >&2 ; \
-	  $(MAKE) $(AM_MAKEFLAGS) NUT_MAKE_SKIP_FANOUT=true SUBDIR_MAKE_VERBOSE=1 TGT='$@' -ks $(SPELLCHECK_DIRS)
+	  $(MAKE) $(AM_MAKEFLAGS) NUT_MAKE_SKIP_FANOUT=true TGT='$@' -ks $(SPELLCHECK_DIRS)
 
 # Auto-parallel recipe (if current 'make' implementation supports the "-j N"
 # syntax; the optional MAXPARMAKES may be set in NUT CI farm style builds):

--- a/Makefile.am
+++ b/Makefile.am
@@ -86,15 +86,24 @@ all-recursive: all-fanout-maybe
 
 # Run the standard build if going sequential (or with unknown MAKEFLAGS),
 # or fanout if parallel (presuming GNU/BSD/Sun make at least):
+SUBDIR_MAKE_VERBOSE = 1
 all-fanout-maybe:
 	+@if [ x"$(NUT_MAKE_SKIP_FANOUT)" = xtrue ] ; then \
-		echo "  SUBDIR-MAKE       $@: skip optimization for parallel make - NUT_MAKE_SKIP_FANOUT is set" ; exit 0 ; \
+		if [ x"$(SUBDIR_MAKE_VERBOSE)" = x1 ] ; then \
+			echo "  SUBDIR-MAKE       $@: skip optimization for parallel make - NUT_MAKE_SKIP_FANOUT is set" ; \
+		fi ; \
+		exit 0 ; \
 	  fi ; \
 	  case "-$(MAKEFLAGS) $(AM_MAKEFLAGS)" in \
 		*-j|*-j" "*|*-{j,l}{0,1,2,3,4,5,6,7,8,9}*|*-[jl][0123456789]*|*{-l,--jobs,--load-average,--max-load}" "{-,0,1,2,3,4,5,6,7,8,9}*|*--jobserver*|*--jobs" "[0123456789]*|*--load-average" "[0123456789]*|*--max-load" "[0123456789]*) \
-			echo "  SUBDIR-MAKE       $@: implement optimization for parallel make as 'make all-fanout-subdirs'" ; \
+			if [ x"$(SUBDIR_MAKE_VERBOSE)" = x1 ] ; then \
+				echo "  SUBDIR-MAKE       $@: implement optimization for parallel make as 'make all-fanout-subdirs'" ; \
+			fi ; \
 			$(MAKE) $(AM_MAKEFLAGS) all-fanout-subdirs ;; \
-		*)	echo "  SUBDIR-MAKE       $@: skip optimization for parallel make - we seem to run sequentially now, seen MAKEFLAGS='$(MAKEFLAGS)' AM_MAKEFLAGS='$(AM_MAKEFLAGS)'" ;; \
+		*) \
+			if [ x"$(SUBDIR_MAKE_VERBOSE)" = x1 ] ; then \
+				echo "  SUBDIR-MAKE       $@: skip optimization for parallel make - we seem to run sequentially now, seen MAKEFLAGS='$(MAKEFLAGS)' AM_MAKEFLAGS='$(AM_MAKEFLAGS)'" ; \
+			fi ;; \
 	  esac
 
 # We start with a pass to `make all` in `common` dir because our wild recipes
@@ -162,10 +171,14 @@ endif KEEP_NUT_REPORT
 SUBDIR_TGT_RULE = ( \
 	TGT="`echo '$@' | awk -F/ '{print $$1}'`" ; \
 	DIR="`echo '$@' | sed 's,^[^/]*/,,'`" ; \
-	echo "  SUBDIR-MAKE       STARTING: 'make $$TGT' in $$DIR ..." ; \
+	if [ x"$(SUBDIR_MAKE_VERBOSE)" = x1 ] ; then \
+		echo "  SUBDIR-MAKE       STARTING: 'make $$TGT' in $$DIR ..." ; \
+	fi ; \
 	cd "$(abs_builddir)/$${DIR}" && \
 	$(MAKE) $(AM_MAKEFLAGS) $${SUBDIR_TGT_MAKEFLAGS-} "$${TGT}" || { RES=$$?; echo "  SUBDIR-MAKE       FAILURE: 'make $$TGT' in $$DIR" >&2 ; exit $$RES ; } ; \
-	echo "  SUBDIR-MAKE       SUCCESS: 'make $$TGT' in $$DIR" ; \
+	if [ x"$(SUBDIR_MAKE_VERBOSE)" = x1 ] ; then \
+		echo "  SUBDIR-MAKE       SUCCESS: 'make $$TGT' in $$DIR" ; \
+	fi ; \
 	)
 
 # A way to quickly handle SUBDIRS_ALL_LIBS_LOCAL as dependency for all others

--- a/Makefile.am
+++ b/Makefile.am
@@ -626,28 +626,10 @@ $(SPELLCHECK_DIRS_LAST): prep-src-docs/docs/man prep-src-docs/docs $(SPELLCHECK_
 spellcheck:
 	+@$(MAKE) $(AM_MAKEFLAGS) SUBDIR_MAKE_VERBOSE=0 -ks $(SPELLCHECK_DIRS)
 
+# Tricky TGT to pass sort-of-same rules (and dir list) as spellcheck,
+# but using the correct make target for this goal:
 spellcheck-interactive:
-	+@RES=0; \
-	(cd $(builddir)/docs && $(MAKE) $(AM_MAKEFLAGS) -s $(abs_top_builddir)/docs/.prep-src-docs) || RES=$$? ; \
-	(cd $(builddir)/docs/man && $(MAKE) $(AM_MAKEFLAGS) -s $(abs_top_builddir)/docs/man/.prep-src-docs) || RES=$$? ; \
-	(cd $(builddir)/docs && $(MAKE) $(AM_MAKEFLAGS) -s $@) || RES=$$? ; \
-	(cd $(builddir)/docs/man && $(MAKE) $(AM_MAKEFLAGS) -s $@) || RES=$$? ; \
-	(cd $(builddir)/conf && $(MAKE) $(AM_MAKEFLAGS) -s $@) || RES=$$? ; \
-	(cd $(builddir)/data && $(MAKE) $(AM_MAKEFLAGS) -s $@) || RES=$$? ; \
-	(cd $(builddir)/data/html && $(MAKE) $(AM_MAKEFLAGS) -s $@) || RES=$$? ; \
-	(cd $(builddir)/scripts && $(MAKE) $(AM_MAKEFLAGS) -s $@) || RES=$$? ; \
-	(cd $(builddir)/scripts/Solaris && $(MAKE) $(AM_MAKEFLAGS) -s $@) || RES=$$? ; \
-	(cd $(builddir)/scripts/Windows && $(MAKE) $(AM_MAKEFLAGS) -s $@) || RES=$$? ; \
-	(cd $(builddir)/scripts/devd && $(MAKE) $(AM_MAKEFLAGS) -s $@) || RES=$$? ; \
-	(cd $(builddir)/scripts/external_apis && $(MAKE) $(AM_MAKEFLAGS) -s $@) || RES=$$? ; \
-	(cd $(builddir)/scripts/hotplug && $(MAKE) $(AM_MAKEFLAGS) -s $@) || RES=$$? ; \
-	(cd $(builddir)/scripts/installer && $(MAKE) $(AM_MAKEFLAGS) -s $@) || RES=$$? ; \
-	(cd $(builddir)/scripts/python && $(MAKE) $(AM_MAKEFLAGS) -s $@) || RES=$$? ; \
-	(cd $(builddir)/scripts/systemd && $(MAKE) $(AM_MAKEFLAGS) -s $@) || RES=$$? ; \
-	(cd $(builddir)/scripts/udev && $(MAKE) $(AM_MAKEFLAGS) -s $@) || RES=$$? ; \
-	(cd $(builddir)/scripts/upsdrvsvcctl && $(MAKE) $(AM_MAKEFLAGS) -s $@) || RES=$$? ; \
-	(cd $(builddir)/tests/NIT && $(MAKE) $(AM_MAKEFLAGS) SPELLCHECK_REPORT_MAYBE_UPDATED_DICT=yes -s $@) || RES=$$? ; \
-	exit $$RES
+	+@$(MAKE) $(AM_MAKEFLAGS) SUBDIR_MAKE_VERBOSE=0 TGT='$@' -ks $(SPELLCHECK_DIRS)
 
 # Auto-parallel recipe (if current 'make' implementation supports the "-j N"
 # syntax; the optional MAXPARMAKES may be set in NUT CI farm style builds):

--- a/Makefile.am
+++ b/Makefile.am
@@ -169,8 +169,8 @@ endif KEEP_NUT_REPORT
 # target in specified dir is the goal, all as separate targets for this
 # level's Makefile:
 SUBDIR_TGT_RULE = ( \
-	TGT="`echo '$@' | awk -F/ '{print $$1}'`" ; \
-	DIR="`echo '$@' | sed 's,^[^/]*/,,'`" ; \
+	[ x"$${TGT-}" != x ] || TGT="`echo '$@' | awk -F/ '{print $$1}'`" ; \
+	[ x"$${DIR-}" != x ] || DIR="`echo '$@' | sed 's,^[^/]*/,,'`" ; \
 	if [ x"$(SUBDIR_MAKE_VERBOSE)" = x1 ] ; then \
 		echo "  SUBDIR-MAKE       STARTING: 'make $$TGT' in $$DIR ..." ; \
 	fi ; \

--- a/Makefile.am
+++ b/Makefile.am
@@ -84,24 +84,27 @@ SUBDIRS_ALL_LIBS_LOCAL = \
 #all all-recursive all-am-local all-local: all-fanout-maybe
 all-recursive: all-fanout-maybe
 
+# Verbosity for fanout rule tracing; 0/1 (or "default" that may auto-set
+# to 0 or 1 in some rules below)
+SUBDIR_MAKE_VERBOSE = default
+
 # Run the standard build if going sequential (or with unknown MAKEFLAGS),
 # or fanout if parallel (presuming GNU/BSD/Sun make at least):
-SUBDIR_MAKE_VERBOSE = 1
 all-fanout-maybe:
 	+@if [ x"$(NUT_MAKE_SKIP_FANOUT)" = xtrue ] ; then \
-		if [ x"$(SUBDIR_MAKE_VERBOSE)" = x1 ] ; then \
+		if [ x"$(SUBDIR_MAKE_VERBOSE)" != x0 ] ; then \
 			echo "  SUBDIR-MAKE       $@: skip optimization for parallel make - NUT_MAKE_SKIP_FANOUT is set" ; \
 		fi ; \
 		exit 0 ; \
 	  fi ; \
 	  case "-$(MAKEFLAGS) $(AM_MAKEFLAGS)" in \
 		*-j|*-j" "*|*-{j,l}{0,1,2,3,4,5,6,7,8,9}*|*-[jl][0123456789]*|*{-l,--jobs,--load-average,--max-load}" "{-,0,1,2,3,4,5,6,7,8,9}*|*--jobserver*|*--jobs" "[0123456789]*|*--load-average" "[0123456789]*|*--max-load" "[0123456789]*) \
-			if [ x"$(SUBDIR_MAKE_VERBOSE)" = x1 ] ; then \
+			if [ x"$(SUBDIR_MAKE_VERBOSE)" != x0 ] ; then \
 				echo "  SUBDIR-MAKE       $@: implement optimization for parallel make as 'make all-fanout-subdirs'" ; \
 			fi ; \
 			$(MAKE) $(AM_MAKEFLAGS) all-fanout-subdirs ;; \
 		*) \
-			if [ x"$(SUBDIR_MAKE_VERBOSE)" = x1 ] ; then \
+			if [ x"$(SUBDIR_MAKE_VERBOSE)" != x0 ] ; then \
 				echo "  SUBDIR-MAKE       $@: skip optimization for parallel make - we seem to run sequentially now, seen MAKEFLAGS='$(MAKEFLAGS)' AM_MAKEFLAGS='$(AM_MAKEFLAGS)'" ; \
 			fi ;; \
 	  esac
@@ -171,12 +174,12 @@ endif KEEP_NUT_REPORT
 SUBDIR_TGT_RULE = ( \
 	[ x"$${TGT-}" != x ] || TGT="`echo '$@' | awk -F/ '{print $$1}'`" ; \
 	[ x"$${DIR-}" != x ] || DIR="`echo '$@' | sed 's,^[^/]*/,,'`" ; \
-	if [ x"$(SUBDIR_MAKE_VERBOSE)" = x1 ] ; then \
+	if [ x"$(SUBDIR_MAKE_VERBOSE)" != x0 ] ; then \
 		echo "  SUBDIR-MAKE       STARTING: 'make $$TGT' in $$DIR ..." ; \
 	fi ; \
 	cd "$(abs_builddir)/$${DIR}" && \
 	$(MAKE) $(AM_MAKEFLAGS) $${SUBDIR_TGT_MAKEFLAGS-} "$${TGT}" || { RES=$$?; echo "  SUBDIR-MAKE       FAILURE: 'make $$TGT' in $$DIR" >&2 ; exit $$RES ; } ; \
-	if [ x"$(SUBDIR_MAKE_VERBOSE)" = x1 ] ; then \
+	if [ x"$(SUBDIR_MAKE_VERBOSE)" != x0 ] ; then \
 		echo "  SUBDIR-MAKE       SUCCESS: 'make $$TGT' in $$DIR" ; \
 	fi ; \
 	)
@@ -631,7 +634,7 @@ $(SPELLCHECK_DIRS_LAST): prep-src-docs/docs/man prep-src-docs/docs $(SPELLCHECK_
 spellcheck spellcheck-interactive:
 	+@if [ x"$(NUT_MAKE_SKIP_FANOUT)" = xtrue ] ; then \
 		RES=0 ; \
-		if [ x"$(SUBDIR_MAKE_VERBOSE)" = x1 ] ; then \
+		if [ x"$(SUBDIR_MAKE_VERBOSE)" != x0 ] ; then \
 			echo "  SUBDIR-MAKE       $@: skip optimization for parallel make - NUT_MAKE_SKIP_FANOUT is set" ; \
 		fi ; \
 		(cd $(builddir)/docs && $(MAKE) $(AM_MAKEFLAGS) -ks $(abs_top_builddir)/docs/.prep-src-docs) || RES=$$? ; \
@@ -646,7 +649,12 @@ spellcheck spellcheck-interactive:
 		done ; \
 		exit $$RES ; \
 	  fi ; \
-	  $(MAKE) $(AM_MAKEFLAGS) SPELLCHECK_TGT='$@' -ks $(SPELLCHECK_DIRS) && exit ; \
+	  SUBDIR_MAKE_VERBOSE="$(SUBDIR_MAKE_VERBOSE)" ; \
+	  if [ x"$(SUBDIR_MAKE_VERBOSE)" = xdefault ] ; then \
+		SUBDIR_MAKE_VERBOSE=0 ; \
+	  fi ; \
+	  export SUBDIR_MAKE_VERBOSE ; \
+	  $(MAKE) $(AM_MAKEFLAGS) SPELLCHECK_TGT='$@' SUBDIR_MAKE_VERBOSE="$${SUBDIR_MAKE_VERBOSE}" -ks $(SPELLCHECK_DIRS) && exit ; \
 	  echo "WARNING: FAILED fanned-out attempt in $@, retrying with NUT_MAKE_SKIP_FANOUT" >&2 ; \
 	  $(MAKE) $(AM_MAKEFLAGS) NUT_MAKE_SKIP_FANOUT=true SPELLCHECK_TGT='$@' -ks $(SPELLCHECK_DIRS)
 
@@ -667,6 +675,9 @@ spellcheck-quick:
 spellcheck-interactive-quick:
 	+@$(MAKE) $(AM_MAKEFLAGS) spellcheck-quick && exit ; \
 	  echo "WARNING: in $@: make spellcheck-quick failed, retrying with spellcheck-interactive" >&2 ; \
+	  if [ x"$(SUBDIR_MAKE_VERBOSE)" = xdefault ] ; then \
+		SUBDIR_MAKE_VERBOSE=1 ; export SUBDIR_MAKE_VERBOSE ; \
+	  fi ; \
 	  $(MAKE) $(AM_MAKEFLAGS) spellcheck-interactive
 
 # Note: the "all-docs" and "check-docs" targets may require tools not

--- a/Makefile.am
+++ b/Makefile.am
@@ -632,20 +632,21 @@ $(SPELLCHECK_DIRS_LAST): prep-src-docs/docs/man prep-src-docs/docs $(SPELLCHECK_
 # FIXME: fanned-out recipes tend to fail early despite "make -ks", so for
 #  now we retry with a not-fanned-out attempt to cover most touch-files
 spellcheck spellcheck-interactive:
-	+@if [ x"$(NUT_MAKE_SKIP_FANOUT)" = xtrue ] ; then \
+	+@SUBDIR_TGT_MAKEFLAGS="$${SUBDIR_TGT_MAKEFLAGS-} -k -s " ; export SUBDIR_TGT_MAKEFLAGS ; \
+	  if [ x"$(NUT_MAKE_SKIP_FANOUT)" = xtrue ] ; then \
 		RES=0 ; \
 		if [ x"$(SUBDIR_MAKE_VERBOSE)" != x0 ] ; then \
 			echo "  SUBDIR-MAKE       $@: skip optimization for parallel make - NUT_MAKE_SKIP_FANOUT is set" ; \
 		fi ; \
-		(cd $(builddir)/docs && $(MAKE) $(AM_MAKEFLAGS) -ks $(abs_top_builddir)/docs/.prep-src-docs) || RES=$$? ; \
-		(cd $(builddir)/docs/man && $(MAKE) $(AM_MAKEFLAGS) -ks $(abs_top_builddir)/docs/man/.prep-src-docs) || RES=$$? ; \
+		(cd $(builddir)/docs && $(MAKE) $(AM_MAKEFLAGS) -k -s $(abs_top_builddir)/docs/.prep-src-docs) || RES=$$? ; \
+		(cd $(builddir)/docs/man && $(MAKE) $(AM_MAKEFLAGS) -k -s $(abs_top_builddir)/docs/man/.prep-src-docs) || RES=$$? ; \
 		for D in $(SPELLCHECK_DIRS_MOST) ; do \
 			D="`echo "$$D" | sed 's,^spellcheck/,,'`" ; \
-			(cd "$(builddir)/$$D" && $(MAKE) $(AM_MAKEFLAGS) -ks $@) || RES=$$? ; \
+			(cd "$(builddir)/$$D" && $(MAKE) $(AM_MAKEFLAGS) -k -s $@) || RES=$$? ; \
 		done ; \
 		for D in $(SPELLCHECK_DIRS_LAST) ; do \
 			D="`echo "$$D" | sed 's,^spellcheck/,,'`" ; \
-			(cd "$(builddir)/$$D" && $(MAKE) $(AM_MAKEFLAGS) SPELLCHECK_REPORT_MAYBE_UPDATED_DICT=yes -ks $@) || RES=$$? ; \
+			(cd "$(builddir)/$$D" && $(MAKE) $(AM_MAKEFLAGS) SPELLCHECK_REPORT_MAYBE_UPDATED_DICT=yes -k -s $@) || RES=$$? ; \
 		done ; \
 		exit $$RES ; \
 	  fi ; \
@@ -654,31 +655,31 @@ spellcheck spellcheck-interactive:
 		SUBDIR_MAKE_VERBOSE=0 ; \
 	  fi ; \
 	  export SUBDIR_MAKE_VERBOSE ; \
-	  $(MAKE) $(AM_MAKEFLAGS) SPELLCHECK_TGT='$@' SUBDIR_MAKE_VERBOSE="$${SUBDIR_MAKE_VERBOSE}" -ks $(SPELLCHECK_DIRS) && exit ; \
+	  $(MAKE) $(AM_MAKEFLAGS) SPELLCHECK_TGT='$@' SUBDIR_MAKE_VERBOSE="$${SUBDIR_MAKE_VERBOSE}" -k -s $(SPELLCHECK_DIRS) && exit ; \
 	  echo "WARNING: FAILED fanned-out attempt in $@, retrying with NUT_MAKE_SKIP_FANOUT" >&2 ; \
-	  $(MAKE) $(AM_MAKEFLAGS) NUT_MAKE_SKIP_FANOUT=true SPELLCHECK_TGT='$@' -ks $(SPELLCHECK_DIRS)
+	  $(MAKE) $(AM_MAKEFLAGS) NUT_MAKE_SKIP_FANOUT=true SPELLCHECK_TGT='$@' -k -s $(SPELLCHECK_DIRS)
 
 # Auto-parallel recipe (if current 'make' implementation supports the "-j N"
 # syntax; the optional MAXPARMAKES may be set in NUT CI farm style builds):
 spellcheck-quick:
 	+@case " $(MAKEFLAGS) $(AM_MAKEFLAGS)" in \
-		*"j"*) $(MAKE) $(AM_MAKEFLAGS) -ks spellcheck && exit ;; \
+		*"j"*) $(MAKE) $(AM_MAKEFLAGS) -k -s spellcheck && exit ;; \
 		*) \
 			if ! [ "$${MAXPARMAKES-}" -gt 1 ] 2>/dev/null ; then \
 				MAXPARMAKES=8 ; \
 			fi ; \
-			$(MAKE) $(AM_MAKEFLAGS) -ks -j $${MAXPARMAKES} spellcheck \
+			$(MAKE) $(AM_MAKEFLAGS) -k -s -j $${MAXPARMAKES} spellcheck \
 			&& exit ;; \
 	  esac
 
 # Run auto-parallel recipe, and if something fails - re-run interactively:
 spellcheck-interactive-quick:
-	+@$(MAKE) $(AM_MAKEFLAGS) spellcheck-quick && exit ; \
+	+@$(MAKE) $(AM_MAKEFLAGS) -k -s spellcheck-quick && exit ; \
 	  echo "WARNING: in $@: make spellcheck-quick failed, retrying with spellcheck-interactive" >&2 ; \
 	  if [ x"$(SUBDIR_MAKE_VERBOSE)" = xdefault ] ; then \
 		SUBDIR_MAKE_VERBOSE=1 ; export SUBDIR_MAKE_VERBOSE ; \
 	  fi ; \
-	  $(MAKE) $(AM_MAKEFLAGS) spellcheck-interactive
+	  $(MAKE) $(AM_MAKEFLAGS) -k -s spellcheck-interactive
 
 # Note: the "all-docs" and "check-docs" targets may require tools not
 # found by `configure` script (and so avoided by conventional recipes)

--- a/Makefile.am
+++ b/Makefile.am
@@ -614,9 +614,18 @@ spellcheck spellcheck-interactive:
 	(cd $(builddir)/tests/NIT && $(MAKE) $(AM_MAKEFLAGS) SPELLCHECK_REPORT_MAYBE_UPDATED_DICT=yes -s $@) || RES=$$? ; \
 	exit $$RES
 
-# Auto-parallel recipe (if current 'make' implementation supports the "-j N" syntax):
+# Auto-parallel recipe (if current 'make' implementation supports the "-j N"
+# syntax; the optional MAXPARMAKES may be set in NUT CI farm style builds):
 spellcheck-quick:
-	+@case " $(MAKEFLAGS) $(AM_MAKEFLAGS)" in *"j"*) $(MAKE) $(AM_MAKEFLAGS) -ks spellcheck && exit ;; *) $(MAKE) $(AM_MAKEFLAGS) -ks -j 8 spellcheck && exit ;; esac
+	+@case " $(MAKEFLAGS) $(AM_MAKEFLAGS)" in \
+		*"j"*) $(MAKE) $(AM_MAKEFLAGS) -ks spellcheck && exit ;; \
+		*) \
+			if ! [ "$${MAXPARMAKES-}" -gt 1 ] 2>/dev/null ; then \
+				MAXPARMAKES=8 ; \
+			fi ; \
+			$(MAKE) $(AM_MAKEFLAGS) -ks -j $${MAXPARMAKES} spellcheck \
+			&& exit ;; \
+	  esac
 
 # Run auto-parallel recipe, and if something fails - re-run interactively:
 spellcheck-interactive-quick:

--- a/Makefile.am
+++ b/Makefile.am
@@ -625,25 +625,29 @@ $(SPELLCHECK_DIRS_LAST): prep-src-docs/docs/man prep-src-docs/docs $(SPELLCHECK_
 # We want to check all files even if some have errors, so sub-make with "-k":
 # Tricky TGT to pass sort-of-same rules (and dir list) as spellcheck,
 # but using the correct make target for this goal:
+# FIXME: fanned-out recipes tend to fail early despite "make -ks", so for
+#  now we retry with a not-fanned-out attempt to cover most touch-files
 spellcheck spellcheck-interactive:
 	+@if [ x"$(NUT_MAKE_SKIP_FANOUT)" = xtrue ] ; then \
+		RES=0 ; \
 		if [ x"$(SUBDIR_MAKE_VERBOSE)" = x1 ] ; then \
 			echo "  SUBDIR-MAKE       $@: skip optimization for parallel make - NUT_MAKE_SKIP_FANOUT is set" ; \
 		fi ; \
-		RES=0 ; \
-		(cd $(builddir)/docs && $(MAKE) $(AM_MAKEFLAGS) -s $(abs_top_builddir)/docs/.prep-src-docs) || RES=$$? ; \
-		(cd $(builddir)/docs/man && $(MAKE) $(AM_MAKEFLAGS) -s $(abs_top_builddir)/docs/man/.prep-src-docs) || RES=$$? ; \
+		(cd $(builddir)/docs && $(MAKE) $(AM_MAKEFLAGS) -ks $(abs_top_builddir)/docs/.prep-src-docs) || RES=$$? ; \
+		(cd $(builddir)/docs/man && $(MAKE) $(AM_MAKEFLAGS) -ks $(abs_top_builddir)/docs/man/.prep-src-docs) || RES=$$? ; \
 		for D in $(SPELLCHECK_DIRS_MOST) ; do \
 			D="`echo "$$D" | sed 's,^spellcheck/,,'`" ; \
-			(cd "$(builddir)/$$D" && $(MAKE) $(AM_MAKEFLAGS) -s $@) || RES=$$? ; \
+			(cd "$(builddir)/$$D" && $(MAKE) $(AM_MAKEFLAGS) -ks $@) || RES=$$? ; \
 		done ; \
 		for D in $(SPELLCHECK_DIRS_LAST) ; do \
 			D="`echo "$$D" | sed 's,^spellcheck/,,'`" ; \
-			(cd "$(builddir)/$$D" && $(MAKE) $(AM_MAKEFLAGS) SPELLCHECK_REPORT_MAYBE_UPDATED_DICT=yes -s $@) || RES=$$? ; \
+			(cd "$(builddir)/$$D" && $(MAKE) $(AM_MAKEFLAGS) SPELLCHECK_REPORT_MAYBE_UPDATED_DICT=yes -ks $@) || RES=$$? ; \
 		done ; \
 		exit $$RES ; \
 	  fi ; \
-	  $(MAKE) $(AM_MAKEFLAGS) SUBDIR_MAKE_VERBOSE=0 TGT='$@' -ks $(SPELLCHECK_DIRS)
+	  $(MAKE) $(AM_MAKEFLAGS) SUBDIR_MAKE_VERBOSE=1 TGT='$@' -ks $(SPELLCHECK_DIRS) && exit ; \
+	  echo "WARNING: FAILED fanned-out attempt in $@, retrying with NUT_MAKE_SKIP_FANOUT" >&2 ; \
+	  $(MAKE) $(AM_MAKEFLAGS) NUT_MAKE_SKIP_FANOUT=true SUBDIR_MAKE_VERBOSE=1 TGT='$@' -ks $(SPELLCHECK_DIRS)
 
 # Auto-parallel recipe (if current 'make' implementation supports the "-j N"
 # syntax; the optional MAXPARMAKES may be set in NUT CI farm style builds):
@@ -660,8 +664,9 @@ spellcheck-quick:
 
 # Run auto-parallel recipe, and if something fails - re-run interactively:
 spellcheck-interactive-quick:
-	+@$(MAKE) $(AM_MAKEFLAGS) -ks spellcheck-quick \
-	 || $(MAKE) $(AM_MAKEFLAGS) spellcheck-interactive
+	+@$(MAKE) $(AM_MAKEFLAGS) spellcheck-quick && exit ; \
+	  echo "WARNING: in $@: make spellcheck-quick failed, retrying with spellcheck-interactive" >&2 ; \
+	  $(MAKE) $(AM_MAKEFLAGS) spellcheck-interactive
 
 # Note: the "all-docs" and "check-docs" targets may require tools not
 # found by `configure` script (and so avoided by conventional recipes)

--- a/Makefile.am
+++ b/Makefile.am
@@ -615,11 +615,12 @@ SPELLCHECK_DIRS_LAST = spellcheck/tests/NIT
 SPELLCHECK_DIRS = $(SPELLCHECK_DIRS_MOST) $(SPELLCHECK_DIRS_LAST)
 
 $(SPELLCHECK_DIRS_MOST): prep-src-docs/docs/man prep-src-docs/docs
-	+@$(SUBDIR_TGT_RULE)
+	+@TGT="$(SPELLCHECK_TGT)"; export TGT; $(SUBDIR_TGT_RULE)
 
 $(SPELLCHECK_DIRS_LAST): prep-src-docs/docs/man prep-src-docs/docs $(SPELLCHECK_DIRS_MOST)
 	+@SUBDIR_TGT_MAKEFLAGS="SPELLCHECK_REPORT_MAYBE_UPDATED_DICT=yes"; \
-	  export SUBDIR_TGT_MAKEFLAGS ; \
+	  export SUBDIR_TGT_MAKEFLAGS; \
+	  TGT="$(SPELLCHECK_TGT)"; export TGT; \
 	  $(SUBDIR_TGT_RULE)
 
 # We want to check all files even if some have errors, so sub-make with "-k":
@@ -645,9 +646,9 @@ spellcheck spellcheck-interactive:
 		done ; \
 		exit $$RES ; \
 	  fi ; \
-	  $(MAKE) $(AM_MAKEFLAGS) TGT='$@' -ks $(SPELLCHECK_DIRS) && exit ; \
+	  $(MAKE) $(AM_MAKEFLAGS) SPELLCHECK_TGT='$@' -ks $(SPELLCHECK_DIRS) && exit ; \
 	  echo "WARNING: FAILED fanned-out attempt in $@, retrying with NUT_MAKE_SKIP_FANOUT" >&2 ; \
-	  $(MAKE) $(AM_MAKEFLAGS) NUT_MAKE_SKIP_FANOUT=true TGT='$@' -ks $(SPELLCHECK_DIRS)
+	  $(MAKE) $(AM_MAKEFLAGS) NUT_MAKE_SKIP_FANOUT=true SPELLCHECK_TGT='$@' -ks $(SPELLCHECK_DIRS)
 
 # Auto-parallel recipe (if current 'make' implementation supports the "-j N"
 # syntax; the optional MAXPARMAKES may be set in NUT CI farm style builds):

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -150,6 +150,15 @@ Overall, NUT CI farm build times got 25%+ shorter (which is important as
    and we suppose this is an interesting case for other projects to draw
    inspiration from for their recipe refactoring. [PR #2825]
 
+ - As an aid for developers and maintainers, a new spell-checking recipe was
+   added to first run non-interactive spelling checks in parallel, and *only*
+   if something fails -- run an interactive check to edit the text and/or the
+   dictionary file. The `make spellcheck` rule now also benefits from the
+   rewritten recipes, as detailed above, to visit directories with text files
+   in parallel. Overall, these changes may save time on multi-CPU systems, if
+   compared to a sequential walk of all texts (or their directories) as was
+   done before. [#2871]
+
  - The `make dist` goal now takes more care to require availability of the man
    pages to put into the prepared distribution archive. These may come either
    from the current build, or inherited from its sources (if using a tarball

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -908,7 +908,7 @@ $(SPELLCHECK_BUILDDIR)/$(SPELLCHECK_SRC_ONE)-spellchecked: $(SPELLCHECK_SRCDIR)/
 SPELLCHECK_AUTO_ONE = ( \
 	SPELLCHECK_SRC_ONE="`basename '$?'`" ; \
 	rm -f "$@".failed ; \
-	$(MAKE) $(AM_MAKEFLAGS) -s -f "$(abs_top_builddir)/docs/Makefile" SPELLCHECK_SRC="" SPELLCHECK_SRC_ONE="$${SPELLCHECK_SRC_ONE}" SPELLCHECK_BUILDDIR="$(SPELLCHECK_BUILDDIR)" SPELLCHECK_SRCDIR="$(SPELLCHECK_SRCDIR)" "$(SPELLCHECK_BUILDDIR)/$${SPELLCHECK_SRC_ONE}-spellchecked" \
+	$(MAKE) $(AM_MAKEFLAGS) -k -s -f "$(abs_top_builddir)/docs/Makefile" SPELLCHECK_SRC="" SPELLCHECK_SRC_ONE="$${SPELLCHECK_SRC_ONE}" SPELLCHECK_BUILDDIR="$(SPELLCHECK_BUILDDIR)" SPELLCHECK_SRCDIR="$(SPELLCHECK_SRCDIR)" "$(SPELLCHECK_BUILDDIR)/$${SPELLCHECK_SRC_ONE}-spellchecked" \
 	|| { RES=$$? ; touch "$@".failed; exit $$RES; } \
 )
 
@@ -957,7 +957,7 @@ spellcheck:
 		fi ; \
 		if [ x"$${SPELLCHECK_NOEXT_DOCS}" != x ] ; then \
 			for docsrc in $${SPELLCHECK_NOEXT_DOCS} ; do \
-				$(MAKE) $(AM_MAKEFLAGS) -s -f "$(abs_top_builddir)/docs/Makefile" SPELLCHECK_SRC="" SPELLCHECK_SRC_ONE="$${docsrc}" SPELLCHECK_BUILDDIR="$(SPELLCHECK_BUILDDIR)" SPELLCHECK_SRCDIR="$(SPELLCHECK_SRCDIR)" "$(SPELLCHECK_BUILDDIR)/$${docsrc}-spellchecked" \
+				$(MAKE) $(AM_MAKEFLAGS) -k -s -f "$(abs_top_builddir)/docs/Makefile" SPELLCHECK_SRC="" SPELLCHECK_SRC_ONE="$${docsrc}" SPELLCHECK_BUILDDIR="$(SPELLCHECK_BUILDDIR)" SPELLCHECK_SRCDIR="$(SPELLCHECK_SRCDIR)" "$(SPELLCHECK_BUILDDIR)/$${docsrc}-spellchecked" \
 				|| FAILED="$$FAILED $(SPELLCHECK_SRCDIR)/$$docsrc"; \
 			done ; \
 		fi ; \

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -185,7 +185,12 @@ ASCIIDOC_PDF = \
 # for a few goals, and among SUBDIRs directly from the top-level Makefile
 # due to some potential dependency collisions with parallel builds.
 SUBDIRS = cables
-SUFFIXES = .txt .html .pdf .txt-spellchecked .txt-prepped .adoc-spellchecked .adoc-prepped
+SUFFIXES = .txt .html .pdf
+SUFFIXES += .txt-spellchecked-auto .txt-spellchecked .txt-prepped
+SUFFIXES += .adoc-spellchecked-auto .adoc-spellchecked .adoc-prepped
+SUFFIXES += .in-spellchecked-auto .in-spellchecked .in-prepped
+SUFFIXES += .sample-spellchecked-auto .sample-spellchecked .sample-prepped
+SUFFIXES += .conf-spellchecked-auto .conf-spellchecked .conf-prepped
 
 # This list is defined by configure script choices and options:
 CHECK_LOCAL_TARGETS = @DOC_CHECK_LIST@
@@ -387,7 +392,7 @@ man:
 	+@if [ x"$(DOCS_NO_MAN)" = xtrue ] ; then echo "  DOC-NOT-MAN     SKIP: $@ called in docs/Makefile" ; exit 0 ; fi ; \
 	  cd $(abs_top_builddir)/docs/man/ && $(MAKE) $(AM_MAKEFLAGS) -f Makefile all
 
-CLEANFILES = *.xml *.html *.pdf *-spellchecked *-contentchecked .check-* docbook-xsl.css docinfo.xml.in.tmp docinfo-since-v*.xml* *-docinfo.xml*
+CLEANFILES = *.xml *.html *.pdf *-spellchecked* *-contentchecked* .check-* docbook-xsl.css docinfo.xml.in.tmp docinfo-since-v*.xml* *-docinfo.xml*
 CLEANFILES += $(top_builddir)/INSTALL.nut $(top_builddir)/UPGRADING $(top_builddir)/ChangeLog.adoc
 CLEANFILES += $(top_builddir)/*.adoc-parsed *.adoc-parsed
 # These two "must be" there per autotools standards, so a "make clean"
@@ -896,8 +901,34 @@ $(SPELLCHECK_BUILDDIR)/$(SPELLCHECK_SRC_ONE)-spellchecked: $(SPELLCHECK_SRCDIR)/
 		     exit $$RES; } ; \
 	 touch "$@"
 
+# If NUT_MAKE_SKIP_FANOUT!=true we have a hack to spellcheck certain files more
+# quickly (in parallel). This approach is constrained to files with a known
+# extension and located in same directory as the Makefile that called them
+# (extension-less docs and relative links are built sequentially).
+SPELLCHECK_AUTO_ONE = ( \
+	SPELLCHECK_SRC_ONE="`basename '$?'`" ; \
+	rm -f "$@".failed ; \
+	$(MAKE) $(AM_MAKEFLAGS) -s -f "$(abs_top_builddir)/docs/Makefile" SPELLCHECK_SRC="" SPELLCHECK_SRC_ONE="$${SPELLCHECK_SRC_ONE}" SPELLCHECK_BUILDDIR="$(SPELLCHECK_BUILDDIR)" SPELLCHECK_SRCDIR="$(SPELLCHECK_SRCDIR)" "$(SPELLCHECK_BUILDDIR)/$${SPELLCHECK_SRC_ONE}-spellchecked" \
+	|| { RES=$$? ; touch "$@".failed; exit $$RES; } \
+)
+
+.txt.txt-spellchecked-auto:
+	+@$(SPELLCHECK_AUTO_ONE)
+
+.adoc.adoc-spellchecked-auto:
+	+@$(SPELLCHECK_AUTO_ONE)
+
+.in.in-spellchecked-auto:
+	+@$(SPELLCHECK_AUTO_ONE)
+
+.sample.sample-spellchecked-auto:
+	+@$(SPELLCHECK_AUTO_ONE)
+
+.conf.conf-spellchecked-auto:
+	+@$(SPELLCHECK_AUTO_ONE)
+
 spellcheck:
-	@if test "$(SPELLCHECK_ENV_DEBUG)" != no ; then \
+	@if test "$(SPELLCHECK_ENV_DEBUG)" = detailed ; then \
 		echo "ASPELL DEBUG : information about the setup follows:"; \
 		LANG=$(ASPELL_ENV_LANG); LC_ALL=$(ASPELL_ENV_LANG); export LANG; export LC_ALL; \
 		$(ASPELL) --help || true; \
@@ -906,13 +937,31 @@ spellcheck:
 		echo "ASPELL proceeding to spellchecking job..."; \
 	 else true; fi
 	+@FAILED="" ; LANG=C; LC_ALL=C; export LANG; export LC_ALL; \
-	 for docsrc in $(SPELLCHECK_SRC); do \
+	 if [ x"$(NUT_MAKE_SKIP_FANOUT)" = xtrue ] ; then \
+		for docsrc in $(SPELLCHECK_SRC); do \
+			if test "$(SPELLCHECK_ENV_DEBUG)" != no ; then \
+				echo "ASPELL MAKEFILE DEBUG: Will see from `pwd` if '$(SPELLCHECK_SRCDIR)/$${docsrc}-spellchecked' is up to date" >&2; \
+			else true ; fi ; \
+			$(MAKE) $(AM_MAKEFLAGS) -s -f "$(abs_top_builddir)/docs/Makefile" SPELLCHECK_SRC="" SPELLCHECK_SRC_ONE="$${docsrc}" SPELLCHECK_BUILDDIR="$(SPELLCHECK_BUILDDIR)" SPELLCHECK_SRCDIR="$(SPELLCHECK_SRCDIR)" "$(SPELLCHECK_BUILDDIR)/$${docsrc}-spellchecked" \
+			|| FAILED="$$FAILED $(SPELLCHECK_SRCDIR)/$$docsrc"; \
+		done ; \
+	 else \
+		SPELLCHECK_AUTO_TGT="`for docsrc in $(SPELLCHECK_SRC); do case "$${docsrc}" in */*) ;; *.adoc|*.txt|*.in|*.conf|*.sample) printf '%s ' "$${docsrc}-spellchecked-auto" ;; esac ; done`" ; \
+		SPELLCHECK_NOEXT_DOCS="`for docsrc in $(SPELLCHECK_SRC); do case "$${docsrc}" in */*) printf '%s ' "$${docsrc}" ;; *.adoc|*.txt|*.in|*.conf|*.sample) ;; *) printf '%s ' "$${docsrc}" ;; esac ; done`" ; \
 		if test "$(SPELLCHECK_ENV_DEBUG)" != no ; then \
-			echo "ASPELL MAKEFILE DEBUG: Will see from `pwd` if '$(SPELLCHECK_SRCDIR)/$${docsrc}-spellchecked' is up to date" >&2; \
+			echo "ASPELL MAKEFILE DEBUG: from `pwd`: SPELLCHECK_NOEXT_DOCS='$${SPELLCHECK_NOEXT_DOCS}' SPELLCHECK_AUTO_TGT='$${SPELLCHECK_AUTO_TGT}'" ; \
 		else true ; fi ; \
-		$(MAKE) $(AM_MAKEFLAGS) -s -f "$(abs_top_builddir)/docs/Makefile" SPELLCHECK_SRC="" SPELLCHECK_SRC_ONE="$${docsrc}" SPELLCHECK_BUILDDIR="$(SPELLCHECK_BUILDDIR)" SPELLCHECK_SRCDIR="$(SPELLCHECK_SRCDIR)" "$(SPELLCHECK_BUILDDIR)/$${docsrc}-spellchecked" \
-		|| FAILED="$$FAILED $(SPELLCHECK_SRCDIR)/$$docsrc"; \
-	 done ; \
+		if [ x"$${SPELLCHECK_AUTO_TGT}" != x ] ; then \
+			$(MAKE) $(AM_MAKEFLAGS) -k -s -f "$(abs_top_builddir)/docs/Makefile" SPELLCHECK_SRC="" SPELLCHECK_BUILDDIR="$(SPELLCHECK_BUILDDIR)" SPELLCHECK_SRCDIR="$(SPELLCHECK_SRCDIR)" $${SPELLCHECK_AUTO_TGT} ; \
+			FAILED="`for docsrc in $(SPELLCHECK_SRC); do if [ -e "$(SPELLCHECK_BUILDDIR)/$${docsrc}-spellchecked-auto.failed" ] ; then printf '%s ' "$(SPELLCHECK_SRCDIR)/$${docsrc}" ; rm -f "$(SPELLCHECK_BUILDDIR)/$${docsrc}-spellchecked-auto.failed" ; fi ; done`" ; \
+		fi ; \
+		if [ x"$${SPELLCHECK_NOEXT_DOCS}" != x ] ; then \
+			for docsrc in $${SPELLCHECK_NOEXT_DOCS} ; do \
+				$(MAKE) $(AM_MAKEFLAGS) -s -f "$(abs_top_builddir)/docs/Makefile" SPELLCHECK_SRC="" SPELLCHECK_SRC_ONE="$${docsrc}" SPELLCHECK_BUILDDIR="$(SPELLCHECK_BUILDDIR)" SPELLCHECK_SRCDIR="$(SPELLCHECK_SRCDIR)" "$(SPELLCHECK_BUILDDIR)/$${docsrc}-spellchecked" \
+				|| FAILED="$$FAILED $(SPELLCHECK_SRCDIR)/$$docsrc"; \
+			done ; \
+		fi ; \
+	 fi ; \
 	 if test -n "$$FAILED" ; then \
 		echo "=====================================================================" ; \
 		echo "FAILED automatic spellcheck for the following sources (relative to `pwd`) using custom dictionary file '$(NUT_SPELL_DICT)': $$FAILED" ; \

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -1412,19 +1412,31 @@ all-man man-man: $(MAN_MANS)
 dist-html: $(DIST_ALL_HTML_PAGES)
 dist-man: $(DIST_ALL_MAN_PAGES)
 
+# This list is defined by configure script choices and options:
+CHECK_LOCAL_TARGETS = @DOC_CHECK_LIST@
+
 if WITH_MANS
 if ! SKIP_MANS
 check-local: check-man
-else
+else SKIP_MANS
 check-local: check-man-txt check-man-pages
 	@echo "Man-page generation was SKIPPED per user request, so pregenerated pages were sanity-checked (if any)" >&2
-endif
-else
+endif SKIP_MANS
+else ! WITH_MANS
 check-local: check-man-txt check-man-pages
 	@echo "Man-page generation was not done, so pregenerated pages were sanity-checked (if any)" >&2
-endif
+endif ! WITH_MANS
 
-check-man check-man-man: check-man-txt check-man-pages check-html-man
+TGT_REQUIRE_CHECK_HTML =
+if WITH_HTML_SINGLE
+TGT_REQUIRE_CHECK_HTML += check-html-man
+else !WITH_HTML_SINGLE
+if WITH_HTML_CHUNKED
+TGT_REQUIRE_CHECK_HTML += check-html-man
+endif WITH_HTML_CHUNKED
+endif !WITH_HTML_SINGLE
+
+check-man check-man-man: check-man-txt check-man-pages $(TGT_REQUIRE_CHECK_HTML)
 
 # the "for" loops might better use $^ but it might be not portable
 check-man-html: check-html-man


### PR DESCRIPTION
* Benefit from more-parallelized runs in `make spellcheck` too by default, following up from work done in #2825
* Some mode bits were planned but misfired, delayed for further commits