### PR TITLE
Update nutdrv_qx_megatec.c

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -148,6 +148,9 @@ https://github.com/networkupstools/nut/milestone/9
  - `nutdrv_qx` driver updates:
    * Introduced `innovart33` protocol support for Ippon Innova RT 3/3 topology
      UPSes. [#2938]
+   * Updated `megatec` protocol for more detailed responses to `I` query
+     which may return `ups.serial` (after a shorter `device.mfr`) and the
+     `battery.runtime` (after a shorter `device.model`). [#2980]
 
  - `usbhid-ups` driver updates:
    * The `cps-hid` subdriver's existing mechanism for fixing broken report

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -150,7 +150,11 @@ https://github.com/networkupstools/nut/milestone/9
      UPSes. [#2938]
    * Updated `megatec` protocol for more detailed responses to `I` query
      which may return `ups.serial` (after a shorter `device.mfr`) and the
-     `battery.runtime` (after a shorter `device.model`). [#2980]
+     `battery.runtime` (after a shorter `device.model`). Note that the
+     expected response is shorter than in other dialects (38 vs. 39 bytes),
+     so if this change breaks anything for your UPS that reported the values
+     above correctly (e.g. the `ups.firmware` version becomes shorter or
+     none of these are reported), please let NUT developers know. [#2980]
 
  - `usbhid-ups` driver updates:
    * The `cps-hid` subdriver's existing mechanism for fixing broken report

--- a/UPGRADING.adoc
+++ b/UPGRADING.adoc
@@ -39,6 +39,14 @@ Changes from 2.8.3 to 2.8.4
 - Added APC BVKxxxM2 to list of devices where `lbrb_log_delay_sec=N` may be
   necessary to address spurious LOWBATT and REPLACEBATT events. [issue #2942]
 
+- In `nutdrv_qx`, updated `megatec` protocol subdriver for more detailed
+  responses to `I` query which may return `ups.serial` (after a shorter
+  `device.mfr`) and the `battery.runtime` (after a shorter `device.model`).
+  Note that the expected response is shorter than in other dialects (38 vs.
+  39 bytes), so if this change breaks anything for your UPS that reported
+  the values above correctly (e.g. the `ups.firmware` version becomes shorter
+  or none of these are reported), please let NUT developers know. [#2980]
+
 Changes from 2.8.2 to 2.8.3
 ---------------------------
 

--- a/drivers/nutdrv_qx_megatec.c
+++ b/drivers/nutdrv_qx_megatec.c
@@ -67,26 +67,38 @@ static item_t	megatec_qx2nut[] = {
 	{ "input.frequency.nominal",	0,	NULL,	"F\r",	"",	22,	'#',	"",	17,	20,	"%.0f",	QX_FLAG_STATIC,	NULL,	NULL,	NULL },
 
 	/*
+	 * Common Qx protocols might only return ups.firmware here:
+	 *
 	 * > [I\r]
 	 * < [#-------------   ------     VT12046Q  \r]
 	 *    012345678901234567890123456789012345678
 	 *    0         1         2         3
+	 *
+	 *  Megatec IC adds serial/runtime support function into the response:
+	 *
+	 *  pc->ups:
+	 * > [I\r]
+	 *  ups->pc:
+	 * < [#MegaTecabcedfhi k130v12345 v3.400000\r]
+	 *    01234567890123456789012345678901234567
+	 *    0         1         2         3
+	 * where:
+	 *  device.mfr=MegaTec
+	 *  ups.serial=abcedfhi
+	 *  device.model=k130v
+	 *  battery.runtime=12345
+	 *  ups.firmware=v3.400000
+	 *
+	 * FIXME: Per example above, this reply is 38 bytes
+	 *  long (including '\r') not 39 as in other dialects
+	 *  and the mappings below; which part is wrong - the
+	 *  example or code?
 	 */
-    /***********
-	Megatec IC adds serial/runtime support function
-	pc->ups:   I\r
-	ups->pc:   #MegaTecabcedfhi k130v12345 v3.400000\r
-	device.mfr=MegaTec
-	ups.serial=abcedfhi
-	device.model=k130v
-	battery.runtime=12345
-	ups.firmware=v3.400000
-	***************/
-	{ "device.mfr",			0,	NULL,	"I\r",	"",	39,	'#',	"",	1,	7,	"%s",	QX_FLAG_STATIC | QX_FLAG_TRIM,	NULL,	NULL,	NULL },//
-	{ "ups.serial",			0,	NULL,	"I\r",	"",	39,	'#',	"",	8,	15,	"%s",	0,	NULL,	NULL,	NULL },//Megatec IC adds "ups.serial" support function
-	{ "device.model",		0,	NULL,	"I\r",	"",	39,	'#',	"",	17,	21,	"%s",	QX_FLAG_STATIC | QX_FLAG_TRIM,	NULL,	NULL,	NULL },
-	{ "battery.runtime",		0,	NULL,	"I\r",	"",	39,	'#',	"",	22,	26,	"%s",	0,	NULL,	NULL,	NULL },//Megatec IC adds "ups.runtime" support function 
-	{ "ups.firmware",		0,	NULL,	"I\r",	"",	39,	'#',	"",	28,	37,	"%s",	QX_FLAG_STATIC | QX_FLAG_TRIM,	NULL,	NULL,	NULL },//
+	{ "device.mfr",			0,	NULL,	"I\r",	"",	39,	'#',	"",	1,	7,	"%s",	QX_FLAG_STATIC | QX_FLAG_TRIM,	NULL,	NULL,	NULL },	/* Shorter field than in other dialects */
+	{ "ups.serial",			0,	NULL,	"I\r",	"",	39,	'#',	"",	8,	15,	"%s",	0,	NULL,	NULL,	NULL },	/* Megatec IC adds "ups.serial" support function */
+	{ "device.model",		0,	NULL,	"I\r",	"",	39,	'#',	"",	17,	21,	"%s",	QX_FLAG_STATIC | QX_FLAG_TRIM,	NULL,	NULL,	NULL },	/* Shorter field than in other dialects */
+	{ "battery.runtime",		0,	NULL,	"I\r",	"",	39,	'#',	"",	22,	26,	"%s",	0,	NULL,	NULL,	NULL },	/* Megatec IC adds "ups.runtime" support function */
+	{ "ups.firmware",		0,	NULL,	"I\r",	"",	39,	'#',	"",	28,	37,	"%s",	QX_FLAG_STATIC | QX_FLAG_TRIM,	NULL,	NULL,	NULL },	/* FIXME: Per example above, this should end at 36 not 37; which part is wrong - example or code? */
 
 	/* Instant commands */
 	{ "beeper.toggle",		0,	NULL,	"Q\r",		"",	0,	0,	"",	0,	0,	NULL,	QX_FLAG_CMD,	NULL,	NULL,	NULL },

--- a/drivers/nutdrv_qx_megatec.c
+++ b/drivers/nutdrv_qx_megatec.c
@@ -25,7 +25,7 @@
 
 #include "nutdrv_qx_megatec.h"
 
-#define MEGATEC_VERSION "Megatec 0.07"
+#define MEGATEC_VERSION "Megatec 0.08"
 
 /* qx2nut lookup table */
 static item_t	megatec_qx2nut[] = {
@@ -89,16 +89,18 @@ static item_t	megatec_qx2nut[] = {
 	 *  battery.runtime=12345
 	 *  ups.firmware=v3.400000
 	 *
-	 * FIXME: Per example above, this reply is 38 bytes
+	 * NOTE: Per example above, this reply is 38 bytes
 	 *  long (including '\r') not 39 as in other dialects
 	 *  and the mappings below; which part is wrong - the
-	 *  example or code?
+	 *  example or code? The "answer_len" field should be
+	 *  about "expected min length of answer" so 38 here
+	 * should cover both variants.
 	 */
-	{ "device.mfr",			0,	NULL,	"I\r",	"",	39,	'#',	"",	1,	7,	"%s",	QX_FLAG_STATIC | QX_FLAG_TRIM,	NULL,	NULL,	NULL },	/* Shorter field than in other dialects */
-	{ "ups.serial",			0,	NULL,	"I\r",	"",	39,	'#',	"",	8,	15,	"%s",	0,	NULL,	NULL,	NULL },	/* Megatec IC adds "ups.serial" support function */
-	{ "device.model",		0,	NULL,	"I\r",	"",	39,	'#',	"",	17,	21,	"%s",	QX_FLAG_STATIC | QX_FLAG_TRIM,	NULL,	NULL,	NULL },	/* Shorter field than in other dialects */
-	{ "battery.runtime",		0,	NULL,	"I\r",	"",	39,	'#',	"",	22,	26,	"%s",	0,	NULL,	NULL,	NULL },	/* Megatec IC adds "ups.runtime" support function */
-	{ "ups.firmware",		0,	NULL,	"I\r",	"",	39,	'#',	"",	28,	37,	"%s",	QX_FLAG_STATIC | QX_FLAG_TRIM,	NULL,	NULL,	NULL },	/* FIXME: Per example above, this should end at 36 not 37; which part is wrong - example or code? */
+	{ "device.mfr",			0,	NULL,	"I\r",	"",	38,	'#',	"",	1,	7,	"%s",	QX_FLAG_STATIC | QX_FLAG_TRIM,	NULL,	NULL,	NULL },	/* Shorter field than in other dialects */
+	{ "ups.serial",			0,	NULL,	"I\r",	"",	38,	'#',	"",	8,	15,	"%s",	0,	NULL,	NULL,	NULL },	/* Megatec IC adds "ups.serial" support function */
+	{ "device.model",		0,	NULL,	"I\r",	"",	38,	'#',	"",	17,	21,	"%s",	QX_FLAG_STATIC | QX_FLAG_TRIM,	NULL,	NULL,	NULL },	/* Shorter field than in other dialects */
+	{ "battery.runtime",		0,	NULL,	"I\r",	"",	38,	'#',	"",	22,	26,	"%s",	0,	NULL,	NULL,	NULL },	/* Megatec IC adds "ups.runtime" support function */
+	{ "ups.firmware",		0,	NULL,	"I\r",	"",	38,	'#',	"",	28,	0,	"%s",	QX_FLAG_STATIC | QX_FLAG_TRIM,	NULL,	NULL,	NULL },	/* Note: Per example above, this should end at 36 not 37 as in other dialects; we say 0 to go to end of line, wherever that is in fact */
 
 	/* Instant commands */
 	{ "beeper.toggle",		0,	NULL,	"Q\r",		"",	0,	0,	"",	0,	0,	NULL,	QX_FLAG_CMD,	NULL,	NULL,	NULL },

--- a/drivers/nutdrv_qx_megatec.c
+++ b/drivers/nutdrv_qx_megatec.c
@@ -72,10 +72,21 @@ static item_t	megatec_qx2nut[] = {
 	 *    012345678901234567890123456789012345678
 	 *    0         1         2         3
 	 */
-
-	{ "device.mfr",			0,	NULL,	"I\r",	"",	39,	'#',	"",	1,	15,	"%s",	QX_FLAG_STATIC | QX_FLAG_TRIM,	NULL,	NULL,	NULL },
-	{ "device.model",		0,	NULL,	"I\r",	"",	39,	'#',	"",	17,	26,	"%s",	QX_FLAG_STATIC | QX_FLAG_TRIM,	NULL,	NULL,	NULL },
-	{ "ups.firmware",		0,	NULL,	"I\r",	"",	39,	'#',	"",	28,	37,	"%s",	QX_FLAG_STATIC | QX_FLAG_TRIM,	NULL,	NULL,	NULL },
+    /***********
+	Megatec IC adds serial/runtime support function
+	pc->ups:   I\r
+	ups->pc:   #MegaTecabcedfhi k130v12345 v3.400000\r
+	device.mfr=MegaTec
+	ups.serial=abcedfhi
+	device.model=k130v
+	battery.runtime=12345
+	ups.firmware=v3.400000
+	***************/
+	{ "device.mfr",			0,	NULL,	"I\r",	"",	39,	'#',	"",	1,	7,	"%s",	QX_FLAG_STATIC | QX_FLAG_TRIM,	NULL,	NULL,	NULL },//
+	{ "ups.serial",			0,	NULL,	"I\r",	"",	39,	'#',	"",	8,	15,	"%s",	0,	NULL,	NULL,	NULL },//Megatec IC adds "ups.serial" support function
+	{ "device.model",		0,	NULL,	"I\r",	"",	39,	'#',	"",	17,	21,	"%s",	QX_FLAG_STATIC | QX_FLAG_TRIM,	NULL,	NULL,	NULL },
+	{ "battery.runtime",		0,	NULL,	"I\r",	"",	39,	'#',	"",	22,	26,	"%s",	0,	NULL,	NULL,	NULL },//Megatec IC adds "ups.runtime" support function 
+	{ "ups.firmware",		0,	NULL,	"I\r",	"",	39,	'#',	"",	28,	37,	"%s",	QX_FLAG_STATIC | QX_FLAG_TRIM,	NULL,	NULL,	NULL },//
 
 	/* Instant commands */
 	{ "beeper.toggle",		0,	NULL,	"Q\r",		"",	0,	0,	"",	0,	0,	NULL,	QX_FLAG_CMD,	NULL,	NULL,	NULL },


### PR DESCRIPTION
Added a parameter battery.runtime

<!-- Comment:
* Please revise the docs/developers.txt for coding style suggestions and
  other considerations applicable to NUT codebase contributions, as well
  as for which text documents to update. See also docs/developer-guide.txt
  for general points on NUT architecture and design.

* Please note that we require "Signed-Off-By" tags in each Git Commit
  message, to conform to the common DCO (Developer Certificate of Origin)
  as posted in LICENSE-DCO at root of NUT codebase as well as published
  at https://developercertificate.org/

* The checklist below is more of a reminder of steps to take and "dangers"
  to look out for. PRs to update this template are also welcome :)

* Local build iterations can be augmented with the ci_build.sh script.
-->

## General points

- [ ] Described the changes in the PR submission or a separate issue, e.g.
  known published or discovered protocols, applicable hardware (expected
  compatible and actually tested/developed against), limitations, etc.

- [ ] There may be multiple commits in the PR, aligned and commented with
  a functional change. Notably, coding style changes better belong in a
  separate PR, but certainly in a dedicated commit to simplify reviews
  of "real" changes in the other commits. Similarly for typo fixes in
  comments or text documents.

- [ ] Please star NUT on GitHub, this helps with sponsorships! ;)

## Frequent "underwater rocks" for driver addition/update PRs

- [ ] Revised existing driver families and added a sub-driver if applicable
  (`nutdrv_qx`, `usbhid-ups`...) or added a brand new driver in the other
  case.

- [ ] Did not extend obsoleted drivers with new hardware support features
  (notably `blazer` and other single-device family drivers for Qx protocols,
  except the new `nutdrv_qx` which should cover them all).

- [ ] For updated existing device drivers, bumped the `DRIVER_VERSION` macro
  or its equivalent.

<!-- Comment:
  Some sub-drivers have `SUBDRIVER_VERSION` or customized names like
  e.g. `MEGATEC_VERSION` in `drivers/nutdrv_qx_megatec.c`
-->

- [ ] For USB devices (HID or not), revised that the driver uses unique
  VID/PID combinations, or raised discussions when this is not the case
  (several vendors do use same interface chips for unrelated protocols).

- [ ] For new USB devices, built and committed the changes for the
  `scripts/upower/95-upower-hid.hwdb` file

- [ ] Proposed NUT data mapping is aligned with existing `docs/nut-names.txt`
  file. If the device exposes useful data points not listed in the file, the
  `experimental.*` namespace can be used as documented there, and discussion
  should be raised on the NUT Developers mailing list to standardize the new
  concept.

- [ ] Updated `data/driver.list.in` if applicable (new tested device info)
<!-- Comment:
Also note below, a point about PR posting for NUT DDL
-->

## Frequent "underwater rocks" for general C code PRs

- [ ] Did not "blindly assume" default integer type sizes and value ranges,
  structure layout and alignment in memory, endianness (layout of bytes and
  bits in memory for multi-byte numeric types), or use of generic `int` where
  language or libraries dictate the use of `size_t` (or `ssize_t` sometimes).

<!-- Comment:
* NOTE: Casting and/or pragmas (support detected at compile time,
  see `m4/ax_c_pragmas.m4`) to silence warnings may be acceptable,
  but only if coupled with range checks or similar actions.
-->

- [ ] Progress and errors are handled with `upsdebugx()`, `upslogx()`,
  `fatalx()` and related methods, not with direct `printf()` or `exit()`.
  Similarly, NUT helpers are used for error-checked memory allocation and
  string operations (except where customized error handling is needed,
  such as unlocking device ports, etc.)

- [ ] Coding style (including whitespace for indentations) follows precedent
  in the code of the file, and examples/guide in `docs/developers.txt` file.

- [ ] For newly added files, the `Makefile.am` recipes were updated and the
  `make distcheck` target passes.

## General documentation updates

- [ ] Updated `docs/acknowledgements.txt` (for vendor-backed device support)

- [ ] Added or updated manual page information in `docs/man/*.txt` files
  and corresponding recipe lists in `docs/man/Makefile.am` for new pages

- [ ] Passed `make spellcheck`, updated spell-checking dictionary in the
  `docs/nut.dict` file if needed (did not remove any words -- the `make`
  rule printout in case of changes suggests how to maintain it).

## Additional work may be needed after posting this PR

- [ ] Propose a PR for NUT DDL with detailed device data dumps from tests
  against real hardware (the more models, the better).

- [ ] Address NUT CI farm build failures for the PR: testing on numerous
  platforms and toolkits can expose issues not seen on just one system.

<!-- Comment:
* One frequent "offence" is the appearance of unexpected (not git-ignored)
  or modification during build of files tracked in Git.

* Another frequent issue is not tracking newly introduced file names in
  `EXTRA_DIST` of the `Makefile.am` (and for `*.in` templates -- of rules
  in the `configure.ac` script) so the `make distcheck` fails.

* Avoid using GNU-specific constructs in the `Makefile.am`, even if that
  means cumbersome ways to build a target. This should not happen in mere
  driver updates, however.

* Also some third-party libraries or OS headers and method argument types
  and counts can differ -- necessitating m4 code for `configure` script
  probing, and `ifdef`, `typedef`, etc. in C code to adapt to the build
  environment (precedents available in NUT codebase). In extreme cases,
  you may need to spin up a VM or container to reproduce those issues
  and iterate on a fix locally; see `docs/config-prereqs.txt` and
  `docs/ci-farm-lxc-setup.txt` for notes taken during preparation of
  the multi-platform NUT CI farm.
-->

- [ ] Revise suggestions from LGTM.COM analysis about "new issues" with
  the changed codebase.

<!-- Comment:
  Take them with a grain of salt, especially with regard to things like
  architecture-dependent range checks, but many of the complaints from
  the tool are indeed useful.
-->
