### PR TITLE
Propose a `ci_build.sh` quicker matrix for `BUILD_TYPE=default-all-errors` scenarios

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1426,7 +1426,11 @@ git-realclean-check:
 # quickly handled by external tools, to group (in life and log) various checks
 # separately from the probably slower/louder stages for test programs like
 # check-NIT:
-check-files-quick: spellcheck-quick check-man
+CHECK_FILES_QUICK_TARGETS = check-man
+if WITH_SPELLCHECK
+CHECK_FILES_QUICK_TARGETS += spellcheck-quick
+endif WITH_SPELLCHECK
+check-files-quick: $(CHECK_FILES_QUICK_TARGETS)
 
 # Autotools hook: run the quick checks before recursing for defaults:
 check-recursive: check-files-quick

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -178,6 +178,14 @@ https://github.com/networkupstools/nut/milestone/9
    name (`man1m`), as different OS distributions have different preferences
    in this regard. [#2950]
 
+ - The `BUILD_TYPE=default-all-errors ci_build.sh` script handling was
+   revised to simplify code, and to default in CI builds to a quicker
+   mode which randomly mixes the selected SSL, USB and UNMAPPED variants
+   (and relies on the dozens of NUT CI farm runs per iteration to likely
+   cover all possible combinations), which should roughly halve the CI
+   build times. Default activity for developer builds should remain as
+   it was -- to try each such "axis" sequentially. [#2973]
+
 
 Release notes for NUT 2.8.3 - what's new since 2.8.2
 ----------------------------------------------------

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -107,7 +107,7 @@ https://github.com/networkupstools/nut/milestone/9
 
  - common driver code:
    * Update reports of failed socket file creation, to help troubleshooting
-     some error cases in the field.
+     some error cases in the field. [#2959]
    * Removed workarounds trying to migrate legacy driver raised `ALARM`
      status tokens into modern `alarm_*` function logic. Rather, we keep
      supporting them as separate from the modern logic, seeing as `upsmon`
@@ -120,6 +120,9 @@ https://github.com/networkupstools/nut/milestone/9
      change, operations that intend to turn off or restart the load, or can
      do that by side effect (e.g. calibration if batteries are old or dead),
      would explicitly `upslogx(LOG_CRIT,...)` by default before commencing.
+     [#2957]
+   * Fixed a couple of ancient memory leaks: one "shared" during driver
+     program initialization, and one specific to `dummy-ups` wind-down. [#2972]
 
  - `dummy-ups` driver updates:
    * A new instruction `ALARM` was added for the `Dummy Mode` operation

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -55,6 +55,12 @@ https://github.com/networkupstools/nut/milestone/9
      v2.8.2), where `configure --with-docs=all` no longer failed a run
      of the `configure` script when some of the required rendering tools
      were not in fact available. [#2842, fixed by #2921]
+   * Some recipe improvements in earlier releases led to `make check` always
+     running a spelling check (if tools are available), even if the explicit
+     `configure --disable-spellcheck` option was used. Now it would not run
+     if disabled (e.g. to speed up CI builds in scenarios that focus on other
+     aspects of the code base), although developers can still use the explicit
+     `make spellcheck*` goals, when tools are in fact available. [#2973]
    * A change in `Makefile.am` recipes to evaluate some driver names in the
      `DRIVERLIST` variables inspected by `configure` script, rather than
      having all their names hard-coded like before, led to inability to

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -2039,25 +2039,25 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-al
             # NOTE: We count different dependency variations separately,
             # and analyze later, to avoid building same (auto+auto) twice
             BUILDSTODO_LIST=()
-            BUILDSTODO_SSL=0
+            BUILDSTODO_SSL="${#NUT_SSL_VARIANTS[@]}"
             for NUT_SSL_VARIANT in "${NUT_SSL_VARIANTS[@]}" ; do
-                BUILDSTODO_SSL="`expr $BUILDSTODO_SSL + 1`"
+                #BUILDSTODO_SSL="`expr $BUILDSTODO_SSL + 1`"
                 if [ x"${BUILD_TYPE}" = x"default-all-errors-exhaustive" ] ; then
                     BUILDSTODO_LIST+=("NUT_SSL_VARIANT=${NUT_SSL_VARIANT}")
                 fi
             done
 
-            BUILDSTODO_USB=0
+            BUILDSTODO_USB="${#NUT_USB_VARIANTS[@]}"
             for NUT_USB_VARIANT in "${NUT_USB_VARIANTS[@]}" ; do
-                BUILDSTODO_USB="`expr $BUILDSTODO_USB + 1`"
+                #BUILDSTODO_USB="`expr $BUILDSTODO_USB + 1`"
                 if [ x"${BUILD_TYPE}" = x"default-all-errors-exhaustive" ] ; then
                     BUILDSTODO_LIST+=("NUT_USB_VARIANT=${NUT_USB_VARIANT}")
                 fi
             done
 
-            BUILDSTODO_UNMAPPED=0
+            BUILDSTODO_UNMAPPED="${#NUT_UNMAPPED_VARIANTS[@]}"
             for NUT_UNMAPPED_VARIANT in "${NUT_UNMAPPED_VARIANTS[@]}" ; do
-                BUILDSTODO_UNMAPPED="`expr $BUILDSTODO_UNMAPPED + 1`"
+                : # BUILDSTODO_UNMAPPED="`expr $BUILDSTODO_UNMAPPED + 1`"
             done
 
             # Use the only one requested right away

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -2107,6 +2107,7 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-al
             # NOT a full matrix
             if [ "${BUILDSTODO_UNMAPPED}" -gt 1 ] ; then
                 BUILDSTODO="`expr $BUILDSTODO + $BUILDSTODO_UNMAPPED - 1`"
+                echo "=== Would build one 'unmapped' variant as part of other scenarios, will only explicitly test the other"
             fi
 
             BUILDSTODO_INITIAL="$BUILDSTODO"

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -2396,12 +2396,12 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-al
             fi
 
             if [ "${#SUCCEEDED[*]}" -gt 0 ]; then
-                echo "SUCCEEDED build(s) with: ${SUCCEEDED[*]}" >&2
+                echo "SUCCEEDED ${#SUCCEEDED[@]} build(s) with: ${SUCCEEDED[*]}" >&2
             fi
 
             if [ "$RES_ALLERRORS" != 0 ]; then
                 # Leading space is included in FAILED
-                echo "FAILED build(s) with code ${RES_ALLERRORS}: ${FAILED[*]}" >&2
+                echo "FAILED ${#FAILED[@]} build(s) with code ${RES_ALLERRORS}: ${FAILED[*]}" >&2
             else
                 echo "(and no build scenarios had failed)" >&2
             fi

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -1947,8 +1947,8 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-al
             # Note this is one scenario where we did not configure_nut()
             # in advance.
             RES_ALLERRORS=0
-            FAILED=""
-            SUCCEEDED=""
+            FAILED=()
+            SUCCEEDED=()
             BUILDSTODO=0
 
             # Technically, let caller provide this setting explicitly
@@ -2110,7 +2110,7 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-al
                         ;;
                 esac || {
                     RES_ALLERRORS=$?
-                    FAILED="${FAILED} NUT_SSL_VARIANT=${NUT_SSL_VARIANT}[configure]"
+                    FAILED+=("NUT_SSL_VARIANT=${NUT_SSL_VARIANT}[configure]")
                     # TOTHINK: Do we want to try clean-up if we likely have no Makefile?
                     if [ "$CI_FAILFAST" = true ]; then
                         echo "===== Aborting because CI_FAILFAST=$CI_FAILFAST" >&2
@@ -2124,10 +2124,10 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-al
                 cd "${CI_BUILDDIR}"
                 # Use default target e.g. "all":
                 build_to_only_catch_errors_target && {
-                    SUCCEEDED="${SUCCEEDED} NUT_SSL_VARIANT=${NUT_SSL_VARIANT}[build]"
+                    SUCCEEDED+=("NUT_SSL_VARIANT=${NUT_SSL_VARIANT}[build]")
                 } || {
                     RES_ALLERRORS=$?
-                    FAILED="${FAILED} NUT_SSL_VARIANT=${NUT_SSL_VARIANT}[build]"
+                    FAILED+=("NUT_SSL_VARIANT=${NUT_SSL_VARIANT}[build]")
                     # Help find end of build (before cleanup noise) in logs:
                     echo "=== FAILED 'NUT_SSL_VARIANT=${NUT_SSL_VARIANT}' build"
                     if [ "$CI_FAILFAST" = true ]; then
@@ -2137,10 +2137,10 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-al
                 }
 
                 build_to_only_catch_errors_check && {
-                    SUCCEEDED="${SUCCEEDED} NUT_SSL_VARIANT=${NUT_SSL_VARIANT}[check]"
+                    SUCCEEDED+=("NUT_SSL_VARIANT=${NUT_SSL_VARIANT}[check]")
                 } || {
                     RES_ALLERRORS=$?
-                    FAILED="${FAILED} NUT_SSL_VARIANT=${NUT_SSL_VARIANT}[check]"
+                    FAILED+=("NUT_SSL_VARIANT=${NUT_SSL_VARIANT}[check]")
                     # Help find end of build (before cleanup noise) in logs:
                     echo "=== FAILED 'NUT_SSL_VARIANT=${NUT_SSL_VARIANT}' check"
                     if [ "$CI_FAILFAST" = true ]; then
@@ -2166,20 +2166,20 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-al
                         ### Avoid having to re-autogen in a loop:
                         optional_dist_clean_check && {
                             if [ "${DO_DIST_CLEAN_CHECK-}" != "no" ] ; then
-                                SUCCEEDED="${SUCCEEDED} NUT_SSL_VARIANT=${NUT_SSL_VARIANT}[dist_clean]"
+                                SUCCEEDED+=("NUT_SSL_VARIANT=${NUT_SSL_VARIANT}[dist_clean]")
                             fi
                         } || {
                             RES_ALLERRORS=$?
-                            FAILED="${FAILED} NUT_SSL_VARIANT=${NUT_SSL_VARIANT}[dist_clean]"
+                            FAILED+=("NUT_SSL_VARIANT=${NUT_SSL_VARIANT}[dist_clean]")
                         }
                     else
                         optional_maintainer_clean_check && {
                             if [ "${DO_MAINTAINER_CLEAN_CHECK-}" != no ] ; then
-                                SUCCEEDED="${SUCCEEDED} NUT_SSL_VARIANT=${NUT_SSL_VARIANT}[maintainer_clean]"
+                                SUCCEEDED+=("NUT_SSL_VARIANT=${NUT_SSL_VARIANT}[maintainer_clean]")
                             fi
                         } || {
                             RES_ALLERRORS=$?
-                            FAILED="${FAILED} NUT_SSL_VARIANT=${NUT_SSL_VARIANT}[maintainer_clean]"
+                            FAILED+=("NUT_SSL_VARIANT=${NUT_SSL_VARIANT}[maintainer_clean]")
                         }
                     fi
                     echo "=== Completed sandbox cleanup-check after NUT_SSL_VARIANT=${NUT_SSL_VARIANT}, $BUILDSTODO build variants remaining"
@@ -2260,7 +2260,7 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-al
                         ;;
                 esac || {
                     RES_ALLERRORS=$?
-                    FAILED="${FAILED} NUT_USB_VARIANT=${NUT_USB_VARIANT}[configure]"
+                    FAILED+=("NUT_USB_VARIANT=${NUT_USB_VARIANT}[configure]")
                     # TOTHINK: Do we want to try clean-up if we likely have no Makefile?
                     if [ "$CI_FAILFAST" = true ]; then
                         echo "===== Aborting because CI_FAILFAST=$CI_FAILFAST" >&2
@@ -2274,10 +2274,10 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-al
                 cd "${CI_BUILDDIR}"
                 # Use default target e.g. "all":
                 build_to_only_catch_errors_target && {
-                    SUCCEEDED="${SUCCEEDED} NUT_USB_VARIANT=${NUT_USB_VARIANT}[build]"
+                    SUCCEEDED+=("NUT_USB_VARIANT=${NUT_USB_VARIANT}[build]")
                 } || {
                     RES_ALLERRORS=$?
-                    FAILED="${FAILED} NUT_USB_VARIANT=${NUT_USB_VARIANT}[build]"
+                    FAILED+=("NUT_USB_VARIANT=${NUT_USB_VARIANT}[build]")
                     # Help find end of build (before cleanup noise) in logs:
                     echo "=== FAILED 'NUT_USB_VARIANT=${NUT_USB_VARIANT}' build"
                     if [ "$CI_FAILFAST" = true ]; then
@@ -2287,10 +2287,10 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-al
                 }
 
                 build_to_only_catch_errors_check && {
-                    SUCCEEDED="${SUCCEEDED} NUT_USB_VARIANT=${NUT_USB_VARIANT}[check]"
+                    SUCCEEDED+=("NUT_USB_VARIANT=${NUT_USB_VARIANT}[check]")
                 } || {
                     RES_ALLERRORS=$?
-                    FAILED="${FAILED} NUT_USB_VARIANT=${NUT_USB_VARIANT}[check]"
+                    FAILED+=("NUT_USB_VARIANT=${NUT_USB_VARIANT}[check]")
                     # Help find end of build (before cleanup noise) in logs:
                     echo "=== FAILED 'NUT_USB_VARIANT=${NUT_USB_VARIANT}' check"
                     if [ "$CI_FAILFAST" = true ]; then
@@ -2314,20 +2314,20 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-al
                         ### Avoid having to re-autogen in a loop:
                         optional_dist_clean_check && {
                             if [ "${DO_DIST_CLEAN_CHECK-}" != "no" ] ; then
-                                SUCCEEDED="${SUCCEEDED} NUT_USB_VARIANT=${NUT_USB_VARIANT}[dist_clean]"
+                                SUCCEEDED+=("NUT_USB_VARIANT=${NUT_USB_VARIANT}[dist_clean]")
                             fi
                         } || {
                             RES_ALLERRORS=$?
-                            FAILED="${FAILED} NUT_USB_VARIANT=${NUT_USB_VARIANT}[dist_clean]"
+                            FAILED+=("NUT_USB_VARIANT=${NUT_USB_VARIANT}[dist_clean]")
                         }
                     else
                         optional_maintainer_clean_check && {
                             if [ "${DO_MAINTAINER_CLEAN_CHECK-}" != no ] ; then
-                                SUCCEEDED="${SUCCEEDED} NUT_USB_VARIANT=${NUT_USB_VARIANT}[maintainer_clean]"
+                                SUCCEEDED+=("NUT_USB_VARIANT=${NUT_USB_VARIANT}[maintainer_clean]")
                             fi
                         } || {
                             RES_ALLERRORS=$?
-                            FAILED="${FAILED} NUT_USB_VARIANT=${NUT_USB_VARIANT}[maintainer_clean]"
+                            FAILED+=("NUT_USB_VARIANT=${NUT_USB_VARIANT}[maintainer_clean]")
                         }
                     fi
                     echo "=== Completed sandbox cleanup-check after NUT_USB_VARIANT=${NUT_USB_VARIANT}, $BUILDSTODO build variants remaining"
@@ -2365,7 +2365,7 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-al
                               configure_nut
                             ) || {
                                 RES_ALLERRORS=$?
-                                FAILED="${FAILED} NUT_UNMAPPED_VARIANT=${NUT_UNMAPPED_VARIANT}[configure]"
+                                FAILED+=("NUT_UNMAPPED_VARIANT=${NUT_UNMAPPED_VARIANT}[configure]")
                                 # TOTHINK: Do we want to try clean-up if we likely have no Makefile?
                                 if [ "$CI_FAILFAST" = true ]; then
                                     echo "===== Aborting because CI_FAILFAST=$CI_FAILFAST" >&2
@@ -2379,10 +2379,10 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-al
                             cd "${CI_BUILDDIR}"
                             # Use default target e.g. "all":
                             build_to_only_catch_errors_target && {
-                                SUCCEEDED="${SUCCEEDED} NUT_UNMAPPED_VARIANT=${NUT_UNMAPPED_VARIANT}[build]"
+                                SUCCEEDED+=("NUT_UNMAPPED_VARIANT=${NUT_UNMAPPED_VARIANT}[build]")
                             } || {
                                 RES_ALLERRORS=$?
-                                FAILED="${FAILED} NUT_UNMAPPED_VARIANT=${NUT_UNMAPPED_VARIANT}[build]"
+                                FAILED+=("NUT_UNMAPPED_VARIANT=${NUT_UNMAPPED_VARIANT}[build]")
                                 # Help find end of build (before cleanup noise) in logs:
                                 echo "=== FAILED 'NUT_UNMAPPED_VARIANT=${NUT_UNMAPPED_VARIANT}' build"
                                 if [ "$CI_FAILFAST" = true ]; then
@@ -2392,10 +2392,10 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-al
                             }
 
                             build_to_only_catch_errors_check && {
-                                SUCCEEDED="${SUCCEEDED} NUT_UNMAPPED_VARIANT=${NUT_UNMAPPED_VARIANT}[check]"
+                                SUCCEEDED+=("NUT_UNMAPPED_VARIANT=${NUT_UNMAPPED_VARIANT}[check]")
                             } || {
                                 RES_ALLERRORS=$?
-                                FAILED="${FAILED} NUT_UNMAPPED_VARIANT=${NUT_UNMAPPED_VARIANT}[check]"
+                                FAILED+=("NUT_UNMAPPED_VARIANT=${NUT_UNMAPPED_VARIANT}[check]")
                                 # Help find end of build (before cleanup noise) in logs:
                                 echo "=== FAILED 'NUT_UNMAPPED_VARIANT=${NUT_UNMAPPED_VARIANT}' check"
                                 if [ "$CI_FAILFAST" = true ]; then
@@ -2419,20 +2419,20 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-al
                                     ### Avoid having to re-autogen in a loop:
                                     optional_dist_clean_check && {
                                         if [ "${DO_DIST_CLEAN_CHECK-}" != "no" ] ; then
-                                            SUCCEEDED="${SUCCEEDED} NUT_UNMAPPED_VARIANT=${NUT_UNMAPPED_VARIANT}[dist_clean]"
+                                            SUCCEEDED+=("NUT_UNMAPPED_VARIANT=${NUT_UNMAPPED_VARIANT}[dist_clean]")
                                         fi
                                     } || {
                                         RES_ALLERRORS=$?
-                                        FAILED="${FAILED} NUT_UNMAPPED_VARIANT=${NUT_UNMAPPED_VARIANT}[dist_clean]"
+                                        FAILED+=("NUT_UNMAPPED_VARIANT=${NUT_UNMAPPED_VARIANT}[dist_clean]")
                                     }
                                 else
                                     optional_maintainer_clean_check && {
                                         if [ "${DO_MAINTAINER_CLEAN_CHECK-}" != no ] ; then
-                                            SUCCEEDED="${SUCCEEDED} NUT_UNMAPPED_VARIANT=${NUT_UNMAPPED_VARIANT}[maintainer_clean]"
+                                            SUCCEEDED+=("NUT_UNMAPPED_VARIANT=${NUT_UNMAPPED_VARIANT}[maintainer_clean]")
                                         fi
                                     } || {
                                         RES_ALLERRORS=$?
-                                        FAILED="${FAILED} NUT_UNMAPPED_VARIANT=${NUT_UNMAPPED_VARIANT}[maintainer_clean]"
+                                        FAILED+=("NUT_UNMAPPED_VARIANT=${NUT_UNMAPPED_VARIANT}[maintainer_clean]")
                                     }
                                 fi
                                 echo "=== Completed sandbox cleanup-check after NUT_UNMAPPED_VARIANT=${NUT_UNMAPPED_VARIANT}, $BUILDSTODO build variants remaining"
@@ -2457,22 +2457,22 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-al
                 echo "=== One final try for optional_maintainer_clean_check:"
                 optional_maintainer_clean_check && {
                     if [ "${DO_MAINTAINER_CLEAN_CHECK-}" != no ] ; then
-                        SUCCEEDED="${SUCCEEDED} [final_maintainer_clean]"
+                        SUCCEEDED+=("[final_maintainer_clean]")
                     fi
                 } || {
                     RES_ALLERRORS=$?
-                    FAILED="${FAILED} [final_maintainer_clean]"
+                    FAILED+=("[final_maintainer_clean]")
                 }
                 echo "=== Completed sandbox maintainer-cleanup-check after all builds"
             fi
 
-            if [ -n "$SUCCEEDED" ]; then
-                echo "SUCCEEDED build(s) with:${SUCCEEDED}" >&2
+            if [ "${#SUCCEEDED[*]}" -gt 0 ]; then
+                echo "SUCCEEDED build(s) with: ${SUCCEEDED[*]}" >&2
             fi
 
             if [ "$RES_ALLERRORS" != 0 ]; then
                 # Leading space is included in FAILED
-                echo "FAILED build(s) with code ${RES_ALLERRORS}:${FAILED}" >&2
+                echo "FAILED build(s) with code ${RES_ALLERRORS}: ${FAILED[*]}" >&2
             else
                 echo "(and no build scenarios had failed)" >&2
             fi

--- a/conf/upsmon.conf.sample.in
+++ b/conf/upsmon.conf.sample.in
@@ -232,6 +232,10 @@ SHUTDOWNCMD "/sbin/shutdown -h +0"
 #
 # Adjust this to keep upsmon from flooding your network, but don't make
 # it too high or it may miss certain short-lived power events.
+#
+# NOTE: This setting is different from a `pollfreq` supported by some of
+# the NUT driver programs, such as usbhid-ups (about how often the driver
+# polls a particular device).
 
 POLLFREQ 5
 

--- a/configure.ac
+++ b/configure.ac
@@ -3581,6 +3581,8 @@ AM_CONDITIONAL(WITH_CHECK_NIT, test "${nut_enable_check_NIT}" = "yes")
 
 dnl ----------------------------------------------------------------------
 dnl checks related to --enable-spellcheck
+dnl NOTE: If the tools are present, you can "make spellcheck" explicitly;
+dnl  this setting is about trying or not to run it as part of "make check".
 
 NUT_CHECK_ASPELL
 NUT_ARG_ENABLE([spellcheck], [Run spellcheck among default checks], [auto])
@@ -3602,7 +3604,8 @@ case "${nut_enable_spellcheck}" in
 esac
 AC_MSG_RESULT([${WITH_SPELLCHECK}])
 
-AM_CONDITIONAL(WITH_SPELLCHECK, test "${WITH_SPELLCHECK}" = "yes")
+NUT_REPORT_FEATURE([requested to spell-check the documentation], [${WITH_SPELLCHECK}], [],
+					[WITH_SPELLCHECK], [Define to enable documentation spell checking as part of default checks], [-])
 
 dnl ----------------------------------------------------------------------
 dnl checks related to --with-doc

--- a/docs/man/index.txt
+++ b/docs/man/index.txt
@@ -7,10 +7,12 @@ endif::website[]
 User manual pages
 -----------------
 
+ifndef::in-nut-manpage[]
 NUT overview
 ~~~~~~~~~~~~
 
 - linkman:nut[7]
+endif::in-nut-manpage[]
 
 Configuration files
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/man/nut.txt
+++ b/docs/man/nut.txt
@@ -147,6 +147,7 @@ The "primary" system is usually also responsible for commanding the managed
   systems would otherwise remain shut down indefinitely (until someone comes
   and reboots them) just because external power returned when the shut down
   spree had already started.
+
 * linkman:upsc[1] is a command-line client for anonymous read-only access,
   used to list devices served by a NUT data server, or to query data points
   reported by a particular device.

--- a/docs/man/nut.txt
+++ b/docs/man/nut.txt
@@ -251,15 +251,16 @@ NUT Drivers as Service instances
 
 Starting with NUT v2.8.0, on systems with service management frameworks
 (like Linux systemd or Solaris/illumos SMF) you may be even inadvertently
-using the linkman:nut-driver-enumerator[8].  This is a script, which may
-also called automatically (via packaging on impacted platforms) at start-up
-or as a service, to process the linkman:ups.conf[5] file and maintain the
-service units (with their dependencies) for each driver section separately.
+using the linkman:nut-driver-enumerator[8] (also known as "NDE") facility.
+This is a script, which may be also called automatically (via packaging on
+supported platforms) at start-up or may be running continuously as a service,
+to process the linkman:ups.conf[5] file and maintain the service units
+(with their dependencies) for each driver section separately.
 
 This sometimes raises eyebrows when end-users try to manually start a NUT
 driver program (either directly or using linkman:upsdrvctl[8] tool), and
 this either fails (because the device is already busy) or gets to conflict
-with the copy of the driver running as a service instance and they begin
+with the copy of the driver running as a service instance, and they begin
 to terminate each other.
 
 Configuring NUT Drivers

--- a/docs/man/nut.txt
+++ b/docs/man/nut.txt
@@ -323,6 +323,7 @@ to secure access to those files and their copies as well.
 :leveloffset: 1
 ///////////////
 
+:in-nut-manpage: true
 include::index.txt[]
 
 ///////////////

--- a/docs/man/upsmon.conf.txt
+++ b/docs/man/upsmon.conf.txt
@@ -361,6 +361,10 @@ Second, there is a point of diminishing returns if you set it too low.
 While upsd normally has all of the data available to it instantly, most
 drivers only refresh the UPS status once every 2 seconds.  Polling any
 more than that usually doesn't get you the information any faster.
++
+NOTE: This setting is different from a `pollfreq` supported by some of
+the NUT driver programs, such as linkman:usbhid-ups[8] (about how often
+the driver polls a particular device).
 
 *POLLFREQALERT* 'seconds'::
 

--- a/docs/man/usbhid-ups.txt
+++ b/docs/man/usbhid-ups.txt
@@ -120,6 +120,9 @@ Set polling frequency for full updates, in seconds. Compared to the quick
 updates performed every "pollinterval" (the latter option is described in
 linkman:ups.conf[5]), the "pollfreq" interval is for polling the less-critical
 variables.  The default value is 30 (in seconds), or 12 sec for CPS devices.
++
+NOTE: This setting is different from a `POLLFREQ` supported by linkman:upsmon[8]
+(for details see its linkman:upsmon.conf[5]).
 
 *pollonly*::
 If this flag is set, the driver will not use Interrupt In transfers during the


### PR DESCRIPTION
The `BUILD_TYPE=default-all-errors ci_build.sh` script handling was revised to simplify code, and to default in CI builds to a quicker mode which randomly mixes the selected SSL, USB and UNMAPPED variants (and relies on the dozens of NUT CI farm runs per iteration to likely cover all possible combinations), which should roughly halve the CI build times. Default activity for developer builds should remain as it was -- to try each such "axis" sequentially.

Also address some older docs deficiencies.