### PR TITLE
Allow mapping functions to return EINVAL for setvar/instcmd to abort consistently

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -160,6 +160,10 @@ https://github.com/networkupstools/nut/milestone/9
      functions rather than direct manipulation. [issue #2928, PR #2936]
 
  - `nutdrv_qx` driver updates:
+   * Added support for "preprocess"/"process" methods called from mapping tables
+     to report back to the driver that an argument value was not supported,
+     so `setvar()` or `instcmd()` can not proceed safely and should return
+     `STAT_SET_CONVERSION_FAILED` or `STAT_INSTCMD_CONVERSION_FAILED`. [#3017]
    * Introduced `innovart33` protocol support for Ippon Innova RT 3/3 topology
      UPSes. [#2938]
    * Updated `megatec` protocol for more detailed responses to `I` query

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -185,6 +185,10 @@ https://github.com/networkupstools/nut/milestone/9
      they get skipped. [issue #3011]
 
  - `usbhid-ups` driver updates:
+   * Added support for "fun"/"nuf" methods called from mapping tables to
+     report back to the driver that an argument value was not supported,
+     so `setvar()` or `instcmd()` can not proceed safely and should return
+     `STAT_SET_CONVERSION_FAILED` or `STAT_INSTCMD_CONVERSION_FAILED`. [#3017]
    * The `cps-hid` subdriver's existing mechanism for fixing broken report
      descriptors was extended to cover a newly reported case of nominal UPS
      power being incorrectly reported due to an unrealistically low maximum

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -175,6 +175,10 @@ https://github.com/networkupstools/nut/milestone/9
      [issue #2708]
 
  - `snmp-ups` driver updates:
+   * Added support for "fun"/"nuf" methods called from mapping tables to
+     report back to the driver that an argument value was not supported,
+     so `setvar()` or `instcmd()` can not proceed safely and should return
+     `STAT_SET_CONVERSION_FAILED` or `STAT_INSTCMD_CONVERSION_FAILED`. [#3017]
    * Fixed `ups.test.date` to be semi-static in `apc-mib` mapping, so it
      would be queried more than once per driver up-time. [issue #3011]
    * Fixed debug-logging around `SU_FLAG_STATIC` entries to clarify when

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3529 utf-8
+personal_ws-1.1 en 3530 utf-8
 AAC
 AAS
 ABI
@@ -2675,6 +2675,7 @@ nss
 ntopAI
 ntopSS
 ntopW
+nuf
 nuget
 num
 numOfBytesFromUPS

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -3785,7 +3785,7 @@ static int su_setOID(int mode, const char *varname, const char *val)
 		upsdebugx(2, "daisychain %s for device.0 are not yet supported!",
 			(mode==SU_MODE_INSTCMD)?"command":"setting");
 		free(tmp_varname);
-		return (mode==SU_MODE_INSTCMD ? STAT_INSTCMD_INVALID : STAT_SET_INVALID);
+		return (mode==SU_MODE_INSTCMD ? (int)STAT_INSTCMD_INVALID : (int)STAT_SET_INVALID);
 	}
 
 	/* Check if it is outlet / outlet.group, or standard variable */
@@ -3852,7 +3852,7 @@ static int su_setOID(int mode, const char *varname, const char *val)
 			/* out of bound item number */
 			upsdebugx(2, "%s: item is out of bound (%i / %i)",
 				__func__, item_number, total_items);
-			return (mode==SU_MODE_INSTCMD ? STAT_INSTCMD_INVALID : STAT_SET_INVALID);
+			return (mode==SU_MODE_INSTCMD ? (int)STAT_INSTCMD_INVALID : (int)STAT_SET_INVALID);
 		}
 		/* find back the item template */
 		item_varname = (char *)xmalloc(SU_INFOSIZE);
@@ -3948,7 +3948,7 @@ static int su_setOID(int mode, const char *varname, const char *val)
 		if (tmp_varname != NULL)
 			free(tmp_varname);
 
-		return (mode==SU_MODE_INSTCMD ? STAT_INSTCMD_UNKNOWN : STAT_SET_UNKNOWN);
+		return (mode==SU_MODE_INSTCMD ? (int)STAT_INSTCMD_UNKNOWN : (int)STAT_SET_UNKNOWN);
 	}
 
 	/* set value into the device, using the provided one, or the default one otherwise */

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -3705,6 +3705,7 @@ static int su_setOID(int mode, const char *varname, const char *val)
 	int daisychain_device_number = -1;
 	/* variable without the potential "device.X" prefix, to find the template */
 	char *tmp_varname = NULL;
+	const char *val_practical = NULL;
 	char setOID[SU_INFOSIZE];
 	/* Used for potentially appending "device.X." to {outlet,outlet.group}.count */
 	char template_count_var[SU_BUFSIZE];
@@ -3960,12 +3961,13 @@ static int su_setOID(int mode, const char *varname, const char *val)
 		upslog_INSTCMD_POWERSTATE_CHECKED(varname, val);
 	}
 
+	val_practical = val ? val : su_info_p->dfl;
 	if (su_info_p->info_flags & ST_FLAG_STRING) {
-		status = nut_snmp_set_str(su_info_p->OID, val ? val : su_info_p->dfl);
+		status = nut_snmp_set_str(su_info_p->OID, val_practical);
 	}
 	else {
 		if (mode==SU_MODE_INSTCMD) {
-			if ( !str_to_long(val ? val : su_info_p->dfl, &value, 10) ) {
+			if ( !str_to_long(val_practical, &value, 10) ) {
 				upsdebugx(1, "%s: cannot execute command '%s': value is not a number!", __func__, varname);
 				return STAT_INSTCMD_CONVERSION_FAILED;
 			}
@@ -3973,10 +3975,10 @@ static int su_setOID(int mode, const char *varname, const char *val)
 		else {
 			/* non string data may imply a value lookup */
 			if (su_info_p->oid2info) {
-				value = su_find_valinfo(su_info_p->oid2info, val ? val : su_info_p->dfl);
+				value = su_find_valinfo(su_info_p->oid2info, val_practical);
 				if (value == -1 && errno == EINVAL) {
 					upsdebugx(1, "%s: cannot set '%s': value %s is not supported by lookup mapping!",
-						__func__, varname, NUT_STRARG(val ? val : su_info_p->dfl));
+						__func__, varname, NUT_STRARG(val_practical));
 					return STAT_SET_CONVERSION_FAILED;
 				}
 			}

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -3941,7 +3941,7 @@ static int su_setOID(int mode, const char *varname, const char *val)
 		if (mode==SU_MODE_INSTCMD) {
 			if ( !str_to_long(val ? val : su_info_p->dfl, &value, 10) ) {
 				upsdebugx(1, "%s: cannot execute command '%s': value is not a number!", __func__, varname);
-				return STAT_INSTCMD_INVALID;
+				return STAT_INSTCMD_CONVERSION_FAILED;
 			}
 		}
 		else {
@@ -3953,7 +3953,7 @@ static int su_setOID(int mode, const char *varname, const char *val)
 				/* Convert value and apply multiplier */
 				if ( !str_to_long(val, &value, 10) ) {
 					upsdebugx(1, "%s: cannot set '%s': value is not a number!", __func__, varname);
-					return STAT_SET_INVALID;
+					return STAT_SET_CONVERSION_FAILED;
 				}
 				value = (long)((double)value / su_info_p->info_len);
 			}
@@ -4010,12 +4010,7 @@ int su_setvar(const char *varname, const char *val)
 
 	ret = su_setOID(SU_MODE_SETVAR, varname, val);
 
-	if (ret == STAT_SET_FAILED)
-		upslog_SET_FAILED(varname, val);
-	else if (ret == STAT_SET_UNKNOWN)
-		upslog_SET_UNKNOWN(varname, val);
-	else if (ret == STAT_SET_INVALID)
-		upslog_SET_INVALID(varname, val);
+	upslog_SET_RESULT(ret, varname, val);
 
 	return ret;
 }
@@ -4054,12 +4049,7 @@ int su_instcmd(const char *cmdname, const char *extradata)
 
 	ret = su_setOID(SU_MODE_INSTCMD, cmdname, extradata);
 
-	if (ret == STAT_INSTCMD_FAILED)
-		upslog_INSTCMD_FAILED(cmdname, extradata);
-	else if (ret == STAT_INSTCMD_UNKNOWN)
-		upslog_INSTCMD_UNKNOWN(cmdname, extradata);
-	else if (ret == STAT_INSTCMD_INVALID)
-		upslog_INSTCMD_INVALID(cmdname, extradata);
+	upslog_INSTCMD_RESULT(ret, cmdname, extradata);
 
 	return ret;
 }

--- a/drivers/upshandler.h
+++ b/drivers/upshandler.h
@@ -210,6 +210,23 @@ struct ups_handler
 		__func__, NUT_STRARG(cmdname), NUT_STRARG(extra));	\
 	} while(0)
 
+#define upslog_INSTCMD_CONVERSION_FAILED(cmdname, extra)	do {	\
+	upslogx(LOG_INSTCMD_CONVERSION_FAILED, "%s: parameter value [%s] is invalid for command [%s]",	\
+		__func__, NUT_STRARG(extra), NUT_STRARG(cmdname));	\
+	} while(0)
+
+/* Note: log only faults; nothing for successful handling */
+#define upslog_INSTCMD_RESULT(ret, cmdname, extra)	do {		\
+	if (ret == STAT_INSTCMD_FAILED)					\
+		upslog_INSTCMD_FAILED(cmdname, extra);			\
+	else if (ret == STAT_INSTCMD_UNKNOWN)				\
+		upslog_INSTCMD_UNKNOWN(cmdname, extra);			\
+	else if (ret == STAT_INSTCMD_INVALID)				\
+		upslog_INSTCMD_INVALID(cmdname, extra);			\
+	else if (ret == STAT_INSTCMD_CONVERSION_FAILED)			\
+		upslog_INSTCMD_CONVERSION_FAILED(cmdname, extra);	\
+	} while(0)
+
 /* setvar(), setcmd() et al -- note they MUST have an argument: */
 #define upsdebug_SET_STARTING(varname, value)	do {		\
 	upsdebugx(1, "Starting %s::%s('%s', '%s')",		\
@@ -229,6 +246,23 @@ struct ups_handler
 #define upslog_SET_FAILED(varname, value)	do {		\
 	upslogx(LOG_SET_FAILED, "%s: FAILED to set variable [%s] to value [%s]",	\
 		__func__, NUT_STRARG(varname), NUT_STRARG(value));	\
+	} while(0)
+
+#define upslog_SET_CONVERSION_FAILED(cmdname, extra)	do {	\
+	upslogx(LOG_SET_CONVERSION_FAILED, "%s: value [%s] is invalid for variable [%s]",	\
+		__func__, NUT_STRARG(extra), NUT_STRARG(cmdname));	\
+	} while(0)
+
+/* Note: log only faults; nothing for successful handling */
+#define upslog_SET_RESULT(ret, cmdname, extra)	do {		\
+	if (ret == STAT_SET_FAILED)				\
+		upslog_SET_FAILED(cmdname, extra);		\
+	else if (ret == STAT_SET_UNKNOWN)			\
+		upslog_SET_UNKNOWN(cmdname, extra);		\
+	else if (ret == STAT_SET_INVALID)			\
+		upslog_SET_INVALID(cmdname, extra);		\
+	else if (ret == STAT_SET_CONVERSION_FAILED)		\
+		upslog_SET_CONVERSION_FAILED(cmdname, extra);	\
 	} while(0)
 
 #endif /* NUT_UPSHANDLER_H */


### PR DESCRIPTION
Note that `errno=EINVAL` means unsupported parameter value for us here.

Inspired by discussion and fixes for PR #2956; follows up from PR #2957.

Updates `usbhid-ups`, `snmp-ups` and to an extent `nutdrv_qx` to have similar functionality with their mappings handling.