### PR TITLE
Fix `usbhid-ups` instant commands that could work without non-trivial args before NUT v2.8.3

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -39,7 +39,13 @@ https://github.com/networkupstools/nut/milestone/9
  - (expected) CI automation for use of data points in drivers that conform
    to patterns defined in link:docs/nut-names.txt[]
 
- - (expected) Bug fixes for fallout possible due to "fightwarn" effort in 2.8.0+
+ - Bug fixes for fallout possible due to "fightwarn" effort in 2.8.0+:
+   * In `usbhid-ups` sources, introduced `HU_FLAG_CMD_PARAM_REQUIRED` (and a
+     `HU_TYPE_CMD_PARAM_REQUIRED` shortcut) for setting in the mapping tables,
+     to specify instant commands that require an argument (either from caller
+     or a non-`NULL` default in the run-time table after device data discovery);
+     if the flag is not set, a zero value is assumed. Incomplete code was a
+     regression of NUT v2.8.3 causing some instant commands to fail. [#2860]
 
  - Fix fallout of development in NUT v2.8.0 and/or v2.8.1 and/or v2.8.2 and/or
    v2.8.3:

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -40,12 +40,14 @@ https://github.com/networkupstools/nut/milestone/9
    to patterns defined in link:docs/nut-names.txt[]
 
  - Bug fixes for fallout possible due to "fightwarn" effort in 2.8.0+:
-   * In `usbhid-ups` sources, introduced `HU_FLAG_CMD_PARAM_REQUIRED` (and a
-     `HU_TYPE_CMD_PARAM_REQUIRED` shortcut) for setting in the mapping tables,
-     to specify instant commands that require an argument (either from caller
-     or a non-`NULL` default in the run-time table after device data discovery);
+   * In `usbhid-ups` sources, introduced optional `HU_FLAG_PARAM_REQUIRED` for
+     `setvar()` or `instcmd()` handling (and a `HU_TYPE_CMD_PARAM_REQUIRED`
+     shortcut) for setting in the mapping table flags, to specify variables
+     or instant commands that require an argument (either from caller or a
+     non-`NULL` default in the run-time table after device data discovery);
      if the flag is not set, a zero value is assumed. Incomplete code was a
-     regression of NUT v2.8.3 causing some instant commands to fail. [#2860]
+     regression of NUT v2.8.3 causing some instant commands to fail. [#2860,
+     #2955]
 
  - Fix fallout of development in NUT v2.8.0 and/or v2.8.1 and/or v2.8.2 and/or
    v2.8.3:

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3494 utf-8
+personal_ws-1.1 en 3495 utf-8
 AAC
 AAS
 ABI
@@ -488,6 +488,7 @@ HOWTO
 HPE
 HPUX
 HREF
+HU
 HUPCL
 HUZKVEIkHnC
 HV

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -900,7 +900,7 @@ int instcmd(const char *cmdname, const char *extradata)
 			return instcmd("load.off.delay", dstate_getinfo("ups.delay.shutdown"));
 		}
 
-		upsdebugx(2, "instcmd: info element unavailable %s\n", cmdname);
+		upsdebugx(2, "instcmd: info element unavailable %s", cmdname);
 		return STAT_INSTCMD_INVALID;
 	}
 
@@ -911,14 +911,14 @@ int instcmd(const char *cmdname, const char *extradata)
 
 	/* Check if the item is an instant command */
 	if (!(hidups_item->hidflags & HU_TYPE_CMD)) {
-		upsdebugx(2, "instcmd: %s is not an instant command\n", cmdname);
+		upsdebugx(2, "instcmd: %s is not an instant command", cmdname);
 		return STAT_INSTCMD_INVALID;
 	}
 
 	/* If extradata is empty, use the default value from the HID-to-NUT table */
 	val = extradata ? extradata : hidups_item->dfl;
 	if (!val) {
-		upsdebugx(2, "instcmd: %s requires an explicit parameter\n", cmdname);
+		upsdebugx(2, "instcmd: %s requires an explicit parameter", cmdname);
 		return STAT_INSTCMD_CONVERSION_FAILED;
 	}
 
@@ -931,13 +931,13 @@ int instcmd(const char *cmdname, const char *extradata)
 
 	/* Actual variable setting */
 	if (HIDSetDataValue(udev, hidups_item->hiddata, value) == 1) {
-		upsdebugx(3, "instcmd: SUCCEED\n");
+		upsdebugx(3, "instcmd: SUCCEED");
 		/* Set the status so that SEMI_STATIC vars are polled */
 		data_has_changed = TRUE;
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upsdebugx(3, "instcmd: FAILED\n"); /* TODO: HANDLED but FAILED, not UNKNOWN! */
+	upsdebugx(3, "instcmd: FAILED"); /* TODO: HANDLED but FAILED, not UNKNOWN! */
 	return STAT_INSTCMD_FAILED;
 }
 
@@ -953,26 +953,26 @@ int setvar(const char *varname, const char *val)
 	hidups_item = find_nut_info(varname);
 
 	if (hidups_item == NULL) {
-		upsdebugx(2, "setvar: info element unavailable %s\n", varname);
+		upsdebugx(2, "setvar: info element unavailable %s", varname);
 		return STAT_SET_UNKNOWN;
 	}
 
 	/* Checking item writability and HID Path */
 	if (!(hidups_item->info_flags & ST_FLAG_RW)) {
-		upsdebugx(2, "setvar: not writable %s\n", varname);
+		upsdebugx(2, "setvar: not writable %s", varname);
 		return STAT_SET_UNKNOWN;
 	}
 
 	/* handle server side variable */
 	if (hidups_item->hidflags & HU_FLAG_ABSENT) {
-		upsdebugx(2, "setvar: setting server side variable %s\n", varname);
+		upsdebugx(2, "setvar: setting server side variable %s", varname);
 		dstate_setinfo(hidups_item->info_type, "%s", val);
 		return STAT_SET_HANDLED;
 	}
 
 	/* HU_FLAG_ABSENT is the only case of HID Path == NULL */
 	if (hidups_item->hidpath == NULL) {
-		upsdebugx(2, "setvar: ID Path is NULL for %s\n", varname);
+		upsdebugx(2, "setvar: ID Path is NULL for %s", varname);
 		return STAT_SET_UNKNOWN;
 	}
 
@@ -985,13 +985,13 @@ int setvar(const char *varname, const char *val)
 
 	/* Actual variable setting */
 	if (HIDSetDataValue(udev, hidups_item->hiddata, value) == 1) {
-		upsdebugx(5, "setvar: SUCCEED\n");
+		upsdebugx(5, "setvar: SUCCEED");
 		/* Set the status so that SEMI_STATIC vars are polled */
 		data_has_changed = TRUE;
 		return STAT_SET_HANDLED;
 	}
 
-	upsdebugx(3, "setvar: FAILED\n"); /* FIXME: HANDLED but FAILED, not UNKNOWN! */
+	upsdebugx(3, "setvar: FAILED"); /* FIXME: HANDLED but FAILED, not UNKNOWN! */
 	return STAT_SET_UNKNOWN;
 }
 
@@ -1253,7 +1253,7 @@ void upsdrv_updateinfo(void)
 		ups_infoval_set(item, value);
 	}
 #ifdef DEBUG
-	upsdebugx(1, "took %.3f seconds handling interrupt reports...\n",
+	upsdebugx(1, "took %.3f seconds handling interrupt reports...",
 		interval());
 #endif
 	/* clear status buffer before beginning */
@@ -1289,7 +1289,7 @@ void upsdrv_updateinfo(void)
 
 	dstate_dataok();
 #ifdef DEBUG
-	upsdebugx(1, "took %.3f seconds handling feature reports...\n",
+	upsdebugx(1, "took %.3f seconds handling feature reports...",
 		interval());
 #endif
 }

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -917,27 +917,32 @@ int instcmd(const char *cmdname, const char *extradata)
 
 	/* If extradata is empty, use the default value from the HID-to-NUT table */
 	val = extradata ? extradata : hidups_item->dfl;
-	if (!val) {
-		if (hidups_item->hidflags & HU_FLAG_CMD_PARAM_REQUIRED) {
-			upsdebugx(2, "instcmd: %s requires an explicit or default parameter", cmdname);
-			return STAT_INSTCMD_CONVERSION_FAILED;
-		}
-
-		/* If we end up with atol() below, it should return 0 on error
-		 * anyway (on platforms where it would not crash due to NULL),
-		 * so we make it portably explicit here as a string "0" to be
-		 * handled below.
-		 */
-		upsdebugx(4, "instcmd: %s got no explicit nor default parameter, "
-			"but does not require one: falling back to \"0\"", cmdname);
-		val = "0";
+	if (!val && hidups_item->hidflags & HU_FLAG_PARAM_REQUIRED) {
+		upsdebugx(2, "instcmd: %s requires an explicit or default parameter", cmdname);
+		return STAT_INSTCMD_CONVERSION_FAILED;
 	}
 
 	/* Lookup the new value if needed */
 	if (hidups_item->hid2info != NULL) {
+		/* item->nuf() is expected to handle NULL if it must */
 		value = hu_find_valinfo(hidups_item->hid2info, val);
 	} else {
-		value = atol(val);
+		if (!val) {
+			/* If we end up with atol(NULL) below, it should return
+			 * 0 on error anyway (on platforms where it would not
+			 * crash instead due to the NULL), so we make it portably
+			 * explicit here.
+			 */
+			/* FIXME: Look up data points (maybe via override.* or
+			 * default.* settings) for delay/etc. when handling
+			 * commands like shutdown.* or load.* ?
+			 */
+			upsdebugx(4, "instcmd: %s got no explicit nor default parameter, "
+				"but does not require one: falling back to 0", cmdname);
+			value = 0;
+		} else {
+			value = atol(val);
+		}
 	}
 
 	/* Actual variable setting */
@@ -987,11 +992,32 @@ int setvar(const char *varname, const char *val)
 		return STAT_SET_UNKNOWN;
 	}
 
+	/* FIXME: This code did not use "dfl"; should it start to?
+	 * If val is empty, use the default value from the HID-to-NUT table */
+	/* if (!val) val = hidups_item->dfl; */
+
+	if (!val && hidups_item->hidflags & HU_FLAG_PARAM_REQUIRED) {
+		upsdebugx(2, "setvar: %s requires an explicit or default parameter", varname);
+		return STAT_SET_CONVERSION_FAILED;
+	}
+
 	/* Lookup the new value if needed */
 	if (hidups_item->hid2info != NULL) {
+		/* item->nuf() is expected to handle NULL if it must */
 		value = hu_find_valinfo(hidups_item->hid2info, val);
 	} else {
-		value = atol(val);
+		if (!val) {
+			/* If we end up with atol(NULL) below, it should return
+			 * 0 on error anyway (on platforms where it would not
+			 * crash instead due to the NULL), so we make it portably
+			 * explicit here.
+			 */
+			upsdebugx(4, "setvar: %s got no explicit nor default parameter, "
+				"but does not require one: falling back to 0", varname);
+			value = 0;
+		} else {
+			value = atol(val);
+		}
 	}
 
 	/* Actual variable setting */

--- a/drivers/usbhid-ups.h
+++ b/drivers/usbhid-ups.h
@@ -4,6 +4,7 @@
  *  2003-2009 Arnaud Quette <http://arnaud.quette.free.fr/contact.html>
  *  2005-2006 Peter Selinger <selinger@users.sourceforge.net>
  *  2007-2009 Arjen de Korte <adkorte-guest@alioth.debian.org>
+ *  2017-2025 Jim Klimov <jimklimov+nut@gmail.com>
  *
  * This program was sponsored by MGE UPS SYSTEMS, and now Eaton
  *

--- a/drivers/usbhid-ups.h
+++ b/drivers/usbhid-ups.h
@@ -200,9 +200,13 @@ typedef struct {
 #define HU_FLAG_STALE			32		/* data stale, don't try too often. */
 /* see 64 below */
 #define HU_FLAG_ENUM			128		/* enum values exist. */
+#define HU_FLAG_CMD_PARAM_REQUIRED	256		/* if also HU_TYPE_CMD, require during
+							 * instcmd() that a non-trivial command
+							 * parameter is passed. */
 
 /* hints for su_ups_set, applicable only to rw vars */
 #define HU_TYPE_CMD			64		/* instant command */
+#define HU_TYPE_CMD_PARAM_REQUIRED	(HU_TYPE_CMD | HU_FLAG_CMD_PARAM_REQUIRED)	/* Shortcut for setting in the mapping tables */
 
 #define HU_CMD_MASK		0x2000
 

--- a/drivers/usbhid-ups.h
+++ b/drivers/usbhid-ups.h
@@ -174,16 +174,16 @@ typedef enum {
 
 typedef struct {
 	const char	*info_type;		/* NUT variable name */
-	int	info_flags;		/* NUT flags (to set in addinfo) */
-	int	info_len;		/* if ST_FLAG_STRING: length of the string */
-					/* if HU_TYPE_CMD: command value */
+	int		info_flags;		/* NUT flags (to set in addinfo) */
+	int		info_len;		/* if ST_FLAG_STRING: length of the string */
+						/* if HU_TYPE_CMD: command value */
 	const char	*hidpath;		/* Full HID Object path (or NULL for server side vars) */
-	HIDData_t *hiddata;		/* Full HID Object data (for caching purpose, filled at runtime) */
+	HIDData_t	*hiddata;		/* Full HID Object data (for caching purpose, filled at runtime) */
 	const char	*dfl;			/* if HU_FLAG_ABSENT: default value ; format otherwise */
-	unsigned long hidflags;		/* driver's own flags */
-	info_lkp_t *hid2info;		/* lookup table between HID and NUT values */
-								/* if HU_FLAG_ENUM is set, hid2info is also used
-								 * as enumerated values (dstate_addenum()) */
+	unsigned long	hidflags;		/* driver's own flags */
+	info_lkp_t	*hid2info;		/* lookup table between HID and NUT values */
+						/* if HU_FLAG_ENUM is set, hid2info is also used
+						 * as enumerated values (dstate_addenum()) */
 
 /*	char *info_HID_format;	*//* FFE: HID format for complex values */
 /*	interpreter interpret;	*//* FFE: interpreter fct, NULL if not needed  */
@@ -192,15 +192,16 @@ typedef struct {
 
 /* TODO: rework flags */
 #define HU_FLAG_STATIC			2		/* retrieve info only once. */
-#define HU_FLAG_SEMI_STATIC		4		/* retrieve info smartly */
+#define HU_FLAG_SEMI_STATIC		4		/* retrieve info smartly. */
 #define HU_FLAG_ABSENT			8		/* data is absent in the device, */
-							/* use default value. */
-#define HU_FLAG_QUICK_POLL		16		/* Mandatory vars	*/
+							/* so we use default value. */
+#define HU_FLAG_QUICK_POLL		16		/* Mandatory vars. */
 #define HU_FLAG_STALE			32		/* data stale, don't try too often. */
-#define HU_FLAG_ENUM			128		/* enum values exist */
+/* see 64 below */
+#define HU_FLAG_ENUM			128		/* enum values exist. */
 
 /* hints for su_ups_set, applicable only to rw vars */
-#define HU_TYPE_CMD				64		/* instant command */
+#define HU_TYPE_CMD			64		/* instant command */
 
 #define HU_CMD_MASK		0x2000
 

--- a/drivers/usbhid-ups.h
+++ b/drivers/usbhid-ups.h
@@ -200,13 +200,13 @@ typedef struct {
 #define HU_FLAG_STALE			32		/* data stale, don't try too often. */
 /* see 64 below */
 #define HU_FLAG_ENUM			128		/* enum values exist. */
-#define HU_FLAG_CMD_PARAM_REQUIRED	256		/* if also HU_TYPE_CMD, require during
-							 * instcmd() that a non-trivial command
-							 * parameter is passed. */
+#define HU_FLAG_PARAM_REQUIRED		256		/* require during setvar() or
+							 * instcmd() that a non-trivial
+							 * value parameter is passed. */
 
 /* hints for su_ups_set, applicable only to rw vars */
 #define HU_TYPE_CMD			64		/* instant command */
-#define HU_TYPE_CMD_PARAM_REQUIRED	(HU_TYPE_CMD | HU_FLAG_CMD_PARAM_REQUIRED)	/* Shortcut for setting in the mapping tables */
+#define HU_TYPE_CMD_PARAM_REQUIRED	(HU_TYPE_CMD | HU_FLAG_PARAM_REQUIRED)	/* Shortcut for setting in the mapping tables */
 
 #define HU_CMD_MASK		0x2000
 


### PR DESCRIPTION
As raised in https://alioth-lists.debian.net/pipermail/nut-upsuser/2025-May/013964.html mailing list discussion, NUT v2.8.3 refused to command an UPS to shut down, while v2.8.2 was successful (to an extent - a command was at least sent, but the UPS was just beeping). This is a regression due to PR #2860, apparently.

* v2.8.3
````
    Hi, my UPS Model Powercom BNT400AP ( made 2017.12 ) on Linux Devuan
    Daedalus and NUT v2.8.3 (install from source tarball with "configure
    --with-usb --with-user=nut --with-group=nut --with-libusb=1.0
    --with-statepath=/run/nut --with-pidpath=/run/nut" options) didn't
    shutdown itself after OS is shutting down by signal of UPS battery is low.

    ...

       0.184242     Initiating UPS [UPS] shutdown
       0.184257     [D1] loop_shutdown_commands: call
    do_loop_shutdown_commands() with driver-default sdcommands
       0.184267     [D1] Starting
    do_loop_shutdown_commands(shudown.default), call depth 1...
       0.184280     [D1] upsdrv_shutdown...
       0.184289     [D1] Starting
    do_loop_shutdown_commands(shutdown.return,shutdown.reboot,load.off.delay,shutdown.stayoff),
    call depth 2...
       0.184299     [D1] instcmd(shutdown.return, [NULL])
       0.184313     [D3] instcmd: using Path
    'UPS.PowerSummary.DelayBeforehutdown'
       0.184321     [D2] instcmd: shutdown.return requires an explicit
    parameter

       0.184331     [D1] instcmd(shutdown.reboot, [NULL])
       0.184348     [D2] find_nut_info: unknown info type: shutdown.reboot
       0.184358     [D3] instcmd: cmdname 'shutdown.reboot' not found;
    checking for alternatives
       0.184371     [D2] instcmd: info element unavailable shutdown.reboot

       0.184387     [D1] instcmd(load.off.delay, [NULL])
       0.184398     [D2] find_nut_info: unknown info type: load.off.delay
       0.184407     [D3] instcmd: cmdname 'load.off.delay' not found;
    checking for alternatives
       0.184418     [D2] instcmd: info element unavailable load.off.delay

       0.184428     [D1] instcmd(shutdown.stayoff, [NULL])
       0.184438     [D3] instcmd: using Path
    'UPS.PowerSummary.DelayBeforehutdown'
       0.184449     [D2] instcmd: shutdown.stayoff requires an explicit
    parameter

       0.184462     [D1] Ending
    do_loop_shutdown_commands(shutdown.return,shutdown.reboot,load.off.delay,shutdown.stayoff),
    call
    depth 2: return-code 2
       0.184471     Shutdown failed!
       0.184483     [D1] set_exit_flag: raising exit flag due to signal -1
       0.184493     [D1] do_loop_shutdown_commands(): command
    'shutdown.default' was handled successfully
       0.184502     [D1] Ending do_loop_shutdown_commands(shutdown.default),
    call depth 1: return-code 0
       0.184512     UPS [UPS]: shutdown request was successful with
    'shutdown.default'
       0.184523     [D1] set_exit_flag: raising exit flag due to
    programmatic abort: EXIT_FAILURE
       0.184540     [D1] upsdrv_cleanup...
       0.184899     [D1] upsnotify: failed to notify about state
    NOTIFY_STATE_STOPPING: no notification tech defined, will not spam more about it
````

* v2.8.2
````
Alexey Korobeinikov
	
May 6, 2025, 5:19 PM (7 days ago)
	
to Jim, Arnaud
Hi! Thank You!

The UPS behavior are chages with NUT v.2.8.2 but more strange

After this command (if power cord unpluged)
/usr/local/ups/bin/usbhid-ups -DDDD -a UPS -k

....
0.188173     [D4] string_to_path: depth = 3
   0.188187     [D4] string_to_path: depth = 3
   0.188199     [D4] string_to_path: depth = 3
   0.188211     [D4] string_to_path: depth = 3
   0.188246     [D2] find_nut_info: unknown info type: load.off.delay
   0.188267     [D2] find_nut_info: unknown info type: load.off.delay
   0.188280     Initiating UPS shutdown
   0.188290     [D1] upsdrv_shutdown...
   0.188298     [D1] instcmd(shutdown.return, [NULL])
   0.188316     [D3] instcmd: using Path 'UPS.PowerSummary.DelayBeforeShutdown'
   0.188332     [D3] powercom_shutdown_nuf: value = (null), command = 5E00
   0.224970     [D3] Report[set]: (3 bytes) => 0f 00 5e
   0.225003     [D4] Set report succeeded
   0.225012     [D3] instcmd: SUCCEED

The UPS are start double beeping every 2 seconds, but didn't turn off himself ( 2 minutes wait )
UPS are still beeping if power are restored
````

This PR restores use of `0` value being passed as instcmd argument if none was given (the earlier use of NULL could segfault on some systems; now it falls back to an explicit `"0"` string).