### PR TITLE
upsmon: introduce OVERCRITICAL for OVER+NOCOMM states

### DIFF
--- a/INSTALL.nut.adoc
+++ b/INSTALL.nut.adoc
@@ -569,6 +569,19 @@ binaries that the package would put into an obscure location like
 would refer to new locations specified by the current build, so such old
 binaries would just consume disk space but not run.
 
+It is recommended to first try installing into a prototyping area, so you
+can review which files get delivered and perhaps which locations you may
+have to tune for a more tightly tailored replacement of an older (packaged)
+installation, in case whole swathes of files that you expect to be present
+in the current system (libraries, drivers, docs) are not getting installed
+by the new build into same path names:
+
+----
+:; rm -rf /tmp/nut ; make DESTDIR=/tmp/nut install -j 8
+:; (cd /tmp/nut && find . | sort) | while read N ; \
+   do [ -e "/$N" ] || echo "=== MISSING: /$N" >&2 ; done
+----
+
 Replacing any NUT deployment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/INSTALL.nut.adoc
+++ b/INSTALL.nut.adoc
@@ -206,7 +206,7 @@ To build NUT from a Git checkout you may need some additional tools
 (referenced just a bit below) and run `./autogen.sh` to generate the
 needed files. For common developer iterations, porting to new platforms,
 or in-place testing, running the `./ci_build.sh` script can be helpful.
-The "<<Installing_inplace,Building NUT for in‐place upgrades or non‐disruptive
+The "<<Installing_inplace,Building NUT for in-place upgrades or non-disruptive
 tests>>" section details some more hints about such workflow, including some
 `systemd` integration.
 
@@ -271,8 +271,8 @@ do this, you will have problems later on when you try to start upsd.
 Build and install
 ~~~~~~~~~~~~~~~~~
 
-NOTE: See also <<Installing_inplace,Building NUT for in‐place upgrades
-or non‐disruptive tests>>.
+NOTE: See also <<Installing_inplace,Building NUT for in-place upgrades
+or non-disruptive tests>>.
 
 [[Configuration]]
 Configuration
@@ -429,7 +429,7 @@ You are now ready to configure NUT, and start testing and using it.
 You can jump directly to the <<Configuration_notes,NUT configuration>>.
 
 [[Installing_inplace]]
-Building NUT for in‐place upgrades or non‐disruptive tests
+Building NUT for in-place upgrades or non-disruptive tests
 ----------------------------------------------------------
 
 NOTE: The NUT GitHub Wiki article at

--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -100,7 +100,7 @@ import org.nut.dynamatrix.*;
     // quietly for things that succeed, and summarizes errors in the end
     dynacfgPipeline['spellcheck_prepconf'] = false
     dynacfgPipeline['spellcheck_configure'] = false
-    dynacfgPipeline['spellcheck'] = '(BUILD_TYPE=default-spellcheck ./ci_build.sh)'
+    dynacfgPipeline['spellcheck'] = '(BUILD_TYPE=default-spellcheck-quick ./ci_build.sh)'
 
 /*
     // For older builds, with only autotools in the tree:

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -60,6 +60,11 @@ https://github.com/networkupstools/nut/milestone/11
      introduced in NUT v2.8.2 for the socket protocol (between driver and
      data server), by returning "ERR INVALID-ARGUMENT", so there is no change
      for the network protocol definition. [#2182]
+   * The `configure --enable-inplace-runtime` option added in NUT v2.8.1 should
+     now also try to detect and set default values for the `--with-drvpath`,
+     `--with-cgipath`, `--datadir` and `--libdir` options to more closely match
+     a packaged setup and avoid confusion with e.g. two incompatible NUT client
+     libraries in system default search path. [#2895]
 
  - Large parts of the NUT User Manual and NUT Developer Guide were relocated
    into the new NUT Quality Assurance and Build Automation Guide (maintained

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -392,7 +392,9 @@ This requirement compromises usability of `make distcheck` on platforms without
 
  - The `upsmon` client can now also report entering and exiting the `OVER`
    (UPS overloaded), `TRIM` and `BOOST` (adjusting for bad input voltage)
-   states. [#1074]
+   states. A setting `OVERDURATION` was introduced to define a timeout
+   after which a non-communicating UPS that was last seen in state `OVER`
+   should be considered critical (or not). [PR #1074, issue #2877]
 
  - Revised `upssched` timer handler that can be called from `upsmon` as its
    `NOTIFYCMD` to not report confusing environment variable values of

--- a/UPGRADING.adoc
+++ b/UPGRADING.adoc
@@ -88,6 +88,10 @@ Changes from 2.8.2 to 2.8.3
     positive values should time-limit the connection attempts), and
     `upscli_get_default_connect_timeout()` to retrieve its copy. [#2847]
 
+- API versions of `libupsclient` and `libnutscan` export more symbols now,
+  and so were bumped to new "current" numbers; this may impact the naming
+  of shared object files to be delivered by updated packaging. [#2895]
+
 - Standard NUT clients including `upsc`, `upscmd`, `upsrw`, `upslog`, `upsmon`,
   `upsimage`, `upsset` and `upsstats`) were updated to default with a 10-second
   connection establishment timeout in case of name resolution lags or

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -2532,7 +2532,8 @@ bindings)
 
     #$MAKE all || \
     $MAKE $PARMAKE_FLAGS all || exit
-    if [ "${CI_SKIP_CHECK}" != true ] ; then $MAKE check || exit ; fi
+    build_to_only_catch_errors_check
+    ### if [ "${CI_SKIP_CHECK}" != true ] ; then $MAKE check || exit ; fi
 
     case "$CI_OS_NAME" in
         windows*)

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -1169,6 +1169,15 @@ build_to_only_catch_errors_check() {
         return 0
     fi
 
+    # Lots of tedious touch-files to make, better run it in parallel separately.
+    # May report absence of "aspell" but would not fail in that case (just noise).
+    if grep "WITH_SPELLCHECK_TRUE=''" config.log >/dev/null 2>/dev/null ; then
+        echo "`date`: Starting a '$MAKE spellcheck-quick' first"
+        $CI_TIME $MAKE $MAKE_FLAGS_QUIET spellcheck-quick \
+        && echo "`date`: SUCCESS" \
+        || return $?
+    fi
+
     echo "`date`: Starting a '$MAKE check' for quick sanity test of the products built with the current compiler and standards"
     $CI_TIME $MAKE $MAKE_FLAGS_QUIET check \
     && echo "`date`: SUCCESS" \

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -174,7 +174,7 @@ esac
 
 # Just in case we get blanks from CI - consider them as not-set:
 if [ -z "`echo "${MAKE-}" | tr -d ' '`" ] ; then
-    if [ "$1" = spellcheck -o "$1" = spellcheck-interactive ] \
+    if [ "$1" = spellcheck -o "$1" = spellcheck-interactive -o "$1" = spellcheck-quick -o "$1" = spellcheck-interactive-quick ] \
     && (command -v gmake) >/dev/null 2>/dev/null \
     ; then
         # GNU make processes quiet mode better, which helps with spellcheck use-case
@@ -1403,7 +1403,7 @@ if [ -z "$BUILD_TYPE" ] ; then
 
         win|windows|cross-windows-mingw) BUILD_TYPE="cross-windows-mingw" ; shift ;;
 
-        spellcheck|spellcheck-interactive)
+        spellcheck|spellcheck-interactive|spellcheck-quick|spellcheck-interactive-quick)
             # Note: this is a little hack to reduce typing
             # and scrolling in (docs) developer iterations.
             case "$CI_OS_NAME" in
@@ -1433,7 +1433,7 @@ if [ -z "$BUILD_TYPE" ] ; then
                 if [ "$1" = spellcheck-interactive ] ; then
                     echo "Only CI-building 'spellcheck', please do the interactive part manually if needed" >&2
                 fi
-                BUILD_TYPE="default-spellcheck"
+                BUILD_TYPE="default-spellcheck-quick"
                 shift
             fi
             ;;
@@ -1455,7 +1455,7 @@ echo "LONG_BIT:`getconf LONG_BIT` WORD_BIT:`getconf WORD_BIT`" || true
 if command -v xxd >/dev/null ; then xxd -c 1 -l 6 | tail -1; else if command -v od >/dev/null; then od -N 1 -j 5 -b | head -1 ; else hexdump -s 5 -n 1 -C | head -1; fi; fi < /bin/ls 2>/dev/null | awk '($2 == 1){print "Endianness: LE"}; ($2 == 2){print "Endianness: BE"}' || true
 
 case "$BUILD_TYPE" in
-default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-spellcheck|default-shellcheck|default-nodoc|default-withdoc|default-withdoc:man|"default-tgt:"*)
+default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-spellcheck|default-spellcheck-quick|default-shellcheck|default-nodoc|default-withdoc|default-withdoc:man|"default-tgt:"*)
     LANG=C
     LC_ALL=C
     export LANG LC_ALL
@@ -1620,7 +1620,7 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
             CONFIG_OPTS+=("--disable-spellcheck")
             DO_DISTCHECK=no
             ;;
-        "default-spellcheck"|"default-shellcheck")
+        "default-spellcheck"|"default-spellcheck-quick"|"default-shellcheck")
             CONFIG_OPTS+=("--with-all=no")
             CONFIG_OPTS+=("--with-libltdl=no")
             CONFIG_OPTS+=("--with-doc=man=skip")
@@ -1869,14 +1869,14 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
             echo "=== Exiting after the custom-build target '$MAKE $BUILD_TGT' succeeded OK"
             exit 0
             ;;
-        "default-spellcheck")
+        "default-spellcheck"|"default-spellcheck-quick")
             [ -z "$CI_TIME" ] || echo "`date`: Trying to spellcheck documentation of the currently tested project..."
             # Note: use the root Makefile's spellcheck recipe which goes into
             # sub-Makefiles known to check corresponding directory's doc files.
             # Note: no PARMAKE_FLAGS here - better have this output readably
             # ordered in case of issues (in sequential replay below).
             ( echo "`date`: Starting the quiet build attempt for target $BUILD_TYPE..." >&2
-              $CI_TIME $MAKE $MAKE_FLAGS_QUIET SPELLCHECK_ERROR_FATAL=yes -k $PARMAKE_FLAGS spellcheck >/dev/null 2>&1 \
+              $CI_TIME $MAKE $MAKE_FLAGS_QUIET SPELLCHECK_ERROR_FATAL=yes -k $PARMAKE_FLAGS "`echo "$BUILD_TYPE" | sed 's,^default-,,'`" >/dev/null 2>&1 \
               && echo "`date`: SUCCEEDED the spellcheck" >&2
             ) || \
             ( echo "`date`: FAILED something in spellcheck above; re-starting a verbose build attempt to give more context first:" >&2

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -398,7 +398,7 @@ optional_prepare_compiler_family() {
 
     if [ -n "$CPP" ] ; then
         # Note: can be a multi-token name like "clang -E" or just not a full pathname
-        ( [ -x "$CPP" ] || $CPP --help >/dev/null 2>/dev/null ) && export CPP
+        ( [ -x "$CPP" ] || $CPP --help >/dev/null 2>/dev/null || { RES=$?; echo "FAILED to look up CPP='$CPP'" >&2 ; exit $RES; } ) && export CPP
     else
         # Avoid "cpp" directly as it may be too "traditional"
         case "$COMPILER_FAMILY" in

--- a/clients/Makefile.am
+++ b/clients/Makefile.am
@@ -112,7 +112,7 @@ endif WITH_SSL
 # object .so names would differ)
 
 # libupsclient version information
-libupsclient_la_LDFLAGS = -version-info 6:2:0
+libupsclient_la_LDFLAGS = -version-info 7:0:0
 libupsclient_la_LDFLAGS += -export-symbols-regex '^(upscli_|nut_debug_level)'
 #|s_upsdebug|fatalx|fatal_with_errno|xcalloc|xbasename|print_banner_once)'
 if HAVE_WINDOWS

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -122,6 +122,12 @@ static	int	exit_flag = 0;
 	/* set if ALARM status can cause UPS to become critical (e.g. when no-comms) */
 static	int	alarmcritical = 1;
 
+	/* Set the time (in seconds) after which OVER can result in a UPS to be
+	considered critical (e.g. when not communicating). Negative values will
+	prevent a UPS from ever becoming critical from overload. A value of zero
+	will have the UPS instantly be considered critical in such situations. */
+static int overdurationtime = -1;
+
 	/* userid for unprivileged process when using fork mode */
 static	char	*run_as_user = NULL;
 
@@ -1277,15 +1283,6 @@ static int is_ups_critical(utype_t *ups)
 	if (ups->commstate == 0) {
 		/* Note: ECO mode not considered easily fatal here */
 
-		/* FIXME: Consider equivalents of alarmcritical for over/trim/boost? */
-		if (flag_isset(ups->status, ST_OVER)) {
-			upslogx(LOG_WARNING,
-				"UPS [%s] was last known to be overloaded "
-				"and currently is not communicating, "
-				"but we make no assumptions if it is dead now",
-				ups->sys);
-		}
-
 		if (flag_isset(ups->status, ST_TRIM)) {
 			upslogx(LOG_WARNING,
 				"UPS [%s] was last known to be "
@@ -1302,6 +1299,36 @@ static int is_ups_critical(utype_t *ups)
 				"and currently is not communicating, "
 				"but we make no assumptions if it is dead now",
 				ups->sys);
+		}
+
+		if (ups->overstate == 1
+			|| flag_isset(ups->status, ST_OVER)) {
+				if (overdurationtime >= 0) {
+					if (now > 0 && (now - ups->oversince < overdurationtime)) {
+						upslogx(LOG_WARNING,
+							"UPS [%s] was last known to be overloaded "
+							"for %" PRIiMAX " sec out of %d sec threshold "
+							"and currently is not communicating, just so you "
+							"know (waiting for OVERDURATION to elapse)",
+							ups->sys,
+							(intmax_t)(now - ups->oversince),
+							overdurationtime);
+					} else {
+						upslogx(LOG_WARNING,
+							"UPS [%s] was last known to be overloaded "
+							"for longer than the set threshold of %d sec "
+							"and is still not communicating, assuming dead",
+							ups->sys,
+							overdurationtime);
+						return 1;
+					}
+				} else {
+					upslogx(LOG_WARNING,
+						"UPS [%s] was last known to be overloaded "
+						"and currently is not communicating, "
+						"but we make no assumptions if it is dead now",
+						ups->sys);
+				}
 		}
 
 		if (ups->alarmstate == 1
@@ -1599,10 +1626,25 @@ static void ups_is_notcal(utype_t *ups)
 
 static void ups_is_over(utype_t *ups)
 {
+	time_t	now;
+
+	time(&now);
+
 	if (flag_isset(ups->status, ST_OVER)) { 	/* no change */
 		upsdebugx(4, "%s: %s (no change)", __func__, ups->sys);
+		if (ups->oversince < 1) {
+			/* Should not happen, but just in case */
+			ups->oversince = now;
+		}
 		return;
 	}
+
+	if (overdurationtime >= 0) {
+		sleepval = pollfreqalert;	/* bump up polling frequency */
+	}
+
+	ups->oversince = now;
+	ups->overstate = 1;
 
 	upsdebugx(3, "%s: %s (first time)", __func__, ups->sys);
 
@@ -1615,6 +1657,9 @@ static void ups_is_over(utype_t *ups)
 static void ups_is_notover(utype_t *ups)
 {
 	/* Called when OVER is NOT among known states */
+	ups->oversince = 0;
+	ups->overstate = 0;
+
 	if (flag_isset(ups->status, ST_OVER)) {	/* actual change */
 		do_notify(ups, NOTIFY_NOTOVER, NULL);
 		clearflag(&ups->status, ST_OVER);
@@ -1940,6 +1985,7 @@ static void addups(int reloading, const char *sys, const char *pvs,
 	tmp->bypassstate = -1;
 	tmp->ecostate = -1;
 	tmp->alarmstate = -1;
+	tmp->overstate = -1;
 
 	/* forget poll-failure logging throttling */
 	tmp->pollfail_log_throttle_count = -1;
@@ -1952,6 +1998,7 @@ static void addups(int reloading, const char *sys, const char *pvs,
 
 	tmp->offsince = 0;
 	tmp->oblbsince = 0;
+	tmp->oversince = 0;
 
 	if (   (!strcasecmp(managerialOption, "primary"))
 	    || (!strcasecmp(managerialOption, "master"))  ) {
@@ -2183,6 +2230,12 @@ static int parse_conf_arg(size_t numargs, char **arg)
 	/* OFFDURATION <num> */
 	if (!strcmp(arg[0], "OFFDURATION")) {
 		offdurationtime = atoi(arg[1]);
+		return 1;
+	}
+
+	/* OVERDURATION <num> */
+	if (!strcmp(arg[0], "OVERDURATION")) {
+		overdurationtime = atoi(arg[1]);
 		return 1;
 	}
 

--- a/clients/upsmon.h
+++ b/clients/upsmon.h
@@ -83,6 +83,7 @@ typedef struct {
 					/* delays not implemented now	*/
 	int	alarmstate;		/* fire on a 0->1 transition;	*/
 					/* delays not implemented now	*/
+	int	overstate;		/* fire on a 0->1 transition;	*/
 
 	/* see detailed comment for pollfail_log_throttle_max in upsmon.c
 	 * about handling of poll failure log throttling (syslog storage I/O)
@@ -97,6 +98,7 @@ typedef struct {
 
 	time_t	offsince;		/* time of recent entry into OFF state	*/
 	time_t	oblbsince;		/* time of recent entry into OB LB state (normally this causes immediate shutdown alert, unless we are configured to delay it)	*/
+	time_t	oversince;		/* time of recent entry into OVER state	*/
 
 	void	*next;
 }	utype_t;
@@ -198,7 +200,7 @@ static struct {
 	{ NOTIFY_NOTTRIM,  "NOTTRIM",  NULL, "UPS %s: no longer trimming incoming voltage", NOTIFY_DEFAULT },
 	{ NOTIFY_BOOST,    "BOOST",    NULL, "UPS %s: boosting incoming voltage", NOTIFY_DEFAULT },
 	{ NOTIFY_NOTBOOST, "NOTBOOST", NULL, "UPS %s: no longer boosting incoming voltage", NOTIFY_DEFAULT },
-	
+
 	/* Special handling, two string placeholders!
 	 * Reported when status_tokens tree changes (and is not empty in the end) */
 	{ NOTIFY_OTHER,    "OTHER",    NULL, "UPS %s: has at least one unclassified status token: [%s]", NOTIFY_DEFAULT },

--- a/common/nutconf.cpp
+++ b/common/nutconf.cpp
@@ -1595,6 +1595,15 @@ void UpsmonConfigParser::onParseDirective(const std::string& directiveName, char
 				_config->forceSsl = bi;
 			}
 		}
+		else if(directiveName == "ALARMCRITICAL")
+		{
+			if(values.size()>0)
+			{
+				nut::BoolInt bi;
+				bi << values.front();
+				_config->alarmCritical = bi;
+			}
+		}
 		else if(directiveName == "HOSTSYNC")
 		{
 			if(values.size()>0)

--- a/common/nutconf.cpp
+++ b/common/nutconf.cpp
@@ -1532,6 +1532,13 @@ void UpsmonConfigParser::onParseDirective(const std::string& directiveName, char
 				_config->oblbDuration = StringToSettableNumber<int>(values.front());
 			}
 		}
+		else if(directiveName == "OVERDURATION")
+		{
+			if(values.size()>0)
+			{
+				_config->overDuration = StringToSettableNumber<int>(values.front());
+			}
+		}
 		else if(directiveName == "SHUTDOWNEXIT")
 		{
 			if(values.size()>0)

--- a/common/nutwriter.cpp
+++ b/common/nutwriter.cpp
@@ -625,6 +625,7 @@ NutWriter::status_t UpsmonConfigWriter::writeConfig(const UpsmonConfiguration & 
 	UPSMON_DIRECTIVEX("POLLFAIL_LOG_THROTTLE_MAX", int, config.pollFailLogThrottleMax,  false);
 	UPSMON_DIRECTIVEX("OFFDURATION",    int,          config.offDuration,    false);
 	UPSMON_DIRECTIVEX("OBLBDURATION",   int,          config.oblbDuration,   false);
+	UPSMON_DIRECTIVEX("OVERDURATION",   int,          config.overDuration,   false);
 	UPSMON_DIRECTIVEX("SHUTDOWNEXIT",   nut::BoolInt, config.shutdownExit,   false);
 
 	UPSMON_DIRECTIVEX("CERTPATH",       std::string,  config.certPath,       true);

--- a/common/nutwriter.cpp
+++ b/common/nutwriter.cpp
@@ -627,6 +627,7 @@ NutWriter::status_t UpsmonConfigWriter::writeConfig(const UpsmonConfiguration & 
 	UPSMON_DIRECTIVEX("OBLBDURATION",   int,          config.oblbDuration,   false);
 	UPSMON_DIRECTIVEX("OVERDURATION",   int,          config.overDuration,   false);
 	UPSMON_DIRECTIVEX("SHUTDOWNEXIT",   nut::BoolInt, config.shutdownExit,   false);
+	UPSMON_DIRECTIVEX("ALARMCRITICAL",  nut::BoolInt, config.alarmCritical,  false);
 
 	UPSMON_DIRECTIVEX("CERTPATH",       std::string,  config.certPath,       true);
 

--- a/conf/upsmon.conf.sample.in
+++ b/conf/upsmon.conf.sample.in
@@ -441,6 +441,25 @@ POWERDOWNFLAG "@POWERDOWNFLAG@"
 OFFDURATION 30
 
 # --------------------------------------------------------------------------
+# OVERDURATION - timeout after which OVER status can cause a critical UPS
+# OVERDURATION -1
+#
+# This setting handles how a UPS that is overloaded should be treated in
+# situations when it is not fully communicating. Because such a UPS may be
+# in a potentially severe state, some users may want their systems to be
+# shutdown either immediately or after a set timeout has elapsed. The
+# OVERDURATION setting defines this timeout (in seconds), after which an
+# overloaded UPS that is not communicating will be considered critical.
+#
+# A value of zero means the UPS will instantly be considered critical when
+# overloaded and not communicating. In case a negative value is set (the
+# default), such a UPS will never be considered critical, at least not
+# because of the overload itself.
+#
+
+OVERDURATION -1
+
+# --------------------------------------------------------------------------
 # OBLBDURATION - put "OB LB" state into effect if it persists for this many
 # seconds
 #

--- a/configure.ac
+++ b/configure.ac
@@ -4120,7 +4120,7 @@ AC_MSG_RESULT([${solarispkg_ips}])
 AM_CONDITIONAL(WITH_SOLARIS_PKG_IPS, test x"$solarispkg_ips" = x"yes")
 
 
-dnl NOTE: Be sure to customize e.g.  --datarootdir=/usr/share/nut to install
+dnl NOTE: Be sure to customize e.g.  --datadir=/usr/share/nut to install
 dnl these scripts not into default location as e.g. /usr/share/solaris-smf
 AC_MSG_CHECKING(whether to install Solaris SMF files)
 solarissmf="auto"

--- a/configure.ac
+++ b/configure.ac
@@ -6231,3 +6231,13 @@ AS_IF([test -s "${ABS_TOP_SRCDIR}/install-sh" && grep -w MKDIRPROG "${ABS_TOP_SR
 		 AC_MSG_WARN([=====================================================])
 	])
 ])
+
+AS_IF([test x"${NUT_VERSION_DEPLOYED-}" = x"<reenter>"], [
+	AC_MSG_NOTICE([==========================================================])
+	AC_MSG_NOTICE([You have configured a build for "in-place" replacement])
+	AC_MSG_NOTICE([of an existing NUT installation. You are advised to first])
+	AC_MSG_NOTICE([install into a temporary DESTDIR and verify the fliesystem])
+	AC_MSG_NOTICE([layout of the new build against what you already have.])
+	AC_MSG_NOTICE([Check INSTALL.nut.adoc for practical details and example.])
+	AC_MSG_NOTICE([==========================================================])
+])

--- a/configure.ac
+++ b/configure.ac
@@ -483,8 +483,24 @@ AS_IF([test x"$nut_enable_inplace_runtime" = xyes -a x"${NUT_VERSION_DEPLOYED-}"
     eval conftemp=\"${conftemp}\"
     PREFIX_BINDIR="${conftemp}"
 
+    dnl Not-set CGI or DRV paths would be defaulted in due time,
+    dnl probably to bindir. Do not enforce any opinions here.
+    conftemp="${with_cgipath}"
+    eval conftemp=\"${conftemp}\"
+    eval conftemp=\"${conftemp}\"
+    PREFIX_CGIDIR="${conftemp}"
+    AS_CASE([${PREFIX_CGIDIR}], [yes|no], [PREFIX_CGIDIR=""])
+
+    conftemp="${with_drvpath}"
+    eval conftemp=\"${conftemp}\"
+    eval conftemp=\"${conftemp}\"
+    PREFIX_DRVDIR="${conftemp}"
+    AS_CASE([${PREFIX_DRVDIR}], [yes|no], [PREFIX_DRVDIR=""])
+
     DEPLOYED_SBINDIR="${PREFIX_SBINDIR}"
     DEPLOYED_BINDIR="${PREFIX_BINDIR}"
+    DEPLOYED_CGIDIR="${PREFIX_CGIDIR}"
+    DEPLOYED_DRVDIR="${PREFIX_DRVDIR}"
     dnl Note use of AC_PATH_PROG for specific pathname (not AC_CHECK_PROGS which picks filename variants)!
     dnl Note: "ordinary" users might not have "sbin" in their default PATH, so appending it:
     dnl Note: in some systems, the file in PATH is a shell
@@ -492,6 +508,10 @@ AS_IF([test x"$nut_enable_inplace_runtime" = xyes -a x"${NUT_VERSION_DEPLOYED-}"
     AC_PATH_PROG([DEPLOYED_UPSD], [upsd], [], [${PREFIX_SBINDIR}:${PATH}:/sbin:/usr/sbin:/usr/local/sbin])
     dnl ...however "upsc" is a userland tool so should be there:
     AC_PATH_PROG([DEPLOYED_UPSC], [upsc], [], [${PREFIX_BINDIR}:${PATH}])
+    dnl Assume some driver that is commonly/always installed; check also Debian-ish packaged locations:
+    AC_PATH_PROG([DEPLOYED_DUMMYUPS], [dummy-ups], [], [${PREFIX_DRVDIR}:${PREFIX_BINDIR}:${PATH}:/usr/lib/nut:/lib/nut])
+    dnl The CGI client suite is very optional, may well be absent:
+    AC_PATH_PROG([DEPLOYED_UPSIMAGE], [upsimage.cgi], [], [${PREFIX_CGIDIR}:${PREFIX_BINDIR}:${PATH}:/usr/lib/cgi-bin/nut:/usr/libexec/cgi-bin/nut:/usr/libexec/nut:/usr/libexec/nut/cgi-bin:/usr/lib/nut:/usr/lib/nut/cgi-bin])
     AS_IF([test -x "${DEPLOYED_UPSD}"], [
         AX_REALPATH([$DEPLOYED_UPSD], [DEPLOYED_UPSD])
         DEPLOYED_SBINDIR="`dirname "${DEPLOYED_UPSD}"`"
@@ -499,6 +519,14 @@ AS_IF([test x"$nut_enable_inplace_runtime" = xyes -a x"${NUT_VERSION_DEPLOYED-}"
     AS_IF([test -x "${DEPLOYED_UPSC}"], [
         AX_REALPATH([$DEPLOYED_UPSC], [DEPLOYED_UPSC])
         DEPLOYED_BINDIR="`dirname "${DEPLOYED_UPSC}"`"
+        ])
+    AS_IF([test -x "${DEPLOYED_DUMMYUPS}"], [
+        AX_REALPATH([$DEPLOYED_DUMMYUPS], [DEPLOYED_DUMMYUPS])
+        DEPLOYED_DRVDIR="`dirname "${DEPLOYED_DUMMYUPS}"`"
+        ])
+    AS_IF([test -x "${DEPLOYED_UPSIMAGE}"], [
+        AX_REALPATH([$DEPLOYED_UPSIMAGE], [DEPLOYED_UPSIMAGE])
+        DEPLOYED_CGIDIR="`dirname "${DEPLOYED_UPSIMAGE}"`"
         ])
 
     DEPLOYED_PREFIX=""
@@ -508,15 +536,22 @@ AS_IF([test x"$nut_enable_inplace_runtime" = xyes -a x"${NUT_VERSION_DEPLOYED-}"
             [DEPLOYED_PREFIX="`dirname "${DEPLOYED_BINDIR}"`"])]
     )
 
+    AC_PATH_PROG([LDD], [ldd])
+
     AC_MSG_CHECKING([for CONFIG_FLAGS of an already deployed NUT build (if it reports those)])
 
     CONFIG_FLAGS_DEPLOYED=""
     NUT_VERSION_DEPLOYED=""
+    DEPLOYED_LIBDIR=""
     dnl TODO: Similar query can be done for BINDIR tools
     dnl and for libupsclient-config if deployed locally
+    dnl First check upsc, dummy-ups or nut-scanner (TBD)
+    dnl to detect not only version and CONFIG_OPTS but
+    dnl also the shared library location the best we can.
     for DEPLOYED_TOOL in \
-        "${DEPLOYED_UPSD}" \
         "${DEPLOYED_UPSC}" \
+        "${DEPLOYED_DUMMYUPS}" \
+        "${DEPLOYED_UPSD}" \
     ; do
         AS_IF([test x"${DEPLOYED_TOOL}" = x], [continue])
         AS_IF([test -x "${DEPLOYED_TOOL}"], [], [continue])
@@ -534,6 +569,18 @@ AS_IF([test x"$nut_enable_inplace_runtime" = xyes -a x"${NUT_VERSION_DEPLOYED-}"
         && test x"${NUT_VERSION_DEPLOYED}" != x \
         || NUT_VERSION_DEPLOYED=""
 
+        dnl FIXME: Find some more portable solution? Use a platform-dependent
+        dnl  "case" or various toolkits?
+        dnl  * Probably no need to fuss for Windows builds, as they would
+        dnl    anyway use the DLL near EXE after installation.
+        AS_IF([test -x "${LDD}" 2>/dev/null], [
+            for TOKEN in `$LDD "${DEPLOYED_TOOL}" 2>&1 | grep libupsclient` ; do
+                case "${TOKEN}" in
+                    /*/libupsclient*) DEPLOYED_LIBDIR="`dirname "$TOKEN"`" ;;
+                esac
+            done
+        ])
+
         AS_IF([test x"${CONFIG_FLAGS_DEPLOYED}${NUT_VERSION_DEPLOYED}" = x], [], [break])
     done
 
@@ -544,25 +591,110 @@ AS_IF([test x"$nut_enable_inplace_runtime" = xyes -a x"${NUT_VERSION_DEPLOYED-}"
     ])
 
     dnl Account for custom paths if known/found:
+    AS_CASE(["${CONFIG_FLAGS_DEPLOYED} ${CONFIG_FLAGS}"],
+        [*--prefix=*], [
+            for F in ${CONFIG_FLAGS_DEPLOYED} ${CONFIG_FLAGS} ; do
+                case "$F" in
+                    "--prefix="*) prefix="`echo "$F" | ( IFS='=' read K V ; echo "$V" )`" ;;
+                esac
+            done
+        ]
+    )
+
     AS_IF([test x"${DEPLOYED_PREFIX}" != x && test x"${DEPLOYED_PREFIX}" != x"${prefix}"],
         AC_MSG_WARN([Deployed NUT installation uses a PREFIX different from one specified (wins) or derived (loses) for this build: '${DEPLOYED_PREFIX}' vs. '${prefix}'])
         [AS_CASE(["${CONFIG_FLAGS_DEPLOYED} ${CONFIG_FLAGS}"],
             [*--prefix=*], [],
-            [CONFIG_FLAGS_DEPLOYED="${CONFIG_FLAGS_DEPLOYED} --prefix='${DEPLOYED_PREFIX}'"])
+            [CONFIG_FLAGS_DEPLOYED="${CONFIG_FLAGS_DEPLOYED} --prefix='${DEPLOYED_PREFIX}'"
+             dnl Help re-evaluate it from verbatim defaults in later
+             dnl deployed path determinations e.g. for data(root)dir:
+             prefix="${DEPLOYED_PREFIX}"
+        ])
     ])
+    dnl FIXME? Re-evaluate cgipath and/or drvpath if they are defined with a
+    dnl verbatim '${prefix}' inside, and no hits found in earlier attempts?
 
     AS_IF([test x"${DEPLOYED_SBINDIR}" != x && test x"${DEPLOYED_SBINDIR}" != x"${PREFIX_SBINDIR}"],
-        AC_MSG_WARN([Deployed NUT installation uses a SBINDIR different from one specified (wins) or derived (loses) for this build: '${DEPLOYED_SBINDIR}' vs. '${sbindir}'])
+        AC_MSG_WARN([Deployed NUT installation uses a SBINDIR different from one specified (wins) or derived (loses) for this build: '${DEPLOYED_SBINDIR}' vs. '${PREFIX_SBINDIR}' ('${sbindir}')])
         [AS_CASE(["${CONFIG_FLAGS_DEPLOYED} ${CONFIG_FLAGS}"],
             [*--sbindir=*], [],
             [CONFIG_FLAGS_DEPLOYED="${CONFIG_FLAGS_DEPLOYED} --sbindir='${DEPLOYED_SBINDIR}'"])
     ])
 
     AS_IF([test x"${DEPLOYED_BINDIR}" != x && test x"${DEPLOYED_BINDIR}" != x"${PREFIX_BINDIR}"],
-        AC_MSG_WARN([Deployed NUT installation uses a BINDIR different from one specified (wins) or derived (loses) for this build: '${DEPLOYED_BINDIR}' vs. '${bindir}'])
+        AC_MSG_WARN([Deployed NUT installation uses a BINDIR different from one specified (wins) or derived (loses) for this build: '${DEPLOYED_BINDIR}' vs. '${PREFIX_BINDIR}' ('${bindir}')])
         [AS_CASE(["${CONFIG_FLAGS_DEPLOYED} ${CONFIG_FLAGS}"],
             [*--bindir=*], [],
             [CONFIG_FLAGS_DEPLOYED="${CONFIG_FLAGS_DEPLOYED} --bindir='${DEPLOYED_BINDIR}'"])
+    ])
+
+    AS_IF([test x"${DEPLOYED_CGIDIR}" != x && test x"${DEPLOYED_CGIDIR}" != x"${PREFIX_CGIDIR}"],
+        AC_MSG_WARN([Deployed NUT installation uses a CGIDIR different from one specified (wins) or derived (loses) for this build: '${DEPLOYED_CGIDIR}' vs. '${PREFIX_CGIDIR}' ('${with_cgipath}')])
+        [AS_CASE(["${CONFIG_FLAGS_DEPLOYED} ${CONFIG_FLAGS}"],
+            [*--with-cgipath=*], [],
+            [CONFIG_FLAGS_DEPLOYED="${CONFIG_FLAGS_DEPLOYED} --with-cgipath='${DEPLOYED_CGIDIR}'"])
+    ])
+
+    AS_IF([test x"${DEPLOYED_DRVDIR}" != x && test x"${DEPLOYED_DRVDIR}" != x"${PREFIX_DRVDIR}"],
+        AC_MSG_WARN([Deployed NUT installation uses a DRVDIR different from one specified (wins) or derived (loses) for this build: '${DEPLOYED_DRVDIR}' vs. '${PREFIX_DRVDIR}' ('${with_drvpath}')])
+        [AS_CASE(["${CONFIG_FLAGS_DEPLOYED} ${CONFIG_FLAGS}"],
+            [*--with-drvpath=*], [],
+            [CONFIG_FLAGS_DEPLOYED="${CONFIG_FLAGS_DEPLOYED} --with-drvpath='${DEPLOYED_DRVDIR}'"])
+    ])
+
+
+    AS_CASE(["${CONFIG_FLAGS_DEPLOYED} ${CONFIG_FLAGS}"],
+        [*--datarootdir=*], [
+            for F in ${CONFIG_FLAGS_DEPLOYED} ${CONFIG_FLAGS} ; do
+                case "$F" in
+                    "--datarootdir="*) datarootdir="`echo "$F" | ( IFS='=' read K V ; echo "$V" )`" ;;
+                esac
+            done
+        ]
+    )
+
+    conftemp="${datarootdir}"
+    eval conftemp=\"${conftemp}\"
+    eval conftemp=\"${conftemp}\"
+    PREFIX_DATAROOTDIR="${conftemp}"
+    dnl The dataroot dir (system-wide) here is used to search for datadir candidate info
+
+    AS_CASE(["${CONFIG_FLAGS_DEPLOYED} ${CONFIG_FLAGS}"],
+        [*--datadir=*], [
+            for F in ${CONFIG_FLAGS_DEPLOYED} ${CONFIG_FLAGS} ; do
+                case "$F" in
+                    "--datadir="*) datadir="`echo "$F" | ( IFS='=' read K V ; echo "$V" )`" ;;
+                esac
+            done
+        ]
+    )
+
+    conftemp="${datadir}"
+    eval conftemp=\"${conftemp}\"
+    eval conftemp=\"${conftemp}\"
+    PREFIX_DATADIR="${conftemp}"
+    DATADIR="${PREFIX_DATADIR}"
+    DEPLOYED_DATADIR=""
+
+    AS_IF([test -e "${PREFIX_DATAROOTDIR}/nut/cmdvartab" || test -e "${PREFIX_DATAROOTDIR}/nut/driver.list"],
+        [DEPLOYED_DATADIR="${PREFIX_DATAROOTDIR}/nut"],
+        [AS_IF([test -e "${PREFIX_DATAROOTDIR}/cmdvartab" || test -e "${PREFIX_DATAROOTDIR}/driver.list"],
+            [DEPLOYED_DATADIR="${PREFIX_DATAROOTDIR}"],
+            [dnl FIXME: Be careful on WIN32 and its "find" vs. that in MINGW?
+             DEPLOYED_DATADIR="`find "${PREFIX_DATAROOTDIR}" -name cmdvartab | head -1 | sed 's,/@<:@^/@:>@*$,,'`" || DEPLOYED_DATADIR=""
+             AS_IF([test -z "${DEPLOYED_DATADIR}"], [DEPLOYED_DATADIR="`find "${PREFIX_DATAROOTDIR}" -name driver.list | head -1 | sed 's,/@<:@^/@:>@*$,,'`" || DEPLOYED_DATADIR=""])
+            ]
+        )]
+    )
+    AS_IF([test -z "${DEPLOYED_DATADIR}" && test -d "${PREFIX_DATAROOTDIR}/nut"], [DEPLOYED_DATADIR="${PREFIX_DATAROOTDIR}/nut"])
+
+    AS_IF([test x"${DEPLOYED_DATADIR}" != x && test x"${DEPLOYED_DATADIR}" != x"${PREFIX_DATADIR}"],
+        AC_MSG_WARN([Deployed NUT installation uses a DATADIR different from one specified (wins) or derived (loses) for this build: '${DEPLOYED_DATADIR}' vs. '${PREFIX_DATADIR}' ('${datadir}')])
+        [AS_CASE(["${CONFIG_FLAGS_DEPLOYED} ${CONFIG_FLAGS}"],
+            [*--datadir=*], [],
+            [CONFIG_FLAGS_DEPLOYED="${CONFIG_FLAGS_DEPLOYED} --datadir='${DEPLOYED_DATADIR}'"
+             DATADIR="${DEPLOYED_DATADIR}"
+            ])
     ])
 
     AS_CASE(["${CONFIG_FLAGS_DEPLOYED} ${CONFIG_FLAGS}"],
@@ -579,7 +711,14 @@ AS_IF([test x"$nut_enable_inplace_runtime" = xyes -a x"${NUT_VERSION_DEPLOYED-}"
         dnl NOTE: Single-quotes are correct for autotools default,
         dnl expanded at runtime (see conftemp tricks below)
 
-        AC_MSG_CHECKING([for in-place replacement default sysconfdir (better than '${sysconfdir}')])
+        conftemp="${sysconfdir}"
+        eval conftemp=\"${conftemp}\"
+        eval conftemp=\"${conftemp}\"
+        dnl Evaluated here for the message; CONFPATH will be re-evaluated
+        dnl below, after we decide on the sysconfdir value we really like.
+        PREFIX_SYSCONFDIR="${conftemp}"
+
+        AC_MSG_CHECKING([for in-place replacement default sysconfdir, better than '${PREFIX_SYSCONFDIR}' ('${sysconfdir}')])
         DEPLOYED_SYSCONFDIR=""
 
         dnl TODO: Any more reasonable defaults? Pile them on here :)
@@ -633,7 +772,17 @@ AS_IF([test x"$nut_enable_inplace_runtime" = xyes -a x"${NUT_VERSION_DEPLOYED-}"
     conftemp="${libdir}"
     eval conftemp=\"${conftemp}\"
     eval conftemp=\"${conftemp}\"
-    LIBDIR="${conftemp}"
+    PREFIX_LIBDIR="${conftemp}"
+    LIBDIR="${PREFIX_LIBDIR}"
+
+    AS_IF([test x"${DEPLOYED_LIBDIR}" != x && test x"${DEPLOYED_LIBDIR}" != x"${PREFIX_LIBDIR}"],
+        AC_MSG_WARN([Deployed NUT installation uses a LIBDIR different from one specified (wins) or derived (loses) for this build: '${DEPLOYED_LIBDIR}' vs. '${PREFIX_LIBDIR}' ('${libdir}')])
+        [AS_CASE(["${CONFIG_FLAGS_DEPLOYED} ${CONFIG_FLAGS}"],
+            [*--libdir=*], [],
+            [CONFIG_FLAGS_DEPLOYED="${CONFIG_FLAGS_DEPLOYED} --libdir='${DEPLOYED_LIBDIR}'"
+             LIBDIR="${DEPLOYED_LIBDIR}"
+            ])
+    ])
 
     AS_CASE(["${CONFIG_FLAGS_DEPLOYED} ${CONFIG_FLAGS}"],
         [*--libexecdir=*], [
@@ -760,7 +909,7 @@ AS_IF([test x"$nut_enable_inplace_runtime" = xyes -a x"${NUT_VERSION_DEPLOYED-}"
     ])
 
     AS_IF([test x"${CONFIG_FLAGS_DEPLOYED}" != x], [
-        AC_MSG_NOTICE([Detected CONFIG_FLAGS of an already deployed NUT installation, using them for --inplace-runtime configuration (restarting script)])
+        AC_MSG_NOTICE([Detected CONFIG_FLAGS for an already deployed NUT installation, using them for --inplace-runtime configuration (restarting script)])
         dnl For multiply-specified flags with conflicting values, last mention wins:
         AC_MSG_NOTICE([exec "$0" $CONFIG_FLAGS_DEPLOYED $CONFIG_FLAGS --disable-inplace-runtime])
         AS_IF([test x"${NUT_VERSION_DEPLOYED}" != x], [

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -758,6 +758,8 @@ GENERATE_PDF = ( \
 )
 
 *.pdf: docinfo.xml
+# Technically only needed for PDF generation, but some other recipes still complained
+qa-guide.adoc-prepped \
 qa-guide.pdf: docinfo-since-v2.8.3.xml qa-guide-docinfo.xml
 .txt-prepped.pdf:
 	@$(GENERATE_PDF)

--- a/docs/config-prereqs.txt
+++ b/docs/config-prereqs.txt
@@ -210,7 +210,8 @@ metadata about recently published package revisions:
 :; apt-get install \
     aspell aspell-en
 
-# For other doc types (man-page, PDF, HTML) generation - massive packages (TEX, X11):
+# For other doc types (man-page, PDF, HTML) generation - massive packages
+# (TEX, X11):
 :; apt-get install \
     asciidoc source-highlight python3-pygments dblatex
 
@@ -317,7 +318,8 @@ file (as the aged distributions become less served by mirrors), such as:
 +
 ------
 # e.g. for CentOS7 currently:
-:; yum install https://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm
+:; yum install \
+   https://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm
 
 # And edit /etc/yum.repos.d/epel.repo to uncomment and set the baseurl=...
 # lines, and comment away the mirrorlist= lines (if yum hiccups otherwise)
@@ -336,7 +338,8 @@ detailing how to replace `/etc/yum.repos.d/` contents (you can wholesale rename
 the existing directory and populate a new one with `curl` downloads from the
 article), and additional key trust for EPEL packages:
 ------
-:; yum install https://dl.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm
+:; yum install \
+   https://dl.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm
 ------
 
 Set up CentOS packages for NUT
@@ -413,7 +416,8 @@ drivers in distro packaging of NUT. Resolution and doc PRs are welcome.
 :; yum install \
     aspell aspell-en
 
-# For other doc types (man-page, PDF, HTML) generation - massive packages (TEX, X11):
+# For other doc types (man-page, PDF, HTML) generation - massive packages
+# (TEX, X11):
 :; yum install \
     asciidoc source-highlight python-pygments dblatex
 
@@ -441,8 +445,10 @@ drivers in distro packaging of NUT. Resolution and doc PRs are welcome.
     neon-devel
 #?# is python-augeas needed? exists at least...
 #?# no (lib)i2c-devel ...
-#?# no (lib)ipmimonitoring-devel ... would "freeipmi-ipmidetectd" cut it at least for run-time?
-#?# no (lib)gpio(d)-devel - starts with CentOS 8 (or extra repositories for later minor releases of CentOS 7)
+#?# no (lib)ipmimonitoring-devel ... would "freeipmi-ipmidetectd"
+#?#     cut it at least for run-time?
+#?# no (lib)gpio(d)-devel - starts with CentOS 8 (or extra repositories
+#?#     for later minor releases of CentOS 7)
 
 # Some NUT code related to lua may be currently limited to lua-5.1
 # or possibly 5.2; the former is default in CentOS 7 releases...
@@ -642,7 +648,14 @@ For procedures below, this is automated via `root` profile to become a
 `slackpkg-install` command:
 ----
 :; grep "slackpkg-install" ~/.profile || {
-    echo 'slackpkg-install() { for P in "$@" ; do echo "=== $P:"; slackpkg info "$P" || slackpkg install "$P" || break ; done; }' >> ~/.profile
+    cat >> ~/.profile << 'EOF'
+slackpkg-install() {
+    for P in "$@" ; do
+        echo "=== $P:"
+        slackpkg info "$P" || slackpkg install "$P" || break
+    done
+}
+EOF
    }
 :; . ~/.profile
 ----
@@ -737,7 +750,8 @@ like this:
 :; wget -m -l1 http://www.slackware.com/~alien/slackbuilds/asciidoc/pkg/ && \
     find . -name '*.t?z'
 
-:; installpkg ./www.slackware.com/~alien/slackbuilds/asciidoc/pkg/asciidoc-8.1.0-noarch-2.tgz
+:; (cd ./www.slackware.com/~alien/slackbuilds/asciidoc/pkg/ && \
+    installpkgasciidoc-8.1.0-noarch-2.tgz )
 ----
 
 Note that some packages are further separated by Slackware version, e.g. with
@@ -819,7 +833,8 @@ below.
 :; pkg install \
     aspell en-aspell
 
-# For other doc types (man-page, PDF, HTML) generation - massive packages (TEX, X11):
+# For other doc types (man-page, PDF, HTML) generation - massive packages
+# (TEX, X11):
 :; pkg install \
     asciidoc source-highlight textproc/py-pygments dblatex
 
@@ -963,7 +978,8 @@ default site.
 :; pkg_add \
     aspell
 
-# For other doc types (man-page, PDF, HTML) generation - massive packages (TEX, X11):
+# For other doc types (man-page, PDF, HTML) generation - massive packages
+# (TEX, X11):
 :; pkg_add \
     asciidoc source-highlight py-pygments dblatex \
     docbook2x docbook-to-man
@@ -985,7 +1001,8 @@ default site.
 # to only deliver a numbered SO library name), e.g.:
 :; pkg_add neon && \
    if ! test -s /usr/local/lib/libneon.so ; then
-    ln -s "`cd /usr/local/lib && ls -1 libneon.so.* | sort -n | tail -1`" /usr/local/lib/libneon.so
+    ln -s "`cd /usr/local/lib && ls -1 libneon.so.* | sort -n | tail -1`" \
+        /usr/local/lib/libneon.so
    fi
 
 # Select a LUA-5.1 (or possibly 5.2?) version
@@ -1009,11 +1026,15 @@ Recommended:
         done ; \
    )
 
-:; ( cd /usr/bin && for T in gcc g++ cpp ; do ln -s "$T" "$T-4.2.1" ; done )
-:; ( cd /usr/lib/ccache && for T in gcc g++ cpp ; do ln -s "$T" "$T-4.2.1" ; done )
+:; ( cd /usr/bin && for T in gcc g++ cpp ; \
+    do ln -s "$T" "$T-4.2.1" ; done )
+:; ( cd /usr/lib/ccache && for T in gcc g++ cpp ; \
+    do ln -s "$T" "$T-4.2.1" ; done )
 
-:; ( cd /usr/bin && for T in clang clang++ clang-cpp ; do ln -s "$T" "$T-7.0.1" ; done )
-:; ( cd /usr/lib/ccache && for T in clang clang++ clang-cpp ; do ln -s "$T" "$T-7.0.1" ; done )
+:; ( cd /usr/bin && for T in clang clang++ clang-cpp ; \
+    do ln -s "$T" "$T-7.0.1" ; done )
+:; ( cd /usr/lib/ccache && for T in clang clang++ clang-cpp ; \
+    do ln -s "$T" "$T-7.0.1" ; done )
 ------
 
 For compatibility with common setups on other operating systems, can add
@@ -1058,7 +1079,8 @@ Note that `PATH` for builds on NetBSD should include `local` and
 `pkg`; the default after installation of the test system was:
 
 ------
-:; PATH="/sbin:/usr/sbin:/bin:/usr/bin:/usr/pkg/sbin:/usr/pkg/bin:/usr/X11R7/bin:/usr/local/sbin:/usr/local/bin"
+:; PATH="/sbin:/usr/sbin:/bin:/usr/bin:/usr/pkg/sbin:/usr/pkg/bin"
+:; PATH="$PATH:/usr/X11R7/bin:/usr/local/sbin:/usr/local/bin"
 :; export PATH
 ------
 
@@ -1088,7 +1110,8 @@ this document describes, but if an e.g. older release lacks it, it can be added
 using the older tooling:
 
 ----
-:; PKG_PATH="http://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/$(uname -r|cut -f '1 2' -d.)/All/"
+:; CDN="http://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD"
+:; PKG_PATH="${CDN}/$(uname -p)/$(uname -r|cut -f '1 2' -d.)/All/"
 :; export PKG_PATH
 :; pkg_add pkgin
 ----
@@ -1277,10 +1300,12 @@ Typical tooling would include:
 :; pkg install \
     aspell text/aspell/en
 
-# For other doc types (man-page, PDF, HTML) generation - massive packages (TEX, X11):
+# For other doc types (man-page, PDF, HTML) generation - massive packages
+# (TEX, X11):
 :; pkg install \
     asciidoc libxslt \
-    docbook/dtds docbook/dsssl docbook/xsl docbook docbook/sgml-common pygments-39 \
+    docbook/dtds docbook/dsssl docbook/xsl docbook docbook/sgml-common \
+    pygments-39 \
     image/graphviz expect graphviz-tcl
 
 # For CGI graph generation - massive packages (X11):
@@ -1290,7 +1315,8 @@ Typical tooling would include:
 :; pkg install \
     openssl library/mozilla-nss \
     library/augeas python/augeas \
-    libusb-1 libusbugen system/library/usb/libusb system/header/header-usb driver/usb/ugen \
+    libusb-1 libusbugen system/library/usb/libusb \
+    system/header/header-usb driver/usb/ugen \
     libmodbus \
     library/neon \
     system/management/snmp/net-snmp \
@@ -1414,10 +1440,11 @@ site for setup details.
 :; pkg install sudo bash application/mc wget rsync pigz pbzip2 p7zip top
 
 # NOTE: not all compiler versions may be served by all releases (e.g. OmniOS
-# did not deliver clang in Core nor Extra repos for quite a while), some are
-# obsoleted over time. While OmniOS LTS 151046 offers a range of clang 13 to
-# 17, current stable (151052) includes also 18 and 19. Unlike OpenIndiana,
-# OmniOS does not provide implicit (not-numbered) packages for clang or gcc.
+# did not deliver clang in Core nor Extra repositories for quite a while),
+# and some are obsoleted over time. While OmniOS 151036 lacked any clang,
+# LTS 151046 offered a range of clang 13 to 17, and current stable (151052)
+# includes also 18 and 19. Unlike OpenIndiana, OmniOS does not provide
+# implicit default (not-numbered) packages for neither clang nor gcc.
 # Check your distro repository offers with:
 :; pkg info -r '*clang*' '*gcc*'
 :; pkg search -r '*bin/g++*'
@@ -1598,12 +1625,14 @@ Overall, the successful test build using the NUT standard CI helper script
 `ci_build.sh` had the following shell session settings:
 
 ----
-### Common pre-sets from .profile or .bashrc:
+### Common pre-sets from .profile or .bashrc (long lines wrapped for readability):
 ### bash-2.03$ echo $PATH
-### /usr/bin:/usr/dt/bin:/usr/openwin/bin:/bin:/usr/ucb:/usr/tgcware/bin:/usr/tgcware/gnu:/usr/tgcware/gcc42/bin:/usr/tgcware/i386-pc-solaris2.8/bin
+###   /usr/bin:/usr/dt/bin:/usr/openwin/bin:/bin:/usr/ucb:/usr/tgcware/bin:\
+###   /usr/tgcware/gnu:/usr/tgcware/gcc42/bin:/usr/tgcware/i386-pc-solaris2.8/bin
 
 ### bash-2.03$ echo $LD_LIBRARY_PATH
-### /usr/lib:/usr/tgcware/lib:/usr/tgcware/gcc42/lib:/usr/tgcware/i386-pc-solaris2.8/lib
+###   /usr/lib:/usr/tgcware/lib:/usr/tgcware/gcc42/lib:\
+###   /usr/tgcware/i386-pc-solaris2.8/lib
 
 ### Further tuning for the build itself:
 :; git clean -fffdddxxx
@@ -1852,7 +1881,8 @@ export PATH
 
 # Alternately there is libusb-compat (libusb-1.0 codebase exposing the older
 # libusb-0.1 API) which SHOULD NOT be installed along with the real libusb-0.1:
-# :; pacman -S --needed mingw-w64-x86_64-libusb-compat-git mingw-w64-clang-x86_64-libusb-compat-git
+# :; pacman -S --needed mingw-w64-x86_64-libusb-compat-git \
+#        mingw-w64-clang-x86_64-libusb-compat-git
 
 # This also pulls *-devel of several other projects:
 :; pacman -S --needed \
@@ -1877,7 +1907,8 @@ and lack a set for `clang` tools; easy-peasy fix with:
 
 ----
 :; cd /mingw64/lib/ccache/bin
-:; for T in clang clang++ clang-cpp ; do sed "s/gcc/$T/" < gcc > "$T" ; chmod +x "$T" ; done
+:; for T in clang clang++ clang-cpp ; do \
+    sed "s/gcc/$T/" < gcc > "$T" ; chmod +x "$T" ; done
 ----
 
 Note that default `ccache` seems quirky on Windows MSYS2, possibly due to

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -805,9 +805,17 @@ at run time.
 	--datadir=PATH
 
 Change the data directory, i.e., where architecture independent
-read-only data is installed.  By default this is `<prefix>/share`,
-i.e. `/usr/local/ups/share`.  At the moment, this directory only
-holds two files -- the optional `cmdvartab` and `driver.list`.
+read-only data for the currently built project is installed.
+By GNU Autotools default, this is `<prefix>/share` (same as the
+system-wide "data root" which we also consult for third-party data
+such as Augeas lens delivery locations), i.e. `/usr/local/ups/share`.
++
+Typically this is reconfigured to a `'${datarootdir}/nut'` value.
++
+At the moment, this directory only holds two files by default -- the
+optional `cmdvartab` and `driver.list`, but may hold additional data
+on certain systems (e.g. FreeBSD quirks, Solaris SMF or init methods,
+sometimes documentation).
 
 	--mandir=PATH
 

--- a/docs/maintainer-guide.txt
+++ b/docs/maintainer-guide.txt
@@ -90,6 +90,15 @@ MAINTAINER SANDBOX (to be completed and pushed)
   and nut-website building and checking, and with maintainer GPG keys in
   the chain
 
+NOTE: DO NOT RUSH to issue the release right away. There are always some
+last-minute discoveries and days/weeks of delays before a perfect release
+does ultimately happen. Use `vX.Y.Z-rcN` tags until completely certain that
+a release is final (perhaps by tagging the last RC with `vX.Y.Z` later).
+Note that some third-party tools like PyPI repo do not permit replacing
+artifacts associated with a particular release version/tag, and changing
+Git tags on public repositories is generally considered as a bad practice.
+So best to avoid it in the first place.
+
 * clean up "in-development" bits from files (which we would revert after
   release), e.g.:
 ** TODO etc. referring planned future in the `NEWS.adoc` and `UPDATING.adoc`

--- a/docs/maintainer-guide.txt
+++ b/docs/maintainer-guide.txt
@@ -116,6 +116,20 @@ So best to avoid it in the first place.
 :; git commit -sm 'NEWS.adoc, UPGRADING.adoc, docs/docinfo.xml.in: finalize text before NUT v2.8.0 release'
 ----
 
+* revise the lists of symbols exported by shared libraries delivered by NUT:
+  some changes may be seen right in the respective `Makefile.am`, but since
+  we use regular expressions, the set of method names may change between
+  releases implicitly. Use `nm` or similar tools to review symbols exposed
+  on an older build and the newer ones. For version bump algorithm consult
+  https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
+  (since we are likely to change common source code between releases, the
+  "revision" is likely to increment always, to reflect that the library was
+  rebuilt from different sources -- unless we bump "current" instead and
+  reset "revision" to 0 due to new symbols).
++
+TODO: Maintain proper library scripts (maybe in Git) with exact lists of
+symbol names and API versions, similar to what `GNUC` or `SUNW` libraries do.
+
 * revise the contents of `NEWS.adoc` and `UPDATING.adoc` files; verify that
   any recent changes to drivers (including `main.c` and other major impact
   from common code) and sub-drivers (`*-hid.c` for `usbhid-ups`, `*-mib.c`

--- a/docs/man/upsmon.conf.txt
+++ b/docs/man/upsmon.conf.txt
@@ -425,6 +425,25 @@ NOTE: so far we support the device reporting an "OFF" state which usually
 means completely un-powering the load; a bug-tracker issue was logged to
 design similar support for just some manageable outlets or outlet groups.
 
+*OVERDURATION* 'seconds'::
+
+This setting handles how a UPS that is overloaded should be treated in
+situations when it is not fully communicating. Because such a UPS may 
+be in a potentially severe state, some users may want their systems 
+to be shutdown either immediately or after a set timeout has elapsed. 
+The OVERDURATION setting defines this timeout (in seconds), after which 
+an overloaded UPS that is not communicating will be considered critical.
++
+A negative value means an overloaded UPS will never be considered 
+critical (at least not because of the overload itself). A value of zero 
+means the UPS will instantly be considered critical when overloaded and 
+not communicating. Built-in default value is -1 (seconds).
++
+NOTE: This setting only affects the behavior when a UPS is both 
+overloaded and not communicating. When the UPS is communicating 
+normally, an overload condition may raise notifications but won't 
+trigger a system shutdown on its own.
+
 *OBLBDURATION* 'seconds'::
 
 NUT normally raises alarms for immediate shutdown (FSD) for consumers of an

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3454 utf-8
+personal_ws-1.1 en 3455 utf-8
 AAC
 AAS
 ABI
@@ -1845,6 +1845,7 @@ datadir
 datagrams
 datalink
 dataok
+datarootdir
 dataset
 datasets
 datasheet

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3455 utf-8
+personal_ws-1.1 en 3457 utf-8
 AAC
 AAS
 ABI
@@ -152,6 +152,7 @@ CBI
 CCC
 CCCC
 CDC
+CDN
 CDS
 CELLPADDING
 CELLSPACING
@@ -2674,6 +2675,7 @@ openmp
 openpimi
 openssh
 openssl
+openwin
 oper
 optimizations
 optiups

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -2686,6 +2686,7 @@ other's
 otheruser
 ouGDQn
 outliers
+OVERDURATION
 ovmf
 pF
 pacman

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -1505,7 +1505,7 @@ public:
 	void parseFromString(const std::string& str);
 
 	Settable<int>          debugMin, pollFailLogThrottleMax;
-	Settable<int>          offDuration, oblbDuration;
+	Settable<int>          offDuration, oblbDuration, overDuration;
 	Settable<std::string>  runAsUser, shutdownCmd, notifyCmd, powerDownFlag;
 	/* yes|no (boolean) or a delay */
 	Settable<nut::BoolInt> shutdownExit;

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -1510,7 +1510,7 @@ public:
 	/* yes|no (boolean) or a delay */
 	Settable<nut::BoolInt> shutdownExit;
 	/* practically boolean, but in 0|1 written form (bool01 fiddling) */
-	Settable<nut::BoolInt> certVerify, forceSsl;
+	Settable<nut::BoolInt> certVerify, forceSsl, alarmCritical;
 	Settable<std::string>  certPath;
 	CertIdent              certIdent;
 	std::list<CertHost>    certHosts;

--- a/scripts/augeas/nutupsmonconf.aug.in
+++ b/scripts/augeas/nutupsmonconf.aug.in
@@ -41,7 +41,7 @@ let comment  = Util.comment
 let quoted_string = del "\"" "\"" . store /[^"\n]+/ . del "\"" "\""
 
 (* UPS identifier
- * <upsname>[@<hostname>[:<port>]] 
+ * <upsname>[@<hostname>[:<port>]]
  *
  * There might be a cleaner way to write this
  *  but I'm stuck with (hostname | hostname . port)?
@@ -69,6 +69,7 @@ let upsmon_num_signed_re = "DEBUG_MIN"
                   | "POLLFAIL_LOG_THROTTLE_MAX"
                   | "OFFDURATION"
                   | "OBLBDURATION"
+                  | "OVERDURATION"
 
 let upsmon_num_bool_re = "SHUTDOWNEXIT"
 

--- a/scripts/augeas/nutupsmonconf.aug.in
+++ b/scripts/augeas/nutupsmonconf.aug.in
@@ -75,6 +75,7 @@ let upsmon_num_bool_re = "SHUTDOWNEXIT"
 
 let upsmon_bool_re = "CERTVERIFY"
                   | "FORCESSL"
+                  | "ALARMCRITICAL"
 
 let upsmon_num    = [ del_spc . key upsmon_num_re . sep_spc . store num . eol ]
 

--- a/tests/nutconf_ut.cpp
+++ b/tests/nutconf_ut.cpp
@@ -218,6 +218,7 @@ void NutConfigUnitTest::testUpsmonConfiguration() {
 	config.overDuration  = -1;
 	config.certVerify    = (*(tmpPtr = new nut::BoolInt()) << false); delete tmpPtr;
 	config.forceSsl      = (*(tmpPtr = new nut::BoolInt()) << "1"); delete tmpPtr;
+	config.alarmCritical = (*(tmpPtr = new nut::BoolInt()) << "1"); delete tmpPtr;
 
 	config.certIdent.certName    = "My test cert";
 	config.certIdent.certDbPass  = "DbPwd!";
@@ -249,6 +250,7 @@ void NutConfigUnitTest::testUpsmonConfiguration() {
 		"SHUTDOWNEXIT yes\n"
 		"CERTVERIFY 0\n"
 		"FORCESSL 1\n"
+		"ALARMCRITICAL 1\n"
 		"HOSTSYNC 15\n"
 		"DEADTIME 30\n"
 		"RBWARNTIME 43200\n"

--- a/tests/nutconf_ut.cpp
+++ b/tests/nutconf_ut.cpp
@@ -215,6 +215,7 @@ void NutConfigUnitTest::testUpsmonConfiguration() {
 	// is due to Settable<> formal type mismatch)
 	config.shutdownExit  = (*(tmpPtr = new nut::BoolInt()) << "true"); delete tmpPtr;
 	config.oblbDuration  = -1;
+	config.overDuration  = -1;
 	config.certVerify    = (*(tmpPtr = new nut::BoolInt()) << false); delete tmpPtr;
 	config.forceSsl      = (*(tmpPtr = new nut::BoolInt()) << "1"); delete tmpPtr;
 
@@ -244,6 +245,7 @@ void NutConfigUnitTest::testUpsmonConfiguration() {
 		"POLLFREQALERT 10\n"
 		"OFFDURATION 30\n"
 		"OBLBDURATION -1\n"
+		"OVERDURATION -1\n"
 		"SHUTDOWNEXIT yes\n"
 		"CERTVERIFY 0\n"
 		"FORCESSL 1\n"

--- a/tools/nut-scanner/Makefile.am
+++ b/tools/nut-scanner/Makefile.am
@@ -99,7 +99,7 @@ libnutscan_la_LDFLAGS += @NETLIBS_GETADDRS@
 # object .so names would differ)
 #
 # libnutscan version information
-libnutscan_la_LDFLAGS += -version-info 2:6:0
+libnutscan_la_LDFLAGS += -version-info 3:0:0
 
 # libnutscan exported symbols regex
 # WARNING: Since the library includes parts of libcommon (as much as needed


### PR DESCRIPTION
closes #2877 

introduces `OVERCRITICAL` for upsmon.

```
*OVERCRITICAL* 'seconds'::

This setting handles how a UPS that is overloaded should be treated in
situations when it is not fully communicating. Because such a UPS may 
be in a potentially severe state, some users may want their systems 
to be shutdown either immediately or after a set timeout has elapsed. 
The OVERCRITICAL setting defines this timeout (in seconds), after which 
an overloaded UPS that is not communicating will be considered critical.
+
A negative value means an overloaded UPS will never be considered 
critical (at least not because of the overload itself). A value of zero 
means the UPS will instantly be considered critical when overloaded and 
not communicating. Built-in default value is -1 (seconds).
+
NOTE: This setting only affects the behavior when a UPS is both 
overloaded and not communicating. When the UPS is communicating 
normally, an overload condition may raise notifications but won't 
trigger a system shutdown on its own.
```

We may later extend this to `TRIM` and `BOOST` but to me that makes no sense at present. Boosting/trimming input voltage is to me not a potentially severe state but rather within expected operation of any UPS, so nothing FSD-worthy even in NOCOMM.

As for the default value, I think something not `-1` would be safer/preferable, but that'd change the present release behavior?