### PR TITLE
drivers/apc_modbus.c: Fix interframe delay

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -157,6 +157,10 @@ https://github.com/networkupstools/nut/milestone/9
    * Added APC BVKxxxM2 to list of devices where `lbrb_log_delay_sec=N` may be
      necessary to address spurious LOWBATT and REPLACEBATT events. [#2942]
 
+ - `apc_modbus` driver updates:
+   * The time stamp and inter-frame delay accounting was fixed, alleviating
+     one of the problems reported in issue #2609. [PR #2982]
+
  - New NUT drivers:
    * Introduced a `ve-direct` driver for Victron Energy UPS/solar panels
      monitoring. Most specific reported values are in an `experimental.*`

--- a/drivers/apc_modbus.c
+++ b/drivers/apc_modbus.c
@@ -44,7 +44,7 @@
 #endif
 
 #define DRIVER_NAME	"NUT APC Modbus driver " DRIVER_NAME_NUT_MODBUS_HAS_USB_WITH_STR " USB support (libmodbus link type: " NUT_MODBUS_LINKTYPE_STR ")"
-#define DRIVER_VERSION	"0.14"
+#define DRIVER_VERSION	"0.15"
 
 #if defined NUT_MODBUS_HAS_USB
 


### PR DESCRIPTION
The delay is supposed to be from *end* of a frame to *start* of the next. Also fix the type used for timestamp calculations (useconds_t is not big enough and overflows).

Fixes one aspect of issue #2609