### PR TITLE
dstate: clean separation of UPS-statused based ALARM and modern alarm_*-driven ALARMs

### DIFF
--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -820,7 +820,8 @@ static void ups_is_alarm(utype_t *ups)
 				do_notify(ups, NOTIFY_ALARM, alarms);
 			}
 		} else {
-			upsdebugx(4, "%s: %s: still on alarm, failed to get current ups.alarm value",
+			upsdebugx(4, "%s: %s: still on alarm, failed to get current ups.alarm value, "
+				"perhaps it is just a legacy driver (but we keep probing it to be safe)",
 				__func__, ups->sys);
 		}
 		return;
@@ -842,9 +843,10 @@ static void ups_is_alarm(utype_t *ups)
 			__func__, ups->sys, alarms);
 		do_notify(ups, NOTIFY_ALARM, alarms);
 	} else {
-		upsdebugx(4, "%s: %s: failed to get current ups.alarm value",
+		upsdebugx(4, "%s: %s: failed to get current ups.alarm value, perhaps "
+			"it is just a legacy driver (but we keep probing it to be safe)",
 			__func__, ups->sys);
-		do_notify(ups, NOTIFY_ALARM, NULL);
+		do_notify(ups, NOTIFY_ALARM, "n/a");
 		alarms[0] = '\0';
 	}
 	strncpy(alarms_prev, alarms, sizeof(alarms_prev));

--- a/docs/new-drivers.txt
+++ b/docs/new-drivers.txt
@@ -218,6 +218,10 @@ formatting string to those expectations.  In this case, you would use
 	char *fmt = "Mega-Zapper %d";
 	dstate_setinfo_dynamic("ups.model", fmt, "%d", rating);
 
+Please note that `ups.alarm` should no longer be manually set, but rather
+the appropriate alarm functions should be used instead. For more details,
+see below in the `UPS alarms` section.
+
 Setting flags
 ~~~~~~~~~~~~~
 
@@ -261,9 +265,10 @@ Possible values for status_set:
 	BOOST   -- UPS is boosting incoming voltage
 	FSD     -- Forced Shutdown (restricted use, see the note below)
 
-Internally, an `ALARM` value would be added (typically as first in the list)
-if the `ups.alarm` is currently not empty. For more details, see below in
-`alarm_set()` description.
+`ALARM` should no longer be raised through the UPS status.
+An `ALARM` value will be added internally (typically as first in the list)
+if an alarm was set and committed through the appropriate alarm functions.
+For more details, see below in the `UPS alarms` section.
 
 [NOTE]
 ======

--- a/tests/driver_methods_utest.c
+++ b/tests/driver_methods_utest.c
@@ -75,39 +75,52 @@ int main(int argc, char **argv) {
 	cases_passed = 0;
 	cases_failed = 0;
 
-	/* test case #1 */
+	/* test case #1 (from scratch) */
+	/* we test for duplicate status tokens (no alarms) */
+	/* expectation: no duplicates among status tokens */
 	status_init();
-	nut_debug_level = 6;
 	status_set(" OL ");
 	status_set("OL BOOST");
 	status_set("OB ");
 	status_set(" BOOST");
 	status_commit();
-	valueStr = dstate_getinfo("ups.status");
-	nut_debug_level = 0;
-	report_0_means_pass(strcmp(valueStr, "OL BOOST OB"));
-	printf(" test for ups.status: '%s'; any duplicates?\n", NUT_STRARG(valueStr));
 
-	/* test case #2, build on top of #1 */
+	valueStr = dstate_getinfo("ups.status");
+	report_0_means_pass(strcmp(valueStr, "OL BOOST OB"));
+	printf(" test for ups.status: '%s'; got no duplicates?\n", NUT_STRARG(valueStr));
+
+	/* test case #2 (built on top of #1) */
+	/* we raise an alarm using the modern alarm functions */
+	/* expectation: alarm status token is present */
+	/* note: normally we would re-init and re-set the values */
 	alarm_init();
 	alarm_set("Test alarm 1");
 	alarm_set("[Test alarm 2]");
 	alarm_set("Test alarm 1");
 	alarm_commit();
-	/* Note: normally we re-init and re-set the values */
-	status_commit();
+	status_commit(); /* to register ALARM status */
+
 	valueStr = dstate_getinfo("ups.status");
 	report_0_means_pass(strcmp(valueStr, "ALARM OL BOOST OB"));
-	printf(" test for ups.status: '%s'; got alarm?\n", NUT_STRARG(valueStr));
+	printf(" test for ups.status: '%s'; got alarm, no duplicates?\n", NUT_STRARG(valueStr));
 
-	/* test case #3, build on top of #2 */
+	/* test case #3 (built on top of #2) */
+	/* we raise an alarm using the modern alarm functions */
+	/* expectation: three alarm messages stored in ups.alarm */
+	/* note: normally we would re-init and re-set the values */
 	valueStr = dstate_getinfo("ups.alarm");
-	/* NOTE: no dedup here! */
 	report_0_means_pass(strcmp(valueStr, "Test alarm 1 [Test alarm 2] Test alarm 1"));
 	printf(" test for ups.alarm: '%s'; got 3 alarms?\n", NUT_STRARG(valueStr));
 
-	/* test case #4, build on top of #1 and #2 */
-	/* Note: normally we re-init and re-set the values */
+	/* test case #4 (built on top of #3) */
+	/* reset the status, see if the raised modern alarm persists */
+	/* expectation: alarm remains, no duplicate tokens reported */
+	/* note: normally we would re-init and re-set the values */
+	status_init();
+	status_set(" OL ");
+	status_set("OL BOOST");
+	status_set("OB ");
+	status_set(" BOOST");
 	status_set("BOO");
 	status_set("BOO");
 	status_set("OST");
@@ -115,11 +128,28 @@ int main(int argc, char **argv) {
 	status_set("OOS");
 	status_set("OOS");
 	status_commit();
+
 	valueStr = dstate_getinfo("ups.status");
 	report_0_means_pass(strcmp(valueStr, "ALARM OL BOOST OB BOO OST OOS"));
-	printf(" test for ups.status: '%s'; any duplicates?\n", NUT_STRARG(valueStr));
+	printf(" test for ups.status: '%s'; got alarm, no duplicates?\n", NUT_STRARG(valueStr));
 
-	/* test case #5+#6 from scratch */
+	/* test case #5 (built on top of #4) */
+	/* reset the status, see if the raised modern alarm persists */
+	/* expectation: three alarm messages still stored in ups.alarm */
+	/* note: normally we would re-init and re-set the values */
+	valueStr = dstate_getinfo("ups.alarm");
+	report_0_means_pass(strcmp(valueStr, "Test alarm 1 [Test alarm 2] Test alarm 1"));
+	printf(" test for ups.alarm: '%s'; got 3 alarms?\n", NUT_STRARG(valueStr));
+
+	/* clear testing state for next from-scratch test */
+	alarm_init();
+	alarm_commit();
+	status_init();
+	status_commit();
+
+	/* test case #6 (from scratch) */
+	/* mix legacy alarm status and modern alarm functions */
+	/* expectation: alarm status token is present, no duplicates */
 	status_init();
 	alarm_init();
 	status_set("OL BOOST");
@@ -131,13 +161,25 @@ int main(int argc, char **argv) {
 
 	valueStr = dstate_getinfo("ups.status");
 	report_0_means_pass(strcmp(valueStr, "ALARM OL BOOST OB"));
-	printf(" test for ups.status with explicit ALARM set via status_set() and alarm_set() was not used first: '%s'; any duplicate ALARM?\n", NUT_STRARG(valueStr));
+	printf(" test for ups.status with explicit ALARM set via status_set() and alarm_set() was not used first: '%s'; got alarm, no duplicates?\n", NUT_STRARG(valueStr));
 
+	/* test case #7 (built on top of #6) */
+	/* mix legacy alarm status and modern alarm functions */
+	/* expectation: 1 alarm message is recorded in ups.alarm */
+	/* note: normally we would re-init and re-set the values */
 	valueStr = dstate_getinfo("ups.alarm");
 	report_0_means_pass(strcmp(valueStr, "[Test alarm 2]"));
-	printf(" test for ups.alarm  with explicit ALARM set via status_set() and alarm_set() was not used first: '%s'; got 1 alarm (injected N/A replaced by later explicit text)\n", NUT_STRARG(valueStr));
+	printf(" test for ups.alarm with explicit ALARM set via status_set() and alarm_set() was not used first: '%s'; got 1 alarm?\n", NUT_STRARG(valueStr));
 
-	/* test case #7+#8 from scratch */
+	/* clear testing state for next from-scratch test */
+	alarm_init();
+	alarm_commit();
+	status_init();
+	status_commit();
+
+	/* test case #8 (from scratch) */
+	/* mix legacy alarm status and modern alarm functions (reverse) */
+	/* expectation: alarm status token is present, no duplicates */
 	status_init();
 	alarm_init();
 	status_set("OL BOOST");
@@ -149,78 +191,129 @@ int main(int argc, char **argv) {
 
 	valueStr = dstate_getinfo("ups.status");
 	report_0_means_pass(strcmp(valueStr, "ALARM OL BOOST OB"));
-	printf(" test for ups.status with explicit ALARM set via status_set() and alarm_set() was used first: '%s'; any duplicate ALARM?\n", NUT_STRARG(valueStr));
+	printf(" test for ups.status with explicit ALARM set via status_set() and alarm_set() was used first: '%s'; got alarm, no duplicates?\n", NUT_STRARG(valueStr));
 
+	/* test case #9 (built on top of #8) */
+	/* mix legacy alarm status and modern alarm functions (reverse) */
+	/* expectation: 1 alarm message is recorded in ups.alarm */
+	/* note: normally we would re-init and re-set the values */
 	valueStr = dstate_getinfo("ups.alarm");
 	report_0_means_pass(strcmp(valueStr, "[Test alarm 2]"));
-	printf(" test for ups.alarm  with explicit ALARM set via status_set() and alarm_set() was used first: '%s'; got 1 alarm (none injected)\n", NUT_STRARG(valueStr));
+	printf(" test for ups.alarm with explicit ALARM set via status_set() and alarm_set() was used first: '%s'; got 1 alarm?\n", NUT_STRARG(valueStr));
 
-	/* test case #9+#10 from scratch */
-	status_init();
+	/* clear testing state for next from-scratch test */
 	alarm_init();
+	alarm_commit();
+	status_init();
+	status_commit();
+
+	/* test case #10 (from scratch) */
+	/* legacy alarm status and no modern alarm functions */
+	/* expectation: alarm status token is present, no duplicates */
+	status_init();
 	status_set("OL BOOST");
 	status_set("ALARM");
 	status_set("OB");
-	alarm_commit();
 	status_commit();
 
 	valueStr = dstate_getinfo("ups.status");
 	report_0_means_pass(strcmp(valueStr, "ALARM OL BOOST OB"));
-	printf(" test for ups.status with explicit ALARM set via status_set() and no extra alarm_set(): '%s'; any duplicate ALARM?\n", NUT_STRARG(valueStr));
+	printf(" test for ups.status with explicit ALARM set via status_set() and no extra alarm_ funcs: '%s'; got alarm, no duplicates?\n", NUT_STRARG(valueStr));
 
+	/* test case #11 (built on top of #10) */
+	/* legacy alarm status and no modern alarm functions */
+	/* expectation: no alarm message is recorded in ups.alarm */
+	/* note: normally we would re-init and re-set the values */
 	valueStr = dstate_getinfo("ups.alarm");
-	report_0_means_pass(strcmp(NUT_STRARG(valueStr), "[N/A]"));
-	printf(" test for ups.alarm  with explicit ALARM set via status_set() and no extra alarm_set(): '%s'; got 1 (injected) alarm\n", NUT_STRARG(valueStr));
+	report_0_means_pass(valueStr != NULL); /* should be NULL */
+	printf(" test for ups.alarm with explicit ALARM set via status_set() and no extra alarm_ funcs: '%s'; got NULL?\n", NUT_STRARG(valueStr));
 
-	/* test case #11+#12 from scratch */
-	/* flush ups.alarm report */
-	alarm_init();
-	alarm_commit();
+	/* clear testing state for next from-scratch test */
+	/* alarm_ was not used, should be cleared from before */
+	status_init();
+	status_commit();
+
+	/* test case #12 (from scratch) */
+	/* ignored LB */
+	/* expectation: previous legacy alarm is cleared, LB ignored */
+	dstate_setinfo("driver.flag.ignorelb", "enabled");
 
 	status_init();
-	alarm_init();
 	status_set("OL BOOST");
-	status_set("ALARM");
 	status_set("OB");
 	status_set("LB");	/* Should be honoured */
 	status_commit();
 
 	valueStr = dstate_getinfo("ups.status");
-	report_0_means_pass(strcmp(valueStr, "ALARM OL BOOST OB LB"));
-	printf(" test for ups.status with explicit ALARM set via status_set() and no extra alarm_set() nor alarm_commit(): '%s'; is ALARM reported?\n", NUT_STRARG(valueStr));
+	report_0_means_pass(strcmp(valueStr, "OL BOOST OB"));
+	printf(" test for ups.status with ignored LB: '%s'; got no alarm, ignored LB, no duplicates?\n", NUT_STRARG(valueStr));
 
-	valueStr = dstate_getinfo("ups.alarm");
-/*
-	report_0_means_pass(valueStr != NULL);	// pass if valueStr is NULL
-	printf(" test for ups.alarm  with explicit ALARM set via status_set() and no extra alarm_set() nor alarm_commit(): '%s'; got no alarms spelled out\n", NUT_STRARG(valueStr));
-*/
-	report_0_means_pass(strcmp(NUT_STRARG(valueStr), "[N/A]"));
-	printf(" test for ups.alarm  with explicit ALARM set via status_set() and no extra alarm_set() nor alarm_commit(): '%s'; got 1 (injected) alarm\n", NUT_STRARG(valueStr));
-
-	/* test case #13+#14 from scratch */
-	/* flush ups.alarm report */
+	/* clear testing state for next from-scratch test */
 	alarm_init();
 	alarm_commit();
-
-	dstate_setinfo("driver.flag.ignorelb", "enabled");
-
 	status_init();
-	alarm_init();
-	status_set("OL BOOST");
-	alarm_set("[N/A]");
-	alarm_set("[Test alarm 2]");
-	status_set("OB");
-	status_set("LB");	/* Should be ignored */
-	alarm_commit();
 	status_commit();
 
-	valueStr = dstate_getinfo("ups.status");
-	report_0_means_pass(strcmp(valueStr, "ALARM OL BOOST OB"));
-	printf(" test for ups.status with explicit alarm_set(N/A) and another alarm_set(): '%s'; is ALARM reported?\n", NUT_STRARG(valueStr));
+	/* test case #13 (from scratch) */
+	/* alarm raised with modern alarm functions, no status, no status commit */
+	/* expectation: empty status, no whitespace */
+	alarm_init();
+	alarm_set("[Test alarm]");
+	alarm_commit();
 
+	valueStr = dstate_getinfo("ups.status");
+	report_0_means_pass(strcmp(valueStr, "\0"));
+	printf(" test for ups.status with alarm_ set and no status_commit(): '%s'; got empty, no whitespace?\n", NUT_STRARG(valueStr));
+
+	/* test case #14 (built on top of #13) */
+	/* alarm raised with modern alarm functions, no status, no status commit */
+	/* expectation: 1 alarm message is recorded in ups.alarm */
+	/* note: normally we would re-init and re-set the values */
 	valueStr = dstate_getinfo("ups.alarm");
-	report_0_means_pass(strcmp(valueStr, "[N/A] [Test alarm 2]"));
-	printf(" test for ups.alarm  with explicit alarm_set(N/A) and another alarm_set(): '%s'; got both alarms, namesake of not-injected is not overwritten\n", NUT_STRARG(valueStr));
+	report_0_means_pass(strcmp(valueStr, "[Test alarm]"));
+	printf(" test for ups.status with alarm_ set and no status_commit(): '%s'; got 1 alarm?\n", NUT_STRARG(valueStr));
+
+	/* clear testing state for next from-scratch test */
+	alarm_init();
+	alarm_commit();
+	status_init();
+	status_commit();
+
+	/* test case #15 (from scratch) */
+	/* alarm raised with modern alarm functions, no status, but status commit */
+	/* expectation: alarm status token is present, no leading/trailing spaces */
+	alarm_init();
+	alarm_set("alarm");
+	alarm_commit();
+	status_commit(); /* to register ALARM status */
+
+	valueStr = dstate_getinfo("ups.status");
+	report_0_means_pass(strcmp(valueStr, "ALARM"));
+	printf(" test for ups.status with alarm_ set, no status and status_commit(): '%s'; got alarm, no whitespace?\n", NUT_STRARG(valueStr));
+
+	/* clear testing state for next from-scratch test */
+	alarm_init();
+	alarm_commit();
+	status_init();
+	status_commit();
+
+	/* test case #16 (from scratch) */
+	/* alarm raised with modern alarm functions, status commit before alarm commit */
+	/* expectation: empty status, no whitespace */
+	alarm_init();
+	alarm_set("alarm");
+	status_commit();
+	alarm_commit(); /* too late? */
+
+	valueStr = dstate_getinfo("ups.status");
+	report_0_means_pass(strcmp(valueStr, "\0"));
+	printf(" test for ups.status with alarm_ set, status_commit() before alarm_commit(): '%s'; got empty, no whitespace?\n", NUT_STRARG(valueStr));
+
+	/* clear testing state before finish */
+	alarm_init();
+	alarm_commit();
+	status_init();
+	status_commit();
 
 	/* finish */
 	printf("test_rules completed. Total cases %d, passed %d, failed %d\n",


### PR DESCRIPTION
follow up to #2931, fixes #2928 
implements the ideas of https://github.com/networkupstools/nut/pull/2931#issuecomment-2841705269

this PR amends the various involved parts to clean separation of legacy UPS-status coupled `ALARM`
and modern `alarm_`-driven `ALARM`, which are decoupled from UPS status aside from the token itself.

it removes making assumptions on legacy UPS-status coupled `ALARM` and removes workarounds trying
to port any such legacy `ALARM` statuses into the UPS-status decoupled `alarm_` schema, because this would
mean later having to couple them back to UPS-status again to be able to exit these alarm states. (within `dstate`)

this PR allows for both to co-exist peacefully with the only limitation being that a `ups.alarm` does not get
injected when it is not otherwise published directly and manually by the (legacy) driver. `ups.alarm` published
manually by the (legacy) UPS driver will still raise appropriate (seperate) notifications, be tracked by `upsmon`
and function normally as if they were raised by the modern `alarm_` functions (from the `upsmon` perspective).

the `upsmon` does not care where in `dstate` an `ALARM` token was set, nor if done so by legacy or modern method.

the tests now cover both legacy, mixed and modern scenarios respectively, as well as some more curious edge-cases.
further work is in progress to modernize the few remaining legacy drivers to use the `status_` and `alarm_` functions.
this ongoing work will later be published in separate PRs.