### PR TITLE
drivers/cps-hid.c: add report descriptor fix for ConfigActivePower

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -62,6 +62,11 @@ https://github.com/networkupstools/nut/milestone/9
      and misfired on some platforms, and the way to print had a theoretical
      potential for buffer overflow. [#2915]
 
+ - `usbhid-ups` updates:
+   * The `cps-hid` subdriver's existing mechanism for fixing broken report
+     descriptors was extended to cover a newly reported case of nominal UPS
+     power being incorrectly reported due to an unrealistically low maximum
+     threshold, as seen with a EC850LCD device. [issue #2917, PR #2919]
 
 Release notes for NUT 2.8.3 - what's new since 2.8.2
 ----------------------------------------------------

--- a/drivers/cps-hid.c
+++ b/drivers/cps-hid.c
@@ -32,7 +32,7 @@
 #include "cps-hid.h"
 #include "usb-common.h"
 
-#define CPS_HID_VERSION      "CyberPower HID 0.83"
+#define CPS_HID_VERSION      "CyberPower HID 0.84"
 
 /* Cyber Power Systems */
 #define CPS_VENDORID 0x0764
@@ -49,7 +49,9 @@
  */
 #define CPS_VOLTAGE_LOGMIN 0
 #define CPS_VOLTAGE_LOGMAX 511 /* Includes safety margin. */
-#define CPS_WATTAGE_LOGMAX 2048 /* Should cover most affected models. */
+
+/* Should be a realistic max value covering most affected UPS. */
+#define CPS_NOMINALPWR_LOGMAX 2048
 
 /*! Battery voltage scale factor.
  * For some devices, the reported battery voltage is off by factor
@@ -667,7 +669,7 @@ static int cps_fix_report_desc(HIDDevice_t *pDev, HIDDesc_t *pDesc_arg) {
 		}
 	}
 
-	/* Fix for nominal power reporting getting clipped by LogMax. */
+	/* Fix for nominal power reporting getting clipped by a too restrictive LogMax. */
 	if ((pData=FindObject_with_ID_Node(pDesc_arg, 24 /* 0x18 */, USAGE_POW_CONFIG_ACTIVE_POWER))) {
 		long power_logmax = pData->LogMax;
 
@@ -675,16 +677,14 @@ static int cps_fix_report_desc(HIDDevice_t *pDev, HIDDesc_t *pDesc_arg) {
 			"LogMin: %ld LogMax: %ld",
 			pData->LogMin, power_logmax);
 
-		if (power_logmax < CPS_WATTAGE_LOGMAX) {
-			/* Set a generous maximum that won't restrict UPS reporting.
+		if (power_logmax < CPS_NOMINALPWR_LOGMAX) {
+			/* Set a generous maximum value that will not restrict UPS reporting.
 			*
 			* Current findings suggest that the values sent by the UPS are
-			* accurate, but then get clipped by too strict LogMax thresholds:
+			* accurate, but then get clipped by a too strict LogMax threshold:
 			* https://github.com/networkupstools/nut/issues/2917#issuecomment-2832243477
-			*
-			* This could later be expanded to more advanced fiddling, where necessary.
 			*/
-			pData->LogMax = CPS_WATTAGE_LOGMAX;
+			pData->LogMax = CPS_NOMINALPWR_LOGMAX;
 
 			upsdebugx(3, "Fixing Report Descriptor: "
 				"set ConfigActivePower LogMax = %ld",

--- a/drivers/cps-hid.c
+++ b/drivers/cps-hid.c
@@ -49,6 +49,7 @@
  */
 #define CPS_VOLTAGE_LOGMIN 0
 #define CPS_VOLTAGE_LOGMAX 511 /* Includes safety margin. */
+#define CPS_WATTAGE_LOGMAX 2048 /* Should cover most affected models. */
 
 /*! Battery voltage scale factor.
  * For some devices, the reported battery voltage is off by factor
@@ -664,6 +665,29 @@ static int cps_fix_report_desc(HIDDevice_t *pDev, HIDDesc_t *pDesc_arg) {
 				}
 			}
 		}
+	}
+
+	/* Fix for nominal power reporting getting clipped by LogMax. */
+	if ((pData=FindObject_with_ID_Node(pDesc_arg, 24 /* 0x18 */, USAGE_POW_CONFIG_ACTIVE_POWER))) {
+		upsdebugx(4, "Original Report Descriptor: ConfigActivePower "
+			"LogMin: %ld LogMax: %ld",
+			pData->LogMin, pData->LogMax);
+
+		/* Set a generous maximum that won't restrict UPS reporting.
+		 *
+		 * Current findings suggest that the values sent by the UPS are
+		 * accurate, but then get clipped by too strict LogMax thresholds:
+		 * https://github.com/networkupstools/nut/issues/2917#issuecomment-2832243477
+		 *
+		 * This could later be expanded to more advanced fiddling, where necessary.
+		 */
+		pData->LogMax = CPS_WATTAGE_LOGMAX;
+
+		upsdebugx(3, "Fixing Report Descriptor: "
+			"set ConfigActivePower LogMax = %ld",
+			pData->LogMax);
+
+		retval = 1;
 	}
 
 	if (!retval) {


### PR DESCRIPTION
fix #2917 

Findings in the linked issue suggest that at least one model in the `cps_fix_report_desc` model range suffers also from a broken descriptor for reporting the UPS nominal power (`ConfigActivePower`). The value seemingly gets correctly sent by the UPS, but is then clipped by a too low `LogMax` of that affected descriptor:  [nut-issue-2917.log](https://github.com/user-attachments/files/19923182/nut-issue-2917.log)

```
Apr 26 08:43:04 Tower rc.nut:    0.035598#011[D3:181672] Report[get]: (3 bytes) => 18 fe 01
Apr 26 08:43:04 Tower rc.nut:    0.035600#011[D5:181672] PhyMax = 0, PhyMin = 0, LogMax = 450, LogMin = -1
Apr 26 08:43:04 Tower rc.nut:    0.035601#011[D5:181672] Unit = 0000d121, UnitExp = 7
Apr 26 08:43:04 Tower rc.nut:    0.035602#011[D5:181672] Exponent = 0
Apr 26 08:43:04 Tower rc.nut:    0.035603#011[D5:181672] hid_lookup_path: 00840004 -> UPS
Apr 26 08:43:04 Tower rc.nut:    0.035604#011[D5:181672] hid_lookup_path: 0084001c -> Output
Apr 26 08:43:04 Tower rc.nut:    0.035604#011[D5:181672] hid_lookup_path: 00840044 -> ConfigActivePower
Apr 26 08:43:04 Tower rc.nut:    0.035606#011[D1:181672] Path: UPS.Output.ConfigActivePower, Type: Feature, ReportID: 0x18, Offset: 0, Size: 16, Value: 450
```

We can see above that 510W (correct) gets sent (`Report[buf]: (3 bytes) => 18 fe 01`) but is clipped by `LogMax = 450` (wrong).

This PR introduces a simple enough fix as part of `cps_fix_report_desc`, operating under the assumption that other models with broken descriptors may also require this descriptor fixed and that the value sent by the UPS is in principal the correct value.

Hard-setting the `LogMax` to a reasonable ceiling value of `2048` (W/VA) as an early investigation fix should cover most UPS of the affected ranges and have little negative side affects as long as correct values are in principal sent by the UPS. This can later be expanded to more advanced fiddling, should further investigations result in incorrect values getting sent for either.
