### PR TITLE
scripts/external_apis/enphase - correct number conversion, service file

### DIFF
--- a/scripts/external_apis/enphase/enphase-monitor.in
+++ b/scripts/external_apis/enphase/enphase-monitor.in
@@ -5,7 +5,7 @@
 #
 # Copyright (C) 2025 Scott Shambarger
 #
-# Enphase Monitor for NUT dummy-ups v0.9.1
+# Enphase Monitor for NUT dummy-ups v0.9.2
 # Author: Scott Shambarger <devel@shambarger.net>
 #
 # Enphase Monitor is designed to work with Network UPS Tools
@@ -36,7 +36,8 @@
 #
 #   DISABLE_METERS= # any value to disable power reporting
 #   ENVOY_HOST="envoy.local" # ip/hostname of IQ Gateway on local network
-#   STATE_DIR="$NUT_STATEPATH" # (e.g. "/var/lib/ups") # writable directory for portfile/tokens
+#   STATE_DIR="$NUT_STATEPATH" # writable directory for portfile/tokens
+#                                (e.g. "/var/lib/ups")
 #   POLLFREQ=60 # seconds between API queries, min 5
 #   POLLFREQALERT=20 # seconds between API queries when on battery, min 5
 #   TOKEN_FILE="enphase-<ups>.token" # path defaults to STATE_DIR
@@ -221,7 +222,8 @@ die() { warn "enphase-monitor $UPS: $*"; exit 1; }
 
 int100() { # <int> = <float, either radix> * 100
   LC_NUMERIC=C printf -v _i "%.2f" "${2/,/.}"
-  printf -v "$1" "%s" "${_i/./}"
+  _i=${_i/./}
+  printf -v "$1" "%s" "${_i#0}"
 }
 
 fmtfloat() { # <precision> <dest> <float, either radix>

--- a/scripts/external_apis/enphase/enphase-monitor@.service.in
+++ b/scripts/external_apis/enphase/enphase-monitor@.service.in
@@ -25,9 +25,9 @@ User=@RUN_AS_USER@
 ### ExecStartPre=/bin/cp @CONFPATH@/enphase-%I.default /dev/shm/nut/enphase-%I.seq
 # First run once to scrap obsolete data from the existing file
 # Replace -s with -x to start in nocomms (no network APIs) below:
-ExecStartPre=@libexec@/enphase-monitor -s %I
+ExecStartPre=@NUT_LIBEXECDIR@/enphase-monitor -s %I
 # Start as the continuously running service
-ExecStart=@libexec@/enphase-monitor %I
+ExecStart=@NUT_LIBEXECDIR@/enphase-monitor %I
 Type=exec
 # Restart really always, do not stop trying:
 StartLimitInterval=0


### PR DESCRIPTION
Floats <1.0 were being handled as octal, corrected to use decimal. This resulted in incorrect calculations, and could result in "value too great for base" bash errors.

Corrected path substitution in enphase-monitor service file.
