### PR TITLE
drivers/nutdrv_hashx: Add new driver for PowerManager+ serial supported devices

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -195,3 +195,9 @@ N: zakx
 E: zakx@zakx.de
 D: Updating device support docs after unnecessarily writing a redundant
 D: driver first
+
+N: Marco Trevisan (Treviño)
+E: mail@3v1n0.net
+W: https://3v1n0.net
+D: Author of the nutdrv_hashx driver
+P: rsa4096/D4C501DA 48EB 797A 0817 5093 9449 C2F5 0996 635F

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -84,6 +84,13 @@ https://github.com/networkupstools/nut/milestone/9
      monitoring. Most specific reported values are in an `experimental.*`
      namespace, as a community we need to come up with standard naming for
      those via `docs/nut-names.txt`. [#440]
+   * Introduced a `nutdrv_hashx` driver for numerous devices from Ablerex,
+     Atlantis Land, Epyc, Infosec, ION, PowerWalker, Right Power Technology,
+     Salicru, UPS Solutions and other vendors (originally shipped with a
+     "PowerMaster+", "PowerMaster" or "PowerGuide" software companion suite).
+     This seems to be a protocol developed by Cyber Energy for serial-port
+     devices, subsequently used by different vendors in their own products
+     or re-branded Cyber Energy creations. [#2940]
 
 
 Release notes for NUT 2.8.3 - what's new since 2.8.2

--- a/data/cmdvartab
+++ b/data/cmdvartab
@@ -264,6 +264,8 @@ CMDDESC experimental.ecomode.start.auto "Put UPS in Bypass mode then High Effici
 CMDDESC experimental.ecomode.stop.auto "Take the UPS out of High Efficiency (aka ECO) mode after exiting Bypass mode"
 CMDDESC experimental.essmode.enable "Put UPS in Energy Saver System (aka ESS) mode"
 CMDDESC experimental.essmode.disable "Take the UPS out of Energy Saver System (aka ESS) mode"
+CMDDESC experimental.test.beeper.start "Start testing the UPS beeper"
+CMDDESC experimental.test.beeper.stop "Stop a UPS beeper test"
 CMDDESC reset.input.minmax "Reset minimum and maximum input voltage status"
 CMDDESC reset.watchdog "Reset watchdog timer"
 CMDDESC beeper.on "Obsolete (use beeper.enable)"

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -50,6 +50,7 @@
 "Ablerex"	"ups"	"2"	"MSIII series"	"USB"	"nutdrv_qx"
 "Ablerex"	"ups"	"2"	"GRs series"	"USB"	"nutdrv_qx"
 "Ablerex"	"ups"	"2"	"GRs Plus series"	"USB"	"nutdrv_qx"
+"Ablerex"	"ups"	"1"	"(various)" "Serial"	"nutdrv_hashx" # https://www.ablerex.eu/download/
 
 "ActivePower"	"ups"	"2"	"400VA"	""	"blazer_ser"
 "ActivePower"	"ups"	"2"	"1400VA"	""	"blazer_ser"
@@ -156,7 +157,31 @@
 "Atlantis Land"	"ups"	"2"	"OnePower 841+ (A03-P841)"	"USB"	"nutdrv_qx"
 "Atlantis Land"	"ups"	"2"	"(various)"	"Serial"	"nutdrv_qx"
 "Atlantis Land"	"ups"	"2"	"(various)"	"USB"	"nutdrv_qx"
+"Atlantis Land"	"ups"	"1"	"A03-0P10002P-RC"	"Serial"	"nutdrv_hashx"
+"Atlantis Land"	"ups"	"1"	"A03-0P1002"	"Serial"	"nutdrv_hashx"
+"Atlantis Land"	"ups"	"1"	"A03-0P1002XLN"	"Serial"	"nutdrv_hashx"
+"Atlantis Land"	"ups"	"1"	"A03-0P1302-RC"	"Serial"	"nutdrv_hashx"
+"Atlantis Land"	"ups"	"1"	"A03-0P1502P"	"Serial"	"nutdrv_hashx"
+"Atlantis Land"	"ups"	"1"	"A03-0P1502P-RC"	"Serial"	"nutdrv_hashx"
+"Atlantis Land"	"ups"	"1"	"A03-0P2002-RC"	"Serial"	"nutdrv_hashx"
+"Atlantis Land"	"ups"	"1"	"A03-0P2002P"	"Serial"	"nutdrv_hashx"
+"Atlantis Land"	"ups"	"1"	"A03-0P2002P-RC"	"Serial"	"nutdrv_hashx"
+"Atlantis Land"	"ups"	"1"	"A03-0P3002P"	"Serial"	"nutdrv_hashx"
+"Atlantis Land"	"ups"	"1"	"A03-0P3002P-RC"	"Serial"	"nutdrv_hashx"
+"Atlantis Land"	"ups"	"1"	"A03-0P3002XLN"	"Serial"	"nutdrv_hashx"
+"Atlantis Land"	"ups"	"1"	"A03-0P6002P-RC"	"Serial"	"nutdrv_hashx"
+"Atlantis Land"	"ups"	"1"	"A03-HP1003"	"Serial"	"nutdrv_hashx"
+"Atlantis Land"	"ups"	"1"	"A03-HP1503"	"Serial"	"nutdrv_hashx"
+"Atlantis Land"	"ups"	"1"	"A03-HP2003"	"Serial"	"nutdrv_hashx"
+"Atlantis Land"	"ups"	"1"	"A03-HP3003P"	"Serial"	"nutdrv_hashx"
+"Atlantis Land"	"ups"	"1"	"A03-HP4003P"	"Serial"	"nutdrv_hashx"
+"Atlantis Land"	"ups"	"1"	"A03-PDU1000-RC"	"Serial"	"nutdrv_hashx"
+"Atlantis Land"	"ups"	"1"	"A03-S1000LE"	"Serial"	"nutdrv_hashx"
+"Atlantis Land"	"ups"	"1"	"A03-S1000P"	"Serial"	"nutdrv_hashx"
+"Atlantis Land"	"ups"	"1"	"A03-S120 (Rev.22.0)"	"Serial"	"nutdrv_hashx"
 "Atlantis Land"	"ups"	"1"	"A03-S1200"	"Serial"	"nutdrv_hashx"
+"Atlantis Land"	"ups"	"1"	"A03-S1501 (Rev.22.0)"	"Serial"	"nutdrv_hashx"
+"Atlantis Land"	"ups"	"1"	"A03-S2001 (Rev.22.0)"	"Serial"	"nutdrv_hashx"
 
 "Aviem Systems"	"ups"	"2"	"Aviem Power RT 1000-3000VA"	""	"blazer_ser"
 "Aviem Systems"	"ups"	"2"	"Aviem Pro 2000VA"	"USB"	"blazer_usb"	# https://github.com/networkupstools/nut/issues/827
@@ -237,6 +262,7 @@
 "Crown"	"ups"	"2"	"CMU-SP1200IEC"	"USB"	"nutdrv_qx port=auto vendorid=0001 productid=0000 protocol=hunnox langid_fix=0x0409 novendor noscanlangid"	# https://github.com/networkupstools/nut/pull/638 caveats at https://github.com/networkupstools/nut/issues/1014
 
 "Cyber Energy"	"ups"	"3"	"Models with USB"	"USB"	"usbhid-ups"	# https://alioth-lists.debian.net/pipermail/nut-upsdev/2024-February/007966.html https://alioth-lists.debian.net/pipermail/nut-upsdev/2024-June/008002.html
+"Cyber Energy"	"ups"	"1"	"Models with Serial"	"Serial"	"nutdrv_hashx"  # https://www.cyberenergy.com/en/Product/software
 
 "Cyber Power Systems"	"ups"	"1"	"550SL"	""	"genericups upstype=7"
 "Cyber Power Systems"	"ups"	"1"	"725SL"	""	"genericups upstype=7"
@@ -581,6 +607,7 @@
 "Infosec"	"ups"	"2"	"X2, X3, X4, E2, E3, E4"	"USB"	"blazer_usb"
 "Infosec"	"ups"	"2"	"XP 500"	"USB"	"blazer_usb"
 "Infosec"	"ups"	"2"	"XP 1000"	""	"blazer_ser"
+"Infosec"	"ups"	"1"	"(various)" "Serial"	"nutdrv_hashx" # https://www.infosec-ups.com/en/powermaster
 
 "IPAR"	"ups"	"2"	"Mini Energy ME 800"	"USB"	"blazer_usb"
 
@@ -1176,6 +1203,7 @@
 "PowerWalker"	"ups"	"3"	"PR1500LCDRT2U"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/818
 "PowerWalker"	"ups"	"2"	"VI 3000 SCL"	"USB"	"blazer_usb" # https://github.com/networkupstools/nut/issues/971
 "PowerWalker"	"ups"	"3"	"VI 750T/HID"	"USB"	"usbhid-ups" # https://powerwalker.com/?page=select&cat=VI_THID&lang=en https://github.com/networkupstools/nut/issues/774
+"PowerWalker"	"ups"	"1"	"(various)" "Serial"	"nutdrv_hashx"  # https://powerwalker.com/software/
 
 "Powerware"	"ups"	"4"	"3110"	""	"genericups upstype=7"
 "Powerware"	"ups"	"4"	"3115"	""	"genericups upstype=11"
@@ -1267,6 +1295,8 @@
 "Riello"	"ups"	"3"	"(various)"	"Netman 204 SNMP Card"	"snmp-ups"	# Note: in https://github.com/networkupstools/nut/issues/1878 submitted not as 'Netman Plus', clarification requested
 "Riello"	"ups"	"3"	"(various)"	"Netman 208 SNMP Card"	"snmp-ups"	# Note: in https://github.com/networkupstools/nut/issues/1878 submitted not as 'Netman Plus', clarification requested
 
+"Right Power Technology"	"ups"	"1"	"(various)" "Serial"	"nutdrv_hashx"  https://www.rightpowerups.com.my/faq-download/
+
 "Rocketfish"	"ups"	"3"	"RF-1000VA / RF-1025VA"	"USB"	"usbhid-ups"
 
 "Rucelf"	"ups"	"2"	"Rucelf UPOII-3000-96-EL"	""	"blazer_ser" # http://www.rucelf.ua/en/catalog/upoii-3000-96-el/
@@ -1281,6 +1311,7 @@
 "Salicru"	"ups"	"3"	"SLC TWIN RT3"	"usb"	"usbhid-ups (experimental)"
 "Salicru"	"ups"	"3"	"SPS 850 ADV T"	"usb"	"usbhid-ups (experimental)" # https://www.salicru.com/sps-850-adv-t.html https://github.com/networkupstools/nut/issues/1416
 "Salicru"	"ups"	"3"	"SPS 3000 ADV RT2"	"usb"	"usbhid-ups (experimental)" # https://www.salicru.com/sps-3000-adv-rt2.html
+"Salicru"	"ups"	"1"	"(various)" "Serial"	"nutdrv_hashx"  # https://www.salicru.com/softwares-usb-rs-232.html
 
 "Santak"	"ups"	"2"	"Castle C*K"	"Serial"	"blazer_ser"	# https://github.com/networkupstools/nut/issues/1039
 "Santak"	"ups"	"2"	"MT*-PRO"	"Serial"	"blazer_ser"	# https://github.com/networkupstools/nut/issues/1039

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -156,6 +156,7 @@
 "Atlantis Land"	"ups"	"2"	"OnePower 841+ (A03-P841)"	"USB"	"nutdrv_qx"
 "Atlantis Land"	"ups"	"2"	"(various)"	"Serial"	"nutdrv_qx"
 "Atlantis Land"	"ups"	"2"	"(various)"	"USB"	"nutdrv_qx"
+"Atlantis Land"	"ups"	"1"	"A03-S1200"	"Serial"	"nutdrv_hashx"
 
 "Aviem Systems"	"ups"	"2"	"Aviem Power RT 1000-3000VA"	""	"blazer_ser"
 "Aviem Systems"	"ups"	"2"	"Aviem Pro 2000VA"	"USB"	"blazer_usb"	# https://github.com/networkupstools/nut/issues/827

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -50,7 +50,7 @@
 "Ablerex"	"ups"	"2"	"MSIII series"	"USB"	"nutdrv_qx"
 "Ablerex"	"ups"	"2"	"GRs series"	"USB"	"nutdrv_qx"
 "Ablerex"	"ups"	"2"	"GRs Plus series"	"USB"	"nutdrv_qx"
-"Ablerex"	"ups"	"1"	"(various)" "Serial"	"nutdrv_hashx" # https://www.ablerex.eu/download/
+"Ablerex"	"ups"	"1"	"(various)" "Serial"	"nutdrv_hashx"	# https://www.ablerex.eu/download/
 
 "ActivePower"	"ups"	"2"	"400VA"	""	"blazer_ser"
 "ActivePower"	"ups"	"2"	"1400VA"	""	"blazer_ser"
@@ -262,7 +262,7 @@
 "Crown"	"ups"	"2"	"CMU-SP1200IEC"	"USB"	"nutdrv_qx port=auto vendorid=0001 productid=0000 protocol=hunnox langid_fix=0x0409 novendor noscanlangid"	# https://github.com/networkupstools/nut/pull/638 caveats at https://github.com/networkupstools/nut/issues/1014
 
 "Cyber Energy"	"ups"	"3"	"Models with USB"	"USB"	"usbhid-ups"	# https://alioth-lists.debian.net/pipermail/nut-upsdev/2024-February/007966.html https://alioth-lists.debian.net/pipermail/nut-upsdev/2024-June/008002.html
-"Cyber Energy"	"ups"	"1"	"Models with Serial"	"Serial"	"nutdrv_hashx"  # https://www.cyberenergy.com/en/Product/software
+"Cyber Energy"	"ups"	"1"	"Models with Serial"	"Serial"	"nutdrv_hashx"	# https://www.cyberenergy.com/en/Product/software
 
 "Cyber Power Systems"	"ups"	"1"	"550SL"	""	"genericups upstype=7"
 "Cyber Power Systems"	"ups"	"1"	"725SL"	""	"genericups upstype=7"
@@ -496,7 +496,7 @@
 "Fideltronik"	"ups"	"1"	"Ares 700 and larger"	""	"genericups upstype=6"
 "Fideltronik"	"ups"	"2"	"LUPUS 500"	"USB"	"nutdrv_qx"
 "Fideltronik"	"ups"	"1"	"Other Ares models"	""	"genericups upstype=19"
-"Fideltronik INIGO"	"ups"	"2"	"Viper 1200"	"USB"	"nutdrv_qx" # http://fideltronikinigo.com/viper/viper-1200/
+"Fideltronik INIGO"	"ups"	"2"	"Viper 1200"	"USB"	"nutdrv_qx"	# http://fideltronikinigo.com/viper/viper-1200/
 
 "Fiskars"	"ups"	"4"	"PowerRite MAX"	""	"upscode2"
 "Fiskars"	"ups"	"4"	"PowerServer 10"	""	"upscode2"
@@ -607,7 +607,7 @@
 "Infosec"	"ups"	"2"	"X2, X3, X4, E2, E3, E4"	"USB"	"blazer_usb"
 "Infosec"	"ups"	"2"	"XP 500"	"USB"	"blazer_usb"
 "Infosec"	"ups"	"2"	"XP 1000"	""	"blazer_ser"
-"Infosec"	"ups"	"1"	"(various)" "Serial"	"nutdrv_hashx" # https://www.infosec-ups.com/en/powermaster
+"Infosec"	"ups"	"1"	"(various)" "Serial"	"nutdrv_hashx"	# https://www.infosec-ups.com/en/powermaster
 
 "IPAR"	"ups"	"2"	"Mini Energy ME 800"	"USB"	"blazer_usb"
 
@@ -1125,7 +1125,7 @@
 "Phasak"	"ups"	"2"	"400VA / 600VA"	""	"blazer_ser"
 "Phasak"	"ups"	"2"	"9465 or P6N"	"USB"	"nutdrv_qx"	# https://github.com/networkupstools/nut/issues/1187 => Voltronic-QS-Hex protocol detected
 
-"PhoenixContact"	"ups"	"4"	"QUINT-UPS/24DC"	"2320461"	"phoenixcontact_modbus" #https://www.phoenixcontact.com/online/portal/us?uri=pxc-oc-itemdetail:pid=2320461
+"PhoenixContact"	"ups"	"4"	"QUINT-UPS/24DC"	"2320461"	"phoenixcontact_modbus"	#https://www.phoenixcontact.com/online/portal/us?uri=pxc-oc-itemdetail:pid=2320461
 
 "PiJuice"	"ups"	"5"	"PiJuice HAT"	""	"pijuice"	# https://github.com/PiSupply/PiJuice/issues/124
 "PiJuice"	"ups"	"5"	"PiJuice Zero pHAT"	""	"pijuice"
@@ -1191,19 +1191,19 @@
 "PowerWalker"	"ups"	"2"	"Line-Interactive VI 850 LCD"	"USB"	"blazer_usb"
 "PowerWalker"	"ups"	"2"	"Online VFI 1000RT/1500RT/2000RT/3000RT/6000RT/10000RT LCD"	"USB"	"blazer_usb"
 "PowerWalker"	"ups"	"2"	"Line-Interactive VI 1000RT/1500RT/2000RT/3000RT LCD"	"USB"	"blazer_usb"
-"PowerWalker"	"ups"	"2"	"VFI 1000 CG PF1"	""	"nutdrv_qx" # https://powerwalker.com/?page=product&item=10122108&lang=en
-"PowerWalker"	"ups"	"3"	"VFI 2000 TGS"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/560 and https://github.com/networkupstools/nut/pull/564
-"PowerWalker"	"ups"	"3"	"VI 650 SH"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/483
-"PowerWalker"	"ups"	"3"	"VI 650/850 SHL"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/646
-"PowerWalker"	"ups"	"3"	"VI 1200 SHL"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/1270
-"PowerWalker"	"ups"	"3"	"VI 2200 SHL"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/756
-"PowerWalker"	"ups"	"3"	"VI 1200 SH"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/646
-"PowerWalker"	"ups"	"3"	"VI 2200 SH"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/646
-"PowerWalker"	"ups"	"3"	"Basic VI 1000 SB"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/818
-"PowerWalker"	"ups"	"3"	"PR1500LCDRT2U"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/818
-"PowerWalker"	"ups"	"2"	"VI 3000 SCL"	"USB"	"blazer_usb" # https://github.com/networkupstools/nut/issues/971
-"PowerWalker"	"ups"	"3"	"VI 750T/HID"	"USB"	"usbhid-ups" # https://powerwalker.com/?page=select&cat=VI_THID&lang=en https://github.com/networkupstools/nut/issues/774
-"PowerWalker"	"ups"	"1"	"(various)" "Serial"	"nutdrv_hashx"  # https://powerwalker.com/software/
+"PowerWalker"	"ups"	"2"	"VFI 1000 CG PF1"	""	"nutdrv_qx"	# https://powerwalker.com/?page=product&item=10122108&lang=en
+"PowerWalker"	"ups"	"3"	"VFI 2000 TGS"	"USB"	"usbhid-ups"	# https://github.com/networkupstools/nut/issues/560 and https://github.com/networkupstools/nut/pull/564
+"PowerWalker"	"ups"	"3"	"VI 650 SH"	"USB"	"usbhid-ups"	# https://github.com/networkupstools/nut/issues/483
+"PowerWalker"	"ups"	"3"	"VI 650/850 SHL"	"USB"	"usbhid-ups"	# https://github.com/networkupstools/nut/issues/646
+"PowerWalker"	"ups"	"3"	"VI 1200 SHL"	"USB"	"usbhid-ups"	# https://github.com/networkupstools/nut/issues/1270
+"PowerWalker"	"ups"	"3"	"VI 2200 SHL"	"USB"	"usbhid-ups"	# https://github.com/networkupstools/nut/issues/756
+"PowerWalker"	"ups"	"3"	"VI 1200 SH"	"USB"	"usbhid-ups"	# https://github.com/networkupstools/nut/issues/646
+"PowerWalker"	"ups"	"3"	"VI 2200 SH"	"USB"	"usbhid-ups"	# https://github.com/networkupstools/nut/issues/646
+"PowerWalker"	"ups"	"3"	"Basic VI 1000 SB"	"USB"	"usbhid-ups"	# https://github.com/networkupstools/nut/issues/818
+"PowerWalker"	"ups"	"3"	"PR1500LCDRT2U"	"USB"	"usbhid-ups"	# https://github.com/networkupstools/nut/issues/818
+"PowerWalker"	"ups"	"2"	"VI 3000 SCL"	"USB"	"blazer_usb"	# https://github.com/networkupstools/nut/issues/971
+"PowerWalker"	"ups"	"3"	"VI 750T/HID"	"USB"	"usbhid-ups"	# https://powerwalker.com/?page=select&cat=VI_THID&lang=en https://github.com/networkupstools/nut/issues/774
+"PowerWalker"	"ups"	"1"	"(various)" "Serial"	"nutdrv_hashx"	# https://powerwalker.com/software/
 
 "Powerware"	"ups"	"4"	"3110"	""	"genericups upstype=7"
 "Powerware"	"ups"	"4"	"3115"	""	"genericups upstype=11"
@@ -1295,23 +1295,23 @@
 "Riello"	"ups"	"3"	"(various)"	"Netman 204 SNMP Card"	"snmp-ups"	# Note: in https://github.com/networkupstools/nut/issues/1878 submitted not as 'Netman Plus', clarification requested
 "Riello"	"ups"	"3"	"(various)"	"Netman 208 SNMP Card"	"snmp-ups"	# Note: in https://github.com/networkupstools/nut/issues/1878 submitted not as 'Netman Plus', clarification requested
 
-"Right Power Technology"	"ups"	"1"	"(various)" "Serial"	"nutdrv_hashx"  https://www.rightpowerups.com.my/faq-download/
+"Right Power Technology"	"ups"	"1"	"(various)" "Serial"	"nutdrv_hashx"	# https://www.rightpowerups.com.my/faq-download/
 
 "Rocketfish"	"ups"	"3"	"RF-1000VA / RF-1025VA"	"USB"	"usbhid-ups"
 
-"Rucelf"	"ups"	"2"	"Rucelf UPOII-3000-96-EL"	""	"blazer_ser" # http://www.rucelf.ua/en/catalog/upoii-3000-96-el/
+"Rucelf"	"ups"	"2"	"Rucelf UPOII-3000-96-EL"	""	"blazer_ser"	# http://www.rucelf.ua/en/catalog/upoii-3000-96-el/
 
 "Salicru"	"ups"	"2"	"SPS ONE 700VA"	"USB"	"blazer_usb"
 "Salicru"	"ups"	"2"	"SPS ONE 900VA"	"USB"	"nutdrv_qx"	# https://github.com/networkupstools/nut/issues/1623
 "Salicru"	"ups"	"2"	"SPS ONE 2000VA"	"USB"	"nutdrv_qx"	# https://www.salicru.com/en/ups/sps-one.html https://github.com/networkupstools/nut/issues/554
 "Salicru"	"ups"	"3"	"SPS 650/850 HOME"	"usb"	"usbhid-ups (experimental)"
-"Salicru"	"ups"	"3"	"SLC TWIN PRO2"	"usb"	"usbhid-ups (experimental)" # https://github.com/networkupstools/nut/issues/450
-"Salicru"	"ups"	"3"	"SLC-1500-TWIN PRO3"	"usb"	"usbhid-ups (experimental)" # https://github.com/networkupstools/nut/issues/1142
+"Salicru"	"ups"	"3"	"SLC TWIN PRO2"	"usb"	"usbhid-ups (experimental)"	# https://github.com/networkupstools/nut/issues/450
+"Salicru"	"ups"	"3"	"SLC-1500-TWIN PRO3"	"usb"	"usbhid-ups (experimental)"	# https://github.com/networkupstools/nut/issues/1142
 "Salicru"	"ups"	"3"	"SLC TWINPRO3"	"usb"	"usbhid-ups (experimental)"
 "Salicru"	"ups"	"3"	"SLC TWIN RT3"	"usb"	"usbhid-ups (experimental)"
-"Salicru"	"ups"	"3"	"SPS 850 ADV T"	"usb"	"usbhid-ups (experimental)" # https://www.salicru.com/sps-850-adv-t.html https://github.com/networkupstools/nut/issues/1416
-"Salicru"	"ups"	"3"	"SPS 3000 ADV RT2"	"usb"	"usbhid-ups (experimental)" # https://www.salicru.com/sps-3000-adv-rt2.html
-"Salicru"	"ups"	"1"	"(various)" "Serial"	"nutdrv_hashx"  # https://www.salicru.com/softwares-usb-rs-232.html
+"Salicru"	"ups"	"3"	"SPS 850 ADV T"	"usb"	"usbhid-ups (experimental)"	# https://www.salicru.com/sps-850-adv-t.html https://github.com/networkupstools/nut/issues/1416
+"Salicru"	"ups"	"3"	"SPS 3000 ADV RT2"	"usb"	"usbhid-ups (experimental)"	# https://www.salicru.com/sps-3000-adv-rt2.html
+"Salicru"	"ups"	"1"	"(various)" "Serial"	"nutdrv_hashx"	# https://www.salicru.com/softwares-usb-rs-232.html
 
 "Santak"	"ups"	"2"	"Castle C*K"	"Serial"	"blazer_ser"	# https://github.com/networkupstools/nut/issues/1039
 "Santak"	"ups"	"2"	"MT*-PRO"	"Serial"	"blazer_ser"	# https://github.com/networkupstools/nut/issues/1039
@@ -1378,7 +1378,7 @@
 "Sweex"	"ups"	"2"	"INTELLIGENT UPS 1500VA P220"	"USB"	"blazer_usb (USB ID 0665:5161)"	# http://www.sweex.com/en/notebook-pc-accessoires/ups/PP220/
 
 "Syndome"	"ups"	"2"	"Era 500VA"	"USB"	"blazer_usb"
-"Syndome"	"ups"	"3"	"Atom LCD-1000"	"USB"	"usbhid-ups" # https://github.com/networkupstools/nut/issues/483
+"Syndome"	"ups"	"3"	"Atom LCD-1000"	"USB"	"usbhid-ups"	# https://github.com/networkupstools/nut/issues/483
 
 "Sysgration"	"ups"	"2"	"UPGUARDS Pro650"	""	"blazer_ser"
 

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -284,7 +284,7 @@ check-pdf: .check-pdf
 # but causes re-run of the check every time.
 ChangeLog.html-contentchecked:
 	@FAILED=""; \
-	 entry_filter() { sed -e 's/ *[\"<].*//' -e 's/\([[(){}|+?.*]\|]\)/\\\1/g' ; } ; \
+	 entry_filter() { sed -e 's/ *[\"<].*//' -e 's/\([][(){}|+?.*]\)/\\\1/g' ; } ; \
 	 if [ -s '$(top_builddir)/ChangeLog' ] && [ -s ChangeLog.html ] ; then \
 	    SECOND_ENTRY="`grep -E '^[0-9]' '$(top_builddir)/ChangeLog' | head -2 | tail -1 | entry_filter`" || SECOND_ENTRY="" ; \
 	    FIRST_ENTRY="`grep -E '^[0-9]' '$(top_builddir)/ChangeLog' | head -1 | entry_filter`" || FIRST_ENTRY="" ; \

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -284,7 +284,7 @@ check-pdf: .check-pdf
 # but causes re-run of the check every time.
 ChangeLog.html-contentchecked:
 	@FAILED=""; \
-	 entry_filter() { sed -e 's/ *[\"<].*//' ; } ; \
+	 entry_filter() { sed -e 's/ *[\"<].*//' -e 's/\([[(){}|+?.*]\|]\)/\\\1/g' ; } ; \
 	 if [ -s '$(top_builddir)/ChangeLog' ] && [ -s ChangeLog.html ] ; then \
 	    SECOND_ENTRY="`grep -E '^[0-9]' '$(top_builddir)/ChangeLog' | head -2 | tail -1 | entry_filter`" || SECOND_ENTRY="" ; \
 	    FIRST_ENTRY="`grep -E '^[0-9]' '$(top_builddir)/ChangeLog' | head -1 | entry_filter`" || FIRST_ENTRY="" ; \

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -284,10 +284,11 @@ check-pdf: .check-pdf
 # but causes re-run of the check every time.
 ChangeLog.html-contentchecked:
 	@FAILED=""; \
+	 entry_filter() { sed -e 's/ *[\"<].*//' ; } ; \
 	 if [ -s '$(top_builddir)/ChangeLog' ] && [ -s ChangeLog.html ] ; then \
-	    SECOND_ENTRY="`grep -E '^[0-9]' '$(top_builddir)/ChangeLog' | head -2 | tail -1 | sed 's/ *[\"<].*//'`" || SECOND_ENTRY="" ; \
-	    FIRST_ENTRY="`grep -E '^[0-9]' '$(top_builddir)/ChangeLog' | head -1 | sed 's/ *[\"<].*//'`" || FIRST_ENTRY="" ; \
-	    LAST_ENTRY="`grep -E '^[0-9]' '$(top_builddir)/ChangeLog' | tail -1 | sed 's/ *[\"<].*//'`" || LAST_ENTRY="" ; \
+	    SECOND_ENTRY="`grep -E '^[0-9]' '$(top_builddir)/ChangeLog' | head -2 | tail -1 | entry_filter`" || SECOND_ENTRY="" ; \
+	    FIRST_ENTRY="`grep -E '^[0-9]' '$(top_builddir)/ChangeLog' | head -1 | entry_filter`" || FIRST_ENTRY="" ; \
+	    LAST_ENTRY="`grep -E '^[0-9]' '$(top_builddir)/ChangeLog' | tail -1 | entry_filter`" || LAST_ENTRY="" ; \
 	    if [ -n "$${FIRST_ENTRY}" ] ; then \
 	        O="`grep -cE "^$${FIRST_ENTRY}" '$(top_builddir)/ChangeLog'`" ; \
 	        N="`grep -cE "title.*$${FIRST_ENTRY}" 'ChangeLog.html'`" ; \

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -826,6 +826,7 @@ SRC_SERIAL_PAGES = \
 	oneac.txt	\
 	microdowell.txt	\
 	microsol-apc.txt	\
+	nutdrv_hashx.txt	\
 	nutdrv_siemens_sitop.txt	\
 	optiups.txt	\
 	powercom.txt 	\
@@ -874,6 +875,7 @@ INST_MAN_SERIAL_PAGES = \
 	oneac.$(MAN_SECTION_CMD_SYS)		\
 	microdowell.$(MAN_SECTION_CMD_SYS)	\
 	microsol-apc.$(MAN_SECTION_CMD_SYS)	\
+	nutdrv_hashx.$(MAN_SECTION_CMD_SYS)	\
 	nutdrv_siemens_sitop.$(MAN_SECTION_CMD_SYS)	\
 	optiups.$(MAN_SECTION_CMD_SYS)	\
 	powercom.$(MAN_SECTION_CMD_SYS) 	\
@@ -940,6 +942,7 @@ INST_HTML_SERIAL_MANS = \
 	oneac.html		\
 	microdowell.html	\
 	microsol-apc.html	\
+	nutdrv_hashx.html	\
 	nutdrv_siemens_sitop.html	\
 	optiups.html	\
 	powercom.html 	\

--- a/docs/man/nutdrv_hashx.txt
+++ b/docs/man/nutdrv_hashx.txt
@@ -1,0 +1,80 @@
+NUTDRV_HASHX(8)
+===============
+
+NAME
+----
+
+nutdrv_hashx - Driver for #* protocol serial based UPS equipment
+
+SYNOPSIS
+--------
+
+*nutdrv_hashx* -h
+
+*nutdrv_hashx* -a 'UPS_NAME' ['OPTIONS']
+
+NOTE: This man page only documents the hardware-specific features of the
+*nutdrv_hashx* driver.  For information about the core driver, see
+linkman:nutupsdrv[8].
+
+SUPPORTED HARDWARE
+------------------
+
+The protocol originates from Cyber Energy that apparently developed the
+protocol for their UPS and it was used then by various other vendors
+(that in some cases they just re-brand the Cyber Energy products).
+
+The *nutdrv_hashx* driver is expected to work with various UPSes from
+'Ablerex', 'Atlantis Land', 'Epyc', 'Infosec', 'ION', 'PowerWalker',
+'Right Power Technology', 'Salicru', 'UPS Solutions' and various others.
+
+Long story short: if your UPS came with a software called 'PowerMaster+'
+(or the older 'PowerMaster' and 'PowerGuide'), chances are high that it
+works with this driver.
+
+Only devices with a serial interface are supported.
+
+KNOWN ISSUES AND BUGS
+---------------------
+
+The driver has only been tested with a single line-interactive device
+(Atlantis Land A03-S1200) so far, thus the protocol reverse engineering
+has been currently limited to what such device supports.
+
+Thus the lack of these features:
+
+* Specific support for PDU or ATS devices.
+* Detection of the UPS type (line-interactive / online).
+* Detection of max/min voltage ratings.
+* Detection of load banks.
+* Detection of Extended battery modules.
+* Detection of Over voltage state.
+* Detection of Under voltage state.
+* Detection of Frequency failure state.
+* Detection of Wiring Fault state.
+* Detection of lack of Neutral line connection.
+* Detection of UPS generators.
+* Detection of other Battery / UPS error states.
+* Reading of actual Voltage, Frequency, Current, Power factor, Temperature values.
+* Reading the status of the battery packs.
+* Bypass modes usage and detection.
+* USB Support (PM+ mentions being it supported, unsure if with the same protocol).
+
+The driver shutdown function is not implemented (while it's supported), so other
+arrangements must be made to turn off the UPS.
+
+AUTHORS
+-------
+
+Marco Trevisan <mail@3v1n0.net>
+
+The core driver:
+~~~~~~~~~~~~~~~~
+
+linkman:nutupsdrv[8]
+
+Internet resources:
+~~~~~~~~~~~~~~~~~~~
+
+* The NUT (Network UPS Tools) home page: https://www.networkupstools.org/
+* PowerMaster+: https://www.powermonitor.software/

--- a/docs/nut-names.txt
+++ b/docs/nut-names.txt
@@ -1069,6 +1069,16 @@ to last as part of NUT standard protocol in the long run.
     | Take the UPS out of Energy Saver System (aka ESS) mode
 |========================================================================
 
+.Vendor-dependent instant commands
+[options="header"]
+|========================================================================
+| Name                              | Driver/Devices        | Description
+| experimental.test.beeper.start    |
+    | Start testing the UPS beeper
+| experimental.test.beeper.stop     |
+    | Stop a UPS beeper test
+|========================================================================
+
 Currently the commands above are present in one subdriver and are specific
 to the vendor's proposed power state machine. The plan is to generalize the
 concept with vendor specifics, similarly to `experimental.ups.mode.buzzwords`.

--- a/docs/nut-names.txt
+++ b/docs/nut-names.txt
@@ -1073,9 +1073,9 @@ to last as part of NUT standard protocol in the long run.
 [options="header"]
 |========================================================================
 | Name                              | Driver/Devices        | Description
-| experimental.test.beeper.start    |
+| experimental.test.beeper.start    | nutdrv_hashx => Atlantis Land
     | Start testing the UPS beeper
-| experimental.test.beeper.stop     |
+| experimental.test.beeper.stop     | nutdrv_hashx => Atlantis Land
     | Stop a UPS beeper test
 |========================================================================
 

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3473 utf-8
+personal_ws-1.1 en 3480 utf-8
 AAC
 AAS
 ABI
@@ -312,6 +312,7 @@ Dsystemtap
 Dynamix
 Dynex
 EAGAIN
+EB
 EE
 EEPROM
 EFI
@@ -358,6 +359,7 @@ Emilien
 Energia
 EnergySaving
 Enphase's
+Epyc
 Erikson
 Eriksson
 Evgeny
@@ -966,10 +968,12 @@ PowerAlert
 PowerCOM
 PowerCom
 PowerES
+PowerGuide
 PowerKinetics
 PowerMac
 PowerMan
 PowerManagerII
+PowerMaster
 PowerMust
 PowerNet
 PowerOff
@@ -1318,6 +1322,8 @@ TopGuard
 Toth
 TrackingID
 TrackingResult
+Trevisan
+Treviño
 Tripp
 TrippLite
 Tru
@@ -2134,6 +2140,7 @@ gzip
 hal
 hardcoded
 hasFeature
+hashx
 hb
 hcd
 hcl

--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -66,7 +66,7 @@ NUTSW_DRIVERLIST = $(NUTSW_DRIVERLIST_DUMMY_UPS) \
 SERIAL_DRIVERLIST = al175 bcmxcp belkin belkinunv bestfcom	\
  bestfortress bestuferrups bestups etapro everups 	\
  gamatronic genericups isbmex liebert liebert-esp2 liebert-gxe masterguard metasys	\
- mge-utalk microdowell microsol-apc mge-shut oneac optiups powercom rhino	\
+ mge-utalk microdowell microsol-apc mge-shut nutdrv_hashx oneac optiups powercom rhino	\
  safenet nutdrv_siemens-sitop solis tripplite tripplitesu upscode2 victronups powerpanel \
  blazer_ser ivtscd apcsmart apcsmart-old riello_ser sms_ser bicker_ser ve-direct
 if HAVE_LINUX_SERIAL_H
@@ -180,6 +180,8 @@ microsol_apc_SOURCES = microsol-apc.c microsol-common.c
 microsol_apc_LDADD = $(LDADD) -lm
 nhs_ser_SOURCES = nhs_ser.c
 nhs_ser_LDADD = $(LDADD) -lm
+nutdrv_hashx_SOURCES = nutdrv_hashx.c
+nutdrv_hashx_LDADD = $(LDADD) -lm
 oneac_SOURCES = oneac.c
 optiups_SOURCES = optiups.c
 powercom_SOURCES = powercom.c

--- a/drivers/nutdrv_hashx.c
+++ b/drivers/nutdrv_hashx.c
@@ -510,7 +510,7 @@ void upsdrv_updateinfo(void)
 	upsdebug_hex(6, "Poll: status bytes", status_bytes, status_bytes_size);
 
 	if (!status_bytes || status_bytes_size < 5) {
-		upslogx(LOG_ERR, "Status bytes are not enough: %" PRIiSIZE,
+		upslogx(LOG_ERR, "Status bytes are not enough: %" PRIuSIZE,
 		        status_bytes_size);
 		dstate_dataok();
 		return;

--- a/drivers/nutdrv_hashx.c
+++ b/drivers/nutdrv_hashx.c
@@ -125,7 +125,8 @@ static struct hashx_cmd_t {
 {
 	{ "beeper.enable", COMMAND_SET_BEEPER_ENABLED":1" },
 	{ "beeper.disable", COMMAND_SET_BEEPER_ENABLED":0" },
-	/* FIXME: We need a test.beeper command too. */
+	{ "experimental.test.beeper.start", COMMAND_START_BEEPER_TEST },
+	{ "experimental.test.beeper.stop", COMMAND_STOP_TEST },
 	{ "test.battery.start.deep", COMMAND_START_BATTERY_RUNTIME_TEST },
 	{ "test.battery.start.quick", COMMAND_START_BATTERY_TEST },
 	{ "test.battery.stop", COMMAND_STOP_TEST },

--- a/drivers/nutdrv_hashx.c
+++ b/drivers/nutdrv_hashx.c
@@ -1,0 +1,599 @@
+/* nutdrv_hashx.c - Driver for serial UPS units with #* protocols
+ *
+ * Copyright (C)
+ *   2025 Marco Trevisan (Treviño) <mail@3v1n0.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ */
+
+#include "common.h"
+#include "config.h"
+#include "dstate.h"
+#include "main.h"
+#include "nut_stdint.h"
+#include "powerpanel.h"
+#include "serial.h"
+#include "str.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#define ENDCHAR		'\r'
+#define IGNCHARS	""
+
+#define DRIVER_NAME	"Generic #* Serial driver"
+#define DRIVER_VERSION	"0.01"
+
+#define SESSION_ID	"OoNUTisAMAZINGoO"
+#define SESSION_HASH	"74279F35A48F5F13"
+
+/* These commands have been tested on an Atlantis Land A03-S1200 */
+#define COMMAND_GET_SESSION_HASH		"X19" /*-> #16-hex-values */
+#define COMMAND_SET_SESSION_ID			"K19" /* :value -> Status value */
+#define COMMAND_SET_BEEPER_ENABLED		"K60" /* :0|1 -> Status value */
+#define COMMAND_SET_FREQUENCY_MODE		"K39" /* :0|1 -> Status value */
+#define COMMAND_GET_BYPASS_CONDITION_MANDATORY	"X87" /* -> #\xc7\x97\xf0\xf0 */
+#define COMMAND_SET_BYPASS_CONDITION_MANDATORY	"K87" /* :0|1 -> Status value */
+#define COMMAND_GET_BYPASS_CONDITION_OVERLOAD	"X15" /* -> #10 */
+#define COMMAND_SET_BYPASS_CONDITION_OVERLOAD	"K15" /* :0|1 -> Status value */
+#define COMMAND_GET_UPS_DEVICE_INFO		"X41" /* -> #1200,PE02022.002,000000000000,000000000000000000 */
+#define COMMAND_GET_INPUT_VOLTAGE_SETTINGS	"X27" /* -> #230,290,162,10,300 */
+#define COMMAND_GET_INPUT_VOLTAGE_UPPER_BOUND	"X51" /* -> #290 */
+#define COMMAND_GET_INPUT_VOLTAGE_LOWER_BOUND	"X60" /* -> #162 */
+#define COMMAND_GET_UPS_POWER_INFO		"X72" /* -> #1200,0720,230,40,70,05.20 */
+#define COMMAND_GET_STATUS			"B"   /* -> #I239.0O237.0L007B100V27.0F50.1H50.1R040S\x80\0x84\0xd0\x80\x80\0xc0 */
+#define COMMAND_START_BATTERY_TEST		"A"   /* -> Status value */
+#define COMMAND_START_BATTERY_RUNTIME_TEST	"AH"  /* -> Status value */
+#define COMMAND_START_BEEPER_TEST		"AU"  /* -> Status value */
+#define COMMAND_STOP_TEST			"KA"  /* -> Status value */
+
+#define COMMAND_UNKNOWN5			"X5"  /* -> #12,2,7,0,5,480 */
+#define COMMAND_UNKNOWN71			"X71" /* -> #\x80\x80 */
+
+/* Commands supported by the protocol that PowerMaster+ uses and not supported
+ * by the devices tested so far:
+ *  X4
+ *  X5
+ *  X15
+ *  X14 | K14:(0|1)
+ *  X17
+ *  X23
+ *  X24
+ *  X27
+ *  X28
+ *  X29
+ *  X30
+ *  X33
+ *  X41
+ *  X43
+ *  X51
+ *  X53
+ *  X58
+ *  X60
+ *  X61
+ *  X71
+ *  X72
+ *  X73
+ *  X80
+ *  X87
+ *  X88
+ *  X98
+ *  X99
+ */
+
+enum {
+	STATUS_SUCCESS			= 0,
+	/* Generic failure */
+	STATUS_FAILURE			= -1,
+	/* If the command is not known or supported by the device */
+	STATUS_COMMAND_NOT_SUPPORTED	= -3,
+	/* When a command parameter is not valid (e.g. "K60:foo") */
+	STATUS_COMMAND_VALUE_INVALID	= -4,
+	/* When a command is currently unavailable (e.g. "AH" while charging ) */
+	STATUS_COMMAND_UNAVAILABLE	= -10,
+
+	/* Local error: when a parsing error occurred */
+	STATUS_UNKNOWN_FAILURE          = -255,
+};
+
+upsdrv_info_t upsdrv_info = {
+	DRIVER_NAME,
+	DRIVER_VERSION,
+	"Marco Trevisan <mail@3v1n0.net>",
+	DRV_EXPERIMENTAL,
+	{ NULL }
+};
+
+static ssize_t hashx_recv(char *buf, size_t bufsize)
+{
+	ssize_t nread;
+
+	nread = ser_get_line(upsfd, buf, bufsize - 1, ENDCHAR, IGNCHAR,
+	                     SER_WAIT_SEC, SER_WAIT_USEC);
+
+	assert(nread < (ssize_t) bufsize);
+	buf[nread] = '\0';
+
+	if (nut_debug_level >= 4) {
+		char base_msg[128];
+		int n;
+
+		n = snprintf(base_msg, sizeof(base_msg),
+		             "%s: read %" PRIiSIZE ": ", __func__, nread);
+		assert(n > 0);
+		upsdebug_ascii(4, base_msg, buf, nread);
+	}
+
+	if (nread > 0 && *buf != '#') {
+		upslogx(LOG_ERR, "Unexpected reply for #-protocol: %s", buf);
+	}
+
+	return nread;
+}
+
+static int hashx_status_value(char *buf, size_t bufsize)
+{
+	ssize_t nread;
+	int ret = STATUS_UNKNOWN_FAILURE;
+
+	if ((nread = hashx_recv(buf, bufsize)) < 2 || nread > 3) {
+		upslogx(LOG_ERR, "Not an UPS status value: %s", buf);
+		return ret;
+	}
+
+	if (!str_to_int(buf + 1, &ret, 10)) {
+		upslogx(LOG_ERR, "Failed to convert %s to number", buf + 1);
+		return ret;
+	}
+
+	upsdebugx(5, "Read status is %d", ret);
+	return ret;
+}
+
+/*
+ * This is how PowerMaster+ 1.2.3 does when connecting to the UPS:
+ * [pid 22999] write(219, "\r", 1)         = 1
+ * [pid 22999] write(219, "X19\r", 4)      = 4
+ * [pid 22999] write(219, "K19:RRO3143QJqhb1GCj\r", 21) = 21
+ * [pid 22999] write(219, "X19\r", 4)      = 4
+ * [pid 22999] write(219, "X41\r", 4)      = 4
+ * [pid 23000] write(219, "\r", 1)         = 1
+ * [pid 23000] write(219, "X41\r", 4)      = 4
+ * [pid 23000] write(219, "B\r", 2)        = 2
+ * [pid 23000] write(219, "X27\r", 4)      = 4
+ * [pid 23000] write(219, "X72\r", 4)      = 4
+ * [pid 23000] write(219, "X5\r", 3)       = 3
+ * [pid 23000] write(219, "X53\r", 4)      = 4
+ * [pid 23000] write(219, "X87\r", 4)      = 4
+ * [pid 23000] write(219, "X28\r", 4)      = 4
+ * [pid 23000] write(219, "X51\r", 4)      = 4
+ * [pid 23000] write(219, "X60\r", 4)      = 4
+ * [pid 23000] write(219, "X15\r", 4)      = 4
+ * [pid 23000] write(219, "K14:0\r", 6)    = 6
+ * [pid 23000] write(219, "X4\r", 3)       = 3
+ * [pid 23000] write(219, "X58\r", 4)      = 4
+ * [pid 23000] write(219, "X30\r", 4)      = 4
+ * [pid 23000] write(219, "X71\r", 4)      = 4
+ * [pid 23000] write(219, "X43\r", 4)      = 4
+ * [pid 23000] write(219, "X73\r", 4)      = 4
+ * [pid 23000] write(219, "X88\r", 4)      = 4
+ * [pid 23000] write(219, "X17\r", 4)      = 4
+ * [pid 23000] write(219, "X98\r", 4)      = 4
+ * [pid 23000] write(219, "X14\r", 4)      = 4
+ * [pid 23000] write(219, "X99\r", 4)      = 4
+ * [pid 23000] write(219, "X29\r", 4)      = 4
+ * [pid 23000] write(219, "X61\r", 4)      = 4
+ * [pid 23000] write(219, "X33\r", 4)      = 4
+ * [pid 23000] write(219, "X23\r", 4)      = 4
+ * [pid 23000] write(219, "X24\r", 4)      = 4
+ * [pid 23000] write(219, "X80\r", 4)      = 4
+ * [pid 23000] write(219, "B\r", 2)        = 2
+ * [pid 23000] write(219, "B\r", 2)        = 2
+ * .... These last ones are the polling requests repeated forever ....
+ */
+
+void upsdrv_initinfo(void)
+{
+	ssize_t transferred;
+	char buf[256];
+	char *reply;
+	int status;
+	int ival;
+	double dval;
+	size_t i;
+
+	for (i = 0; ; ++i) {
+		upsdebugx(4, "Checking if device supports the #-protocol... [%" PRIuSIZE "]", i+1);
+		if ((transferred = ser_send_char(upsfd, ENDCHAR)) != 1) {
+			fatalx(EXIT_FAILURE, "%s: Initialization failure %s",
+			       __func__, device_path);
+		}
+		if ((status = hashx_status_value(buf, sizeof(buf))) == -1) {
+			break;
+		}
+
+		if (i < 3) {
+			continue;
+		}
+
+		fatalx(EXIT_FAILURE, "%s: unexpected hash protocol response: %s (status %d)",
+		       __func__, buf, status);
+	}
+
+	/* The K19 function needs a 16 bytes value and the device should reply
+	 * with an hash or a crc of it, it's not clear what's the algorithm it
+	 * uses, but given that the returned value is static, we can just always
+	 * send one value we know about, to verify the protocol.
+	 */
+	if ((transferred = ser_send(upsfd, COMMAND_SET_SESSION_ID":"SESSION_ID"%c", ENDCHAR)) != 21) {
+		fatalx(EXIT_FAILURE, "%s: Failed to set session ID: %s",
+			__func__, SESSION_ID);
+	}
+	if ((status = hashx_status_value(buf, sizeof(buf))) != STATUS_SUCCESS) {
+		fatalx(EXIT_FAILURE, "%s: unexpected hash protocol response: %s (status %d)",
+		       __func__, buf, status);
+	}
+
+	if ((transferred = ser_send(upsfd, COMMAND_GET_SESSION_HASH"%c", ENDCHAR)) != 4) {
+		fatalx(EXIT_FAILURE, "%s: Failed to get session hash", __func__);
+	}
+	if ((transferred = hashx_recv(buf, sizeof(buf))) != strlen(SESSION_HASH) + 1 ||
+	    (transferred > 0 && strncmp(buf, "#"SESSION_HASH, sizeof(buf)) != 0)) {
+		fatalx(EXIT_FAILURE, "%s: unexpected hash protocol response: %s",
+		       __func__, buf);
+	}
+
+	/* XXX: Maybe now repeat the same with a random value, without checking
+	 * the content of the returned value, but just in case the UPS uses this
+	 * value as a "session" identifier, to make sure we are starting a new
+	 * one.
+	 * Another option could be to keep a list of known request, response
+	 * pair values and use them randomly.
+	 * However, not doing it for now since it seems unneeded, while just
+	 * always reusing the same value works good enough in my tests.
+	 */
+
+	dstate_setinfo("device.type", "ups");
+	dstate_setinfo("ups.type", "online");
+
+	/* FIXME: We need to understand how PowerManager+ figures this out,
+	 * as it supports both On-Line and Line Interactive devices.
+	 * Or is it related to the support to the bypass feature?
+	 * Maybe it's what `X5` command provides? We need to test more devices!
+	 */
+	dstate_setinfo("ups.mode", "line-interactive");
+
+	if ((transferred = ser_send(upsfd, COMMAND_GET_UPS_DEVICE_INFO"%c", ENDCHAR)) != 4) {
+		fatalx(EXIT_FAILURE, "%s: Failed to get UPS info", __func__);
+	}
+	if ((transferred = hashx_recv(buf, sizeof(buf))) < 3) {
+		fatalx(EXIT_FAILURE, "%s: unexpected UPS info response: %s",
+		       __func__, buf);
+	}
+	/* This is in the format:
+	 * #1200,PE02022.002,000000000000,000000000000000000
+	 *  1    2           3            4
+	 * 1) Model
+	 * 2) Firmware version
+	 * 3) ??? [maybe device serial number?]
+	 * 4) ??? [as above?]
+	 */
+	reply = buf + 1;
+	dstate_setinfo("device.model", "%s", strsep(&reply, ","));
+	if (reply) {
+		dstate_setinfo("ups.firmware", "%s", strsep(&reply, ","));
+	}
+
+	if ((transferred = ser_send(upsfd, COMMAND_GET_INPUT_VOLTAGE_SETTINGS"%c", ENDCHAR)) != 4) {
+		upslogx(LOG_ERR, "%s: Failed to get UPS voltage settings", __func__);
+	}
+	if ((transferred = hashx_recv(buf, sizeof(buf))) < 3) {
+		upslogx(LOG_ERR, "%s: unexpected UPS voltage settings response: %s",
+			__func__, buf);
+	}
+	/* This is in the format:
+	 * #230,290,162,10,300
+	 *  1   2   3   4  5
+	 * 1) Supplied power voltage
+	 * 2) Power failure voltage upper bound
+	 * 3) Power failure voltage lower bound
+	 * 4) ???
+	 * 5) ???
+	 */
+	reply = buf + 1;
+	if (str_to_int(strsep(&reply, ","), &ival, 10)) {
+		dstate_setinfo("input.voltage.nominal", "%d", ival);
+	}
+	if (reply && str_to_int(strsep(&reply, ","), &ival, 10)) {
+		dstate_setinfo("input.voltage.high.critical", "%d", ival);
+	}
+	if (reply && str_to_int(strsep(&reply, ","), &ival, 10)) {
+		dstate_setinfo("input.voltage.low.critical", "%d", ival);
+	}
+
+	if ((transferred = ser_send(upsfd, COMMAND_GET_UPS_POWER_INFO"%c", ENDCHAR)) != 4) {
+		upslogx(LOG_ERR, "%s: Failed to get UPS power info", __func__);
+	}
+	if ((transferred = hashx_recv(buf, sizeof(buf))) < 3) {
+		upslogx(LOG_ERR, "%s: unexpected UPS power info response: %s",
+		        __func__, buf);
+	}
+	/* This is in the format:
+	 * #1200,0720,230,40,70,05.20
+	 *  1    2    3   4  5  6
+	 * 1) Volt-Amp nominal rating
+	 * 2) Real power nominal rating
+	 * 3) Input voltage nominal rating
+	 * 4) Frequency rating lower bound
+	 * 5) Frequency rating upper bound
+	 * 6) Output Current nominal rating
+	 */
+	reply = buf + 1;
+	if (str_to_int(strsep(&reply, ","), &ival, 10)) {
+		dstate_setinfo("ups.power.nominal", "%d", ival);
+	}
+	if (reply && str_to_int(strsep(&reply, ","), &ival, 10)) {
+		dstate_setinfo("ups.realpower.nominal", "%d", ival);
+	}
+	if (reply && str_to_int(strsep(&reply, ","), &ival, 10)) {
+		dstate_setinfo("input.voltage.nominal", "%d", ival);
+	}
+	if (reply && str_to_double(strsep(&reply, ","), &dval, 10)) {
+		dstate_setinfo("input.frequency.low", "%.1f", dval);
+	}
+	if (reply && str_to_double(strsep(&reply, ","), &dval, 10)) {
+		dstate_setinfo("input.frequency.high", "%.1f", dval);
+	}
+	if (reply && str_to_double(strsep(&reply, ","), &dval, 10)) {
+		dstate_setinfo("output.current.nominal", "%.1f", dval);
+	}
+
+	if (strsep(&reply, ",") != NULL) {
+		upslogx(LOG_WARNING, "This UPS returns unexpected power info fields (%s), "
+		        "previously decoded values may have not been correctly assigned!",
+		        buf + 1);
+	}
+}
+
+void upsdrv_updateinfo(void)
+{
+	char buf[256];
+	ssize_t transferred;
+	size_t i;
+	char *status;
+	int ret;
+	float input_voltage = -1;
+	float output_voltage = -1;
+	float battery_voltage = -1;
+	float input_frequency = -1;
+	float output_frequency = -1;
+	int output_load = -1;
+	int battery_charge = -1;
+	int remaining_runtime = -1;
+	char *status_bytes = NULL;
+	size_t status_bytes_size = 0;
+
+	if ((transferred = ser_send(upsfd, COMMAND_GET_STATUS"%c", ENDCHAR)) != 2) {
+		upslogx(LOG_ERR, "%s: Failed to get status", __func__);
+		dstate_datastale();
+		return;
+	}
+	if ((transferred = hashx_recv(buf, sizeof(buf))) <= 0) {
+		upslogx(LOG_ERR, "%s: unexpected status response: %s", __func__, buf);
+		dstate_datastale();
+		return;
+	}
+
+	/* This is in the format:
+	 * #I239.0O237.0L007B100V27.0F50.1H50.1R040S\x80\0x84\0xd0\x80\x80\0xc0
+	 *  I     O     L   B   V    F    H    R   S
+	 * I) Input voltage
+	 * O) Output voltage
+	 * L) Load
+	 * B) Battery capacity
+	 * V) Battery voltage
+	 * F) Utility frequency
+	 * H) Output frequency
+	 * R) Runtime (in minutes)
+	 * S) UPS Status bytes (see below)
+	 */
+	status = buf + 1;
+	if ((ret = sscanf(status, "I%fO%fL%dB%dV%fF%fH%fR%dS",
+		              &input_voltage, &output_voltage, &output_load,
+		              &battery_charge, &battery_voltage, &input_frequency,
+		              &output_frequency, &remaining_runtime)) == EOF ||
+		              ret < 1) {
+		upslogx(LOG_ERR, "%s: Impossible to parse: %s", __func__, status);
+		dstate_datastale();
+		return;
+	}
+
+	upsdebugx(6, "Poll: input voltage %.1f, output voltage %.1f, load balance %d%%, "
+	          "battery level: %d%%, battery voltage: %.1f, input frequency: %.1f, "
+	          "output frequency %.1f, remaining runtime: %d minutes",
+	          input_voltage, output_voltage, output_load,
+	          battery_charge, battery_voltage, input_frequency,
+	          output_frequency, remaining_runtime);
+
+	if (input_voltage >= 0) {
+		dstate_setinfo("input.voltage", "%.1f", input_voltage);
+	}
+
+	if (output_voltage >= 0) {
+		dstate_setinfo("output.voltage", "%.1f", output_voltage);
+	}
+
+	if (battery_voltage >= 0) {
+		dstate_setinfo("battery.voltage", "%.1f", battery_voltage);
+	}
+
+	if (input_frequency >= 0) {
+		dstate_setinfo("input.frequency", "%.1f", input_frequency);
+	}
+
+	if (output_frequency >= 0) {
+		dstate_setinfo("output.frequency", "%.1f", output_frequency);
+	}
+
+	if (output_load >= 0) {
+		dstate_setinfo("ups.load", "%d", output_load);
+	}
+
+	if (battery_charge >= 0) {
+		/* In some devices battery.charge.approx seems to be more appropriate */
+		dstate_setinfo("battery.charge", "%d", battery_charge);
+	}
+
+	if (remaining_runtime >= 0) {
+		dstate_setinfo("battery.runtime", "%d", remaining_runtime * 60);
+	}
+
+	if ((status_bytes = strchr(buf, 'S'))) {
+		status_bytes += 1;
+		status_bytes_size = transferred - (status_bytes - buf);
+	}
+
+	assert(status_bytes != NULL || status_bytes_size == 0);
+	upsdebug_hex(6, "Poll: status bytes", status_bytes, status_bytes_size);
+
+	if (!status_bytes || status_bytes_size < 5) {
+		upslogx(LOG_ERR, "Status bytes are not enough: %" PRIiSIZE,
+		        status_bytes_size);
+		dstate_dataok();
+		return;
+	}
+
+	/* Status bytes values:                 0  1  2  3  4  5
+	 *   On AC, fully charged:              80 84 d0 80 80 c0
+	 *   On AC, high battery, charging:     80 84 90 80 80 c0
+	 *   Testing battery, fully charged:    88 80 88 88 80 c0
+	 *   Testing battery, charging:         88 80 8c 88 80 c0
+	 *        ... battery level at 0:       88 80 8c 88 a0 c0
+	 *   Runtime Estimation, fully charged: 88 80 c8 88 80 c0
+	 *        ... lowest level, charging:   a0 84 94 80 a0 c0
+	 *   Battery low charging:              80 84 94 80 80 c0
+	 *   Battery low charging + beep:       90 84 94 80 80 c0
+	 *   Battery very low, charging:        80 84 94 88 a0 c0
+	 *        ... after more charge:        80 84 94 80 a0 c0
+	 *        ... after more charge:        80 84 94 88 80 c0
+	 *        ...testing beep:              90 84 94 88 80 c0
+	 *   Discharging from fully:            c0 83 88 88 80 c0
+	 *   Discharging:                       c0 83 8c 80 80 c0
+	 *   Discharging, more load:            c0 83 8c 88 80 c0
+	 *   Discharging Battery very low:      c0 83 8c 80 a0 c0
+	 *   Discharging Battery alarm:         e0 83 8c 80 a0 c0
+	 *   UPS output off, charging:          80 84 94 80 c0 c0
+	 */
+
+	alarm_init();
+	status_init();
+
+	/* Remove the common bit from the status bytes. */
+	for (i = 0; i < status_bytes_size; ++i) {
+		status_bytes[i] &= ~0x80;
+	}
+
+	if (status_bytes[0] & 0x08) {
+		upsdebugx(6, "Poll, status: Performing calibration test");
+		status_set("CAL");
+	}
+
+	if (!(status_bytes[1] & 0x04)) {
+		upsdebugx(6, "Poll, status: Running on battery");
+		dstate_setinfo("battery.charger.status", "discharging");
+		status_set("OB");
+	} else if ((status_bytes[2] & 0x50) == 0x50) {
+		upsdebugx(6, "Poll, status: Running on AC");
+		dstate_setinfo("battery.charger.status", "resting");
+		status_set("OL");
+	} else {
+		upsdebugx(6, "Poll, status: Running on AC, battery is charging");
+		dstate_setinfo("battery.charger.status", "charging");
+		status_set("OL");
+	}
+
+	/* XXX: This happens when battery level is marked as 0 here, but there's
+	 * still time until the UPS is actually beeping as the critical low level.
+	 * Maybe we should ignore this instead and just consider this state as
+	 * only OB and set the LB bit only when critically low?
+	 */
+	if (status_bytes[4] & 0x20) {
+		upsdebugx(6, "Poll, status: Battery is low");
+		status_set("LB");
+	} else {
+		upsdebugx(6, "Poll, status: Battery is high");
+		status_set("HB");
+	}
+
+	if (status_bytes[0] & 0x20) {
+		upsdebugx(6, "Poll, status: Battery is critically low");
+		if ((status_bytes[0] & 0x08)) {
+			alarm_set("TEST MODE: Battery is critically low!");
+		} else {
+			alarm_set("Battery is critically low, UPS is about to turn off!");
+		}
+	}
+
+	if ((status_bytes[4] & 0x40)) {
+		upsdebugx(6, "Poll, status: UPS outlets are off");
+		status_set("OFF");
+	}
+
+	/* TODO: Find out the bit in case of OVER, but I wasn't able to get mine
+	 * there, as I was either consuming too much (making it go crazy and in
+	 * self-protection) or too low :(
+	 */
+
+	status_commit();
+	dstate_dataok();
+	alarm_commit();
+}
+
+void upsdrv_shutdown(void)
+{
+	/* TODO: Find the command used to shutdown... It's definitely supported.
+	 */
+	upslogx(LOG_ERR, "shutdown not supported");
+	if (handling_upsdrv_shutdown > 0) {
+		set_exit_flag(EF_EXIT_FAILURE);
+	}
+}
+
+void upsdrv_help(void)
+{
+}
+
+void upsdrv_makevartable(void)
+{
+}
+
+void upsdrv_initups(void)
+{
+	upsdebugx(3, "Opening device %s", device_path);
+
+	upsfd = ser_open(device_path);
+
+	if (INVALID_FD_SER(upsfd)) {
+		fatalx(EXIT_FAILURE, "%s: failed to open %s", __func__, device_path);
+	}
+
+	ser_set_speed(upsfd, device_path, B2400);
+}
+
+void upsdrv_cleanup(void)
+{
+	ser_close(upsfd, device_path);
+}

--- a/drivers/skel.c
+++ b/drivers/skel.c
@@ -5,7 +5,7 @@
 	for more information, refer to:
 	* docs/developers.txt
 	* docs/new-drivers.txt
-	* docs/new-names.txt
+	* docs/nut-names.txt
 
 	and possibly also to:
 	* docs/hid-subdrivers.txt for USB/HID devices


### PR DESCRIPTION
From the main commit:

```
Add an initial driver for the "#*" protocol support that is used by many
UPS out there that rely on the proprietary software suites PowerMaster+,
PowerMaster, PowerGuide and so on...

The naming of the driver has been chosen since all the UPS replies start
with an "#", while there's not a definitive common pattern for the queries
or commands.

Apparently the same protocol is used by various UPS devices, both online
and line-interactive (given that many producers advertise to use the
said programs), and only in serial mode (AFAIK). Although this driver has
solely been tested with the Atlantis Land S1200 line-interactive UPS.

So there may be missing features (such as the bypass mode) or lack of
information. However most of the decoding has been done and the driver
is enough to update the UPS status for monitoring and shutdown purposes.

As for now, the status updates and immediate commands features have been
implemented.
```

Few further things:
 - Mentioned more devices to the supported devices list (as per what their website state)
 - I would like to make the `nut-scanner` to look for these devices, but it would imply duplicating lots of `scan_eaton_serial.c` code or move it to a common place, so maybe that's another PR? As we don't have a generic place for serial scanning AFAIK.

## General points

- [x] Described the changes in the PR submission or a separate issue, e.g.
  known published or discovered protocols, applicable hardware (expected
  compatible and actually tested/developed against), limitations, etc.

- [x] There may be multiple commits in the PR, aligned and commented with
  a functional change. Notably, coding style changes better belong in a
  separate PR, but certainly in a dedicated commit to simplify reviews
  of "real" changes in the other commits. Similarly for typo fixes in
  comments or text documents.

- [x] Please star NUT on GitHub, this helps with sponsorships! ;)

## Frequent "underwater rocks" for driver addition/update PRs

- [x] Revised existing driver families and added a sub-driver if applicable
  (`nutdrv_qx`, `usbhid-ups`...) or added a brand new driver in the other
  case.

- [x] Did not extend obsoleted drivers with new hardware support features
  (notably `blazer` and other single-device family drivers for Qx protocols,
  except the new `nutdrv_qx` which should cover them all).

- [x] Proposed NUT data mapping is aligned with existing `docs/nut-names.txt`
  file. If the device exposes useful data points not listed in the file, the
  `experimental.*` namespace can be used as documented there, and discussion
  should be raised on the NUT Developers mailing list to standardize the new
  concept.

- [x] Updated `data/driver.list.in` if applicable (new tested device info)
<!-- Comment:
Also note below, a point about PR posting for NUT DDL
-->

## Frequent "underwater rocks" for general C code PRs

- [x] Did not "blindly assume" default integer type sizes and value ranges,
  structure layout and alignment in memory, endianness (layout of bytes and
  bits in memory for multi-byte numeric types), or use of generic `int` where
  language or libraries dictate the use of `size_t` (or `ssize_t` sometimes).

- [x] Progress and errors are handled with `upsdebugx()`, `upslogx()`,
  `fatalx()` and related methods, not with direct `printf()` or `exit()`.
  Similarly, NUT helpers are used for error-checked memory allocation and
  string operations (except where customized error handling is needed,
  such as unlocking device ports, etc.)

- [x] Coding style (including whitespace for indentations) follows precedent
  in the code of the file, and examples/guide in `docs/developers.txt` file.

- [x] For newly added files, the `Makefile.am` recipes were updated and the
  `make distcheck` target passes.

## General documentation updates

- [x] Added or updated manual page information in `docs/man/*.txt` files
  and corresponding recipe lists in `docs/man/Makefile.am` for new pages

- [x] Passed `make spellcheck`, updated spell-checking dictionary in the
  `docs/nut.dict` file if needed (did not remove any words -- the `make`
  rule printout in case of changes suggests how to maintain it).

## Additional work may be needed after posting this PR

- [ ] Propose a PR for NUT DDL with detailed device data dumps from tests
  against real hardware (the more models, the better).

- [ ] Address NUT CI farm build failures for the PR: testing on numerous
  platforms and toolkits can expose issues not seen on just one system.

- [ ] Revise suggestions from LGTM.COM analysis about "new issues" with
  the changed codebase.

Closes: #2769