### PR TITLE
Fix external man page links

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -302,6 +302,10 @@ https://github.com/networkupstools/nut/milestone/9
  - Revised generation of links to external manual pages in HTML rendering
    of NUT manual pages (previous recipe iterations left DocBook XML `ulink`
    tag "as is", which was not understood by web browsers).
+   [follow-up to PR #2797]
+
+ - Made the distro-dependent URL template for man pages configurable.
+   [follow-up to PR #2797]
 
  - Revised `make install-as-root` to fall back to legacy ways of enabling
    services, if `systemctl preset-all` fails (assumed due to a systemd 252

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -299,6 +299,10 @@ https://github.com/networkupstools/nut/milestone/9
    build times. Default activity for developer builds should remain as
    it was -- to try each such "axis" sequentially. [#2973]
 
+ - Revised generation of links to external manual pages in HTML rendering
+   of NUT manual pages (previous recipe iterations left DocBook XML `ulink`
+   tag "as is", which was not understood by web browsers).
+
  - Revised `make install-as-root` to fall back to legacy ways of enabling
    services, if `systemctl preset-all` fails (assumed due to a systemd 252
    bug). [#3022]

--- a/configure.ac
+++ b/configure.ac
@@ -2529,6 +2529,9 @@ NUT_ARG_WITH([docs-man-section-misc], [man page section for overviews, conventio
 
 NUT_ARG_WITH([docs-man-dir-as-base], [are platform man directories named by base number (yes) or full section name (no)], [${DEFAULT_MAN_DIR_AS_BASE}])
 
+NUT_ARG_WITH([docs-man-linkmanext-template], [asciidoc template for "linkmanext" tags (distro-dependent)], [auto])
+NUT_ARG_WITH([docs-man-linkmanext2-template], [asciidoc template for "linkmanext2" tags (distro-dependent)], [auto])
+
 dnl NOTE: Until X-Mas 2021, the default was "legacy" (now "medium")
 NUT_ARG_ENABLE([warnings],
     [enable warning presets that were picked as useful in maintainership and CI practice (variants include gcc-minimal, gcc-medium, gcc-hard, clang-minimal, clang-medium, clang-hard, all; auto-choosers: hard, medium, minimal, yes=auto='gcc or clang or all at hardcoded default difficulty')],
@@ -4206,6 +4209,22 @@ MAN_DIR_AS_BASE="${nut_with_docs_man_dir_as_base}"
 AC_DEFINE_UNQUOTED([MAN_DIR_AS_BASE], ["${MAN_DIR_AS_BASE}"], [are platform man directories named by base number (yes) or full section name (no)])
 AM_CONDITIONAL(MAN_DIR_AS_BASE, test "${MAN_DIR_AS_BASE}" = "yes")
 AC_SUBST(MAN_DIR_AS_BASE)
+
+dnl FIXME: handle "no" in a way to not link to distro man pages?
+dnl FIXME: spread out default templates per platform/distro
+AC_MSG_CHECKING([asciidoc template to use for linkmanext macro])
+AS_CASE([${nut_with_docs_man_linkmanext_template}],
+	[auto|yes|""|no], [ASCIIDOC_TEMPLATE_LINKMANEXT='https://linux.die.net/man/{0}/{target}'],
+		[ASCIIDOC_TEMPLATE_LINKMANEXT="${nut_with_docs_man_linkmanext_template}"])
+AC_SUBST([ASCIIDOC_TEMPLATE_LINKMANEXT])
+AC_MSG_RESULT([${ASCIIDOC_TEMPLATE_LINKMANEXT}])
+
+AC_MSG_CHECKING([asciidoc template to use for linkmanext2 macro])
+AS_CASE([${nut_with_docs_man_linkmanext2_template}],
+	[auto|yes|""|no], [ASCIIDOC_TEMPLATE_LINKMANEXT2='https://linux.die.net/man/{2}/{target}'],
+		[ASCIIDOC_TEMPLATE_LINKMANEXT2="${nut_with_docs_man_linkmanext2_template}"])
+AC_SUBST([ASCIIDOC_TEMPLATE_LINKMANEXT2])
+AC_MSG_RESULT([${ASCIIDOC_TEMPLATE_LINKMANEXT2}])
 
 dnl ----------------------------------------------------------------------
 dnl checks related to --with-dev
@@ -6633,9 +6652,11 @@ AC_CONFIG_FILES([
  data/html/Makefile
  data/Makefile
  data/driver.list
+ docs/asciidoc.conf
  docs/Makefile
  docs/cables/Makefile
  docs/docinfo.xml
+ docs/man/asciidoc.conf
  docs/man/Makefile
  drivers/Makefile
  include/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -4212,17 +4212,25 @@ AM_CONDITIONAL(MAN_DIR_AS_BASE, test "${MAN_DIR_AS_BASE}" = "yes")
 AC_SUBST(MAN_DIR_AS_BASE)
 
 dnl FIXME: handle "no" in a way to not link to distro man pages?
-dnl FIXME: spread out default templates per platform/distro
+dnl FIXME: spread out default templates per platform/distro some more
 AC_MSG_CHECKING([asciidoc template to use for linkmanext macro])
 AS_CASE([${nut_with_docs_man_linkmanext_template}],
-	[auto|yes|""|no], [ASCIIDOC_TEMPLATE_LINKMANEXT='https://linux.die.net/man/{0}/{target}'],
+	[auto|yes|""|no], [AS_CASE([${target_os}],
+		[solaris*|sunos*|SunOS*|illumos*], [ASCIIDOC_TEMPLATE_LINKMANEXT='https://docs.oracle.com/cd/E86824_01/html/E54763/{target}-{0}.html'],
+		[freebsd*], [ASCIIDOC_TEMPLATE_LINKMANEXT='https://man.freebsd.org/cgi/man.cgi?query={target}&sektion={0}'],
+		[openbsd*], [ASCIIDOC_TEMPLATE_LINKMANEXT='https://man.openbsd.org/man{0}/{target}.{0}],
+			[ASCIIDOC_TEMPLATE_LINKMANEXT='https://linux.die.net/man/{0}/{target}'])],
 		[ASCIIDOC_TEMPLATE_LINKMANEXT="${nut_with_docs_man_linkmanext_template}"])
 AC_SUBST([ASCIIDOC_TEMPLATE_LINKMANEXT])
 AC_MSG_RESULT([${ASCIIDOC_TEMPLATE_LINKMANEXT}])
 
 AC_MSG_CHECKING([asciidoc template to use for linkmanext2 macro])
 AS_CASE([${nut_with_docs_man_linkmanext2_template}],
-	[auto|yes|""|no], [ASCIIDOC_TEMPLATE_LINKMANEXT2='https://linux.die.net/man/{2}/{target}'],
+	[auto|yes|""|no], [AS_CASE([${target_os}],
+		[solaris*|sunos*|SunOS*|illumos*], [ASCIIDOC_TEMPLATE_LINKMANEXT2='https://docs.oracle.com/cd/E86824_01/html/E54763/{target}-{2}.html'],
+		[freebsd*], [ASCIIDOC_TEMPLATE_LINKMANEXT2='https://man.freebsd.org/cgi/man.cgi?query={target}&sektion={2}'],
+		[openbsd*], [ASCIIDOC_TEMPLATE_LINKMANEXT2='https://man.openbsd.org/man{2}/{target}.{2}],
+			[ASCIIDOC_TEMPLATE_LINKMANEXT2='https://linux.die.net/man/{2}/{target}'])],
 		[ASCIIDOC_TEMPLATE_LINKMANEXT2="${nut_with_docs_man_linkmanext2_template}"])
 AC_SUBST([ASCIIDOC_TEMPLATE_LINKMANEXT2])
 AC_MSG_RESULT([${ASCIIDOC_TEMPLATE_LINKMANEXT2}])

--- a/configure.ac
+++ b/configure.ac
@@ -2531,6 +2531,7 @@ NUT_ARG_WITH([docs-man-dir-as-base], [are platform man directories named by base
 
 NUT_ARG_WITH([docs-man-linkmanext-template], [asciidoc template for "linkmanext" tags (distro-dependent)], [auto])
 NUT_ARG_WITH([docs-man-linkmanext2-template], [asciidoc template for "linkmanext2" tags (distro-dependent)], [auto])
+NUT_ARG_ENABLE([docs-man-linkmanext-section-rewrite], [Should external man page sections be adjusted in URL references?], [auto])
 
 dnl NOTE: Until X-Mas 2021, the default was "legacy" (now "medium")
 NUT_ARG_ENABLE([warnings],
@@ -4225,6 +4226,20 @@ AS_CASE([${nut_with_docs_man_linkmanext2_template}],
 		[ASCIIDOC_TEMPLATE_LINKMANEXT2="${nut_with_docs_man_linkmanext2_template}"])
 AC_SUBST([ASCIIDOC_TEMPLATE_LINKMANEXT2])
 AC_MSG_RESULT([${ASCIIDOC_TEMPLATE_LINKMANEXT2}])
+
+AC_MSG_CHECKING([whether to rewrite man page sections in linkmanext* macro URLs])
+AS_CASE([${nut_docs_man_linkmanext_section_rewrite}],
+	[yes|""], [ASCIIDOC_LINKMANEXT_SECTION_REWRITE="yes"],
+	[no], [ASCIIDOC_LINKMANEXT_SECTION_REWRITE="no"],
+	[auto], [AS_IF([test "${MAN_SECTION_API}${MAN_SECTION_CFG}${MAN_SECTION_CMD_SYS}${MAN_SECTION_CMD_USR}${MAN_SECTION_MISC}" = x35817],
+			[ASCIIDOC_LINKMANEXT_SECTION_REWRITE="no"],
+			[ASCIIDOC_LINKMANEXT_SECTION_REWRITE="yes"])
+		],
+		[ASCIIDOC_LINKMANEXT_SECTION_REWRITE="yes"]
+	)
+AM_CONDITIONAL(ASCIIDOC_LINKMANEXT_SECTION_REWRITE, [test "${ASCIIDOC_LINKMANEXT_SECTION_REWRITE}" = yes])
+AC_SUBST(ASCIIDOC_LINKMANEXT_SECTION_REWRITE)
+AC_MSG_RESULT([${ASCIIDOC_LINKMANEXT_SECTION_REWRITE}])
 
 dnl ----------------------------------------------------------------------
 dnl checks related to --with-dev

--- a/configure.ac
+++ b/configure.ac
@@ -4213,12 +4213,16 @@ AC_SUBST(MAN_DIR_AS_BASE)
 
 dnl FIXME: handle "no" in a way to not link to distro man pages?
 dnl FIXME: spread out default templates per platform/distro some more
+dnl NOTE: FreeBSD default URLs use a query string, with an ampersand,
+dnl  which is hard to render for both docbook and man pages:
+dnl  https://man.freebsd.org/cgi/man.cgi?query={target}&sektion={0}
+dnl  Luckily, they have a fallback.
 AC_MSG_CHECKING([asciidoc template to use for linkmanext macro])
 AS_CASE([${nut_with_docs_man_linkmanext_template}],
 	[auto|yes|""|no], [AS_CASE([${target_os}],
 		[solaris*|sunos*|SunOS*|illumos*], [ASCIIDOC_TEMPLATE_LINKMANEXT='https://docs.oracle.com/cd/E86824_01/html/E54763/{target}-{0}.html'],
-		[freebsd*], [ASCIIDOC_TEMPLATE_LINKMANEXT='https://man.freebsd.org/cgi/man.cgi?query={target}&sektion={0}'],
-		[openbsd*], [ASCIIDOC_TEMPLATE_LINKMANEXT='https://man.openbsd.org/man{0}/{target}.{0}],
+		[freebsd*], [ASCIIDOC_TEMPLATE_LINKMANEXT='https://man.freebsd.org/cgi/man.cgi?{target}({0})'],
+		[openbsd*], [ASCIIDOC_TEMPLATE_LINKMANEXT='https://man.openbsd.org/man{0}/{target}.{0}'],
 			[ASCIIDOC_TEMPLATE_LINKMANEXT='https://linux.die.net/man/{0}/{target}'])],
 		[ASCIIDOC_TEMPLATE_LINKMANEXT="${nut_with_docs_man_linkmanext_template}"])
 AC_SUBST([ASCIIDOC_TEMPLATE_LINKMANEXT])
@@ -4228,8 +4232,8 @@ AC_MSG_CHECKING([asciidoc template to use for linkmanext2 macro])
 AS_CASE([${nut_with_docs_man_linkmanext2_template}],
 	[auto|yes|""|no], [AS_CASE([${target_os}],
 		[solaris*|sunos*|SunOS*|illumos*], [ASCIIDOC_TEMPLATE_LINKMANEXT2='https://docs.oracle.com/cd/E86824_01/html/E54763/{target}-{2}.html'],
-		[freebsd*], [ASCIIDOC_TEMPLATE_LINKMANEXT2='https://man.freebsd.org/cgi/man.cgi?query={target}&sektion={2}'],
-		[openbsd*], [ASCIIDOC_TEMPLATE_LINKMANEXT2='https://man.openbsd.org/man{2}/{target}.{2}],
+		[freebsd*], [ASCIIDOC_TEMPLATE_LINKMANEXT2='https://man.freebsd.org/cgi/man.cgi?{target}({2})'],
+		[openbsd*], [ASCIIDOC_TEMPLATE_LINKMANEXT2='https://man.openbsd.org/man{2}/{target}.{2}'],
 			[ASCIIDOC_TEMPLATE_LINKMANEXT2='https://linux.die.net/man/{2}/{target}'])],
 		[ASCIIDOC_TEMPLATE_LINKMANEXT2="${nut_with_docs_man_linkmanext2_template}"])
 AC_SUBST([ASCIIDOC_TEMPLATE_LINKMANEXT2])

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -33,3 +33,4 @@ docinfo.xml.in.tmp
 /.check-pdf
 /.check-html-single
 /.check-html-chunked
+/asciidoc.conf

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -1142,6 +1142,7 @@ MAINTAINERCLEANFILES += $(NUT_SPELL_DICT).usage-report
 # When building out-of-tree, be sure to have all asciidoc resources
 # under the same dir structure (tool limitation)
 PREP_SRC = $(EXTRA_DIST) $(SPELLCHECK_SRC_DEFAULT)
+ASCIIDOC_LINKMANEXT_SECTION_REWRITE = @ASCIIDOC_LINKMANEXT_SECTION_REWRITE@
 
 # NOTE: Some "make" implementations prefix a relative or absent path to
 # the filenames in PREP_SRC, others (e.g. Sun make) prepend the absolute
@@ -1184,7 +1185,15 @@ $(abs_top_builddir)/docs/.prep-src-docs: $(PREP_SRC) Makefile
 	                -e 's,\(linkman:[^ []*\[\)5\],\1$(MAN_SECTION_CFG)],g' \
 	                -e 's,\(linkman:[^ []*\[\)8\],\1$(MAN_SECTION_CMD_SYS)],g' \
 	                -e 's,\(linkman:[^ []*\[\)1\],\1$(MAN_SECTION_CMD_USR)],g' \
-	                -e 's,\(linkman:[^ []*\[\)7\],\1$(MAN_SECTION_MISC)],g' ; \
+	                -e 's,\(linkman:[^ []*\[\)7\],\1$(MAN_SECTION_MISC)],g' | \
+	            if [ x"$(ASCIIDOC_LINKMANEXT_SECTION_REWRITE)" = xyes ] ; then \
+	                sed \
+	                -e 's,\(linkmanext2?:[^ []*\[\)3\],\1$(MAN_SECTION_API)],g' \
+	                -e 's,\(linkmanext2?:[^ []*\[\)5\],\1$(MAN_SECTION_CFG)],g' \
+	                -e 's,\(linkmanext2?:[^ []*\[\)8\],\1$(MAN_SECTION_CMD_SYS)],g' \
+	                -e 's,\(linkmanext2?:[^ []*\[\)1\],\1$(MAN_SECTION_CMD_USR)],g' \
+	                -e 's,\(linkmanext2?:[^ []*\[\)7\],\1$(MAN_SECTION_MISC)],g' ; \
+	            else cat ; fi; \
 	        fi < "$${F}" > "$${F}-prepped" || exit ;; \
 	        esac; \
 	        COUNT="`expr $$COUNT + 1`" ; \
@@ -1245,7 +1254,15 @@ $(abs_top_builddir)/docs/.prep-src-docs: $(PREP_SRC) Makefile
 	                -e 's,\(linkman:[^ []*\[\)5\],\1$(MAN_SECTION_CFG)],g' \
 	                -e 's,\(linkman:[^ []*\[\)8\],\1$(MAN_SECTION_CMD_SYS)],g' \
 	                -e 's,\(linkman:[^ []*\[\)1\],\1$(MAN_SECTION_CMD_USR)],g' \
-	                -e 's,\(linkman:[^ []*\[\)7\],\1$(MAN_SECTION_MISC)],g' ; \
+	                -e 's,\(linkman:[^ []*\[\)7\],\1$(MAN_SECTION_MISC)],g' | \
+	            if [ x"$(ASCIIDOC_LINKMANEXT_SECTION_REWRITE)" = xyes ] ; then \
+	                sed \
+	                -e 's,\(linkmanext2?:[^ []*\[\)3\],\1$(MAN_SECTION_API)],g' \
+	                -e 's,\(linkmanext2?:[^ []*\[\)5\],\1$(MAN_SECTION_CFG)],g' \
+	                -e 's,\(linkmanext2?:[^ []*\[\)8\],\1$(MAN_SECTION_CMD_SYS)],g' \
+	                -e 's,\(linkmanext2?:[^ []*\[\)1\],\1$(MAN_SECTION_CMD_USR)],g' \
+	                -e 's,\(linkmanext2?:[^ []*\[\)7\],\1$(MAN_SECTION_MISC)],g' ; \
+	            else cat ; fi; \
 	        fi < "$${linkroot}/$${F}" > "$${linkroot}/$${F}-prepped" \
 	        || { rm -f "$@.working" ; exit 1 ; } ;; \
 	        esac ; \

--- a/docs/asciidoc.conf.in
+++ b/docs/asciidoc.conf.in
@@ -105,9 +105,9 @@ ifdef::xhtml11_format[]
 # FIXME: Allow to define external man page URL structure and whether
 #  sections should change via configure script options:
 [linkmanext-inlinemacro]
-<ulink url="https://linux.die.net/man/{0}/{target}">{target}{0?({0})}</ulink>
+<ulink url="@ASCIIDOC_TEMPLATE_LINKMANEXT@">{target}{0?({0})}</ulink>
 [linkmanext2-inlinemacro]
-<ulink url="https://linux.die.net/man/{2}/{target}">{1={target}}{2?({2})}</ulink>
+<ulink url="@ASCIIDOC_TEMPLATE_LINKMANEXT2@">{1={target}}{2?({2})}</ulink>
 [linkdoc-inlinemacro]
 <ulink url="{target}.html{2?#{2}}">{1}</ulink>{3?suggestsrcdoc:{3}[]}
 [linksingledoc-inlinemacro]
@@ -128,9 +128,9 @@ ifdef::chunked_format[]
 # FIXME: Allow to define external man page URL structure and whether
 #  sections should change via configure script options:
 [linkmanext-inlinemacro]
-<ulink url="https://linux.die.net/man/{0}/{target}">{target}{0?({0})}</ulink>
+<ulink url="@ASCIIDOC_TEMPLATE_LINKMANEXT@">{target}{0?({0})}</ulink>
 [linkmanext2-inlinemacro]
-<ulink url="https://linux.die.net/man/{2}/{target}">{1={target}}{2?({2})}</ulink>
+<ulink url="@ASCIIDOC_TEMPLATE_LINKMANEXT2@">{1={target}}{2?({2})}</ulink>
 [linkdoc-inlinemacro]
 <ulink url="../{target}.chunked/{4=index}.html{2?#{2}}">{1}</ulink>{3?suggestsrcdoc:{3}[]}
 [linksingledoc-inlinemacro]
@@ -148,9 +148,9 @@ ifdef::pdf_format[]
 # FIXME: Allow to define external man page URL structure and whether
 #  sections should change via configure script options:
 [linkmanext-inlinemacro]
-<ulink url="https://linux.die.net/man/{0}/{target}">{target}{0?({0})}</ulink>
+<ulink url="@ASCIIDOC_TEMPLATE_LINKMANEXT@">{target}{0?({0})}</ulink>
 [linkmanext2-inlinemacro]
-<ulink url="https://linux.die.net/man/{2}/{target}">{1={target}}{2?({2})}</ulink>
+<ulink url="@ASCIIDOC_TEMPLATE_LINKMANEXT2@">{1={target}}{2?({2})}</ulink>
 [linkdoc-inlinemacro]
 <ulink url="{target}.pdf{2?#{2}}">{1}</ulink>{3?suggestsrcdoc:{3}[]}
 [linksingledoc-inlinemacro]

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -420,6 +420,14 @@ NOTE: The resulting `GITLOG_START_POINT` value may also impact the oldest
 version considered by maintainer helper script `docs/docinfo.xml.sh` (if it
 specifies a `v*` tag, otherwise `v2.6.0` is used).
 
+	--with-docs-man-linkmanext-template='https://linux.die.net/man/{0}/{target}'
+	--with-docs-man-linkmanext2-template='https://linux.die.net/man/{2}/{target}'
+
+NUT manual pages can refer to system-provided programs, files or syscalls
+using custom-defined `linkmanext` or `linkmanext2` asciidoc macros.
+The options above should help packagers manage this; defaults are set for
+Linux standard filesystem layout.
+
 Python support
 ~~~~~~~~~~~~~~
 

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -422,11 +422,13 @@ specifies a `v*` tag, otherwise `v2.6.0` is used).
 
 	--with-docs-man-linkmanext-template='https://linux.die.net/man/{0}/{target}'
 	--with-docs-man-linkmanext2-template='https://linux.die.net/man/{2}/{target}'
+	--enable-docs-man-linkmanext-section-rewrite
 
 NUT manual pages can refer to system-provided programs, files or syscalls
 using custom-defined `linkmanext` or `linkmanext2` asciidoc macros.
-The options above should help packagers manage this; defaults are set for
-Linux standard filesystem layout.
+They in turn use man page sections, which may be subject to rewrites similar
+to those applied to NUT pages themselves. The options above should help
+packagers manage this; defaults are set for Linux standard filesystem layout.
 
 Python support
 ~~~~~~~~~~~~~~

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -430,6 +430,11 @@ They in turn use man page sections, which may be subject to rewrites similar
 to those applied to NUT pages themselves. The options above should help
 packagers manage this; defaults are set for Linux standard filesystem layout.
 
+NOTE: Avoid characters special for XML or HTML mark-up needed in the template
+(notably the `&` "ampersand" in HTML URLs with queries), entities like `&amp;`
+must be used to pass docbook part (not man page generation though) and then
+it stays in the final document, making the URL invalid. PRs welcome :)
+
 Python support
 ~~~~~~~~~~~~~~
 

--- a/docs/man/.gitignore
+++ b/docs/man/.gitignore
@@ -16,3 +16,4 @@
 /.check-html-man
 /.check-man-pages
 /.check-man-txt
+/asciidoc.conf

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -2028,6 +2028,7 @@ spellcheck spellcheck-interactive spellcheck-sortdict:
 # the built man pages in the tarball for end-users without an asciidoc
 # stack (causing a dependency loop)!
 PREP_SRC = $(LINKMAN_INCLUDE_GENERATED) $(SRC_ALL_PAGES) asciidoc.conf
+ASCIIDOC_LINKMANEXT_SECTION_REWRITE = @ASCIIDOC_LINKMANEXT_SECTION_REWRITE@
 
 # NOTE: Some "make" implementations prefix a relative or absent path to
 # the filenames in PREP_SRC, others (e.g. Sun make) prepend the absolute
@@ -2090,7 +2091,15 @@ $(abs_top_builddir)/docs/man/.prep-src-docs: $(PREP_SRC) Makefile
 	                -e '1 s,\(^.*(\)5)$$,\1$(MAN_SECTION_CFG)),g' \
 	                -e '1 s,\(^.*(\)8)$$,\1$(MAN_SECTION_CMD_SYS)),g' \
 	                -e '1 s,\(^.*(\)1)$$,\1$(MAN_SECTION_CMD_USR)),g' \
-	                -e '1 s,\(^.*(\)7)$$,\1$(MAN_SECTION_MISC)),g' ; \
+	                -e '1 s,\(^.*(\)7)$$,\1$(MAN_SECTION_MISC)),g' | \
+	            if [ x"$(ASCIIDOC_LINKMANEXT_SECTION_REWRITE)" = xyes ] ; then \
+	                sed \
+	                -e 's,\(linkmanext2?:[^ []*\[\)3\],\1$(MAN_SECTION_API)],g' \
+	                -e 's,\(linkmanext2?:[^ []*\[\)5\],\1$(MAN_SECTION_CFG)],g' \
+	                -e 's,\(linkmanext2?:[^ []*\[\)8\],\1$(MAN_SECTION_CMD_SYS)],g' \
+	                -e 's,\(linkmanext2?:[^ []*\[\)1\],\1$(MAN_SECTION_CMD_USR)],g' \
+	                -e 's,\(linkmanext2?:[^ []*\[\)7\],\1$(MAN_SECTION_MISC)],g' ; \
+	            else cat ; fi; \
 	        fi < "$${F}" > "$${F}-prepped" || exit ;; \
 	        esac ; \
 	        COUNT="`expr $$COUNT + 1`" ; \
@@ -2155,7 +2164,15 @@ $(abs_top_builddir)/docs/man/.prep-src-docs: $(PREP_SRC) Makefile
 	                -e '1 s,\(^.*(\)5)$$,\1$(MAN_SECTION_CFG)),g' \
 	                -e '1 s,\(^.*(\)8)$$,\1$(MAN_SECTION_CMD_SYS)),g' \
 	                -e '1 s,\(^.*(\)1)$$,\1$(MAN_SECTION_CMD_USR)),g' \
-	                -e '1 s,\(^.*(\)7)$$,\1$(MAN_SECTION_MISC)),g' ; \
+	                -e '1 s,\(^.*(\)7)$$,\1$(MAN_SECTION_MISC)),g' | \
+	            if [ x"$(ASCIIDOC_LINKMANEXT_SECTION_REWRITE)" = xyes ] ; then \
+	                sed \
+	                -e 's,\(linkmanext2?:[^ []*\[\)3\],\1$(MAN_SECTION_API)],g' \
+	                -e 's,\(linkmanext2?:[^ []*\[\)5\],\1$(MAN_SECTION_CFG)],g' \
+	                -e 's,\(linkmanext2?:[^ []*\[\)8\],\1$(MAN_SECTION_CMD_SYS)],g' \
+	                -e 's,\(linkmanext2?:[^ []*\[\)1\],\1$(MAN_SECTION_CMD_USR)],g' \
+	                -e 's,\(linkmanext2?:[^ []*\[\)7\],\1$(MAN_SECTION_MISC)],g' ; \
+	            else cat ; fi; \
 	        fi < "$${linkroot}/$${F}" > "$${linkroot}/$${F}-prepped" \
 	        || { rm -f "$@.working" ; exit 1 ; } ;; \
 	        esac ; \

--- a/docs/man/asciidoc.conf
+++ b/docs/man/asciidoc.conf
@@ -4,7 +4,7 @@
 # Usage: linkman:command[manpage-section]
 # Usage: linkman2:command-page[displayed-command,manpage-section]
 #
-# Note:
+# Notes:
 # - in linkman, {0} is the manpage section, while {target} is the command.
 # - in linkman2, {0} is the whole list of attributes, {1} is the command to be
 #   shown, {2} is the manpage section, while {target} is the command page.
@@ -12,6 +12,8 @@
 #   These macros are intended for system man pages (e.g. HTML links might lead
 #   to a generic internet site, or possibly to a distro-provided library
 #   online or locally).
+# - UNLIKE docs/asciidoc.conf we should not use "ulink" here, otherwise it
+#   goes "as is" into the generated HTML (and is not understood by browsers)!
 
 #
 # Show NUT link as: <command>(<section>); if section is defined, else just show
@@ -54,9 +56,11 @@ ifdef::backend-xhtml11[]
 # FIXME: Allow to define external man page URL structure and whether
 #  sections should change via configure script options:
 [linkmanext-inlinemacro]
-<ulink url="https://linux.die.net/man/{0}/{target}">{target}{0?({0})}</ulink>
+<a href="https://linux.die.net/man/{0}/{target}">{target}{0?({0})}</a>
+#<ulink url="https://linux.die.net/man/{0}/{target}">{target}{0?({0})}</ulink>
 [linkmanext2-inlinemacro]
-<ulink url="https://linux.die.net/man/{2}/{target}">{1={target}}{2?({2})}</ulink>
+<a href="https://linux.die.net/man/{2}/{target}">{1={target}}{2?({2})}</a>
+#<ulink url="https://linux.die.net/man/{2}/{target}">{1={target}}{2?({2})}</ulink>
 # Override HTML footer, to include NUT version
 [footer-text]
 Last updated {docdate} {doctime} -- Network UPS Tools {nutversion}

--- a/docs/man/asciidoc.conf.in
+++ b/docs/man/asciidoc.conf.in
@@ -56,11 +56,9 @@ ifdef::backend-xhtml11[]
 # FIXME: Allow to define external man page URL structure and whether
 #  sections should change via configure script options:
 [linkmanext-inlinemacro]
-<a href="https://linux.die.net/man/{0}/{target}">{target}{0?({0})}</a>
-#<ulink url="https://linux.die.net/man/{0}/{target}">{target}{0?({0})}</ulink>
+<a href="@ASCIIDOC_TEMPLATE_LINKMANEXT@">{target}{0?({0})}</a>
 [linkmanext2-inlinemacro]
-<a href="https://linux.die.net/man/{2}/{target}">{1={target}}{2?({2})}</a>
-#<ulink url="https://linux.die.net/man/{2}/{target}">{1={target}}{2?({2})}</ulink>
+<a href="@ASCIIDOC_TEMPLATE_LINKMANEXT2@">{1={target}}{2?({2})}</a>
 # Override HTML footer, to include NUT version
 [footer-text]
 Last updated {docdate} {doctime} -- Network UPS Tools {nutversion}

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3530 utf-8
+personal_ws-1.1 en 3531 utf-8
 AAC
 AAS
 ABI
@@ -3293,6 +3293,7 @@ uid
 uint
 ukUNV
 ul
+ulink
 un
 uname
 uncomment


### PR DESCRIPTION
HTML rendering of NUT docs (including man pages) after PR #2797 included references to online versions of system-provided man pages (for standard commands). This was initially based on https://linux.die.net resource.

This PR fixes the man page rendering from `ulink` (docbook xml) to `a href` (direct html) tags, and extends the man page referencing macros to allow building packaged references to custom distro-dependent resources.

Man page sections involved in these references may also be rewritten; more work is however needed to create correct URLs because different distros might place system commands into various places (there may not be one transformation pattern to cover everything). And, of course, any such remote URL is subject to availability of an online resource not managed by NUT...