### PR TITLE
drivers/usbhid-ups.c: handle also APC BKnnnM2[_-]CH tweaks…

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -179,8 +179,9 @@ https://github.com/networkupstools/nut/milestone/9
      descriptors was extended to cover a newly reported case of nominal UPS
      power being incorrectly reported due to an unrealistically low maximum
      threshold, as seen with a EC850LCD device. [issue #2917, PR #2919]
-   * Added APC BVKxxxM2 to list of devices where `lbrb_log_delay_sec=N` may be
-     necessary to address spurious LOWBATT and REPLACEBATT events. [#2942]
+   * Added APC BKxxxM2-CH to list of devices where `lbrb_log_delay_sec=N` may be
+     necessary to address spurious LOWBATT and REPLACEBATT events. [PR #3007,
+     issue #2347, issue #3006]
 
  - New NUT drivers:
    * Introduced a `ve-direct` driver for Victron Energy UPS/solar panels
@@ -507,7 +508,8 @@ This requirement compromises usability of `make distcheck` on platforms without
    * Added support for `lbrb_log_delay_sec=N` setting to delay propagation of
      `LB` or `LB+RB` state (buggy with APC BXnnnnMI devices circa 2023-2024).
      This may work better with flags like `onlinedischarge_calibration` and
-     `lbrb_log_delay_without_calibrating` for some devices. [#2347]
+     `lbrb_log_delay_without_calibrating` for some devices. [issue #2347,
+     PR #2565]
    * General suggestion from `possibly_supported()` message method for devices
      with VendorID=`0x06da` (Phoenixtec), seen in some models supported by
      MGE HID or Liebert HID, updated to suggest trying `nutdrv_qx`. [#334]

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -89,6 +89,7 @@
 "APC"	"ups"	"3"	"Back-UPS BF500"	"USB"	"usbhid-ups"
 "APC"	"ups"	"3"	"BACK-UPS XS LCD"	"USB"	"usbhid-ups"
 "APC"	"ups"	"3"	"Back-UPS XS 1000M (Back-UPS Pro 1000, Model BX1000M)"	"USB"	"usbhid-ups"	# https://github.com/networkupstools/nut/issues/139
+"APC"	"ups"	"3"	"Back-UPS BK****M2-CH Series (may need tweaks since 2023)"	"USB"	"usbhid-ups lbrb_log_delay_sec=N lbrb_log_delay_without_calibrating onlinedischarge_calibration"	# https://github.com/networkupstools/nut/issues/3006
 "APC"	"ups"	"3"	"Back-UPS BX****MI Series (may need tweaks since 2023)"	"USB"	"usbhid-ups lbrb_log_delay_sec=N lbrb_log_delay_without_calibrating onlinedischarge_calibration"	# https://github.com/networkupstools/nut/issues/2347
 "APC"	"ups"	"3"	"Back-UPS BVK****M2 Series (may need tweaks)"	"USB"	"usbhid-ups lbrb_log_delay_sec=N lbrb_log_delay_without_calibrating onlinedischarge_calibration"	# https://github.com/networkupstools/nut/issues/2942
 "APC"	"ups"	"3"	"SMC2200BI-BR"	"USB"	"usbhid-ups"	# https://github.com/networkupstools/nut/issues/557

--- a/docs/man/usbhid-ups.txt
+++ b/docs/man/usbhid-ups.txt
@@ -189,9 +189,11 @@ Set to delay status-setting (and log messages) about device entering `LB` or
 `LB+RB` state.
 +
 Some APC BXnnnnMI device models or firmware versions (reportedly 2023-2024),
-or APC BVKnnnnM2 device models, frequently report "low battery", "replace
-battery", and "all ok" states changing rapidly within a couple of seconds,
-sometimes (but not always) preceded by `OL+DISCHRG` (presumably calibration).
+or APC BVKnnnnM2 device models, or APC BKnnnnM2-CH (a China-market-only model),
+frequently report "low battery", "replace battery", and "all ok" states
+changing rapidly within a couple of seconds, sometimes (but not always)
+preceded by `OL+DISCHRG` (presumably calibration).
++
 This setting lets the driver ignore short-lived states and only pay attention
 if they persist longer than this setting (and the device power state is `OL`).
 

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3527 utf-8
+personal_ws-1.1 en 3529 utf-8
 AAC
 AAS
 ABI
@@ -92,6 +92,8 @@ BCD
 BCHARGE
 BCM
 BD
+BKnnnnM
+BKxxxM
 BMC
 BNT
 BOH

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -29,7 +29,7 @@
  */
 
 #define DRIVER_NAME	"Generic HID driver"
-#define DRIVER_VERSION	"0.65"
+#define DRIVER_VERSION	"0.66"
 
 #define HU_VAR_WAITBEFORERECONNECT "waitbeforereconnect"
 
@@ -1568,25 +1568,35 @@ void upsdrv_initups(void)
 			lbrb_log_delay_sec = ipv;
 		}
 	} else {
-		/* Activate APC BXnnnMI/BXnnnnMI/BVKnnnM2/BVKnnnnM2 tweaks, for details see
+		/* Activate APC BXnnnMI/BXnnnnMI/BVKnnnM2/BVKnnnnM2/BKnnnM2[_-]CH tweaks, for details see
 		 * https://github.com/networkupstools/nut/issues/2347
+		 * https://github.com/networkupstools/nut/issues/2565
+		 * https://github.com/networkupstools/nut/issues/2944
+		 * https://github.com/networkupstools/nut/issues/3006
 		 */
 		size_t	productLen = hd->Product ? strlen(hd->Product) : 0;
 
 		/* FIXME: Consider also ups.mfr.date as 2023 or newer?
 		 * Eventually up to some year this gets fixed?
 		 */
-		if ((hd->Vendor
-			&&  productLen > 6	/* BXnnnMI at least */
-			&&  (!strcmp(hd->Vendor, "APC") || !strcmp(hd->Vendor, "American Power Conversion"))
+		if (hd->Vendor && productLen > 0
+		&& (!strcmp(hd->Vendor, "APC") || !strcmp(hd->Vendor, "American Power Conversion"))
+		&& ((
+			    productLen > 6	/* BXnnnMI at least */
 			&&  (strstr(hd->Product, " BX") || strstr(hd->Product, "BX") == hd->Product)
-			&&  (hd->Product[productLen - 2] == 'M' && hd->Product[productLen - 1] == 'I'))
-		|| (hd->Vendor
-			&&  productLen > 7	/* BVKnnnM2 at least */
-			&&  (!strcmp(hd->Vendor, "APC") || !strcmp(hd->Vendor, "American Power Conversion"))
+			&&   hd->Product[productLen - 2] == 'M' && hd->Product[productLen - 1] == 'I'
+			) || (
+			    productLen > 7	/* BVKnnnM2 at least */
 			&&  (strstr(hd->Product, " BVK") || strstr(hd->Product, "BVK") == hd->Product)
-			&&  (hd->Product[productLen - 2] == 'M' && hd->Product[productLen - 1] == '2'))
-		) {
+			&&   hd->Product[productLen - 2] == 'M' && hd->Product[productLen - 1] == '2'
+			) || (
+			    productLen > 9	/* BKnnnM2-CH at least, e.h. "Back-UPS BK650M2_CH" */
+			&&  (strstr(hd->Product, " BK") || strstr(hd->Product, "BK") == hd->Product)
+			&&   hd->Product[productLen - 5] == 'M' && hd->Product[productLen - 4] == '2'
+			&&  (hd->Product[productLen - 3] == '-' || hd->Product[productLen - 3] == '_')
+			&&   hd->Product[productLen - 2] == 'C' && hd->Product[productLen - 1] == 'H'
+			)
+		)) {
 			int	got_lbrb_log_delay_without_calibrating = testvar("lbrb_log_delay_without_calibrating") ? 1 : 0,
 				got_onlinedischarge_calibration = testvar("onlinedischarge_calibration") ? 1 : 0,
 				got_onlinedischarge_log_throttle_sec = testvar("onlinedischarge_log_throttle_sec") ? 1 : 0;


### PR DESCRIPTION
…for lbrb_log_delay_without_calibrating/onlinedischarge_calibration [#3006, #2347]

Update docs, data/driver.list.in suggestions;
refactor the if-clause to detect if the tweak
applies to the device being handled.

Closes: #3006