### PR TITLE
Help users address bad state files

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -74,6 +74,8 @@ https://github.com/networkupstools/nut/milestone/9
      potential for buffer overflow. [#2915]
 
  - common driver code:
+   * Update reports of failed socket file creation, to help troubleshooting
+     some error cases in the field.
    * Removed workarounds trying to migrate legacy driver raised `ALARM`
      status tokens into modern `alarm_*` function logic. Rather, we keep
      supporting them as separate from the modern logic, seeing as `upsmon`

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -113,6 +113,14 @@ static void sock_fail(const char *fn)
 		printf(" - mkdir %s\n", dflt_statepath());
 		break;
 
+	case EADDRINUSE:
+	case EADDRNOTAVAIL:
+		printf("\nThings to try:\n\n");
+		printf(" - ps -ef | grep '%s'\n   To check if another copy of the driver is running; if not:\n\n", progname);
+		printf(" - ls -la %s\n   To check if a (non-socket) filesystem object already exists there\n\n", fn);
+		printf(" - rm -rf %s\n   To remove any offending files (a new driver instance creates its own)\n", fn);
+		break;
+
 	default:
 		break;
 	}

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -79,24 +79,27 @@ static void sock_fail(const char *fn)
 	printf("\nFatal error: unable to create listener socket\n\n");
 	printf("bind %s failed: %s\n", fn, strerror(sockerr));
 
-	pwuser = getpwuid(getuid());
-
-	if (!pwuser) {
-		fatal_with_errno(EXIT_FAILURE, "getpwuid");
-	}
-
 	/* deal with some common problems */
 	switch (errno)
 	{
 	case EACCES:
-		printf("\nCurrent user: %s (UID %d)\n\n",
-			pwuser->pw_name, (int)pwuser->pw_uid);
+		pwuser = getpwuid(getuid());
+
+		if (pwuser) {
+			printf("\nCurrent user: %s (UID %" PRIiMAX ")\n\n",
+				NUT_STRARG(pwuser->pw_name),
+				(intmax_t)pwuser->pw_uid);
+		}
 
 		printf("Things to try:\n\n");
 		printf(" - set different owners or permissions on %s\n\n",
 			dflt_statepath());
-		printf(" - run this as some other user "
+		printf(" - run this program as some other user "
 			"(try -u <username>)\n");
+
+		if (!pwuser) {
+			fatal_with_errno(EXIT_FAILURE, "getpwuid");
+		}
 		break;
 
 	case ENOENT:

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -116,7 +116,10 @@ static void sock_fail(const char *fn)
 	case EADDRINUSE:
 	case EADDRNOTAVAIL:
 		printf("\nThings to try:\n\n");
-		printf(" - ps -ef | grep '%s'\n   To check if another copy of the driver is running; if not:\n\n", progname);
+		printf(" - ps -ef | grep '%s'\t(Linux, GNU userland)\n"
+		       " - ps -xawwu | grep '%s'\t(BSD, Solaris, embedded)\n"
+		       "   To check if another copy of the driver is running; if not:\n\n",
+		       progname, progname);
 		printf(" - ls -la %s\n   To check if a (non-socket) filesystem object already exists there\n\n", fn);
 		printf(" - rm -rf %s\n   To remove any offending files (a new driver instance creates its own)\n", fn);
 		break;


### PR DESCRIPTION
As recently noted in the mailing list discussion, it is possible to shoot oneself in the foot by pre-creating the state files (e.g. local unix socket) just because driver logs mention that one is absent. This PR should help the users fix their foot back :)

````
:; mkdir /tmp/dummy-ups-test
:; NUT_STATEPATH=/tmp ./drivers/dummy-ups -s test -x port= -DDDDDD
...
   1.001350     [D5] send_to_all: SETINFO driver.state "init.quiet"

Fatal error: unable to create listener socket

bind /tmp/dummy-ups-test failed: Address already in use

Things to try:

 - ps -ef | grep 'dummy-ups'    (Linux, GNU userland)
 - ps -xawwu | grep 'dummy-ups' (BSD, Solaris, embedded)
   To check if another copy of the driver is running; if not:

 - ls -la /tmp/dummy-ups-test
   To check if a (non-socket) filesystem object already exists there

 - rm -rf /tmp/dummy-ups-test
   To remove any offending files (a new driver instance creates its own)

   1.001437     Exiting.
...
````