### PR TITLE
CI: Follow-up for `make check-parallel-builds`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1476,7 +1476,7 @@ check-parallel-builds:
 		$(MAKE) $(AM_MAKEFLAGS) -k -s $${MAXPARMAKES_OPT} clean || { RES=$$?; echo "$@: FAILED: make clean before going to $$D" >&2; exit $$RES; } ; \
 		echo "  $@	in $${D}" ; \
 		( cd "$$D" && $(MAKE) $(AM_MAKEFLAGS) -k -s $${MAXPARMAKES_OPT} ) || { RES=$$?; echo "$@: FAILED: parallel make in $$D" >&2; \
-		  echo "To investigate, try:  $(MAKE) $(MAKEFLAGS) $(AM_MAKEFLAGS) $${MAXPARMAKES_OPT} clean ; automake -f && ./config.status && clear && (cd $${D}/ && $(MAKE) $(MAKEFLAGS) $(AM_MAKEFLAGS) V=1 $${MAXPARMAKES_OPT} 2>&1 ; echo $?) | tee /tmp/make.log ; grep -E '(\] Error|No rule to)' /tmp/make.log && less /tmp/make.log"; \
+		  echo "To investigate, try:  (MAKEFLAGS='$(MAKEFLAGS)' ; export MAKEFLAGS; $(MAKE) $(AM_MAKEFLAGS) $${MAXPARMAKES_OPT} clean ; automake -f && ./config.status && clear && (cd $${D}/ && $(MAKE) $(AM_MAKEFLAGS) V=1 $${MAXPARMAKES_OPT} 2>&1 ; echo $$?) | tee /tmp/make.log ; RES=$$? ; grep -E '(\] Error|No rule to)' /tmp/make.log && less /tmp/make.log ; exit $$RES )"; \
 		  echo "If builds were interrupted before, you may also have to re-initialize the build area completely, e.g.:  git clean -fdX ; ./ci_build.sh && $(MAKE) $(MAKEFLAGS) $(AM_MAKEFLAGS) $@" ; \
 		  exit $$RES; } ; \
 		DIRS="$${DIRS} $${D}" ; \

--- a/Makefile.am
+++ b/Makefile.am
@@ -697,16 +697,21 @@ spellcheck spellcheck-interactive:
 
 # Auto-parallel recipe (if current 'make' implementation supports the "-j N"
 # syntax; the optional MAXPARMAKES may be set in NUT CI farm style builds):
-spellcheck-quick:
-	+@case " $(MAKEFLAGS) $(AM_MAKEFLAGS)" in \
-		*"j"*) $(MAKE) $(AM_MAKEFLAGS) -k -s spellcheck && exit ;; \
+SET_PARMAKES_OPT = \
+	+@PARMAKES_OPT=""; \
+	  case " $(MAKEFLAGS) $(AM_MAKEFLAGS)" in \
+		*"j"*) ;; \
 		*) \
 			if ! [ "$${MAXPARMAKES-}" -gt 1 ] 2>/dev/null ; then \
 				MAXPARMAKES=8 ; \
 			fi ; \
-			$(MAKE) $(AM_MAKEFLAGS) -k -s -j $${MAXPARMAKES} spellcheck \
-			&& exit ;; \
+			PARMAKES_OPT="-j $${MAXPARMAKES}" ; \
+		;; \
 	  esac
+
+spellcheck-quick:
+	+@$(SET_PARMAKES_OPT); \
+	  $(MAKE) $(AM_MAKEFLAGS) -k -s ${PARMAKES_OPT} spellcheck
 
 # Run auto-parallel recipe, and if something fails - re-run interactively:
 spellcheck-interactive-quick:
@@ -1460,23 +1465,14 @@ CHECK_PARALLEL_BUILDS_REGEN = true
 check-parallel-builds:
 	if [ x"$(CHECK_PARALLEL_BUILDS_REGEN)" = xtrue ] ; then automake -f ; fi
 	if [ x"$(CHECK_PARALLEL_BUILDS_REGEN)" = xtrue ] ; then ./config.status ; fi
-	+@MAXPARMAKES_OPT=""; \
-	  case " $(MAKEFLAGS) $(AM_MAKEFLAGS)" in \
-		*"j"*) ;; \
-		*) \
-			if ! [ "$${MAXPARMAKES-}" -gt 1 ] 2>/dev/null ; then \
-				MAXPARMAKES=8 ; \
-			fi ; \
-			MAXPARMAKES_OPT="-j $${MAXPARMAKES}" ; \
-		;; \
-	  esac ; \
+	+@$(SET_PARMAKES_OPT); \
 	  DIRS=""; \
 	  for D in `find . -name '*.c' -o -name '*.cpp' | sed 's,/[^/]*\.cp*$$,,' | uniq` ; do \
 		[ -e "$$D/Makefile.am" ] && [ -s "$$D/Makefile" ] || continue ; \
-		$(MAKE) $(AM_MAKEFLAGS) -k -s $${MAXPARMAKES_OPT} clean || { RES=$$?; echo "$@: FAILED: make clean before going to $$D" >&2; exit $$RES; } ; \
+		$(MAKE) $(AM_MAKEFLAGS) -k -s $${PARMAKES_OPT} clean || { RES=$$?; echo "$@: FAILED: make clean before going to $$D" >&2; exit $$RES; } ; \
 		echo "  $@	in $${D}" ; \
-		( cd "$$D" && $(MAKE) $(AM_MAKEFLAGS) -k -s $${MAXPARMAKES_OPT} ) || { RES=$$?; echo "$@: FAILED: parallel make in $$D" >&2; \
-		  echo "To investigate, try:  (MAKEFLAGS='$(MAKEFLAGS)' ; export MAKEFLAGS; $(MAKE) $(AM_MAKEFLAGS) $${MAXPARMAKES_OPT} clean ; automake -f && ./config.status && clear && (cd $${D}/ && $(MAKE) $(AM_MAKEFLAGS) V=1 $${MAXPARMAKES_OPT} 2>&1 ; echo $$?) | tee /tmp/make.log ; RES=$$? ; grep -E '(\] Error|No rule to)' /tmp/make.log && less /tmp/make.log ; exit $$RES )"; \
+		( cd "$$D" && $(MAKE) $(AM_MAKEFLAGS) -k -s $${PARMAKES_OPT} ) || { RES=$$?; echo "$@: FAILED: parallel make in $$D" >&2; \
+		  echo "To investigate, try:  (MAKEFLAGS='$(MAKEFLAGS)' ; export MAKEFLAGS; $(MAKE) $(AM_MAKEFLAGS) $${PARMAKES_OPT} clean ; automake -f && ./config.status && clear && (cd $${D}/ && $(MAKE) $(AM_MAKEFLAGS) V=1 $${PARMAKES_OPT} 2>&1 ; echo $$?) | tee /tmp/make.log ; RES=$$? ; grep -E '(\] Error|No rule to)' /tmp/make.log && less /tmp/make.log ; exit $$RES )"; \
 		  echo "If builds were interrupted before, you may also have to re-initialize the build area completely, e.g.:  git clean -fdX ; ./ci_build.sh && $(MAKE) $(MAKEFLAGS) $(AM_MAKEFLAGS) $@" ; \
 		  exit $$RES; } ; \
 		DIRS="$${DIRS} $${D}" ; \

--- a/Makefile.am
+++ b/Makefile.am
@@ -1444,6 +1444,10 @@ check-files-quick: $(CHECK_FILES_QUICK_TARGETS)
 # Autotools hook: run the quick checks before recursing for defaults:
 check-recursive: check-files-quick
 
+# Caller can set this to "false" to not regenerate below
+# (e.g. in CI vs. developer iterations):
+CHECK_PARALLEL_BUILDS_REGEN = true
+
 # Not pulled in directly so far, can be used by developers to verify that build
 # rules (inlcuding dependencies pulled from other directories) make sense and
 # do not cause conflict by writing into same file names. Something that builds
@@ -1454,8 +1458,8 @@ check-recursive: check-files-quick
 # Auto-parallel recipe (if current 'make' implementation supports the "-j N"
 # syntax; the optional MAXPARMAKES may be set in NUT CI farm style builds):
 check-parallel-builds:
-	automake -f
-	./config.status
+	if [ x"$(CHECK_PARALLEL_BUILDS_REGEN)" = xtrue ] ; then automake -f ; fi
+	if [ x"$(CHECK_PARALLEL_BUILDS_REGEN)" = xtrue ] ; then ./config.status ; fi
 	+@MAXPARMAKES_OPT=""; \
 	  case " $(MAKEFLAGS) $(AM_MAKEFLAGS)" in \
 		*"j"*) ;; \

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -2318,6 +2318,12 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-al
                         ;;
                 esac
 
+                # Snippet from autogen.sh: restore files required by autoconf
+                # for non-"foreign" projects that a deep clean in other loops
+                # could have destroyed:
+                [ -f "${SCRIPTDIR}/NEWS" ] || { echo "Please see NEWS.adoc for actual contents" > "${SCRIPTDIR}/NEWS"; }
+                [ -f "${SCRIPTDIR}/README" ] || { echo "Please see README.adoc for actual contents" > "${SCRIPTDIR}/README"; }
+
                 configure_nut
                 ) || {
                     RES_ALLERRORS=$?

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -641,6 +641,11 @@ for L in $NODE_LABELS ; do
             [ -n "$CANBUILD_WITH_LIBLTDL" ] || CANBUILD_WITH_LIBLTDL=no ;;
         "NUT_BUILD_CAPS=libltdl"|"NUT_BUILD_CAPS=libltdl=yes")
             [ -n "$CANBUILD_WITH_LIBLTDL" ] || CANBUILD_WITH_LIBLTDL=yes ;;
+
+        # For now like this; VM systems with a clock skew can have natural
+        # problems with parallel tasks, which we can not do much about.
+        "NUT_BUILD_CAPS=check-parallel-builds=no")
+            [ -n "${CI_DO_CHECK_PARALLEL_BUILDS-}" ] || CI_DO_CHECK_PARALLEL_BUILDS=false ;;
     esac
 done
 


### PR DESCRIPTION
More tuning after PRs #3030 and #3033. Enable the feature via `BUILD_TYPE="default-all-errors" ./ci_build.sh` runs, and address some rough edges.