### PR TITLE
drivers/bcmxcp.c: fix latched on to RB alarm

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -172,6 +172,10 @@ https://github.com/networkupstools/nut/milestone/9
    * The time stamp and inter-frame delay accounting was fixed, alleviating
      one of the problems reported in issue #2609. [PR #2982]
 
+ - `bcmxcp` driver updates:
+   * The latching on to a previous replace battery status was fixed, with its
+     alarm state variable now correctly being reset; issue #2999. [PR #3002]
+
  - New NUT drivers:
    * Introduced a `ve-direct` driver for Victron Energy UPS/solar panels
      monitoring. Most specific reported values are in an `experimental.*`

--- a/drivers/bcmxcp.c
+++ b/drivers/bcmxcp.c
@@ -116,7 +116,7 @@ TODO List:
 #include "bcmxcp.h"
 
 #define DRIVER_NAME	"BCMXCP UPS driver"
-#define DRIVER_VERSION	"0.37"
+#define DRIVER_VERSION	"0.38"
 
 #define MAX_NUT_NAME_LENGTH 128
 #define NUT_OUTLET_POSITION   7
@@ -1656,6 +1656,7 @@ void upsdrv_updateinfo(void)
 	{
 		bcmxcp_status.alarm_on_battery = 0;
 		bcmxcp_status.alarm_low_battery = 0;
+		bcmxcp_status.alarm_replace_battery = 0;
 
 		/* Set alarms */
 		alarm_init();


### PR DESCRIPTION
fixes #2999 