### PR TITLE
`snmp-ups`: debug when static entries are skipped; fix `ups.test.date` in `apc-mib` to be semi-static

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -177,6 +177,8 @@ https://github.com/networkupstools/nut/milestone/9
  - `snmp-ups` driver updates:
    * Fixed `ups.test.date` to be semi-static in `apc-mib` mapping, so it
      would be queried more than once per driver up-time. [issue #3011]
+   * Fixed debug-logging around `SU_FLAG_STATIC` entries to clarify when
+     they get skipped. [issue #3011]
 
  - `usbhid-ups` driver updates:
    * The `cps-hid` subdriver's existing mechanism for fixing broken report

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -174,6 +174,10 @@ https://github.com/networkupstools/nut/milestone/9
    * Converted to NUT standard use of `status_set()` with single-token values.
      [issue #2708]
 
+ - `snmp-ups` driver updates:
+   * Fixed `ups.test.date` to be semi-static in `apc-mib` mapping, so it
+     would be queried more than once per driver up-time. [issue #3011]
+
  - `usbhid-ups` driver updates:
    * The `cps-hid` subdriver's existing mechanism for fixing broken report
      descriptors was extended to cover a newly reported case of nominal UPS

--- a/drivers/apc-mib.c
+++ b/drivers/apc-mib.c
@@ -26,7 +26,7 @@
 
 #include "apc-mib.h"
 
-#define APCC_MIB_VERSION	"1.60"
+#define APCC_MIB_VERSION	"1.61"
 
 #define APC_UPS_DEVICE_MODEL	".1.3.6.1.4.1.318.1.1.1.1.1.1.0"
 /* FIXME: Find a better oid_auto_check vs. sysOID for this one? */
@@ -249,7 +249,7 @@ static snmp_info_t apcc_mib[] = {
 	snmp_info_default("battery.date", ST_FLAG_STRING | ST_FLAG_RW, 8, ".1.3.6.1.4.1.318.1.1.1.2.1.3.0", "", SU_FLAG_OK | SU_FLAG_STATIC, NULL),
 	snmp_info_default("ups.id", ST_FLAG_STRING | ST_FLAG_RW, 8, ".1.3.6.1.4.1.318.1.1.1.1.1.2.0", "", SU_FLAG_OK | SU_FLAG_STATIC, NULL),
 	snmp_info_default("ups.test.result", ST_FLAG_STRING, SU_INFOSIZE, APCC_OID_TESTDIAGRESULTS, "", SU_FLAG_OK, apcc_testdiag_results),
-	snmp_info_default("ups.test.date", ST_FLAG_STRING | ST_FLAG_RW, 8, ".1.3.6.1.4.1.318.1.1.1.7.2.4.0", "", SU_FLAG_OK | SU_FLAG_STATIC, NULL),
+	snmp_info_default("ups.test.date", ST_FLAG_STRING | ST_FLAG_RW, 8, ".1.3.6.1.4.1.318.1.1.1.7.2.4.0", "", SU_FLAG_OK | SU_FLAG_SEMI_STATIC, NULL),
 	snmp_info_default("output.voltage", 0, 0.1, ".1.3.6.1.4.1.318.1.1.1.4.3.1.0", "", SU_FLAG_OK | SU_FLAG_UNIQUE, NULL),
 	snmp_info_default("output.voltage", 0, 1, ".1.3.6.1.4.1.318.1.1.1.4.2.1.0", "", SU_FLAG_OK, NULL),
 	snmp_info_default("output.phases", ST_FLAG_STRING, 2, ".1.3.6.1.4.1.318.1.1.1.9.3.2.1.2.1", "", SU_FLAG_STATIC | SU_FLAG_OK, NULL),

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -177,7 +177,7 @@ static const char *mibname;
 static const char *mibvers;
 
 #define DRIVER_NAME	"Generic SNMP UPS driver"
-#define DRIVER_VERSION	"1.35"
+#define DRIVER_VERSION	"1.36"
 
 /* driver description structure */
 upsdrv_info_t	upsdrv_info = {
@@ -3201,13 +3201,16 @@ bool_t snmp_ups_walk(int mode)
 			}
 
 			/* skip static elements in update mode */
-			if ((mode == SU_WALKMODE_UPDATE) && (su_info_p->flags & SU_FLAG_STATIC))
+			if ((mode == SU_WALKMODE_UPDATE) && (su_info_p->flags & SU_FLAG_STATIC)) {
+				upsdebugx(1, "Skipping static entry %s", su_info_p->OID);
 				continue;
+			}
 
 			/* Set default value if we cannot fetch it */
 			/* and set static flag on this element.
 			 * Not applicable to outlets (need SU_FLAG_STATIC tagging) */
-			if ((su_info_p->flags & SU_FLAG_ABSENT)
+			if (
+				    (su_info_p->flags & SU_FLAG_ABSENT)
 				&& !(su_info_p->flags & SU_OUTLET)
 				&& !(su_info_p->flags & SU_OUTLET_GROUP)
 				&& !(su_info_p->flags & SU_AMBIENT_TEMPLATE))
@@ -3229,6 +3232,9 @@ bool_t snmp_ups_walk(int mode)
 							/* Set default value if we cannot fetch it from ups. */
 							su_setinfo(su_info_p, NULL);
 						}
+						upsdebugx(1, "Defaulting absent entry and setting to static: %s", su_info_p->OID);
+					} else {
+						upsdebugx(1, "Setting absent entry to static (no defautl provided): %s", su_info_p->OID);
 					}
 					su_info_p->flags |= SU_FLAG_STATIC;
 				}


### PR DESCRIPTION
Closes: #3011 

Wondering if `upsdebugx(1, ...)` verbosity level used to report activity on other entry flags would be too "loud" with skipped statics?..

@sirmeili: would you have a chance to test this fix? See e.g. https://github.com/networkupstools/nut/wiki/Building-NUT-for-in%E2%80%90place-upgrades-or-non%E2%80%90disruptive-tests about building custom NUT from sources (using this PR's source branch in my fork, if it is not merged by then). You would probably need to leave the driver running, get a last `ups.test.date` at that time, initiate a test and wait for up to `semistaticfreq` (default 10) update cycles or so to see if the new date value gets reported.