### PR TITLE
Enhance in-place builds (detect libdir, datadir, drvpath, cgipath), fix NUT library "current" versions

### DIFF
--- a/INSTALL.nut.adoc
+++ b/INSTALL.nut.adoc
@@ -569,6 +569,19 @@ binaries that the package would put into an obscure location like
 would refer to new locations specified by the current build, so such old
 binaries would just consume disk space but not run.
 
+It is recommended to first try installing into a prototyping area, so you
+can review which files get delivered and perhaps which locations you may
+have to tune for a more tightly tailored replacement of an older (packaged)
+installation, in case whole swathes of files that you expect to be present
+in the current system (libraries, drivers, docs) are not getting installed
+by the new build into same path names:
+
+----
+:; rm -rf /tmp/nut ; make DESTDIR=/tmp/nut install -j 8
+:; (cd /tmp/nut && find . | sort) | while read N ; \
+   do [ -e "/$N" ] || echo "=== MISSING: /$N" >&2 ; done
+----
+
 Replacing any NUT deployment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/INSTALL.nut.adoc
+++ b/INSTALL.nut.adoc
@@ -206,7 +206,7 @@ To build NUT from a Git checkout you may need some additional tools
 (referenced just a bit below) and run `./autogen.sh` to generate the
 needed files. For common developer iterations, porting to new platforms,
 or in-place testing, running the `./ci_build.sh` script can be helpful.
-The "<<Installing_inplace,Building NUT for in‐place upgrades or non‐disruptive
+The "<<Installing_inplace,Building NUT for in-place upgrades or non-disruptive
 tests>>" section details some more hints about such workflow, including some
 `systemd` integration.
 
@@ -271,8 +271,8 @@ do this, you will have problems later on when you try to start upsd.
 Build and install
 ~~~~~~~~~~~~~~~~~
 
-NOTE: See also <<Installing_inplace,Building NUT for in‐place upgrades
-or non‐disruptive tests>>.
+NOTE: See also <<Installing_inplace,Building NUT for in-place upgrades
+or non-disruptive tests>>.
 
 [[Configuration]]
 Configuration
@@ -429,7 +429,7 @@ You are now ready to configure NUT, and start testing and using it.
 You can jump directly to the <<Configuration_notes,NUT configuration>>.
 
 [[Installing_inplace]]
-Building NUT for in‐place upgrades or non‐disruptive tests
+Building NUT for in-place upgrades or non-disruptive tests
 ----------------------------------------------------------
 
 NOTE: The NUT GitHub Wiki article at

--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -100,7 +100,7 @@ import org.nut.dynamatrix.*;
     // quietly for things that succeed, and summarizes errors in the end
     dynacfgPipeline['spellcheck_prepconf'] = false
     dynacfgPipeline['spellcheck_configure'] = false
-    dynacfgPipeline['spellcheck'] = '(BUILD_TYPE=default-spellcheck ./ci_build.sh)'
+    dynacfgPipeline['spellcheck'] = '(BUILD_TYPE=default-spellcheck-quick ./ci_build.sh)'
 
 /*
     // For older builds, with only autotools in the tree:

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -60,6 +60,11 @@ https://github.com/networkupstools/nut/milestone/11
      introduced in NUT v2.8.2 for the socket protocol (between driver and
      data server), by returning "ERR INVALID-ARGUMENT", so there is no change
      for the network protocol definition. [#2182]
+   * The `configure --enable-inplace-runtime` option added in NUT v2.8.1 should
+     now also try to detect and set default values for the `--with-drvpath`,
+     `--with-cgipath`, `--datadir` and `--libdir` options to more closely match
+     a packaged setup and avoid confusion with e.g. two incompatible NUT client
+     libraries in system default search path. [#2895]
 
  - Large parts of the NUT User Manual and NUT Developer Guide were relocated
    into the new NUT Quality Assurance and Build Automation Guide (maintained

--- a/UPGRADING.adoc
+++ b/UPGRADING.adoc
@@ -88,6 +88,10 @@ Changes from 2.8.2 to 2.8.3
     positive values should time-limit the connection attempts), and
     `upscli_get_default_connect_timeout()` to retrieve its copy. [#2847]
 
+- API versions of `libupsclient` and `libnutscan` export more symbols now,
+  and so were bumped to new "current" numbers; this may impact the naming
+  of shared object files to be delivered by updated packaging. [#2895]
+
 - Standard NUT clients including `upsc`, `upscmd`, `upsrw`, `upslog`, `upsmon`,
   `upsimage`, `upsset` and `upsstats`) were updated to default with a 10-second
   connection establishment timeout in case of name resolution lags or

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -2532,7 +2532,8 @@ bindings)
 
     #$MAKE all || \
     $MAKE $PARMAKE_FLAGS all || exit
-    if [ "${CI_SKIP_CHECK}" != true ] ; then $MAKE check || exit ; fi
+    build_to_only_catch_errors_check
+    ### if [ "${CI_SKIP_CHECK}" != true ] ; then $MAKE check || exit ; fi
 
     case "$CI_OS_NAME" in
         windows*)

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -1169,6 +1169,15 @@ build_to_only_catch_errors_check() {
         return 0
     fi
 
+    # Lots of tedious touch-files to make, better run it in parallel separately.
+    # May report absence of "aspell" but would not fail in that case (just noise).
+    if grep "WITH_SPELLCHECK_TRUE=''" config.log >/dev/null 2>/dev/null ; then
+        echo "`date`: Starting a '$MAKE spellcheck-quick' first"
+        $CI_TIME $MAKE $MAKE_FLAGS_QUIET spellcheck-quick \
+        && echo "`date`: SUCCESS" \
+        || return $?
+    fi
+
     echo "`date`: Starting a '$MAKE check' for quick sanity test of the products built with the current compiler and standards"
     $CI_TIME $MAKE $MAKE_FLAGS_QUIET check \
     && echo "`date`: SUCCESS" \

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -174,7 +174,7 @@ esac
 
 # Just in case we get blanks from CI - consider them as not-set:
 if [ -z "`echo "${MAKE-}" | tr -d ' '`" ] ; then
-    if [ "$1" = spellcheck -o "$1" = spellcheck-interactive ] \
+    if [ "$1" = spellcheck -o "$1" = spellcheck-interactive -o "$1" = spellcheck-quick -o "$1" = spellcheck-interactive-quick ] \
     && (command -v gmake) >/dev/null 2>/dev/null \
     ; then
         # GNU make processes quiet mode better, which helps with spellcheck use-case
@@ -1403,7 +1403,7 @@ if [ -z "$BUILD_TYPE" ] ; then
 
         win|windows|cross-windows-mingw) BUILD_TYPE="cross-windows-mingw" ; shift ;;
 
-        spellcheck|spellcheck-interactive)
+        spellcheck|spellcheck-interactive|spellcheck-quick|spellcheck-interactive-quick)
             # Note: this is a little hack to reduce typing
             # and scrolling in (docs) developer iterations.
             case "$CI_OS_NAME" in
@@ -1433,7 +1433,7 @@ if [ -z "$BUILD_TYPE" ] ; then
                 if [ "$1" = spellcheck-interactive ] ; then
                     echo "Only CI-building 'spellcheck', please do the interactive part manually if needed" >&2
                 fi
-                BUILD_TYPE="default-spellcheck"
+                BUILD_TYPE="default-spellcheck-quick"
                 shift
             fi
             ;;
@@ -1455,7 +1455,7 @@ echo "LONG_BIT:`getconf LONG_BIT` WORD_BIT:`getconf WORD_BIT`" || true
 if command -v xxd >/dev/null ; then xxd -c 1 -l 6 | tail -1; else if command -v od >/dev/null; then od -N 1 -j 5 -b | head -1 ; else hexdump -s 5 -n 1 -C | head -1; fi; fi < /bin/ls 2>/dev/null | awk '($2 == 1){print "Endianness: LE"}; ($2 == 2){print "Endianness: BE"}' || true
 
 case "$BUILD_TYPE" in
-default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-spellcheck|default-shellcheck|default-nodoc|default-withdoc|default-withdoc:man|"default-tgt:"*)
+default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-spellcheck|default-spellcheck-quick|default-shellcheck|default-nodoc|default-withdoc|default-withdoc:man|"default-tgt:"*)
     LANG=C
     LC_ALL=C
     export LANG LC_ALL
@@ -1620,7 +1620,7 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
             CONFIG_OPTS+=("--disable-spellcheck")
             DO_DISTCHECK=no
             ;;
-        "default-spellcheck"|"default-shellcheck")
+        "default-spellcheck"|"default-spellcheck-quick"|"default-shellcheck")
             CONFIG_OPTS+=("--with-all=no")
             CONFIG_OPTS+=("--with-libltdl=no")
             CONFIG_OPTS+=("--with-doc=man=skip")
@@ -1869,14 +1869,14 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
             echo "=== Exiting after the custom-build target '$MAKE $BUILD_TGT' succeeded OK"
             exit 0
             ;;
-        "default-spellcheck")
+        "default-spellcheck"|"default-spellcheck-quick")
             [ -z "$CI_TIME" ] || echo "`date`: Trying to spellcheck documentation of the currently tested project..."
             # Note: use the root Makefile's spellcheck recipe which goes into
             # sub-Makefiles known to check corresponding directory's doc files.
             # Note: no PARMAKE_FLAGS here - better have this output readably
             # ordered in case of issues (in sequential replay below).
             ( echo "`date`: Starting the quiet build attempt for target $BUILD_TYPE..." >&2
-              $CI_TIME $MAKE $MAKE_FLAGS_QUIET SPELLCHECK_ERROR_FATAL=yes -k $PARMAKE_FLAGS spellcheck >/dev/null 2>&1 \
+              $CI_TIME $MAKE $MAKE_FLAGS_QUIET SPELLCHECK_ERROR_FATAL=yes -k $PARMAKE_FLAGS "`echo "$BUILD_TYPE" | sed 's,^default-,,'`" >/dev/null 2>&1 \
               && echo "`date`: SUCCEEDED the spellcheck" >&2
             ) || \
             ( echo "`date`: FAILED something in spellcheck above; re-starting a verbose build attempt to give more context first:" >&2

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -398,7 +398,7 @@ optional_prepare_compiler_family() {
 
     if [ -n "$CPP" ] ; then
         # Note: can be a multi-token name like "clang -E" or just not a full pathname
-        ( [ -x "$CPP" ] || $CPP --help >/dev/null 2>/dev/null ) && export CPP
+        ( [ -x "$CPP" ] || $CPP --help >/dev/null 2>/dev/null || { RES=$?; echo "FAILED to look up CPP='$CPP'" >&2 ; exit $RES; } ) && export CPP
     else
         # Avoid "cpp" directly as it may be too "traditional"
         case "$COMPILER_FAMILY" in

--- a/clients/Makefile.am
+++ b/clients/Makefile.am
@@ -112,7 +112,7 @@ endif WITH_SSL
 # object .so names would differ)
 
 # libupsclient version information
-libupsclient_la_LDFLAGS = -version-info 6:2:0
+libupsclient_la_LDFLAGS = -version-info 7:0:0
 libupsclient_la_LDFLAGS += -export-symbols-regex '^(upscli_|nut_debug_level)'
 #|s_upsdebug|fatalx|fatal_with_errno|xcalloc|xbasename|print_banner_once)'
 if HAVE_WINDOWS

--- a/configure.ac
+++ b/configure.ac
@@ -4120,7 +4120,7 @@ AC_MSG_RESULT([${solarispkg_ips}])
 AM_CONDITIONAL(WITH_SOLARIS_PKG_IPS, test x"$solarispkg_ips" = x"yes")
 
 
-dnl NOTE: Be sure to customize e.g.  --datarootdir=/usr/share/nut to install
+dnl NOTE: Be sure to customize e.g.  --datadir=/usr/share/nut to install
 dnl these scripts not into default location as e.g. /usr/share/solaris-smf
 AC_MSG_CHECKING(whether to install Solaris SMF files)
 solarissmf="auto"

--- a/configure.ac
+++ b/configure.ac
@@ -6231,3 +6231,13 @@ AS_IF([test -s "${ABS_TOP_SRCDIR}/install-sh" && grep -w MKDIRPROG "${ABS_TOP_SR
 		 AC_MSG_WARN([=====================================================])
 	])
 ])
+
+AS_IF([test x"${NUT_VERSION_DEPLOYED-}" = x"<reenter>"], [
+	AC_MSG_NOTICE([==========================================================])
+	AC_MSG_NOTICE([You have configured a build for "in-place" replacement])
+	AC_MSG_NOTICE([of an existing NUT installation. You are advised to first])
+	AC_MSG_NOTICE([install into a temporary DESTDIR and verify the fliesystem])
+	AC_MSG_NOTICE([layout of the new build against what you already have.])
+	AC_MSG_NOTICE([Check INSTALL.nut.adoc for practical details and example.])
+	AC_MSG_NOTICE([==========================================================])
+])

--- a/configure.ac
+++ b/configure.ac
@@ -483,8 +483,24 @@ AS_IF([test x"$nut_enable_inplace_runtime" = xyes -a x"${NUT_VERSION_DEPLOYED-}"
     eval conftemp=\"${conftemp}\"
     PREFIX_BINDIR="${conftemp}"
 
+    dnl Not-set CGI or DRV paths would be defaulted in due time,
+    dnl probably to bindir. Do not enforce any opinions here.
+    conftemp="${with_cgipath}"
+    eval conftemp=\"${conftemp}\"
+    eval conftemp=\"${conftemp}\"
+    PREFIX_CGIDIR="${conftemp}"
+    AS_CASE([${PREFIX_CGIDIR}], [yes|no], [PREFIX_CGIDIR=""])
+
+    conftemp="${with_drvpath}"
+    eval conftemp=\"${conftemp}\"
+    eval conftemp=\"${conftemp}\"
+    PREFIX_DRVDIR="${conftemp}"
+    AS_CASE([${PREFIX_DRVDIR}], [yes|no], [PREFIX_DRVDIR=""])
+
     DEPLOYED_SBINDIR="${PREFIX_SBINDIR}"
     DEPLOYED_BINDIR="${PREFIX_BINDIR}"
+    DEPLOYED_CGIDIR="${PREFIX_CGIDIR}"
+    DEPLOYED_DRVDIR="${PREFIX_DRVDIR}"
     dnl Note use of AC_PATH_PROG for specific pathname (not AC_CHECK_PROGS which picks filename variants)!
     dnl Note: "ordinary" users might not have "sbin" in their default PATH, so appending it:
     dnl Note: in some systems, the file in PATH is a shell
@@ -492,6 +508,10 @@ AS_IF([test x"$nut_enable_inplace_runtime" = xyes -a x"${NUT_VERSION_DEPLOYED-}"
     AC_PATH_PROG([DEPLOYED_UPSD], [upsd], [], [${PREFIX_SBINDIR}:${PATH}:/sbin:/usr/sbin:/usr/local/sbin])
     dnl ...however "upsc" is a userland tool so should be there:
     AC_PATH_PROG([DEPLOYED_UPSC], [upsc], [], [${PREFIX_BINDIR}:${PATH}])
+    dnl Assume some driver that is commonly/always installed; check also Debian-ish packaged locations:
+    AC_PATH_PROG([DEPLOYED_DUMMYUPS], [dummy-ups], [], [${PREFIX_DRVDIR}:${PREFIX_BINDIR}:${PATH}:/usr/lib/nut:/lib/nut])
+    dnl The CGI client suite is very optional, may well be absent:
+    AC_PATH_PROG([DEPLOYED_UPSIMAGE], [upsimage.cgi], [], [${PREFIX_CGIDIR}:${PREFIX_BINDIR}:${PATH}:/usr/lib/cgi-bin/nut:/usr/libexec/cgi-bin/nut:/usr/libexec/nut:/usr/libexec/nut/cgi-bin:/usr/lib/nut:/usr/lib/nut/cgi-bin])
     AS_IF([test -x "${DEPLOYED_UPSD}"], [
         AX_REALPATH([$DEPLOYED_UPSD], [DEPLOYED_UPSD])
         DEPLOYED_SBINDIR="`dirname "${DEPLOYED_UPSD}"`"
@@ -499,6 +519,14 @@ AS_IF([test x"$nut_enable_inplace_runtime" = xyes -a x"${NUT_VERSION_DEPLOYED-}"
     AS_IF([test -x "${DEPLOYED_UPSC}"], [
         AX_REALPATH([$DEPLOYED_UPSC], [DEPLOYED_UPSC])
         DEPLOYED_BINDIR="`dirname "${DEPLOYED_UPSC}"`"
+        ])
+    AS_IF([test -x "${DEPLOYED_DUMMYUPS}"], [
+        AX_REALPATH([$DEPLOYED_DUMMYUPS], [DEPLOYED_DUMMYUPS])
+        DEPLOYED_DRVDIR="`dirname "${DEPLOYED_DUMMYUPS}"`"
+        ])
+    AS_IF([test -x "${DEPLOYED_UPSIMAGE}"], [
+        AX_REALPATH([$DEPLOYED_UPSIMAGE], [DEPLOYED_UPSIMAGE])
+        DEPLOYED_CGIDIR="`dirname "${DEPLOYED_UPSIMAGE}"`"
         ])
 
     DEPLOYED_PREFIX=""
@@ -508,15 +536,22 @@ AS_IF([test x"$nut_enable_inplace_runtime" = xyes -a x"${NUT_VERSION_DEPLOYED-}"
             [DEPLOYED_PREFIX="`dirname "${DEPLOYED_BINDIR}"`"])]
     )
 
+    AC_PATH_PROG([LDD], [ldd])
+
     AC_MSG_CHECKING([for CONFIG_FLAGS of an already deployed NUT build (if it reports those)])
 
     CONFIG_FLAGS_DEPLOYED=""
     NUT_VERSION_DEPLOYED=""
+    DEPLOYED_LIBDIR=""
     dnl TODO: Similar query can be done for BINDIR tools
     dnl and for libupsclient-config if deployed locally
+    dnl First check upsc, dummy-ups or nut-scanner (TBD)
+    dnl to detect not only version and CONFIG_OPTS but
+    dnl also the shared library location the best we can.
     for DEPLOYED_TOOL in \
-        "${DEPLOYED_UPSD}" \
         "${DEPLOYED_UPSC}" \
+        "${DEPLOYED_DUMMYUPS}" \
+        "${DEPLOYED_UPSD}" \
     ; do
         AS_IF([test x"${DEPLOYED_TOOL}" = x], [continue])
         AS_IF([test -x "${DEPLOYED_TOOL}"], [], [continue])
@@ -534,6 +569,18 @@ AS_IF([test x"$nut_enable_inplace_runtime" = xyes -a x"${NUT_VERSION_DEPLOYED-}"
         && test x"${NUT_VERSION_DEPLOYED}" != x \
         || NUT_VERSION_DEPLOYED=""
 
+        dnl FIXME: Find some more portable solution? Use a platform-dependent
+        dnl  "case" or various toolkits?
+        dnl  * Probably no need to fuss for Windows builds, as they would
+        dnl    anyway use the DLL near EXE after installation.
+        AS_IF([test -x "${LDD}" 2>/dev/null], [
+            for TOKEN in `$LDD "${DEPLOYED_TOOL}" 2>&1 | grep libupsclient` ; do
+                case "${TOKEN}" in
+                    /*/libupsclient*) DEPLOYED_LIBDIR="`dirname "$TOKEN"`" ;;
+                esac
+            done
+        ])
+
         AS_IF([test x"${CONFIG_FLAGS_DEPLOYED}${NUT_VERSION_DEPLOYED}" = x], [], [break])
     done
 
@@ -544,25 +591,110 @@ AS_IF([test x"$nut_enable_inplace_runtime" = xyes -a x"${NUT_VERSION_DEPLOYED-}"
     ])
 
     dnl Account for custom paths if known/found:
+    AS_CASE(["${CONFIG_FLAGS_DEPLOYED} ${CONFIG_FLAGS}"],
+        [*--prefix=*], [
+            for F in ${CONFIG_FLAGS_DEPLOYED} ${CONFIG_FLAGS} ; do
+                case "$F" in
+                    "--prefix="*) prefix="`echo "$F" | ( IFS='=' read K V ; echo "$V" )`" ;;
+                esac
+            done
+        ]
+    )
+
     AS_IF([test x"${DEPLOYED_PREFIX}" != x && test x"${DEPLOYED_PREFIX}" != x"${prefix}"],
         AC_MSG_WARN([Deployed NUT installation uses a PREFIX different from one specified (wins) or derived (loses) for this build: '${DEPLOYED_PREFIX}' vs. '${prefix}'])
         [AS_CASE(["${CONFIG_FLAGS_DEPLOYED} ${CONFIG_FLAGS}"],
             [*--prefix=*], [],
-            [CONFIG_FLAGS_DEPLOYED="${CONFIG_FLAGS_DEPLOYED} --prefix='${DEPLOYED_PREFIX}'"])
+            [CONFIG_FLAGS_DEPLOYED="${CONFIG_FLAGS_DEPLOYED} --prefix='${DEPLOYED_PREFIX}'"
+             dnl Help re-evaluate it from verbatim defaults in later
+             dnl deployed path determinations e.g. for data(root)dir:
+             prefix="${DEPLOYED_PREFIX}"
+        ])
     ])
+    dnl FIXME? Re-evaluate cgipath and/or drvpath if they are defined with a
+    dnl verbatim '${prefix}' inside, and no hits found in earlier attempts?
 
     AS_IF([test x"${DEPLOYED_SBINDIR}" != x && test x"${DEPLOYED_SBINDIR}" != x"${PREFIX_SBINDIR}"],
-        AC_MSG_WARN([Deployed NUT installation uses a SBINDIR different from one specified (wins) or derived (loses) for this build: '${DEPLOYED_SBINDIR}' vs. '${sbindir}'])
+        AC_MSG_WARN([Deployed NUT installation uses a SBINDIR different from one specified (wins) or derived (loses) for this build: '${DEPLOYED_SBINDIR}' vs. '${PREFIX_SBINDIR}' ('${sbindir}')])
         [AS_CASE(["${CONFIG_FLAGS_DEPLOYED} ${CONFIG_FLAGS}"],
             [*--sbindir=*], [],
             [CONFIG_FLAGS_DEPLOYED="${CONFIG_FLAGS_DEPLOYED} --sbindir='${DEPLOYED_SBINDIR}'"])
     ])
 
     AS_IF([test x"${DEPLOYED_BINDIR}" != x && test x"${DEPLOYED_BINDIR}" != x"${PREFIX_BINDIR}"],
-        AC_MSG_WARN([Deployed NUT installation uses a BINDIR different from one specified (wins) or derived (loses) for this build: '${DEPLOYED_BINDIR}' vs. '${bindir}'])
+        AC_MSG_WARN([Deployed NUT installation uses a BINDIR different from one specified (wins) or derived (loses) for this build: '${DEPLOYED_BINDIR}' vs. '${PREFIX_BINDIR}' ('${bindir}')])
         [AS_CASE(["${CONFIG_FLAGS_DEPLOYED} ${CONFIG_FLAGS}"],
             [*--bindir=*], [],
             [CONFIG_FLAGS_DEPLOYED="${CONFIG_FLAGS_DEPLOYED} --bindir='${DEPLOYED_BINDIR}'"])
+    ])
+
+    AS_IF([test x"${DEPLOYED_CGIDIR}" != x && test x"${DEPLOYED_CGIDIR}" != x"${PREFIX_CGIDIR}"],
+        AC_MSG_WARN([Deployed NUT installation uses a CGIDIR different from one specified (wins) or derived (loses) for this build: '${DEPLOYED_CGIDIR}' vs. '${PREFIX_CGIDIR}' ('${with_cgipath}')])
+        [AS_CASE(["${CONFIG_FLAGS_DEPLOYED} ${CONFIG_FLAGS}"],
+            [*--with-cgipath=*], [],
+            [CONFIG_FLAGS_DEPLOYED="${CONFIG_FLAGS_DEPLOYED} --with-cgipath='${DEPLOYED_CGIDIR}'"])
+    ])
+
+    AS_IF([test x"${DEPLOYED_DRVDIR}" != x && test x"${DEPLOYED_DRVDIR}" != x"${PREFIX_DRVDIR}"],
+        AC_MSG_WARN([Deployed NUT installation uses a DRVDIR different from one specified (wins) or derived (loses) for this build: '${DEPLOYED_DRVDIR}' vs. '${PREFIX_DRVDIR}' ('${with_drvpath}')])
+        [AS_CASE(["${CONFIG_FLAGS_DEPLOYED} ${CONFIG_FLAGS}"],
+            [*--with-drvpath=*], [],
+            [CONFIG_FLAGS_DEPLOYED="${CONFIG_FLAGS_DEPLOYED} --with-drvpath='${DEPLOYED_DRVDIR}'"])
+    ])
+
+
+    AS_CASE(["${CONFIG_FLAGS_DEPLOYED} ${CONFIG_FLAGS}"],
+        [*--datarootdir=*], [
+            for F in ${CONFIG_FLAGS_DEPLOYED} ${CONFIG_FLAGS} ; do
+                case "$F" in
+                    "--datarootdir="*) datarootdir="`echo "$F" | ( IFS='=' read K V ; echo "$V" )`" ;;
+                esac
+            done
+        ]
+    )
+
+    conftemp="${datarootdir}"
+    eval conftemp=\"${conftemp}\"
+    eval conftemp=\"${conftemp}\"
+    PREFIX_DATAROOTDIR="${conftemp}"
+    dnl The dataroot dir (system-wide) here is used to search for datadir candidate info
+
+    AS_CASE(["${CONFIG_FLAGS_DEPLOYED} ${CONFIG_FLAGS}"],
+        [*--datadir=*], [
+            for F in ${CONFIG_FLAGS_DEPLOYED} ${CONFIG_FLAGS} ; do
+                case "$F" in
+                    "--datadir="*) datadir="`echo "$F" | ( IFS='=' read K V ; echo "$V" )`" ;;
+                esac
+            done
+        ]
+    )
+
+    conftemp="${datadir}"
+    eval conftemp=\"${conftemp}\"
+    eval conftemp=\"${conftemp}\"
+    PREFIX_DATADIR="${conftemp}"
+    DATADIR="${PREFIX_DATADIR}"
+    DEPLOYED_DATADIR=""
+
+    AS_IF([test -e "${PREFIX_DATAROOTDIR}/nut/cmdvartab" || test -e "${PREFIX_DATAROOTDIR}/nut/driver.list"],
+        [DEPLOYED_DATADIR="${PREFIX_DATAROOTDIR}/nut"],
+        [AS_IF([test -e "${PREFIX_DATAROOTDIR}/cmdvartab" || test -e "${PREFIX_DATAROOTDIR}/driver.list"],
+            [DEPLOYED_DATADIR="${PREFIX_DATAROOTDIR}"],
+            [dnl FIXME: Be careful on WIN32 and its "find" vs. that in MINGW?
+             DEPLOYED_DATADIR="`find "${PREFIX_DATAROOTDIR}" -name cmdvartab | head -1 | sed 's,/@<:@^/@:>@*$,,'`" || DEPLOYED_DATADIR=""
+             AS_IF([test -z "${DEPLOYED_DATADIR}"], [DEPLOYED_DATADIR="`find "${PREFIX_DATAROOTDIR}" -name driver.list | head -1 | sed 's,/@<:@^/@:>@*$,,'`" || DEPLOYED_DATADIR=""])
+            ]
+        )]
+    )
+    AS_IF([test -z "${DEPLOYED_DATADIR}" && test -d "${PREFIX_DATAROOTDIR}/nut"], [DEPLOYED_DATADIR="${PREFIX_DATAROOTDIR}/nut"])
+
+    AS_IF([test x"${DEPLOYED_DATADIR}" != x && test x"${DEPLOYED_DATADIR}" != x"${PREFIX_DATADIR}"],
+        AC_MSG_WARN([Deployed NUT installation uses a DATADIR different from one specified (wins) or derived (loses) for this build: '${DEPLOYED_DATADIR}' vs. '${PREFIX_DATADIR}' ('${datadir}')])
+        [AS_CASE(["${CONFIG_FLAGS_DEPLOYED} ${CONFIG_FLAGS}"],
+            [*--datadir=*], [],
+            [CONFIG_FLAGS_DEPLOYED="${CONFIG_FLAGS_DEPLOYED} --datadir='${DEPLOYED_DATADIR}'"
+             DATADIR="${DEPLOYED_DATADIR}"
+            ])
     ])
 
     AS_CASE(["${CONFIG_FLAGS_DEPLOYED} ${CONFIG_FLAGS}"],
@@ -579,7 +711,14 @@ AS_IF([test x"$nut_enable_inplace_runtime" = xyes -a x"${NUT_VERSION_DEPLOYED-}"
         dnl NOTE: Single-quotes are correct for autotools default,
         dnl expanded at runtime (see conftemp tricks below)
 
-        AC_MSG_CHECKING([for in-place replacement default sysconfdir (better than '${sysconfdir}')])
+        conftemp="${sysconfdir}"
+        eval conftemp=\"${conftemp}\"
+        eval conftemp=\"${conftemp}\"
+        dnl Evaluated here for the message; CONFPATH will be re-evaluated
+        dnl below, after we decide on the sysconfdir value we really like.
+        PREFIX_SYSCONFDIR="${conftemp}"
+
+        AC_MSG_CHECKING([for in-place replacement default sysconfdir, better than '${PREFIX_SYSCONFDIR}' ('${sysconfdir}')])
         DEPLOYED_SYSCONFDIR=""
 
         dnl TODO: Any more reasonable defaults? Pile them on here :)
@@ -633,7 +772,17 @@ AS_IF([test x"$nut_enable_inplace_runtime" = xyes -a x"${NUT_VERSION_DEPLOYED-}"
     conftemp="${libdir}"
     eval conftemp=\"${conftemp}\"
     eval conftemp=\"${conftemp}\"
-    LIBDIR="${conftemp}"
+    PREFIX_LIBDIR="${conftemp}"
+    LIBDIR="${PREFIX_LIBDIR}"
+
+    AS_IF([test x"${DEPLOYED_LIBDIR}" != x && test x"${DEPLOYED_LIBDIR}" != x"${PREFIX_LIBDIR}"],
+        AC_MSG_WARN([Deployed NUT installation uses a LIBDIR different from one specified (wins) or derived (loses) for this build: '${DEPLOYED_LIBDIR}' vs. '${PREFIX_LIBDIR}' ('${libdir}')])
+        [AS_CASE(["${CONFIG_FLAGS_DEPLOYED} ${CONFIG_FLAGS}"],
+            [*--libdir=*], [],
+            [CONFIG_FLAGS_DEPLOYED="${CONFIG_FLAGS_DEPLOYED} --libdir='${DEPLOYED_LIBDIR}'"
+             LIBDIR="${DEPLOYED_LIBDIR}"
+            ])
+    ])
 
     AS_CASE(["${CONFIG_FLAGS_DEPLOYED} ${CONFIG_FLAGS}"],
         [*--libexecdir=*], [
@@ -760,7 +909,7 @@ AS_IF([test x"$nut_enable_inplace_runtime" = xyes -a x"${NUT_VERSION_DEPLOYED-}"
     ])
 
     AS_IF([test x"${CONFIG_FLAGS_DEPLOYED}" != x], [
-        AC_MSG_NOTICE([Detected CONFIG_FLAGS of an already deployed NUT installation, using them for --inplace-runtime configuration (restarting script)])
+        AC_MSG_NOTICE([Detected CONFIG_FLAGS for an already deployed NUT installation, using them for --inplace-runtime configuration (restarting script)])
         dnl For multiply-specified flags with conflicting values, last mention wins:
         AC_MSG_NOTICE([exec "$0" $CONFIG_FLAGS_DEPLOYED $CONFIG_FLAGS --disable-inplace-runtime])
         AS_IF([test x"${NUT_VERSION_DEPLOYED}" != x], [

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -758,6 +758,8 @@ GENERATE_PDF = ( \
 )
 
 *.pdf: docinfo.xml
+# Technically only needed for PDF generation, but some other recipes still complained
+qa-guide.adoc-prepped \
 qa-guide.pdf: docinfo-since-v2.8.3.xml qa-guide-docinfo.xml
 .txt-prepped.pdf:
 	@$(GENERATE_PDF)

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -805,9 +805,17 @@ at run time.
 	--datadir=PATH
 
 Change the data directory, i.e., where architecture independent
-read-only data is installed.  By default this is `<prefix>/share`,
-i.e. `/usr/local/ups/share`.  At the moment, this directory only
-holds two files -- the optional `cmdvartab` and `driver.list`.
+read-only data for the currently built project is installed.
+By GNU Autotools default, this is `<prefix>/share` (same as the
+system-wide "data root" which we also consult for third-party data
+such as Augeas lens delivery locations), i.e. `/usr/local/ups/share`.
++
+Typically this is reconfigured to a `'${datarootdir}/nut'` value.
++
+At the moment, this directory only holds two files by default -- the
+optional `cmdvartab` and `driver.list`, but may hold additional data
+on certain systems (e.g. FreeBSD quirks, Solaris SMF or init methods,
+sometimes documentation).
 
 	--mandir=PATH
 

--- a/docs/maintainer-guide.txt
+++ b/docs/maintainer-guide.txt
@@ -90,6 +90,15 @@ MAINTAINER SANDBOX (to be completed and pushed)
   and nut-website building and checking, and with maintainer GPG keys in
   the chain
 
+NOTE: DO NOT RUSH to issue the release right away. There are always some
+last-minute discoveries and days/weeks of delays before a perfect release
+does ultimately happen. Use `vX.Y.Z-rcN` tags until completely certain that
+a release is final (perhaps by tagging the last RC with `vX.Y.Z` later).
+Note that some third-party tools like PyPI repo do not permit replacing
+artifacts associated with a particular release version/tag, and changing
+Git tags on public repositories is generally considered as a bad practice.
+So best to avoid it in the first place.
+
 * clean up "in-development" bits from files (which we would revert after
   release), e.g.:
 ** TODO etc. referring planned future in the `NEWS.adoc` and `UPDATING.adoc`

--- a/docs/maintainer-guide.txt
+++ b/docs/maintainer-guide.txt
@@ -116,6 +116,20 @@ So best to avoid it in the first place.
 :; git commit -sm 'NEWS.adoc, UPGRADING.adoc, docs/docinfo.xml.in: finalize text before NUT v2.8.0 release'
 ----
 
+* revise the lists of symbols exported by shared libraries delivered by NUT:
+  some changes may be seen right in the respective `Makefile.am`, but since
+  we use regular expressions, the set of method names may change between
+  releases implicitly. Use `nm` or similar tools to review symbols exposed
+  on an older build and the newer ones. For version bump algorithm consult
+  https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
+  (since we are likely to change common source code between releases, the
+  "revision" is likely to increment always, to reflect that the library was
+  rebuilt from different sources -- unless we bump "current" instead and
+  reset "revision" to 0 due to new symbols).
++
+TODO: Maintain proper library scripts (maybe in Git) with exact lists of
+symbol names and API versions, similar to what `GNUC` or `SUNW` libraries do.
+
 * revise the contents of `NEWS.adoc` and `UPDATING.adoc` files; verify that
   any recent changes to drivers (including `main.c` and other major impact
   from common code) and sub-drivers (`*-hid.c` for `usbhid-ups`, `*-mib.c`

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3454 utf-8
+personal_ws-1.1 en 3455 utf-8
 AAC
 AAS
 ABI
@@ -1845,6 +1845,7 @@ datadir
 datagrams
 datalink
 dataok
+datarootdir
 dataset
 datasets
 datasheet

--- a/tools/nut-scanner/Makefile.am
+++ b/tools/nut-scanner/Makefile.am
@@ -99,7 +99,7 @@ libnutscan_la_LDFLAGS += @NETLIBS_GETADDRS@
 # object .so names would differ)
 #
 # libnutscan version information
-libnutscan_la_LDFLAGS += -version-info 2:6:0
+libnutscan_la_LDFLAGS += -version-info 3:0:0
 
 # libnutscan exported symbols regex
 # WARNING: Since the library includes parts of libcommon (as much as needed


### PR DESCRIPTION
Also update docs and revise some nuances with `ci_build.sh` script.

Triggered by investigation for issue #2895

Also checks new worker revisions for `cross-mingw` and native Linux (both bumped to Ubuntu 25.04, with `clang-20` on the latter). A few manually-run builds with different conditions did not show up major surprises though.