### PR TITLE
apc_modbus: Fix invalid memory access for USB vendor/product/serial

### DIFF
--- a/drivers/apc_modbus.c
+++ b/drivers/apc_modbus.c
@@ -79,7 +79,7 @@ static const HIDNode_t modbus_rtu_usb_usage_tx = 0xff8600fd;
 /* Variables */
 static modbus_t *modbus_ctx = NULL;
 #if defined NUT_MODBUS_HAS_USB
-static USBDevice_t usbdevice;
+static USBDevice_t usbdevice = {0};
 static USBDeviceMatcher_t *reopen_matcher = NULL;
 static USBDeviceMatcher_t *regex_matcher = NULL;
 static USBDeviceMatcher_t *best_matcher = NULL;
@@ -1659,9 +1659,9 @@ static void _apc_modbus_usb_lib_to_nut(const modbus_usb_device_t *device, USBDev
 
 	out->VendorID = device->vid;
 	out->ProductID = device->pid;
-	out->Vendor = device->vendor_str;
-	out->Product = device->product_str;
-	out->Serial = device->serial_str;
+	out->Vendor = device->vendor_str ? strdup(device->vendor_str) : NULL;
+	out->Product = device->product_str ? strdup(device->product_str) : NULL;
+	out->Serial = device->serial_str ? strdup(device->serial_str) : NULL;
 	out->bcdDevice = device->bcd_device;
 
 	res = snprintf(bus_buf, sizeof(bus_buf), "%03u", device->bus);
@@ -1983,5 +1983,14 @@ void upsdrv_cleanup(void)
 #if defined NUT_MODBUS_HAS_USB
 	USBFreeExactMatcher(reopen_matcher);
 	USBFreeExactMatcher(regex_matcher);
+
+	if (usbdevice.Vendor)
+		free(usbdevice.Vendor);
+	if (usbdevice.Product)
+		free(usbdevice.Product);
+	if (usbdevice.Serial)
+		free(usbdevice.Serial);
+
+	memset(&usbdevice, 0, sizeof(usbdevice));
 #endif /* defined NUT_MODBUS_HAS_USB */
 }


### PR DESCRIPTION
As requested in #2289. Only compile tested, but hopefully it should be a fairly obvious fix.