### PR TITLE
Add APC BVKnnnnM2 to list of devices affected by spurious LB/RB messages

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -78,6 +78,9 @@ https://github.com/networkupstools/nut/milestone/9
      descriptors was extended to cover a newly reported case of nominal UPS
      power being incorrectly reported due to an unrealistically low maximum
      threshold, as seen with a EC850LCD device. [issue #2917, PR #2919]
+   * Added APC BVKxxxM2 to list of devices where `lbrb_log_delay_sec=N` may be
+     necessary to address spurious LOWBATT and REPLACEBATT events. [#2942]
+
 
  - New NUT drivers:
    * Introduced a `ve-direct` driver for Victron Energy UPS/solar panels

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -81,7 +81,6 @@ https://github.com/networkupstools/nut/milestone/9
    * Added APC BVKxxxM2 to list of devices where `lbrb_log_delay_sec=N` may be
      necessary to address spurious LOWBATT and REPLACEBATT events. [#2942]
 
-
  - New NUT drivers:
    * Introduced a `ve-direct` driver for Victron Energy UPS/solar panels
      monitoring. Most specific reported values are in an `experimental.*`

--- a/UPGRADING.adoc
+++ b/UPGRADING.adoc
@@ -25,6 +25,8 @@ Changes from 2.8.3 to 2.8.4
 ---------------------------
 
 - PLANNED: Keep track of any further API clean-up?
+- Added APC BVKxxxM2 to list of devices where `lbrb_log_delay_sec=N` may be 
+  necessary to address spurious LOWBATT and REPLACEBATT events. [issue #2942]
 
 Changes from 2.8.2 to 2.8.3
 ---------------------------

--- a/UPGRADING.adoc
+++ b/UPGRADING.adoc
@@ -25,7 +25,8 @@ Changes from 2.8.3 to 2.8.4
 ---------------------------
 
 - PLANNED: Keep track of any further API clean-up?
-- Added APC BVKxxxM2 to list of devices where `lbrb_log_delay_sec=N` may be 
+
+- Added APC BVKxxxM2 to list of devices where `lbrb_log_delay_sec=N` may be
   necessary to address spurious LOWBATT and REPLACEBATT events. [issue #2942]
 
 Changes from 2.8.2 to 2.8.3

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -85,6 +85,7 @@
 "APC"	"ups"	"3"	"BACK-UPS XS LCD"	"USB"	"usbhid-ups"
 "APC"	"ups"	"3"	"Back-UPS XS 1000M (Back-UPS Pro 1000, Model BX1000M)"	"USB"	"usbhid-ups"	# https://github.com/networkupstools/nut/issues/139
 "APC"	"ups"	"3"	"Back-UPS BX****MI Series (may need tweaks since 2023)"	"USB"	"usbhid-ups lbrb_log_delay_sec=N lbrb_log_delay_without_calibrating onlinedischarge_calibration"	# https://github.com/networkupstools/nut/issues/2347
+"APC"	"ups"	"3"	"Back-UPS BVK****M2 Series (may need tweaks)"	"USB"	"usbhid-ups lbrb_log_delay_sec=N lbrb_log_delay_without_calibrating onlinedischarge_calibration"	# https://github.com/networkupstools/nut/issues/2942
 "APC"	"ups"	"3"	"SMC2200BI-BR"	"USB"	"usbhid-ups"	# https://github.com/networkupstools/nut/issues/557
 "APC"	"ups"	"3"	"Smart-UPS (USB)"	"USB"	"usbhid-ups"
 "APC"	"ups"	"3"	"Smart-UPS 750 (SMT750I, USB)"	"USB"	"usbhid-ups"

--- a/docs/man/usbhid-ups.txt
+++ b/docs/man/usbhid-ups.txt
@@ -186,11 +186,11 @@ Set to delay status-setting (and log messages) about device entering `LB` or
 `LB+RB` state.
 +
 Some APC BXnnnnMI device models or firmware versions (reportedly 2023-2024)
-frequently report low battery, replace battery, and all ok within a couple
-of seconds, sometimes but not always preceded by OL+DISCHRG (presumably
-calibration). This setting lets the driver ignore short-lived states and
-only pay attention if they persist longer than this setting (and the device
-power state is `OL`).
+or APC BVKnnnnM2 device models frequently report low battery, replace battery,
+and all ok within a couple of seconds, sometimes but not always preceded by 
+OL+DISCHRG (presumably calibration). This setting lets the driver ignore short-
+lived states and only pay attention if they persist longer than this setting 
+(and the device power state is `OL`).
 
 *lbrb_log_delay_without_calibrating*::
 Set to apply `lbrb_log_delay_sec` even if device is not calibrating.

--- a/docs/man/usbhid-ups.txt
+++ b/docs/man/usbhid-ups.txt
@@ -185,12 +185,12 @@ the `OL+DISCHRG` message logging is not triggered by variations of the charge.
 Set to delay status-setting (and log messages) about device entering `LB` or
 `LB+RB` state.
 +
-Some APC BXnnnnMI device models or firmware versions (reportedly 2023-2024)
-or APC BVKnnnnM2 device models frequently report low battery, replace battery,
-and all ok within a couple of seconds, sometimes but not always preceded by 
-OL+DISCHRG (presumably calibration). This setting lets the driver ignore short-
-lived states and only pay attention if they persist longer than this setting 
-(and the device power state is `OL`).
+Some APC BXnnnnMI device models or firmware versions (reportedly 2023-2024),
+or APC BVKnnnnM2 device models, frequently report "low battery", "replace
+battery", and "all ok" states changing rapidly within a couple of seconds,
+sometimes (but not always) preceded by `OL+DISCHRG` (presumably calibration).
+This setting lets the driver ignore short-lived states and only pay attention
+if they persist longer than this setting (and the device power state is `OL`).
 
 *lbrb_log_delay_without_calibrating*::
 Set to apply `lbrb_log_delay_sec` even if device is not calibrating.

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3473 utf-8
+personal_ws-1.1 en 3475 utf-8
 AAC
 AAS
 ABI
@@ -103,6 +103,8 @@ BTS
 BTV
 BUFRD
 BUZ
+BVKnnnnM
+BVKxxxM
 BXnnnnMI
 BYP
 BZ

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -29,7 +29,7 @@
  */
 
 #define DRIVER_NAME	"Generic HID driver"
-#define DRIVER_VERSION	"0.62"
+#define DRIVER_VERSION	"0.63"
 
 #define HU_VAR_WAITBEFORERECONNECT "waitbeforereconnect"
 
@@ -1519,7 +1519,7 @@ void upsdrv_initups(void)
 			lbrb_log_delay_sec = ipv;
 		}
 	} else {
-		/* Activate APC BXnnnMI/BXnnnnMI tweaks, for details see
+		/* Activate APC BXnnnMI/BXnnnnMI/BVKnnnM2/BVKnnnnM2 tweaks, for details see
 		 * https://github.com/networkupstools/nut/issues/2347
 		 */
 		size_t	productLen = hd->Product ? strlen(hd->Product) : 0;
@@ -1527,11 +1527,16 @@ void upsdrv_initups(void)
 		/* FIXME: Consider also ups.mfr.date as 2023 or newer?
 		 * Eventually up to some year this gets fixed?
 		 */
-		if (hd->Vendor
-		&&  productLen > 6	/* BXnnnMI at least */
-		&&  (!strcmp(hd->Vendor, "APC") || !strcmp(hd->Vendor, "American Power Conversion"))
-		&&  (strstr(hd->Product, " BX") || strstr(hd->Product, "BX") == hd->Product)
-		&&  (hd->Product[productLen - 2] == 'M' && hd->Product[productLen - 1] == 'I')
+		if ((hd->Vendor
+			&&  productLen > 6	/* BXnnnMI at least */
+			&&  (!strcmp(hd->Vendor, "APC") || !strcmp(hd->Vendor, "American Power Conversion"))
+			&&  (strstr(hd->Product, " BX") || strstr(hd->Product, "BX") == hd->Product)
+			&&  (hd->Product[productLen - 2] == 'M' && hd->Product[productLen - 1] == 'I'))
+		|| (hd->Vendor
+			&&  productLen > 7	/* BVKnnnM2 at least */
+			&&  (!strcmp(hd->Vendor, "APC") || !strcmp(hd->Vendor, "American Power Conversion"))
+			&&  (strstr(hd->Product, " BVK") || strstr(hd->Product, "BVK") == hd->Product)
+			&&  (hd->Product[productLen - 2] == 'M' && hd->Product[productLen - 1] == '2'))
 		) {
 			int	got_lbrb_log_delay_without_calibrating = testvar("lbrb_log_delay_without_calibrating") ? 1 : 0,
 				got_onlinedischarge_calibration = testvar("onlinedischarge_calibration") ? 1 : 0,


### PR DESCRIPTION
PR #2565 addresses issue #2347 wherein APC BXnnnnMI devices are logging LOWBATT/REPLACEBATT messages.

BVK750M2 (which appears to have been released 2021/2022) appears to be affected by this, at least the one that I purchased 1Q 2025 in the US.

Other models in this lineup per APC's product brochure are BVK950M2 and BVK1200M2.

This PR does the following:

- addresses #2942 
- updates `upshid-ups.c` to add APC BVKnnnnM2 to the detection code and also increments the driver version number 
- updates `NEWS.adoc` to note the update
- updates `UPGRADING.adoc` to note the update
- updates `driver.list.in` to add the model
- updates `usbhid-ups.txt` to add the model

Comments, suggestions, corrections, testers?  Apologies if I missed anything as I'm relatively a novice at this.  Thank you, and a big thank you to @jimklimov for the original tweak in #2565.