### PR TITLE
Fix build on Debian 13

### DIFF
--- a/docs/config-prereqs.txt
+++ b/docs/config-prereqs.txt
@@ -106,8 +106,8 @@ recommended for build agents with immutable system areas, etc.
 Build prerequisites to make NUT from scratch on various Operating Systems
 -------------------------------------------------------------------------
 
-Debian 10/11/12
-~~~~~~~~~~~~~~~
+Debian 10/11/12/13
+~~~~~~~~~~~~~~~~~~
 
 Being a popular baseline among Linux distributions, Debian is an
 important build target. Related common operating systems include
@@ -197,7 +197,11 @@ metadata about recently published package revisions:
 # provide an `msgfmt` implementation, e.g.:
 #   :; apt-get install gettext
 #
-# To install the Python NUT-Monitor app, you may need some modules:
+# To install the Python NUT-Monitor app, you may need some modules.
+# Ideally, they would be packaged, named according to major Python version:
+#   :; apt-get install python3-pyqt5
+#
+# If not packaged for your distro:
 #   :; apt-get install pip
 # For Python3:
 #   :; python3 -m pip install PyQt5 configparser
@@ -213,6 +217,12 @@ metadata about recently published package revisions:
 # For CGI graph generation - massive packages (X11):
 :; apt-get install \
     libgd-dev
+
+# Debian 13 serves metadata needed for NUT to find where to install the
+# service unit files in a separate development package; earlier distro
+# releases did not seem to require it explicitly:
+:; apt-get install \
+    systemd-dev
 
 # Optionally for sd_notify integration:
 :; apt-get install \
@@ -274,7 +284,7 @@ complete environments):
     qemu-user-static
 ------
 
-NOTE: For Jenkins agents, also need to `apt-get install openjdk-17-jdk-headless`.
+NOTE: For Jenkins agents, also need to `apt-get install openjdk-21-jdk-headless`.
 You may have to ensure that `/proc` is mounted in the target chroot
 (or do this from the running container).
 

--- a/drivers/asem.c
+++ b/drivers/asem.c
@@ -67,7 +67,7 @@
 #endif
 
 #define DRIVER_NAME	"ASEM"
-#define DRIVER_VERSION	"0.14"
+#define DRIVER_VERSION	"0.15"
 
 /* Valid on ASEM PB1300 UPS */
 #define BQ2060_ADDRESS	0x0B
@@ -80,7 +80,7 @@
 
 #define ACCESS_DEVICE(fd, address) \
 	if (ioctl(fd, I2C_SLAVE, address) < 0) { \
-		fatal_with_errno(EXIT_FAILURE, "Failed to acquire bus access and/or talk to i2c slave 0x%02X", address); \
+		fatal_with_errno(EXIT_FAILURE, "Failed to acquire bus access and/or talk to i2c slave 0x%02X", (unsigned int)address); \
 	}
 
 static unsigned long lb_threshold = LOW_BATTERY_THRESHOLD;
@@ -202,7 +202,7 @@ void upsdrv_updateinfo(void)
 		return;
 	}
 	online = (i2c_status & 0x8000) != 0;
-	upsdebugx(3, "Charger status 0x%02X, online %d", i2c_status, online);
+	upsdebugx(3, "Charger status 0x%02X, online %d", (unsigned int)i2c_status, online);
 
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_EXTRA_SEMI_STMT)
 # pragma GCC diagnostic push
@@ -222,7 +222,7 @@ void upsdrv_updateinfo(void)
 		upslogx(LOG_ERR, "Could not read bq2060 status word at address 0x16");
 		return;
 	}
-	upsdebugx(3, "bq2060 status 0x04%X", i2c_status);
+	upsdebugx(3, "bq2060 status 0x04%X", (unsigned int)i2c_status);
 	/* Busy, leave data as stale, try next time */
 	if (i2c_status & 0x0001) {
 		dstate_datastale();
@@ -232,7 +232,7 @@ void upsdrv_updateinfo(void)
 	/* Error, leave data as stale, try next time */
 	if (i2c_status & 0x000F) {
 		dstate_datastale();
-		upslogx(LOG_WARNING, "bq2060 returned error code 0x%02X", i2c_status & 0x000F);
+		upslogx(LOG_WARNING, "bq2060 returned error code 0x%02X", (unsigned int)i2c_status & 0x000F);
 		return;
 	}
 

--- a/drivers/generic_gpio_libgpiod.c
+++ b/drivers/generic_gpio_libgpiod.c
@@ -31,7 +31,7 @@
 #endif
 
 #define DRIVER_NAME	"GPIO UPS driver (API " WITH_LIBGPIO_VERSION_STR ")"
-#define DRIVER_VERSION	"1.03"
+#define DRIVER_VERSION	"1.04"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -151,8 +151,11 @@ void gpio_open(struct gpioups_t *gpioupsfdlocal) {
 		upslogx(LOG_NOTICE, "GPIO chip [%s] opened", gpioupsfdlocal->chipName);
 		gpioupsfdlocal->chipLinesCount = gpiod_chip_num_lines(libgpiod_data->gpioChipHandle);
 #else	/* #if WITH_LIBGPIO_VERSION >= 0x00020000 */
+		struct gpiod_chip_info *chipInfo;
+		struct gpiod_line_settings *lineSettings;
+
 		upslogx(LOG_NOTICE, "GPIO chip [%s] opened, api version 2", gpioupsfdlocal->chipName);
-		struct gpiod_chip_info *chipInfo = gpiod_chip_get_info(libgpiod_data->gpioChipHandle);
+		chipInfo = gpiod_chip_get_info(libgpiod_data->gpioChipHandle);
 		gpioupsfdlocal->chipLinesCount = gpiod_chip_info_get_num_lines(chipInfo);
 		gpiod_chip_info_free(chipInfo);
 #endif	/* WITH_LIBGPIO_VERSION */
@@ -179,7 +182,7 @@ void gpio_open(struct gpioups_t *gpioupsfdlocal) {
 		);
 #else	/* #if WITH_LIBGPIO_VERSION >= 0x00020000 */
 		libgpiod_data->values = xcalloc(gpioupsfdlocal->upsLinesCount, sizeof(*libgpiod_data->values));
-		struct gpiod_line_settings *lineSettings = gpiod_line_settings_new();
+		lineSettings = gpiod_line_settings_new();
 		libgpiod_data->lineConfig = gpiod_line_config_new();
 		libgpiod_data->config = gpiod_request_config_new();
 		if(!lineSettings || !libgpiod_data->lineConfig || !libgpiod_data->config) {

--- a/drivers/generic_gpio_libgpiod.c
+++ b/drivers/generic_gpio_libgpiod.c
@@ -78,7 +78,8 @@ static void reserve_lines_libgpiod(struct gpioups_t *gpioupsfd, int inner);
  */
 static void reserve_lines_libgpiod(struct gpioups_t *gpioupsfdlocal, int inner) {
 	struct libgpiod_data_t *libgpiod_data = (struct libgpiod_data_t *)(gpioupsfdlocal->lib_data);
-	upsdebugx(5, "reserve_lines_libgpiod runOptions 0x%x, inner %d", gpioupsfdlocal->runOptions, inner);
+	upsdebugx(5, "reserve_lines_libgpiod runOptions 0x%x, inner %d",
+		(unsigned int)gpioupsfdlocal->runOptions, inner);
 
 	if(((gpioupsfdlocal->runOptions&ROPT_REQRES) != 0) == inner) {
 #if WITH_LIBGPIO_VERSION < 0x00020000

--- a/drivers/generic_gpio_libgpiod.c
+++ b/drivers/generic_gpio_libgpiod.c
@@ -216,7 +216,8 @@ void gpio_open(struct gpioups_t *gpioupsfdlocal) {
 #if WITH_LIBGPIO_VERSION >= 0x00020000
 	gpioRc=gpiod_line_request_get_values(libgpiod_data->request, gpioupsfdlocal->upsLinesStates);
 	if(gpioRc==0) {
-		for(int i=0; i < gpioupsfdlocal->upsLinesCount; i++) {
+		int i;
+		for(i=0; i < gpioupsfdlocal->upsLinesCount; i++) {
 			gpioupsfdlocal->upsLinesStates[i] = libgpiod_data->values[i];
 		}
 	}

--- a/drivers/hwmon_ina219.c
+++ b/drivers/hwmon_ina219.c
@@ -37,7 +37,7 @@
 #define BATTERY_CHARGE_LOW                  15
 
 #define DRIVER_NAME                         "hwmon-INA219 UPS driver"
-#define DRIVER_VERSION                      "0.02"
+#define DRIVER_VERSION                      "0.03"
 
 upsdrv_info_t upsdrv_info = {
 	DRIVER_NAME,
@@ -394,7 +394,7 @@ void upsdrv_initinfo(void)
 	dstate_setinfo("device.description", "%s",
 			"Bidirectional Current/Power Monitor With I2C Interface");
 
-	dstate_setinfo("battery.charge.low", "%d", battery_charge_low);
+	dstate_setinfo("battery.charge.low", "%u", battery_charge_low);
 }
 
 static unsigned int battery_charge_compute(void)
@@ -452,7 +452,7 @@ void upsdrv_updateinfo(void)
 
 	dstate_setinfo("battery.voltage", "%.3f", voltage / 1000.0);
 	dstate_setinfo("battery.current", "%.3f", current / 1000.0);
-	dstate_setinfo("battery.charge", "%d", charge);
+	dstate_setinfo("battery.charge", "%u", charge);
 
 	if (charge <= battery_charge_low && current > 0)
 		dstate_setinfo("battery.runtime", "%d", 60); // 1 minute

--- a/tests/generic_gpio_liblocal.c
+++ b/tests/generic_gpio_liblocal.c
@@ -229,9 +229,9 @@ void gpiod_request_config_set_consumer(struct gpiod_request_config *config,
 
 int gpiod_line_request_get_values(struct gpiod_line_request *request,
 				  enum gpiod_line_value *values) {
-	NUT_UNUSED_VARIABLE(request);
 	unsigned int	i;
 	int	pinPos = 1;
+	NUT_UNUSED_VARIABLE(request);
 
 	if(errReqFor_line_get_value_bulk) {
 		errReqFor_line_get_value_bulk=0;

--- a/tests/generic_gpio_utest.c
+++ b/tests/generic_gpio_utest.c
@@ -331,9 +331,9 @@ int main(int argc, char **argv) {
 				 * because scanf() does not support asterisk for
 				 * width specifier; have to create it on the fly.
 				 */
-				snprintf(fmt, sizeof(fmt), "%%%us", NUT_GPIO_CHIPNAMEBUF-1);
+				snprintf(fmt, sizeof(fmt), "%%%us", (unsigned int)NUT_GPIO_CHIPNAMEBUF-1);
 				fEof=fscanf(testData, fmt, chipNameLocal);
-				snprintf(fmt, sizeof(fmt), "%%%us", NUT_GPIO_SUBTYPEBUF-1);
+				snprintf(fmt, sizeof(fmt), "%%%us", (unsigned int)NUT_GPIO_SUBTYPEBUF-1);
 				fEof=fscanf(testData, fmt, subType);
 #ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_NONLITERAL
 #pragma GCC diagnostic pop

--- a/tools/nutconf/nutconf-cli.cpp
+++ b/tools/nutconf/nutconf-cli.cpp
@@ -590,7 +590,8 @@ void Options::dump(std::ostream & stream) const {
 
 
 Options::Options(char * const argv[], int argc): m_last(nullptr) {
-	for (int i = 1; i < argc; ++i) {
+	int i;
+	for (i = 1; i < argc; ++i) {
 		const std::string arg(argv[i]);
 
 		// Empty string is the current option argument, too


### PR DESCRIPTION
Added a Debian 13 build agent (LXC container) to the NUT CI farm. The system has a few differences from Debian 12, notably mis-detection of systemd directories (new prereq package needed), and more complaints from its brew of clang-19 static analysis.

CC @axet