### PR TITLE
Clarify message for `nutdrv_qx` mismatch of `port!="auto"` and presence of USB settings

### DIFF
--- a/drivers/hwmon_ina219.c
+++ b/drivers/hwmon_ina219.c
@@ -150,7 +150,7 @@ static int scan_hwmon_ina219(const char *sysfs_hwmon_dir)
 	if (strcmp(device_path, "auto")) {
 		if ((ret = detect_ina219(device_path)) < 0) {
 			fatal_with_errno(EXIT_FAILURE,
-					"not a valid hwmon ina219 dir: '%s'\n", device_path);
+					"'port' does not specify a valid hwmon ina219 dir: '%s'", device_path);
 		}
 
 		snprintf(ina219_base_path, sizeof(ina219_base_path), "%s", device_path);

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -3285,7 +3285,7 @@ void	upsdrv_initups(void)
 
 	/* Whether the device is connected through USB or serial */
 	if (
-		!strcasecmp(dstate_getinfo("driver.parameter.port"), "auto") ||
+		!strcasecmp(device_path, "auto") ||
 		getval("subdriver") ||
 		getval("vendorid") ||
 		getval("productid") ||

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -3294,12 +3294,19 @@ void	upsdrv_initups(void)
 		getval("serial") ||
 		getval("bus") ||
 		getval("langid_fix")
-#if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
+# if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
 		|| getval("busport")
-#endif
+# endif
 	) {
 		/* USB */
 		is_usb = 1;
+
+		/* FIXME: Revise when/if we add support for port devfs paths */
+		/* NOTE: We also get a more detailed message below with
+		 * the warn_if_bad_usb_port_filename() method */
+		if (strcasecmp(device_path, "auto")) {
+			upslogx(LOG_WARNING, "WARNING: port='%s' would be ignored, since other options indicate USB mode", device_path);
+		}
 	} else {
 		/* Serial */
 		is_usb = 0;


### PR DESCRIPTION
There should have been a message since v2.8.0 or so, but this one clarifies the situation even further (see the now-two WARNING entries below):
````
:; NUT_STATEPATH=/tmp ./drivers/nutdrv_qx -s test -x vendorid=1234 -x port=/dev/ttyUSB0

Network UPS Tools 2.8.3.85-85+g5d3ff46f9 (development iteration after 2.8.3) -
    Generic Q* USB/Serial driver 0.42
USB communication driver (libusb 1.0) 0.50
WARNING: port='/dev/ttyUSB0' would be ignored, since other options indicate USB mode
WARNING: warn_if_bad_usb_port_filename(): port argument specified to
  the driver is "/dev/ttyUSB0" but USB drivers do not use it and rely on
  libusb walking all devices and matching their identification metadata.
  NUT documentation recommends port="auto" for USB devices to avoid confusion.
libusb1: Could not open any HID devices: no USB buses (or devices) found
No supported devices found. Please check your device availability with 'lsusb'
and make sure you have an up-to-date version of NUT. If this does not help,
try running the driver with at least 'subdriver', 'vendorid' and 'productid'
options specified. Please refer to the man page for details about these options
(man 8 nutdrv_qx).
````