### PR TITLE
Instcmd setvar brushup

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -157,11 +157,7 @@ EXTRA_DIST = LICENSE-GPL2 LICENSE-GPL3 LICENSE-DCO MAINTAINERS
 # Since the renaming of documentation to `*.adoc` extension to help IDE
 # and GitHub UIs to render the source files in a pretty fashion, we need
 # to list them:
-EXTRA_DIST += INSTALL.nut.adoc UPGRADING.adoc TODO.adoc NEWS.adoc README.adoc
-
-# As long as we do not tarball the script (or should we?), do not deliver
-# its doc either:
-# EXTRA_DIST += ci_build.adoc
+EXTRA_DIST += INSTALL.nut.adoc UPGRADING.adoc TODO.adoc NEWS.adoc README.adoc ci_build.adoc
 
 # Tarballs created by `make dist` include the `configure.ac` and `m4/*` sources
 # but lack NUT magic logic to recreate the `configure` script if someone would

--- a/Makefile.am
+++ b/Makefile.am
@@ -157,7 +157,12 @@ EXTRA_DIST = LICENSE-GPL2 LICENSE-GPL3 LICENSE-DCO MAINTAINERS
 # Since the renaming of documentation to `*.adoc` extension to help IDE
 # and GitHub UIs to render the source files in a pretty fashion, we need
 # to list them:
-EXTRA_DIST += INSTALL.nut.adoc UPGRADING.adoc TODO.adoc NEWS.adoc README.adoc ci_build.adoc
+EXTRA_DIST += INSTALL.nut.adoc UPGRADING.adoc TODO.adoc NEWS.adoc README.adoc
+
+# The document is now part of qa-guide; the script might be a bit git-oriented,
+# but can be useful in builds from tarball, probably. Anyhow, having the doc
+# without the tool which it documents is odd.
+EXTRA_DIST += ci_build.sh ci_build.adoc
 
 # Tarballs created by `make dist` include the `configure.ac` and `m4/*` sources
 # but lack NUT magic logic to recreate the `configure` script if someone would

--- a/Makefile.am
+++ b/Makefile.am
@@ -157,7 +157,11 @@ EXTRA_DIST = LICENSE-GPL2 LICENSE-GPL3 LICENSE-DCO MAINTAINERS
 # Since the renaming of documentation to `*.adoc` extension to help IDE
 # and GitHub UIs to render the source files in a pretty fashion, we need
 # to list them:
-EXTRA_DIST += INSTALL.nut.adoc UPGRADING.adoc TODO.adoc NEWS.adoc README.adoc ci_build.adoc
+EXTRA_DIST += INSTALL.nut.adoc UPGRADING.adoc TODO.adoc NEWS.adoc README.adoc
+
+# As long as we do not tarball the script (or should we?), do not deliver
+# its doc either:
+# EXTRA_DIST += ci_build.adoc
 
 # Tarballs created by `make dist` include the `configure.ac` and `m4/*` sources
 # but lack NUT magic logic to recreate the `configure` script if someone would

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -88,7 +88,10 @@ https://github.com/networkupstools/nut/milestone/9
      [issue #2928, PRs #2931 and #2934]
    * Introduced some macros in `drivers/upshandler.h` for common syslog level
      definitions and message wording for beginning and failing `instcmd()` or
-     `setvar()` operations consistently in different drivers.
+     `setvar()` operations consistently in different drivers. As a related
+     change, operations that intend to turn off or restart the load, or can
+     do that by side effect (e.g. calibration if batteries are old or dead),
+     would explicitly `upslogx(LOG_CRIT,...)` by default before commencing.
 
  - `dummy-ups` driver updates:
    * A new instruction `ALARM` was added for the `Dummy Mode` operation

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -86,6 +86,9 @@ https://github.com/networkupstools/nut/milestone/9
      does not care where the token itself was raised for its notifications.
      Driver-code related test-cases were updated to reflect these changes.
      [issue #2928, PRs #2931 and #2934]
+   * Introduced some macros in `drivers/upshandler.h` for common syslog level
+     definitions and message wording for beginning and failing `instcmd()` or
+     `setvar()` operations consistently in different drivers.
 
  - `dummy-ups` driver updates:
    * A new instruction `ALARM` was added for the `Dummy Mode` operation

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -2323,7 +2323,10 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-sp
 
             # Tack a remaining yes/no in the end to whatever scenario is there;
             # NOT a full matrix
-            if [ "${BUILDSTODO_UNMAPPED}" -gt 1 ] ; then
+            if [ "${BUILDSTODO_UNMAPPED}" -gt 1 ] && \
+            (   [ "$CI_FAILFAST" != "true" ] \
+             || [ "$CI_FAILFAST" = "true" -a "$RES_ALLERRORS" = 0 ] \
+            ) ; then
                 for NUT_UNMAPPED_VARIANT in $NUT_UNMAPPED_VARIANTS ; do
                     case "${NUT_UNMAPPED_VARIANT}" in
                         no) ;;	# we already did the default ("no") implicitly

--- a/clients/upsclient.c
+++ b/clients/upsclient.c
@@ -887,11 +887,11 @@ static int upscli_sslinit(UPSCONN_t *ups, int verifycert)
 		upsdebugx(3, "SSL connected (%s)", SSL_get_version(ups->ssl));
 		break;
 	case 0:
-		upslog_with_errno(1, "SSL_connect do not accept handshake.");
+		upsdebug_with_errno(1, "SSL_connect do not accept handshake.");
 		ssl_error(ups->ssl, res);
 		return -1;
 	default:
-		upslog_with_errno(1, "Unknown return value from SSL_connect %d", res);
+		upsdebug_with_errno(1, "Unknown return value from SSL_connect %d", res);
 		ssl_error(ups->ssl, res);
 		return -1;
 	}

--- a/drivers/adelsystem_cbi.c
+++ b/drivers/adelsystem_cbi.c
@@ -822,6 +822,7 @@ int upscmd(const char *cmdname, const char *extra)
 
 	if (!strcasecmp(cmdname, "load.off")) {
 		data = 1;
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		rval = register_write(mbctx, regs[FSD].xaddr, regs[FSD].type, &data);
 		if (rval == -1) {
 			upsdebugx(2,
@@ -844,6 +845,8 @@ int upscmd(const char *cmdname, const char *extra)
 		int cnt = FSD_REPEAT_CNT;	 /* shutdown repeat counter */
 		struct timeval start;
 		long etime;
+
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 
 		/* retry sending shutdown command on error */
 		while ((rval = upscmd("load.off", NULL)) != STAT_INSTCMD_HANDLED && cnt > 0) {

--- a/drivers/al175.c
+++ b/drivers/al175.c
@@ -1307,11 +1307,13 @@ static int instcmd(const char *cmdname, const char *extra)
 	 */
 
 	if (!strcasecmp(cmdname, "test.battery.start")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		err = START_BATTERY_TEST(24, 1);
 		return (!err ? STAT_INSTCMD_HANDLED : STAT_INSTCMD_FAILED);
 	}
 
 	if (!strcasecmp(cmdname, "test.battery.stop")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		err = STOP_BATTERY_TEST();
 		return (!err ? STAT_INSTCMD_HANDLED : STAT_INSTCMD_FAILED);
 	}

--- a/drivers/al175.c
+++ b/drivers/al175.c
@@ -52,7 +52,7 @@ typedef	uint8_t byte_t;
 
 
 #define DRIVER_NAME	"Eltek AL175/COMLI driver"
-#define DRIVER_VERSION	"0.16"
+#define DRIVER_VERSION	"0.17"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -1295,7 +1295,9 @@ static int instcmd(const char *cmdname, const char *extra)
 {
 	int err;
 
-	upsdebugx(1, "INSTCMD: %s", cmdname);
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
 	io_new_transaction(/*timeout=*/5);
 
@@ -1314,7 +1316,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		return (!err ? STAT_INSTCMD_HANDLED : STAT_INSTCMD_FAILED);
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/apc_modbus.c
+++ b/drivers/apc_modbus.c
@@ -44,7 +44,7 @@
 #endif
 
 #define DRIVER_NAME	"NUT APC Modbus driver " DRIVER_NAME_NUT_MODBUS_HAS_USB_WITH_STR " USB support (libmodbus link type: " NUT_MODBUS_LINKTYPE_STR ")"
-#define DRIVER_VERSION	"0.13"
+#define DRIVER_VERSION	"0.14"
 
 #if defined NUT_MODBUS_HAS_USB
 
@@ -1224,6 +1224,8 @@ static int _apc_modbus_setvar(const char *nut_varname, const char *str_value)
 	apc_modbus_register_t *apc_map = NULL, *apc_value = NULL;
 	uint16_t reg_value[16];
 
+	upsdebug_SET_STARTING(nut_varname, str_value);
+
 	for (mi = 0; mi < SIZEOF_ARRAY(apc_modbus_register_maps) && apc_value == NULL; mi++) {
 		apc_map = apc_modbus_register_maps[mi];
 
@@ -1236,12 +1238,12 @@ static int _apc_modbus_setvar(const char *nut_varname, const char *str_value)
 	}
 
 	if (!apc_map || !apc_value) {
-		upslogx(LOG_WARNING, "%s: [%s] is unknown", __func__, nut_varname);
+		upslog_SET_UNKNOWN(nut_varname, str_value);
 		return STAT_SET_UNKNOWN;
 	}
 
 	if (!(apc_value->value_flags & APC_VF_RW)) {
-		upslogx(LOG_WARNING, "%s: [%s] is not writable", __func__, nut_varname);
+		upslogx(LOG_SET_INVALID, "%s: [%s] is not writable", __func__, nut_varname);
 		return STAT_SET_INVALID;
 	}
 
@@ -1249,7 +1251,7 @@ static int _apc_modbus_setvar(const char *nut_varname, const char *str_value)
 
 	if (apc_value->value_converter && apc_value->value_converter->nut_to_apc) {
 		if (!apc_value->value_converter->nut_to_apc(str_value, reg_value, apc_value->modbus_len)) {
-			upslogx(LOG_WARNING, "%s: [%s] failed to convert value", __func__, nut_varname);
+			upslogx(LOG_SET_CONVERSION_FAILED, "%s: [%s] failed to convert value", __func__, nut_varname);
 			return STAT_SET_CONVERSION_FAILED;
 		}
 	} else {
@@ -1292,7 +1294,7 @@ static int _apc_modbus_setvar(const char *nut_varname, const char *str_value)
 		}
 
 		if (!r) {
-			upslogx(LOG_WARNING, "%s: [%s] failed to convert value", __func__, nut_varname);
+			upslogx(LOG_SET_CONVERSION_FAILED, "%s: [%s] failed to convert value", __func__, nut_varname);
 			return STAT_SET_CONVERSION_FAILED;
 		}
 	}
@@ -1393,7 +1395,9 @@ static int _apc_modbus_instcmd(const char *nut_cmdname, const char *extra)
 	apc_modbus_command_t *apc_command = NULL;
 	uint16_t value[4]; /* Max 64-bit */
 
+	/* May be used in logging below, but not as a command argument */
 	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(nut_cmdname, extra);
 
 	for (i = 0; apc_modbus_command_map[i].nut_command_name; i++) {
 		if (!strcasecmp(nut_cmdname, apc_modbus_command_map[i].nut_command_name)) {
@@ -1403,21 +1407,21 @@ static int _apc_modbus_instcmd(const char *nut_cmdname, const char *extra)
 	}
 
 	if (!apc_command) {
-		upslogx(LOG_WARNING, "%s: [%s] is unknown", __func__, nut_cmdname);
+		upslog_INSTCMD_UNKNOWN(nut_cmdname, extra);
 		return STAT_INSTCMD_UNKNOWN;
 	}
 
 	assert(apc_command->modbus_len <= SIZEOF_ARRAY(value));
 
 	if (!_apc_modbus_from_uint64(apc_command->value, value, apc_command->modbus_len)) {
-		upslogx(LOG_WARNING, "%s: [%s] failed to convert value", __func__, nut_cmdname);
+		upslogx(LOG_INSTCMD_CONVERSION_FAILED, "%s: [%s] failed to convert value", __func__, nut_cmdname);
 		return STAT_INSTCMD_CONVERSION_FAILED;
 	}
 
 	addr = apc_command->modbus_addr;
 	nb = apc_command->modbus_len;
 	if (modbus_write_registers(modbus_ctx, addr, nb, value) < 0) {
-		upslogx(LOG_ERR, "%s: Write of %d:%d failed: %s (%s)", __func__, addr, addr + nb, modbus_strerror(errno), device_path);
+		upslogx(LOG_INSTCMD_FAILED, "%s: Write of %d:%d failed: %s (%s)", __func__, addr, addr + nb, modbus_strerror(errno), device_path);
 		_apc_modbus_handle_error(modbus_ctx);
 		return STAT_INSTCMD_FAILED;
 	}

--- a/drivers/apc_modbus.c
+++ b/drivers/apc_modbus.c
@@ -1420,6 +1420,7 @@ static int _apc_modbus_instcmd(const char *nut_cmdname, const char *extra)
 
 	addr = apc_command->modbus_addr;
 	nb = apc_command->modbus_len;
+	upslog_INSTCMD_POWERSTATE_CHECKED(nut_cmdname, extra);
 	if (modbus_write_registers(modbus_ctx, addr, nb, value) < 0) {
 		upslogx(LOG_INSTCMD_FAILED, "%s: Write of %d:%d failed: %s (%s)", __func__, addr, addr + nb, modbus_strerror(errno), device_path);
 		_apc_modbus_handle_error(modbus_ctx);

--- a/drivers/apcsmart-old.c
+++ b/drivers/apcsmart-old.c
@@ -25,7 +25,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"APC Smart protocol driver (old)"
-#define DRIVER_VERSION	"2.34"
+#define DRIVER_VERSION	"2.35"
 
 static upsdrv_info_t table_info = {
 	"APC command table",
@@ -1321,13 +1321,15 @@ static int setvar(const char *varname, const char *val)
 {
 	apc_vartab_t	*vt;
 
+	upsdebug_SET_STARTING(varname, val);
+
 	vt = vartab_lookup_name(varname);
 
 	if (!vt)
 		return STAT_SET_UNKNOWN;
 
 	if ((vt->flags & APC_RW) == 0) {
-		upslogx(LOG_WARNING, "setvar: [%s] is not writable", varname);
+		upslogx(LOG_SET_INVALID, "setvar: [%s] is not writable", varname);
 		return STAT_SET_INVALID;
 	}
 
@@ -1337,7 +1339,7 @@ static int setvar(const char *varname, const char *val)
 	if (vt->flags & APC_STRING)
 		return setvar_string(vt, val);
 
-	upslogx(LOG_WARNING, "setvar: Unknown type for [%s]", varname);
+	upslogx(LOG_SET_UNKNOWN, "setvar: Unknown type for [%s]", varname);
 	return STAT_SET_UNKNOWN;
 }
 
@@ -1351,7 +1353,7 @@ static int do_cmd(apc_cmdtab_t *ct)
 	ret = ser_send_char(upsfd, ct->cmd);
 
 	if (ret != 1) {
-		upslog_with_errno(LOG_ERR, "do_cmd: ser_send_char failed");
+		upslog_with_errno(LOG_INSTCMD_FAILED, "do_cmd: ser_send_char failed");
 		return STAT_INSTCMD_HANDLED;		/* FUTURE: failed */
 	}
 
@@ -1362,7 +1364,7 @@ static int do_cmd(apc_cmdtab_t *ct)
 		ret = ser_send_char(upsfd, ct->cmd);
 
 		if (ret != 1) {
-			upslog_with_errno(LOG_ERR, "do_cmd: ser_send_char failed");
+			upslog_with_errno(LOG_INSTCMD_FAILED, "do_cmd: ser_send_char failed");
 			return STAT_INSTCMD_HANDLED;	/* FUTURE: failed */
 		}
 	}
@@ -1373,7 +1375,7 @@ static int do_cmd(apc_cmdtab_t *ct)
 		return STAT_INSTCMD_HANDLED;		/* FUTURE: failed */
 
 	if (strcmp(buf, "OK") != 0) {
-		upslogx(LOG_WARNING, "Got [%s] after command [%s]",
+		upslogx(LOG_INSTCMD_FAILED, "Got [%s] after command [%s]",
 			buf, ct->name);
 
 		return STAT_INSTCMD_HANDLED;		/* FUTURE: failed */
@@ -1410,6 +1412,10 @@ static int instcmd(const char *cmdname, const char *extra)
 	int	i;
 	apc_cmdtab_t	*ct;
 
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 	ct = NULL;
 
 	for (i = 0; apc_cmdtab[i].name != NULL; i++)
@@ -1417,14 +1423,14 @@ static int instcmd(const char *cmdname, const char *extra)
 			ct = &apc_cmdtab[i];
 
 	if (!ct) {
-		upslogx(LOG_WARNING, "instcmd: unknown command [%s] [%s]",
-			cmdname, extra);
+		upslog_INSTCMD_UNKNOWN(cmdname, extra);
 		return STAT_INSTCMD_UNKNOWN;
 	}
 
 	if ((ct->flags & APC_PRESENT) == 0) {
-		upslogx(LOG_WARNING, "instcmd: command [%s] [%s] is not supported",
-			cmdname, extra);
+		upslogx(LOG_INSTCMD_UNKNOWN,
+			"%s: command [%s] [%s] is not supported on this device",
+			__func__, NUT_STRARG(cmdname), NUT_STRARG(extra));
 		return STAT_INSTCMD_UNKNOWN;
 	}
 

--- a/drivers/apcsmart-old.c
+++ b/drivers/apcsmart-old.c
@@ -1434,11 +1434,17 @@ static int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_UNKNOWN;
 	}
 
-	if (!strcasecmp(cmdname, "calibrate.start"))
+	if (!strcasecmp(cmdname, "calibrate.start")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		return do_cal(1);
+	}
 
-	if (!strcasecmp(cmdname, "calibrate.stop"))
+	if (!strcasecmp(cmdname, "calibrate.stop")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		return do_cal(0);
+	}
+
+	upslog_INSTCMD_POWERSTATE_CHECKED(cmdname, extra);
 
 	if (ct->flags & APC_NASTY)
 		return instcmd_chktime(ct);

--- a/drivers/apcsmart.c
+++ b/drivers/apcsmart.c
@@ -2092,22 +2092,34 @@ static int instcmd(const char *cmd, const char *ext)
 
 	/* we're good to go, handle special stuff first, then generic cmd */
 
-	if (!strcasecmp(cmd, "calibrate.start"))
+	if (!strcasecmp(cmd, "calibrate.start")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmd, ext);
 		return do_cal(1);
+	}
 
-	if (!strcasecmp(cmd, "calibrate.stop"))
+	if (!strcasecmp(cmd, "calibrate.stop")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmd, ext);
 		return do_cal(0);
+	}
 
-	if (!strcasecmp(cmd, "load.on"))
+	if (!strcasecmp(cmd, "load.on")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmd, ext);
 		return do_loadon();
+	}
 
-	if (!strcasecmp(cmd, "load.off"))
+	if (!strcasecmp(cmd, "load.off")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmd, ext);
 		return sdcmd_Z(0);
+	}
 
-	if (!strcasecmp(cmd, "shutdown.stayoff"))
+	if (!strcasecmp(cmd, "shutdown.stayoff")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmd, ext);
 		return sdcmd_K(0);
+	}
 
 	if (!strcasecmp(cmd, "shutdown.return")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmd, ext);
+
 		if (!ext || !*ext)
 			return sdcmd_S(0);
 
@@ -2119,6 +2131,7 @@ static int instcmd(const char *cmd, const char *ext)
 	}
 
 	/* nothing special here */
+	upslog_INSTCMD_POWERSTATE_CHECKED(cmd, ext);
 	return do_cmd(ct);
 }
 

--- a/drivers/apcsmart.c
+++ b/drivers/apcsmart.c
@@ -37,7 +37,7 @@
 #include "apcsmart_tabs.h"
 
 #define DRIVER_NAME	"APC Smart protocol driver"
-#define DRIVER_VERSION	"3.35"
+#define DRIVER_VERSION	"3.36"
 
 #ifdef WIN32
 # ifndef ECANCELED
@@ -1609,7 +1609,8 @@ static int sdcmd_AT(const void *str)
 	ret = apc_write_long(temp);
 	/* Range-check: padto is 2 or 3 per above */
 	if (ret != (ssize_t)padto + 1) {
-		upslogx(LOG_ERR,
+		/* FIXME: ...INSTCMD_CONVERSION_FAILED ?*/
+		upslogx(LOG_INSTCMD_FAILED,
 			"issuing [%s] with %" PRIuSIZE " digits failed",
 			prtchr(APC_CMD_GRACEDOWN), padto);
 		return STAT_INSTCMD_FAILED;
@@ -1619,7 +1620,8 @@ static int sdcmd_AT(const void *str)
 	if (ret == STAT_INSTCMD_HANDLED || padto == 3)
 		return (int)ret;
 
-	upslogx(LOG_ERR,
+	/* FIXME: ...INSTCMD_CONVERSION_FAILED ?*/
+	upslogx(LOG_INSTCMD_FAILED,
 		"command [%s] with 2 digits doesn't work - try 3 digits",
 		prtchr(APC_CMD_GRACEDOWN));
 	/*
@@ -1867,13 +1869,13 @@ static int setvar_enum(apc_vartab_t *vt, const char *val)
 
 		/* check for wraparound */
 		if (!strcmp(ptr, orig)) {
-			upslogx(LOG_ERR, "%s: variable %s wrapped", __func__, vt->name);
+			upslogx(LOG_SET_FAILED, "%s: variable %s wrapped", __func__, vt->name);
 
 			return STAT_SET_FAILED;
 		}
 	}
 
-	upslogx(LOG_ERR, "%s: gave up after 6 tries for %s", __func__, vt->name);
+	upslogx(LOG_SET_FAILED, "%s: gave up after 6 tries for %s", __func__, vt->name);
 
 	/* refresh data from the hardware */
 	poll_data(vt);
@@ -1889,7 +1891,7 @@ static int setvar_string(apc_vartab_t *vt, const char *val)
 
 	/* sanitize length */
 	if (strlen(val) > APC_STRLEN) {
-		upslogx(LOG_ERR, "%s: value (%s) too long", __func__, val);
+		upslogx(LOG_SET_FAILED, "%s: value (%s) too long", __func__, val);
 		return STAT_SET_FAILED;
 	}
 
@@ -1927,12 +1929,12 @@ static int setvar_string(apc_vartab_t *vt, const char *val)
 	ret = apc_read(temp, sizeof(temp), SER_AA);
 
 	if (ret < 1) {
-		upslogx(LOG_ERR, "%s: %s", __func__, "short final read");
+		upslogx(LOG_SET_FAILED, "%s: %s", __func__, "short final read");
 		return STAT_SET_FAILED;
 	}
 
 	if (!strcmp(temp, "NO")) {
-		upslogx(LOG_ERR, "%s: %s", __func__, "got NO at final read");
+		upslogx(LOG_SET_FAILED, "%s: %s", __func__, "got NO at final read");
 		return STAT_SET_FAILED;
 	}
 
@@ -1948,13 +1950,15 @@ static int setvar(const char *varname, const char *val)
 {
 	apc_vartab_t	*vt;
 
+	upsdebug_SET_STARTING(varname, val);
+
 	vt = vt_lookup_name(varname);
 
 	if (!vt)
 		return STAT_SET_UNKNOWN;
 
 	if ((vt->flags & APC_RW) == 0) {
-		upslogx(LOG_WARNING, "%s: [%s] is not writable", __func__, varname);
+		upslogx(LOG_SET_UNKNOWN, "%s: [%s] is not writable", __func__, varname);
 		return STAT_SET_UNKNOWN;
 	}
 
@@ -1964,7 +1968,7 @@ static int setvar(const char *varname, const char *val)
 	if (vt->flags & APC_STRING)
 		return setvar_string(vt, val);
 
-	upslogx(LOG_WARNING, "%s: unknown type for [%s]", __func__, varname);
+	upslogx(LOG_SET_UNKNOWN, "%s: unknown type for [%s]", __func__, varname);
 	return STAT_SET_UNKNOWN;
 }
 
@@ -2014,7 +2018,7 @@ static int do_cmd(const apc_cmdtab_t *ct)
 		return STAT_INSTCMD_FAILED;
 
 	if (strcmp(temp, "OK")) {
-		upslogx(LOG_WARNING, "%s: got [%s] after command [%s]",
+		upslogx(LOG_INSTCMD_FAILED, "%s: got [%s] after command [%s]",
 			__func__, temp, ct->name);
 
 		return STAT_INSTCMD_FAILED;
@@ -2051,6 +2055,8 @@ static int instcmd(const char *cmd, const char *ext)
 	int i;
 	apc_cmdtab_t *ct = NULL;
 
+	upsdebug_INSTCMD_STARTING(cmd, ext);
+
 	for (i = 0; apc_cmdtab[i].name != NULL; i++) {
 		/* cmd must match */
 		if (strcasecmp(apc_cmdtab[i].name, cmd))
@@ -2069,13 +2075,12 @@ static int instcmd(const char *cmd, const char *ext)
 	}
 
 	if (!ct) {
-		upslogx(LOG_WARNING, "%s: unknown command [%s %s]", __func__, cmd,
-				ext ? ext : "\b");
-		return STAT_INSTCMD_INVALID;
+		upslog_INSTCMD_UNKNOWN(cmd, ext);
+		return STAT_INSTCMD_UNKNOWN;
 	}
 
 	if (!(ct->flags & APC_PRESENT)) {
-		upslogx(LOG_WARNING, "%s: command [%s %s] recognized, but"
+		upslogx(LOG_INSTCMD_INVALID, "%s: command [%s %s] recognized, but"
 		       " not supported by your UPS model", __func__, cmd,
 				ext ? ext : "\b");
 		return STAT_INSTCMD_INVALID;

--- a/drivers/belkin.c
+++ b/drivers/belkin.c
@@ -426,6 +426,7 @@ static int instcmd(const char *cmdname, const char *extra)
 	if (!strcasecmp(cmdname, "shutdown.return")) {
 		ssize_t	res;
 
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		res = init_communication();
 		if (res < 0) {
 			printf("Detection failed.  Trying a shutdown command anyway.\n");
@@ -448,26 +449,31 @@ static int instcmd(const char *cmdname, const char *extra)
 	}
 
 	if (!strcasecmp(cmdname, "load.off")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		do_off();
 		return STAT_INSTCMD_HANDLED;
 	}
 
 	if (!strcasecmp(cmdname, "load.on")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		send_belkin_command(CONTROL,POWER_ON,"1;1");
 		return STAT_INSTCMD_HANDLED;
 	}
 
 	if (!strcasecmp(cmdname, "test.battery.start.quick")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		send_belkin_command(CONTROL,TEST,TEST_10SEC);
 		return STAT_INSTCMD_HANDLED;
 	}
 
 	if (!strcasecmp(cmdname, "test.battery.start.deep")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		send_belkin_command(CONTROL,TEST,TEST_DEEP);
 		return STAT_INSTCMD_HANDLED;
 	}
 
 	if (!strcasecmp(cmdname, "test.battery.stop")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		send_belkin_command(CONTROL,TEST,TEST_CANCEL);
 		return STAT_INSTCMD_HANDLED;
 	}

--- a/drivers/belkin.c
+++ b/drivers/belkin.c
@@ -29,7 +29,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"Belkin Smart protocol driver"
-#define DRIVER_VERSION	"0.28"
+#define DRIVER_VERSION	"0.29"
 
 static ssize_t init_communication(void);
 static ssize_t get_belkin_reply(char *buf);
@@ -409,6 +409,10 @@ static void do_off(void)
 
 static int instcmd(const char *cmdname, const char *extra)
 {
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 	if (!strcasecmp(cmdname, "beeper.disable")) {
 		do_beeper_off();
 		return STAT_INSTCMD_HANDLED;
@@ -468,7 +472,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/belkinunv.c
+++ b/drivers/belkinunv.c
@@ -94,7 +94,7 @@
 #include "serial.h"
 
 #define DRIVER_NAME	"Belkin 'Universal UPS' driver"
-#define DRIVER_VERSION	"0.11"
+#define DRIVER_VERSION	"0.12"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -1204,6 +1204,10 @@ int instcmd(const char *cmdname, const char *extra)
 {
 	int r;
 
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 	/* We use test.failure.start to initiate a "deep battery test".
 	   This does not really simulate a 'power failure', because we
 	   won't start shutdown procedures during a test.
@@ -1290,7 +1294,7 @@ int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 
@@ -1298,6 +1302,8 @@ int instcmd(const char *cmdname, const char *extra)
 static int setvar(const char *varname, const char *val)
 {
 	int i;
+
+	upsdebug_SET_STARTING(varname, val);
 
 	if (!strcasecmp(varname, "input.sensitivity")) {
 		for (i=0; i<asize(voltsens); i++) {
@@ -1329,7 +1335,7 @@ static int setvar(const char *varname, const char *val)
 		return STAT_SET_HANDLED;  /* Future: failure if result==-1 */
 	}
 
-	upslogx(LOG_NOTICE, "setvar: unknown var [%s]", varname);
+	upslog_SET_UNKNOWN(varname, val);
 	return STAT_SET_UNKNOWN;
 }
 

--- a/drivers/belkinunv.c
+++ b/drivers/belkinunv.c
@@ -1229,21 +1229,25 @@ int instcmd(const char *cmdname, const char *extra)
 	}
 
 	if (!strcasecmp(cmdname, "test.failure.start")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		r = belkin_nut_write_int(REG_TESTSTATUS, 2);
 		if (r == -1) upslogx(LOG_WARNING, "Command '%s' failed", cmdname);
 		return STAT_INSTCMD_HANDLED;  /* Future: failure if r==-1 */
 	}
 	if (!strcasecmp(cmdname, "test.failure.stop")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		r = belkin_nut_write_int(REG_TESTSTATUS, 3);
 		if (r == -1) upslogx(LOG_WARNING, "Command '%s' failed", cmdname);
 		return STAT_INSTCMD_HANDLED;  /* Future: failure if r==-1 */
 	}
 	if (!strcasecmp(cmdname, "test.battery.start")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		r = belkin_nut_write_int(REG_TESTSTATUS, 1);
 		if (r == -1) upslogx(LOG_WARNING, "Command '%s' failed", cmdname);
 		return STAT_INSTCMD_HANDLED;  /* Future: failure if r==-1 */
 	}
 	if (!strcasecmp(cmdname, "test.battery.stop")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		r = belkin_nut_write_int(REG_TESTSTATUS, 3);
 		if (r == -1) upslogx(LOG_WARNING, "Command '%s' failed", cmdname);
 		return STAT_INSTCMD_HANDLED;  /* Future: failure if r==-1 */
@@ -1264,12 +1268,14 @@ int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;  /* Future: failure if r==-1 */
 	}
 	if (!strcasecmp(cmdname, "shutdown.stayoff")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		r = belkin_nut_write_int(REG_RESTARTTIMER, 0);
 		r |= belkin_nut_write_int(REG_SHUTDOWNTIMER, 1); /* 1 second */
 		if (r == -1) upslogx(LOG_WARNING, "Command '%s' failed", cmdname);
 		return STAT_INSTCMD_HANDLED;  /* Future: failure if r==-1 */
 	}
 	if (!strcasecmp(cmdname, "shutdown.reboot")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		/* restarttimer is in minutes, shutdowntimer is in
 		   seconds.  Still, restarttimer=1 is not safe,
 		   because it might be decremented before
@@ -1282,6 +1288,7 @@ int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;  /* Future: failure if r==-1 */
 	}
 	if (!strcasecmp(cmdname, "shutdown.reboot.graceful")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		r = belkin_nut_write_int(REG_RESTARTTIMER, 2); /* 2 minutes */
 		r |= belkin_nut_write_int(REG_SHUTDOWNTIMER, 40); /* 40 seconds */
 		if (r == -1) upslogx(LOG_WARNING, "Command '%s' failed", cmdname);

--- a/drivers/bestfcom.c
+++ b/drivers/bestfcom.c
@@ -45,7 +45,7 @@
 #include "serial.h"
 
 #define DRIVER_NAME	"Best Ferrups/Fortress driver"
-#define DRIVER_VERSION	"0.16"
+#define DRIVER_VERSION	"0.17"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -472,7 +472,9 @@ static void ups_sync(void)
 static
 int instcmd(const char *cmdname, const char *extra)
 {
+	/* May be used in logging below, but not as a command argument */
 	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
 	if (!strcasecmp(cmdname, "shutdown.return")) {
 		/* NB: hard-wired password */
@@ -484,7 +486,7 @@ int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/bestfcom.c
+++ b/drivers/bestfcom.c
@@ -477,6 +477,8 @@ int instcmd(const char *cmdname, const char *extra)
 	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
 	if (!strcasecmp(cmdname, "shutdown.return")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
+
 		/* NB: hard-wired password */
 		ser_send(upsfd, "pw377\r");
 		/* power off in 10 seconds and restart when line power returns,

--- a/drivers/bestfortress.c
+++ b/drivers/bestfortress.c
@@ -531,7 +531,8 @@ static int instcmd (const char *cmdname, const char *extra)
 	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
 	if (!strcasecmp(cmdname, "load.off")) {
-		upslogx(LOG_CRIT, "%s: %s: OFF/stayoff in 1s",
+		/* upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra); */
+		upslogx(LOG_INSTCMD_POWERSTATE, "%s: %s: OFF/stayoff in 1s",
 			__func__, cmdname);
 		autorestart (0);
 		upssend ("OFF1\r");
@@ -549,7 +550,9 @@ static int instcmd (const char *cmdname, const char *extra)
 			grace = "30";
 		}
 
-		upslogx(LOG_CRIT, "%s: OFF/restart in %s seconds", __func__, grace);
+		/* upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra); */
+		upslogx(LOG_INSTCMD_POWERSTATE, "%s: OFF/restart in %s seconds",
+			__func__, grace);
 
 		/* Start again, overriding front panel setting. */
 		autorestart (1);

--- a/drivers/bestfortress.c
+++ b/drivers/bestfortress.c
@@ -35,7 +35,7 @@
 #endif
 
 #define DRIVER_NAME     "Best Fortress UPS driver"
-#define DRIVER_VERSION  "0.12"
+#define DRIVER_VERSION  "0.13"
 
 /* driver description structure */
 upsdrv_info_t   upsdrv_info = {
@@ -461,7 +461,10 @@ static void autorestart (int restart)
 static int upsdrv_setvar (const char *var, const char * data) {
 	int parameter;
 	size_t len = strlen(data);
-	upsdebugx(1, "%s: %s %s (%" PRIuSIZE " bytes)", __func__, var, data, len);
+
+	upsdebug_SET_STARTING(var, data);
+	upsdebugx(1, "%s: (%" PRIuSIZE " bytes)", __func__, len);
+
 	if (strcmp("input.transfer.low", var) == 0) {
 		parameter = 7;
 	}
@@ -478,15 +481,17 @@ static int upsdrv_setvar (const char *var, const char * data) {
 		 * exist.  If the former, change to LOG_ERR and if the
 		 * latter change to LOG_DEBUG.
 		 */
-		upslogx(LOG_INFO, "%s: unsettable variable %s", __func__, var);
+		upslog_SET_UNKNOWN(var, data);
 		return STAT_SET_UNKNOWN;
 	}
+
 	ups_setsuper (1);
 	assert (len < INT_MAX);
 	if (setparam (parameter, (int)len, data)) {
 		dstate_setinfo (var, "%*s", (int)len, data);
 	}
 	ups_setsuper (0);
+
 	return STAT_SET_HANDLED;
 }
 
@@ -521,6 +526,10 @@ void upsdrv_shutdown(void)
 
 static int instcmd (const char *cmdname, const char *extra)
 {
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 	if (!strcasecmp(cmdname, "load.off")) {
 		upslogx(LOG_CRIT, "%s: %s: OFF/stayoff in 1s",
 			__func__, cmdname);
@@ -551,9 +560,9 @@ static int instcmd (const char *cmdname, const char *extra)
 		upsdebugx(2, "%s: %s: end", __func__, cmdname);
 		return STAT_INSTCMD_HANDLED;
 	}
+
 	/* \todo Software error or user error? */
-	upslogx(LOG_ERR, "%s: unknown command [%s] [%s]",
-		__func__, cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/bestuferrups.c
+++ b/drivers/bestuferrups.c
@@ -377,6 +377,8 @@ int instcmd(const char *cmdname, const char *extra)
 	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
 	if (!strcasecmp(cmdname, "shutdown.return")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
+
 		/* NB: hard-wired password */
 		ser_send(upsfd, "pw377\r");
 		/* power off in 1 second and restart when line power returns */

--- a/drivers/bestuferrups.c
+++ b/drivers/bestuferrups.c
@@ -33,7 +33,7 @@
 #include "serial.h"
 
 #define DRIVER_NAME	"Best Ferrups Series ME/RE/MD driver"
-#define DRIVER_VERSION	"0.07"
+#define DRIVER_VERSION	"0.08"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -372,7 +372,9 @@ static void ups_sync(void)
 static
 int instcmd(const char *cmdname, const char *extra)
 {
+	/* May be used in logging below, but not as a command argument */
 	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
 	if (!strcasecmp(cmdname, "shutdown.return")) {
 		/* NB: hard-wired password */
@@ -383,7 +385,7 @@ int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/bestups.c
+++ b/drivers/bestups.c
@@ -123,11 +123,13 @@ static int instcmd(const char *cmdname, const char *extra)
 	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
 	if (!strcasecmp(cmdname, "test.battery.stop")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		ser_send_pace(upsfd, UPSDELAY, "CT\r");
 		return STAT_INSTCMD_HANDLED;
 	}
 
 	if (!strcasecmp(cmdname, "test.battery.start")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		ser_send_pace(upsfd, UPSDELAY, "T\r");
 		return STAT_INSTCMD_HANDLED;
 	}

--- a/drivers/bestups.c
+++ b/drivers/bestups.c
@@ -29,7 +29,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"Best UPS driver"
-#define DRIVER_VERSION	"1.10"
+#define DRIVER_VERSION	"1.11"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -118,6 +118,10 @@ static void model_set(const char *abbr, const char *rating)
 
 static int instcmd(const char *cmdname, const char *extra)
 {
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 	if (!strcasecmp(cmdname, "test.battery.stop")) {
 		ser_send_pace(upsfd, UPSDELAY, "CT\r");
 		return STAT_INSTCMD_HANDLED;
@@ -128,7 +132,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/bicker_ser.c
+++ b/drivers/bicker_ser.c
@@ -108,7 +108,7 @@
 #include "serial.h"
 
 #define DRIVER_NAME	"Bicker serial protocol"
-#define DRIVER_VERSION	"0.03"
+#define DRIVER_VERSION	"0.04"
 
 #define BICKER_SOH	0x01
 #define BICKER_EOT	0x04
@@ -671,13 +671,15 @@ static ssize_t bicker_shutdown(void)
 
 static int bicker_instcmd(const char *cmdname, const char *extra)
 {
+	/* May be used in logging below, but not as a command argument */
 	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
 	if (!strcasecmp(cmdname, "shutdown.return")) {
 		bicker_shutdown();
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s]", cmdname);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 
@@ -686,6 +688,8 @@ static int bicker_setvar(const char *varname, const char *val)
 	const BickerMapping *mapping;
 	unsigned i;
 	BickerParameter parameter;
+
+	upsdebug_SET_STARTING(varname, val);
 
 	/* This should not be needed because when `bicker_write()` is
 	 * successful the `parameter` struct is populated but gcc seems
@@ -718,7 +722,7 @@ static int bicker_setvar(const char *varname, const char *val)
 		}
 	}
 
-	upslogx(LOG_NOTICE, "setvar: unknown variable [%s]", varname);
+	upslog_SET_UNKNOWN(varname, val);
 	return STAT_SET_UNKNOWN;
 }
 

--- a/drivers/bicker_ser.c
+++ b/drivers/bicker_ser.c
@@ -646,7 +646,7 @@ static ssize_t bicker_delayed_shutdown(uint8_t seconds)
 
 	ret = bicker_receive_known(0x03, 0x32, &response, 1);
 	if (ret >= 0) {
-		upslogx(LOG_INFO, "Shutting down in %d seconds: response = 0x%02X",
+		upslogx(LOG_INSTCMD_POWERSTATE, "Shutting down in %d seconds: response = 0x%02X",
 			seconds, (unsigned)response);
 	}
 
@@ -676,7 +676,9 @@ static int bicker_instcmd(const char *cmdname, const char *extra)
 	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
 	if (!strcasecmp(cmdname, "shutdown.return")) {
-		bicker_shutdown();
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
+		if (bicker_shutdown() >= 0)
+			return STAT_INSTCMD_HANDLED;
 	}
 
 	upslog_INSTCMD_UNKNOWN(cmdname, extra);

--- a/drivers/blazer.c
+++ b/drivers/blazer.c
@@ -424,6 +424,7 @@ static int blazer_instcmd(const char *cmdname, const char *extra)
 		 * As an exception, Best UPS units will report "ACK" in case of success!
 		 * Other UPSes will reply "(ACK" in case of success.
 		 */
+		upslog_INSTCMD_POWERSTATE_CHECKED(cmdname, extra);
 		if (blazer_command(buf, buf, sizeof(buf)) > 0) {
 			if (strncmp(buf, "ACK", 3) && strncmp(buf, "(ACK", 4)) {
 				upslogx(LOG_INSTCMD_FAILED, "instcmd: command [%s] failed", cmdname);
@@ -436,6 +437,7 @@ static int blazer_instcmd(const char *cmdname, const char *extra)
 	}
 
 	if (!strcasecmp(cmdname, "shutdown.return")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 
 		/*
 		 * Sn: Shutdown after n minutes and then turn on when mains is back
@@ -468,6 +470,7 @@ static int blazer_instcmd(const char *cmdname, const char *extra)
 		}
 
 	} else if (!strcasecmp(cmdname, "shutdown.stayoff")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 
 		/*
 		 * SnR0000
@@ -491,6 +494,7 @@ static int blazer_instcmd(const char *cmdname, const char *extra)
 			return STAT_INSTCMD_FAILED;
 		}
 
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		snprintf(buf, sizeof(buf), "T%02ld\r", delay);
 	} else {
 		upslog_INSTCMD_UNKNOWN(cmdname, extra);

--- a/drivers/blazer.c
+++ b/drivers/blazer.c
@@ -409,7 +409,7 @@ static int blazer_instcmd(const char *cmdname, const char *extra)
 	char	buf[SMALLBUF] = "";
 	int	i;
 
-	upslogx(LOG_INFO, "instcmd(%s, %s)", cmdname, extra ? extra : "[NULL]");
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
 	for (i = 0; instcmd[i].cmd; i++) {
 
@@ -426,7 +426,7 @@ static int blazer_instcmd(const char *cmdname, const char *extra)
 		 */
 		if (blazer_command(buf, buf, sizeof(buf)) > 0) {
 			if (strncmp(buf, "ACK", 3) && strncmp(buf, "(ACK", 4)) {
-				upslogx(LOG_ERR, "instcmd: command [%s] failed", cmdname);
+				upslogx(LOG_INSTCMD_FAILED, "instcmd: command [%s] failed", cmdname);
 				return STAT_INSTCMD_FAILED;
 			}
 		}
@@ -485,7 +485,7 @@ static int blazer_instcmd(const char *cmdname, const char *extra)
 		long	delay = extra ? strtol(extra, NULL, 10) : 10;
 
 		if ((delay < 1) || (delay > 99)) {
-			upslogx(LOG_ERR,
+			upslogx(LOG_INSTCMD_FAILED,
 				"instcmd: command [%s] failed, delay [%s] out of range",
 				cmdname, extra);
 			return STAT_INSTCMD_FAILED;
@@ -493,7 +493,7 @@ static int blazer_instcmd(const char *cmdname, const char *extra)
 
 		snprintf(buf, sizeof(buf), "T%02ld\r", delay);
 	} else {
-		upslogx(LOG_ERR, "instcmd: command [%s] not found", cmdname);
+		upslog_INSTCMD_UNKNOWN(cmdname, extra);
 		return STAT_INSTCMD_UNKNOWN;
 	}
 
@@ -504,7 +504,7 @@ static int blazer_instcmd(const char *cmdname, const char *extra)
 	 */
 	if (blazer_command(buf, buf, sizeof(buf)) > 0) {
 		if (strncmp(buf, "ACK", 3) && strncmp(buf, "(ACK", 4)) {
-			upslogx(LOG_ERR, "instcmd: command [%s] failed", cmdname);
+			upslogx(LOG_INSTCMD_FAILED, "instcmd: command [%s] failed", cmdname);
 			return STAT_INSTCMD_FAILED;
 		}
 	}

--- a/drivers/blazer_ser.c
+++ b/drivers/blazer_ser.c
@@ -31,7 +31,7 @@
 #include "blazer.h"
 
 #define DRIVER_NAME	"Megatec/Q1 protocol serial driver"
-#define DRIVER_VERSION	"1.63"
+#define DRIVER_VERSION	"1.64"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/blazer_usb.c
+++ b/drivers/blazer_usb.c
@@ -37,7 +37,7 @@
 #endif	/* WIN32 */
 
 #define DRIVER_NAME	"Megatec/Q1 protocol USB driver"
-#define DRIVER_VERSION	"0.22"
+#define DRIVER_VERSION	"0.23"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/clone.c
+++ b/drivers/clone.c
@@ -498,6 +498,10 @@ static int sstate_dead(int maxage)
 
 static int instcmd(const char *cmdname, const char *extra)
 {
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 	if (!strcasecmp(cmdname, "shutdown.return")) {
 		if (outlet && (ups.timer.shutdown < 0)) {
 			ups.timer.shutdown = offdelay;
@@ -518,13 +522,15 @@ static int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 
 
 static int setvar(const char *varname, const char *val)
 {
+	upsdebug_SET_STARTING(varname, val);
+
 	if (!strcasecmp(varname, "battery.charge.low")) {
 		battery.charge.low = strtod(val, NULL);
 		dstate_setinfo("battery.charge.low", "%f", battery.charge.low);
@@ -537,7 +543,7 @@ static int setvar(const char *varname, const char *val)
 		return STAT_SET_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "setvar: unknown variable [%s]", varname);
+	upslog_SET_UNKNOWN(varname, val);
 	return STAT_SET_UNKNOWN;
 }
 

--- a/drivers/clone.c
+++ b/drivers/clone.c
@@ -503,6 +503,7 @@ static int instcmd(const char *cmdname, const char *extra)
 	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
 	if (!strcasecmp(cmdname, "shutdown.return")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		if (outlet && (ups.timer.shutdown < 0)) {
 			ups.timer.shutdown = offdelay;
 			status_set("FSD");
@@ -513,6 +514,7 @@ static int instcmd(const char *cmdname, const char *extra)
 	}
 
 	if (!strcasecmp(cmdname, "shutdown.stayoff")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		if (outlet && (ups.timer.shutdown < 0)) {
 			ups.timer.shutdown = offdelay;
 			status_set("FSD");

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -840,7 +840,7 @@ static int sock_arg(conn_t *conn, size_t numarg, char **arg)
 			cmdparam = arg[2];
 			cmdid = arg[4];
 		} else if (numarg != 2) {
-			upslogx(LOG_NOTICE, "Malformed INSTCMD request");
+			upslogx(LOG_INSTCMD_INVALID, "Malformed INSTCMD request");
 			return 0;
 		}
 
@@ -876,11 +876,11 @@ static int sock_arg(conn_t *conn, size_t numarg, char **arg)
 		}
 
 		if (cmdparam) {
-			upslogx(LOG_NOTICE,
+			upslogx(LOG_INSTCMD_UNKNOWN,
 				"Got INSTCMD '%s' '%s', but driver lacks a handler",
 				NUT_STRARG(cmdname), NUT_STRARG(cmdparam));
 		} else {
-			upslogx(LOG_NOTICE,
+			upslogx(LOG_INSTCMD_UNKNOWN,
 				"Got INSTCMD '%s', but driver lacks a handler",
 				NUT_STRARG(cmdname));
 		}
@@ -914,7 +914,7 @@ static int sock_arg(conn_t *conn, size_t numarg, char **arg)
 				setid = arg[4];
 			}
 			else {
-				upslogx(LOG_NOTICE, "Got SET <var> with unsupported parameters (%s/%s)",
+				upslogx(LOG_SET_INVALID, "Got SET <var> with unsupported parameters (%s/%s)",
 					arg[3], arg[4]);
 				return 0;
 			}
@@ -949,7 +949,7 @@ static int sock_arg(conn_t *conn, size_t numarg, char **arg)
 			return 1;
 		}
 
-		upslogx(LOG_NOTICE, "Got SET, but driver lacks a handler");
+		upslogx(LOG_SET_UNKNOWN, "Got SET, but driver lacks a handler");
 		return 1;
 	}
 

--- a/drivers/dummy-ups.c
+++ b/drivers/dummy-ups.c
@@ -399,6 +399,7 @@ static int instcmd(const char *cmdname, const char *extra)
 
 /*
 	if (!strcasecmp(cmdname, "test.battery.stop")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		ser_send_buf(upsfd, ...);
 		return STAT_INSTCMD_HANDLED;
 	}

--- a/drivers/dummy-ups.c
+++ b/drivers/dummy-ups.c
@@ -48,7 +48,7 @@
 #include "dummy-ups.h"
 
 #define DRIVER_NAME	"Device simulation and repeater driver"
-#define DRIVER_VERSION	"0.21"
+#define DRIVER_VERSION	"0.22"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info =

--- a/drivers/dummy-ups.c
+++ b/drivers/dummy-ups.c
@@ -393,6 +393,10 @@ void upsdrv_shutdown(void)
 
 static int instcmd(const char *cmdname, const char *extra)
 {
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 /*
 	if (!strcasecmp(cmdname, "test.battery.stop")) {
 		ser_send_buf(upsfd, ...);
@@ -404,7 +408,7 @@ static int instcmd(const char *cmdname, const char *extra)
 	 * if (mode == MODE_META) => ?
 	 */
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 
@@ -582,7 +586,7 @@ static int setvar(const char *varname, const char *val)
 {
 	dummy_info_t *item;
 
-	upsdebugx(2, "entering setvar(%s, %s)", varname, val);
+	upsdebug_SET_STARTING(varname, val);
 
 	/* FIXME: the below is only valid if (mode == MODE_DUMMY)
 	 * if (mode == MODE_REPEATER) => forward

--- a/drivers/dummy-ups.c
+++ b/drivers/dummy-ups.c
@@ -591,7 +591,11 @@ static int setvar(const char *varname, const char *val)
 	if (!strncmp(varname, "ups.status", 10))
 	{
 		status_init();
-		 /* FIXME: split and check values (support multiple values), à la usbhid-ups */
+		/* FIXME: split and check values (support multiple values),
+		 *  à la usbhid-ups.
+		 * UPDATE: Since NUT v2.8.3, status_set() does the splitting,
+		 *  but what about "checking values"?
+		 */
 		status_set(val);
 		status_commit();
 

--- a/drivers/etapro.c
+++ b/drivers/etapro.c
@@ -55,7 +55,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"ETA PRO driver"
-#define DRIVER_VERSION	"0.08"
+#define DRIVER_VERSION	"0.09"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -189,6 +189,10 @@ etapro_set_off_timer(unsigned int seconds)
 
 static int instcmd(const char *cmdname, const char *extra)
 {
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 	if (!strcasecmp(cmdname, "load.off")) {
 		etapro_set_off_timer(1);
 		return STAT_INSTCMD_HANDLED;
@@ -205,7 +209,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/etapro.c
+++ b/drivers/etapro.c
@@ -194,16 +194,19 @@ static int instcmd(const char *cmdname, const char *extra)
 	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
 	if (!strcasecmp(cmdname, "load.off")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		etapro_set_off_timer(1);
 		return STAT_INSTCMD_HANDLED;
 	}
 
 	if (!strcasecmp(cmdname, "load.on")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		etapro_set_on_timer(1);
 		return STAT_INSTCMD_HANDLED;
 	}
 
 	if (!strcasecmp(cmdname, "shutdown.return")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		etapro_set_on_timer(SHUTDOWN_GRACE_TIME + SHUTDOWN_TO_RETURN_TIME);
 		etapro_set_off_timer(SHUTDOWN_GRACE_TIME);
 		return STAT_INSTCMD_HANDLED;

--- a/drivers/everups.c
+++ b/drivers/everups.c
@@ -187,6 +187,7 @@ int instcmd(const char *cmdname, const char *extra)
 	/* Shutdown UPS */
 	if (!strcasecmp(cmdname, "load.off"))
 	{
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		if (!Code(2)) {
 			upslog_with_errno(LOG_INSTCMD_UNKNOWN, "Code failed");
 			return STAT_INSTCMD_UNKNOWN;

--- a/drivers/everups.c
+++ b/drivers/everups.c
@@ -21,7 +21,7 @@
 #include "serial.h"
 
 #define DRIVER_NAME	"Ever UPS driver (serial)"
-#define DRIVER_VERSION	"0.07"
+#define DRIVER_VERSION	"0.08"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -177,7 +177,9 @@ void upsdrv_updateinfo(void)
 static
 int instcmd(const char *cmdname, const char *extra)
 {
+	/* May be used in logging below, but not as a command argument */
 	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
 	/* FIXME: Which one is this - "load.off",
 	 * "shutdown.stayoff" or "shutdown.return"? */
@@ -186,13 +188,13 @@ int instcmd(const char *cmdname, const char *extra)
 	if (!strcasecmp(cmdname, "load.off"))
 	{
 		if (!Code(2)) {
-			upslog_with_errno(LOG_INFO, "Code failed");
+			upslog_with_errno(LOG_INSTCMD_UNKNOWN, "Code failed");
 			return STAT_INSTCMD_UNKNOWN;
 		}
 		ser_send_char(upsfd, 28);
 		ser_send_char(upsfd, 1);  /* 1.28 sec */
 		if (!Code(1)) {
-			upslog_with_errno(LOG_INFO, "Code failed");
+			upslog_with_errno(LOG_INSTCMD_UNKNOWN, "Code failed");
 			return STAT_INSTCMD_UNKNOWN;
 		}
 		ser_send_char(upsfd, 13);
@@ -201,7 +203,7 @@ int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/gamatronic.c
+++ b/drivers/gamatronic.c
@@ -352,6 +352,7 @@ int instcmd(const char *cmdname, const char *extra)
 
 /*
 	if (!strcasecmp(cmdname, "test.battery.stop")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		ser_send_buf(upsfd, ...);
 		return STAT_INSTCMD_HANDLED;
 	}
@@ -362,6 +363,7 @@ int instcmd(const char *cmdname, const char *extra)
 		char msgbuf[SMALLBUF];
 
 		msglen = snprintf(msgbuf, sizeof(msgbuf), "-1");
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		sec_cmd(SEC_SETCMD, SEC_SHUTDOWN, msgbuf, &msglen);
 
 		msglen = snprintf(msgbuf, sizeof(msgbuf), "1");

--- a/drivers/gamatronic.c
+++ b/drivers/gamatronic.c
@@ -33,7 +33,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"Gamatronic UPS driver"
-#define DRIVER_VERSION	"0.07"
+#define DRIVER_VERSION	"0.08"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -346,6 +346,10 @@ void upsdrv_shutdown(void)
 static
 int instcmd(const char *cmdname, const char *extra)
 {
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 /*
 	if (!strcasecmp(cmdname, "test.battery.stop")) {
 		ser_send_buf(upsfd, ...);
@@ -372,7 +376,7 @@ int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/generic_modbus.c
+++ b/drivers/generic_modbus.c
@@ -31,7 +31,7 @@
 #endif
 
 #define DRIVER_NAME	"NUT Generic Modbus driver (libmodbus link type: " NUT_MODBUS_LINKTYPE_STR ")"
-#define DRIVER_VERSION	"0.06"
+#define DRIVER_VERSION	"0.07"
 
 /* variables */
 static modbus_t *mbctx = NULL;                             /* modbus memory context */
@@ -571,6 +571,10 @@ int upscmd(const char *cmd, const char *arg)
 	struct timeval start;
 	long etime;
 
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(arg);
+	upsdebug_INSTCMD_STARTING(cmd, arg);
+
 	if (!strcasecmp(cmd, "load.off")) {
 		if (sigar[FSD_T].addr != NOTUSED &&
 		    (sigar[FSD_T].type == COIL || sigar[FSD_T].type == HOLDING)
@@ -578,13 +582,14 @@ int upscmd(const char *cmd, const char *arg)
 			data = 1 ^ sigar[FSD_T].noro;
 			rval = register_write(mbctx, sigar[FSD_T].addr, sigar[FSD_T].type, &data);
 			if (rval == -1) {
-				upslogx(2, "ERROR:(%s) modbus_write_register: addr:0x%08x, regtype: %u, path:%s",
+				upsdebugx(2, "ERROR:(%s) modbus_write_register: addr:0x%08x, regtype: %u, path:%s",
 					modbus_strerror(errno),
 					(unsigned int)(sigar[FSD_T].addr),
 					sigar[FSD_T].type,
 					device_path
 				);
-				upslogx(LOG_NOTICE, "load.off: failed (communication error) [%s] [%s]", cmd, arg);
+
+				upslogx(LOG_INSTCMD_FAILED, "load.off: failed (communication error) [%s] [%s]", cmd, NUT_STRARG(arg));
 				rval = STAT_INSTCMD_FAILED;
 			} else {
 				upsdebugx(2, "load.off: addr: 0x%x, data: %d",
@@ -605,13 +610,14 @@ int upscmd(const char *cmd, const char *arg)
 				data = 0 ^ sigar[FSD_T].noro;
 				rval = register_write(mbctx, sigar[FSD_T].addr, sigar[FSD_T].type, &data);
 				if (rval == -1) {
-					upslogx(LOG_ERR, "ERROR:(%s) modbus_write_register: addr:0x%08x, regtype: %u, path:%s\n",
+					upsdebugx(2, "ERROR:(%s) modbus_write_register: addr:0x%08x, regtype: %u, path:%s\n",
 						modbus_strerror(errno),
 						(unsigned int)(sigar[FSD_T].addr),
 						sigar[FSD_T].type,
 						device_path
 					);
-					upslogx(LOG_NOTICE, "load.off: failed (communication error) [%s] [%s]", cmd, arg);
+
+					upslogx(LOG_INSTCMD_FAILED, "load.off: failed (communication error) [%s] [%s]", cmd, NUT_STRARG(arg));
 					rval = STAT_INSTCMD_FAILED;
 				} else {
 					upsdebugx(2, "load.off: addr: 0x%x, data: %d, elapsed time: %lims",
@@ -623,9 +629,8 @@ int upscmd(const char *cmd, const char *arg)
 				}
 			}
 		} else {
-			upslogx(LOG_NOTICE,"load.off: failed (FSD address undefined or invalid register type)  [%s] [%s]",
-				cmd,
-				arg
+			upslogx(LOG_INSTCMD_FAILED, "load.off: failed (FSD address undefined or invalid register type)  [%s] [%s]",
+				NUT_STRARG(cmd), NUT_STRARG(arg)
 			);
 			rval = STAT_INSTCMD_FAILED;
 		}
@@ -649,12 +654,12 @@ int upscmd(const char *cmd, const char *arg)
 		switch (rval) {
 			case STAT_INSTCMD_FAILED:
 			case STAT_INSTCMD_INVALID:
-				upslogx(LOG_ERR, "shutdown failed");
+				upslogx(LOG_INSTCMD_FAILED, "shutdown failed");
 				if (handling_upsdrv_shutdown > 0)
 					set_exit_flag(EF_EXIT_FAILURE);
 				return rval;
 			case STAT_INSTCMD_UNKNOWN:
-				upslogx(LOG_ERR, "shutdown not supported");
+				upslogx(LOG_INSTCMD_UNKNOWN, "shutdown not supported");
 				if (handling_upsdrv_shutdown > 0)
 					set_exit_flag(EF_EXIT_FAILURE);
 				return rval;
@@ -665,7 +670,7 @@ int upscmd(const char *cmd, const char *arg)
 				break;
 		}
 	} else {
-		upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmd, arg);
+		upslog_INSTCMD_UNKNOWN(cmd, arg);
 		rval = STAT_INSTCMD_UNKNOWN;
 	}
 	return rval;

--- a/drivers/generic_modbus.c
+++ b/drivers/generic_modbus.c
@@ -576,6 +576,7 @@ int upscmd(const char *cmd, const char *arg)
 	upsdebug_INSTCMD_STARTING(cmd, arg);
 
 	if (!strcasecmp(cmd, "load.off")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmd, arg);
 		if (sigar[FSD_T].addr != NOTUSED &&
 		    (sigar[FSD_T].type == COIL || sigar[FSD_T].type == HOLDING)
 		) {
@@ -639,6 +640,7 @@ int upscmd(const char *cmd, const char *arg)
 		 * "shutdown.stayoff" or "shutdown.return"? */
 		int cnt = FSD_REPEAT_CNT;    /* shutdown repeat counter */
 
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmd, arg);
 		/* retry sending shutdown command on error */
 		while ((rval = upscmd("load.off", NULL)) != STAT_INSTCMD_HANDLED && cnt > 0) {
 			rval = gettimeofday(&start, NULL);

--- a/drivers/huawei-ups2000.c
+++ b/drivers/huawei-ups2000.c
@@ -55,7 +55,7 @@
 #endif
 
 #define DRIVER_NAME	"NUT Huawei UPS2000 (1kVA-3kVA) RS-232 Modbus driver (libmodbus link type: " NUT_MODBUS_LINKTYPE_STR ")"
-#define DRIVER_VERSION	"0.09"
+#define DRIVER_VERSION	"0.10"
 
 #define CHECK_BIT(var,pos) ((var) & (1<<(pos)))
 #define MODBUS_SLAVE_ID 1
@@ -1198,6 +1198,8 @@ static int setvar(const char *name, const char *val)
 	int i;
 	int r;
 
+	upsdebug_SET_STARTING(name, val);
+
 	for (i = 0; ups2000_rw_var[i].name != NULL; i++) {
 		if (!strcasecmp(ups2000_rw_var[i].name, name)) {
 			r = ups2000_rw_var[i].setter(ups2000_rw_var[i].reg, val);
@@ -1212,13 +1214,14 @@ static int setvar(const char *name, const char *val)
 		}
 	}
 
+	upslog_SET_UNKNOWN(name, val);
 	return STAT_SET_UNKNOWN;
 
 found:
 	if (r == STAT_SET_FAILED)
-		upslogx(LOG_ERR, "setvar: setting variable [%s] to [%s] failed", name, val);
+		upslog_SET_FAILED(name, val);
 	else if (r == STAT_SET_INVALID)
-		upslogx(LOG_WARNING, "setvar: [%s] is not valid for variable [%s]", val, name);
+		upslog_SET_INVALID(name, val);
 	return r;
 }
 
@@ -1470,7 +1473,10 @@ static int instcmd(const char *cmd, const char *extra)
 	int i;
 	int status;
 	struct ups2000_cmd_t *cmd_action = NULL;
+
+	/* May be used in logging below, but not as a command argument */
 	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmd, extra);
 
 	for (i = 0; ups2000_cmd[i].cmd != NULL; i++) {
 		if (!strcasecmp(cmd, ups2000_cmd[i].cmd)) {
@@ -1479,14 +1485,15 @@ static int instcmd(const char *cmd, const char *extra)
 	}
 
 	if (!cmd_action) {
-		upslogx(LOG_WARNING, "instcmd: command [%s] unknown", cmd);
+		upslog_INSTCMD_UNKNOWN(cmd, extra);
 		return STAT_INSTCMD_UNKNOWN;
 	}
 
 	if (cmd_action->handler_func) {
 		/* handled by a function */
 		if (cmd_action->reg1 < 0) {
-			upslogx(LOG_WARNING, "instcmd: command [%s] reg1 is negative", cmd);
+			/* FIXME: ...INSTCMD_CONVERSION_FAILED ? */
+			upslogx(LOG_INSTCMD_UNKNOWN, "instcmd: command [%s] reg1 is negative", cmd);
 			return STAT_INSTCMD_UNKNOWN;
 		} else {
 			status = cmd_action->handler_func((uint16_t)cmd_action->reg1);
@@ -1521,7 +1528,7 @@ static int instcmd(const char *cmd, const char *extra)
 	}
 
 	if (status == STAT_INSTCMD_FAILED)
-		upslogx(LOG_ERR, "instcmd: command [%s] failed", cmd);
+		upslog_INSTCMD_FAILED(cmd, extra);
 	else if (status == STAT_INSTCMD_HANDLED)
 		upslogx(LOG_INFO, "instcmd: command [%s] handled", cmd);
 	return status;
@@ -1565,13 +1572,15 @@ static int ups2000_instcmd_load_on(const uint16_t reg)
 		 * enter normal mode, but "load.on" is not supposed to affect the
 		 * normal/bypass status. Also log an error and suggest "bypass.stop".
 		 */
-		upslogx(LOG_ERR, "load.on error: UPS is already on, and is in bypass mode. "
+		/* FIXME: ..._INVALID ? */
+		upslogx(LOG_INSTCMD_FAILED, "load.on error: UPS is already on, and is in bypass mode. "
 				 "To enter normal mode, use bypass.stop");
 		return STAT_INSTCMD_FAILED;
 	}
 	else {
 		/* unreachable, see comments for r != 0 at the beginning */
-		upslogx(LOG_ERR, "load.on error: invalid ups.status (%s) detected. "
+		/* FIXME: ..._INVALID ? */
+		upslogx(LOG_INSTCMD_FAILED, "load.on error: invalid ups.status (%s) detected. "
 				 "Please file a bug report!", status);
 		return STAT_INSTCMD_FAILED;
 	}
@@ -1597,7 +1606,7 @@ static int ups2000_instcmd_bypass_start(const uint16_t reg)
 
 	/* bypass input has a power failure, refuse to bypass */
 	if (!bypass_available) {
-		upslogx(LOG_ERR, "bypass input is abnormal, refuse to enter bypass mode.");
+		upslogx(LOG_INSTCMD_FAILED, "bypass input is abnormal, refuse to enter bypass mode.");
 		return STAT_INSTCMD_FAILED;
 	}
 

--- a/drivers/huawei-ups2000.c
+++ b/drivers/huawei-ups2000.c
@@ -1489,6 +1489,8 @@ static int instcmd(const char *cmd, const char *extra)
 		return STAT_INSTCMD_UNKNOWN;
 	}
 
+	upslog_INSTCMD_POWERSTATE_CHECKED(cmd, extra);
+
 	if (cmd_action->handler_func) {
 		/* handled by a function */
 		if (cmd_action->reg1 < 0) {

--- a/drivers/isbmex.c
+++ b/drivers/isbmex.c
@@ -390,6 +390,7 @@ int instcmd(const char *cmdname, const char *extra)
 			set_exit_flag(EF_EXIT_FAILURE);
 */
 
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		for (i = 0; i <= 5; i++)
 		{
 			ser_send_char(upsfd, '#');

--- a/drivers/isbmex.c
+++ b/drivers/isbmex.c
@@ -27,7 +27,7 @@
 #include <string.h>
 
 #define DRIVER_NAME	"ISBMEX UPS driver"
-#define DRIVER_VERSION	"0.11"
+#define DRIVER_VERSION	"0.12"
 
 /* driver description structure */
 upsdrv_info_t	upsdrv_info = {
@@ -362,7 +362,9 @@ void upsdrv_updateinfo(void)
 static
 int instcmd(const char *cmdname, const char *extra)
 {
+	/* May be used in logging below, but not as a command argument */
 	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
 	/* FIXME: Which one is this - "load.off",
 	 * "shutdown.stayoff" or "shutdown.return"? */
@@ -397,7 +399,7 @@ int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/ivtscd.c
+++ b/drivers/ivtscd.c
@@ -25,7 +25,7 @@
 #include "attribute.h"
 
 #define DRIVER_NAME	"IVT Solar Controller driver"
-#define DRIVER_VERSION	"0.06"
+#define DRIVER_VERSION	"0.07"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -122,12 +122,16 @@ static ssize_t ivt_status(void)
 
 static int instcmd(const char *cmdname, const char *extra)
 {
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 	if (!strcasecmp(cmdname, "reset.input.minmax")) {
 		ser_send(upsfd, "L");
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/liebert-esp2.c
+++ b/drivers/liebert-esp2.c
@@ -544,6 +544,7 @@ static int instcmd(const char *cmdname, const char *extra)
 
 /*
 	if (!strcasecmp(cmdname, "test.battery.stop")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		ser_send_buf(upsfd, ...);
 		return STAT_INSTCMD_HANDLED;
 	}

--- a/drivers/liebert-esp2.c
+++ b/drivers/liebert-esp2.c
@@ -28,7 +28,7 @@
 #define IsBitSet(val, bit) ((val) & (1 << (bit)))
 
 #define DRIVER_NAME	"Liebert ESP-II serial UPS driver"
-#define DRIVER_VERSION	"0.08"
+#define DRIVER_VERSION	"0.09"
 
 #define UPS_SHUTDOWN_DELAY 12 /* it means UPS will be shutdown 120 sec */
 #define SHUTDOWN_CMD_LEN  8
@@ -538,18 +538,25 @@ void upsdrv_shutdown(void)
 
 static int instcmd(const char *cmdname, const char *extra)
 {
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 /*
 	if (!strcasecmp(cmdname, "test.battery.stop")) {
 		ser_send_buf(upsfd, ...);
 		return STAT_INSTCMD_HANDLED;
 	}
 */
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 
 static int setvar(const char *varname, const char *val)
 {
+	upsdebug_SET_STARTING(varname, val);
+
 /*
 	if (!strcasecmp(varname, "ups.test.interval")) {
 
@@ -557,7 +564,8 @@ static int setvar(const char *varname, const char *val)
 		return STAT_SET_HANDLED;
 	}
 */
-	upslogx(LOG_NOTICE, "setvar: unknown variable [%s] [%s]", varname, val);
+
+	upslog_SET_UNKNOWN(varname, val);
 	return STAT_SET_UNKNOWN;
 }
 

--- a/drivers/liebert-gxe.c
+++ b/drivers/liebert-gxe.c
@@ -24,7 +24,7 @@
 #include "ydn23.h"
 
 #define DRIVER_NAME	"Liebert GXE Series UPS driver"
-#define DRIVER_VERSION	"0.03"
+#define DRIVER_VERSION	"0.04"
 
 #define PROBE_RETRIES	3
 #define DEFAULT_STALE_RETRIES	3
@@ -99,6 +99,10 @@ static int instcmd(const char *cmdname, const char *extra)
 	int	retry, ret, len = 4;
 	char	*data = NULL;
 
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 	if (!strcasecmp(cmdname, "test.battery.start"))
 		data = "1002";
 	else if (!strcasecmp(cmdname, "test.battery.stop"))
@@ -108,7 +112,7 @@ static int instcmd(const char *cmdname, const char *extra)
 	else if (!strcasecmp(cmdname, "load.off"))
 		data = "2003";
 	else {
-		upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+		upslog_INSTCMD_UNKNOWN(cmdname, extra);
 		return STAT_INSTCMD_UNKNOWN;
 	}
 
@@ -125,7 +129,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		}
 	}
 
-	upslogx(LOG_WARNING, "instcmd: remote failed response, try again");
+	upslogx(LOG_INSTCMD_FAILED, "instcmd: remote failed response, try again");
 	return STAT_INSTCMD_FAILED;
 }
 

--- a/drivers/liebert-gxe.c
+++ b/drivers/liebert-gxe.c
@@ -103,15 +103,19 @@ static int instcmd(const char *cmdname, const char *extra)
 	NUT_UNUSED_VARIABLE(extra);
 	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
-	if (!strcasecmp(cmdname, "test.battery.start"))
+	if (!strcasecmp(cmdname, "test.battery.start")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		data = "1002";
-	else if (!strcasecmp(cmdname, "test.battery.stop"))
+	} else if (!strcasecmp(cmdname, "test.battery.stop")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		data = "1003";
-	else if (!strcasecmp(cmdname, "load.on"))
+	} else if (!strcasecmp(cmdname, "load.on")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		data = "2001";
-	else if (!strcasecmp(cmdname, "load.off"))
+	} else if (!strcasecmp(cmdname, "load.off")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		data = "2003";
-	else {
+	} else {
 		upslog_INSTCMD_UNKNOWN(cmdname, extra);
 		return STAT_INSTCMD_UNKNOWN;
 	}

--- a/drivers/macosx-ups.c
+++ b/drivers/macosx-ups.c
@@ -29,7 +29,7 @@
 #include "IOKit/ps/IOPSKeys.h"
 
 #define DRIVER_NAME	"Mac OS X UPS meta-driver"
-#define DRIVER_VERSION	"1.42"
+#define DRIVER_VERSION	"1.43"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -292,12 +292,16 @@ void upsdrv_shutdown(void)
 /*
 static int instcmd(const char *cmdname, const char *extra)
 {
+	/ * May be used in logging below, but not as a command argument * /
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 	if (!strcasecmp(cmdname, "test.battery.stop")) {
 		ser_send_buf(upsfd, ...);
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s]", cmdname);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 */
@@ -320,12 +324,14 @@ static int instcmd(const char *cmdname, const char *extra)
 /*
 static int setvar(const char *varname, const char *val)
 {
-	if (!strcasecmp(varname, "ups.test.interval")) {
+	upsdebug_SET_STARTING(varname, val);
+
+ 	if (!strcasecmp(varname, "ups.test.interval")) {
 		ser_send_buf(upsfd, ...);
 		return STAT_SET_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "setvar: unknown variable [%s]", varname);
+	upslog_SET_UNKNOWN(varname, val);
 	return STAT_SET_UNKNOWN;
 }
 */

--- a/drivers/macosx-ups.c
+++ b/drivers/macosx-ups.c
@@ -297,6 +297,7 @@ static int instcmd(const char *cmdname, const char *extra)
 	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
 	if (!strcasecmp(cmdname, "test.battery.stop")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		ser_send_buf(upsfd, ...);
 		return STAT_INSTCMD_HANDLED;
 	}

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -830,6 +830,8 @@ int do_loop_shutdown_commands(const char *sdcmds, char **cmdused) {
 				upsdebugx(1, "Handle 'shutdown.default' directly, "
 					"ignore other `sdcommands` (if any): %s",
 					sdcmds);
+				/* TOTHINK : These logs are handled in driver codes */
+				/* upslog_INSTCMD_POWERSTATE_CHANGE("shutdown.default", NULL); */
 				upsdrv_shutdown();
 				cmdret = STAT_INSTCMD_HANDLED;
 				/* commented below */
@@ -846,9 +848,14 @@ int do_loop_shutdown_commands(const char *sdcmds, char **cmdused) {
 			continue;
 
 		if (!strcmp(s, "shutdown.default")) {
+			/* TOTHINK : These logs are handled in driver codes */
+			/* We are trying (if at all implemented), so "maybe"... */
+			/* upslog_INSTCMD_POWERSTATE_MAYBE(s, NULL); */
 			upsdrv_shutdown();
 			cmdret = STAT_INSTCMD_HANDLED;
 		} else {
+			/* TOTHINK : These logs are handled in driver codes */
+			/* upslog_INSTCMD_POWERSTATE_CHECKED(s, NULL); */
 			cmdret = upsh.instcmd(s, NULL);
 		}
 

--- a/drivers/masterguard.c
+++ b/drivers/masterguard.c
@@ -31,7 +31,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"MASTERGUARD UPS driver"
-#define DRIVER_VERSION	"0.28"
+#define DRIVER_VERSION	"0.29"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -543,7 +543,9 @@ void upsdrv_updateinfo(void)
 static
 int instcmd(const char *cmdname, const char *extra)
 {
+	/* May be used in logging below, but not as a command argument */
 	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
 	/* Shutdown UPS */
 	if (!strcasecmp(cmdname, "shutdown.return"))
@@ -554,7 +556,7 @@ int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/masterguard.c
+++ b/drivers/masterguard.c
@@ -550,6 +550,8 @@ int instcmd(const char *cmdname, const char *extra)
 	/* Shutdown UPS */
 	if (!strcasecmp(cmdname, "shutdown.return"))
 	{
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
+
 		/* ups will come up within a minute if utility is restored */
 		ser_send_pace(upsfd, UPS_PACE, "%s", "S.2R0001\x0D" );
 

--- a/drivers/metasys.c
+++ b/drivers/metasys.c
@@ -28,7 +28,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"Metasystem UPS driver"
-#define DRIVER_VERSION	"0.11"
+#define DRIVER_VERSION	"0.12"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -933,6 +933,10 @@ static int instcmd(const char *cmdname, const char *extra)
 		return instcmd("beeper.enable", NULL);
 	}
 
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 	if (!strcasecmp(cmdname, "shutdown.return")) {
 		/* Same stuff as upsdrv_shutdown() */
 		if (! autorestart) {
@@ -1077,7 +1081,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/metasys.c
+++ b/drivers/metasys.c
@@ -938,6 +938,8 @@ static int instcmd(const char *cmdname, const char *extra)
 	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
 	if (!strcasecmp(cmdname, "shutdown.return")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
+
 		/* Same stuff as upsdrv_shutdown() */
 		if (! autorestart) {
 			command[0]=UPS_SET_TIMES_ON_BATTERY;
@@ -964,6 +966,8 @@ static int instcmd(const char *cmdname, const char *extra)
 	}
 
 	if (!strcasecmp(cmdname, "shutdown.stayoff")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
+
 		/* schedule a shutdown in 30 seconds with no restart (-1) */
 		command[0]=UPS_SET_SCHEDULING;
 		command[1]=0x1e;					/* remaining  */
@@ -980,6 +984,8 @@ static int instcmd(const char *cmdname, const char *extra)
 	}
 
 	if (!strcasecmp(cmdname, "shutdown.stop")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
+
 		/* set shutdown and restart time to -1 (no shutdown, no restart) */
 		command[0]=UPS_SET_SCHEDULING;
 		command[1]=0xff;					/* remaining  */
@@ -996,6 +1002,8 @@ static int instcmd(const char *cmdname, const char *extra)
 	}
 
 	if (!strcasecmp(cmdname, "test.failure.start")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
+
 		/* force ups on battery power */
 		command[0]=UPS_SET_BATTERY_TEST;
 		command[1]=0x01;
@@ -1007,6 +1015,8 @@ static int instcmd(const char *cmdname, const char *extra)
 	}
 
 	if (!strcasecmp(cmdname, "test.failure.stop")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
+
 		/* restore standard mode (mains power) */
 		command[0]=UPS_SET_BATTERY_TEST;
 		command[1]=0x02;
@@ -1018,6 +1028,8 @@ static int instcmd(const char *cmdname, const char *extra)
 	}
 
 	if (!strcasecmp(cmdname, "test.battery.start")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
+
 		/* launch battery test */
 		command[0]=UPS_SET_BATTERY_TEST;
 		command[1]=0x00;

--- a/drivers/mge-utalk.c
+++ b/drivers/mge-utalk.c
@@ -550,6 +550,8 @@ int instcmd(const char *cmdname, const char *extra)
 	/* Start battery test */
 	if (!strcasecmp(cmdname, "test.battery.start"))
 	{
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
+
 		mge_command(temp, sizeof(temp), "Bx 1");
 		upsdebugx(2, "UPS response to %s was %s", cmdname, temp);
 
@@ -575,18 +577,22 @@ int instcmd(const char *cmdname, const char *extra)
 	if (!strcasecmp(cmdname, "shutdown.stayoff"))
 	{
 		sdtype = SD_STAYOFF;
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		upsdrv_shutdown();
 	}
 
 	if (!strcasecmp(cmdname, "shutdown.return"))
 	{
 		sdtype = SD_RETURN;
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		upsdrv_shutdown();
 	}
 
 	/* Power Off [all] plugs */
 	if (!strcasecmp(cmdname, "load.off"))
 	{
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
+
 		/* TODO: Powershare (per plug) control */
 		mge_command(temp, sizeof(temp), "Wy 65535");
 		upsdebugx(2, "UPS response to Select All Plugs was %s", temp);
@@ -607,6 +613,8 @@ int instcmd(const char *cmdname, const char *extra)
 	/* Power On all plugs */
 	if (!strcasecmp(cmdname, "load.on"))
 	{
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
+
 		/* TODO: add per plug control */
 		mge_command(temp, sizeof(temp), "Wy 65535");
 		upsdebugx(2, "UPS response to Select All Plugs was %s", temp);
@@ -626,10 +634,11 @@ int instcmd(const char *cmdname, const char *extra)
 
 	/* Switch on/off Maintenance Bypass */
 	if ((!strcasecmp(cmdname, "bypass.start"))
-		|| (!strcasecmp(cmdname, "bypass.stop")))
+	 || (!strcasecmp(cmdname, "bypass.stop")))
 	{
 		/* TODO: add control on bypass value */
 		/* read maintenance bypass status */
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		if(mge_command(temp, sizeof(temp), "Ps") > 0)
 		{
 			if (temp[0] == '1')

--- a/drivers/mge-utalk.c
+++ b/drivers/mge-utalk.c
@@ -69,7 +69,7 @@
 /* --------------------------------------------------------------- */
 
 #define DRIVER_NAME	"MGE UPS SYSTEMS/U-Talk driver"
-#define DRIVER_VERSION	"0.98"
+#define DRIVER_VERSION	"0.99"
 
 
 /* driver description structure */
@@ -543,6 +543,10 @@ int instcmd(const char *cmdname, const char *extra)
 {
 	char temp[BUFFLEN];
 
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 	/* Start battery test */
 	if (!strcasecmp(cmdname, "test.battery.start"))
 	{
@@ -648,7 +652,7 @@ int instcmd(const char *cmdname, const char *extra)
 		}
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 
@@ -659,6 +663,8 @@ int setvar(const char *varname, const char *val)
 {
 	char temp[BUFFLEN];
 	char cmd[15];
+
+	upsdebug_SET_STARTING(varname, val);
 
 	/* TODO : add some controls */
 
@@ -675,6 +681,7 @@ int setvar(const char *varname, const char *val)
 	}
 
 	upsdebugx(1, "setvar: Variable %s not supported by UPS", varname);
+	upslog_SET_UNKNOWN(varname, val);
 	return STAT_SET_UNKNOWN;
 }
 

--- a/drivers/mge-utalk.c
+++ b/drivers/mge-utalk.c
@@ -671,9 +671,10 @@ int setvar(const char *varname, const char *val)
 		/* Execute command */
 		mge_command(temp, sizeof(temp), cmd);
 		upslogx(LOG_INFO, "setvar: UPS response to Set %s to %s was %s", varname, val, temp);
-	} else
-		upsdebugx(1, "setvar: Variable %s not supported by UPS", varname);
+		return STAT_SET_HANDLED;
+	}
 
+	upsdebugx(1, "setvar: Variable %s not supported by UPS", varname);
 	return STAT_SET_UNKNOWN;
 }
 

--- a/drivers/microdowell.c
+++ b/drivers/microdowell.c
@@ -44,7 +44,7 @@
 #define MAX_SHUTDOWN_DELAY_LEN 5
 
 #define DRIVER_NAME	"MICRODOWELL UPS driver"
-#define DRIVER_VERSION	"0.05"
+#define DRIVER_VERSION	"0.06"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -655,8 +655,9 @@ int instcmd(const char *cmdname, const char *extra)
 	unsigned char *p ;
 	/* int i ; */
 
-	upsdebugx(1, "instcmd(%s, %s)", cmdname, extra);
-
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
 	if (strcasecmp(cmdname, "load.on") == 0)
 		{
@@ -772,6 +773,7 @@ int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 		}
 
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 
@@ -791,13 +793,16 @@ int setvar(const char *varname, const char *val)
 {
 	unsigned int delay;
 
+	upsdebug_SET_STARTING(varname, val);
+
 	if (sscanf(val, "%u", &delay) != 1)
-		{
+	{
+		/* FIXME: ..._CONVERSION_FAILED? log it? */
 		return STAT_SET_UNKNOWN;
-		}
+	}
 
 	if (strcasecmp(varname, "ups.delay.start") == 0)
-		{
+	{
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || defined (HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_COMPARE) )
 # pragma GCC diagnostic push
 #endif
@@ -828,10 +833,10 @@ int setvar(const char *varname, const char *val)
 		dstate_setinfo("ups.delay.start", "%u", ups.WakeUpDelay);
 		dstate_dataok();
 		return STAT_SET_HANDLED;
-		}
+	}
 
 	if (strcasecmp(varname, "ups.delay.shutdown") == 0)
-		{
+	{
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || defined (HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_COMPARE) )
 # pragma GCC diagnostic push
 #endif
@@ -862,8 +867,9 @@ int setvar(const char *varname, const char *val)
 		dstate_setinfo("ups.delay.shutdown", "%u", ups.ShutdownDelay);
 		dstate_dataok();
 		return STAT_SET_HANDLED;
-		}
+	}
 
+	upslog_SET_UNKNOWN(varname, val);
 	return STAT_SET_UNKNOWN;
 }
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_BESIDEFUNC) && (!defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_INSIDEFUNC) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS_BESIDEFUNC) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE_BESIDEFUNC) || defined (HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_COMPARE_BESIDEFUNC) )

--- a/drivers/microdowell.c
+++ b/drivers/microdowell.c
@@ -669,6 +669,9 @@ int instcmd(const char *cmdname, const char *extra)
 		OutBuff[5] = 0 ;
 		OutBuff[6] = 0 ;
 		OutBuff[7] = 0 ;
+
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
+
 		if ((p = CmdSerial(OutBuff, LEN_SD_ONESHOT, InpBuff)) != NULL)
 			{
 			p += 3 ;	/* 'p' points to received data */
@@ -693,6 +696,9 @@ int instcmd(const char *cmdname, const char *extra)
 		OutBuff[5] = 0 ;
 		OutBuff[6] = 0 ;
 		OutBuff[7] = 0 ;
+
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
+
 		if ((p = CmdSerial(OutBuff, LEN_SD_ONESHOT, InpBuff)) != NULL)
 			{
 			p += 3 ;	/* 'p' points to received data */
@@ -726,6 +732,8 @@ int instcmd(const char *cmdname, const char *extra)
 		OutBuff[6] = (ups.WakeUpDelay >> 8) & 0xFF ;		/* WUDELAY (...) */
 		OutBuff[7] = (ups.WakeUpDelay & 0xFF ) ;			/* WUDELAY (LSB) */
 
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
+
 		if ((p = CmdSerial(OutBuff, LEN_SD_ONESHOT, InpBuff)) != NULL)
 			{
 			p += 3 ;	/* 'p' points to received data */
@@ -758,6 +766,8 @@ int instcmd(const char *cmdname, const char *extra)
 		OutBuff[5] = 0 ;	/* WUDELAY (MSB)	Wakeup value (seconds) */
 		OutBuff[6] = 0 ;	/* WUDELAY (...) */
 		OutBuff[7] = 0 ;	/* WUDELAY (LSB) */
+
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 
 		if ((p = CmdSerial(OutBuff, LEN_SD_ONESHOT, InpBuff)) != NULL)
 			{

--- a/drivers/microsol-common.c
+++ b/drivers/microsol-common.c
@@ -660,6 +660,10 @@ static void get_updated_info(void)
 
 static int instcmd(const char *cmdname, const char *extra)
 {
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 	/* Power-cycle UPS */
 	if (!strcasecmp(cmdname, "shutdown.return")) {
 		ser_send_char(upsfd, CMD_SHUTRET);	/* 0xDE */
@@ -672,7 +676,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/microsol-common.c
+++ b/drivers/microsol-common.c
@@ -666,12 +666,14 @@ static int instcmd(const char *cmdname, const char *extra)
 
 	/* Power-cycle UPS */
 	if (!strcasecmp(cmdname, "shutdown.return")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		ser_send_char(upsfd, CMD_SHUTRET);	/* 0xDE */
 		return STAT_INSTCMD_HANDLED;
 	}
 
 	/* Power-off UPS */
 	if (!strcasecmp(cmdname, "shutdown.stayoff")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		ser_send_char(upsfd, CMD_SHUT);	/* 0xDD */
 		return STAT_INSTCMD_HANDLED;
 	}

--- a/drivers/netxml-ups.c
+++ b/drivers/netxml-ups.c
@@ -494,6 +494,7 @@ static int instcmd(const char *cmdname, const char *extra)
 
 /*
 	if (!strcasecmp(cmdname, "test.battery.stop")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		ser_send_buf(upsfd, ...);
 		return STAT_INSTCMD_HANDLED;
 	}

--- a/drivers/nut-ipmipsu.c
+++ b/drivers/nut-ipmipsu.c
@@ -27,7 +27,7 @@
 #include "nut-ipmi.h"
 
 #define DRIVER_NAME	"IPMI PSU driver"
-#define DRIVER_VERSION	"0.34"
+#define DRIVER_VERSION	"0.35"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -170,12 +170,16 @@ void upsdrv_shutdown(void)
 /*
 static int instcmd(const char *cmdname, const char *extra)
 {
+	/ * May be used in logging below, but not as a command argument * /
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 	if (!strcasecmp(cmdname, "test.battery.stop")) {
 		ser_send_buf(upsfd, ...);
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s]", cmdname);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 */
@@ -183,12 +187,14 @@ static int instcmd(const char *cmdname, const char *extra)
 /*
 static int setvar(const char *varname, const char *val)
 {
-	if (!strcasecmp(varname, "ups.test.interval")) {
+	upsdebug_SET_STARTING(varname, val);
+
+  	if (!strcasecmp(varname, "ups.test.interval")) {
 		ser_send_buf(upsfd, ...);
 		return STAT_SET_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "setvar: unknown variable [%s]", varname);
+	upslog_SET_UNKNOWN(varname, val);
 	return STAT_SET_UNKNOWN;
 }
 */

--- a/drivers/nut-ipmipsu.c
+++ b/drivers/nut-ipmipsu.c
@@ -175,6 +175,7 @@ static int instcmd(const char *cmdname, const char *extra)
 	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
 	if (!strcasecmp(cmdname, "test.battery.stop")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		ser_send_buf(upsfd, ...);
 		return STAT_INSTCMD_HANDLED;
 	}

--- a/drivers/nutdrv_atcl_usb.c
+++ b/drivers/nutdrv_atcl_usb.c
@@ -683,6 +683,7 @@ int instcmd(const char *cmdname, const char *extra)
 			"%s: attempting to call usb_interrupt_write(01 00 00 00 00 00 00 00)",
 			__func__);
 
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		ret = usb_interrupt_write(udev,
 			SHUTDOWN_ENDPOINT, (usb_ctrl_charbuf)shutdown_packet,
 			SHUTDOWN_PACKETSIZE, ATCL_USB_TIMEOUT);

--- a/drivers/nutdrv_atcl_usb.c
+++ b/drivers/nutdrv_atcl_usb.c
@@ -28,7 +28,7 @@
 
 /* driver version */
 #define DRIVER_NAME	"'ATCL FOR UPS' USB driver"
-#define DRIVER_VERSION	"1.19"
+#define DRIVER_VERSION	"1.20"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -661,7 +661,9 @@ void upsdrv_updateinfo(void)
 static
 int instcmd(const char *cmdname, const char *extra)
 {
+	/* May be used in logging below, but not as a command argument */
 	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
 	/* FIXME: Which one is this - "load.off",
 	 * "shutdown.stayoff" or "shutdown.return"? */
@@ -711,7 +713,7 @@ int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/nutdrv_hashx.c
+++ b/drivers/nutdrv_hashx.c
@@ -36,7 +36,7 @@
 #define IGNCHARS	""
 
 #define DRIVER_NAME	"Generic #* Serial driver"
-#define DRIVER_VERSION	"0.01"
+#define DRIVER_VERSION	"0.02"
 
 #define SESSION_ID	"OoNUTisAMAZINGoO"
 #define SESSION_HASH	"74279F35A48F5F13"
@@ -606,6 +606,10 @@ static int hashx_instcmd(const char *cmd_name, const char *extra)
 {
 	size_t i;
 
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmd_name, extra);
+
 	for (i = 0; i < sizeof (hashx_cmd) / sizeof (*hashx_cmd); ++i) {
 		int status;
 
@@ -616,12 +620,12 @@ static int hashx_instcmd(const char *cmd_name, const char *extra)
 		if ((status = hashx_send_command(hashx_cmd[i].ups_cmd)) == STATUS_SUCCESS)
 			return STAT_INSTCMD_HANDLED;
 
-		upslogx(LOG_ERR, "Failed to execute command [%s] [%s]: %d",
-		        cmd_name, extra, status);
+		upslogx(LOG_INSTCMD_FAILED, "Failed to execute command [%s] [%s]: %d",
+		        NUT_STRARG(cmd_name), NUT_STRARG(extra), status);
 		return STAT_INSTCMD_FAILED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmd_name, extra);
+	upslog_INSTCMD_UNKNOWN(cmd_name, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/nutdrv_hashx.c
+++ b/drivers/nutdrv_hashx.c
@@ -617,6 +617,7 @@ static int hashx_instcmd(const char *cmd_name, const char *extra)
 			continue;
 		}
 
+		upslog_INSTCMD_POWERSTATE_CHECKED(cmd_name, extra);
 		if ((status = hashx_send_command(hashx_cmd[i].ups_cmd)) == STATUS_SUCCESS)
 			return STAT_INSTCMD_HANDLED;
 

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -2475,6 +2475,7 @@ int	instcmd(const char *cmdname, const char *extradata)
 
 	/* Check for fallback if not found */
 	if (item == NULL) {
+		/* Process aliases/fallbacks */
 
 		if (!strcasecmp(cmdname, "load.on")) {
 			return instcmd("load.on.delay", "0");
@@ -2551,6 +2552,7 @@ int	instcmd(const char *cmdname, const char *extradata)
 		snprintf(value, sizeof(value), "%s", "");
 
 	/* Send the command, get the reply */
+	upslog_INSTCMD_POWERSTATE_CHECKED(cmdname, extradata);
 	if (qx_process(item, strlen(value) > 0 ? value : NULL)) {
 		/* Something went wrong */
 		upslogx(LOG_INSTCMD_FAILED, "%s: FAILED", __func__);

--- a/drivers/nutdrv_qx_blazer-common.c
+++ b/drivers/nutdrv_qx_blazer-common.c
@@ -191,6 +191,8 @@ void	blazer_initups_light(item_t *qx2nut)
 /* Preprocess setvars */
 int	blazer_process_setvar(item_t *item, char *value, const size_t valuelen)
 {
+	/* upsdebug_SET_STARTING(item->info_type, value); */
+
 	if (!strlen(value)) {
 		upsdebugx(2, "%s: value not given for %s", __func__, item->info_type);
 		return -1;
@@ -231,7 +233,8 @@ int	blazer_process_setvar(item_t *item, char *value, const size_t valuelen)
 
 	} else {
 
-		/* Don't know what happened */
+		/* Don't know what happened: unknown entry for pre-processing? */
+		/* upslog_SET_UNKNOWN(item->info_type, value); */
 		return -1;
 
 	}
@@ -242,6 +245,8 @@ int	blazer_process_setvar(item_t *item, char *value, const size_t valuelen)
 /* Preprocess instant commands */
 int	blazer_process_command(item_t *item, char *value, const size_t valuelen)
 {
+	/* upsdebug_INSTCMD_STARTING(item->info_type, value); */
+
 	if (!strcasecmp(item->info_type, "shutdown.return")) {
 
 		/* Sn: Shutdown after n minutes and then turn on when mains is back
@@ -351,7 +356,8 @@ int	blazer_process_command(item_t *item, char *value, const size_t valuelen)
 
 	} else {
 
-		/* Don't know what happened */
+		/* Don't know what happened: unknown entry for pre-processing? */
+		/* upslog_INSTCMD_UNKNOWN(item->info_type, value); */
 		return -1;
 
 	}

--- a/drivers/nutdrv_qx_voltronic.c
+++ b/drivers/nutdrv_qx_voltronic.c
@@ -1863,6 +1863,8 @@ static int	voltronic_process_setvar(item_t *item, char *value, const size_t valu
 {
 	double	val;
 
+	/* upsdebug_SET_STARTING(item->info_type, value); */
+
 	if (!strlen(value)) {
 		upsdebugx(2, "%s: value not given for %s", __func__, item->info_type);
 		return -1;
@@ -1938,6 +1940,8 @@ static int	voltronic_process_setvar(item_t *item, char *value, const size_t valu
 static int	voltronic_process_command(item_t *item, char *value, const size_t valuelen)
 {
 	char	buf[SMALLBUF] = "";
+
+	/* upsdebug_INSTCMD_STARTING(item->info_type, value); */
 
 	if (!strcasecmp(item->info_type, "shutdown.return")) {
 
@@ -2060,7 +2064,8 @@ static int	voltronic_process_command(item_t *item, char *value, const size_t val
 
 	} else {
 
-		/* Don't know what happened */
+		/* Don't know what happened: unknown entry for pre-processing? */
+		/* upslog_INSTCMD_UNKNOWN(item->info_type, value); */
 		return -1;
 
 	}

--- a/drivers/nutdrv_siemens_sitop.c
+++ b/drivers/nutdrv_siemens_sitop.c
@@ -56,7 +56,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"Siemens SITOP UPS500 series driver"
-#define DRIVER_VERSION	"0.06"
+#define DRIVER_VERSION	"0.07"
 
 #define RX_BUFFER_SIZE 100
 
@@ -160,6 +160,10 @@ static int check_for_new_data(void) {
 
 
 static int instcmd(const char *cmdname, const char *extra) {
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 	/* Note: the UPS does not really like to receive data.
 	 * For example, sending an "R" without \n hangs the serial port.
 	 * In that situation, the UPS will no longer send any status updates.
@@ -180,7 +184,7 @@ static int instcmd(const char *cmdname, const char *extra) {
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/nutdrv_siemens_sitop.c
+++ b/drivers/nutdrv_siemens_sitop.c
@@ -172,13 +172,15 @@ static int instcmd(const char *cmdname, const char *extra) {
 	 * lost as well.
 	 */
 	if (!strcasecmp(cmdname, "shutdown.return")) {
-		upslogx(LOG_NOTICE, "instcmd: sending command R");
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
+		upsdebugx(1, "instcmd: sending command R");
 		ser_send_pace(upsfd, 200000, "\n\nR\n\n");
 		ser_send_pace(upsfd, 200000, "R\n\n");
 		return STAT_INSTCMD_HANDLED;
 	}
 	if (!strcasecmp(cmdname, "shutdown.stayoff")) {
-		upslogx(LOG_NOTICE, "instcmd: sending command S");
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
+		upsdebugx(1, "instcmd: sending command S");
 		ser_send_pace(upsfd, 200000, "\n\nS\n\n");
 		ser_send_pace(upsfd, 200000, "S\n\n");
 		return STAT_INSTCMD_HANDLED;

--- a/drivers/oneac.c
+++ b/drivers/oneac.c
@@ -48,7 +48,7 @@ int setcmd(const char* varname, const char* setvalue);
 int instcmd(const char *cmdname, const char *extra);
 
 #define DRIVER_NAME	"Oneac EG/ON/OZ/OB UPS driver"
-#define DRIVER_VERSION	"0.84"
+#define DRIVER_VERSION	"0.85"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -853,7 +853,9 @@ int instcmd(const char *cmdname, const char *extra)
 {
 	int i;
 
-	upsdebugx(2, "In instcmd with %s and extra %s.", cmdname, extra);
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
 	if (!strcasecmp(cmdname, "test.failure.start")) {
 		ser_send(upsfd, "%s%s", SIM_PWR_FAIL, COMMAND_END);
@@ -938,14 +940,14 @@ int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s]", cmdname);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 
 
 int setcmd(const char* varname, const char* setvalue)
 {
-	upsdebugx(2, "In setcmd for %s with %s...", varname, setvalue);
+	upsdebug_SET_STARTING(varname, setvalue);
 
 	if (!strcasecmp(varname, "ups.delay.shutdown"))
 	{
@@ -954,6 +956,7 @@ int setcmd(const char* varname, const char* setvalue)
 		{
 			if (atoi(setvalue) > 65535)
 			{
+				/* FIXME: ..._INVALID? ..._CONVERSION_FAILED? */
 				upsdebugx(2, "Too big for OZ/OB (>65535)...(%s)", setvalue);
 				return STAT_SET_UNKNOWN;
 			}
@@ -962,6 +965,7 @@ int setcmd(const char* varname, const char* setvalue)
 		{
 			if (atoi(setvalue) > 999)
 			{
+				/* FIXME: ..._INVALID? ..._CONVERSION_FAILED? */
 				upsdebugx(2, "Too big for EG/ON (>999)...(%s)", setvalue);
 				return STAT_SET_UNKNOWN;
 			}
@@ -1059,7 +1063,6 @@ int setcmd(const char* varname, const char* setvalue)
 		return STAT_SET_UNKNOWN;
 	}
 
-	upslogx(LOG_NOTICE, "setcmd: unknown command [%s]", varname);
-
+	upslog_SET_UNKNOWN(varname, setvalue);
 	return STAT_SET_UNKNOWN;
 }

--- a/drivers/oneac.c
+++ b/drivers/oneac.c
@@ -858,11 +858,13 @@ int instcmd(const char *cmdname, const char *extra)
 	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
 	if (!strcasecmp(cmdname, "test.failure.start")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		ser_send(upsfd, "%s%s", SIM_PWR_FAIL, COMMAND_END);
 		return STAT_INSTCMD_HANDLED;
 	}
 
 	if (!strcasecmp(cmdname, "shutdown.return")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 
 		i = atoi(dstate_getinfo("ups.delay.shutdown"));
 
@@ -882,27 +884,32 @@ int instcmd(const char *cmdname, const char *extra)
 	}
 
 	if (!strcasecmp(cmdname, "shutdown.reboot")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		ser_send(upsfd, "%s", SHUTDOWN);
 		return STAT_INSTCMD_HANDLED;
 	}
 
 	if (!strcasecmp(cmdname, "shutdown.stop")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		ser_send(upsfd, "%c%s", DELAYED_SHUTDOWN_PREFIX, COMMAND_END);
 		return STAT_INSTCMD_HANDLED;
 	}
 
 	if (!strcasecmp(cmdname, "test.battery.start.quick")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		do_battery_test();
 		return STAT_INSTCMD_HANDLED;
 	}
 
 	if (!strcasecmp(cmdname, "test.battery.start.deep")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		ser_send(upsfd, "%s%s", TEST_BATT_DEEP, COMMAND_END);
 		return STAT_INSTCMD_HANDLED;
 	}
 
 	if (!strcasecmp(cmdname, "test.battery.stop"))
 	{
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		if ((strncmp (UpsFamily, FAMILY_EG, FAMILY_SIZE) == 0) ||
 			(strncmp (UpsFamily, FAMILY_ON, FAMILY_SIZE) == 0))
 		{

--- a/drivers/oneac.c
+++ b/drivers/oneac.c
@@ -856,7 +856,7 @@ int instcmd(const char *cmdname, const char *extra)
 	upsdebugx(2, "In instcmd with %s and extra %s.", cmdname, extra);
 
 	if (!strcasecmp(cmdname, "test.failure.start")) {
-		ser_send(upsfd,"%s%s",SIM_PWR_FAIL,COMMAND_END);
+		ser_send(upsfd, "%s%s", SIM_PWR_FAIL, COMMAND_END);
 		return STAT_INSTCMD_HANDLED;
 	}
 
@@ -868,24 +868,24 @@ int instcmd(const char *cmdname, const char *extra)
 			(strncmp (UpsFamily, FAMILY_OB, FAMILY_SIZE) == 0))
 		{
 			upsdebugx(3, "Shutdown using %c%d...", DELAYED_SHUTDOWN_PREFIX, i);
-			ser_send(upsfd,"%c%d%s",DELAYED_SHUTDOWN_PREFIX, i, COMMAND_END);
+			ser_send(upsfd, "%c%d%s", DELAYED_SHUTDOWN_PREFIX, i, COMMAND_END);
 		}
 		else
 		{
 			upsdebugx(3, "Shutdown using %c%03d...",DELAYED_SHUTDOWN_PREFIX, i);
-			ser_send(upsfd,"%c%03d%s",DELAYED_SHUTDOWN_PREFIX, i, COMMAND_END);
+			ser_send(upsfd, "%c%03d%s", DELAYED_SHUTDOWN_PREFIX, i, COMMAND_END);
 		}
 
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	if(!strcasecmp(cmdname, "shutdown.reboot")) {
+	if (!strcasecmp(cmdname, "shutdown.reboot")) {
 		ser_send(upsfd, "%s", SHUTDOWN);
 		return STAT_INSTCMD_HANDLED;
 	}
 
 	if (!strcasecmp(cmdname, "shutdown.stop")) {
-		ser_send(upsfd,"%c%s",DELAYED_SHUTDOWN_PREFIX,COMMAND_END);
+		ser_send(upsfd, "%c%s", DELAYED_SHUTDOWN_PREFIX, COMMAND_END);
 		return STAT_INSTCMD_HANDLED;
 	}
 
@@ -904,37 +904,37 @@ int instcmd(const char *cmdname, const char *extra)
 		if ((strncmp (UpsFamily, FAMILY_EG, FAMILY_SIZE) == 0) ||
 			(strncmp (UpsFamily, FAMILY_ON, FAMILY_SIZE) == 0))
 		{
-			ser_send(upsfd,"%s00%s",BAT_TEST_PREFIX,COMMAND_END);
+			ser_send(upsfd, "%s00%s", BAT_TEST_PREFIX, COMMAND_END);
 		}
 		else
 		{
-			ser_send(upsfd,"%c%s",TEST_ABORT,COMMAND_END);
+			ser_send(upsfd, "%c%s", TEST_ABORT, COMMAND_END);
 		}
 		return STAT_INSTCMD_HANDLED;
 	}
 
 	if (!strcasecmp(cmdname, "reset.input.minmax")) {
-		ser_send(upsfd,"%c%s",RESET_MIN_MAX, COMMAND_END);
+		ser_send(upsfd, "%c%s", RESET_MIN_MAX, COMMAND_END);
 		return STAT_INSTCMD_HANDLED;
 	}
 
 	if (!strcasecmp(cmdname, "beeper.enable")) {
-		ser_send(upsfd,"%c%c%s",SETX_BUZZER_PREFIX, BUZZER_ENABLED,COMMAND_END);
+		ser_send(upsfd, "%c%c%s", SETX_BUZZER_PREFIX, BUZZER_ENABLED, COMMAND_END);
 		return STAT_INSTCMD_HANDLED;
 	}
 
 	if (!strcasecmp(cmdname, "beeper.disable")) {
-		ser_send(upsfd,"%c%c%s",SETX_BUZZER_PREFIX,BUZZER_DISABLED,COMMAND_END);
+		ser_send(upsfd, "%c%c%s", SETX_BUZZER_PREFIX, BUZZER_DISABLED, COMMAND_END);
 		return STAT_INSTCMD_HANDLED;
 	}
 
 	if (!strcasecmp(cmdname, "beeper.mute")) {
-		ser_send(upsfd,"%c%c%s",SETX_BUZZER_PREFIX, BUZZER_MUTED, COMMAND_END);
+		ser_send(upsfd, "%c%c%s", SETX_BUZZER_PREFIX, BUZZER_MUTED, COMMAND_END);
 		return STAT_INSTCMD_HANDLED;
 	}
 
 	if (!strcasecmp(cmdname, "test.panel.start")) {
-		ser_send(upsfd,"%s%s",TEST_INDICATORS, COMMAND_END);
+		ser_send(upsfd, "%s%s", TEST_INDICATORS, COMMAND_END);
 		return STAT_INSTCMD_HANDLED;
 	}
 

--- a/drivers/optiups.c
+++ b/drivers/optiups.c
@@ -240,6 +240,7 @@ static int instcmd(const char *cmdname, const char *extra)
 
 	if (!strcasecmp(cmdname, "test.failure.start"))
 	{
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		optiquery( "Ts" );
 		return STAT_INSTCMD_HANDLED;
 	}
@@ -248,6 +249,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		/* You do realize this will kill power to ourself.
 		 * Would probably only be useful for killing power for
 		 * a computer with upsmon in "secondary" mode */
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		if ( optimodel == OPTIMODEL_ZINTO )
 		{
 			optiquery( "Ct1" );
@@ -261,6 +263,7 @@ static int instcmd(const char *cmdname, const char *extra)
 	}
 	else if (!strcasecmp(cmdname, "load.on"))
 	{
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		if ( optimodel == OPTIMODEL_ZINTO )
 		{
 			optiquery( "Ct1" );
@@ -276,6 +279,7 @@ static int instcmd(const char *cmdname, const char *extra)
 	{
 		/* This shuts down the UPS.  When the power returns to the UPS,
 		 *   it will power back up in its default state. */
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		if ( optimodel == OPTIMODEL_ZINTO )
 		{
 			optiquery( "Ct1" );
@@ -292,6 +296,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		/* This actually stays off as long as the batteries hold,
 		 *   if the line power comes back before the batteries die,
 		 *   the UPS will never powerup its output stage!!! */
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		if ( optimodel == OPTIMODEL_ZINTO )
 		{
 			optiquery( "Ct1" );
@@ -305,6 +310,7 @@ static int instcmd(const char *cmdname, const char *extra)
 	else if (!strcasecmp(cmdname, "shutdown.stop"))
 	{
 		/* Aborts a shutdown that is counting down via the Cs command */
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		optiquery( "Cs-0000001" );
 		return STAT_INSTCMD_HANDLED;
 	}

--- a/drivers/optiups.c
+++ b/drivers/optiups.c
@@ -28,7 +28,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"Opti-UPS driver"
-#define DRIVER_VERSION	"1.07"
+#define DRIVER_VERSION	"1.08"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -234,6 +234,10 @@ static void optifill( ezfill_t *a, size_t len )
 /* Handle custom (but standardized) NUT commands */
 static int instcmd(const char *cmdname, const char *extra)
 {
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 	if (!strcasecmp(cmdname, "test.failure.start"))
 	{
 		optiquery( "Ts" );
@@ -305,7 +309,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 
@@ -313,6 +317,8 @@ static int instcmd(const char *cmdname, const char *extra)
 static int setvar(const char *varname, const char *val)
 {
 	int status;
+
+	upsdebug_SET_STARTING(varname, val);
 
 	if (sscanf(val, "%d", &status) != 1) {
 		return STAT_SET_UNKNOWN;
@@ -326,6 +332,7 @@ static int setvar(const char *varname, const char *val)
 		return STAT_SET_HANDLED;
 	}
 
+	upslog_SET_UNKNOWN(varname, val);
 	return STAT_SET_UNKNOWN;
 }
 

--- a/drivers/pijuice.c
+++ b/drivers/pijuice.c
@@ -23,7 +23,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME                         "PiJuice UPS driver"
-#define DRIVER_VERSION                      "0.13"
+#define DRIVER_VERSION                      "0.14"
 
 /*
  * Linux I2C userland is a bit of a mess until distros refresh to
@@ -833,7 +833,9 @@ void upsdrv_updateinfo(void)
 static
 int instcmd(const char *cmdname, const char *extra)
 {
+	/* May be used in logging below, but not as a command argument */
 	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
 	/* FIXME: Which one is this - "load.off",
 	 * "shutdown.stayoff" or "shutdown.return"? */
@@ -845,7 +847,7 @@ int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/pijuice.c
+++ b/drivers/pijuice.c
@@ -842,6 +842,8 @@ int instcmd(const char *cmdname, const char *extra)
 
 	/* Shutdown UPS */
 	if (!strcasecmp(cmdname, "shutdown.stayoff")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
+
 		set_power_off();
 
 		return STAT_INSTCMD_HANDLED;

--- a/drivers/powercom.c
+++ b/drivers/powercom.c
@@ -322,17 +322,20 @@ static int instcmd (const char *cmdname, const char *extra)
 	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
 	if (!strcasecmp(cmdname, "test.battery.start")) {
-	    ser_send_char (upsfd, BATTERY_TEST);
-	    return STAT_INSTCMD_HANDLED;
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
+		ser_send_char (upsfd, BATTERY_TEST);
+		return STAT_INSTCMD_HANDLED;
 	}
 	if (!strcasecmp(cmdname, "shutdown.return")) {
 		/* NOTE: In this context, "return" is UPS behavior after the
 		 * wall-power gets restored. The routine exits the driver anyway.
 		 */
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		shutdown_ret();
 		return STAT_INSTCMD_HANDLED;
 	}
 	if (!strcasecmp(cmdname, "shutdown.stayoff")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		shutdown_halt();
 		return STAT_INSTCMD_HANDLED;
 	}

--- a/drivers/powercom.c
+++ b/drivers/powercom.c
@@ -86,7 +86,7 @@
 #include "nut_float.h"
 
 #define DRIVER_NAME	"PowerCom protocol UPS driver"
-#define DRIVER_VERSION	"0.24"
+#define DRIVER_VERSION	"0.25"
 
 /* driver description structure */
 upsdrv_info_t	upsdrv_info = {
@@ -317,6 +317,10 @@ static void shutdown_ret(void)
 /* registered instant commands */
 static int instcmd (const char *cmdname, const char *extra)
 {
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 	if (!strcasecmp(cmdname, "test.battery.start")) {
 	    ser_send_char (upsfd, BATTERY_TEST);
 	    return STAT_INSTCMD_HANDLED;
@@ -333,7 +337,7 @@ static int instcmd (const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/powerman-pdu.c
+++ b/drivers/powerman-pdu.c
@@ -23,7 +23,7 @@
 #include <libpowerman.h>	/* pm_err_t and other beasts */
 
 #define DRIVER_NAME	"Powerman PDU client driver"
-#define DRIVER_VERSION	"0.15"
+#define DRIVER_VERSION	"0.16"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -54,7 +54,9 @@ static int instcmd(const char *cmdname, const char *extra)
 	char *cmdindex = NULL;
 	char outletname[SMALLBUF];
 
-	upsdebugx(1, "entering instcmd (%s)", cmdname);
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
 	/* only consider the end of the command */
 	if ( (cmdsuffix = strrchr(cmdname, '.')) == NULL )
@@ -90,7 +92,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		return (rv==PM_ESUCCESS)?STAT_INSTCMD_HANDLED:STAT_INSTCMD_INVALID;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 
@@ -163,12 +165,14 @@ void upsdrv_shutdown(void)
 /*
 static int setvar(const char *varname, const char *val)
 {
+	upsdebug_SET_STARTING(varname, val);
+ 
 	if (!strcasecmp(varname, "outlet.n.delay.*")) {
 		...
 		return STAT_SET_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "setvar: unknown variable [%s]", varname);
+	upslog_SET_UNKNOWN(varname, val);
 	return STAT_SET_UNKNOWN;
 }
 */

--- a/drivers/powerman-pdu.c
+++ b/drivers/powerman-pdu.c
@@ -99,7 +99,7 @@ void upsdrv_updateinfo(void)
 	pm_err_t rv = PM_ESUCCESS;
 
 	if ( (rv = query_all(pm, WALKMODE_UPDATE)) != PM_ESUCCESS) {
-		upslogx(2, "Error: %s (%i)\n", pm_strerror(rv, ebuf, sizeof(ebuf)), errno);
+		upsdebugx(2, "Error: %s (%i)\n", pm_strerror(rv, ebuf, sizeof(ebuf)), errno);
 		/* FIXME: try to reconnect?
 		 *	dstate_datastale();
 		 */
@@ -122,7 +122,7 @@ void upsdrv_initinfo(void)
 
 	/* Now walk the data tree */
 	if ( (rv = query_all(pm, WALKMODE_INIT)) != PM_ESUCCESS) {
-		upslogx(2, "Error: %s\n", pm_strerror(rv, ebuf, sizeof(ebuf)));
+		upsdebugx(2, "Error: %s\n", pm_strerror(rv, ebuf, sizeof(ebuf)));
 		/* FIXME: try to reconnect?
 		 *	dstate_datastale();
 		 */

--- a/drivers/powerman-pdu.c
+++ b/drivers/powerman-pdu.c
@@ -76,18 +76,21 @@ static int instcmd(const char *cmdname, const char *extra)
 
 	/* Power on the outlet */
 	if (!strcasecmp(cmdsuffix, "on")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		rv = pm_node_on(pm, outletname);
 		return (rv==PM_ESUCCESS)?STAT_INSTCMD_HANDLED:STAT_INSTCMD_INVALID;
 	}
 
 	/* Power off the outlet */
 	if (!strcasecmp(cmdsuffix, "off")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		rv = pm_node_off(pm, outletname);
 		return (rv==PM_ESUCCESS)?STAT_INSTCMD_HANDLED:STAT_INSTCMD_INVALID;
 	}
 
 	/* Cycle the outlet */
 	if (!strcasecmp(cmdsuffix, "cycle")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		rv = pm_node_cycle(pm, outletname);
 		return (rv==PM_ESUCCESS)?STAT_INSTCMD_HANDLED:STAT_INSTCMD_INVALID;
 	}

--- a/drivers/powerp-bin.c
+++ b/drivers/powerp-bin.c
@@ -271,6 +271,7 @@ static int powpan_instcmd(const char *cmdname, const char *extra)
 			continue;
 		}
 
+		upslog_INSTCMD_POWERSTATE_CHECKED(cmdname, extra);
 		ret = powpan_command(cmdtab[i].command, cmdtab[i].len);
 		assert(cmdtab[i].len < SSIZE_MAX);
 		if (ret >= 0 &&

--- a/drivers/powerp-bin.c
+++ b/drivers/powerp-bin.c
@@ -36,7 +36,7 @@
 
 #include <math.h>
 
-#define POWERPANEL_BIN_VERSION	"Powerpanel-Binary 0.62"
+#define POWERPANEL_BIN_VERSION	"Powerpanel-Binary 0.64"
 
 typedef struct {
 	unsigned char	start;
@@ -260,6 +260,10 @@ static int powpan_instcmd(const char *cmdname, const char *extra)
 {
 	int	i;
 
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 	for (i = 0; cmdtab[i].cmd != NULL; i++) {
 		ssize_t	ret;
 
@@ -276,11 +280,11 @@ static int powpan_instcmd(const char *cmdname, const char *extra)
 			return STAT_INSTCMD_HANDLED;
 		}
 
-		upslogx(LOG_ERR, "%s: command [%s] [%s] failed", __func__, cmdname, extra);
+		upslog_INSTCMD_FAILED(cmdname, extra);
 		return STAT_INSTCMD_FAILED;
 	}
 
-	upslogx(LOG_ERR, "%s: command [%s] not found", __func__, cmdname);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 
@@ -288,6 +292,8 @@ static int powpan_setvar(const char *varname, const char *val)
 {
 	char	command[SMALLBUF];
 	int 	i, j;
+
+	upsdebug_SET_STARTING(varname, val);
 
 	for (i = 0;  vartab[i].var != NULL; i++) {
 
@@ -314,15 +320,15 @@ static int powpan_setvar(const char *varname, const char *val)
 				return STAT_SET_HANDLED;
 			}
 
-			upslogx(LOG_ERR, "powpan_setvar: setting variable [%s] to [%s] failed", varname, val);
-			return STAT_SET_UNKNOWN;
+			upslog_SET_FAILED(varname, val);
+			return STAT_SET_UNKNOWN;	/* FIXME: ..._FAILED ? */
 		}
 
-		upslogx(LOG_ERR, "powpan_setvar: [%s] is not valid for variable [%s]", val, varname);
-		return STAT_SET_UNKNOWN;
+		upslog_SET_INVALID(varname, val);
+		return STAT_SET_UNKNOWN;	/* FIXME: ..._INVALID? */
 	}
 
-	upslogx(LOG_ERR, "powpan_setvar: variable [%s] not found", varname);
+	upslog_SET_UNKNOWN(varname, val);
 	return STAT_SET_UNKNOWN;
 }
 

--- a/drivers/powerp-txt.c
+++ b/drivers/powerp-txt.c
@@ -36,7 +36,7 @@
 
 #include <ctype.h>
 
-#define POWERPANEL_TEXT_VERSION	"Powerpanel-Text 0.63"
+#define POWERPANEL_TEXT_VERSION	"Powerpanel-Text 0.64"
 
 typedef struct {
 	float          i_volt;
@@ -146,6 +146,10 @@ static int powpan_instcmd(const char *cmdname, const char *extra)
 		return powpan_instcmd("beeper.enable", NULL);
 	}
 
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 	for (i = 0; cmdtab[i].cmd != NULL; i++) {
 
 		if (strcasecmp(cmdname, cmdtab[i].cmd)) {
@@ -156,7 +160,7 @@ static int powpan_instcmd(const char *cmdname, const char *extra)
 			return STAT_INSTCMD_HANDLED;
 		}
 
-		upslogx(LOG_ERR, "%s: command [%s] [%s] failed", __func__, cmdname, extra);
+		upslog_INSTCMD_FAILED(cmdname, extra);
 		return STAT_INSTCMD_FAILED;
 	}
 
@@ -179,7 +183,7 @@ static int powpan_instcmd(const char *cmdname, const char *extra)
 			snprintf(command, sizeof(command), "S%02ldR%04ld\r", offdelay / 60, ondelay);
 		}
 	} else {
-		upslogx(LOG_NOTICE, "%s: command [%s] [%s] unknown", __func__, cmdname, extra);
+		upslog_INSTCMD_UNKNOWN(cmdname, extra);
 		return STAT_INSTCMD_UNKNOWN;
 	}
 
@@ -187,7 +191,7 @@ static int powpan_instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_ERR, "%s: command [%s] [%s] failed", __func__, cmdname, extra);
+	upslog_INSTCMD_FAILED(cmdname, extra);
 	return STAT_INSTCMD_FAILED;
 }
 
@@ -195,6 +199,8 @@ static int powpan_setvar(const char *varname, const char *val)
 {
 	char	command[SMALLBUF];
 	int 	i;
+
+	upsdebug_SET_STARTING(varname, val);
 
 	for (i = 0;  vartab[i].var != NULL; i++) {
 
@@ -214,11 +220,11 @@ static int powpan_setvar(const char *varname, const char *val)
 			return STAT_SET_HANDLED;
 		}
 
-		upslogx(LOG_ERR, "%s: setting variable [%s] to [%s] failed", __func__, varname, val);
-		return STAT_SET_UNKNOWN;
+		upslog_SET_FAILED(varname, val);
+		return STAT_SET_UNKNOWN;	/* FIXME: ..._FAILED? */
 	}
 
-	upslogx(LOG_ERR, "%s: variable [%s] not found", __func__, varname);
+	upslog_SET_UNKNOWN(varname, val);
 	return STAT_SET_UNKNOWN;
 }
 

--- a/drivers/powerp-txt.c
+++ b/drivers/powerp-txt.c
@@ -156,6 +156,7 @@ static int powpan_instcmd(const char *cmdname, const char *extra)
 			continue;
 		}
 
+		upslog_INSTCMD_POWERSTATE_CHECKED(cmdname, extra);
 		if ((powpan_command(cmdtab[i].command) == 2) && (!strcasecmp(powpan_answer, "#0"))) {
 			return STAT_INSTCMD_HANDLED;
 		}
@@ -165,18 +166,21 @@ static int powpan_instcmd(const char *cmdname, const char *extra)
 	}
 
 	if (!strcasecmp(cmdname, "shutdown.return")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		if (offdelay < 60) {
 			snprintf(command, sizeof(command), "Z.%ld\r", offdelay / 6);
 		} else {
 			snprintf(command, sizeof(command), "Z%02ld\r", offdelay / 60);
 		}
 	} else if (!strcasecmp(cmdname, "shutdown.stayoff")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		if (offdelay < 60) {
 			snprintf(command, sizeof(command), "S.%ld\r", offdelay / 6);
 		} else {
 			snprintf(command, sizeof(command), "S%02ld\r", offdelay / 60);
 		}
 	} else if (!strcasecmp(cmdname, "shutdown.reboot")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		if (offdelay < 60) {
 			snprintf(command, sizeof(command), "S.%ldR%04ld\r", offdelay / 6, ondelay);
 		} else {

--- a/drivers/rhino.c
+++ b/drivers/rhino.c
@@ -663,6 +663,7 @@ static int instcmd(const char *cmdname, const char *extra)
 	if (!strcasecmp(cmdname, "shutdown.stayoff"))
 	{
 		/* shutdown now (one way) */
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		/* send_command( CMD_SHUT ); */
 		sendshut();
 		return STAT_INSTCMD_HANDLED;
@@ -671,6 +672,7 @@ static int instcmd(const char *cmdname, const char *extra)
 	if (!strcasecmp(cmdname, "load.on"))
 	{
 		/* liga Saida */
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		ret = send_command( 3 );
 		if ( ret < 1 )
 			upslogx(LOG_ERR, "send_command 3 failed");
@@ -680,6 +682,7 @@ static int instcmd(const char *cmdname, const char *extra)
 	if (!strcasecmp(cmdname, "load.off"))
 	{
 		/* desliga Saida */
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		ret = send_command( 4 );
 		if ( ret < 1 )
 			upslogx(LOG_ERR, "send_command 4 failed");
@@ -689,6 +692,7 @@ static int instcmd(const char *cmdname, const char *extra)
 	if (!strcasecmp(cmdname, "bypass.start"))
 	{
 		/* liga Bypass */
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		ret = send_command( 5 );
 		if ( ret < 1 )
 			upslogx(LOG_ERR, "send_command 5 failed");
@@ -698,6 +702,7 @@ static int instcmd(const char *cmdname, const char *extra)
 	if (!strcasecmp(cmdname, "bypass.stop"))
 	{
 		/* desliga Bypass */
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		ret = send_command( 6 );
 		if ( ret < 1 )
 			upslogx(LOG_ERR, "send_command 6 failed");

--- a/drivers/rhino.c
+++ b/drivers/rhino.c
@@ -38,7 +38,7 @@
 #include "timehead.h"
 
 #define DRIVER_NAME	"Microsol Rhino UPS driver"
-#define DRIVER_VERSION	"0.55"
+#define DRIVER_VERSION	"0.56"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -656,6 +656,10 @@ static int instcmd(const char *cmdname, const char *extra)
 {
 	ssize_t ret = 0;
 
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 	if (!strcasecmp(cmdname, "shutdown.stayoff"))
 	{
 		/* shutdown now (one way) */
@@ -700,7 +704,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/richcomm_usb.c
+++ b/drivers/richcomm_usb.c
@@ -30,7 +30,7 @@
 
 /* driver version */
 #define DRIVER_NAME	"Richcomm dry-contact to USB driver"
-#define DRIVER_VERSION	"0.14"
+#define DRIVER_VERSION	"0.15"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -716,7 +716,9 @@ void upsdrv_updateinfo(void)
 static
 int instcmd(const char *cmdname, const char *extra)
 {
+	/* May be used in logging below, but not as a command argument */
 	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
 	/* Shutdown UPS */
 	if (!strcasecmp(cmdname, "shutdown.return"))
@@ -773,7 +775,7 @@ int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/richcomm_usb.c
+++ b/drivers/richcomm_usb.c
@@ -761,6 +761,7 @@ int instcmd(const char *cmdname, const char *extra)
 		char	restart[QUERY_PACKETSIZE] = { 0x02, 0x01, 0x00, 0x00 };
 		char	reply[REPLY_PACKETSIZE];
 
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		execute_and_retrieve_query(prepare, reply);
 
 		/*

--- a/drivers/riello_ser.c
+++ b/drivers/riello_ser.c
@@ -48,7 +48,7 @@
 #include "riello.h"
 
 #define DRIVER_NAME	"Riello serial driver"
-#define DRIVER_VERSION	"0.12"
+#define DRIVER_VERSION	"0.15"
 
 #define DEFAULT_OFFDELAY   5  /*!< seconds (max 0xFF) */
 #define DEFAULT_BOOTDELAY  5  /*!< seconds (max 0xFF) */
@@ -407,6 +407,10 @@ static int riello_instcmd(const char *cmdname, const char *extra)
 	uint16_t delay;
 	const char	*delay_char;
 
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 	if (!riello_test_bit(&DevData.StatusCode[0], 1)) {
 		if (!strcasecmp(cmdname, "load.off")) {
 			delay = 0;
@@ -686,7 +690,7 @@ static int riello_instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 
@@ -1209,12 +1213,14 @@ void upsdrv_shutdown(void)
 /*
 static int setvar(const char *varname, const char *val)
 {
-	if (!strcasecmp(varname, "ups.test.interval")) {
+	upsdebug_SET_STARTING(varname, val);
+
+ 	if (!strcasecmp(varname, "ups.test.interval")) {
 		ser_send_buf(upsfd, ...);
 		return STAT_SET_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "setvar: unknown variable [%s]", varname);
+	upslog_SET_UNKNOWN(varname, val);
 	return STAT_SET_UNKNOWN;
 }
 */

--- a/drivers/riello_ser.c
+++ b/drivers/riello_ser.c
@@ -413,6 +413,8 @@ static int riello_instcmd(const char *cmdname, const char *extra)
 
 	if (!riello_test_bit(&DevData.StatusCode[0], 1)) {
 		if (!strcasecmp(cmdname, "load.off")) {
+			upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
+
 			delay = 0;
 			riello_init_serial();
 
@@ -443,6 +445,9 @@ static int riello_instcmd(const char *cmdname, const char *extra)
 
 		if (!strcasecmp(cmdname, "load.off.delay")) {
 			int	ipv;
+
+			upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
+
 			delay_char = dstate_getinfo("ups.delay.shutdown");
 			ipv = atoi(delay_char);
 			if (ipv < 0 || (intmax_t)ipv > (intmax_t)UINT16_MAX) return STAT_INSTCMD_FAILED;
@@ -475,6 +480,8 @@ static int riello_instcmd(const char *cmdname, const char *extra)
 		}
 
 		if (!strcasecmp(cmdname, "load.on")) {
+			upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
+
 			delay = 0;
 			riello_init_serial();
 
@@ -524,6 +531,9 @@ static int riello_instcmd(const char *cmdname, const char *extra)
 
 		if (!strcasecmp(cmdname, "load.on.delay")) {
 			int	ipv;
+
+			upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
+
 			delay_char = dstate_getinfo("ups.delay.reboot");
 			ipv = atoi(delay_char);
 			if (ipv < 0 || (intmax_t)ipv > (intmax_t)UINT16_MAX) return STAT_INSTCMD_FAILED;
@@ -578,6 +588,9 @@ static int riello_instcmd(const char *cmdname, const char *extra)
 	else {
 		if (!strcasecmp(cmdname, "shutdown.return")) {
 			int	ipv;
+
+			upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
+
 			delay_char = dstate_getinfo("ups.delay.shutdown");
 			ipv = atoi(delay_char);
 			if (ipv < 0 || (intmax_t)ipv > (intmax_t)UINT16_MAX) return STAT_INSTCMD_FAILED;
@@ -612,6 +625,8 @@ static int riello_instcmd(const char *cmdname, const char *extra)
 	}
 
 	if (!strcasecmp(cmdname, "shutdown.stop")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
+
 		riello_init_serial();
 
 		if (typeRielloProtocol == DEV_RIELLOGPSER)
@@ -664,6 +679,8 @@ static int riello_instcmd(const char *cmdname, const char *extra)
 	}
 
 	if (!strcasecmp(cmdname, "test.battery.start")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
+
 		riello_init_serial();
 		if (typeRielloProtocol == DEV_RIELLOGPSER)
 			length = riello_prepare_tb(bufOut, gpser_error_control);

--- a/drivers/riello_usb.c
+++ b/drivers/riello_usb.c
@@ -596,6 +596,8 @@ static int riello_instcmd(const char *cmdname, const char *extra)
 	if (!riello_test_bit(&DevData.StatusCode[0], 1)) {
 
 		if (!strcasecmp(cmdname, "load.off")) {
+			upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
+
 			delay = 0;
 
 			length = riello_prepare_cs(bufOut, gpser_error_control, delay);
@@ -622,6 +624,9 @@ static int riello_instcmd(const char *cmdname, const char *extra)
 
 		if (!strcasecmp(cmdname, "load.off.delay")) {
 			int ipv;
+
+			upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
+
 			delay_char = dstate_getinfo("ups.delay.shutdown");
 			ipv = atoi(delay_char);
 			/* With a "char" in the name, might assume we fit... but :) */
@@ -651,6 +656,8 @@ static int riello_instcmd(const char *cmdname, const char *extra)
 		}
 
 		if (!strcasecmp(cmdname, "load.on")) {
+			upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
+
 			delay = 0;
 
 			length = riello_prepare_cr(bufOut, gpser_error_control, delay);
@@ -677,6 +684,9 @@ static int riello_instcmd(const char *cmdname, const char *extra)
 
 		if (!strcasecmp(cmdname, "load.on.delay")) {
 			int ipv;
+
+			upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
+
 			delay_char = dstate_getinfo("ups.delay.reboot");
 			ipv = atoi(delay_char);
 			/* With a "char" in the name, might assume we fit... but :) */
@@ -708,6 +718,9 @@ static int riello_instcmd(const char *cmdname, const char *extra)
 	else {
 		if (!strcasecmp(cmdname, "shutdown.return")) {
 			int ipv;
+
+			upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
+
 			delay_char = dstate_getinfo("ups.delay.shutdown");
 			ipv = atoi(delay_char);
 			/* With a "char" in the name, might assume we fit... but :) */
@@ -738,6 +751,8 @@ static int riello_instcmd(const char *cmdname, const char *extra)
 	}
 
 	if (!strcasecmp(cmdname, "shutdown.stop")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
+
 		length = riello_prepare_cd(bufOut, gpser_error_control);
 		recv = riello_command(&bufOut[0], &bufIn[0], length, LENGTH_DEF);
 
@@ -784,6 +799,8 @@ static int riello_instcmd(const char *cmdname, const char *extra)
 	}
 
 	if (!strcasecmp(cmdname, "test.battery.start")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
+
 		length = riello_prepare_tb(bufOut, gpser_error_control);
 		recv = riello_command(&bufOut[0], &bufIn[0], length, LENGTH_DEF);
 

--- a/drivers/riello_usb.c
+++ b/drivers/riello_usb.c
@@ -36,7 +36,7 @@
 #include "riello.h"
 
 #define DRIVER_NAME	"Riello USB driver"
-#define DRIVER_VERSION	"0.14"
+#define DRIVER_VERSION	"0.15"
 
 #define DEFAULT_OFFDELAY   5  /*!< seconds (max 0xFF) */
 #define DEFAULT_BOOTDELAY  5  /*!< seconds (max 0xFF) */
@@ -589,6 +589,10 @@ static int riello_instcmd(const char *cmdname, const char *extra)
 	uint16_t delay;
 	const char	*delay_char;
 
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 	if (!riello_test_bit(&DevData.StatusCode[0], 1)) {
 
 		if (!strcasecmp(cmdname, "load.off")) {
@@ -802,7 +806,7 @@ static int riello_instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/safenet.c
+++ b/drivers/safenet.c
@@ -41,7 +41,7 @@
 #include "safenet.h"
 
 #define DRIVER_NAME	"Generic SafeNet UPS driver"
-#define DRIVER_VERSION	"1.82"
+#define DRIVER_VERSION	"1.83"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -176,6 +176,10 @@ static int instcmd(const char *cmdname, const char *extra)
 		return instcmd("beeper.enable", NULL);
 	}
 
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 	/*
 	 * Start the UPS selftest
 	 */
@@ -289,7 +293,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/safenet.c
+++ b/drivers/safenet.c
@@ -184,6 +184,8 @@ static int instcmd(const char *cmdname, const char *extra)
 	 * Start the UPS selftest
 	 */
 	if (!strcasecmp(cmdname, "test.battery.start")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
+
 		if (safenet_command(COM_BATT_TEST)) {
 			return STAT_INSTCMD_FAILED;
 		} else {
@@ -195,6 +197,8 @@ static int instcmd(const char *cmdname, const char *extra)
 	 * Stop the UPS selftest
 	 */
 	if (!strcasecmp(cmdname, "test.battery.stop")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
+
 		if (safenet_command(COM_STOP_TEST)) {
 			return STAT_INSTCMD_FAILED;
 		} else {
@@ -206,6 +210,8 @@ static int instcmd(const char *cmdname, const char *extra)
 	 * Start simulated mains failure
 	 */
 	if (!strcasecmp (cmdname, "test.failure.start")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
+
 		if (safenet_command(COM_MAINS_TEST)) {
 			return STAT_INSTCMD_FAILED;
 		} else {
@@ -217,6 +223,8 @@ static int instcmd(const char *cmdname, const char *extra)
 	 * Stop simulated mains failure
 	 */
 	if (!strcasecmp (cmdname, "test.failure.stop")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
+
 		if (safenet_command(COM_STOP_TEST)) {
 			return STAT_INSTCMD_FAILED;
 		} else {
@@ -270,6 +278,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		command[5] += ((offdelay % 100) / 10);
 		command[6] +=  (offdelay % 10);
 
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		safenet_command(command);
 		return STAT_INSTCMD_HANDLED;
 	}
@@ -289,6 +298,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		command[9] += ((ondelay % 100) / 10);
 		command[10] += (ondelay % 10);
 
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		safenet_command(command);
 		return STAT_INSTCMD_HANDLED;
 	}

--- a/drivers/skel.c
+++ b/drivers/skel.c
@@ -132,11 +132,13 @@ static int instcmd(const char *cmdname, const char *extra)
 	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
 	if (!strcasecmp(cmdname, "test.battery.stop")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		ser_send_buf(upsfd, ...);
 		return STAT_INSTCMD_HANDLED;
 	}
 
 	if (!strcasecmp(cmdname, "shutdown.stayoff")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		ser_send_buf(upsfd, ...);
 		return STAT_INSTCMD_HANDLED;
 	}

--- a/drivers/skel.c
+++ b/drivers/skel.c
@@ -22,7 +22,7 @@
 /* #define IGNCHARS	""	*/
 
 #define DRIVER_NAME	"Skeleton UPS driver"
-#define DRIVER_VERSION	"0.06"
+#define DRIVER_VERSION	"0.07"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -127,6 +127,10 @@ void upsdrv_shutdown(void)
 /*
 static int instcmd(const char *cmdname, const char *extra)
 {
+	/ * May be used in logging below, but not as a command argument * /
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 	if (!strcasecmp(cmdname, "test.battery.stop")) {
 		ser_send_buf(upsfd, ...);
 		return STAT_INSTCMD_HANDLED;
@@ -137,7 +141,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 */
@@ -145,12 +149,14 @@ static int instcmd(const char *cmdname, const char *extra)
 /*
 static int setvar(const char *varname, const char *val)
 {
-	if (!strcasecmp(varname, "ups.test.interval")) {
+	upsdebug_SET_STARTING(varname, val);
+
+ 	if (!strcasecmp(varname, "ups.test.interval")) {
 		ser_send_buf(upsfd, ...);
 		return STAT_SET_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "setvar: unknown variable [%s]", varname);
+	upslog_SET_UNKNOWN(varname, val);
 	return STAT_SET_UNKNOWN;
 }
 */

--- a/drivers/sms_ser.c
+++ b/drivers/sms_ser.c
@@ -258,6 +258,8 @@ static int sms_instcmd(const char *cmdname, const char *extra) {
 
     if (!strcasecmp(cmdname, "test.battery.start")) {
         long delay = extra ? strtol(extra, NULL, 10) : 10;
+
+        upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
         length = sms_prepare_test_battery_nsec(&bufOut[0], delay);
 
         if (ser_send_buf(upsfd, bufOut, length) == 0) {
@@ -269,6 +271,7 @@ static int sms_instcmd(const char *cmdname, const char *extra) {
     }
 
     if (!strcasecmp(cmdname, "test.battery.start.quick")) {
+        upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
         length = sms_prepare_test_battery_low(&bufOut[0]);
 
         if (ser_send_buf(upsfd, bufOut, length) == 0) {
@@ -281,6 +284,7 @@ static int sms_instcmd(const char *cmdname, const char *extra) {
     }
 
     if (!strcasecmp(cmdname, "test.battery.stop")) {
+        upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
         length = sms_prepare_cancel_test(&bufOut[0]);
 
         if (ser_send_buf(upsfd, bufOut, length) == 0) {
@@ -305,6 +309,7 @@ static int sms_instcmd(const char *cmdname, const char *extra) {
     }
 
     if (!strcasecmp(cmdname, "shutdown.return")) {
+        upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
         length = sms_prepare_shutdown_restore(&bufOut[0]);
 
         if (ser_send_buf(upsfd, bufOut, length) == 0) {
@@ -326,6 +331,8 @@ static int sms_instcmd(const char *cmdname, const char *extra) {
                 upsdebugx(3, "tried to set up extra shutdown.reboot delay ut it was out of range, keeping default");
             }
         }
+
+        upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
         length = sms_prepare_shutdown_nsec(&bufOut[0], delay);
 
         if (ser_send_buf(upsfd, bufOut, length) == 0) {
@@ -338,6 +345,7 @@ static int sms_instcmd(const char *cmdname, const char *extra) {
     }
 
     if (!strcasecmp(cmdname, "shutdown.stop")) {
+        upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
         length = sms_prepare_cancel_shutdown(&bufOut[0]);
 
         if (ser_send_buf(upsfd, bufOut, length) == 0) {

--- a/drivers/sms_ser.c
+++ b/drivers/sms_ser.c
@@ -30,8 +30,8 @@
 
 #define ENDCHAR '\r'
 
-#define DRIVER_NAME "SMS Brazil UPS driver"
-#define DRIVER_VERSION "1.02"
+#define DRIVER_NAME	"SMS Brazil UPS driver"
+#define DRIVER_VERSION	"1.03"
 
 #define QUERY_SIZE 7
 #define BUFFER_SIZE 18
@@ -254,6 +254,8 @@ static int get_ups_features(void) {
 static int sms_instcmd(const char *cmdname, const char *extra) {
     size_t length;
 
+    upsdebug_INSTCMD_STARTING(cmdname, extra);
+
     if (!strcasecmp(cmdname, "test.battery.start")) {
         long delay = extra ? strtol(extra, NULL, 10) : 10;
         length = sms_prepare_test_battery_nsec(&bufOut[0], delay);
@@ -347,11 +349,13 @@ static int sms_instcmd(const char *cmdname, const char *extra) {
         return STAT_INSTCMD_HANDLED;
     }
 
-    upslogx(LOG_NOTICE, "sms_instcmd: unknown command [%s]", cmdname);
+    upslog_INSTCMD_UNKNOWN(cmdname, extra);
     return STAT_INSTCMD_UNKNOWN;
 }
 
 static int sms_setvar(const char *varname, const char *val) {
+    upsdebug_SET_STARTING(varname, val);
+
     if (!strcasecmp(varname, "ups.delay.reboot")) {
         int ipv = atoi(val);
         if (ipv >= 0)
@@ -359,6 +363,8 @@ static int sms_setvar(const char *varname, const char *val) {
         dstate_setinfo("ups.delay.reboot", "%u", bootdelay);
         return STAT_SET_HANDLED;
     }
+
+    upslog_SET_UNKNOWN(varname, val);
     return STAT_SET_UNKNOWN;
 }
 

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -695,7 +695,7 @@ void upsdrv_initups(void)
 	}
 
 	if (status == TRUE)
-		upslogx(0, "Detected %s on host %s (mib: %s %s)",
+		upslogx(LOG_INFO, "Detected %s on host %s (mib: %s %s)",
 			 model, device_path, mibname, mibvers);
 	else
 		fatalx(EXIT_FAILURE, "%s MIB wasn't found on %s", mibs, g_snmp_sess.peername);

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -3921,6 +3921,7 @@ static int su_setOID(int mode, const char *varname, const char *val)
 			upsdebugx(1, "%s: cannot execute command '%s': a provided or default value is needed!", __func__, varname);
 			return STAT_SET_INVALID;
 		}
+		upslog_INSTCMD_POWERSTATE_CHECKED(varname, val);
 	}
 
 	if (su_info_p->info_flags & ST_FLAG_STRING) {

--- a/drivers/solis.c
+++ b/drivers/solis.c
@@ -48,7 +48,7 @@
 #include "timehead.h"
 
 #define DRIVER_NAME	"Microsol Solis UPS driver"
-#define DRIVER_VERSION	"0.71"
+#define DRIVER_VERSION	"0.72"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -896,6 +896,10 @@ static void get_update_info(void) {
 }
 
 static int instcmd(const char *cmdname, const char *extra) {
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 	if (!strcasecmp(cmdname, "shutdown.return")) {
 		/* shutdown and restart */
 		/* FIXME: check with HW if this is not
@@ -912,7 +916,7 @@ static int instcmd(const char *cmdname, const char *extra) {
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 
 }

--- a/drivers/solis.c
+++ b/drivers/solis.c
@@ -973,12 +973,12 @@ void upsdrv_shutdown(void) {
 	 * general handling of other `sdcommands` here */
 
 	if (!SourceFail) {     /* on line */
-		upslog_INSTCMD_POWERSTATE_CHANGE("shutdown.return", NULL);
+		upslog_INSTCMD_POWERSTATE_CHANGE("shutdown.return", (char *)NULL);
 		upslogx(LOG_NOTICE, "On line, sending shutdown+return command...\n");
 		ser_send_char(upsfd, CMD_SHUTRET );
 		/* Seems AKA: instcmd("shutdown.return", NULL); */
 	} else {
-		upslog_INSTCMD_POWERSTATE_CHANGE("shutdown.stayoff", NULL);
+		upslog_INSTCMD_POWERSTATE_CHANGE("shutdown.stayoff", (char *)NULL);
 		upslogx(LOG_NOTICE, "On battery, sending normal shutdown command...\n");
 		ser_send_char(upsfd, CMD_SHUT);
 		/* Seems AKA: instcmd("shutdown.stayoff", NULL); */

--- a/drivers/solis.c
+++ b/drivers/solis.c
@@ -904,6 +904,7 @@ static int instcmd(const char *cmdname, const char *extra) {
 		/* shutdown and restart */
 		/* FIXME: check with HW if this is not
 		 *  a "shutdown.reboot" instead (or also)? */
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		ser_send_char(upsfd, CMD_SHUTRET); /* 0xDE */
 		/* ser_send_char(upsfd, ENDCHAR); */
 		return STAT_INSTCMD_HANDLED;
@@ -911,6 +912,7 @@ static int instcmd(const char *cmdname, const char *extra) {
 
 	if (!strcasecmp(cmdname, "shutdown.stayoff")) {
 		/* shutdown now (one way) */
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		ser_send_char(upsfd, CMD_SHUT); /* 0xDD */
 		/* ser_send_char(upsfd, ENDCHAR); */
 		return STAT_INSTCMD_HANDLED;
@@ -971,10 +973,12 @@ void upsdrv_shutdown(void) {
 	 * general handling of other `sdcommands` here */
 
 	if (!SourceFail) {     /* on line */
+		upslog_INSTCMD_POWERSTATE_CHANGE("shutdown.return", NULL);
 		upslogx(LOG_NOTICE, "On line, sending shutdown+return command...\n");
 		ser_send_char(upsfd, CMD_SHUTRET );
 		/* Seems AKA: instcmd("shutdown.return", NULL); */
 	} else {
+		upslog_INSTCMD_POWERSTATE_CHANGE("shutdown.stayoff", NULL);
 		upslogx(LOG_NOTICE, "On battery, sending normal shutdown command...\n");
 		ser_send_char(upsfd, CMD_SHUT);
 		/* Seems AKA: instcmd("shutdown.stayoff", NULL); */

--- a/drivers/tripplite.c
+++ b/drivers/tripplite.c
@@ -117,7 +117,7 @@
 #include <ctype.h>
 
 #define DRIVER_NAME	"Tripp-Lite SmartUPS driver"
-#define DRIVER_VERSION	"0.97"
+#define DRIVER_VERSION	"0.98"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -235,6 +235,10 @@ static int instcmd(const char *cmdname, const char *extra)
 {
 	char buf[256];
 
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 	if (!strcasecmp(cmdname, "test.battery.start")) {
 		send_cmd(":A\r", buf, sizeof buf);
 		return STAT_INSTCMD_HANDLED;
@@ -280,12 +284,14 @@ static int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 
 static int setvar(const char *varname, const char *val)
 {
+	upsdebug_SET_STARTING(varname, val);
+
 	if (!strcasecmp(varname, "ups.delay.shutdown")) {
 		int ipv = atoi(val);
 		if (ipv >= 0)
@@ -307,6 +313,8 @@ static int setvar(const char *varname, const char *val)
 		dstate_setinfo("ups.delay.reboot", "%u", bootdelay);
 		return STAT_SET_HANDLED;
 	}
+
+	upslog_SET_UNKNOWN(varname, val);
 	return STAT_SET_UNKNOWN;
 }
 

--- a/drivers/tripplite.c
+++ b/drivers/tripplite.c
@@ -240,46 +240,57 @@ static int instcmd(const char *cmdname, const char *extra)
 	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
 	if (!strcasecmp(cmdname, "test.battery.start")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		send_cmd(":A\r", buf, sizeof buf);
 		return STAT_INSTCMD_HANDLED;
 	}
 	if (!strcasecmp(cmdname, "load.off")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		send_cmd(":K0\r", buf, sizeof buf);
 		return STAT_INSTCMD_HANDLED;
 	}
 	if (!strcasecmp(cmdname, "load.on")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		send_cmd(":K1\r", buf, sizeof buf);
 		return STAT_INSTCMD_HANDLED;
 	}
 	if (!strcasecmp(cmdname, "outlet.1.load.off")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		send_cmd(":K2\r", buf, sizeof buf);
 		return STAT_INSTCMD_HANDLED;
 	}
 	if (!strcasecmp(cmdname, "outlet.1.load.on")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		send_cmd(":K3\r", buf, sizeof buf);
 		return STAT_INSTCMD_HANDLED;
 	}
 	if (!strcasecmp(cmdname, "outlet.2.load.off")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		send_cmd(":K4\r", buf, sizeof buf);
 		return STAT_INSTCMD_HANDLED;
 	}
 	if (!strcasecmp(cmdname, "outlet.2.load.on")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		send_cmd(":K5\r", buf, sizeof buf);
 		return STAT_INSTCMD_HANDLED;
 	}
 	if (!strcasecmp(cmdname, "shutdown.reboot")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		do_reboot_now();
 		return STAT_INSTCMD_HANDLED;
 	}
 	if (!strcasecmp(cmdname, "shutdown.reboot.graceful")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		do_reboot();
 		return STAT_INSTCMD_HANDLED;
 	}
 	if (!strcasecmp(cmdname, "shutdown.return")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		soft_shutdown();
 		return STAT_INSTCMD_HANDLED;
 	}
 	if (!strcasecmp(cmdname, "shutdown.stayoff")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		hard_shutdown();
 		return STAT_INSTCMD_HANDLED;
 	}

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -513,24 +513,24 @@ static const char *hexascdump(unsigned char *msg, size_t len)
 
 static enum tl_model_t decode_protocol(unsigned int proto)
 {
-	switch(proto) {
+	switch (proto) {
 		case 0x0004:
-			upslogx(3, "Using older SMART protocol (%04x)", proto);
+			upslogx(LOG_INFO, "Using older SMART protocol (%04x)", proto);
 			return TRIPP_LITE_SMART_0004;
 		case 0x1001:
-			upslogx(3, "Using OMNIVS protocol (%x)", proto);
+			upslogx(LOG_INFO, "Using OMNIVS protocol (%x)", proto);
 			return TRIPP_LITE_OMNIVS;
 		case 0x2001:
-			upslogx(3, "Using OMNIVS 2001 protocol (%x)", proto);
+			upslogx(LOG_INFO, "Using OMNIVS 2001 protocol (%x)", proto);
 			return TRIPP_LITE_OMNIVS_2001;
 		case 0x3003:
-			upslogx(3, "Using SMARTPRO protocol (%x)", proto);
+			upslogx(LOG_INFO, "Using SMARTPRO protocol (%x)", proto);
 			return TRIPP_LITE_SMARTPRO;
 		case 0x3005:
-			upslogx(3, "Using binary SMART protocol (%x)", proto);
+			upslogx(LOG_INFO, "Using binary SMART protocol (%x)", proto);
 			return TRIPP_LITE_SMART_3005;
 		default:
-			printf("Unknown protocol (%04x)", proto);
+			upslogx(LOG_INFO, "Unknown protocol (%04x)", proto);
 			break;
 	}
 
@@ -576,7 +576,7 @@ static void decode_v(const unsigned char *value)
 			  break;
 
 		default:
-			  upslogx(2, "Unknown input voltage range: 0x%02x", (unsigned int)ivn);
+			  upslogx(LOG_WARNING, "Unknown input voltage range: 0x%02x", (unsigned int)ivn);
 			  break;
 	}
 
@@ -587,7 +587,7 @@ static void decode_v(const unsigned char *value)
 			switchable_load_banks = lb;
 		} else {
 			if( lb != 'X' ) {
-				upslogx(2, "Unknown number of switchable load banks: 0x%02x",
+				upslogx(LOG_WARNING, "Unknown number of switchable load banks: 0x%02x",
 					(unsigned int)lb);
 			}
 		}
@@ -689,7 +689,7 @@ static int send_cmd(const unsigned char *msg, size_t msg_len, unsigned char *rep
 			(usb_ctrl_charbufsize)sizeof(buffer_out));
 
 		if(ret != sizeof(buffer_out)) {
-			upslogx(1, "libusb_set_report() returned %d instead of %" PRIuSIZE,
+			upsdebugx(3, "libusb_set_report() returned %d instead of %" PRIuSIZE,
 				ret, sizeof(buffer_out));
 			return ret;
 		}
@@ -705,7 +705,7 @@ static int send_cmd(const unsigned char *msg, size_t msg_len, unsigned char *rep
 				(usb_ctrl_charbufsize)sizeof(buffer_out),
 				RECV_WAIT_MSEC);
 			if(ret != sizeof(buffer_out)) {
-				upslogx(1, "libusb_get_interrupt() returned %d instead of %u while sending %s",
+				upsdebugx(3, "libusb_get_interrupt() returned %d instead of %u while sending %s",
 					ret, (unsigned)(sizeof(buffer_out)),
 					hexascdump(buffer_out, sizeof(buffer_out)));
 			}
@@ -1088,7 +1088,7 @@ void upsdrv_initinfo(void)
 				fatalx(EXIT_FAILURE, "Could not reset watchdog. Please check and"
 						"see if usbhid-ups(8) works with this UPS.");
 			} else {
-				upslogx(3, "Could not reset watchdog. Please send model "
+				upslogx(LOG_ERR, "Could not reset watchdog. Please send model "
 						"information to nut-upsdev mailing list");
 			}
 		}
@@ -1677,7 +1677,7 @@ void upsdrv_initups(void)
 
 	hd = &curDevice;
 
-	upslogx(1, "Detected a UPS: %s/%s", hd->Vendor ? hd->Vendor : "unknown", hd->Product ? hd->Product : "unknown");
+	upslogx(LOG_INFO, "Detected a UPS: %s/%s", hd->Vendor ? hd->Vendor : "unknown", hd->Product ? hd->Product : "unknown");
 
 	dstate_setinfo("ups.vendorid", "%04x", hd->VendorID);
 	dstate_setinfo("ups.productid", "%04x", hd->ProductID);

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -926,37 +926,44 @@ static int instcmd(const char *cmdname, const char *extra)
 
 	if (is_smart_protocol()) {
 		if (!strcasecmp(cmdname, "test.battery.start")) {
+			upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 			send_cmd((const unsigned char *)"A", 2, buf, sizeof buf);
 			return STAT_INSTCMD_HANDLED;
 		}
 
-		if(!strcasecmp(cmdname, "reset.input.minmax")) {
+		if (!strcasecmp(cmdname, "reset.input.minmax")) {
 			return (send_cmd((const unsigned char *)"Z", 2, buf, sizeof buf) == 2) ? STAT_INSTCMD_HANDLED : STAT_INSTCMD_UNKNOWN;
 		}
 	}
 
 	if (!strcasecmp(cmdname, "load.off")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		return control_outlet(0, 0) ? STAT_INSTCMD_HANDLED : STAT_INSTCMD_UNKNOWN;
 	}
 	if (!strcasecmp(cmdname, "load.on")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		return control_outlet(0, 1) ? STAT_INSTCMD_HANDLED : STAT_INSTCMD_UNKNOWN;
 	}
 	/* code for individual outlets is in setvar() */
 #if 0
 	if (!strcasecmp(cmdname, "shutdown.reboot")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		do_reboot_now();
 		return STAT_INSTCMD_HANDLED;
 	}
 	if (!strcasecmp(cmdname, "shutdown.reboot.graceful")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		do_reboot();
 		return STAT_INSTCMD_HANDLED;
 	}
 	if (!strcasecmp(cmdname, "shutdown.stayoff")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		hard_shutdown();
 		return STAT_INSTCMD_HANDLED;
 	}
 #endif
 	if (!strcasecmp(cmdname, "shutdown.return")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		soft_shutdown();
 		return STAT_INSTCMD_HANDLED;
 	}

--- a/drivers/tripplitesu.c
+++ b/drivers/tripplitesu.c
@@ -126,7 +126,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"Tripp Lite SmartOnline driver"
-#define DRIVER_VERSION	"0.09"
+#define DRIVER_VERSION	"0.10"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -472,6 +472,10 @@ static int instcmd(const char *cmdname, const char *extra)
 	int i;
 	char parm[20];
 
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 	if (!strcasecmp(cmdname, "load.off")) {
 		for (i = 0; i < ups.outlet_banks; i++) {
 			snprintf(parm, sizeof(parm), "%d;1", i + 1);
@@ -523,12 +527,14 @@ static int instcmd(const char *cmdname, const char *extra)
 		do_command(SET, TEST, "0", NULL);
 		return STAT_INSTCMD_HANDLED;
 	}
-	upslogx(LOG_NOTICE, "instcmd: unknown command [%s] [%s]", cmdname, extra);
+
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 
 static int setvar(const char *varname, const char *val)
 {
+	upsdebug_SET_STARTING(varname, val);
 
 	if (!strcasecmp(varname, "ups.id")) {
 		set_identification(val);
@@ -551,7 +557,7 @@ static int setvar(const char *varname, const char *val)
 		return STAT_SET_HANDLED;
 	}
 
-	upslogx(LOG_NOTICE, "setvar: unknown var [%s]", varname);
+	upslog_SET_UNKNOWN(varname, val);
 	return STAT_SET_UNKNOWN;
 }
 

--- a/drivers/tripplitesu.c
+++ b/drivers/tripplitesu.c
@@ -477,6 +477,7 @@ static int instcmd(const char *cmdname, const char *extra)
 	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
 	if (!strcasecmp(cmdname, "load.off")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		for (i = 0; i < ups.outlet_banks; i++) {
 			snprintf(parm, sizeof(parm), "%d;1", i + 1);
 			do_command(SET, RELAY_OFF, parm, NULL);
@@ -484,6 +485,7 @@ static int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 	if (!strcasecmp(cmdname, "load.on")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		for (i = 0; i < ups.outlet_banks; i++) {
 			snprintf(parm, sizeof(parm), "%d;1", i + 1);
 			do_command(SET, RELAY_ON, parm, NULL);
@@ -491,18 +493,21 @@ static int instcmd(const char *cmdname, const char *extra)
 		return STAT_INSTCMD_HANDLED;
 	}
 	if (!strcasecmp(cmdname, "shutdown.reboot")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		auto_reboot(1);
 		do_command(SET, TSU_SHUTDOWN_RESTART, "1", NULL);
 		do_command(SET, TSU_SHUTDOWN_ACTION, "10", NULL);
 		return STAT_INSTCMD_HANDLED;
 	}
 	if (!strcasecmp(cmdname, "shutdown.reboot.graceful")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		auto_reboot(1);
 		do_command(SET, TSU_SHUTDOWN_RESTART, "1", NULL);
 		do_command(SET, TSU_SHUTDOWN_ACTION, "60", NULL);
 		return STAT_INSTCMD_HANDLED;
 	}
 	if (!strcasecmp(cmdname, "shutdown.return")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		auto_reboot(1);
 		do_command(SET, TSU_SHUTDOWN_RESTART, "1", NULL);
 		do_command(SET, TSU_SHUTDOWN_ACTION, "10", NULL);
@@ -510,20 +515,24 @@ static int instcmd(const char *cmdname, const char *extra)
 	}
 #if 0 /* doesn't seem to work */
 	if (!strcasecmp(cmdname, "shutdown.stayoff")) {
+		upslog_INSTCMD_POWERSTATE_CHANGE(cmdname, extra);
 		auto_reboot(0);
 		do_command(SET, TSU_SHUTDOWN_ACTION, "10", NULL);
 		return STAT_INSTCMD_HANDLED;
 	}
 #endif
 	if (!strcasecmp(cmdname, "shutdown.stop")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		do_command(SET, TSU_SHUTDOWN_ACTION, "0", NULL);
 		return STAT_INSTCMD_HANDLED;
 	}
 	if (!strcasecmp(cmdname, "test.battery.start")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		do_command(SET, TEST, "3", NULL);
 		return STAT_INSTCMD_HANDLED;
 	}
 	if (!strcasecmp(cmdname, "test.battery.stop")) {
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		do_command(SET, TEST, "0", NULL);
 		return STAT_INSTCMD_HANDLED;
 	}

--- a/drivers/upscode2.c
+++ b/drivers/upscode2.c
@@ -43,7 +43,7 @@
 #include "nut_float.h"
 
 #define DRIVER_NAME	"UPScode II UPS driver"
-#define DRIVER_VERSION	"0.93"
+#define DRIVER_VERSION	"0.94"
 
 /* driver description structure */
 upsdrv_info_t	upsdrv_info = {
@@ -907,7 +907,7 @@ static int instcmd (const char *auxcmd, const char *data)
 		return instcmd("beeper.enable", NULL);
 	}
 
-	upsdebugx(1, "Instcmd: %s %s", auxcmd, data ? data : "\"\"");
+	upsdebug_INSTCMD_STARTING(auxcmd, (data ? data : "\"\""));
 
 	for (cp = commands; cp->cmd; cp++) {
 		if (strcasecmp(cp->cmd, auxcmd)) {
@@ -922,7 +922,7 @@ static int instcmd (const char *auxcmd, const char *data)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upslogx(LOG_INFO, "instcmd: unknown command %s", auxcmd);
+	upslog_INSTCMD_UNKNOWN(auxcmd, data);
 	return STAT_INSTCMD_UNKNOWN;
 }
 
@@ -931,7 +931,7 @@ static int setvar (const char *var, const char *data)
 {
 	cmd_t *cp;
 
-	upsdebugx(1, "Setvar: %s %s", var, data);
+	upsdebug_SET_STARTING(var, data);
 
 	for (cp = variables; cp->cmd; cp++) {
 		if (strcasecmp(cp->cmd, var)) {
@@ -941,7 +941,8 @@ static int setvar (const char *var, const char *data)
 		return STAT_SET_HANDLED;
 	}
 
-	upslogx(LOG_INFO, "Setvar: unsettable variable %s", var);
+	upslogx(LOG_SET_UNKNOWN, "%s: unsettable variable %s",
+		__func__, NUT_STRARG(var));
 	return STAT_SET_UNKNOWN;
 }
 

--- a/drivers/upscode2.c
+++ b/drivers/upscode2.c
@@ -913,6 +913,9 @@ static int instcmd (const char *auxcmd, const char *data)
 		if (strcasecmp(cp->cmd, auxcmd)) {
 			continue;
 		}
+
+		upslog_INSTCMD_POWERSTATE_CHECKED(auxcmd, data);
+
 		upscsend(cp->upsc);
 		if (cp->upsp) {
 			upscsend(cp->upsp);

--- a/drivers/upshandler.h
+++ b/drivers/upshandler.h
@@ -1,6 +1,7 @@
 /* upshandler.h - function callbacks used by the drivers
 
    Copyright (C) 2003  Russell Kroll <rkroll@exploits.org>
+   Copyright (C) 2025  Jim Klimov <jimklimov+nut@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -44,5 +45,129 @@ struct ups_handler
 	int	(*setvar)(const char *, const char *);
 	int	(*instcmd)(const char *, const char *);
 };
+
+/* Log levels; packagers might want to fiddle with NOTICE vs. WARN or ERR,
+ * maybe even CRIT for shutdown commands?.. or we might eventually tie this
+ * into nut_debug_level run-time verbosity.
+ * Up to NUT v2.8.3 everything was LOG_NOTICE except in a few drivers.
+ * Conversion to these macros allows all drivers to behave consistently.
+ */
+#ifndef UPSHANDLER_LOGLEVEL_DIFFERENTIATE
+# define UPSHANDLER_LOGLEVEL_DIFFERENTIATE	1 /* 0 to LOG_NOTICE everything by default */
+#endif
+
+#ifndef LOG_INSTCMD_UNKNOWN
+# if UPSHANDLER_LOGLEVEL_DIFFERENTIATE
+#  define	LOG_INSTCMD_UNKNOWN	LOG_WARNING
+# else
+#  define	LOG_INSTCMD_UNKNOWN	LOG_NOTICE
+# endif
+#endif
+
+#ifndef LOG_INSTCMD_INVALID
+# if UPSHANDLER_LOGLEVEL_DIFFERENTIATE
+#  define	LOG_INSTCMD_INVALID	LOG_WARNING
+# else
+#  define	LOG_INSTCMD_INVALID	LOG_NOTICE
+# endif
+#endif
+
+#ifndef LOG_INSTCMD_FAILED
+# if UPSHANDLER_LOGLEVEL_DIFFERENTIATE
+#  define	LOG_INSTCMD_FAILED	LOG_ERR
+# else
+#  define	LOG_INSTCMD_FAILED	LOG_NOTICE
+# endif
+#endif
+
+#ifndef LOG_INSTCMD_CONVERSION_FAILED
+# if UPSHANDLER_LOGLEVEL_DIFFERENTIATE
+#  define	LOG_INSTCMD_CONVERSION_FAILED	LOG_ERR
+# else
+#  define	LOG_INSTCMD_CONVERSION_FAILED	LOG_WARNING
+# endif
+#endif
+
+/* FIXME: Define here and apply in drivers log levels for mere HANDLED
+ *  states (INFO), and for instcmd about shutdowns (CRIT) in particular;
+ *  see bestfortress.c for some practical inspiration.
+ */
+
+#ifndef LOG_SET_UNKNOWN
+# if UPSHANDLER_LOGLEVEL_DIFFERENTIATE
+#  define	LOG_SET_UNKNOWN	LOG_WARNING
+# else
+#  define	LOG_SET_UNKNOWN	LOG_NOTICE
+# endif
+#endif
+
+#ifndef LOG_SET_INVALID
+# if UPSHANDLER_LOGLEVEL_DIFFERENTIATE
+#  define	LOG_SET_INVALID	LOG_WARNING
+# else
+#  define	LOG_SET_INVALID	LOG_NOTICE
+# endif
+#endif
+
+#ifndef LOG_SET_FAILED
+# if UPSHANDLER_LOGLEVEL_DIFFERENTIATE
+#  define	LOG_SET_FAILED	LOG_ERR
+# else
+#  define	LOG_SET_FAILED	LOG_NOTICE
+# endif
+#endif
+
+#ifndef LOG_SET_CONVERSION_FAILED
+# if UPSHANDLER_LOGLEVEL_DIFFERENTIATE
+#  define	LOG_SET_CONVERSION_FAILED	LOG_ERR
+# else
+#  define	LOG_SET_CONVERSION_FAILED	LOG_WARNING
+# endif
+#endif
+
+/* Call upslogx() with certain log level and wording/markup, so different
+ * driver programs present a consistent picture to their end-users.
+ */
+/* instcmd(), upscmd() et al -- note an argument is optional: */
+#define upsdebug_INSTCMD_STARTING(cmdname, extra)	do {		\
+	upsdebugx(1, "Starting %s::%s('%s', '%s')",		\
+		__FILE__, __func__, NUT_STRARG(cmdname), NUT_STRARG(extra));	\
+	} while(0)
+
+#define upslog_INSTCMD_UNKNOWN(cmdname, extra)	do {		\
+	upslogx(LOG_INSTCMD_UNKNOWN, "%s: unknown command [%s] [%s]",	\
+		__func__, NUT_STRARG(cmdname), NUT_STRARG(extra));	\
+	} while(0)
+
+#define upslog_INSTCMD_INVALID(cmdname, extra)	do {		\
+	upslogx(LOG_INSTCMD_INVALID, "%s: parameter [%s] is invalid for command [%s]",	\
+		__func__, NUT_STRARG(extra), NUT_STRARG(cmdname));	\
+	} while(0)
+
+#define upslog_INSTCMD_FAILED(cmdname, extra)	do {		\
+	upslogx(LOG_INSTCMD_FAILED, "%s: FAILED command [%s] [%s]",	\
+		__func__, NUT_STRARG(cmdname), NUT_STRARG(extra));	\
+	} while(0)
+
+/* setvar(), setcmd() et al -- note they MUST have an argument: */
+#define upsdebug_SET_STARTING(varname, value)	do {		\
+	upsdebugx(1, "Starting %s::%s('%s', '%s')",		\
+		__FILE__, __func__, NUT_STRARG(varname), NUT_STRARG(value));	\
+	} while(0)
+
+#define upslog_SET_UNKNOWN(varname, value)	do {		\
+	upslogx(LOG_SET_UNKNOWN, "%s: unknown variable [%s] [%s]",	\
+		__func__, NUT_STRARG(varname), NUT_STRARG(value));	\
+	} while(0)
+
+#define upslog_SET_INVALID(varname, value)	do {		\
+	upslogx(LOG_SET_INVALID, "%s: value [%s] is invalid for variable [%s]",	\
+		__func__, NUT_STRARG(value), NUT_STRARG(varname));	\
+	} while(0)
+
+#define upslog_SET_FAILED(varname, value)	do {		\
+	upslogx(LOG_SET_FAILED, "%s: FAILED to set variable [%s] to value [%s]",	\
+		__func__, NUT_STRARG(varname), NUT_STRARG(value));	\
+	} while(0)
 
 #endif /* NUT_UPSHANDLER_H */

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -1813,7 +1813,7 @@ static int callback(
 		return 0;
 	}
 
-	upslogx(2, "Using subdriver: %s", subdriver->name);
+	upslogx(LOG_INFO, "Using subdriver: %s", subdriver->name);
 
 	if (subdriver->fix_report_desc(arghd, pDesc)) {
 		upsdebugx(2, "Report Descriptor Fixed");

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -29,7 +29,7 @@
  */
 
 #define DRIVER_NAME	"Generic HID driver"
-#define DRIVER_VERSION	"0.64"
+#define DRIVER_VERSION	"0.65"
 
 #define HU_VAR_WAITBEFORERECONNECT "waitbeforereconnect"
 
@@ -836,9 +836,7 @@ int instcmd(const char *cmdname, const char *extradata)
 		return instcmd("beeper.enable", NULL);
 	}
 
-	upsdebugx(1, "instcmd(%s, %s)",
-		cmdname,
-		extradata ? extradata : "[NULL]");
+	upsdebug_INSTCMD_STARTING(cmdname, extradata);
 
 	/* Retrieve and check netvar & item_path */
 	hidups_item = find_nut_info(cmdname);
@@ -900,7 +898,9 @@ int instcmd(const char *cmdname, const char *extradata)
 			return instcmd("load.off.delay", dstate_getinfo("ups.delay.shutdown"));
 		}
 
+		/* FIXME: ..._UNKNOWN? */
 		upsdebugx(2, "instcmd: info element unavailable %s", cmdname);
+		upslog_INSTCMD_INVALID(cmdname, extradata);
 		return STAT_INSTCMD_INVALID;
 	}
 
@@ -948,7 +948,8 @@ int instcmd(const char *cmdname, const char *extradata)
 		return STAT_INSTCMD_HANDLED;
 	}
 
-	upsdebugx(3, "instcmd: FAILED"); /* TODO: HANDLED but FAILED, not UNKNOWN! */
+	/* upsdebugx(3, "instcmd: FAILED"); / * FIXME: return HANDLED but FAILED, not UNKNOWN! */
+	upslog_INSTCMD_FAILED(cmdname, extradata);
 	return STAT_INSTCMD_FAILED;
 }
 
@@ -958,13 +959,14 @@ int setvar(const char *varname, const char *val)
 	hid_info_t	*hidups_item;
 	double		value;
 
-	upsdebugx(1, "setvar(%s, %s)", varname, val);
+	upsdebug_SET_STARTING(varname, val);
 
 	/* retrieve and check netvar & item_path */
 	hidups_item = find_nut_info(varname);
 
 	if (hidups_item == NULL) {
 		upsdebugx(2, "setvar: info element unavailable %s", varname);
+		upslog_SET_UNKNOWN(varname, val);
 		return STAT_SET_UNKNOWN;
 	}
 
@@ -1002,7 +1004,8 @@ int setvar(const char *varname, const char *val)
 		return STAT_SET_HANDLED;
 	}
 
-	upsdebugx(3, "setvar: FAILED"); /* FIXME: HANDLED but FAILED, not UNKNOWN! */
+	/* upsdebugx(3, "setvar: FAILED"); / * FIXME: return HANDLED but FAILED, not UNKNOWN! */
+	upslog_SET_FAILED(varname, val);
 	return STAT_SET_UNKNOWN;
 }
 

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -843,6 +843,8 @@ int instcmd(const char *cmdname, const char *extradata)
 
 	/* Check for fallback if not found */
 	if (hidups_item == NULL) {
+		/* Process alias/fallback names */
+
 		upsdebugx(3, "%s: cmdname '%s' not found; "
 			"checking for alternatives",
 			__func__, cmdname);
@@ -940,7 +942,14 @@ int instcmd(const char *cmdname, const char *extradata)
 		value = atol(val);
 	}
 
-	/* Actual variable setting */
+	/* Actual variable setting (as far as firmware is concerned) */
+	{	/* scoping + workaround for "error: the address of `argtmp` will always evaluate as `true`" */
+		char	argtmp[LARGEBUF], *s = NULL;
+		if (snprintf(argtmp, sizeof(argtmp), "%s (%f)",
+			NUT_STRARG(extradata), value) > 0)
+			s = argtmp;
+		upslog_INSTCMD_POWERSTATE_CHECKED(cmdname, s);
+	}
 	if (HIDSetDataValue(udev, hidups_item->hiddata, value) == 1) {
 		upsdebugx(3, "instcmd: SUCCEED");
 		/* Set the status so that SEMI_STATIC vars are polled */

--- a/drivers/ve-direct.c
+++ b/drivers/ve-direct.c
@@ -68,7 +68,7 @@ static int ve_process_text_buffer(void)
 	ch = ~ch + 1;
 	if (ch != checksum[9])
 	{
-		upslogx(1, "invalid checksum: %d %d", ch, checksum[9]);
+		upsdebugx(1, "invalid checksum: %d %d", ch, checksum[9]);
 		ve_copy(checksum + 10);
 		return 0;
 	}

--- a/drivers/ve-direct.c
+++ b/drivers/ve-direct.c
@@ -22,7 +22,7 @@
 #include "serial.h"
 
 #define DRIVER_NAME	"Victron Energy Direct UPS and solar controller driver"
-#define DRIVER_VERSION	"0.21"
+#define DRIVER_VERSION	"0.22"
 
 #define VE_GET	7
 #define VE_SET	8
@@ -187,7 +187,7 @@ static int ve_command(const char ve_cmd, const char *ve_extra, char *ve_return, 
 		}
 		else
 		{
-			upslogx(1, "invalid checksum on reply to command %c", line[1]);
+			upslogx(LOG_INSTCMD_FAILED, "invalid checksum on reply to command %c", line[1]);
 			return STAT_INSTCMD_FAILED;
 		}
 
@@ -211,6 +211,8 @@ static int ve_command(const char ve_cmd, const char *ve_extra, char *ve_return, 
 
 static int instcmd(const char *cmdname, const char *extra)
 {
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
+
 	/* experimental: many of the names below are not among
 	 * standard docs/nut-names.txt
 	 */
@@ -224,7 +226,8 @@ static int instcmd(const char *cmdname, const char *extra)
 		return ve_command(VE_SET, "FCEE0000", NULL, 0);
 	if (!strcasecmp(cmdname, "beeper.enable"))
 		return ve_command(VE_SET, "FCEE0001", NULL, 0);
-	upsdebugx(1, "instcmd: unknown command: %s", cmdname);
+
+	upslog_INSTCMD_UNKNOWN(cmdname, extra);
 	return STAT_INSTCMD_UNKNOWN;
 }
 

--- a/drivers/victronups.c
+++ b/drivers/victronups.c
@@ -106,6 +106,7 @@ static int instcmd(const char *cmdname, const char *extra)
 
 	if(!strcasecmp(cmdname, "calibrate.start"))
 	{
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		if(get_data("vTi5!",temp))
 		{
 			upsdebugx(1, "instcmd: ser_send calibrate.start failed");
@@ -120,6 +121,7 @@ static int instcmd(const char *cmdname, const char *extra)
 	}
 	else if(!strcasecmp(cmdname, "calibrate.stop"))
 	{
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		if(get_data("vTi2!",temp))
 		{
 			upsdebugx(1, "instcmd: ser_send calibrate.stop failed");
@@ -133,6 +135,7 @@ static int instcmd(const char *cmdname, const char *extra)
 	}
 	else if(!strcasecmp(cmdname, "test.battery.stop"))
 	{
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		if(get_data("vTi2!",temp))
 		{
 			upsdebugx(1, "instcmd: ser_send test.battery.stop failed");
@@ -146,6 +149,7 @@ static int instcmd(const char *cmdname, const char *extra)
 	}
 	else if(!strcasecmp(cmdname, "test.battery.start"))
 	{
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		if(get_data("vTi4!",temp))
 		{
 			upsdebugx(1, "instcmd: ser_send test.battery.start failed");
@@ -187,6 +191,7 @@ static int instcmd(const char *cmdname, const char *extra)
 	}
 	else if(!strcasecmp(cmdname, "bypass.stop"))
 	{
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		if(get_data("vTi2!",temp))
 		{
 			upsdebugx(1, "instcmd: ser_send bypass.stop failed");
@@ -200,6 +205,7 @@ static int instcmd(const char *cmdname, const char *extra)
 	}
 	else if(!strcasecmp(cmdname, "bypass.start"))
 	{
+		upslog_INSTCMD_POWERSTATE_MAYBE(cmdname, extra);
 		if(get_data("vTi101!",temp))
 		{
 			upsdebugx(1, "instcmd: ser_send bypass.start failed");

--- a/drivers/victronups.c
+++ b/drivers/victronups.c
@@ -32,7 +32,7 @@
 #include "serial.h"
 
 #define DRIVER_NAME	"GE/IMV/Victron UPS driver"
-#define DRIVER_VERSION	"0.24"
+#define DRIVER_VERSION	"0.25"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -99,6 +99,10 @@ static int get_data (const char *out_string, char *in_string)
 static int instcmd(const char *cmdname, const char *extra)
 {
 	char temp[ LENGTH_TEMP ];
+
+	/* May be used in logging below, but not as a command argument */
+	NUT_UNUSED_VARIABLE(extra);
+	upsdebug_INSTCMD_STARTING(cmdname, extra);
 
 	if(!strcasecmp(cmdname, "calibrate.start"))
 	{
@@ -210,7 +214,7 @@ static int instcmd(const char *cmdname, const char *extra)
 	}
 	else
 	{
-		upsdebugx(1, "instcmd: unknown command: [%s] [%s]", cmdname, extra);
+		upslog_INSTCMD_UNKNOWN(cmdname, extra);
 		return STAT_INSTCMD_UNKNOWN;
 	}
 }


### PR DESCRIPTION
Follows up from #2955 to consistently log instant command and variable setting, so drivers differ less for end-user experience.

Previously all drivers tended to do this differently, which made troubleshooting harder. Now they would all follow the same logic and message structure, at least in broad strokes, and specifically would try to `upslog*()` => syslog any operations that can impact power delivery to the useful load. So if a system crashes with a self-inflicted power outage, there's a chance it would have already recorded why.

While here, also identified some cases where `upslog*()` methods' first argument was a number, not a syslog macro name. Probably some time ago someone could not choose between `upslogx()` and `upsdebugx()`?..

NOTE: Code of these methods is peppered with TODO/FIXME comments regarding cleaner use of return codes (INVALID/UNKNOWN/FAILED/...) where apparently some reply types in headers and dstate (and data server side) appeared later than these methods. This was largely ignored and may be a focus of another PR eventually; some more such comments were added where the current responses seemed imperfect, however this was on a best-effort basis when something caught my eye, so probably some similar cases were missed.