### PR TITLE
drivers/main.c, drivers/dummy-ups.c: fix memory issues

### DIFF
--- a/drivers/dummy-ups.c
+++ b/drivers/dummy-ups.c
@@ -564,22 +564,26 @@ void upsdrv_initups(void)
 
 void upsdrv_cleanup(void)
 {
-	if ( (mode == MODE_META) || (mode == MODE_REPEATER) )
-	{
-		if (ups)
-		{
-			upscli_disconnect(ups);
-		}
-
-		free(client_upsname);
-		free(hostname);
+	if (ups) {
+		upscli_disconnect(ups);
 		free(ups);
+		ups = NULL;
 	}
 
-	if (ctx)
-	{
+	if (client_upsname) {
+		free(client_upsname);
+		client_upsname = NULL;
+	}
+
+	if (hostname) {
+		free(hostname);
+		hostname = NULL;
+	}
+
+	if (ctx) {
 		pconf_finish(ctx);
 		free(ctx);
+		ctx = NULL;
 	}
 }
 

--- a/drivers/dummy-ups.c
+++ b/drivers/dummy-ups.c
@@ -571,15 +571,15 @@ void upsdrv_cleanup(void)
 			upscli_disconnect(ups);
 		}
 
-		if (ctx)
-		{
-			pconf_finish(ctx);
-			free(ctx);
-		}
-
 		free(client_upsname);
 		free(hostname);
 		free(ups);
+	}
+
+	if (ctx)
+	{
+		pconf_finish(ctx);
+		free(ctx);
 	}
 }
 

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -1792,11 +1792,16 @@ static void splitxarg(char *inbuf)
 	}
 
 	/* see if main handles this first */
-	if (main_arg(buf, val))
+	if (main_arg(buf, val)) {
+		free(buf);
+
 		return;
+	}
 
 	/* otherwise store it for later */
 	storeval(buf, val);
+
+	free(buf);
 }
 
 /* dump the list from the vartable for external parsers */


### PR DESCRIPTION
I ran into these with a failed `dummy-ups` startup, was not sure if warranting a bumped driver subversion:

- `drivers/main.c`: `splitxarg()` did not free an allocated temporary buffer after either early or normal return from func.
- `drivers/dummy-ups.c`: `upsdrv_cleanup()` mode conditional logic prevented `ctx` to be freed on early stage `fatalx`, before it could be freed in the regular updating loop due to idleness, should be freed regardless of mode if not `NULL`.

```
==2634263== Memcheck, a memory error detector
==2634263== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==2634263== Using Valgrind-3.25.0 and LibVEX; rerun with -h for copyright info
==2634263== Command: /usr/bin/dummy-ups -s abc -x port=auto
==2634263== 
Network UPS Tools 2.8.3.1 (development iteration after 2.8.3) - Device simulation and repeater driver 0.22
Can't open dummy-ups definition file /etc/nut/auto: Can't open /etc/nut/auto: No such file or directory
==2634263== 
==2634263== HEAP SUMMARY:
==2634263==     in use at exit: 26,674 bytes in 4 blocks
==2634263==   total heap usage: 215 allocs, 211 frees, 71,045 bytes allocated
==2634263== 
==2634263== 10 bytes in 1 blocks are definitely lost in loss record 1 of 4
==2634263==    at 0x48497C4: malloc (vg_replace_malloc.c:446)
==2634263==    by 0x4939689: strdup (in /lib64/libc-2.41.so)
==2634263==    by 0x418513: xstrdup (common.c:3923)
==2634263==    by 0x408ECD: splitxarg (main.c:1783)
==2634263==    by 0x409DBC: main (main.c:2330)
==2634263== 
==2634263== 16 bytes in 1 blocks are still reachable in loss record 2 of 4
==2634263==    at 0x4850A5F: calloc (vg_replace_malloc.c:1675)
==2634263==    by 0x41A3C8: pconf_init (parseconf.c:418)
==2634263==    by 0x404B1C: parse_data_file (dummy-ups.c:782)
==2634263==    by 0x403933: upsdrv_initinfo (dummy-ups.c:142)
==2634263==    by 0x40AB33: main (main.c:2860)
==2634263== 
==2634263== 368 bytes in 1 blocks are still reachable in loss record 3 of 4
==2634263==    at 0x48497C4: malloc (vg_replace_malloc.c:446)
==2634263==    by 0x4183DB: xmalloc (common.c:3877)
==2634263==    by 0x404AED: parse_data_file (dummy-ups.c:779)
==2634263==    by 0x403933: upsdrv_initinfo (dummy-ups.c:142)
==2634263==    by 0x40AB33: main (main.c:2860)
==2634263== 
==2634263== LEAK SUMMARY:
==2634263==    definitely lost: 10 bytes in 1 blocks
==2634263==    indirectly lost: 0 bytes in 0 blocks
==2634263==      possibly lost: 0 bytes in 0 blocks
==2634263==    still reachable: 384 bytes in 2 blocks
==2634263==         suppressed: 26,280 bytes in 1 blocks
==2634263== 
==2634263== For lists of detected and suppressed errors, rerun with: -s
==2634263== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```