### PR TITLE
Fix `configure --with-drivers=dummy-ups`

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -46,7 +46,11 @@ https://github.com/networkupstools/nut/milestone/9
    * Fixed a regression in recipes of NUT v2.8.3 release (as compared to
      v2.8.2), where `configure --with-docs=all` no longer failed a run
      of the `configure` script when some of the required rendering tools
-     were not in fact available. [#2842]
+     were not in fact available. [#2842, fixed by #2921]
+   * A change in `Makefile.am` recipes to evaluate some driver names in the
+     `DRIVERLIST` variables inspected by `configure` script, rather than
+     having all their names hard-coded like before, led to inability to
+     `configure --with-drivers=dummy-ups`. [#2825, #2927, fixed by PR #2929]
 
  - common code:
    * Revised common `writepid()` to use `altpidpath()` as location for the

--- a/configure.ac
+++ b/configure.ac
@@ -2153,7 +2153,7 @@ AC_ARG_WITH(drivers,
 								;;
 						esac
 					done
-				) | tr '\n' ' ' | sed -e "s,${SPACE}${SPACES}, ," -e "s,${SPACES}\$,,"
+				) | tr '\n' ' ' | sed -e "s,${SPACE}${SPACES}, ,g" -e "s,${SPACES}\$,,"
 			)
 
 			for DRVLIST_NAME in $DRVLIST_NAMES; do

--- a/configure.ac
+++ b/configure.ac
@@ -2135,6 +2135,7 @@ AC_ARG_WITH(drivers,
 					[LB="@<:@"; RB="@:>@"],
 					[LB="[["; RB="]]"]
 				)
+				dnl ###DEBUG### echo "RECURSIVE SEARCH FOR: '$1'" >&2
 				SPACE="`printf "$LB"' \t'"$RB"`"
 				SPACES="${SPACE}*"
 				sed -e "s/${SPACES}""$LB"'+'"$RB"'*='"${SPACES}/=/" \
@@ -2153,11 +2154,35 @@ AC_ARG_WITH(drivers,
 								;;
 						esac
 					done
-				) | tr '\n' ' ' | sed -e "s,${SPACE}${SPACES}, ,g" -e "s,${SPACES}\$,," -e 's,\$(EXEEXT),,'
+					echo ""
+				) | tr '\n' ' ' | sed -e 's,\$(EXEEXT),,g' \
+				| tr ' ' '\n' | while read TOKEN ; do
+					case x"${TOKEN}" in
+						x)	;;
+						'x$('*')') get_drivers_makefile_value "`echo "${TOKEN}" | sed -e 's,^\$(,,' -e 's,)$,,'`" ;;
+						'x${'*'}') get_drivers_makefile_value "`echo "${TOKEN}" | sed -e 's,^\${,,' -e 's,}$,,'`" ;;
+						*)	echo "${TOKEN} " ;;
+					esac
+				done dnl ###DEBUG### | tee -a /dev/stderr
+			)
+
+			get_drvlist() (
+				m4_version_prereq(2.62,
+					[LB="@<:@"; RB="@:>@"],
+					[LB="[["; RB="]]"]
+				)
+				dnl ###DEBUG### echo "SEARCH FOR: '$1'" >&2
+				SPACE="`printf "$LB"' \t'"$RB"`"
+				SPACES="${SPACE}*"
+
+				dnl Let it recurse, and only then we collect the
+				dnl result into one string with reduced spaces:
+				get_drivers_makefile_value "$1" \
+				| tr '\n' ' ' | sed -e "s,${SPACE}${SPACES}, ,g" -e "s,${SPACES}\$,,"
 			)
 
 			for DRVLIST_NAME in $DRVLIST_NAMES; do
-				OUT="`get_drivers_makefile_value "$DRVLIST_NAME"`" \
+				OUT="`get_drvlist "$DRVLIST_NAME"`" \
 				&& test -n "$OUT" || OUT=""
 				eval $DRVLIST_NAME="\$OUT"
 				AC_MSG_NOTICE([Will check custom driver selection against $DRVLIST_NAME="$OUT"])

--- a/configure.ac
+++ b/configure.ac
@@ -2129,7 +2129,7 @@ AC_ARG_WITH(drivers,
 				POWERMAN_DRIVERLIST IPMI_DRIVERLIST GPIO_DRIVERLIST"
 
 			dnl Gets ONE Makefile assignment value
-			get_drvlist() (
+			get_drivers_makefile_value() (
 				dnl Note escaped brackets - "against" m4 parser
 				m4_version_prereq(2.62,
 					[LB="@<:@"; RB="@:>@"],
@@ -2157,7 +2157,7 @@ AC_ARG_WITH(drivers,
 			)
 
 			for DRVLIST_NAME in $DRVLIST_NAMES; do
-				OUT="`get_drvlist "$DRVLIST_NAME"`" \
+				OUT="`get_drivers_makefile_value "$DRVLIST_NAME"`" \
 				&& test -n "$OUT" || OUT=""
 				eval $DRVLIST_NAME="\$OUT"
 				AC_MSG_NOTICE([Will check custom driver selection against $DRVLIST_NAME="$OUT"])

--- a/configure.ac
+++ b/configure.ac
@@ -2148,12 +2148,12 @@ AC_ARG_WITH(drivers,
 						esac
 						case "$LINE" in
 							"$1"=*)
-								echo "$LINE" | sed -e 's,^'"$LB"'^='"$RB"'*=,,' -e 's,\$,,'
+								echo "$LINE" | sed -e 's,^'"$LB"'^='"$RB"'*=,,'
 								V=$C
 								;;
 						esac
 					done
-				) | tr '\n' ' ' | sed -e "s,${SPACE}${SPACES}, ,g" -e "s,${SPACES}\$,,"
+				) | tr '\n' ' ' | sed -e "s,${SPACE}${SPACES}, ,g" -e "s,${SPACES}\$,," -e 's,\$(EXEEXT),,'
 			)
 
 			for DRVLIST_NAME in $DRVLIST_NAMES; do

--- a/configure.ac
+++ b/configure.ac
@@ -2128,6 +2128,7 @@ AC_ARG_WITH(drivers,
 				MACOSX_DRIVERLIST MODBUS_DRIVERLIST LINUX_I2C_DRIVERLIST
 				POWERMAN_DRIVERLIST IPMI_DRIVERLIST GPIO_DRIVERLIST"
 
+			dnl Gets ONE Makefile assignment value
 			get_drvlist() (
 				dnl Note escaped brackets - "against" m4 parser
 				m4_version_prereq(2.62,
@@ -2138,12 +2139,12 @@ AC_ARG_WITH(drivers,
 				SPACES="${SPACE}*"
 				sed -e "s/${SPACES}""$LB"'+'"$RB"'*='"${SPACES}/=/" \
 				    -e "s/^${SPACES}//" < "$srcdir/drivers/Makefile.am" \
-				| {
+				| (
 					C=false; V=false
 					while read LINE ; do
 						case "$LINE" in
 							*'\') C=true; if $V ; then echo "$LINE" ; fi ;;
-							*) C=false; V=false ;;
+							*) if $C ; then exit 0; fi ; C=false; V=false ;;
 						esac
 						case "$LINE" in
 							"$1"=*)
@@ -2152,7 +2153,7 @@ AC_ARG_WITH(drivers,
 								;;
 						esac
 					done
-				} | tr '\n' ' ' | sed -e "s,${SPACE}${SPACES}, ," -e "s,${SPACES}\$,,"
+				) | tr '\n' ' ' | sed -e "s,${SPACE}${SPACES}, ," -e "s,${SPACES}\$,,"
 			)
 
 			for DRVLIST_NAME in $DRVLIST_NAMES; do


### PR DESCRIPTION
Fixes: #2927
Fallout-of: #2825

* Introduce recursive evaluation of `Makefile.am` variables while we search the driver lists for program names - so now we do not get a dollar-token (sans the dollar) in the output, and then a driver name unknown for the build request.
* Ignore the `$(EXEEXT)` that was tacked to `dummy-ups` specifically to solve the problems PR #2825 addressed.