### PR TITLE
HCL automation: Driver list markup check

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,8 +38,9 @@ ACLOCAL_AMFLAGS = -I m4
 #
 # List of source subdirectories to build and distribute, used to spawn automake
 # (alas sequential) target recipes. The order matters, as several subdirectories
-# depend on stuff in "common" or tools being built first!
-SUBDIRS = include common clients conf data drivers tools \
+# depend on stuff in "common" or tools being built first! Also "data" depends
+# (during "dist" time) on scripts in "tools".
+SUBDIRS = include common clients conf drivers tools data \
   lib scripts server tests docs/man docs
 
 # Note: not generated from SUBDIRS, because not all are recursive:

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,1 +1,2 @@
 /driver.list
+/*.tabbed

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -10,7 +10,7 @@ dist-hook:
 	@$(distdir)/../tools/driver-list-format.sh
 
 check-local:
-	@$(top_srcdir)/tools/driver-list-format.sh --check
+	@abs_top_builddir='$(abs_top_builddir)' abs_top_srcdir='$(abs_top_srcdir)' $(top_srcdir)/tools/driver-list-format.sh --check
 
 # NOTE: Due to portability, we do not use a GNU percent-wildcard extension.
 # We also have to export some variables that may be tainted by relative

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -6,6 +6,12 @@ dist_data_DATA = cmdvartab
 nodist_data_DATA = driver.list
 EXTRA_DIST = evolution500.seq epdu-managed.dev
 
+dist-hook:
+	@$(distdir)/../tools/driver-list-format.sh
+
+check-local:
+	@$(top_srcdir)/tools/driver-list-format.sh --check
+
 # NOTE: Due to portability, we do not use a GNU percent-wildcard extension.
 # We also have to export some variables that may be tainted by relative
 # paths when parsing the other makefile (e.g. MKDIR_P that may be defined

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -26,4 +26,4 @@ spellcheck spellcheck-interactive spellcheck-sortdict:
 	+$(MAKE) -f $(top_builddir)/docs/Makefile $(AM_MAKEFLAGS) MKDIR_P="$(MKDIR_P)" builddir="$(builddir)" srcdir="$(srcdir)" top_builddir="$(top_builddir)" top_srcdir="$(top_srcdir)" SPELLCHECK_SRC="cmdvartab" SPELLCHECK_SRCDIR="$(srcdir)" SPELLCHECK_BUILDDIR="$(builddir)" $@
 
 MAINTAINERCLEANFILES = Makefile.in .dirstamp
-CLEANFILES = *.pdf *.html *-spellchecked
+CLEANFILES = *.pdf *.html *-spellchecked *.tabbed

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -50,7 +50,7 @@
 "Ablerex"	"ups"	"2"	"MSIII series"	"USB"	"nutdrv_qx"
 "Ablerex"	"ups"	"2"	"GRs series"	"USB"	"nutdrv_qx"
 "Ablerex"	"ups"	"2"	"GRs Plus series"	"USB"	"nutdrv_qx"
-"Ablerex"	"ups"	"1"	"(various)" "Serial"	"nutdrv_hashx"	# https://www.ablerex.eu/download/
+"Ablerex"	"ups"	"1"	"(various)"	"Serial"	"nutdrv_hashx"	# https://www.ablerex.eu/download/
 
 "ActivePower"	"ups"	"2"	"400VA"	""	"blazer_ser"
 "ActivePower"	"ups"	"2"	"1400VA"	""	"blazer_ser"
@@ -138,7 +138,7 @@
 "ARTronic"	"ups"	"2"	"ARTon Platinium Combo 3.1 10/15/20 kVA"	"USB"	"blazer_usb"
 "ARTronic"	"ups"	"2"	"ARTon Platinium RT 1/2/3/6/10 kVA"	"USB"	"blazer_usb"
 
-"Armac"	"ups"	"2"	"R/2000I/PSW and PF1 series"	"(USB ID 0925:1234)" "nutdrv_qx"
+"Armac"	"ups"	"2"	"R/2000I/PSW and PF1 series"	"(USB ID 0925:1234)"	"nutdrv_qx"
 
 "ASEM SPA"	"ups"	"5"	"PB1300 UPS"	"i2c"	"asem"
 
@@ -437,7 +437,7 @@
 "Eaton"	"pdu"	"5"	"ePDU Managed"	""	"snmp-ups"
 "Eaton"	"pdu"	"5"	"ePDU Switched"	""	"snmp-ups"
 "Eaton"	"pdu"	"5"	"ePDU Monitored"	""	"snmp-ups or netxml-ups"
-"Eaton"	"ups"	"5"	"ePDU EMSV0001" "nLogic rebranded"	"snmp-ups"
+"Eaton"	"ups"	"5"	"ePDU EMSV0001"	"nLogic rebranded"	"snmp-ups"
 "Eaton"	"ups"	"5"	"Powerware 3105"	"USB"	"bcmxcp_usb"	# http://powerquality.eaton.com/Products-services/Backup-Power-UPS/3105-eol.aspx
 "Eaton"	"ups"	"5"	"Powerware 9125"	"USB card"	"bcmxcp_usb"
 "Eaton"	"ups"	"5"	"Powerware 9130"	""	"bcmxcp or usbhid-ups"
@@ -608,7 +608,7 @@
 "Infosec"	"ups"	"2"	"X2, X3, X4, E2, E3, E4"	"USB"	"blazer_usb"
 "Infosec"	"ups"	"2"	"XP 500"	"USB"	"blazer_usb"
 "Infosec"	"ups"	"2"	"XP 1000"	""	"blazer_ser"
-"Infosec"	"ups"	"1"	"(various)" "Serial"	"nutdrv_hashx"	# https://www.infosec-ups.com/en/powermaster
+"Infosec"	"ups"	"1"	"(various)"	"Serial"	"nutdrv_hashx"	# https://www.infosec-ups.com/en/powermaster
 
 "IPAR"	"ups"	"2"	"Mini Energy ME 800"	"USB"	"blazer_usb"
 
@@ -707,7 +707,7 @@
 
 "Liebert"	"ups"	"2"	"ITON 600VA"	""	"blazer_ser"
 "Liebert"	"ups"	"5"	"UPStation GXT2"	"contact-closure cable"	"liebert"
-"Liebert"	"ups"	"4"	"GXE 1-3kVA"   		"Serial"	"liebert-gxe (experimental)"
+"Liebert"	"ups"	"4"	"GXE 1-3kVA"	"Serial"	"liebert-gxe (experimental)"
 "Liebert"	"ups"	"1"	"GXT2-3000RT230"	""	"liebert-esp2 (experimental)"
 "Liebert"	"ups"	"3"	"GXT4-1500RT120"	"USB"	"usbhid-ups"	# https://alioth-lists.debian.net/pipermail/nut-upsdev/2024-September/008013.html
 "Liebert"	"ups"	"3"	"PowerSure Personal XT"	"USB"	"usbhid-ups"
@@ -1204,7 +1204,7 @@
 "PowerWalker"	"ups"	"3"	"PR1500LCDRT2U"	"USB"	"usbhid-ups"	# https://github.com/networkupstools/nut/issues/818
 "PowerWalker"	"ups"	"2"	"VI 3000 SCL"	"USB"	"blazer_usb"	# https://github.com/networkupstools/nut/issues/971
 "PowerWalker"	"ups"	"3"	"VI 750T/HID"	"USB"	"usbhid-ups"	# https://powerwalker.com/?page=select&cat=VI_THID&lang=en https://github.com/networkupstools/nut/issues/774
-"PowerWalker"	"ups"	"1"	"(various)" "Serial"	"nutdrv_hashx"	# https://powerwalker.com/software/
+"PowerWalker"	"ups"	"1"	"(various)"	"Serial"	"nutdrv_hashx"	# https://powerwalker.com/software/
 
 "Powerware"	"ups"	"4"	"3110"	""	"genericups upstype=7"
 "Powerware"	"ups"	"4"	"3115"	""	"genericups upstype=11"
@@ -1296,7 +1296,7 @@
 "Riello"	"ups"	"3"	"(various)"	"Netman 204 SNMP Card"	"snmp-ups"	# Note: in https://github.com/networkupstools/nut/issues/1878 submitted not as 'Netman Plus', clarification requested
 "Riello"	"ups"	"3"	"(various)"	"Netman 208 SNMP Card"	"snmp-ups"	# Note: in https://github.com/networkupstools/nut/issues/1878 submitted not as 'Netman Plus', clarification requested
 
-"Right Power Technology"	"ups"	"1"	"(various)" "Serial"	"nutdrv_hashx"	# https://www.rightpowerups.com.my/faq-download/
+"Right Power Technology"	"ups"	"1"	"(various)"	"Serial"	"nutdrv_hashx"	# https://www.rightpowerups.com.my/faq-download/
 
 "Rocketfish"	"ups"	"3"	"RF-1000VA / RF-1025VA"	"USB"	"usbhid-ups"
 
@@ -1312,7 +1312,7 @@
 "Salicru"	"ups"	"3"	"SLC TWIN RT3"	"usb"	"usbhid-ups (experimental)"
 "Salicru"	"ups"	"3"	"SPS 850 ADV T"	"usb"	"usbhid-ups (experimental)"	# https://www.salicru.com/sps-850-adv-t.html https://github.com/networkupstools/nut/issues/1416
 "Salicru"	"ups"	"3"	"SPS 3000 ADV RT2"	"usb"	"usbhid-ups (experimental)"	# https://www.salicru.com/sps-3000-adv-rt2.html
-"Salicru"	"ups"	"1"	"(various)" "Serial"	"nutdrv_hashx"	# https://www.salicru.com/softwares-usb-rs-232.html
+"Salicru"	"ups"	"1"	"(various)"	"Serial"	"nutdrv_hashx"	# https://www.salicru.com/softwares-usb-rs-232.html
 
 "Santak"	"ups"	"2"	"Castle C*K"	"Serial"	"blazer_ser"	# https://github.com/networkupstools/nut/issues/1039
 "Santak"	"ups"	"2"	"MT*-PRO"	"Serial"	"blazer_ser"	# https://github.com/networkupstools/nut/issues/1039
@@ -1320,24 +1320,24 @@
 "Siemens"	"ups"	"4"	"SITOP UPS500"	"serial"	"nutdrv_siemens_sitop (experimental, untested)"
 "Siemens"	"ups"	"4"	"SITOP UPS500"	"USB"	"nutdrv_siemens_sitop (experimental)"
 
-"SKE"		"ups"	"2"	"SK600"		"USB"	"nutdrv_qx port=auto vendorid=0001 productid=0000 bus=003"
+"SKE"	"ups"	"2"	"SK600"	"USB"	"nutdrv_qx port=auto vendorid=0001 productid=0000 bus=003"
 
 "SmartLabs"	"pdu"	"1"	"2412S Power Line Modem"	"for X10/Insteon"	"powerman-pdu (experimental)"
 
 "SMS (Brazil)"	"ups"	"2"	"Manager III"	""	"blazer_ser"
 
-"SNR"	"ups"	"2" "SNR-UPS-LID-600"	""  "nutdrv_qx"
-"SNR"	"ups"	"2" "SNR-UPS-LID-600-XPS"	""  "nutdrv_qx"
-"SNR"	"ups"	"2" "SNR-UPS-LID-600-LED-C13"	""  "nutdrv_qx"
-"SNR"	"ups"	"2" "SNR-UPS-LID-600-LED-C13-PRO"	""  "nutdrv_qx"
-"SNR"	"ups"	"2" "SNR-UPS-LID-800"	""  "nutdrv_qx"
-"SNR"	"ups"	"2" "SNR-UPS-LID-800-LED-С13"	""  "nutdrv_qx"
-"SNR"	"ups"	"2" "SNR-UPS-LID-1000-XPS"	""  "nutdrv_qx"
-"SNR"	"ups"	"2" "SNR-UPS-LID-1200"	""  "nutdrv_qx"
-"SNR"	"ups"	"2" "SNR-UPS-LID-1500"	""  "nutdrv_qx"
-"SNR"	"ups"	"2" "SNR-UPS-LID-2000"	""  "nutdrv_qx"
-"SNR"	"ups"	"2" "SNR-UPS-LID-2000-XPS"	""  "nutdrv_qx"
-"SNR"	"ups"	"2" "SNR-UPS-LID-3000-XPS"	""  "nutdrv_qx"
+"SNR"	"ups"	"2"	"SNR-UPS-LID-600"	""	"nutdrv_qx"
+"SNR"	"ups"	"2"	"SNR-UPS-LID-600-XPS"	""	"nutdrv_qx"
+"SNR"	"ups"	"2"	"SNR-UPS-LID-600-LED-C13"	""	"nutdrv_qx"
+"SNR"	"ups"	"2"	"SNR-UPS-LID-600-LED-C13-PRO"	""	"nutdrv_qx"
+"SNR"	"ups"	"2"	"SNR-UPS-LID-800"	""	"nutdrv_qx"
+"SNR"	"ups"	"2"	"SNR-UPS-LID-800-LED-С13"	""	"nutdrv_qx"
+"SNR"	"ups"	"2"	"SNR-UPS-LID-1000-XPS"	""	"nutdrv_qx"
+"SNR"	"ups"	"2"	"SNR-UPS-LID-1200"	""	"nutdrv_qx"
+"SNR"	"ups"	"2"	"SNR-UPS-LID-1500"	""	"nutdrv_qx"
+"SNR"	"ups"	"2"	"SNR-UPS-LID-2000"	""	"nutdrv_qx"
+"SNR"	"ups"	"2"	"SNR-UPS-LID-2000-XPS"	""	"nutdrv_qx"
+"SNR"	"ups"	"2"	"SNR-UPS-LID-3000-XPS"	""	"nutdrv_qx"
 
 "SOLA"	"ups"	"1"	"305"	"cable INT-0025C"	"genericups upstype=7"
 "SOLA"	"ups"	"1"	"325"	""	"blazer_ser or bestups"

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -162,8 +162,6 @@ dist-hook:
 		echo "----------------------------------------------------------------------"; \
 	fi
 
-	@$(distdir)/driver-list-format.sh;
-
 MAINTAINERCLEANFILES = Makefile.in .dirstamp
 
 # Can be recreated by `make` or `configure`,

--- a/tools/driver-list-format.sh
+++ b/tools/driver-list-format.sh
@@ -15,13 +15,36 @@
 CURRENT_PATH="`dirname $0`"
 DRVLIST_PATH=""
 
-if [ -f "${CURRENT_PATH}/data/driver.list.in" ]; then
-	DRVLIST_PATH="${CURRENT_PATH}"
+# Integrate with Makefile recipes
+if [ -n "${srcdir}" ] && [ -f "${srcdir}/driver.list.in" ] ; then
+	DRVLIST_PATH="${srcdir}"
+elif [ -n "${abs_srcdir}" ] && [ -f "${abs_srcdir}/driver.list.in" ] ; then
+	DRVLIST_PATH="${abs_srcdir}"
+elif [ -n "${top_srcdir}" ] && [ -f "${top_srcdir}/data/driver.list.in" ] ; then
+	DRVLIST_PATH="${top_srcdir}/data"
+elif [ -n "${abs_top_srcdir}" ] && [ -f "${abs_top_srcdir}/data/driver.list.in" ] ; then
+	DRVLIST_PATH="${abs_top_srcdir}/data"
+elif [ -f "${CURRENT_PATH}/data/driver.list.in" ]; then
+	DRVLIST_PATH="${CURRENT_PATH}/data"
 elif [ -f "${CURRENT_PATH}/../data/driver.list.in" ]; then
-	DRVLIST_PATH="${CURRENT_PATH}/.."
+	DRVLIST_PATH="${CURRENT_PATH}/../data"
 else
-	echo "$0: Can't find driver.list in . or .., aborting" >&2
+	echo "$0: ERROR: Can't find driver.list in . or .., aborting" >&2
 	exit 1
+fi
+
+TMPBUILD_PATH=""
+if [ -n "${builddir}" ] && [ -d "${builddir}" ] ; then
+	TMPBUILD_PATH="${builddir}"
+elif [ -n "${abs_builddir}" ] && [ -d "${abs_builddir}" ] ; then
+	TMPBUILD_PATH="${abs_builddir}"
+elif [ -n "${top_builddir}" ] && [ -d "${top_builddir}" ] ; then
+	TMPBUILD_PATH="${top_builddir}/data"
+elif [ -n "${abs_top_builddir}" ] && [ -d "${abs_top_builddir}" ] ; then
+	TMPBUILD_PATH="${abs_top_builddir}/data"
+else
+	echo "$0: WARNING: no builddir was specified, using srcdir of the files for output" >&2
+	TMPBUILD_PATH="${DRVLIST_PATH}"
 fi
 
 ACTION="Ensuring"
@@ -38,7 +61,7 @@ TABCHAR="`printf '\t'`"
 echo "$0: $ACTION whether driver.list[.in] are well formatted"
 for drvfile in driver.list.in driver.list
 do
-	if [ -f "${DRVLIST_PATH}/data/${drvfile}" ]; then
+	if [ -f "${DRVLIST_PATH}/${drvfile}" ]; then
 		# For every non-comment line:
 		# * replace quote-spaces-quote (or technically any amount
 		#   of blank space/tab characters) with quote-TAB-quote
@@ -49,40 +72,40 @@ do
 			-e '/^#/!s/\"[[:blank:]]\+\"/\"\t\"/g' \
 			-e '/^#/!s/[[:blank:]]*$//' \
 			-e '/^#/!s/\" \+\#/\"\t\#/' \
-		< "${DRVLIST_PATH}/data/${drvfile}" \
-		> "${DRVLIST_PATH}/data/${drvfile}.tabbed" \
+		< "${DRVLIST_PATH}/${drvfile}" \
+		> "${TMPBUILD_PATH}/${drvfile}.tabbed" \
 		&& \
 		{
 			# verify that lines are either empty, all-comments,
 			# or have six quoted fields (and optional comment);
 			# the fields may be empty (just two double-quotes).
-			BADLINES="`grep -vE '(^$|^#|^"[^"]*"'"${TABCHAR}"'"[^"]*"'"${TABCHAR}"'"[^"]*"'"${TABCHAR}"'"[^"]*"'"${TABCHAR}"'"[^"]*"'"${TABCHAR}"'"[^"]*("|"'"${TABCHAR}"'#.*)$)' < "${DRVLIST_PATH}/data/${drvfile}.tabbed"`"
+			BADLINES="`grep -vE '(^$|^#|^"[^"]*"'"${TABCHAR}"'"[^"]*"'"${TABCHAR}"'"[^"]*"'"${TABCHAR}"'"[^"]*"'"${TABCHAR}"'"[^"]*"'"${TABCHAR}"'"[^"]*("|"'"${TABCHAR}"'#.*)$)' < "${TMPBUILD_PATH}/${drvfile}.tabbed"`"
 			if [ x"${BADLINES}" != x ] ; then
-				echo "$0: ERROR: markup of '${DRVLIST_PATH}/data/${drvfile}' needs to be fixed: some lines are not exactly 6 fields (and optional comment)" >&2
+				echo "$0: ERROR: markup of '${DRVLIST_PATH}/${drvfile}' needs to be fixed: some lines are not exactly 6 fields (and optional comment)" >&2
 				echo "$BADLINES" | head -5
 				RES=1
 				false
 			fi
 		} && \
 		if [ x"${ACTION}" = xEnsuring ] ; then
-			if diff "${DRVLIST_PATH}/data/${drvfile}.tabbed" "${DRVLIST_PATH}/data/${drvfile}" >/dev/null ; then
+			if diff "${TMPBUILD_PATH}/${drvfile}.tabbed" "${DRVLIST_PATH}/${drvfile}" >/dev/null ; then
 				# Same content
-				rm -f "${DRVLIST_PATH}/data/${drvfile}.tabbed"
+				rm -f "${TMPBUILD_PATH}/${drvfile}.tabbed"
 			else
 				# Ensure new content is applied
-				mv -f "${DRVLIST_PATH}/data/${drvfile}.tabbed" "${DRVLIST_PATH}/data/${drvfile}"
+				mv -f "${TMPBUILD_PATH}/${drvfile}.tabbed" "${DRVLIST_PATH}/${drvfile}"
 			fi
 		else # Checking
-			diff -u "${DRVLIST_PATH}/data/${drvfile}.tabbed" "${DRVLIST_PATH}/data/${drvfile}" \
+			diff -u "${TMPBUILD_PATH}/${drvfile}.tabbed" "${DRVLIST_PATH}/${drvfile}" \
 			|| { GITACT=""
 			     case "${drvfile}" in *.in) GITACT=" and commit the git change" ;; esac
-			     echo "$0: ERROR: markup of '${DRVLIST_PATH}/data/${drvfile}' needs to be fixed: re-run this script without args${GITACT}, please" >&2
+			     echo "$0: ERROR: markup of '${DRVLIST_PATH}/${drvfile}' needs to be fixed: re-run this script without args${GITACT}, please" >&2
 			     RES=1
 			   }
 		fi \
 		|| RES=$?
 
-		echo "$0: Processed ${DRVLIST_PATH}/data/${drvfile}"
+		echo "$0: Processed ${DRVLIST_PATH}/${drvfile}"
 	else
 		echo "$0: Skipping ${drvfile} as it is missing..."
 	fi

--- a/tools/driver-list-format.sh
+++ b/tools/driver-list-format.sh
@@ -57,6 +57,7 @@ RES=0
 # Some sed/grep implementations tend to have a problem with "\t"
 # (treat it as escaped "t" character); substitutions are okay:
 TABCHAR="`printf '\t'`"
+VALID_LINE='(^$|^#|^"[^"]*"'"${TABCHAR}"'"[^"]*"'"${TABCHAR}"'"[^"]*"'"${TABCHAR}"'"[^"]*"'"${TABCHAR}"'"[^"]*"'"${TABCHAR}"'"[^"]*("|"'"${TABCHAR}"'#.*)$)'
 
 echo "$0: $ACTION whether driver.list[.in] are well formatted"
 for drvfile in driver.list.in driver.list
@@ -79,7 +80,7 @@ do
 			# verify that lines are either empty, all-comments,
 			# or have six quoted fields (and optional comment);
 			# the fields may be empty (just two double-quotes).
-			BADLINES="`grep -vE '(^$|^#|^"[^"]*"'"${TABCHAR}"'"[^"]*"'"${TABCHAR}"'"[^"]*"'"${TABCHAR}"'"[^"]*"'"${TABCHAR}"'"[^"]*"'"${TABCHAR}"'"[^"]*("|"'"${TABCHAR}"'#.*)$)' < "${TMPBUILD_PATH}/${drvfile}.tabbed"`"
+			BADLINES="`grep -vE "${VALID_LINE}" < "${TMPBUILD_PATH}/${drvfile}.tabbed"`"
 			if [ x"${BADLINES}" != x ] ; then
 				echo "$0: ERROR: markup of '${DRVLIST_PATH}/${drvfile}' needs to be fixed: some lines are not exactly 6 fields (and optional comment)" >&2
 				echo "$BADLINES" | head -5

--- a/tools/driver-list-format.sh
+++ b/tools/driver-list-format.sh
@@ -59,7 +59,13 @@ do
 			fi
 		} && \
 		if [ x"${ACTION}" = xEnsuring ] ; then
-			mv -f "${DRVLIST_PATH}/data/${drvfile}.tabbed" "${DRVLIST_PATH}/data/${drvfile}"
+			if diff "${DRVLIST_PATH}/data/${drvfile}.tabbed" "${DRVLIST_PATH}/data/${drvfile}" >/dev/null ; then
+				# Same content
+				rm -f "${DRVLIST_PATH}/data/${drvfile}.tabbed"
+			else
+				# Ensure new content is applied
+				mv -f "${DRVLIST_PATH}/data/${drvfile}.tabbed" "${DRVLIST_PATH}/data/${drvfile}"
+			fi
 		else # Checking
 			diff -u "${DRVLIST_PATH}/data/${drvfile}.tabbed" "${DRVLIST_PATH}/data/${drvfile}" \
 			|| { GITACT=""

--- a/tools/driver-list-format.sh
+++ b/tools/driver-list-format.sh
@@ -32,13 +32,20 @@ do
 		# For every non-comment line:
 		# * replace quote-spaces-quote with quote-TAB-quote
 		# * strip trailing blank characters at the end of line
-		sed -e '/^#/!s/\" \+\"/\"\t\"/g' -e "/^#/!s/[[:blank:]]*$//" < "${DRVLIST_PATH}/data/${drvfile}" > "${DRVLIST_PATH}/data/${drvfile}.tabbed" && \
+		sed \
+			-e '/^#/!s/\" \+\"/\"\t\"/g' \
+			-e '/^#/!s/[[:blank:]]*$//' \
+		< "${DRVLIST_PATH}/data/${drvfile}" \
+		> "${DRVLIST_PATH}/data/${drvfile}.tabbed" \
+		&& \
 		if [ x"${ACTION}" = xEnsuring ] ; then
 			mv -f "${DRVLIST_PATH}/data/${drvfile}.tabbed" "${DRVLIST_PATH}/data/${drvfile}"
 		else # Checking
 			diff "${DRVLIST_PATH}/data/${drvfile}.tabbed" "${DRVLIST_PATH}/data/${drvfile}" >/dev/null \
 			|| { echo "File '${DRVLIST_PATH}/data/${drvfile}' markup needs to be fixed (run $0 and commit the git change, please)" >&2 ; RES=1 ; }
-		fi || RES=$?
+		fi \
+		|| RES=$?
+
 		echo "Processed ${DRVLIST_PATH}/data/${drvfile}"
 	else
 		echo "Skipping ${drvfile} as it is missing..."

--- a/tools/driver-list-format.sh
+++ b/tools/driver-list-format.sh
@@ -1,7 +1,13 @@
 #!/bin/sh
 ################################################################################
 #
-# Ensure that driver.list and driver.list.in are properly formatted (with tabs)
+# Ensure or read-only check that generated driver.list and source driver.list.in
+# files are properly formatted (non-comment lines contain 6 fields separated
+# with tabs, optionally with a trailing comment).
+#
+# Copyright (C)
+#	2015-2016	Arnaud Quette <arnaud.quette@free.fr>
+#	2025		Jim Klimov <jimklimov+nut@gmail.com>
 #
 ################################################################################
 

--- a/tools/driver-list-format.sh
+++ b/tools/driver-list-format.sh
@@ -29,6 +29,9 @@ echo "$ACTION whether driver.list[.in] are well formatted"
 for drvfile in driver.list.in driver.list
 do
 	if [ -f "${DRVLIST_PATH}/data/${drvfile}" ]; then
+		# For every non-comment line:
+		# * replace quote-spaces-quote with quote-TAB-quote
+		# * strip trailing blank characters at the end of line
 		sed -e '/^#/!s/\" \+\"/\"\t\"/g' -e "/^#/!s/[[:blank:]]*$//" < "${DRVLIST_PATH}/data/${drvfile}" > "${DRVLIST_PATH}/data/${drvfile}.tabbed" && \
 		if [ x"${ACTION}" = xEnsuring ] ; then
 			mv -f "${DRVLIST_PATH}/data/${drvfile}.tabbed" "${DRVLIST_PATH}/data/${drvfile}"

--- a/tools/driver-list-format.sh
+++ b/tools/driver-list-format.sh
@@ -14,7 +14,7 @@ if [ -f "${CURRENT_PATH}/data/driver.list.in" ]; then
 elif [ -f "${CURRENT_PATH}/../data/driver.list.in" ]; then
 	DRVLIST_PATH="${CURRENT_PATH}/.."
 else
-	echo "Can't find driver.list in . or .."
+	echo "$0: Can't find driver.list in . or .., aborting" >&2
 	exit 1
 fi
 
@@ -25,7 +25,7 @@ fi
 
 RES=0
 
-echo "$ACTION whether driver.list[.in] are well formatted"
+echo "$0: $ACTION whether driver.list[.in] are well formatted"
 for drvfile in driver.list.in driver.list
 do
 	if [ -f "${DRVLIST_PATH}/data/${drvfile}" ]; then
@@ -44,16 +44,20 @@ do
 		if [ x"${ACTION}" = xEnsuring ] ; then
 			mv -f "${DRVLIST_PATH}/data/${drvfile}.tabbed" "${DRVLIST_PATH}/data/${drvfile}"
 		else # Checking
-			diff "${DRVLIST_PATH}/data/${drvfile}.tabbed" "${DRVLIST_PATH}/data/${drvfile}" >/dev/null \
-			|| { echo "File '${DRVLIST_PATH}/data/${drvfile}' markup needs to be fixed (run $0 and commit the git change, please)" >&2 ; RES=1 ; }
+			diff -u "${DRVLIST_PATH}/data/${drvfile}.tabbed" "${DRVLIST_PATH}/data/${drvfile}" \
+			|| { GITACT=""
+			     case "${drvfile}" in *.in) GITACT=" and commit the git change" ;; esac
+			     echo "$0: ERROR: markup of '${DRVLIST_PATH}/data/${drvfile}' needs to be fixed: re-run this script without args${GITACT}, please" >&2
+			     RES=1
+			   }
 		fi \
 		|| RES=$?
 
-		echo "Processed ${DRVLIST_PATH}/data/${drvfile}"
+		echo "$0: Processed ${DRVLIST_PATH}/data/${drvfile}"
 	else
-		echo "Skipping ${drvfile} as it is missing..."
+		echo "$0: Skipping ${drvfile} as it is missing..."
 	fi
 done
-echo "done"
+echo "$0: done ($RES)"
 
 exit $RES

--- a/tools/driver-list-format.sh
+++ b/tools/driver-list-format.sh
@@ -34,12 +34,13 @@ for drvfile in driver.list.in driver.list
 do
 	if [ -f "${DRVLIST_PATH}/data/${drvfile}" ]; then
 		# For every non-comment line:
-		# * replace quote-spaces-quote with quote-TAB-quote
+		# * replace quote-spaces-quote (or technically any amount
+		#   of blank space/tab characters) with quote-TAB-quote
 		# * strip trailing blank characters at the end of line
 		# * if there is a trailing comment, make sure it is
 		#   also TAB-separated (from the presumed sixth field)
 		sed \
-			-e '/^#/!s/\" \+\"/\"\t\"/g' \
+			-e '/^#/!s/\"[[:blank:]]\+\"/\"\t\"/g' \
 			-e '/^#/!s/[[:blank:]]*$//' \
 			-e '/^#/!s/\" \+\#/\"\t\#/' \
 		< "${DRVLIST_PATH}/data/${drvfile}" \

--- a/tools/driver-list-format.sh
+++ b/tools/driver-list-format.sh
@@ -32,9 +32,12 @@ do
 		# For every non-comment line:
 		# * replace quote-spaces-quote with quote-TAB-quote
 		# * strip trailing blank characters at the end of line
+		# * if there is a trailing comment, make sure it is
+		#   also TAB-separated (from the presumed sixth field)
 		sed \
 			-e '/^#/!s/\" \+\"/\"\t\"/g' \
 			-e '/^#/!s/[[:blank:]]*$//' \
+			-e '/^#/!s/\" \+\#/\"\t\#/' \
 		< "${DRVLIST_PATH}/data/${drvfile}" \
 		> "${DRVLIST_PATH}/data/${drvfile}.tabbed" \
 		&& \

--- a/tools/driver-list-format.sh
+++ b/tools/driver-list-format.sh
@@ -18,15 +18,29 @@ else
 	exit 1
 fi
 
-echo "Checking whether driver.list[.in] are well formatted"
+ACTION="Ensuring"
+if [ x"${1-}" = x"--check" ] ; then
+	ACTION="Checking"
+fi
+
+RES=0
+
+echo "$ACTION whether driver.list[.in] are well formatted"
 for drvfile in driver.list.in driver.list
 do
 	if [ -f "${DRVLIST_PATH}/data/${drvfile}" ]; then
-		sed -e '/^#/!s/\" \+\"/\"\t\"/g' -e "/^#/!s/[[:blank:]]*$//" < "${DRVLIST_PATH}/data/${drvfile}" > "${DRVLIST_PATH}/data/${drvfile}.tabbed"
-		mv -f "${DRVLIST_PATH}/data/${drvfile}.tabbed" "${DRVLIST_PATH}/data/${drvfile}"
+		sed -e '/^#/!s/\" \+\"/\"\t\"/g' -e "/^#/!s/[[:blank:]]*$//" < "${DRVLIST_PATH}/data/${drvfile}" > "${DRVLIST_PATH}/data/${drvfile}.tabbed" && \
+		if [ x"${ACTION}" = xEnsuring ] ; then
+			mv -f "${DRVLIST_PATH}/data/${drvfile}.tabbed" "${DRVLIST_PATH}/data/${drvfile}"
+		else # Checking
+			diff "${DRVLIST_PATH}/data/${drvfile}.tabbed" "${DRVLIST_PATH}/data/${drvfile}" >/dev/null \
+			|| { echo "File '${DRVLIST_PATH}/data/${drvfile}' markup needs to be fixed (run $0 and commit the git change, please)" >&2 ; RES=1 ; }
+		fi || RES=$?
 		echo "Processed ${DRVLIST_PATH}/data/${drvfile}"
 	else
 		echo "Skipping ${drvfile} as it is missing..."
 	fi
 done
 echo "done"
+
+exit $RES


### PR DESCRIPTION
We already had the `tools/driver-list-format.sh` script since 2016 ed7a2ded00 (ported from 2015's f77974cc13 origins in `configure.ac`) that "ensured" the format of `data/drivers.list(.in)` files to have TAB-separated fields, by editing the files (and always succeeding). This was only called as part of `make dist` and adjusted the published files (with no enforcement that original git sources changes should get committed if the script edits anything).

This PR revises the script to also have a `--check` mode, so developers can see any added discrepancies as part of `make check`, and are told how to ensure and commit fixes.

It also adds and revises the checks, such as avoiding mix of spaces and tabs (or multiple tabs) as a separator, ensuring the optional comment is also tab-separated from the last (sixth) field, and that here are exactly 6 tab-separated required fields present (as double-quoted zero or more non-quote characters).

Actually several older entries were not compliant and got updated.

Finally, a (C) is added to the header along with purpose comment update :)

Overall, this should help contributors propose HCL updates while we all have peace of mind that nothing got fat-fingered and would break later (nut-website generation, etc.)