### PR TITLE
[CI] Introduce a `make check-parallel-builds` recipe

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,15 @@ jobs:
             ./ci_build.sh
 
       - run:
-          name: "ccache stats after build"
+          name: "ccache stats after initial build"
+          command: ccache -s || true
+
+      - run:
+          name: "verify parallel build recipes in subdirs"
+          command: make -s -j check-parallel-builds || exit
+
+      - run:
+          name: "ccache stats after a few rebuilds"
           command: ccache -s || true
 
       # NOTE: Detailed key name allows every scenario to only track its

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -75,15 +75,15 @@ jobs:
         sudo apt install libltdl-dev libtool libtool-bin cppcheck ccache libgd-dev libcppunit-dev libsystemd-dev libssl-dev libnss3-dev augeas-tools libaugeas-dev augeas-lenses libusb-dev libusb-1.0-0-dev libmodbus-dev libsnmp-dev libpowerman0-dev libfreeipmi-dev libipmimonitoring-dev libavahi-common-dev libavahi-core-dev libavahi-client-dev libgpiod-dev libneon27-dev libi2c-dev i2c-tools lm-sensors
 
     # Make build identification more useful (no fallbacks)
-    - name: Try to get more Git metadata
-      run: |
-        git remote -v || true
-        git branch -a || true
-        for R in `git remote` ; do git fetch $R master ; done || true
-        git fetch --tags
+    #- name: Try to get more Git metadata
+    #  run: |
+    #    git remote -v || true
+    #    git branch -a || true
+    #    for R in `git remote` ; do git fetch $R master ; done || true
+    #    git fetch --tags
 
-    - name: Debug gitlog2version processing
-      run: bash -x ./tools/gitlog2version.sh || true
+    #- name: Debug gitlog2version processing
+    #  run: bash -x ./tools/gitlog2version.sh || true
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -97,7 +97,8 @@ jobs:
       run: |
         ./autogen.sh
         ./configure --enable-warnings --enable-Werror --enable-Wcolor --with-all=auto --with-dev --without-docs ${{matrix.compiler}} --with-ssl=${{matrix.NUT_SSL_VARIANTS}} --with-usb=${{matrix.NUT_USB_VARIANTS}}
-        make -s -j 8
+        make -s -j 8 || exit
+        make -s -j check-parallel-builds || exit
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -74,6 +74,17 @@ jobs:
         case x"${{matrix.compiler}}" in x*clang*) sudo apt install clang ;; x*) sudo apt install gcc g++ ;; esac
         sudo apt install libltdl-dev libtool libtool-bin cppcheck ccache libgd-dev libcppunit-dev libsystemd-dev libssl-dev libnss3-dev augeas-tools libaugeas-dev augeas-lenses libusb-dev libusb-1.0-0-dev libmodbus-dev libsnmp-dev libpowerman0-dev libfreeipmi-dev libipmimonitoring-dev libavahi-common-dev libavahi-core-dev libavahi-client-dev libgpiod-dev libneon27-dev libi2c-dev i2c-tools lm-sensors
 
+    # Make build identification more useful (no fallbacks)
+    - name: Try to get more Git metadata
+      run: |
+        git remote -v || true
+        git branch -a || true
+        for R in `git remote` ; do git fetch $R master ; done || true
+        git fetch --tags
+
+    - name: Debug gitlog2version processing
+      run: bash -x ./tools/gitlog2version.sh || true
+
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     #- name: Autobuild
@@ -98,7 +109,10 @@ jobs:
         ./autogen.sh
         ./configure --enable-warnings --enable-Werror --enable-Wcolor --with-all=auto --with-dev --without-docs ${{matrix.compiler}} --with-ssl=${{matrix.NUT_SSL_VARIANTS}} --with-usb=${{matrix.NUT_USB_VARIANTS}}
         make -s -j 8 || exit
-        make -s -j check-parallel-builds || exit
+
+    - if: matrix.language == 'cpp'
+      name: NUT CI Build to verify parallel build recipes in subdirs
+      run: make -s -j check-parallel-builds || exit
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun

--- a/Makefile.am
+++ b/Makefile.am
@@ -1443,3 +1443,38 @@ check-files-quick: $(CHECK_FILES_QUICK_TARGETS)
 
 # Autotools hook: run the quick checks before recursing for defaults:
 check-recursive: check-files-quick
+
+# Not pulled in directly so far, can be used by developers to verify that build
+# rules (inlcuding dependencies pulled from other directories) make sense and
+# do not cause conflict by writing into same file names. Something that builds
+# from root directory arrange nicely, but needs careful balancing on a tightrope
+# if developers build pieces of code right in the directory of their interest.
+# It is recommended to have "ccache" (or similar) setup working, to minimize the
+# time cost and workload of compilations involved in these looped build retries.
+# Auto-parallel recipe (if current 'make' implementation supports the "-j N"
+# syntax; the optional MAXPARMAKES may be set in NUT CI farm style builds):
+check-parallel-builds:
+	automake -f
+	./config.status
+	+@MAXPARMAKES_OPT=""; \
+	  case " $(MAKEFLAGS) $(AM_MAKEFLAGS)" in \
+		*"j"*) ;; \
+		*) \
+			if ! [ "$${MAXPARMAKES-}" -gt 1 ] 2>/dev/null ; then \
+				MAXPARMAKES=8 ; \
+			fi ; \
+			MAXPARMAKES_OPT="-j $${MAXPARMAKES}" ; \
+		;; \
+	  esac ; \
+	  DIRS=""; \
+	  for D in `find . -name '*.c' -o -name '*.cpp' | sed 's,/[^/]*\.cp*$$,,' | uniq` ; do \
+		[ -e "$$D/Makefile.am" ] && [ -s "$$D/Makefile" ] || continue ; \
+		$(MAKE) $(AM_MAKEFLAGS) -k -s $${MAXPARMAKES_OPT} clean || { RES=$$?; echo "$@: FAILED: make clean before going to $$D" >&2; exit $$RES; } ; \
+		echo "  $@	in $${D}" ; \
+		( cd "$$D" && $(MAKE) $(AM_MAKEFLAGS) -k -s $${MAXPARMAKES_OPT} ) || { RES=$$?; echo "$@: FAILED: parallel make in $$D" >&2; \
+		  echo "To investigate, try:  $(MAKE) $(MAKEFLAGS) $(AM_MAKEFLAGS) $${MAXPARMAKES_OPT} clean ; automake -f && ./config.status && clear && (cd $${D}/ && $(MAKE) $(MAKEFLAGS) $(AM_MAKEFLAGS) V=1 $${MAXPARMAKES_OPT} 2>&1 ; echo $?) | tee /tmp/make.log ; grep -E '(\] Error|No rule to)' /tmp/make.log && less /tmp/make.log"; \
+		  echo "If builds were interrupted before, you may also have to re-initialize the build area completely, e.g.:  git clean -fdX ; ./ci_build.sh && $(MAKE) $(MAKEFLAGS) $(AM_MAKEFLAGS) $@" ; \
+		  exit $$RES; } ; \
+		DIRS="$${DIRS} $${D}" ; \
+	  done ; \
+	  echo "$@: SUCCESS in all checked directories:$${DIRS}" >&2

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -311,6 +311,13 @@ https://github.com/networkupstools/nut/milestone/9
    services, if `systemctl preset-all` fails (assumed due to a systemd 252
    bug). [#3022]
 
+ - Added a `make check-parallel-builds` recipe to help troubleshoot recipes
+   in sub-directories, and improved build-ability of existing NUT sources
+   starting from scratch there. This is a workflow useful for NUT development
+   (e.g. to focus only on drivers, or tests, or nut-scanner) but not so much
+   for end-user packaging where everything builds from the root directory.
+   [follows up from PR #2825, highlights why issue #2584 better be solved]
+
 
 Release notes for NUT 2.8.3 - what's new since 2.8.2
 ----------------------------------------------------

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -316,7 +316,8 @@ https://github.com/networkupstools/nut/milestone/9
    starting from scratch there. This is a workflow useful for NUT development
    (e.g. to focus only on drivers, or tests, or nut-scanner) but not so much
    for end-user packaging where everything builds from the root directory.
-   [follows up from PR #2825, highlights why issue #2584 better be solved]
+   [PR #3030, follows up from PR #2825, highlights why issue #2584 better
+   be solved]
 
 
 Release notes for NUT 2.8.3 - what's new since 2.8.2

--- a/clients/Makefile.am
+++ b/clients/Makefile.am
@@ -24,6 +24,12 @@ $(top_builddir)/common/libcommonversion.la \
 $(top_builddir)/common/libparseconf.la: dummy
 	+@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
+# Builds from root dir arrange stuff decently. Make sure parallel builds
+# started from scratch right in this dir get dependencies in proper order
+# (sub-makes are independent as far as trying to write into same files):
+$(top_builddir)/common/libcommon.la: $(top_builddir)/common/libparseconf.la
+$(top_builddir)/common/libcommonclient.la: $(top_builddir)/common/libparseconf.la
+
 LDADD_FULL = \
 	$(top_builddir)/common/libcommon.la \
 	$(top_builddir)/common/libcommonversion.la \

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -670,7 +670,7 @@
 "Kanji"	"ups"	"1"	"800 VA"	"USB"	"nutdrv_atcl_usb"
 
 "Kebo"	"ups"	"2"	"1200D/D Series"	""	"blazer_ser"
-"Kebo"	"ups"	"2"	"UPS-1000D (UPS-1000VA)"	"USB"	"blazer_usb"	# https://github.com/networkupstools/nut/issues/981
+"Kebo"	"ups"	"2"	"UPS-1000D (UPS-1000VA)"	"USB"	"blazer_usb langid_fix=0x4095 subdriver=krauler"	# https://github.com/networkupstools/nut/issues/981
 "Kebo"	"ups"	"2"	"UPS-650VA"	"USB"	"megatec_usb"
 
 "KOLFF"	"ups"	"2"	"BLACK NOVA 1K/2K/3K/6K/10K/20K TOWER"	"USB"	"blazer_usb"
@@ -1424,6 +1424,8 @@
 "Tecnoware"	"ups"	"2"	"Easy Power 1200"	""	"blazer_ser"
 "Tecnoware"	"ups"	"2"	"UPS ERA LCD 0.65"	"USB"	"blazer_usb langid_fix=0x409"
 "Tecnoware"	"ups"	"2"	"UPS ERA PLUS 1100"	"USB"	"blazer_usb"	# https://www.tecnoware.com/Prodotti/FGCERAPL1100/ups-era-plus-1100.aspx https://github.com/networkupstools/nut/issues/747
+
+"Tescom"	"ups"	"2"	"LEO Plus LCD 1500A"	"USB"	"blazer_usb langid_fix=0x4095 subdriver=krauler"	# https://github.com/networkupstools/nut/issues/981
 
 "Texas Instruments"	"ups"	"5"	"INA219"	"hwmon"	"hwmon_ina219"
 

--- a/docs/nut-versioning.adoc
+++ b/docs/nut-versioning.adoc
@@ -104,6 +104,18 @@ Occasionally there may be tagged pre-releases, which follow the standard
 semver markup, like `v2.8.0-rc3` (in git), however they would be converted
 to NUT SEMVER here (as a number of commits since previous release) by default.
 
+A special case, which can mostly be seen in CI builds, concerns shallow git
+checkouts -- when the currently built commit history is "grafted" (perhaps
+down to there being only one commit in the whole git index), and we do not
+know of any intersections with git tags or development trunk.  In this case,
+the script may not only fall back to a built-in version following a legacy
+`X.Y.Z.1` pattern for non-release builds (like `2.8.3.1`), but would also
+append a `-0-g{HASH}` suffix to the long values (`VER5`, `VER50`, `DECS5`,
+`DESC50`) yielding e.g. `2.8.3.1.0-0+gb3f21f9` for a build from a shallow
+git checkout of commit `b3f21f9` of a code base which otherwise fell back
+to `2.8.3.1` hard-coded in its copy of the script (bumped by a maintainer
+as part of the release process).
+
 Using gitlog2version.sh
 -----------------------
 

--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -16,6 +16,14 @@ $(top_builddir)/common/libparseconf.la \
 $(top_builddir)/clients/libupsclient.la: dummy
 	+@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
+# Builds from root dir arrange stuff decently. Make sure parallel builds
+# started from scratch right in this dir get dependencies in proper order
+# (sub-makes are independent as far as trying to write into same files):
+$(top_builddir)/common/libcommon.la: $(top_builddir)/common/libparseconf.la
+# Internally (clients/Makefile.am) libupsclient.la requires libcommonclient.la
+# and that in turn libparseconf.la:
+$(top_builddir)/clients/libupsclient.la: $(top_builddir)/common/libparseconf.la
+
 # by default, link programs in this directory with libcommon.la
 # (libtool version of the static lib, in order to access LTLIBOBJS)
 #FIXME: SERLIBS is only useful for LDADD_DRIVERS_SERIAL not for LDADD_COMMON
@@ -459,11 +467,11 @@ libdummy_upsdrvquery_la_LDFLAGS = -no-undefined -static
 EXTRA_LTLIBRARIES += libdummy_mockdrv.la
 libdummy_mockdrv_la_SOURCES = main.c dstate.c
 libdummy_mockdrv_la_CFLAGS = $(AM_CFLAGS) -DDRIVERS_MAIN_WITHOUT_MAIN=1
-libdummy_mockdrv_la_LDFLAGS = \
-	-static \
+libdummy_mockdrv_la_LIBADD = \
 	$(top_builddir)/common/libcommon.la \
 	$(top_builddir)/common/libcommonversion.la \
 	$(top_builddir)/common/libparseconf.la
+libdummy_mockdrv_la_LDFLAGS = -static
 
 # Also define a library with serial-port UPS routines needed for nut-scanner
 noinst_LTLIBRARIES = libserial-nutscan.la

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -47,8 +47,11 @@
 #include "netvision-mib.h"
 #include "eaton-pdu-genesis2-mib.h"
 #include "eaton-pdu-marlin-mib.h"
+#include "eaton-pdu-nlogic-mib.h"
 #include "eaton-pdu-pulizzi-mib.h"
 #include "eaton-pdu-revelation-mib.h"
+#include "eaton-ups-pwnm2-mib.h"
+#include "eaton-ups-pxg-mib.h"
 #include "raritan-pdu-mib.h"
 #include "raritan-px2-mib.h"
 #include "baytech-mib.h"
@@ -69,9 +72,6 @@
 #include "emerson-avocent-pdu-mib.h"
 #include "hpe-pdu-mib.h"
 #include "hpe-pdu3-cis-mib.h"
-#include "eaton-pdu-nlogic-mib.h"
-#include "eaton-ups-pwnm2-mib.h"
-#include "eaton-ups-pxg-mib.h"
 
 /* Address API change */
 #if ( ! NUT_HAVE_LIBNETSNMP_usmAESPrivProtocol ) && ( ! defined usmAESPrivProtocol )

--- a/server/Makefile.am
+++ b/server/Makefile.am
@@ -15,6 +15,11 @@ $(top_builddir)/common/libcommonversion.la \
 $(top_builddir)/common/libparseconf.la: dummy
 	+@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
+# Builds from root dir arrange stuff decently. Make sure parallel builds
+# started from scratch right in this dir get dependencies in proper order
+# (sub-makes are independent as far as trying to write into same files):
+$(top_builddir)/common/libcommon.la: $(top_builddir)/common/libparseconf.la
+
 # Avoid per-target CFLAGS, because this will prevent re-use of object
 # files. In any case, CFLAGS are only -I options, so there is no harm,
 # but only add them if we really use the target.

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -34,6 +34,28 @@ check_SCRIPTS =
 check-NIT check-NIT-devel:
 	+cd "$(builddir)/NIT" && $(MAKE) $(AM_MAKEFLAGS) $@
 
+# Make sure out-of-dir dependencies exist (especially when dev-building
+# only some parts of NUT; note libnutclient* are for C++ but would not
+# be referenced unless that build ability is detected and enabled):
+$(top_builddir)/drivers/libdummy_mockdrv.la \
+$(top_builddir)/common/libnutconf.la \
+$(top_builddir)/common/libcommonclient.la \
+$(top_builddir)/common/libcommon.la \
+$(top_builddir)/common/libparseconf.la \
+$(top_builddir)/clients/libnutclient.la \
+$(top_builddir)/clients/libnutclientstub.la: dummy
+	+@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
+
+# Builds from root dir arrange stuff decently. Make sure parallel builds
+# started from scratch right in this dir get dependencies in proper order
+# (sub-makes are independent as far as trying to write into same files):
+$(top_builddir)/common/libcommon.la $(top_builddir)/common/libcommonclient.la: $(top_builddir)/common/libparseconf.la
+$(top_builddir)/common/libnutconf.la: $(top_builddir)/common/libcommonclient.la
+$(top_builddir)/drivers/libdummy_mockdrv.la: $(top_builddir)/common/libcommon.la
+#... $(top_builddir)/common/libcommonversion.la $(top_builddir)/common/libparseconf.la
+$(top_builddir)/clients/libnutclient.la: $(top_builddir)/common/libcommonclient.la
+$(top_builddir)/clients/libnutclientstub.la: $(top_builddir)/clients/libnutclient.la
+
 nutlogtest_SOURCES = nutlogtest.c
 nutlogtest_LDADD = $(top_builddir)/common/libcommon.la
 
@@ -123,13 +145,6 @@ driver_methods_utest_SOURCES = driver_methods_utest.c
 driver_methods_utest_LDADD = $(top_builddir)/drivers/libdummy_mockdrv.la
 driver_methods_utest_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/tests -DDRIVERS_MAIN_WITHOUT_MAIN=1
 
-# Make sure out-of-dir dependencies exist (especially when dev-building parts):
-$(top_builddir)/drivers/libdummy_mockdrv.la \
-$(top_builddir)/common/libnutconf.la \
-$(top_builddir)/common/libcommonclient.la \
-$(top_builddir)/common/libcommon.la: dummy
-	+@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
-
 ### Optional tests which can not be built everywhere
 # List of src files for CppUnit tests
 CPPUNITTESTSRC = example.cpp nutclienttest.cpp
@@ -173,11 +188,6 @@ cppnit_LDADD   = $(top_builddir)/clients/libnutclientstub.la
 cppnit_LDADD  += $(top_builddir)/clients/libnutclient.la
 cppnit_SOURCES = $(CPPCLIENTTESTSRC) $(CPPUNITTESTERSRC)
 
-# Make sure out-of-dir C++ dependencies exist (especially when dev-building
-# only some parts of NUT):
-$(top_builddir)/clients/libnutclient.la \
-$(top_builddir)/clients/libnutclientstub.la: dummy
-	+@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
 else !HAVE_CPPUNIT
 # Just redistribute test source into tarball if not building tests

--- a/tools/gitlog2version.sh
+++ b/tools/gitlog2version.sh
@@ -140,7 +140,7 @@ fi
 [ x"${NUT_VERSION_PREFER_GIT-}" = xfalse ] || { [ -e "${abs_top_srcdir}/.git" ] && NUT_VERSION_PREFER_GIT=true || NUT_VERSION_PREFER_GIT=false ; }
 
 check_shallow_git() {
-    if git log --oneline --decorate=short | tail -1 | grep -w grafted || [ 10 -gt `git log --oneline | wc -l` ] ; then
+    if git log --oneline --decorate=short | tail -1 | grep -w grafted >&2 || [ 10 -gt `git log --oneline | wc -l` ] ; then
         echo "$0: $1" >&2
     fi
 }

--- a/tools/gitlog2version.sh
+++ b/tools/gitlog2version.sh
@@ -139,6 +139,12 @@ fi
 # Must be "true" or "false" exactly, interpreted as such below:
 [ x"${NUT_VERSION_PREFER_GIT-}" = xfalse ] || { [ -e "${abs_top_srcdir}/.git" ] && NUT_VERSION_PREFER_GIT=true || NUT_VERSION_PREFER_GIT=false ; }
 
+check_shallow_git() {
+    if git log --oneline --decorate=short | tail -1 | grep -w grafted || [ 10 -gt `git log --oneline | wc -l` ] ; then
+        echo "$0: $1" >&2
+    fi
+}
+
 getver_git() {
     # NOTE: The chosen trunk branch must be up to date (may be "origin/master"
     # or "upstream/master", etc.) for resulting version discovery to make sense.
@@ -161,6 +167,7 @@ getver_git() {
         done
         if [ x"${NUT_VERSION_GIT_TRUNK-}" = x ] ; then
             echo "$0: FAILED to discover a NUT_VERSION_GIT_TRUNK in this workspace" >&2
+            check_shallow_git "NOTE: Current checkout is shallow, the workspace may not include enough context to describe it"
             return 1
         fi
     fi
@@ -188,7 +195,11 @@ getver_git() {
     # Follow https://semver.org/#spec-item-10 about build metadata:
     # it is (a dot-separated list) separated by a plus sign from preceding
     DESC="`echo "${DESC}" | sed 's/\(-[0-9][0-9]*\)-\(g[0-9a-fA-F][0-9a-fA-F]*\)$/\1+\2/'`"
-    if [ x"${DESC}" = x ] ; then echo "$0: FAILED to 'git describe' this codebase" >&2 ; return 1 ; fi
+    if [ x"${DESC}" = x ] ; then
+        echo "$0: FAILED to 'git describe' this codebase" >&2
+        check_shallow_git "NOTE: Current checkout is shallow, may not include enough history to describe it"
+        return 1
+    fi
 
     # Does the current commit correspond to an `(alpha|beta|rc)NUM` git tag
     # (may be un-annotated)? Note that `git describe` picks the value to
@@ -206,7 +217,12 @@ getver_git() {
     # at the tagged commit (it is the merge base for itself and any of
     # its descendants):
     BASE="`git merge-base HEAD "${NUT_VERSION_GIT_TRUNK}"`" || BASE=""
-    if [ x"${BASE}" = x ] ; then echo "$0: FAILED to get a git merge-base of this codebase vs. '${NUT_VERSION_GIT_TRUNK}'" >&2 ; DESC=""; return  1; fi
+    if [ x"${BASE}" = x ] ; then
+        echo "$0: FAILED to get a git merge-base of this codebase vs. '${NUT_VERSION_GIT_TRUNK}'" >&2
+        check_shallow_git "NOTE: Current checkout is shallow, may not include enough history to describe it or find intersections with other trees"
+        DESC=""
+        return 1
+    fi
 
     # Nearest (annotated by default) tag preceding the HEAD in history:
     TAG="`echo "${DESC}" | sed 's/-[0-9][0-9]*[+-]g[0-9a-fA-F][0-9a-fA-F]*$//'`"

--- a/tools/nut-scanner/Makefile.am
+++ b/tools/nut-scanner/Makefile.am
@@ -23,6 +23,10 @@ BUILT_SOURCES = $(NUT_SCANNER_DEPS)
 CLEANFILES = $(BUILT_SOURCES)
 EXTRA_DIST = README.adoc
 
+# Built by same rule, so order them and avoid stepping on each other's toes
+# (TODO: Better deps automation than hard-coding here?)
+nutscan-usb.h: nutscan-snmp.h
+
 # Make sure we have the freshest files (no-op if built earlier and then
 # no driver sources and other dependencies were edited by a developer)
 $(NUT_SCANNER_DEPS): dummy

--- a/tools/nut-scanner/Makefile.am
+++ b/tools/nut-scanner/Makefile.am
@@ -33,13 +33,25 @@ $(NUT_SCANNER_DEPS): dummy
 	+@cd .. && $(MAKE) $(AM_MAKEFLAGS) nut-scanner-deps
 
 # Make sure out-of-dir dependencies exist (especially when dev-building parts):
+$(top_builddir)/include/nut_version.h \
 $(top_builddir)/clients/libupsclient-version.h \
+$(top_builddir)/common/libparseconf.la \
 $(top_builddir)/common/libnutwincompat.la \
 $(top_builddir)/drivers/libserial-nutscan.la \
 $(top_builddir)/common/libcommonstr.la \
 $(top_builddir)/common/libcommonversion.la \
 $(top_builddir)/common/libcommon.la: dummy
 	+@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
+
+# Builds from root dir arrange stuff decently. Make sure parallel builds
+# started from scratch right in this dir get dependencies in proper order
+# (sub-makes are independent as far as trying to write into same files):
+$(top_builddir)/common/libcommon.la: $(top_builddir)/common/libparseconf.la
+$(top_builddir)/common/libcommonversion.la: $(top_builddir)/include/nut_version.h
+# To extract the values used in the factually built library, this header's
+# recipe internally (clients/Makefile.am) requires libupsclient.la, and in
+# turn libcommonclient.la and in turn libparseconf.la:
+$(top_builddir)/clients/libupsclient-version.h: $(top_builddir)/common/libparseconf.la
 
 # do not hard depend on '../clients/libupsclient-version.h', since it blocks
 # 'dist', and is only required for actual build, in which case

--- a/tools/nutconf/Makefile.am
+++ b/tools/nutconf/Makefile.am
@@ -11,6 +11,22 @@
 
 all: $(bin_PROGRAMS)
 
+# Make sure out-of-dir dependencies exist (especially when dev-building parts):
+$(top_builddir)/common/libparseconf.la \
+$(top_builddir)/common/libcommonclient.la \
+$(top_builddir)/common/libcommon.la \
+$(top_builddir)/common/libcommonversion.la \
+$(top_builddir)/common/libnutconf.la \
+$(top_builddir)/tools/nut-scanner/libnutscan.la: dummy
+	+@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
+
+# Builds from root dir arrange stuff decently. Make sure parallel builds
+# started from scratch right in this dir get dependencies in proper order
+# (sub-makes are independent as far as trying to write into same files):
+$(top_builddir)/tools/nut-scanner/libnutscan.la: $(top_builddir)/common/libcommon.la $(top_builddir)/common/libcommonversion.la
+$(top_builddir)/common/libcommon.la $(top_builddir)/common/libcommonclient.la: $(top_builddir)/common/libparseconf.la
+$(top_builddir)/common/libnutconf.la: $(top_builddir)/common/libcommonclient.la
+
 bin_PROGRAMS =
 
 # Currently nutconf and related codebase causes woes for static analysis
@@ -31,13 +47,6 @@ nutconf_LDADD += $(top_builddir)/tools/nut-scanner/libnutscan.la
 endif WITH_LIBLTDL
 
 endif WITH_NUTCONF
-
-# Make sure out-of-dir dependencies exist (especially when dev-building parts):
-$(top_builddir)/common/libcommon.la \
-$(top_builddir)/common/libcommonversion.la \
-$(top_builddir)/common/libnutconf.la \
-$(top_builddir)/tools/nut-scanner/libnutscan.la: dummy
-	+@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
 dummy:
 


### PR DESCRIPTION
Make sure (parallel) builds started from scratch in NUT subdirs with code are viable recipe-wise, and add a way to keep making sure in the future :)

Not attached to NUT CI farm runs currently, but added to other CI hosting pipelines (GHA/CodeQL, CircleCI).

Piggy-back a few small fixes elsewhere.