### PR TITLE
WIN32: add run-time warnings and in-code comment tags for known-incomplete platform code base with `NUT_WIN32_INCOMPLETE*`

### DIFF
--- a/clients/message.c
+++ b/clients/message.c
@@ -11,4 +11,4 @@ int main(int argc, char ** argv)
 
 	return 0;
 }
-#endif
+#endif	/* WIN32 */

--- a/clients/nutclient.cpp
+++ b/clients/nutclient.cpp
@@ -1,6 +1,12 @@
 /* nutclient.cpp - nutclient C++ library implementation
 
-   Copyright (C) 2012  Emilien Kia <emilien.kia@gmail.com>
+    Copyright (C) 2012 Eaton
+
+        Author: Emilien Kia <emilien.kia@gmail.com>
+
+    Copyright (C) 2024-2025 NUT Community
+
+        Author: Jim Klimov  <jimklimov+nut@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/clients/nutclient.cpp
+++ b/clients/nutclient.cpp
@@ -41,7 +41,7 @@
 /* this include is needed on AIX to have errno stored in thread local storage */
 #  include <pthread.h>
 # endif
-#endif
+#endif	/* !WIN32 */
 
 #include <errno.h>
 #include <string.h>
@@ -124,7 +124,7 @@ static inline int sktclose(int fh)
 #    define AIX_NBCONNECT_0(status) (0)
 #  endif  /* end of AIX WA for non-blocking connect */
 
-#endif /* WIN32 */
+#endif /* !WIN32 */
 /* End of Windows/Linux Socket compatibility layer */
 
 
@@ -281,13 +281,13 @@ void Socket::connect(const std::string& host, uint16_t port)
 
 #ifndef WIN32
 	long			fd_flags;
-#else
+#else	/* WIN32 */
 	HANDLE event = NULL;
 	unsigned long argp;
 
 	WSADATA WSAdata;
 	WSAStartup(2,&WSAdata);
-#endif
+#endif	/* WIN32 */
 
 	_sock = INVALID_SOCKET;
 
@@ -333,9 +333,9 @@ void Socket::connect(const std::string& host, uint16_t port)
 			throw nut::NutException("Out of memory");
 #ifndef WIN32
 		case EAI_SYSTEM:
-#else
+#else	/* WIN32 */
 		case WSANO_RECOVERY:
-#endif
+#endif	/* WIN32 */
 			if (_debugConnect) std::cerr <<
 				"[D2] Socket::connect(): " <<
 				"connect not successful: " <<
@@ -390,7 +390,7 @@ void Socket::connect(const std::string& host, uint16_t port)
 			fd_flags = fcntl(sock_fd, F_GETFL);
 			fd_flags |= O_NONBLOCK;
 			fcntl(sock_fd, F_SETFL, fd_flags);
-#else
+#else	/* WIN32 */
 			event = CreateEvent(NULL, /* Security */
 					FALSE, /* auto-reset */
 					FALSE, /* initial state */
@@ -399,7 +399,7 @@ void Socket::connect(const std::string& host, uint16_t port)
 			/* Associate socket event to the socket via its Event object */
 			WSAEventSelect( sock_fd, event, FD_CONNECT );
 			CloseHandle(event);
-#endif
+#endif	/* WIN32 */
 		}
 
 		if (_debugConnect) std::cerr <<
@@ -419,9 +419,9 @@ void Socket::connect(const std::string& host, uint16_t port)
 
 #ifndef WIN32
 			if(errno == EINPROGRESS || SOLARIS_i386_NBCONNECT_ENOENT(errno) || AIX_NBCONNECT_0(errno)) {
-#else
+#else	/* WIN32 */
 			if(errno == WSAEWOULDBLOCK) {
-#endif
+#endif	/* WIN32 */
 				FD_ZERO(&wfds);
 				FD_SET(sock_fd, &wfds);
 				select(sock_fd+1, nullptr, &wfds, nullptr,
@@ -498,10 +498,10 @@ void Socket::connect(const std::string& host, uint16_t port)
 			fd_flags = fcntl(sock_fd, F_GETFL);
 			fd_flags &= ~O_NONBLOCK;
 			fcntl(sock_fd, F_SETFL, fd_flags);
-#else
+#else	/* WIN32 */
 			argp = 0;
 			ioctlsocket(sock_fd, FIONBIO, &argp);
-#endif
+#endif	/* WIN32 */
 		}
 
 		if (_debugConnect) std::cerr <<
@@ -518,14 +518,14 @@ void Socket::connect(const std::string& host, uint16_t port)
 
 #ifndef WIN32
 	if (_sock < 0) {
-#else
+#else	/* WIN32 */
 	if (_sock == INVALID_SOCKET) {
 		/* In tracing one may see 18446744073709551615 = "-1" after
 		 * conversion from 'long long unsigned int' to 'int'
 		 * 64-bit WINSOCK API with UINT_PTR , see gory details at e.g.
 		 * https://github.com/openssl/openssl/issues/7282#issuecomment-430633656
 		 */
-#endif
+#endif	/* WIN32 */
 		if (_debugConnect) std::cerr <<
 			"[D2] Socket::connect(): " <<
 			"invalid _sock = " << _sock <<

--- a/clients/upsc.c
+++ b/clients/upsc.c
@@ -26,7 +26,7 @@
 #include <netdb.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
-#endif
+#endif	/* !WIN32 */
 
 #include "nut_stdint.h"
 #include "upsclient.h"

--- a/clients/upscmd.c
+++ b/clients/upscmd.c
@@ -28,9 +28,9 @@
 #include <sys/types.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
-#else
+#else	/* WIN32 */
 #include "wincompat.h"
-#endif
+#endif	/* WIN32 */
 
 #include "nut_stdint.h"
 #include "upsclient.h"

--- a/clients/upslog.c
+++ b/clients/upslog.c
@@ -48,13 +48,13 @@
 
 #ifdef WIN32
 #include "wincompat.h"
-#endif
+#endif	/* WIN32 */
 
 	static	int	reopen_flag = 0, exit_flag = 0;
 	static	size_t	max_loops = 0;
 #ifndef WIN32
 	static	sigset_t	nut_upslog_sigmask;
-#endif
+#endif	/* !WIN32 */
 	/* NOTE: The logbuffer is reused for each loop cycle (each device)
 	 * and the logformat is one for all "systems" in this program run */
 	static	char	logbuffer[LARGEBUF], *logformat = NULL;
@@ -154,7 +154,7 @@ static void set_print_now_flag(int sig)
 
 	/* no need to do anything, the signal will cause sleep to be interrupted */
 }
-#endif
+#endif	/* !WIN32 */
 
 /* handlers: reload on HUP, exit on INT/QUIT/TERM */
 static void setup_signals(void)
@@ -181,7 +181,9 @@ static void setup_signals(void)
 	sa.sa_handler = set_print_now_flag;
 	if (sigaction(SIGUSR1, &sa, NULL) < 0)
 		fatal_with_errno(EXIT_FAILURE, "Can't install SIGUSR1 handler");
-#endif
+#else	/* WIN32 */
+	NUT_WIN32_INCOMPLETE_MAYBE_NOT_APPLICABLE();
+#endif	/* WIN32 */
 }
 
 static void help(const char *prog)
@@ -552,9 +554,9 @@ int main(int argc, char **argv)
 						fatalx(EXIT_FAILURE, "Argument '-m upsspec,logfile' requires exactly 2 components in the tuple");
 #ifndef WIN32
 					monhost_ups_current->logtarget = add_logfile(strsep(&m_arg, ","));
-#else
+#else	/* WIN32 */
 					monhost_ups_current->logtarget = add_logfile(filter_path(strsep(&m_arg, ",")));
-#endif
+#endif	/* WIN32 */
 					monhost_ups_current->ups = NULL;
 					if (m_arg) /* Had a third comma - also unexpected! */
 						fatalx(EXIT_FAILURE, "Argument '-m upsspec,logfile' requires exactly 2 components in the tuple");
@@ -568,9 +570,9 @@ int main(int argc, char **argv)
 			case 'l':
 #ifndef WIN32
 				logfn = optarg;
-#else
+#else	/* WIN32 */
 				logfn = filter_path(optarg);
-#endif
+#endif	/* WIN32 */
 				break;
 
 			case 'i':
@@ -665,9 +667,9 @@ int main(int argc, char **argv)
 		monhost = argv[0];
 #ifndef WIN32
 		logfn = argv[1];
-#else
+#else	/* WIN32 */
 		logfn = filter_path(argv[1]);
-#endif
+#endif	/* WIN32 */
 		interval = atoi(argv[2]);
 	}
 

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -4,7 +4,7 @@
      1998  Russell Kroll <rkroll@exploits.org>
      2012  Arnaud Quette <arnaud.quette.free.fr>
      2017  Eaton (author: Arnaud Quette <ArnaudQuette@Eaton.com>)
-     2020-2024  Jim Klimov <jimklimov+nut@gmail.com>
+     2020-2025  Jim Klimov <jimklimov+nut@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -29,9 +29,9 @@
 # include <sys/socket.h>
 # include <unistd.h>
 # include <fcntl.h>
-#else
-# include <wincompat.h>
-#endif
+#else	/* WIN32 */
+# include "wincompat.h"
+#endif	/* WIN32 */
 
 #include "nut_stdint.h"
 #include "upsclient.h"

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -138,11 +138,11 @@ static	int	userfsd = 0, pipefd[2];
 	 * into two upsmon processes for some more security? */
 #ifndef WIN32
 static	int	use_pipe = 1;
-#else
+#else	/* WIN32 */
 	/* Do not fork in WIN32 */
 static	int	use_pipe = 0;
 static HANDLE   mutex = INVALID_HANDLE_VALUE;
-#endif
+#endif	/* WIN32 */
 
 static	utype_t	*firstups = NULL;
 
@@ -152,7 +152,7 @@ static int 	opt_af = AF_UNSPEC;
 	/* signal handling things */
 static	struct sigaction sa;
 static	sigset_t nut_upsmon_sigmask;
-#endif
+#endif	/* !WIN32 */
 
 #ifdef HAVE_SYSTEMD
 # define SERVICE_UNIT_NAME "nut-monitor.service"
@@ -222,7 +222,7 @@ static void wall(const char *text)
 
 	fprintf(wf, "%s\n", text);
 	pclose(wf);
-#else
+#else	/* WIN32 */
 #	define MESSAGE_CMD "message.exe"
 	char * command;
 
@@ -240,7 +240,7 @@ static void wall(const char *text)
 		upslog_with_errno(LOG_NOTICE, "Can't invoke wall");
 	}
 	free(command);
-#endif
+#endif	/* WIN32 */
 }
 
 #ifdef WIN32
@@ -290,7 +290,7 @@ static unsigned __stdcall async_notify(LPVOID param)
 	free(data);
 	return 1;
 }
-#endif
+#endif	/* WIN32 */
 
 static void notify(const char *notice, unsigned int flags, const char *ntype,
 			const char *upsname)
@@ -298,7 +298,7 @@ static void notify(const char *notice, unsigned int flags, const char *ntype,
 #ifndef WIN32
 	char	exec[LARGEBUF];
 	int	ret;
-#endif
+#endif	/* !WIN32 */
 
 	upsdebugx(6, "%s: sending notification for [%s]: type %s with flags 0x%04x: %s",
 		__func__, upsname ? upsname : "upsmon itself", ntype, flags, notice);
@@ -359,7 +359,7 @@ static void notify(const char *notice, unsigned int flags, const char *ntype,
 	upsdebugx(6, "%s (child): exiting after notifications", __func__);
 
 	exit(EXIT_SUCCESS);
-#else
+#else	/* WIN32 */
 	async_notify_t * data;
 	time_t t;
 
@@ -379,7 +379,7 @@ static void notify(const char *notice, unsigned int flags, const char *ntype,
 			0,	/* Creation flags */
 			NULL	/* thread id */
 		      );
-#endif
+#endif	/* WIN32 */
 }
 
 static void do_notify(const utype_t *ups, unsigned int ntype, const char *extra)
@@ -945,7 +945,7 @@ static void doshutdown(void)
 #ifndef WIN32
 		if (geteuid() != 0)
 			upslogx(LOG_WARNING, "Not root, shutdown may fail");
-#endif
+#endif	/* !WIN32 */
 
 		set_pdflag();
 
@@ -973,7 +973,7 @@ static void doshutdown(void)
 				Sleep(2000);
 			}
 		}
-#endif
+#endif	/* WIN32 */
 
 		sret = system(shutdowncmd);
 
@@ -1055,7 +1055,7 @@ static void read_timeout(int sig)
 
 	/* don't do anything here, just return */
 }
-#endif
+#endif	/* !WIN32 */
 
 static void set_alarm(void)
 {
@@ -1068,7 +1068,9 @@ static void set_alarm(void)
 	sa.sa_handler = read_timeout;
 	sigaction(SIGALRM, &sa, NULL);
 	alarm(tv.tv_sec);
-#endif
+#else	/* WIN32 */
+	NUT_WIN32_INCOMPLETE_MAYBE_NOT_APPLICABLE();
+#endif	/* WIN32 */
 }
 
 static void clear_alarm(void)
@@ -1083,7 +1085,9 @@ static void clear_alarm(void)
 #  pragma GCC diagnostic pop
 # endif
 	alarm(0);
-#endif
+#else	/* WIN32 */
+	NUT_WIN32_INCOMPLETE_MAYBE_NOT_APPLICABLE();
+#endif	/* WIN32 */
 }
 
 static int get_var(utype_t *ups, const char *var, char *buf, size_t bufsize)
@@ -2125,9 +2129,9 @@ static int parse_conf_arg(size_t numargs, char **arg)
 		free(powerdownflag);
 #ifndef WIN32
 		powerdownflag = xstrdup(arg[1]);
-#else
+#else	/* WIN32 */
 		powerdownflag = filter_path(arg[1]);
-#endif
+#endif	/* WIN32 */
 
 		if (reload_flag == 0)
 			upslogx(LOG_INFO, "Using power down flag file %s",
@@ -2475,7 +2479,7 @@ static void sigpipe(int sig)
 {
 	upsdebugx(1, "SIGPIPE: dazed and confused, but continuing after signal %i...", sig);
 }
-#endif
+#endif	/* !WIN32 */
 
 /* SIGQUIT, SIGTERM handler */
 static void set_exit_flag(int sig)
@@ -2535,7 +2539,7 @@ static void upsmon_cleanup(void)
 		ReleaseMutex(mutex);
 		CloseHandle(mutex);
 	}
-#endif
+#endif	/* WIN32 */
 }
 
 static void user_fsd(int sig)
@@ -2574,9 +2578,9 @@ static void setup_signals(void)
 
 	sa.sa_handler = set_reload_flag;
 	sigaction(SIGCMD_RELOAD, &sa, NULL);
-#else
+#else	/* WIN32 */
 	pipe_create(UPSMON_PIPE_NAME);
-#endif
+#endif	/* WIN32 */
 }
 
 /* remember the last time the ups was not critical (OB + LB) */
@@ -3189,7 +3193,7 @@ static void help(const char *arg_progname)
 	printf("		 - stop: stop monitoring and exit\n");
 #ifndef WIN32
 	printf("  -P <pid>	send the signal above to specified PID (bypassing PID file)\n");
-#endif
+#endif	/* !WIN32 */
 	printf("  -D		raise debugging level (and stay foreground by default)\n");
 	printf("  -F		stay foregrounded even if no debugging is enabled\n");
 	printf("  -B		stay backgrounded even if debugging is bumped\n");
@@ -3258,7 +3262,7 @@ static void runparent(int fd)
 	close(fd);
 	exit(EXIT_SUCCESS);
 }
-#endif
+#endif	/* !WIN32 */
 
 /* fire up the split parent/child scheme */
 static void start_pipe(void)
@@ -3290,7 +3294,8 @@ static void start_pipe(void)
 
 	/* prevent pipe leaking to NOTIFYCMD */
 	set_close_on_exec(pipefd[1]);
-#endif	/* WIN32 */
+#endif	/* !WIN32 */
+	/* NOTE: Not applicable to WIN32 - no parent/child split */
 }
 
 static void delete_ups(utype_t *target)
@@ -3476,7 +3481,7 @@ int main(int argc, char *argv[])
 #ifndef WIN32
 	pid_t	oldpid = -1;
 	int	cmd = 0;
-#else
+#else	/* WIN32 */
 	const char * cmd = NULL;
 	DWORD ret;
 
@@ -3498,7 +3503,7 @@ int main(int argc, char *argv[])
 	else {
 		prog = drv_name;
 	}
-#endif
+#endif	/* WIN32 */
 
 	print_banner_once(prog, 0);
 
@@ -3531,7 +3536,7 @@ int main(int argc, char *argv[])
 				if ((oldpid = parsepid(optarg)) < 0)
 					help(argv[0]);
 				break;
-#endif
+#endif	/* !WIN32 */
 			case 'D':
 				nut_debug_level++;
 				nut_debug_level_args++;
@@ -3798,7 +3803,7 @@ int main(int argc, char *argv[])
 #ifndef WIN32
 		/* Note: upsmon does not fork in WIN32 */
 		upslogx(LOG_INFO, "Warning: running as one big root process by request (upsmon -p)");
-#endif
+#endif	/* !WIN32 */
 
 		writepid(prog);
 	}
@@ -3823,7 +3828,7 @@ int main(int argc, char *argv[])
 		struct timeval	start, end, now;
 #ifndef WIN32
 		struct timeval	prev;
-#endif
+#endif	/* !WIN32 */
 		double	dt = 0;
 		int	sleep_overhead_tolerance = 5;
 
@@ -4013,7 +4018,7 @@ int main(int argc, char *argv[])
 		gettimeofday(&end, NULL);
 		upsdebugx(4, "%u-sec delay between main loop cycles finished, took %.06f",
 			sleepval, difftimeval(end, start));
-#else
+#else	/* WIN32 */
 		maxhandle = 0;
 		memset(&handles, 0, sizeof(handles));
 
@@ -4080,7 +4085,7 @@ int main(int argc, char *argv[])
 				}
 			}
 		}
-#endif
+#endif	/* WIN32 */
 
 		/* General-purpose handling of time jumps for OSes/run-times
 		 * without NUT direct support for suspend/inhibit */

--- a/clients/upsmon.h
+++ b/clients/upsmon.h
@@ -150,9 +150,9 @@ typedef struct {
 
 #ifdef WIN32
 #define NOTIFY_DEFAULT	NOTIFY_SYSLOG
-#else
+#else	/* !WIN32 */
 #define NOTIFY_DEFAULT	(NOTIFY_SYSLOG | NOTIFY_WALL)
-#endif
+#endif	/* !WIN32 */
 
 /* This is only used in upsmon.c, but might it also have external consumers?..
  * To move or not to move?..
@@ -217,11 +217,11 @@ static struct {
 #define SIGCMD_FSD	SIGUSR1
 #define SIGCMD_STOP	SIGTERM
 #define SIGCMD_RELOAD	SIGHUP
-#else
+#else	/* WIN32 */
 #define SIGCMD_FSD	COMMAND_FSD
 #define SIGCMD_STOP	COMMAND_STOP
 #define SIGCMD_RELOAD	COMMAND_RELOAD
-#endif
+#endif	/* WIN32 */
 
 /* various constants */
 

--- a/clients/upsrw.c
+++ b/clients/upsrw.c
@@ -27,9 +27,9 @@
 #include <netdb.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
-#else
+#else	/* WIN32 */
 #include "wincompat.h"
-#endif
+#endif	/* WIN32 */
 
 #include "nut_stdint.h"
 #include "upsclient.h"

--- a/clients/upssched.c
+++ b/clients/upssched.c
@@ -50,11 +50,11 @@
 # include <unistd.h>
 # include <fcntl.h>
 # include <poll.h>
-#else
+#else	/* WIN32 */
 # include "wincompat.h"
 # include <winsock2.h>
 # include <ws2tcpip.h>
-#endif
+#endif	/* WIN32 */
 
 #include "upssched.h"
 #include "timehead.h"
@@ -76,7 +76,7 @@ static const	char	*upsname, *notify_type;
 #ifdef WIN32
 static OVERLAPPED connect_overlapped;
 # define BUF_LEN 512
-#endif
+#endif	/* WIN32 */
 
 #define PARENT_STARTED		-2
 #define PARENT_UNNECESSARY	-3
@@ -108,14 +108,14 @@ static void exec_cmd(const char *cmd)
 			upslogx(LOG_ERR, "Execute command failure: %s", buf);
 		}
 	}
-#else
+#else	/* WIN32 */
 	if(err != -1) {
 		upslogx(LOG_INFO, "Execute command \"%s\" OK", buf);
 	}
 	else {
 		upslogx(LOG_ERR, "Execute command failure : %s", buf);
 	}
-#endif
+#endif	/* WIN32 */
 
 	return;
 }
@@ -291,7 +291,7 @@ static void us_serialize(int op)
 			break;
 	}
 }
-#endif
+#endif	/* !WIN32 */
 
 static TYPE_FD open_sock(void)
 {
@@ -427,10 +427,10 @@ static int send_to_one(conn_t *conn, const char *fmt, ...)
 		if (VALID_FD(conn->fd)) {
 #ifndef WIN32
 			close(conn->fd);
-#else
+#else	/* WIN32 */
 			FlushFileBuffers(conn->fd);
 			CloseHandle(conn->fd);
-#endif
+#endif	/* WIN32 */
 			conn->fd = ERROR_FD;
 		}
 
@@ -450,7 +450,7 @@ static int send_to_one(conn_t *conn, const char *fmt, ...)
 
 		return 0;	/* failed */
 	}
-#else
+#else	/* WIN32 */
 	DWORD bytesWritten = 0;
 	BOOL  result = FALSE;
 
@@ -502,7 +502,7 @@ static TYPE_FD conn_add(TYPE_FD sockfd)
 	int			salen;
 # else
 	socklen_t	salen;
-#endif
+# endif
 
 	salen = sizeof(saddr);
 	acc = accept(sockfd, (struct sockaddr *) &saddr, &salen);
@@ -739,7 +739,7 @@ static int sock_read(conn_t *conn)
 			upsdebugx(6, "Ending sock_read(): some other problem");
 			return -1;	/* error */
 		}
-#else
+#else	/* WIN32 */
 		DWORD bytesRead;
 		GetOverlappedResult(conn->fd, &conn->read_overlapped, &bytesRead,FALSE);
 		if( bytesRead < 1 ) {
@@ -1109,9 +1109,9 @@ static TYPE_FD get_lock(const char *fn)
 {
 #ifndef WIN32
 	return open(fn, O_RDONLY | O_CREAT | O_EXCL, 0);
-#else
+#else	/* WIN32 */
 	return CreateFile(fn,GENERIC_ALL,0,NULL,CREATE_NEW,FILE_ATTRIBUTE_NORMAL,NULL);
-#endif
+#endif	/* WIN32 */
 }
 
 /* try to connect to bg process, and start one if necessary */
@@ -1148,9 +1148,9 @@ static TYPE_FD check_parent(const char *cmd, const char *arg2)
 		/* blow this away in case we crashed before */
 #ifndef WIN32
 		unlink(lockfn);
-#else
+#else	/* WIN32 */
 		DeleteFile(lockfn);
-#endif
+#endif	/* WIN32 */
 
 		/* give the other one a chance to start it, then try again */
 		usleep(250000);
@@ -1170,9 +1170,9 @@ static void sendcmd(const char *cmd, const char *arg1, const char *arg2)
 	int	ret_s;
 	struct	timeval tv;
 	fd_set	fdread;
-#else
+#else	/* WIN32 */
 	DWORD bytesWritten = 0;
-#endif
+#endif	/* WIN32 */
 	TYPE_FD pipefd;
 
 	/* insanity */
@@ -1397,9 +1397,9 @@ static int conf_arg(size_t numargs, char **arg)
 	if (!strcmp(arg[0], "PIPEFN")) {
 #ifndef WIN32
 		pipefn = xstrdup(arg[1]);
-#else
+#else	/* WIN32 */
 		pipefn = xstrdup("\\\\.\\pipe\\upssched");
-#endif
+#endif	/* WIN32 */
 		return 1;
 	}
 
@@ -1407,9 +1407,9 @@ static int conf_arg(size_t numargs, char **arg)
 	if (!strcmp(arg[0], "LOCKFN")) {
 #ifndef WIN32
 		lockfn = xstrdup(arg[1]);
-#else
+#else	/* WIN32 */
 		lockfn = filter_path(arg[1]);
-#endif
+#endif	/* WIN32 */
 		return 1;
 	}
 

--- a/clients/upssched.h
+++ b/clients/upssched.h
@@ -22,7 +22,7 @@ typedef struct conn_s {
 #ifdef WIN32
 	char		buf[LARGEBUF];
 	OVERLAPPED	read_overlapped;
-#endif
+#endif	/* WIN32 */
 	PCONF_CTX_t	ctx;
 	struct conn_s	*next;
 } conn_t;

--- a/clients/upsset.c
+++ b/clients/upsset.c
@@ -24,9 +24,9 @@
 #include <stdlib.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
-#else
+#else	/* WIN32 */
 #include "wincompat.h"
-#endif
+#endif	/* WIN32 */
 
 #include "nut_stdint.h"
 #include "upsclient.h"

--- a/common/common.c
+++ b/common/common.c
@@ -28,11 +28,11 @@
 # include <pwd.h>
 # include <grp.h>
 # include <sys/un.h>
-#else
-# include <wincompat.h>
+#else	/* WIN32 */
+# include "wincompat.h"
 # include <processthreadsapi.h>
 # include <psapi.h>
-#endif
+#endif	/* WIN32 */
 
 #ifdef HAVE_UNISTD_H
 # include <unistd.h>	/* readlink */

--- a/common/common.c
+++ b/common/common.c
@@ -770,9 +770,9 @@ void open_syslog(const char *progname)
 		break;
 # endif	/* HAVE_SETLOGMASK && HAVE_DECL_LOG_UPTO */
 	}
-#else
+#else	/* WIN32 */
 	EventLogName = progname;
-#endif	/* WIND32 */
+#endif	/* WIN32 */
 }
 
 /* close ttys and become a daemon */
@@ -789,7 +789,7 @@ void background(void)
 
 	if ((pid = fork()) < 0)
 		fatal_with_errno(EXIT_FAILURE, "Unable to enter background");
-#endif
+#endif	/* !WIN32 */
 
 	if (!syslog_disabled)
 		/* not disabled: NUT_DEBUG_SYSLOG is unset or invalid */
@@ -865,7 +865,9 @@ void background(void)
 # ifdef HAVE_SETSID
 	setsid();		/* make a new session to dodge signals */
 # endif
-#endif	/* not WIN32 */
+#else	/* WIN32 */
+	NUT_WIN32_INCOMPLETE_MAYBE_NOT_APPLICABLE();
+#endif	/* WIN32 */
 
 	upslogx(LOG_INFO, "Startup successful");
 }
@@ -886,8 +888,9 @@ struct passwd *get_user_pwent(const char *name)
 		fatalx(EXIT_FAILURE, "OS user %s not found", name);
 	else
 		fatal_with_errno(EXIT_FAILURE, "getpwnam(%s)", name);
-#else
+#else	/* WIN32 */
 	NUT_UNUSED_VARIABLE(name);
+	/* NUT_WIN32_INCOMPLETE_MAYBE_NOT_APPLICABLE(); */
 #endif /* WIN32 */
 
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) || (defined HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE_RETURN) )
@@ -962,10 +965,11 @@ void become_user(struct passwd *pw)
 
 	upsdebugx(1, "Succeeded to become_user(%s): now UID=%jd GID=%jd",
 		pw->pw_name, (intmax_t)getuid(), (intmax_t)getgid());
-#else
+#else	/* WIN32 */
+	/* NUT_WIN32_INCOMPLETE_MAYBE_NOT_APPLICABLE(); */
 	upsdebugx(1, "Can not become_user(%s): not implemented on this platform",
 		pw ? pw->pw_name : "<null>");
-#endif
+#endif	/* WIN32 */
 }
 
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_BESIDEFUNC) && (!defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_INSIDEFUNC) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS_BESIDEFUNC) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE_BESIDEFUNC) )
@@ -987,16 +991,17 @@ void chroot_start(const char *path)
 	if (chroot(path))
 		fatal_with_errno(EXIT_FAILURE, "chroot(%s)", path);
 
-#else
+#else	/* WIN32 */
+	/* NUT_WIN32_INCOMPLETE_MAYBE_NOT_APPLICABLE(); */
 	upsdebugx(1, "Can not chroot into %s: not implemented on this platform", path);
-#endif
+#endif	/* WIN32 */
 
 	if (chdir("/"))
 		fatal_with_errno(EXIT_FAILURE, "chdir(/)");
 
 #ifndef WIN32
 	upsdebugx(1, "chrooted into %s", path);
-#endif
+#endif	/* !WIN32 */
 }
 
 char * getprocname(pid_t pid)
@@ -1076,7 +1081,7 @@ char * getprocname(pid_t pid)
 			LocalFree(WinBuf);
 		}
 	}
-#endif
+#endif	/* WIN32 */
 
 	if (stat("/proc", &st) == 0 && ((st.st_mode & S_IFMT) == S_IFDIR)) {
 		upsdebugx(3, "%s: /proc is an accessible directory, investigating", __func__);
@@ -1409,7 +1414,7 @@ size_t parseprogbasename(char *buf, size_t buflen, const char *progname, size_t 
 		if (progname[i] == '/'
 #ifdef WIN32
 		||  progname[i] == '\\'
-#endif
+#endif	/* WIN32 */
 		) {
 			progbasenamelen = 0;
 			progbasenamedot = 0;
@@ -1526,7 +1531,7 @@ int compareprocname(pid_t pid, const char *procname, const char *progname)
 			goto finish;
 		}
 	}
-#endif
+#endif	/* WIN32 */
 
 	/* TOTHINK: Developer builds wrapped with libtool may be prefixed
 	 * by "lt-" in the filename. Should we re-enter (or wrap around)
@@ -1676,7 +1681,7 @@ char * getfullpath(char * relative_path)
 
 	return(xstrdup(buf));
 }
-#endif
+#endif	/* WIN32 */
 
 /* drop off a pidfile for this process */
 void writepid(const char *name)
@@ -1705,9 +1710,10 @@ void writepid(const char *name)
 	}
 
 	umask(mask);
-#else
+#else	/* WIN32 */
 	NUT_UNUSED_VARIABLE(name);
-#endif
+	NUT_WIN32_INCOMPLETE_MAYBE_NOT_APPLICABLE();
+#endif	/* WIN32 */
 }
 
 /* send sig to pid, returns -1 for error, or
@@ -1883,18 +1889,19 @@ int sendsignalpid(pid_t pid, int sig, const char *progname, int check_current_pr
 	}
 
 	return 0;
-#else
+#else	/* WIN32 */
 	NUT_UNUSED_VARIABLE(pid);
 	NUT_UNUSED_VARIABLE(sig);
 	NUT_UNUSED_VARIABLE(progname);
 	NUT_UNUSED_VARIABLE(check_current_progname);
 	/* Windows builds use named pipes, not signals per se */
+	NUT_WIN32_INCOMPLETE_MAYBE_NOT_APPLICABLE();
 	upslogx(LOG_ERR,
 		"%s: not implemented for Win32 and "
 		"should not have been called directly!",
 		__func__);
 	return -1;
-#endif
+#endif	/* WIN32 */
 }
 
 /* parses string buffer into a pid_t if it passes
@@ -2223,7 +2230,7 @@ int sendsignal(const char *progname, int sig, int check_current_progname)
 
 	return sendsignalfn(fn, sig, progname, check_current_progname);
 }
-#else
+#else	/* WIN32 */
 int sendsignal(const char *progname, const char * sig, int check_current_progname)
 {
 	/* progname is used as the pipe name for WIN32
@@ -2231,20 +2238,20 @@ int sendsignal(const char *progname, const char * sig, int check_current_prognam
 	 */
 	return sendsignalfn(progname, sig, NULL, check_current_progname);
 }
-#endif
+#endif	/* WIN32 */
 
 const char *xbasename(const char *file)
 {
 #ifndef WIN32
 	const char *p = strrchr(file, '/');
-#else
+#else	/* WIN32 */
 	const char *p = strrchr(file, '\\');
 	const char *r = strrchr(file, '/');
 	/* if not found, try '/' */
 	if( r > p ) {
 		p = r;
 	}
-#endif
+#endif	/* WIN32 */
 
 	if (p == NULL)
 		return file;
@@ -2929,7 +2936,7 @@ void nut_report_config_flags(void)
 		);
 #ifdef WIN32
 		fflush(stderr);
-#endif
+#endif	/* WIN32 */
 	}
 
 	/* NOTE: May be ignored or truncated by receiver if that syslog server
@@ -3052,7 +3059,7 @@ vupslog_too_long:
 #ifdef WIN32
 		LPVOID WinBuf;
 		DWORD WinErr = GetLastError();
-#endif
+#endif	/* WIN32 */
 
 		snprintfcat(buf, bufsize, ": %s", strerror(errno_orig));
 
@@ -3070,7 +3077,7 @@ vupslog_too_long:
 
 		snprintfcat(buf, bufsize, " [%s]", (char *)WinBuf);
 		LocalFree(WinBuf);
-#endif
+#endif	/* WIN32 */
 	}
 
 	/* Note: nowadays debug level can be changed during run-time,
@@ -3104,7 +3111,7 @@ vupslog_too_long:
 		}
 #ifdef WIN32
 		fflush(stderr);
-#endif
+#endif	/* WIN32 */
 	}
 	if (xbit_test(upslog_flags, UPSLOG_SYSLOG))
 		syslog(priority, "%s", buf);
@@ -3128,7 +3135,7 @@ const char * confpath(void)
 		/* fall back to built-in pathname relative to binary/workdir */
 		path = getfullpath(PATH_ETC);
 	}
-#endif
+#endif	/* WIN32 */
 
 	/* We assume, here and elsewhere, that
 	 * at least CONFPATH is always defined */
@@ -3154,7 +3161,7 @@ const char * dflt_statepath(void)
 		/* fall back to built-in pathname relative to binary/workdir */
 		path = getfullpath(PATH_VAR_RUN);
 	}
-#endif
+#endif	/* WIN32 */
 
 	/* We assume, here and elsewhere, that
 	 * at least STATEPATH is always defined */
@@ -3187,7 +3194,7 @@ const char * altpidpath(void)
 			/* fall back to built-in pathname relative to binary/workdir */
 			path = getfullpath(PATH_VAR_RUN);
 		}
-#endif
+#endif	/* WIN32 */
 	}
 
 	if ( (path != NULL) && (*path != '\0') )
@@ -3223,7 +3230,7 @@ const char * rootpidpath(void)
 		/* fall back to built-in pathname relative to binary/workdir */
 		path = getfullpath(PATH_ETC);
 	}
-#endif
+#endif	/* WIN32 */
 
 	/* We assume, here and elsewhere, that
 	 * at least PIDPATH is always defined */
@@ -3240,7 +3247,7 @@ void check_unix_socket_filename(const char *fn) {
 #ifndef WIN32
 	struct sockaddr_un	ssaddr;
 	max = sizeof(ssaddr.sun_path);
-#endif
+#endif	/* WIN32 */
 
 	if (len < max)
 		return;
@@ -3620,7 +3627,7 @@ void *xmalloc(size_t size)
 #ifdef WIN32
 	/* FIXME: This is what (x)calloc() is for! */
 	memset(p, 0, size);
-#endif
+#endif	/* WIN32 */
 
 	return p;
 }
@@ -3635,7 +3642,7 @@ void *xcalloc(size_t number, size_t size)
 #ifdef WIN32
 	/* FIXME: calloc() above should have initialized this already! */
 	memset(p, 0, size * number);
-#endif
+#endif	/* WIN32 */
 
 	return p;
 }
@@ -3689,7 +3696,7 @@ ssize_t select_read(const int fd, void *buf, const size_t buflen, const time_t d
 
 	return read(fd, buf, buflen);
 }
-#else
+#else	/* WIN32 */
 ssize_t select_read(serial_handler_t *fd, void *buf, const size_t buflen, const time_t d_sec, const suseconds_t d_usec)
 {
 	/* This function is only called by serial drivers right now */
@@ -3711,7 +3718,7 @@ ssize_t select_read(serial_handler_t *fd, void *buf, const size_t buflen, const 
 
 	return res;
 }
-#endif
+#endif	/* WIN32 */
 
 /* Write up to buflen bytes to fd and return the number of bytes
    written. If no data is available within d_sec + d_usec, return 0.
@@ -3737,7 +3744,7 @@ ssize_t select_write(const int fd, const void *buf, const size_t buflen, const t
 
 	return write(fd, buf, buflen);
 }
-#else
+#else	/* WIN32 */
 /* Note: currently not implemented de-facto for Win32 */
 ssize_t select_write(serial_handler_t *fd, const void *buf, const size_t buflen, const time_t d_sec, const suseconds_t d_usec)
 {
@@ -3746,10 +3753,13 @@ ssize_t select_write(serial_handler_t *fd, const void *buf, const size_t buflen,
 	NUT_UNUSED_VARIABLE(buflen);
 	NUT_UNUSED_VARIABLE(d_sec);
 	NUT_UNUSED_VARIABLE(d_usec);
-	upsdebugx(1, "WARNING: method %s() is not implemented yet for WIN32", __func__);
+
+	NUT_WIN32_INCOMPLETE_LOGWARN();
+	/* upsdebugx(1, "WARNING: method %s() is not implemented yet for WIN32", __func__); */
+
 	return 0;
 }
-#endif
+#endif	/* WIN32 */
 
 /* FIXME: would be good to get more from /etc/ld.so.conf[.d] and/or
  * LD_LIBRARY_PATH and a smarter dependency on build bitness; also
@@ -3834,7 +3844,7 @@ static const char * search_paths_builtin[] = {
 	 * Perhaps a decent fallback idea for all platforms, not just WIN32.
 	 */
 	".",
-#endif
+#endif	/* WIN32 */
 	NULL
 };
 
@@ -4022,7 +4032,7 @@ void upsdebugx_report_search_paths(int level, int report_search_paths_builtin) {
 	if (((s = getenv(varname)) != NULL) && strlen(s) > 0) {
 		upsdebugx(level, "\tWindows via %s:\t%s", varname, s);
 	}
-#endif
+#endif	/* WIN32 */
 }
 
 static char * get_libname_in_dir(const char* base_libname, size_t base_libname_length, const char* dirname, int index) {
@@ -4338,9 +4348,10 @@ void set_close_on_exec(int fd) {
 # ifdef WIN32
 	/* Find a way, if possible at all (WIN32: get INT fd from the HANDLE?) */
 	NUT_UNUSED_VARIABLE(fd);
-# else
+	NUT_WIN32_INCOMPLETE();
+# else	/* !WIN32 */
 	fcntl(fd, F_SETFD, FD_CLOEXEC);
-# endif
+# endif	/* !WIN32 */
 #endif
 }
 

--- a/common/nutconf.cpp
+++ b/common/nutconf.cpp
@@ -1,9 +1,13 @@
 /*
     nutconf.cpp - configuration API
 
-    Copyright (C)
-        2012	Emilien Kia <emilien.kia@gmail.com>
-        2024	Jim Klimov <jimklimov+nut@gmail.com>
+    Copyright (C) 2012 Eaton
+
+        Author: Emilien Kia <emilien.kia@gmail.com>
+
+    Copyright (C) 2024-2025 NUT Community
+
+        Author: Jim Klimov  <jimklimov+nut@gmail.com>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/common/nutipc.cpp
+++ b/common/nutipc.cpp
@@ -72,10 +72,11 @@ pid_t Process::getPPID()
 #ifdef WIN32
 	/* FIXME: Detect HAVE_GETPPID in configure; throw exceptions here?..
 	 * NOTE: Does not seem to be currently used in nutconf codebase. */
+	/* NUT_WIN32_INCOMPLETE(); */
 	return -1;
-#else
+#else	/* !WIN32 */
 	return getppid();
-#endif
+#endif	/* !WIN32 */
 }
 
 
@@ -245,8 +246,9 @@ int Signal::send(Signal::enum_t signame, pid_t pid)
 	e << "Can't send signal " << sig << " to PID " << pid <<
 			": not implemented on this platform yet";
 
+	/* NUT_WIN32_INCOMPLETE(); */
 	throw std::logic_error(e.str());
-#else
+#else	/* !WIN32 */
 	int status = ::kill(pid, sig);
 
 	if (0 == status)
@@ -260,7 +262,7 @@ int Signal::send(Signal::enum_t signame, pid_t pid)
 	e << "Can't send invalid signal " << sig;
 
 	throw std::logic_error(e.str());
-#endif
+#endif	/* !WIN32 */
 }
 
 
@@ -300,6 +302,9 @@ int NutSignal::send(NutSignal::enum_t signame, const std::string & process) {
 
 	// FIXME: What about ALTPIDPATH (for non-root daemons)
 	// and shouldn't we also consider it (e.g. try/catch)?
+	/* FIXME NUT_WIN32_INCOMPLETE : Actually modern Windows supports both
+	 *  slashes, but revise this code so we do not mix them (maybe enforce a
+	 *  specific one - e.g. some other code does replace / with \ in common.c) */
 	pid_file += rootpidpath();
 	pid_file += '/';
 	pid_file += process;

--- a/common/nutipc.cpp
+++ b/common/nutipc.cpp
@@ -5,7 +5,7 @@
 
         Author: Vaclav Krpec  <VaclavKrpec@Eaton.com>
 
-    Copyright (C) 2024 NUT Community
+    Copyright (C) 2024-2025 NUT Community
 
         Author: Jim Klimov  <jimklimov+nut@gmail.com>
 

--- a/common/nutstream.cpp
+++ b/common/nutstream.cpp
@@ -1,9 +1,13 @@
 /*
     nutstream.cpp - NUT stream
 
-    Copyright (C)
-        2012	Vaclav Krpec  <VaclavKrpec@Eaton.com>
-        2024	Jim Klimov <jimklimov+nut@gmail.com>
+    Copyright (C) 2012 Eaton
+
+        Author: Vaclav Krpec  <VaclavKrpec@Eaton.com>
+
+    Copyright (C) 2024-2025 NUT Community
+
+        Author: Jim Klimov  <jimklimov+nut@gmail.com>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/common/nutstream.cpp
+++ b/common/nutstream.cpp
@@ -250,7 +250,7 @@ static const char* getTmpDirPath() {
 	/* Suggestions from https://sourceforge.net/p/mingw/bugs/666/ */
 	static char pathbuf[NUT_PATH_MAX + 1];
 	int i;
-#endif
+#endif	/* WIN32 */
 
 	if (checkExistsWritableDir(s = ::altpidpath()))
 		return s;
@@ -263,7 +263,7 @@ static const char* getTmpDirPath() {
 	i = GetTempPathA(sizeof(pathbuf), pathbuf);
 	if ((i > 0) && (i < NUT_PATH_MAX) && checkExistsWritableDir(pathbuf))
 		return (const char *)pathbuf;
-#endif
+#endif	/* WIN32 */
 
 	if (checkExistsWritableDir(s = ::getenv("TMPDIR")))
 		return s;
@@ -284,14 +284,14 @@ static const char* getTmpDirPath() {
 		return s;
 	if (checkExistsWritableDir(s = "/c/Windows/Temp"))
 		return s;
-#else
+#else	/* !WIN32 */
 	if (checkExistsWritableDir(s = "/dev/shm"))
 		return s;
 	if (checkExistsWritableDir(s = "/run"))
 		return s;
 	if (checkExistsWritableDir(s = "/var/run"))
 		return s;
-#endif
+#endif	/* !WIN32 */
 
 	/* May be applicable to WIN32 depending on emulation environment/mapping */
 	if (checkExistsWritableDir(s = "/tmp"))
@@ -349,12 +349,12 @@ NutFile::NutFile(anonymous_t):
 	/* If it were not "const" we might assign it. But got no big need to.
 	 *   m_name = std::string(filename);
 	 */
-#else
+#else	/* !WIN32 */
 	/* TOTHINK: How to make this use m_tmp_dir? Is it possible generally?  */
 	/* Safer than tmpnam() but we don't know the filename here.
 	 * Not that we need it, system should auto-delete it. */
 	m_impl = ::tmpfile();
-#endif
+#endif	/* !WIN32 */
 
 	if (nullptr == m_impl) {
 		int err_code = errno;
@@ -367,7 +367,7 @@ NutFile::NutFile(anonymous_t):
 		e << ": tried using temporary location " << m_tmp_dir;
 		if (filename[0] != '\0')
 			e << ": OS suggested filename " << filename;
-#endif
+#endif	/* WIN32 */
 
 		throw std::runtime_error(e.str());
 	}
@@ -508,7 +508,8 @@ bool NutFile::open(access_t mode, int & err_code, std::string & err_msg)
 	 * similar when using absolute POSIX-style paths. Do we need a private
 	 * converter?.. Would an end user have MSYS installed at all?
 	 */
-#endif
+	/* NUT_WIN32_INCOMPLETE_DETAILED("might work, might fail"); */
+#endif	/* WIN32 */
 
 	mode_str = strAccessMode(mode);
 	m_impl = ::fopen(m_name.c_str(), mode_str);
@@ -793,8 +794,9 @@ void NutSocket::Address::init_unix(Address & addr, const std::string & path) {
 	e << "Unix sockets not implemented for this platform yet: " << path;
 //			addr.str() << ":" << path;
 
+	/* NUT_WIN32_INCOMPLETE(); */
 	throw std::logic_error(e.str());
-#else
+#else	/* !WIN32 */
 	struct sockaddr_un * un_addr = reinterpret_cast<struct sockaddr_un *>(::malloc(sizeof(struct sockaddr_un)));
 
 	if (nullptr == un_addr)
@@ -811,7 +813,7 @@ void NutSocket::Address::init_unix(Address & addr, const std::string & path) {
 
 	addr.m_sock_addr = reinterpret_cast<struct sockaddr *>(un_addr);
 	addr.m_length    = sizeof(*un_addr);
-#endif
+#endif	/* !WIN32 */
 }
 
 
@@ -1001,7 +1003,6 @@ std::string NutSocket::Address::str() const {
 
 	switch (m_sock_addr->sa_family) {
 #ifndef WIN32
-		/* FIXME: Add support for pipes on Windows? */
 		case AF_UNIX: {
 			struct sockaddr_un * addr = reinterpret_cast<struct sockaddr_un *>(m_sock_addr);
 
@@ -1009,7 +1010,10 @@ std::string NutSocket::Address::str() const {
 
 			break;
 		}
-#endif
+#else	/* WIN32 */
+		/* FIXME: Add support for pipes on Windows? */
+		/* NUT_WIN32_INCOMPLETE(); */
+#endif	/* WIN32 */
 
 		case AF_INET: {
 			struct sockaddr_in * addr = reinterpret_cast<struct sockaddr_in *>(m_sock_addr);

--- a/common/nutwriter.cpp
+++ b/common/nutwriter.cpp
@@ -1,9 +1,13 @@
 /*
     nutwriter.cpp - NUT writer
 
-    Copyright (C)
-        2012	Vaclav Krpec  <VaclavKrpec@Eaton.com>
-        2024	Jim Klimov <jimklimov+nut@gmail.com>
+    Copyright (C) 2012 Eaton
+
+        Author: Vaclav Krpec  <VaclavKrpec@Eaton.com>
+
+    Copyright (C) 2024-2025 NUT Community
+
+        Author: Jim Klimov  <jimklimov+nut@gmail.com>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/common/state.c
+++ b/common/state.c
@@ -30,7 +30,7 @@
 #ifndef WIN32
 #include <sys/socket.h>
 #include <sys/un.h>
-#endif
+#endif	/* !WIN32 */
 
 #include "common.h"
 #include "state.h"

--- a/common/wincompat.c
+++ b/common/wincompat.c
@@ -1639,4 +1639,4 @@ speed_t cfgetospeed(const struct termios *t)
 /* Just avoid: ISO C forbids an empty translation unit [-Werror=pedantic] */
 int main (int argc, char ** argv);
 
-#endif	/* WIN32 */
+#endif	/* !WIN32 */

--- a/drivers/apc_modbus.c
+++ b/drivers/apc_modbus.c
@@ -1020,11 +1020,11 @@ static void _apc_modbus_handle_error(modbus_t *ctx)
 	if (wsa_error == WSAETIMEDOUT) {
 		flush = 1;
 	}
-#else
+#else	/* !WIN32 */
 	if (errno == ETIMEDOUT) {
 		flush = 1;
 	}
-#endif /* WIN32 */
+#endif /* !WIN32 */
 
 	if (flush > 0 && flush_retries++ < 5) {
 		usleep(1000000);

--- a/drivers/apcsmart-old.h
+++ b/drivers/apcsmart-old.h
@@ -24,7 +24,7 @@
 #include <ctype.h>
 #ifndef WIN32
 #include <sys/ioctl.h>
-#endif
+#endif	/* !WIN32 */
 #include "serial.h"
 #include "timehead.h"
 

--- a/drivers/apcsmart.c
+++ b/drivers/apcsmart.c
@@ -43,7 +43,7 @@
 # ifndef ECANCELED
 #  define ECANCELED ERROR_CANCELLED
 # endif
-#endif
+#endif	/* WIN32 */
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/apcsmart.h
+++ b/drivers/apcsmart.h
@@ -69,7 +69,7 @@
 
 #ifndef WIN32
 #include <sys/ioctl.h>
-#endif
+#endif	/* !WIN32 */
 
 /* Basic UPS reply line structure */
 #define ENDCHAR 10		/* APC ends responses with LF (and CR, but it's IGNCRed) */

--- a/drivers/bcmxcp_usb.c
+++ b/drivers/bcmxcp_usb.c
@@ -538,7 +538,7 @@ usb_dev_handle *nutusb_open(const char *port)
 				upsdebugx(1, "Can't set POWERWARE USB configuration: %s", nut_usb_strerror(ret));
 				errout = 1;
 			}
-#endif
+#endif	/* WIN32 */
 			if ((ret = usb_claim_interface(dev_h, 0)) < 0)
 			{
 				upsdebugx(1, "Can't claim POWERWARE USB interface: %s", nut_usb_strerror(ret));

--- a/drivers/belkin.h
+++ b/drivers/belkin.h
@@ -19,7 +19,8 @@
 
 #ifndef WIN32
 #include <sys/ioctl.h>
-#endif
+#endif	/* !WIN32 */
+
 #include "serial.h"
 #include "timehead.h"
 

--- a/drivers/belkinunv.c
+++ b/drivers/belkinunv.c
@@ -502,6 +502,8 @@ static TYPE_FD_SER belkin_std_open_tty(const char *device) {
 		close(fd);
 		return ERROR_FD_SER;
 	}
+#else
+	NUT_WIN32_INCOMPLETE_DETAILED("port locking");
 #endif
 
 	/* sleep at least 0.25 seconds for the UPS to wake up. Belkin's own

--- a/drivers/belkinunv.c
+++ b/drivers/belkinunv.c
@@ -452,7 +452,7 @@ static TYPE_FD_SER belkin_std_open_tty(const char *device) {
 	struct termios tios;
 #ifndef WIN32
 	struct flock flock;
-#endif
+#endif	/* !WIN32 */
 	char buf[128];
 	ssize_t r;
 
@@ -492,7 +492,6 @@ static TYPE_FD_SER belkin_std_open_tty(const char *device) {
 		return ERROR_FD_SER;
 	}
 
-/* TODO: port to WIN32 */
 #ifndef WIN32
 	/* lock the port */
 	memset(&flock, 0, sizeof(flock));
@@ -502,9 +501,10 @@ static TYPE_FD_SER belkin_std_open_tty(const char *device) {
 		close(fd);
 		return ERROR_FD_SER;
 	}
-#else
+#else	/* WIN32 */
+	/* TODO: port to WIN32 */
 	NUT_WIN32_INCOMPLETE_DETAILED("port locking");
-#endif
+#endif	/* WIN32 */
 
 	/* sleep at least 0.25 seconds for the UPS to wake up. Belkin's own
 	   software sleeps 1 second, so that's what we do, too. */
@@ -520,11 +520,11 @@ static TYPE_FD_SER belkin_std_open_tty(const char *device) {
 
 #ifndef WIN32
 	r = read(fd, buf, 127);
-#else
+#else	/* WIN32 */
 /* WIN32 : w32_serial_read is blocking, using select_read with 0ms timeout
  * is non-blocking */
 	r = select_read(fd, buf, 127, 0, 0);
-#endif
+#endif	/* WIN32 */
 
 	if (r == -1 && errno != EAGAIN) {
 		close(fd);
@@ -545,11 +545,11 @@ static int belkin_std_upsread(TYPE_FD_SER fd, unsigned char *buf, int n) {
 	while (count < n) {
 #ifndef WIN32
 		r = read(fd, &buf[count], (size_t)(n-count));
-#else
+#else	/* WIN32 */
 		/* WIN32 : w32_serial_read is blocking, using select_read
 		 * with 0ms timeout is non-blocking */
 		r = select_read(fd, buf, (size_t)(n-count), 0, 0);
-#endif
+#endif	/* WIN32 */
 		if (r==-1 && errno==EAGAIN) {
 			/* non-blocking i/o, no data available */
 			usleep(100000);

--- a/drivers/bestfortress.c
+++ b/drivers/bestfortress.c
@@ -234,12 +234,12 @@ static int upssend(const char *fmt,...) {
 	for (p = buf; *p && sent < INT_MAX - 1; p++) {
 #ifndef WIN32
 		if (write(upsfd, p, 1) != 1)
-#else
+#else	/* WIN32 */
 		DWORD bytes_written;
 		BOOL res;
 		res = WriteFile(upsfd, p, 1, &bytes_written,NULL);
 		if (res == 0 || bytes_written == 0)
-#endif
+#endif	/* WIN32 */
 			return -1;
 
 		/* Note: LGTM.com analysis warns that here

--- a/drivers/blazer_ser.c
+++ b/drivers/blazer_ser.c
@@ -120,7 +120,7 @@ void upsdrv_makevartable(void)
 void upsdrv_initups(void)
 {
 #ifndef TESTING
-#ifndef WIN32 /* TODO : Correctly set the port parameters for WIN32 */
+# ifndef WIN32
 	const struct {
 		const char	*val;
 		const int	dtr;
@@ -187,10 +187,12 @@ void upsdrv_initups(void)
 	 * Allow some time to settle for the cablepower
 	 */
 	usleep(100000);
-#else
-	upsdebugx(0, "blazer_ser: upsdrv_init(): serial port setup for WIN32 currently has not been ported (TODO)");
-#endif /* WIN32 */
-#endif /* TESTING */
+# else	/* WIN32 */
+	/* TODO : Correctly set the port parameters for WIN32 */
+	NUT_WIN32_INCOMPLETE_LOGWARN();
+	/* upsdebugx(0, "blazer_ser: upsdrv_init(): serial port setup for WIN32 currently has not been ported (TODO)"); */
+# endif	/* WIN32 */
+#endif	/* !TESTING */
 	blazer_initups();
 }
 

--- a/drivers/blazer_usb.c
+++ b/drivers/blazer_usb.c
@@ -34,7 +34,7 @@
 #include "blazer.h"
 #ifdef WIN32
 #include "wincompat.h"
-#endif
+#endif	/* WIN32 */
 
 #define DRIVER_NAME	"Megatec/Q1 protocol USB driver"
 #define DRIVER_VERSION	"0.21"
@@ -517,7 +517,7 @@ ssize_t blazer_command(const char *cmd, char *buf, size_t buflen)
 # if EPROTO && WITH_LIBUSB_0_1
 	case -EPROTO:		/* Protocol error */
 # endif
-#endif
+#endif	/* !WIN32 */
 	default:
 		break;
 	}

--- a/drivers/clone-outlet.c
+++ b/drivers/clone-outlet.c
@@ -28,7 +28,7 @@
 #ifndef WIN32
 #include <sys/socket.h>
 #include <sys/un.h>
-#endif
+#endif	/* !WIN32 */
 
 #define DRIVER_NAME	"Clone outlet UPS driver"
 #define DRIVER_VERSION	"0.07"
@@ -72,12 +72,12 @@ static PCONF_CTX_t	sock_ctx;
 static time_t	last_poll = 0, last_heard = 0, last_ping = 0;
 
 #ifndef WIN32
-/* TODO: Why not built in WIN32? */
+/* TODO NUT_WIN32_INCOMPLETE : Why not built in WIN32? */
 static time_t	last_connfail = 0;
-#else
+#else	/* WIN32 */
 static char     	read_buf[SMALLBUF];
 static OVERLAPPED	read_overlapped;
-#endif
+#endif	/* WIN32 */
 
 static int parse_args(size_t numargs, char **arg)
 {
@@ -293,7 +293,7 @@ static TYPE_FD sstate_connect(void)
 	ReadFile(fd, read_buf,
 		sizeof(read_buf) - 1, /*-1 to be sure to have a trailling 0 */
 		NULL, &(read_overlapped));
-#endif
+#endif	/* WIN32 */
 
 	/* sstate_connect() continued for both platforms: */
 	pconf_init(&sock_ctx, NULL);
@@ -321,9 +321,9 @@ static void sstate_disconnect(void)
 
 #ifndef WIN32
 	close(upsfd);
-#else
+#else	/* WIN32 */
 	CloseHandle(upsfd);
-#endif
+#endif	/* WIN32 */
 
 	upsfd = ERROR_FD;
 }
@@ -339,7 +339,7 @@ static int sstate_sendline(const char *buf)
 
 #ifndef WIN32
 	ret = write(upsfd, buf, strlen(buf));
-#else
+#else	/* WIN32 */
 	DWORD bytesWritten = 0;
 	BOOL  result = FALSE;
 
@@ -351,7 +351,7 @@ static int sstate_sendline(const char *buf)
 	else {
 		ret = (int)bytesWritten;
 	}
-#endif
+#endif	/* WIN32 */
 
 	if (ret == (int)strlen(buf)) {
 		return 0;
@@ -387,7 +387,7 @@ static int sstate_readline(void)
 				return -1;
 		}
 	}
-#else
+#else	/* WIN32 */
 	if (INVALID_FD(upsfd)) {
 		return -1;	/* failed */
 	}
@@ -397,7 +397,7 @@ static int sstate_readline(void)
 	DWORD bytesRead;
 	GetOverlappedResult(upsfd, &read_overlapped, &bytesRead, FALSE);
 	ret = bytesRead;
-#endif
+#endif	/* WIN32 */
 
 	for (i = 0; i < ret; i++) {
 

--- a/drivers/clone.c
+++ b/drivers/clone.c
@@ -30,7 +30,7 @@
 #ifndef WIN32
 #include <sys/socket.h>
 #include <sys/un.h>
-#endif
+#endif	/* !WIN32 */
 
 #define DRIVER_NAME	"Clone UPS driver"
 #define DRIVER_VERSION	"0.07"
@@ -70,12 +70,12 @@ static PCONF_CTX_t	sock_ctx;
 static time_t	last_poll = 0, last_heard = 0, last_ping = 0;
 
 #ifndef WIN32
-/* TODO: Why not built in WIN32? */
+/* TODO NUT_WIN32_INCOMPLETE : Why not built in WIN32? */
 static time_t	last_connfail = 0;
-#else
+#else	/* WIN32 */
 static char     	read_buf[SMALLBUF];
 static OVERLAPPED	read_overlapped;
-#endif
+#endif	/* WIN32 */
 
 static int instcmd(const char *cmdname, const char *extra);
 
@@ -308,7 +308,7 @@ static TYPE_FD sstate_connect(void)
 	ReadFile(fd, read_buf,
 		sizeof(read_buf) - 1, /*-1 to be sure to have a trailling 0 */
 		NULL, &(read_overlapped));
-#endif
+#endif	/* WIN32 */
 
 	/* sstate_connect() continued for both platforms: */
 	pconf_init(&sock_ctx, NULL);
@@ -336,9 +336,9 @@ static void sstate_disconnect(void)
 
 #ifndef WIN32
 	close(upsfd);
-#else
+#else	/* WIN32 */
 	CloseHandle(upsfd);
-#endif
+#endif	/* WIN32 */
 
 	upsfd = ERROR_FD;
 }
@@ -354,7 +354,7 @@ static int sstate_sendline(const char *buf)
 
 #ifndef WIN32
 	ret = write(upsfd, buf, strlen(buf));
-#else
+#else	/* WIN32 */
 	DWORD bytesWritten = 0;
 	BOOL  result = FALSE;
 
@@ -366,7 +366,7 @@ static int sstate_sendline(const char *buf)
 	else {
 		ret = (int)bytesWritten;
 	}
-#endif
+#endif	/* WIN32 */
 
 	if (ret == (int)strlen(buf)) {
 		return 0;
@@ -402,7 +402,7 @@ static int sstate_readline(void)
 				return -1;
 		}
 	}
-#else
+#else	/* WIN32 */
 	if (INVALID_FD(upsfd)) {
 		return -1;	/* failed */
 	}
@@ -412,7 +412,7 @@ static int sstate_readline(void)
 	DWORD bytesRead;
 	GetOverlappedResult(upsfd, &read_overlapped, &bytesRead, FALSE);
 	ret = bytesRead;
-#endif
+#endif	/* WIN32 */
 
 	for (i = 0; i < ret; i++) {
 

--- a/drivers/dstate.h
+++ b/drivers/dstate.h
@@ -33,7 +33,7 @@
 
 #ifdef WIN32
 # include "wincompat.h"
-#endif
+#endif	/* WIN32 */
 
 #define DS_LISTEN_BACKLOG 16
 #define DS_MAX_READ 256		/* don't read forever from upsd */
@@ -48,7 +48,7 @@ typedef struct conn_s {
 #ifdef WIN32
 	char    buf[LARGEBUF];
 	OVERLAPPED read_overlapped;
-#endif
+#endif	/* WIN32 */
 	PCONF_CTX_t	ctx;
 	struct conn_s	*prev;
 	struct conn_s	*next;

--- a/drivers/dummy-ups.c
+++ b/drivers/dummy-ups.c
@@ -36,7 +36,7 @@
 #include <netdb.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
-#endif
+#endif	/* !WIN32 */
 
 #include <sys/stat.h>
 #include <string.h>
@@ -239,7 +239,7 @@ static int prepare_filepath(char *fn, size_t buflen)
 	if (device_path[0] == '/'
 #ifdef WIN32
 	||  device_path[1] == ':'	/* "C:\..." */
-#endif
+#endif	/* WIN32 */
 	) {
 		/* absolute path */
 		return snprintf(fn, buflen, "%s", device_path);
@@ -294,12 +294,12 @@ void upsdrv_updateinfo(void)
 				 * the data without complications.
 				 */
 				if ( (INVALID_FD(upsfd) || 0 != fstat (upsfd, &fs)) && 0 != stat (fn, &fs))
-#else
+#else	/* WIN32 */
 				/* Consider GetFileAttributesEx() for WIN32_FILE_ATTRIBUTE_DATA?
 				 *   https://stackoverflow.com/questions/8991192/check-the-file-size-without-opening-file-in-c/8991228#8991228
 				 */
 				if (0 != stat (fn, &fs))
-#endif
+#endif	/* WIN32 */
 				{
 					upsdebugx(2, "%s: MODE_DUMMY_ONCE: Can't stat %s currently", __func__, fn);
 					/* retry ASAP until we get a file */
@@ -538,12 +538,13 @@ void upsdrv_initups(void)
 		 * complications.
 		 */
 		if ( (INVALID_FD(upsfd) || 0 != fstat (upsfd, &datafile_stat)) && 0 != stat (fn, &datafile_stat))
-#else
+#else	/* WIN32 */
 		/* Consider GetFileAttributesEx() for WIN32_FILE_ATTRIBUTE_DATA?
+		 * NUT_WIN32_INCOMPLETE?
 		 *   https://stackoverflow.com/questions/8991192/check-the-file-size-without-opening-file-in-c/8991228#8991228
 		 */
 		if (0 != stat (fn, &datafile_stat))
-#endif
+#endif	/* WIN32 */
 		{
 			upsdebugx(2, "%s: Can't stat %s (%s) currently", __func__, device_path, fn);
 		} else {

--- a/drivers/genericups.c
+++ b/drivers/genericups.c
@@ -21,9 +21,9 @@
 
 #ifndef WIN32
 #include <sys/ioctl.h>
-#else
+#else	/* WIN32 */
 #include "wincompat.h"
-#endif
+#endif	/* WIN32 */
 
 #include "main.h"
 #include "serial.h"
@@ -224,9 +224,9 @@ void upsdrv_updateinfo(void)
 
 #ifndef WIN32
 	ret = ioctl(upsfd, TIOCMGET, &flags);
-#else
+#else	/* WIN32 */
 	ret = w32_getcomm( upsfd, &flags );
-#endif
+#endif	/* WIN32 */
 
 	if (ret != 0) {
 		upslog_with_errno(LOG_INFO, "ioctl failed");
@@ -334,13 +334,15 @@ void upsdrv_shutdown(void)
 	if (flags == TIOCM_ST) {
 
 #ifndef WIN32
-#ifndef HAVE_TCSENDBREAK
+# ifndef HAVE_TCSENDBREAK
 		upslogx(LOG_ERR, "Need to send a BREAK, but don't have tcsendbreak!");
 		if (handling_upsdrv_shutdown > 0)
 			set_exit_flag(EF_EXIT_FAILURE);
 	        return;
-#endif
-#endif
+# endif
+#else	/* WIN32 */
+		NUT_WIN32_INCOMPLETE_DETAILED("Need to send a BREAK at this point, but not addressed for WIN32 yet");
+#endif	/* WIN32 */
 
 		ret = tcsendbreak(upsfd, 4901);
 
@@ -355,9 +357,9 @@ void upsdrv_shutdown(void)
 
 #ifndef WIN32
 	ret = ioctl(upsfd, TIOCMSET, &flags);
-#else
+#else	/* WIN32 */
 	ret = w32_setcomm(upsfd,&flags);
-#endif
+#endif	/* WIN32 */
 
 	if (ret != 0) {
 		upslog_with_errno(LOG_ERR, "ioctl TIOCMSET");
@@ -459,9 +461,9 @@ void upsdrv_initups(void)
 
 #ifndef WIN32
 	if (ioctl(upsfd, TIOCMSET, &upstab[upstype].line_norm)) {
-#else
+#else	/* WIN32 */
 	if (w32_setcomm(upsfd,&upstab[upstype].line_norm)) {
-#endif
+#endif	/* WIN32 */
 		fatal_with_errno(EXIT_FAILURE, "ioctl TIOCMSET");
 	}
 }

--- a/drivers/isbmex.c
+++ b/drivers/isbmex.c
@@ -164,7 +164,7 @@ static const char *getpacket(int *we_know){
 	fd_set readfds;
 	struct timeval tv;
 	int ret;
-#endif
+#endif	/* !WIN32 */
 	int bytes_per_packet=0;
 	static const char *packet_id=NULL;
 	static char buf[256];
@@ -191,7 +191,7 @@ static const char *getpacket(int *we_know){
 	}
 
 	r = read(upsfd,buf,255);
-#else
+#else	/* WIN32 */
 	r = select_read(upsfd,buf,255,5,0);
 	if (r <= 0) {
 		s = "Nothing received from UPS. Check cable conexion";
@@ -199,7 +199,7 @@ static const char *getpacket(int *we_know){
 		D(printf("%s\n",s);)
 		return NULL;
 	}
-#endif
+#endif	/* WIN32 */
 	D(printf("%" PRIiSIZE " bytes read: ",r);)
 
 	buf[r]=0;
@@ -216,12 +216,12 @@ static const char *getpacket(int *we_know){
 		 * and r is smaller, so 255-r is positive */
 		assert (r <= 255);
 		rr = read(upsfd, buf+r, (size_t)(255-r));
-#else
+#else	/* WIN32 */
 		rr = select_read(upsfd,buf+r,255-r,2,0);
 		if (rr <= 0) {
 			return NULL;
 		}
-#endif
+#endif	/* WIN32 */
 		r += rr;
 		if (r < bytes_per_packet) return NULL;
 	}

--- a/drivers/libusb0.c
+++ b/drivers/libusb0.c
@@ -35,7 +35,7 @@
 #include "nut_libusb.h"
 #ifdef WIN32
 #include "wincompat.h"
-#endif
+#endif	/* WIN32 */
 
 #define USB_DRIVER_NAME		"USB communication driver (libusb 0.1)"
 #define USB_DRIVER_VERSION	"0.50"
@@ -318,13 +318,13 @@ static int nut_libusb_open(usb_dev_handle **udevp,
 
 #ifdef WIN32
 	busses = usb_get_busses();
-#else
+#else	/* !WIN32 */
 	/* libusb built-in; not sure why original NUT for WIN32
 	 * code differed or if it is actually better? Or why
 	 * this was not tackled in a few other files for USB?..
 	 */
 	busses = usb_busses;
-#endif
+#endif	/* !WIN32 */
 
 #ifndef __linux__ /* SUN_LIBUSB (confirmed to work on Solaris and FreeBSD) */
 	/* Causes a double free corruption in linux if device is detached! */
@@ -494,7 +494,7 @@ static int nut_libusb_open(usb_dev_handle **udevp,
 			 * attached driver... From libhid */
 #ifdef WIN32
 			usb_set_configuration(udev, 1);
-#endif
+#endif	/* WIN32 */
 			retries = 3;
 			while ((ret = usb_claim_interface(udev, usb_subdriver.hid_rep_index)) < 0) {
 				upsdebugx(2, "failed to claim USB device: %s",
@@ -676,7 +676,7 @@ static int nut_libusb_open(usb_dev_handle **udevp,
 				upsdebugx(2, "Warning: report descriptor too short "
 					"(expected %" PRI_NUT_USB_CTRL_CHARBUFSIZE
 					", got %d)", rdlen, res);
-#else
+#else	/* WIN32 */
 				/* https://github.com/networkupstools/nut/issues/1690#issuecomment-1455206002 */
 				upsdebugx(0, "Warning: report descriptor too short "
 					"(expected %" PRI_NUT_USB_CTRL_CHARBUFSIZE
@@ -796,7 +796,7 @@ static int nut_libusb_strerror(const int ret, const char *desc)
 # endif
 		upsdebugx(2, "%s: %s", desc, usb_strerror());
 		return 0;
-#endif	/* WIN32 */
+#endif	/* !WIN32 */
 
 	case 0: 	/** TOTHINK: Should this (probably LIBUSB_SUCCESS) be quiet? */
 	default:	/* Undetermined, log only */
@@ -836,7 +836,7 @@ static int nut_libusb_get_report(
 
 #ifdef WIN32
 	errno = -ret;
-#endif
+#endif	/* WIN32 */
 
 	/* Ignore "protocol stall" (for unsupported request) on control endpoint */
 	if (ret == -EPIPE) {
@@ -871,7 +871,7 @@ static int nut_libusb_set_report(
 
 #ifdef WIN32
 	errno = -ret;
-#endif
+#endif	/* WIN32 */
 
 	/* Ignore "protocol stall" (for unsupported request) on control endpoint */
 	if (ret == -EPIPE) {
@@ -908,7 +908,7 @@ static int nut_libusb_get_string(
 
 #ifdef WIN32
 	errno = -ret;
-#endif
+#endif	/* WIN32 */
 
 	/** 0 can be seen as an empty string, or as a success for
 	 * logging below - also tends to happen */
@@ -946,7 +946,7 @@ static int nut_libusb_get_interrupt(
 
 #ifdef WIN32
 	errno = -ret;
-#endif
+#endif	/* WIN32 */
 
 	/* Clear stall condition */
 	if (ret == -EPIPE) {

--- a/drivers/libusb1.c
+++ b/drivers/libusb1.c
@@ -292,7 +292,7 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 #ifdef WIN32
 	struct usb_bus *busses;
 	busses = usb_get_busses();
-#endif
+#endif	// WIN32
  */
 
 #ifndef __linux__ /* SUN_LIBUSB (confirmed to work on Solaris and FreeBSD) */
@@ -537,10 +537,10 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 #if (defined HAVE_LIBUSB_DETACH_KERNEL_DRIVER) || (defined HAVE_LIBUSB_DETACH_KERNEL_DRIVER_NP)
 		/* Then, try the explicit detach method.
 		 * This function is available on FreeBSD 10.1-10.3 */
-#ifdef WIN32
+# ifdef WIN32
 		/* TODO: Align with libusb1 - initially from Windows branch made against libusb0 */
 		libusb_set_configuration(udev, 1);
-#endif
+# endif	/* WIN32 */
 
 		retries = 3;
 		while ((ret = libusb_claim_interface(udev, usb_subdriver.hid_rep_index)) != LIBUSB_SUCCESS) {
@@ -754,7 +754,7 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 #ifndef WIN32
 			upsdebugx(2, "Warning: report descriptor too short "
 				"(expected %d, got %d)", rdlen, res);
-#else
+#else	/* WIN32 */
 			/* https://github.com/networkupstools/nut/issues/1690#issuecomment-1455206002 */
 			upsdebugx(0, "Warning: report descriptor too short "
 				"(expected %d, got %d)", rdlen, res);
@@ -889,7 +889,7 @@ static int nut_libusb_strerror(const int ret, const char *desc)
 # endif
 		upsdebugx(2, "%s: %s", desc, libusb_strerror((enum libusb_error)ret));
 		return 0;
-#endif /* WIN32 */
+#endif	/* !WIN32 */
 
 	case LIBUSB_SUCCESS:         /** TOTHINK: Should this be quiet? */
 	case LIBUSB_ERROR_OTHER:     /** Other error */

--- a/drivers/main.h
+++ b/drivers/main.h
@@ -8,7 +8,7 @@
 #include "extstate.h"
 #ifdef WIN32
 #include "wincompat.h"
-#endif
+#endif	/* WIN32 */
 
 /* public functions & variables from main.c, documented in detail there */
 extern const char	*progname, *upsname, *device_name;
@@ -180,10 +180,10 @@ void setup_signals(void);
 #   pragma warn "This OS lacks SIGURG and SIGWINCH, will not handle SIGCMD_DATA_DUMP"
 #  endif
 # endif
-#else
-/* FIXME: handle WIN32 builds for other signals too */
+#else	/* WIN32 */
+/* FIXME NUT_WIN32_INCOMPLETE : handle WIN32 builds for other signals too */
 # define SIGCMD_EXIT                    "driver.exit"
-# define SIGCMD_RELOAD_OR_ERROR         "driver.reload-or-error"
+# define SIGCMD_RELOAD_OR_ERROR         "driver.reload-or-error"	/* NUT_WIN32_INCOMPLETE */
 #endif	/* WIN32 */
 
 #endif /* NUT_MAIN_H_SEEN */

--- a/drivers/mge-hid.c
+++ b/drivers/mge-hid.c
@@ -50,7 +50,7 @@
 #   define LDOUBLE double
 #  endif
 # endif
-#endif
+#endif	/* WIN32 */
 
 #define MGE_HID_VERSION		"MGE HID 1.54"
 

--- a/drivers/mge-utalk.c
+++ b/drivers/mge-utalk.c
@@ -57,7 +57,7 @@
 #include <ctype.h>
 #ifndef WIN32
 #include <sys/ioctl.h>
-#endif
+#endif	/* !WIN32 */
 #include "timehead.h"
 #include "main.h"
 #include "serial.h"
@@ -169,7 +169,7 @@ void upsdrv_initups(void)
 	char buf[BUFFLEN];
 #ifndef WIN32
 	int RTS = TIOCM_RTS;
-#endif
+#endif	/* !WIN32 */
 
 	upsfd = ser_open(device_path);
 	ser_set_speed(upsfd, device_path, B2400);
@@ -181,14 +181,14 @@ void upsdrv_initups(void)
 
 	/* Init serial line */
 	ioctl(upsfd, TIOCMBIC, &RTS);
-#else
+#else	/* WIN32 */
 	if (testvar ("oldmac")) {
 		EscapeCommFunction(((serial_handler_t *)upsfd)->handle,CLRRTS);
 	}
 	else {
 		EscapeCommFunction(((serial_handler_t *)upsfd)->handle,SETRTS);
 	}
-#endif
+#endif	/* WIN32 */
 	enable_ups_comm();
 
 	/* Try to set "Low Battery Level" (if supported and given) */

--- a/drivers/mge-xml.c
+++ b/drivers/mge-xml.c
@@ -37,7 +37,7 @@
 
 #ifdef WIN32
 #include "wincompat.h"
-#endif
+#endif	/* WIN32 */
 
 #define MGE_XML_VERSION		"MGEXML/0.36"
 

--- a/drivers/netxml-ups.c
+++ b/drivers/netxml-ups.c
@@ -50,7 +50,7 @@
 #ifdef WIN32 /* FIXME ?? skip alarm handling */
 #define HAVE_NE_SET_CONNECT_TIMEOUT  1
 #define HAVE_NE_SOCK_CONNECT_TIMEOUT 1
-#endif
+#endif	/* WIN32 */
 
 /* driver description structure */
 upsdrv_info_t	upsdrv_info = {
@@ -283,10 +283,11 @@ void upsdrv_initinfo(void)
 		dstate_setinfo("driver.version.data", "%s", subdriver->version);
 
 		if (testvar("subscribe") && (netxml_alarm_subscribe(subdriver->subscribe) == NE_OK)) {
-/* TODO: port extrafd to Windows */
 #ifndef WIN32
 			extrafd = ne_sock_fd(sock);
-#endif
+#else	/* WIN32 */
+			NUT_WIN32_INCOMPLETE_DETAILED("TODO: port extrafd to Windows");
+#endif	/* WIN32 */
 			time(&lastheard);
 		}
 
@@ -342,19 +343,23 @@ void upsdrv_updateinfo(void)
 			ne_sock_close(sock);
 
 			if (netxml_alarm_subscribe(subdriver->subscribe) == NE_OK) {
-/* TODO: port extrafd to Windows */
 #ifndef WIN32
 				extrafd = ne_sock_fd(sock);
-#endif
+#else	/* WIN32 */
+				NUT_WIN32_INCOMPLETE_DETAILED("TODO: port extrafd to Windows");
+#endif	/* WIN32 */
 				time(&lastheard);
 				return;
 			}
 
 			dstate_datastale();
-/* TODO: port extrafd to Windows */
+
 #ifndef WIN32
 			extrafd = ERROR_FD;
-#endif
+#else	/* WIN32 */
+			NUT_WIN32_INCOMPLETE_DETAILED("TODO: port extrafd to Windows");
+#endif	/* WIN32 */
+
 			return;
 		}
 	}
@@ -661,9 +666,9 @@ void upsdrv_initups(void)
 	if (!nut_debug_level) {
 #ifndef WIN32
 		fp = fopen("/dev/null", "w");
-#else
+#else	/* WIN32 */
 		fp = fopen("nul", "w");
-#endif
+#endif	/* WIN32 */
 	} else {
 		fp = stderr;
 	}

--- a/drivers/nutdrv_atcl_usb.c
+++ b/drivers/nutdrv_atcl_usb.c
@@ -541,14 +541,14 @@ void upsdrv_initups(void)
 		if (i < 3) {
 #ifdef WIN32
 			sleep(5);
-#else
+#else	/* !WIN32 */
 			if (sleep(5) == 0) {
-#endif
+#endif	/* !WIN32 */
 				usb_comm_fail("Can't open USB device, retrying ...");
 				continue;
 #ifndef WIN32
 			}
-#endif
+#endif	/* !WIN32 */
 		}
 
 		fatalx(EXIT_FAILURE,

--- a/drivers/powercom.h
+++ b/drivers/powercom.h
@@ -29,7 +29,7 @@
 #include <sys/stat.h>
 #ifndef WIN32
 #include <sys/ioctl.h>
-#endif
+#endif	/* !WIN32 */
 #include <sys/types.h>
 
 /* nut includes */

--- a/drivers/richcomm_usb.c
+++ b/drivers/richcomm_usb.c
@@ -591,11 +591,11 @@ void upsdrv_initups(void)
 
 #ifndef WIN32
 		if ((i < 32) && (sleep(5) == 0)) {
-#else
-/*FIXME*/
+#else	/* WIN32 */
+/* FIXME NUT_WIN32_INCOMPLETE? */
 		sleep(5);
 		if ((i < 32)) {
-#endif
+#endif	/* WIN32 */
 			usb_comm_fail("Can't open USB device, retrying ...");
 			continue;
 		}

--- a/drivers/riello_ser.c
+++ b/drivers/riello_ser.c
@@ -31,7 +31,7 @@
 
 #ifdef WIN32
 # include "wincompat.h"
-#endif
+#endif	/* WIN32 */
 
 #include "main.h"
 #include "serial.h"
@@ -119,7 +119,7 @@ static ssize_t char_read (char *bytes, size_t size, int read_timeout)
 		return -2;			/* timeout */
 
 	if (FD_ISSET (upsfd, &readfs)) {
-#else
+#else	/* WIN32 */
 		DWORD timeout;
 		COMMTIMEOUTS TOut;
 
@@ -130,19 +130,19 @@ static ssize_t char_read (char *bytes, size_t size, int read_timeout)
 		TOut.ReadTotalTimeoutMultiplier = 0;
 		TOut.ReadTotalTimeoutConstant = timeout;
 		SetCommTimeouts(upsfd, &TOut);
-#endif
+#endif	/* WIN32 */
 
 		ssize_t now;
 #ifndef WIN32
 		now = read (upsfd, bytes, size - (size_t)readen);
-#else
+#else	/* WIN32 */
 		/* FIXME? for some reason this compiles, but the first
 		 * arg to the method should be serial_handler_t* - not
 		 * a HANDLE as upsfd is (in main.c)... then again, many
 		 * other drivers seem to use it just fine...
 		 */
 		now = w32_serial_read(upsfd, bytes, size - (size_t)readen, timeout);
-#endif
+#endif	/* WIN32 */
 
 		if (now < 0) {
 			return -1;
@@ -155,7 +155,7 @@ static ssize_t char_read (char *bytes, size_t size, int read_timeout)
 	else {
 		return -1;
 	}
-#endif
+#endif	/* !WIN32 */
 	return readen;
 }
 

--- a/drivers/riello_usb.c
+++ b/drivers/riello_usb.c
@@ -436,7 +436,7 @@ static int riello_command(uint8_t *cmd, uint8_t *buf, uint16_t length, uint16_t 
 	case -EPROTO:		/* Protocol error */
 # endif
 		break;
-#endif
+#endif	/* !WIN32 */
 
 	default:
 		break;

--- a/drivers/serial.c
+++ b/drivers/serial.c
@@ -27,7 +27,7 @@
 #include <grp.h>
 #include <pwd.h>
 #include <sys/ioctl.h>
-#endif
+#endif	/* !WIN32 */
 #include <ctype.h>
 #include <sys/file.h>
 #include <sys/types.h>
@@ -50,7 +50,7 @@ static void ser_open_error(const char *port)
 #ifndef WIN32
 	struct	passwd	*user;
 	struct	group	*group;
-#endif
+#endif	/* !WIN32 */
 
 	printf("\n");
 
@@ -64,7 +64,7 @@ static void ser_open_error(const char *port)
 		fatalx(EXIT_FAILURE, "Fatal error: unusable configuration");
 	}
 
-/* TODO */
+/* TODO NUT_WIN32_INCOMPLETE? */
 #ifndef WIN32
 	user = getpwuid(getuid());
 
@@ -83,7 +83,7 @@ static void ser_open_error(const char *port)
 	if (group)
 		printf("Serial port group: %s (%d)\n",
 			group->gr_name, (int) fs.st_gid);
-#endif
+#endif	/* !WIN32 */
 
 	printf("     Mode of port: %04o\n\n", (unsigned int) fs.st_mode & 07777);
 
@@ -103,9 +103,9 @@ static void lock_set(TYPE_FD_SER fd, const char *port)
 	if (INVALID_FD_SER(fd)) {
 #ifndef WIN32
 		fatal_with_errno(EXIT_FAILURE, "lock_set: programming error: fd = %d", fd);
-#else
+#else	/* WIN32 */
 		fatal_with_errno(EXIT_FAILURE, "lock_set: programming error: struct = %p", fd);
-#endif
+#endif	/* WIN32 */
 	}
 
 	if (do_lock_port == 0)
@@ -222,13 +222,13 @@ static int ser_set_control(TYPE_FD_SER fd, int line, int state)
 		return ioctl(fd, TIOCMBIC, &line);
 	}
 }
-#endif
+#endif	/* !WIN32 */
 
 int ser_set_dtr(TYPE_FD_SER fd, int state)
 {
 #ifndef WIN32
 	return ser_set_control(fd, TIOCM_DTR, state);
-#else
+#else	/* WIN32 */
 	DWORD action;
 
 	if (state == 0) {
@@ -244,14 +244,14 @@ int ser_set_dtr(TYPE_FD_SER fd, int state)
 	}
 
 	return -1;
-#endif
+#endif	/* WIN32 */
 }
 
 int ser_set_rts(TYPE_FD_SER fd, int state)
 {
 #ifndef WIN32
 	return ser_set_control(fd, TIOCM_RTS, state);
-#else
+#else	/* WIN32 */
 	DWORD action;
 
 	if(state == 0) {
@@ -265,7 +265,7 @@ int ser_set_rts(TYPE_FD_SER fd, int state)
 		return 0;
 	}
 	return -1;
-#endif
+#endif	/* WIN32 */
 }
 
 #ifndef WIN32
@@ -277,42 +277,42 @@ static int ser_get_control(TYPE_FD_SER fd, int line)
 
 	return (flags & line);
 }
-#endif
+#endif	/* !WIN32 */
 
 int ser_get_dsr(TYPE_FD_SER fd)
 {
 #ifndef WIN32
 	return ser_get_control(fd, TIOCM_DSR);
-#else
+#else	/* WIN32 */
 	int flags;
 
 	w32_getcomm(fd->handle, &flags);
 	return (flags & TIOCM_DSR);
-#endif
+#endif	/* WIN32 */
 }
 
 int ser_get_cts(TYPE_FD_SER fd)
 {
 #ifndef WIN32
 	return ser_get_control(fd, TIOCM_CTS);
-#else
+#else	/* WIN32 */
 	int flags;
 
 	w32_getcomm(fd->handle, &flags);
 	return (flags & TIOCM_CTS);
-#endif
+#endif	/* WIN32 */
 }
 
 int ser_get_dcd(TYPE_FD_SER fd)
 {
 #ifndef WIN32
 	return ser_get_control(fd, TIOCM_CD);
-#else
+#else	/* WIN32 */
 	int flags;
 
 	w32_getcomm(fd->handle, &flags);
 	return (flags & TIOCM_CD);
-#endif
+#endif	/* WIN32 */
 }
 
 int ser_close(TYPE_FD_SER fd, const char *port)
@@ -320,9 +320,9 @@ int ser_close(TYPE_FD_SER fd, const char *port)
 	if (INVALID_FD_SER(fd)) {
 #ifndef WIN32
 		fatal_with_errno(EXIT_FAILURE, "ser_close: programming error: fd=%d port=%s", fd, port);
-#else
+#else	/* WIN32 */
 		fatal_with_errno(EXIT_FAILURE, "ser_close: programming error: struct=%p port=%s", fd, port);
-#endif
+#endif	/* WIN32 */
 	}
 
 	if (close(fd) != 0)

--- a/drivers/serial.h
+++ b/drivers/serial.h
@@ -18,9 +18,9 @@
 # else
 #  include <termios.h>
 # endif /* HAVE_SYS_TERMIOS_H */
-#else /* WIN32 */
+#else	/* WIN32 */
 # include "wincompat.h"
-#endif /* WIN32 */
+#endif	/* WIN32 */
 
 #include <unistd.h>             /* for usleep() and useconds_t, latter also might be via <sys/types.h> */
 #include <sys/types.h>
@@ -108,7 +108,7 @@ void ser_comm_good(void);
 #define close(a)	w32_serial_close(a)
 #define read(a,b,c)	w32_serial_read(a,b,c,INFINITE)
 #define write(a,b,c)	w32_serial_write(a,b,c)
-#endif
+#endif	/* WIN32 */
 
 
 #endif	/* SERIAL_H_SEEN */

--- a/drivers/snmp-ups.h
+++ b/drivers/snmp-ups.h
@@ -99,7 +99,7 @@
 # ifdef _WIN32_WINNT
 #  undef _WIN32_WINNT
 # endif
-#endif
+#endif	/* WIN32 */
 
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNUSED_PARAMETER)
 # pragma GCC diagnostic push

--- a/drivers/upsdrvquery.c
+++ b/drivers/upsdrvquery.c
@@ -31,9 +31,9 @@
 #include <sys/wait.h>
 #include <sys/socket.h>
 #include <sys/un.h>
-#else
+#else	/* WIN32 */
 #include "wincompat.h"
-#endif
+#endif	/* WIN32 */
 
 #include "common.h"
 #include "upsdrvquery.h"
@@ -97,7 +97,7 @@ udq_pipe_conn_t *upsdrvquery_connect(const char *sockfn) {
 		free(conn);
 		return NULL;
 	}
-#else
+#else	/* WIN32 */
 	BOOL	result = WaitNamedPipe(sockfn, NMPWAIT_USE_DEFAULT_WAIT);
 
 	if (result == FALSE) {
@@ -169,7 +169,7 @@ udq_pipe_conn_t *upsdrvquery_connect_drvname_upsname(const char *drvname, const 
 			upslog_with_errno(LOG_ERR, "Can't open %s", sockname);
 		return NULL;
 	}
-#else
+#else	/* WIN32 */
 	snprintf(sockname, sizeof(sockname), "\\\\.\\pipe\\%s-%s", drvname, upsname);
 #endif  /* WIN32 */
 
@@ -204,7 +204,7 @@ void upsdrvquery_close(udq_pipe_conn_t *conn) {
 #ifndef WIN32
 	if (VALID_FD(conn->sockfd))
 		close(conn->sockfd);
-#else
+#else	/* WIN32 */
 	if (VALID_FD(conn->overlapped.hEvent)) {
 		CloseHandle(conn->overlapped.hEvent);
 	}
@@ -232,11 +232,11 @@ ssize_t upsdrvquery_read_timeout(udq_pipe_conn_t *conn, struct timeval tv) {
 	ssize_t	ret;
 #ifndef WIN32
 	fd_set	rfds;
-#else
+#else	/* WIN32 */
 	DWORD	bytesRead = 0;
 	BOOL	res = FALSE;
 	struct timeval	start, now, presleep;
-#endif
+#endif	/* WIN32 */
 
 	upsdebugx(5, "%s: tv={sec=%" PRIiMAX ", usec=%06" PRIiMAX "}%s",
 		__func__, (intmax_t)tv.tv_sec, (intmax_t)tv.tv_usec,
@@ -267,7 +267,7 @@ ssize_t upsdrvquery_read_timeout(udq_pipe_conn_t *conn, struct timeval tv) {
 
 	memset(conn->buf, 0, sizeof(conn->buf));
 	ret = read(conn->sockfd, conn->buf, sizeof(conn->buf));
-#else
+#else	/* WIN32 */
 /*
 	if (nut_debug_level > 0 || nut_upsdrvquery_debug_level > 0)
 		upslog_with_errno(LOG_ERR, "Support for this platform is not currently implemented");
@@ -376,7 +376,7 @@ ssize_t upsdrvquery_write(udq_pipe_conn_t *conn, const char *buf) {
 	size_t	buflen = strlen(buf);
 #ifndef WIN32
 	ssize_t	ret;
-#else
+#else	/* WIN32 */
 	DWORD	bytesWritten = 0;
 	BOOL	result = FALSE;
 #endif  /* WIN32 */
@@ -399,7 +399,7 @@ ssize_t upsdrvquery_write(udq_pipe_conn_t *conn, const char *buf) {
 	}
 
 	return ret;
-#else
+#else	/* WIN32 */
 	result = WriteFile(conn->sockfd, buf, buflen, &bytesWritten, NULL);
 	if (result == 0 || bytesWritten != (DWORD)buflen) {
 		if (nut_debug_level > 0 || nut_upsdrvquery_debug_level >= NUT_UPSDRVQUERY_DEBUG_LEVEL_DIALOG)
@@ -449,7 +449,7 @@ ssize_t upsdrvquery_prepare(udq_pipe_conn_t *conn, struct timeval tv) {
 #ifdef WIN32
 		/* Allow a new read to happen later */
 		conn->newread = 1;
-#endif
+#endif	/* WIN32 */
 
 		buf = conn->buf;
 		while (buf && *buf) {
@@ -580,7 +580,7 @@ ssize_t upsdrvquery_request(
 #ifdef WIN32
 		/* Allow a new read to happen later */
 		conn->newread = 1;
-#endif
+#endif	/* WIN32 */
 
 		buf = conn->buf;
 		while (buf && *buf) {

--- a/drivers/usb-common.c
+++ b/drivers/usb-common.c
@@ -480,7 +480,7 @@ int nut_usb_get_string(
 #ifdef WIN32
 		/* only for libusb0 ? */
 		errno = -ret;
-#endif
+#endif	/* WIN32 */
 		return ret;
 	}
 

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -42,7 +42,7 @@
 #include "common.h"
 #ifdef WIN32
 #include "wincompat.h"
-#endif
+#endif	/* WIN32 */
 
 /* include all known subdrivers */
 #include "mge-hid.h"
@@ -2047,7 +2047,7 @@ static bool_t hid_ups_walk(walkmode_t mode)
 # if EPROTO && WITH_LIBUSB_0_1
 		case -EPROTO:		/* Protocol error */
 # endif
-#endif
+#endif	/* !WIN32 */
 		case LIBUSB_ERROR_PIPE:      /* Broken pipe */
 		default:
 			/* Don't know what happened, try again later... */

--- a/include/common.h
+++ b/include/common.h
@@ -34,7 +34,7 @@
 /* for fcntl() and its flags in MSYS2 */
 #  define __POSIX_VISIBLE 200809
 # endif
-#endif
+#endif	/* WIN32 */
 
 /* Need this on AIX when using xlc to get alloca */
 #ifdef _AIX
@@ -66,11 +66,11 @@
 
 #ifndef WIN32
 #include <syslog.h>
-#else
+#else	/* WIN32 */
 #include <winsock2.h>
 #include <windows.h>
 #include <ws2tcpip.h>
-#endif
+#endif	/* WIN32 */
 
 #include <unistd.h>	/* useconds_t */
 #ifndef HAVE_USECONDS_T
@@ -135,7 +135,7 @@ extern "C" {
 # define ERROR_FD_SOCK ERROR_FD
 # define VALID_FD_SOCK(a) VALID_FD(a)
 
-#else /* WIN32 */
+#else	/* WIN32 */
 
 /* Separate definitions of TYPE_FD, ERROR_FD, VALID_FD() macros
  * for usual file descriptors vs. types needed for serial port
@@ -171,7 +171,7 @@ typedef struct serial_handler_s {
 /* difftime returns erroneous value so we use this macro */
 # undef difftime
 # define difftime(t1,t0) (double)(t1 - t0)
-#endif /* WIN32 */
+#endif	/* WIN32 */
 
 /* Two uppercase letters are more readable than one exclamation */
 #define INVALID_FD_SER(a) (!VALID_FD_SER(a))
@@ -308,9 +308,9 @@ pid_t parsepid(const char *buf);
 /* send a signal to another running NUT process */
 #ifndef WIN32
 int sendsignal(const char *progname, int sig, int check_current_progname);
-#else
+#else	/* WIN32 */
 int sendsignal(const char *progname, const char * sig, int check_current_progname);
-#endif
+#endif	/* WIN32 */
 
 int snprintfcat(char *dst, size_t size, const char *fmt, ...)
 	__attribute__ ((__format__ (__printf__, 3, 4)));
@@ -376,10 +376,10 @@ pid_t parsepidfile(const char *pidfn);
  * named driver programs does not request it)
  */
 int sendsignalfn(const char *pidfn, int sig, const char *progname, int check_current_progname);
-#else
+#else	/* WIN32 */
 /* No progname here - communications via named pipe */
 int sendsignalfn(const char *pidfn, const char * sig, const char *progname_ignored, int check_current_progname_ignored);
-#endif
+#endif	/* WIN32 */
 
 const char *xbasename(const char *file);
 
@@ -560,11 +560,11 @@ int match_regex_hex(const regex_t *preg, const int n);
 #ifndef WIN32
 ssize_t select_read(const int fd, void *buf, const size_t buflen, const time_t d_sec, const suseconds_t d_usec);
 ssize_t select_write(const int fd, const void *buf, const size_t buflen, const time_t d_sec, const suseconds_t d_usec);
-#else
+#else	/* WIN32 */
 ssize_t select_read(serial_handler_t *fd, void *buf, const size_t buflen, const time_t d_sec, const suseconds_t d_usec);
 /* Note: currently not implemented de-facto for Win32 */
 ssize_t select_write(serial_handler_t * fd, const void *buf, const size_t buflen, const time_t d_sec, const suseconds_t d_usec);
-#endif
+#endif	/* WIN32 */
 
 char * get_libname(const char* base_libname);
 
@@ -651,7 +651,7 @@ char * getfullpath(char * relative_path);
 #define PATH_BIN "\\..\\bin"
 #define PATH_SBIN "\\..\\sbin"
 #define PATH_LIB "\\..\\lib"
-#endif /* WIN32*/
+#endif	/* WIN32*/
 
 /* Return a difference of two timevals as a floating-point number */
 double difftimeval(struct timeval x, struct timeval y);
@@ -673,7 +673,7 @@ size_t strnlen(const char *s, size_t maxlen);
 
 /* Not all platforms support the flag; this method abstracts
  * its use (or not) to simplify calls in the actual codebase */
-/* TODO: Extend for TYPE_FD and WIN32 eventually? */
+/* TODO NUT_WIN32_INCOMPLETE? : Extend for TYPE_FD and WIN32 eventually? */
 void set_close_on_exec(int fd);
 
 #ifdef __cplusplus

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -1,9 +1,13 @@
 /*
     nutconf.hpp - Nut configuration file manipulation API
 
-    Copyright (C)
-	2012	Emilien Kia <emilien.kia@gmail.com>
-	2024	Jim Klimov <jimklimov+nut@gmail.com>
+    Copyright (C) 2012 Eaton
+
+        Author: Emilien Kia <emilien.kia@gmail.com>
+
+    Copyright (C) 2024-2025 NUT Community
+
+        Author: Jim Klimov  <jimklimov+nut@gmail.com>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/include/nutipc.hpp
+++ b/include/nutipc.hpp
@@ -313,13 +313,14 @@ Process::Child<M>::Child(M main)
 
 	e << "Can't fork: not implemented on this platform yet";
 
+	/* NUT_WIN32_INCOMPLETE(); */
 	throw std::logic_error(e.str());
-#else
+#else	/* !WIN32 */
 	m_pid = ::fork();
 
 	if (!m_pid)
 		::exit(main());
-#endif
+#endif	/* !WIN32 */
 }
 
 
@@ -337,8 +338,9 @@ int Process::Child<M>::wait()
 	e << "Can't wait for PID " << m_pid <<
 		": not implemented on this platform yet";
 
+	/* NUT_WIN32_INCOMPLETE(); */
 	throw std::logic_error(e.str());
-#else
+#else	/* !WIN32 */
 	if (m_exited)
 		return m_exit_code;
 
@@ -359,7 +361,7 @@ int Process::Child<M>::wait()
 	m_exit_code = WEXITSTATUS(m_exit_code);
 
 	return m_exit_code;
-#endif
+#endif	/* !WIN32 */
 }
 
 
@@ -401,7 +403,7 @@ class Signal {
 		VTALRM = SIGVTALRM,  /** Virtual alarm clock               */
 		XCPU   = SIGXCPU,    /** CPU time limit exceeded           */
 		XFSZ   = SIGXFSZ,    /** File size limit exceeded          */
-#endif
+#endif	/* !WIN32 */
 	} enum_t;  // end of typedef enum
 
 	/** Signal list */
@@ -767,8 +769,9 @@ Signal::HandlerThread<H>::HandlerThread(const Signal::List & siglist)
 
 	e << "Can't prepare signal handling thread: not implemented on this platform yet";
 
+	/* NUT_WIN32_INCOMPLETE(); */
 	throw std::logic_error(e.str());
-#else
+#else	/* !WIN32 */
 	// At most one instance per process allowed
 	if (-1 != s_comm_pipe[1])
 		throw std::logic_error(
@@ -824,7 +827,7 @@ Signal::HandlerThread<H>::HandlerThread(const Signal::List & siglist)
 			throw std::runtime_error(e.str());
 		}
 	}
-#endif
+#endif	/* !WIN32 */
 }
 
 

--- a/include/nutipc.hpp
+++ b/include/nutipc.hpp
@@ -43,9 +43,9 @@ extern "C" {
 
 #ifndef WIN32
 # include <sys/wait.h>
-#else
-# include <wincompat.h>
-#endif
+#else	/* WIN32 */
+# include "wincompat.h"
+#endif	/* WIN32 */
 
 #ifdef HAVE_PTHREAD
 # include <pthread.h>

--- a/include/nutipc.hpp
+++ b/include/nutipc.hpp
@@ -5,7 +5,7 @@
 
         Author: Vaclav Krpec  <VaclavKrpec@Eaton.com>
 
-    Copyright (C) 2024 NUT Community
+    Copyright (C) 2024-2025 NUT Community
 
         Author: Jim Klimov  <jimklimov+nut@gmail.com>
 

--- a/include/nutstream.hpp
+++ b/include/nutstream.hpp
@@ -41,7 +41,7 @@ extern "C" {
 #include <sys/types.h>
 #ifndef WIN32
 # include <sys/socket.h>
-#else
+#else	/* WIN32 */
 # if HAVE_WINSOCK2_H
 #  include <winsock2.h>
 # endif
@@ -52,7 +52,7 @@ extern "C" {
  * similar to nutclient.cpp; do not call wincompat.h!
  * FIXME: refactor to reuse the C++ adaptation?
  */
-#endif
+#endif	/* WIN32 */
 }
 
 /* See include/common.h for details behind this */
@@ -338,10 +338,11 @@ class NutFile: public NutStream {
 	inline static const std::string & path_sep() {
 		static std::string pathsep =
 #ifdef WIN32
+			/* FIXME NUT_WIN32_INCOMPLETE : Actually modern Windows supports both slashes */
 			"\\";
-#else
+#else	/* !WIN32 */
 			"/";
-#endif
+#endif	/* !WIN32 */
 		return pathsep;
 	}
 

--- a/include/nutstream.hpp
+++ b/include/nutstream.hpp
@@ -1,9 +1,13 @@
 /*
     nutstream.hpp - NUT stream
 
-    Copyright (C)
-	2012	Vaclav Krpec  <VaclavKrpec@Eaton.com>
-	2024	Jim Klimov <jimklimov+nut@gmail.com>
+    Copyright (C) 2012 Eaton
+
+        Author: Vaclav Krpec  <VaclavKrpec@Eaton.com>
+
+    Copyright (C) 2024-2025 NUT Community
+
+        Author: Jim Klimov  <jimklimov+nut@gmail.com>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/include/nutwriter.hpp
+++ b/include/nutwriter.hpp
@@ -1,9 +1,13 @@
 /*
     nutwriter.hpp - NUT writer
 
-    Copyright (C)
-	2012	Vaclav Krpec  <VaclavKrpec@Eaton.com>
-	2024	Jim Klimov <jimklimov+nut@gmail.com>
+    Copyright (C) 2012 Eaton
+
+        Author: Vaclav Krpec  <VaclavKrpec@Eaton.com>
+
+    Copyright (C) 2024-2025 NUT Community
+
+        Author: Jim Klimov  <jimklimov+nut@gmail.com>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/include/wincompat.h
+++ b/include/wincompat.h
@@ -28,6 +28,19 @@
 #include "common.h"
 #include <limits.h>
 
+/* Used in ifdef code blocks that were not yet implemented as part of
+ * the NUT for Windows upstreaming as a first-class citizen code base.
+ * For more details, see:
+ *   https://github.com/networkupstools/nut/wiki/NUT-for-Windows
+ *   https://github.com/orgs/networkupstools/projects/2/views/1
+ *   https://github.com/networkupstools/nut/issues?q=+label%3AWindows-not-on-par-with-POSIX+sort%3Aupdated-desc+
+ */
+#define NUT_WIN32_INCOMPLETE_DETAILED(str)	upsdebugx(1, "%s:%s::%s() : this method was not fully ported for WIN32: %s", __FILE__, __LINE__, __func__, NUT_STRARG(str))
+#define NUT_WIN32_INCOMPLETE()	upsdebugx(1, "%s:%s::%s() : this method was not fully ported for WIN32", __FILE__, __LINE__, __func__)
+#define NUT_WIN32_INCOMPLETE_LOGWARN()	upslogx(LOG_WARNING, "%s:%s::%s() : this method was not fully ported for WIN32", __FILE__, __LINE__, __func__)
+/* These use-cases need to be revised, maybe hushed later: */
+#define NUT_WIN32_INCOMPLETE_MAYBE_NOT_APPLICABLE()	NUT_WIN32_INCOMPLETE_DETAILED("may be not applicable to the platform")
+
 /* This value is defined in the error.h file of the libusb-win32 sources
  * FIXME: Should only be relevant for builds WITH_LIBUSB_0_1 - #ifdef it so?
  * Conflicts with e.g. /msys64/mingw64/include/errno.h which defines it as 138

--- a/scripts/Windows/wininit.c
+++ b/scripts/Windows/wininit.c
@@ -845,9 +845,9 @@ int main(int argc, char **argv)
 	return EXIT_SUCCESS;
 }
 
-#else
+#else	/* !WIN32 */
 
 /* Just avoid: ISO C forbids an empty translation unit [-Werror=pedantic] */
 int main (int argc, char ** argv);
 
-#endif  /* WIN32 */
+#endif  /* !WIN32 */

--- a/server/conf.c
+++ b/server/conf.c
@@ -76,7 +76,7 @@ static void ups_create(const char *fn, const char *name, const char *desc)
 			name);
 		return;
 	}
-#endif
+#endif	/* WIN32 */
 	temp->sock_fd = sstate_connect(temp);
 
 	/* preload this to the current time to avoid false staleness */
@@ -119,9 +119,9 @@ static void ups_update(const char *fn, const char *name, const char *desc)
 
 #ifndef WIN32
 		close(temp->sock_fd);
-#else
+#else	/* WIN32 */
 		CloseHandle(temp->sock_fd);
-#endif
+#endif	/* WIN32 */
 		temp->sock_fd = ERROR_FD;
 		temp->dumpdone = 0;
 
@@ -571,9 +571,9 @@ static void delete_ups(upstype_t *target)
 			if (VALID_FD(ptr->sock_fd))
 #ifndef WIN32
 				close(ptr->sock_fd);
-#else
+#else	/* WIN32 */
 				CloseHandle(ptr->sock_fd);
-#endif
+#endif	/* WIN32 */
 
 			/* release memory */
 			sstate_infofree(ptr);

--- a/server/netssl.c
+++ b/server/netssl.c
@@ -30,9 +30,9 @@
 #ifndef WIN32
 #include <netinet/in.h>
 #include <sys/socket.h>
-#else
+#else	/* WIN32 */
 #include "wincompat.h"
-#endif
+#endif	/* WIN32 */
 
 #include "upsd.h"
 #include "neterr.h"

--- a/server/nut_ctype.h
+++ b/server/nut_ctype.h
@@ -73,7 +73,7 @@ typedef struct nut_ctype_s {
 	struct nut_ctype_s	*next;
 #ifdef WIN32
 	HANDLE Event;
-#endif
+#endif	/* WIN32 */
 } nut_ctype_t;
 
 #ifdef __cplusplus

--- a/server/stype.h
+++ b/server/stype.h
@@ -25,7 +25,7 @@
 
 #ifndef WIN32
 #include <netdb.h>
-#endif
+#endif	/* !WIN32 */
 
 #ifndef NI_MAXHOST
 #define NI_MAXHOST      1025
@@ -47,7 +47,7 @@ typedef struct stype_s {
 	TYPE_FD_SOCK	sock_fd;
 #ifdef WIN32
 	HANDLE  Event;
-#endif
+#endif	/* WIN32 */
 	struct stype_s	*next;
 } stype_t;
 

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -43,7 +43,7 @@
 #  include <signal.h>
 /* #include <poll.h> */
 # endif
-#else
+#else	/* WIN32 */
 /* Those 2 files for support of getaddrinfo, getnameinfo and freeaddrinfo
    on Windows 2000 and older versions */
 # include <ws2tcpip.h>
@@ -53,7 +53,7 @@
 # include "wincompat.h"
 # undef W32_NETWORK_CALL_OVERRIDE
 # include <getopt.h>
-#endif
+#endif	/* WIN32 */
 
 #include "user.h"
 #include "nut_ctype.h"
@@ -118,7 +118,7 @@ typedef enum {
 	SERVER
 #ifdef WIN32
 	,NAMED_PIPE
-#endif
+#endif	/* WIN32 */
 
 } handler_type_t;
 
@@ -150,10 +150,10 @@ static tracking_t	*tracking_list = NULL;
 #ifndef WIN32
 	/* pollfd  */
 static struct pollfd	*fds = NULL;
-#else
+#else	/* WIN32 */
 static HANDLE		*fds = NULL;
 static HANDLE		mutex = INVALID_HANDLE_VALUE;
-#endif
+#endif	/* WIN32 */
 static handler_t	*handler = NULL;
 
 	/* pid file */
@@ -280,11 +280,14 @@ static void setuptcp(stype_t *server)
 {
 #ifdef WIN32
 	WSADATA WSAdata;
-	WSAStartup(2,&WSAdata);
-	atexit((void(*)(void))WSACleanup);
-#endif
+#endif	/* WIN32 */
 	struct addrinfo		hints, *res, *ai;
 	int	v = 0, one = 1;
+
+#ifdef WIN32
+	WSAStartup(2,&WSAdata);
+	atexit((void(*)(void))WSACleanup);
+#endif	/* WIN32 */
 
 	if (VALID_FD_SOCK(server->sock_fd)) {
 		/* Already bound, e.g. thanks to 'LISTEN *' handling and injection
@@ -495,7 +498,7 @@ static void setuptcp(stype_t *server)
 		if (fcntl(sock_fd, F_SETFL, v | O_NDELAY) == -1) {
 			fatal_with_errno(EXIT_FAILURE, "setuptcp: fcntl(set)");
 		}
-#endif
+#endif	/* !WIN32 */
 
 		if (listen(sock_fd, 16) < 0) {
 			upsdebug_with_errno(3, "setuptcp: listen");
@@ -529,7 +532,7 @@ static void setuptcp(stype_t *server)
 
 		/* Associate socket event to the socket via its Event object */
 		WSAEventSelect( server->sock_fd, server->Event, FD_ACCEPT );
-#endif
+#endif	/* WIN32 */
 
 	freeaddrinfo(res);
 
@@ -577,7 +580,7 @@ static void client_disconnect(nut_ctype_t *client)
 
 #ifdef WIN32
 	CloseHandle(client->Event);
-#endif
+#endif	/* WIN32 */
 
 	if (client->loginups) {
 		declogins(client->loginups);
@@ -821,7 +824,7 @@ static void client_connect(stype_t *server)
 
 	/* Associate socket event to the socket via its Event object */
 	WSAEventSelect( client->sock_fd, client->Event, FD_READ );
-#endif
+#endif	/* WIN32 */
 
 	pconf_init(&client->ctx, NULL);
 
@@ -1075,10 +1078,10 @@ static void driver_free(void)
 		if (VALID_FD(ups->sock_fd)) {
 #ifndef WIN32
 			close(ups->sock_fd);
-#else
+#else	/* WIN32 */
 			DisconnectNamedPipe(ups->sock_fd);
 			CloseHandle(ups->sock_fd);
-#endif
+#endif	/* WIN32 */
 			ups->sock_fd = ERROR_FD;
 		}
 
@@ -1126,7 +1129,7 @@ static void upsd_cleanup(void)
 		ReleaseMutex(mutex);
 		CloseHandle(mutex);
 	}
-#endif
+#endif	/* WIN32 */
 
 	upsdebugx(1, "%s: finished", __func__);
 }
@@ -1163,10 +1166,10 @@ static void poll_reload(void)
 	/* The checks above effectively limit that maxconn is in size_t range */
 	fds = xrealloc(fds, (size_t)maxconn * sizeof(*fds));
 	handler = xrealloc(handler, (size_t)maxconn * sizeof(*handler));
-#else
+#else	/* WIN32 */
 	fds = xrealloc(fds, (size_t)MAXIMUM_WAIT_OBJECTS * sizeof(*fds));
 	handler = xrealloc(handler, (size_t)MAXIMUM_WAIT_OBJECTS * sizeof(*handler));
-#endif
+#endif	/* WIN32 */
 }
 
 /* instant command and setvar status tracking */
@@ -1402,10 +1405,10 @@ static void mainloop(void)
 #ifndef WIN32
 	int	ret;
 	nfds_t	i;
-#else
+#else	/* WIN32 */
 	DWORD	ret;
 	pipe_conn_t * conn;
-#endif
+#endif	/* WIN32 */
 
 	nfds_t	nfds = 0;
 	upstype_t	*ups;
@@ -1617,7 +1620,7 @@ static void mainloop(void)
 			continue;
 		}
 	}
-#else
+#else	/* WIN32 */
 	/* scan through driver sockets */
 	for (ups = firstups; ups && (nfds < maxconn); ups = ups->next) {
 
@@ -1806,7 +1809,7 @@ static void mainloop(void)
 			upsdebugx(2, "%s: <unknown> has data available", __func__);
 			break;
 	}
-#endif
+#endif	/* WIN32 */
 }
 
 static void help(const char *arg_progname)
@@ -1825,7 +1828,7 @@ static void help(const char *arg_progname)
 	printf("		 - stop: stop process and exit\n");
 #ifndef WIN32
 	printf("  -P <pid>	send the signal above to specified PID (bypassing PID file)\n");
-#endif
+#endif	/* !WIN32 */
 	printf("  -D		raise debugging level (and stay foreground by default)\n");
 	printf("  -F		stay foregrounded even if no debugging is enabled\n");
 	printf("  -FF		stay foregrounded and still save the PID file\n");
@@ -1874,9 +1877,9 @@ static void setup_signals(void)
 	/* handle reloading */
 	sa.sa_handler = set_reload_flag;
 	sigaction(SIGHUP, &sa, NULL);
-#else
+#else	/* WIN32 */
 	pipe_create(UPSD_PIPE_NAME);
-#endif
+#endif	/* WIN32 */
 }
 
 void check_perms(const char *fn)
@@ -1895,9 +1898,10 @@ void check_perms(const char *fn)
 	if (st.st_mode & (S_IROTH | S_IXOTH)) {
 		upslogx(LOG_WARNING, "WARNING: %s is world readable (hope you don't have passwords there)", fn);
 	}
-#else
+#else	/* WIN32 */
 	NUT_UNUSED_VARIABLE(fn);
-#endif
+	NUT_WIN32_INCOMPLETE_MAYBE_NOT_APPLICABLE();
+#endif	/* WIN32 */
 }
 
 int main(int argc, char **argv)
@@ -1906,9 +1910,9 @@ int main(int argc, char **argv)
 #ifndef WIN32
 	int	cmd = 0;
 	pid_t	oldpid = -1;
-#else
+#else	/* WIN32 */
 	const char * cmd = NULL;
-#endif
+#endif	/* WIN32 */
 	char	*chroot_path = NULL;
 	const char	*user = RUN_AS_USER;
 	struct passwd	*new_uid = NULL;
@@ -1919,7 +1923,7 @@ int main(int argc, char **argv)
 	statepath = xstrdup(dflt_statepath());
 #ifndef WIN32
 	datapath = xstrdup(NUT_DATADIR);
-#else
+#else	/* WIN32 */
 	datapath = getfullpath(PATH_SHARE);
 
 	/* remove trailing .exe */
@@ -1936,7 +1940,7 @@ int main(int argc, char **argv)
 	else {
 		progname = drv_name;
 	}
-#endif
+#endif	/* WIN32 */
 
 	/* set up some things for later */
 	snprintf(pidfn, sizeof(pidfn), "%s/%s.pid", altpidpath(), progname);
@@ -1991,7 +1995,7 @@ int main(int argc, char **argv)
 				if ((oldpid = parsepid(optarg)) < 0)
 					help(progname);
 				break;
-#endif
+#endif	/* !WIN32 */
 
 			case 'D':
 				nut_debug_level++;
@@ -2153,7 +2157,14 @@ int main(int argc, char **argv)
 				upslogx(LOG_NOTICE, "Try to add '-P $PID' argument");
 			}
 # endif
-#endif	/* not WIN32 */
+#else 	/* WIN32 */
+			/* NOTE: Code above is just suggestions about different
+			 *  ways to send commands on other platforms; nothing
+			 *  to fix here as if it were NUT_WIN32_INCOMPLETE
+			 *  (or maybe suggest restarting NUT service whole?)
+			 */
+			/* NUT_WIN32_INCOMPLETE_DETAILED("could not signal a running daemon (if any)"); */
+#endif	/* WIN32 */
 		}
 
 		exit((cmdret == 0) ? EXIT_SUCCESS : EXIT_FAILURE);
@@ -2189,9 +2200,9 @@ int main(int argc, char **argv)
 	/* default to system limit (may be overridden in upsd.conf) */
 	/* FIXME: Check for overflows (and int size of nfds_t vs. long) - see get_max_pid_t() for example */
 	maxconn = (nfds_t)sysconf(_SC_OPEN_MAX);
-#else
-	maxconn = 64;  /*FIXME : arbitrary value, need adjustement */
-#endif
+#else	/* WIN32 */
+	maxconn = 64;  /*FIXME NUT_WIN32_INCOMPLETE : arbitrary value, need adjustement */
+#endif	/* WIN32 */
 
 	/* handle upsd.conf */
 	load_upsdconf(0);	/* 0 = initial */
@@ -2260,7 +2271,7 @@ int main(int argc, char **argv)
 	} else {
 		upsdebugx(1, "chdired into statepath %s for driver sockets", statepath);
 	}
-#endif
+#endif	/* !WIN32 */
 
 	/* check statepath perms */
 	check_perms(statepath);

--- a/server/upsd.h
+++ b/server/upsd.h
@@ -35,7 +35,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
-#endif
+#endif	/* !WIN32 */
 
 #include "timehead.h"
 
@@ -108,10 +108,10 @@ extern nut_ctype_t	*firstclient;
 #ifndef WIN32
 #define SIGCMD_STOP	SIGTERM
 #define SIGCMD_RELOAD	SIGHUP
-#else
+#else	/* WIN32 */
 #define SIGCMD_STOP    COMMAND_STOP
 #define SIGCMD_RELOAD  COMMAND_RELOAD
-#endif
+#endif	/* WIN32 */
 
 /* awkward way to make a string out of a numeric constant */
 

--- a/server/upstype.h
+++ b/server/upstype.h
@@ -40,7 +40,7 @@ typedef struct upstype_s {
 #ifdef WIN32
 	char 			buf[SMALLBUF];
 	OVERLAPPED		read_overlapped;
-#endif
+#endif	/* WIN32 */
 	int			stale;
 	int			dumpdone;
 	int			data_ok;

--- a/server/user.c
+++ b/server/user.c
@@ -24,7 +24,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
-#endif
+#endif	/* !WIN32 */
 
 #include "common.h"
 #include "parseconf.h"

--- a/tests/cpputest-client.cpp
+++ b/tests/cpputest-client.cpp
@@ -7,7 +7,7 @@
    in isolated-binary fashion.
 
    Copyright (C)
-	2022-2024	Jim Klimov <jimklimov+nut@gmail.com>
+	2022-2025	Jim Klimov <jimklimov+nut@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/tests/cpputest.cpp
+++ b/tests/cpputest.cpp
@@ -2,7 +2,7 @@
 
    Copyright (C)
 	2012	Emilien Kia <emilienkia-guest@alioth.debian.org>
-	2020-2024	Jim Klimov <jimklimov+nut@gmail.com>
+	2020-2025	Jim Klimov <jimklimov+nut@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/tests/generic_gpio_utest.c
+++ b/tests/generic_gpio_utest.c
@@ -154,6 +154,10 @@ int main(int argc, char **argv) {
 
 	testData = fopen (testDescFileName, "r");
 	if(!testData) {
+		/* FIXME NUT_WIN32_INCOMPLETE : Actually modern Windows
+		 *  supports both slashes, but revise this code so we do
+		 *  not mix them (maybe enforce a specific one - e.g. some
+		 *  other code does replace / with \ in common.c) */
 		if (!strchr(testDescFileName, '/')) {
 			/* "srcdir" may be set by automake test harness, see
 			 * https://www.gnu.org/software/automake/manual/1.12.2/html_node/Scripts_002dbased-Testsuites.html

--- a/tests/nutclienttest.cpp
+++ b/tests/nutclienttest.cpp
@@ -2,7 +2,7 @@
 
    Copyright (C)
 	2016  Emilien Kia <emilien.kia@gmail.com>
-	2020 - 2024  Jim Klimov <jimklimov+nut@gmail.com>
+	2020 - 2025  Jim Klimov <jimklimov+nut@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/tests/nutconf_parser_ut.cpp
+++ b/tests/nutconf_parser_ut.cpp
@@ -3,7 +3,7 @@
 
     Copyright (C)
 	2012	Emilien Kia <emilienkia-guest@alioth.debian.org>
-	2024	Jim Klimov <jimklimov+nut@gmail.com>
+	2024-2025	Jim Klimov <jimklimov+nut@gmail.com>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/tests/nutconf_ut.cpp
+++ b/tests/nutconf_ut.cpp
@@ -3,7 +3,7 @@
 
     Copyright (C)
         2012	Vaclav Krpec <VaclavKrpec@Eaton.com>
-        2024    Jim Klimov <jimklimov+nut@gmail.com>
+        2024-2025    Jim Klimov <jimklimov+nut@gmail.com>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/tests/nutipc_ut.cpp
+++ b/tests/nutipc_ut.cpp
@@ -122,10 +122,11 @@ CPPUNIT_TEST_SUITE_REGISTRATION(NutIPCUnitTest);
 
 void NutIPCUnitTest::testExec() {
 #ifdef WIN32
-	/* FIXME: Some other program, maybe NUT's "message" handler, or "cmd -k" etc.?
-	 * And get Process working in the first place */
+	/* FIXME NUT_WIN32_INCOMPLETE:
+	 *  Some other program, maybe NUT's "message" handler, or "cmd -k" etc.?
+	 *  And get Process working in the first place */
 	std::cout << "NutIPCUnitTest::testExec(): skipped on this platform" << std::endl;
-#else
+#else	/* !WIN32 */
 	static const std::string bin = "/bin/sh";
 
 	nut::Process::Executor::Arguments args;
@@ -138,7 +139,7 @@ void NutIPCUnitTest::testExec() {
 	CPPUNIT_ASSERT(123 == child.wait());
 
 	CPPUNIT_ASSERT(0 == nut::Process::execute("test 'Hello world' = 'Hello world'"));
-#endif	/* WIN32 */
+#endif	/* !WIN32 */
 }
 
 
@@ -151,9 +152,10 @@ void NutIPCUnitTest::testSignalHandler(int signal) {
 
 void NutIPCUnitTest::testSignalSend() {
 #ifdef WIN32
-	/* FIXME: Needs implementation for signals via pipes */
+	/* FIXME NUT_WIN32_INCOMPLETE:
+	 *  Needs implementation for signals via pipes */
 	std::cout << "NutIPCUnitTest::testSignalSend(): skipped on this platform" << std::endl;
-#else
+#else	/* !WIN32 */
 	struct sigaction action;
 
 	pid_t my_pid = nut::Process::getPID();
@@ -210,7 +212,7 @@ void NutIPCUnitTest::testSignalSend() {
 	pid_file.removex();
 
 	signal_caught = 0;
-#endif	/* WIN32 */
+#endif	/* !WIN32 */
 }
 
 
@@ -231,9 +233,10 @@ class TestSignalHandler: public nut::Signal::Handler {
 // \todo Describe the point of this test.
 void NutIPCUnitTest::testSignalRecvQuick() {
 #ifdef WIN32
-	/* FIXME: Needs implementation for signals via pipes */
+	/* FIXME NUT_WIN32_INCOMPLETE:
+	 *  Needs implementation for signals via pipes */
 	std::cout << "NutIPCUnitTest::testSignalRecvQuick(): skipped on this platform" << std::endl;
-#else
+#else	/* !WIN32 */
 	// Create signal handler thread
 	nut::Signal::List signals;
 	caught_signals.clear();
@@ -311,14 +314,15 @@ void NutIPCUnitTest::testSignalRecvQuick() {
 	/* Check that received count matches sent count from code above. */
 	CPPUNIT_ASSERT(countUSER1 == 3);
 	CPPUNIT_ASSERT(countUSER2 == 2);
-#endif	/* WIN32 */
+#endif	/* !WIN32 */
 }
 
 void NutIPCUnitTest::testSignalRecvStaggered() {
 #ifdef WIN32
-	/* FIXME: Needs implementation for signals via pipes */
+	/* FIXME NUT_WIN32_INCOMPLETE:
+	 *  Needs implementation for signals via pipes */
 	std::cout << "NutIPCUnitTest::testSignalRecvStaggered(): skipped on this platform" << std::endl;
-#else
+#else	/* !WIN32 */
 	// Create signal handler thread
 	nut::Signal::List signals;
 	caught_signals.clear();
@@ -368,7 +372,7 @@ void NutIPCUnitTest::testSignalRecvStaggered() {
 	caught_signals.pop_front();
 
 	CPPUNIT_ASSERT(caught_signals.front() == nut::Signal::USER1);
-#endif	/* WIN32 */
+#endif	/* !WIN32 */
 }
 
 // Implement out of class declaration to avoid

--- a/tests/nutipc_ut.cpp
+++ b/tests/nutipc_ut.cpp
@@ -5,7 +5,7 @@
 
             \author Vaclav Krpec <VaclavKrpec@Eaton.com>
 
-        Copyright (C) 2024
+        Copyright (C) 2024-2025
 
             \author Jim Klimov <jimklimov+nut@gmail.com>
 

--- a/tests/nutstream_ut.cpp
+++ b/tests/nutstream_ut.cpp
@@ -33,7 +33,7 @@ extern "C" {
 #ifndef WIN32
 # include <sys/select.h>
 # include <sys/wait.h>
-#else
+#else	/* WIN32 */
 # if !(defined random) && !(defined HAVE_RANDOM)
    /* WIN32 names it differently: */
 #  define random() rand()
@@ -357,7 +357,7 @@ static uint16_t getFreePort() {
 		// well, at least attempted
 		wsaStarted = 1;
 	}
-#endif
+#endif	/* WIN32 */
 	while (tries > 0) {
 		uint16_t port = 10000 + static_cast<uint16_t>(reallyRandom() % 40000);
 		nut::NutSocket::Address addr(127, 0, 0, 1, port);
@@ -413,9 +413,10 @@ bool NutSocketUnitTest::Writer::run() {
 
 void NutSocketUnitTest::test() {
 #ifdef WIN32
-	/* FIXME: get Process working in the first place */
+	/* FIXME NUT_WIN32_INCOMPLETE:
+	 *  get Process working in the first place */
 	std::cout << "NutSocketUnitTest::test(): skipped on this platform" << std::endl;
-#else
+#else	/* !WIN32 */
 	// Fork writer
 	pid_t writer_pid = ::fork();
 
@@ -470,7 +471,7 @@ void NutSocketUnitTest::test() {
 	std::stringstream msg_writer_exit;
 	msg_writer_exit << "Got writer_exit=" << writer_exit << ", expected 0";
 	CPPUNIT_ASSERT_MESSAGE(msg_writer_exit.str(), 0    == writer_exit);
-#endif	/* WIN32 */
+#endif	/* !WIN32 */
 }
 
 

--- a/tests/nutstream_ut.cpp
+++ b/tests/nutstream_ut.cpp
@@ -3,7 +3,7 @@
 
     Copyright (C)
         2012	Vaclav Krpec <VaclavKrpec@Eaton.com>
-        2024	Jim Klimov <jimklimov+nut@gmail.com>
+        2024-2025	Jim Klimov <jimklimov+nut@gmail.com>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -49,7 +49,7 @@
 # include <netdb.h>
 # include <sys/ioctl.h>
 # include <net/if.h>
-#else
+#else	/* WIN32 */
 # if defined HAVE_WINSOCK2_H && HAVE_WINSOCK2_H
 #  include <winsock2.h>
 # endif
@@ -62,7 +62,7 @@
 #  define AI_NUMERICSERV NI_NUMERICSERV
 # endif
 # include "wincompat.h"
-#endif
+#endif	/* WIN32 */
 
 #include "nut_stdint.h"
 

--- a/tools/nut-scanner/nutscan-init.c
+++ b/tools/nut-scanner/nutscan-init.c
@@ -46,7 +46,7 @@
 # if defined HAVE_WINSOCK2_H && HAVE_WINSOCK2_H
 #  include <winsock2.h>
 # endif
-#endif
+#endif	/* WIN32 */
 
 /* Flags for code paths we can support in this run (libs available or not
  * needed). For consistency, only set non-zero values via nutscan_init() call.
@@ -155,7 +155,7 @@ void nutscan_init(void)
 	WSADATA WSAdata;
 	WSAStartup(2,&WSAdata);
 	atexit((void(*)(void))WSACleanup);
-#endif
+#endif	/* WIN32 */
 
 	/* Optional filter to not walk things twice */
 	nut_prepare_search_paths();

--- a/tools/nut-scanner/nutscan-ip.c
+++ b/tools/nut-scanner/nutscan-ip.c
@@ -32,7 +32,7 @@
 #ifndef WIN32
 # include <sys/socket.h>
 # include <netdb.h>
-#else
+#else	/* WIN32 */
 /* Those 2 files for support of getaddrinfo, getnameinfo and freeaddrinfo
    on Windows 2000 and older versions */
 # include <ws2tcpip.h>
@@ -41,7 +41,7 @@
 #  define AI_NUMERICSERV NI_NUMERICSERV
 # endif
 # include "wincompat.h"
-#endif
+#endif	/* WIN32 */
 
 static void increment_IPv6(struct in6_addr * addr)
 {

--- a/tools/nut-scanner/nutscan-ip.h
+++ b/tools/nut-scanner/nutscan-ip.h
@@ -28,11 +28,11 @@
 #ifndef WIN32
 #include <arpa/inet.h>
 #include <netinet/in.h>
-#else
+#else	/* WIN32 */
 #include <winsock2.h>
 #include <windows.h>
 #include <ws2tcpip.h>
-#endif
+#endif	/* WIN32 */
 
 #ifdef __cplusplus
 /* *INDENT-OFF* */

--- a/tools/nut-scanner/nutscan-serial.c
+++ b/tools/nut-scanner/nutscan-serial.c
@@ -32,15 +32,15 @@
 #include "common.h"
 #ifdef WIN32
 #include "wincompat.h"
-#endif
+#endif	/* WIN32 */
 
 #ifdef WIN32
 /* Windows: all serial port names start with "COM" */
 #define SERIAL_PORT_PREFIX "COM"
-#else
+#else	/* !WIN32 */
 /* Unix: all serial port names start with "/dev/tty" */
 #define SERIAL_PORT_PREFIX "/dev/tty"
-#endif
+#endif	/* !WIN32 */
 
 #define ERR_OUT_OF_BOUND "Serial port range out of bound (must be 0 to 9 or a to z depending on your system)"
 

--- a/tools/nut-scanner/scan_eaton_serial.c
+++ b/tools/nut-scanner/scan_eaton_serial.c
@@ -413,7 +413,7 @@ nutscan_device_t * nutscan_scan_eaton_serial(const char* ports_range)
 #ifndef WIN32
 	struct sigaction oldact;
 	int change_action_handler = 0;
-#endif
+#endif	/* !WIN32 */
 	char *current_port_name = NULL;
 	char **serial_ports_list;
 	int  current_port_nb;
@@ -454,7 +454,7 @@ nutscan_device_t * nutscan_scan_eaton_serial(const char* ports_range)
 # pragma GCC diagnostic pop
 #endif
 	}
-#endif
+#endif	/* !WIN32 */
 
 	/* port(s) iterator */
 	current_port_nb = 0;
@@ -672,7 +672,7 @@ nutscan_device_t * nutscan_scan_eaton_serial(const char* ports_range)
 # pragma GCC diagnostic pop
 #endif
 	}
-#endif /* WIN32 */
+#endif /* !WIN32 */
 
 	/* free everything... */
 	i = 0;

--- a/tools/nut-scanner/scan_nut.c
+++ b/tools/nut-scanner/scan_nut.c
@@ -329,7 +329,7 @@ nutscan_device_t * nutscan_scan_ip_range_nut(nutscan_ip_range_list_t * irl, cons
 #ifndef WIN32
 	struct sigaction oldact;
 	int change_action_handler = 0;
-#endif
+#endif	/* !WIN32 */
 	struct scan_nut_arg *nut_arg;
 
 #ifdef HAVE_PTHREAD
@@ -431,7 +431,7 @@ nutscan_device_t * nutscan_scan_ip_range_nut(nutscan_ip_range_list_t * irl, cons
 # pragma GCC diagnostic pop
 #endif
 	}
-#endif
+#endif	/* !WIN32 */
 
 	ip_str = nutscan_ip_ranges_iter_init(&ip, irl);
 
@@ -719,7 +719,7 @@ nutscan_device_t * nutscan_scan_ip_range_nut(nutscan_ip_range_list_t * irl, cons
 # pragma GCC diagnostic pop
 #endif
 	}
-#endif
+#endif	/* !WIN32 */
 
 	return nutscan_rewind_device(dev_ret);
 }

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -37,9 +37,9 @@ int nutscan_unload_snmp_library(void);
 
 #ifndef WIN32
 # include <sys/socket.h>
-#else
+#else	/* WIN32 */
 # undef _WIN32_WINNT
-#endif
+#endif	/* WIN32 */
 
 #include <string.h>
 #include <stdio.h>

--- a/tools/nut-scanner/scan_usb.c
+++ b/tools/nut-scanner/scan_usb.c
@@ -382,9 +382,9 @@ static int nut_usb_get_string(
 	ret = nut_usb_get_string_descriptor(udev, StringIdx, langid, buffer, sizeof(buffer));
 	if (ret < 0) {
 #ifdef WIN32
-		/* only for libusb0 ? */
+		/* FIXME NUT_WIN32_INCOMPLETE? : only for libusb0 ? */
 		errno = -ret;
-#endif
+#endif	/* WIN32 */
 		return ret;
 	}
 

--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -43,7 +43,7 @@ int nutscan_unload_neon_library(void);
 # include <netinet/in.h>
 # include <sys/select.h>
 # define SOCK_OPT_CAST
-#else
+#else	/* WIN32 */
 # define SOCK_OPT_CAST (char*)
 /* Those 2 files for support of getaddrinfo, getnameinfo and freeaddrinfo
    on Windows 2000 and older versions */


### PR DESCRIPTION
Follow-up from #1479 thanks to reminder from #2881: with this PR I revisited all mentions of `#if(n)def WIN32` to check context and comments of the code blocks to see if they are no-ops waiting for completion, and added either `NUT_WIN32_INCOMPLETE*()` macros for active message emission, or `NUT_WIN32_INCOMPLETE` in comments, either way to help more quickly locate and address those missing functionalities later.