### PR TITLE
Enhance `usbhid-ups` to report use of data points vs. definitions in a subdriver, to not assume `!OL==OB`, and to report absent `ups.status` values

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -46,6 +46,9 @@ https://github.com/networkupstools/nut/milestone/12
      it does not really talk USB HID). [#3080]
    * Suggest iterative testing with explicit `subdrivers` if collected data
      looks wrong. [#2058, #3061 et al]
+   * Check if the subdriver code (mapping table) and the device report
+     descriptor sit together well -- namely, that we do not unwittingly
+     ignore any useful reports. [#3082]
 
  - `configure` script options:
    * Introduced `--with-python{,2,3}-modules-dir` to specify PyNUT(Client)

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -44,6 +44,8 @@ https://github.com/networkupstools/nut/milestone/12
    * For `ups.status` processing, do not assume that `!online`==`offline`,
      it may well be that the device just did not report anything (e.g. if
      it does not really talk USB HID). [#3080]
+   * Suggest iterative testing with explicit `subdrivers` if collected data
+     looks wrong. [#2058, #3061 et al]
 
  - `configure` script options:
    * Introduced `--with-python{,2,3}-modules-dir` to specify PyNUT(Client)

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -41,6 +41,9 @@ https://github.com/networkupstools/nut/milestone/12
 
  - `usbhid-ups` driver updates:
    * Improved support for Eaton 5S1500LCD (US version). [#2380]
+   * For `ups.status` processing, do not assume that `!online`==`offline`,
+     it may well be that the device just did not report anything (e.g. if
+     it does not really talk USB HID). [#3080]
 
  - `configure` script options:
    * Introduced `--with-python{,2,3}-modules-dir` to specify PyNUT(Client)

--- a/drivers/hidtypes.h
+++ b/drivers/hidtypes.h
@@ -6,6 +6,7 @@
  * Copyright (C)
  *	1998-2003	MGE UPS SYSTEMS, Luc Descotils
  *	2015		Eaton, Arnaud Quette (Update MAX_REPORT)
+ *	2020-2025	Jim Klimov <jimklimov+nut@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -315,6 +316,8 @@ typedef struct {
 	long		PhyMax;				/* Physical Max			*/
 	int8_t		have_PhyMin;			/* Physical Min defined?		*/
 	int8_t		have_PhyMax;			/* Physical Max defined?		*/
+
+	bool		mapping_handled;		/* Did the (sub)driver handling loop care about this report? If not, may be a point for improvement... */
 } HIDData_t;
 
 /*

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -2168,7 +2168,7 @@ static bool_t hid_ups_walk(walkmode_t mode)
 		case LIBUSB_ERROR_PIPE:      /* Broken pipe */
 		default:
 			/* Don't know what happened, try again later... */
-		   upsdebugx(1, "HIDGetDataValue unknown retcode '%i'", retcode);
+			upsdebugx(1, "HIDGetDataValue unknown retcode '%i'", retcode);
 			continue;
 		}
 

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -2542,14 +2542,18 @@ static void ups_status_set(void)
 
 	isCalibrating = status_get("CAL");
 
-	if ((ups_status & STATUS(DISCHRG)) &&
-		!(ups_status & STATUS(DEPLETED))) {
+	if ((ups_status & STATUS(DISCHRG))
+	&& !(ups_status & STATUS(DEPLETED))
+	) {
 		status_set("DISCHRG");		/* discharging */
 	}
-	if ((ups_status & STATUS(CHRG)) &&
-		!(ups_status & STATUS(FULLYCHARGED))) {
+
+	if ((ups_status & STATUS(CHRG))
+	&& !(ups_status & STATUS(FULLYCHARGED))
+	) {
 		status_set("CHRG");		/* charging */
 	}
+
 	if (ups_status & (STATUS(LOWBATT) | STATUS(TIMELIMITEXP) | STATUS(SHUTDOWNIMM))) {
 		if (lbrb_log_delay_sec < 1
 		|| (!isCalibrating && !lbrb_log_delay_without_calibrating)
@@ -2575,9 +2579,11 @@ static void ups_status_set(void)
 	} else {
 		last_lb_start = 0;
 	}
+
 	if (ups_status & STATUS(OVERLOAD)) {
 		status_set("OVER");		/* overload */
 	}
+
 	if ((ups_status & STATUS(REPLACEBATT)) || (ups_status & STATUS(NOBATTERY))) {
 		if (lbrb_log_delay_sec < 1
 		|| (!isCalibrating && !lbrb_log_delay_without_calibrating)
@@ -2604,25 +2610,31 @@ static void ups_status_set(void)
 	} else {
 		last_rb_start = 0;
 	}
+
 	if (ups_status & STATUS(TRIM)) {
 		status_set("TRIM");		/* SmartTrim */
 	}
+
 	if (ups_status & STATUS(BOOST)) {
 		status_set("BOOST");		/* SmartBoost */
 	}
+
 	if (ups_status & (STATUS(BYPASSAUTO) | STATUS(BYPASSMAN))) {
 		status_set("BYPASS");		/* on bypass */
 	}
+
 	if (ups_status & STATUS(ECOMODE)) {
 		buzzmode_set("vendor:default:ECO");	/* on ECO(HE) Mode,
 						 * should not happen
 						 * via ups.status anymore */
 	}
+
 	if (ups_status & STATUS(ESSMODE)) {
 		buzzmode_set("vendor:default:ESS");	/* on ESS Mode,
 						 * should not happen
 						 * via ups.status anymore */
 	}
+
 	if (ups_status & STATUS(OFF)) {
 		status_set("OFF");		/* ups is off */
 	}

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -1671,6 +1671,13 @@ void upsdrv_initups(void)
 		fatalx(EXIT_FAILURE, "Can't initialize data from HID UPS");
 	}
 
+	if (!ups_status)
+		upslogx(LOG_WARNING, "%s: No flag bits for 'ups.status' were explicitly reported; "
+			"it is possible a wrong 'subdriver' option was requested or detected "
+			"(in case of problems with device data, consider testing with other "
+			"explicit driver option 'subdriver' values)",
+			__func__);
+
 	upsdebugx(1, "%s: Optionally adjust some threshold values, if applicable and requested to...", __func__);
 
 	/* Set values below from user settings only if supported by UPS */

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -1887,6 +1887,10 @@ static int callback(
 	if (subdriver->fix_report_desc(arghd, pDesc)) {
 		upsdebugx(2, "Report Descriptor Fixed");
 	}
+	upsdebugx(1, "%s: calling HIDDumpTree(); in case of problems with device data "
+		"please note that a wrong subdriver could have been chosen above; "
+		"consider testing others with an explicit driver option",
+		__func__);
 	HIDDumpTree(udev, arghd, subdriver->utab);
 
 #if !((defined SHUT_MODE) && SHUT_MODE)

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -1665,9 +1665,13 @@ void upsdrv_initups(void)
 		lbrb_log_delay_without_calibrating = 1;
 	}
 
+	upsdebugx(1, "%s: Performing an initial UPS data walk with subdriver %s...",
+		__func__, subdriver->name);
 	if (hid_ups_walk(HU_WALKMODE_INIT) == FALSE) {
 		fatalx(EXIT_FAILURE, "Can't initialize data from HID UPS");
 	}
+
+	upsdebugx(1, "%s: Optionally adjust some threshold values, if applicable and requested to...", __func__);
 
 	/* Set values below from user settings only if supported by UPS */
 	if (dstate_getinfo("battery.charge.low")) {
@@ -1712,6 +1716,8 @@ void upsdrv_initups(void)
 		}
 	}
 
+	upsdebugx(1, "%s: Optionally enable instant commands related to shutdown, if applicable...", __func__);
+
 	/* Enable instant commands below only if supported by UPS */
 	if (find_nut_info("load.off.delay")) {
 		/* Adds default with a delay value of '0' (= immediate) */
@@ -1728,6 +1734,8 @@ void upsdrv_initups(void)
 		dstate_addcmd("shutdown.return");
 		dstate_addcmd("shutdown.stayoff");
 	}
+
+	upsdebugx(1, "%s: finished", __func__);
 }
 
 void upsdrv_cleanup(void)

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -1760,10 +1760,11 @@ void possibly_supported(const char *mfr, HIDDevice_t *arghd)
 {
 	upsdebugx(0,
 "This %s device (%04x:%04x) is not (or perhaps not yet) supported\n"
-"by usbhid-ups. Please make sure you have an up-to-date version of NUT. If\n"
-"this does not fix the problem, try running the driver with the\n"
-"'-x productid=%04x' option. Please report your results to the NUT user's\n"
-"mailing list <nut-upsuser@lists.alioth.debian.org>.\n",
+"by usbhid-ups. Please make sure you have an up-to-date version of NUT.\n"
+"If this does not fix the problem, try running the driver with the\n"
+"'-x productid=%04x' option, or iterate with explicit '-x subdriver=...'\n"
+"option. Please report your results to the NUT user's mailing list\n"
+"at <nut-upsuser@lists.alioth.debian.org>.\n",
 	mfr, arghd->VendorID, arghd->ProductID, arghd->ProductID);
 
 	if (arghd->VendorID == 0x06da) {

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -1885,7 +1885,7 @@ static int callback(
 	}
 
 	if (!subdriver) {
-		upsdebugx(1, "Manufacturer not supported!");
+		upsdebugx(1, "Manufacturer or model not supported!");
 		return 0;
 	}
 

--- a/drivers/usbhid-ups.h
+++ b/drivers/usbhid-ups.h
@@ -139,6 +139,7 @@ extern info_lkp_t kelvin_celsius_conversion[];
 
 typedef enum {
 	ONLINE = 0,	/* on line */
+	OFFLINE,	/* explicitly known as offline */
 	DISCHRG,	/* discharging */
 	CHRG,		/* charging */
 	LOWBATT,	/* low battery */


### PR DESCRIPTION
Closes: #3080
Closes: #3082 

For #3082, example of (un-)usage report with Eaton Ellipse PRO 650 and MGE HID subdriver mapping (so CCing Arnaud - these discrepancies may be or not be vectors for evolution of the mapping):
````
   6.374317     [D1] upsdrv_initups: 94 items are present in the report descriptor from HID UPS, but 42 of them were completely not used by name via the mapping defined in the selected NUT subdriver MGE HID 1.56: UPS.Flow.[4].FlowID (Feature), UPS.HistorySystem.Event.[1].Code (Feature), UPS.HistorySystem.Event.[1].EventID (Feature), UPS.HistorySystem.Event.[2].Code (Feature), UPS.HistorySystem.Event.[2].EventID (Feature), UPS.HistorySystem.Event.[3].Code (Feature), UPS.HistorySystem.Event.[3].EventID (Feature), UPS.HistorySystem.Event.[4].Code (Feature), UPS.HistorySystem.Event.[4].EventID (Feature), UPS.HistorySystem.Event.[5].Code (Feature), UPS.HistorySystem.Event.[5].EventID (Feature), UPS.OutletSystem.Outlet.[1].FlowID (Feature), UPS.OutletSystem.Outlet.[2].FlowID (Feature), UPS.OutletSystem.Outlet.[2].PresentStatus.Present (Feature), UPS.OutletSystem.Outlet.[2].PresentStatus.Present (Input), UPS.OutletSystem.Outlet.[3].FlowID (Feature), UPS.OutletSystem.Outlet.[3].PresentStatus.Present (Feature), UPS.OutletSystem.Outlet.[3].PresentStatus.Present (Input), UPS.OutletSystem.OutletSystemID (Feature), UPS.PowerConverter.Inverter.PresentStatus.InternalFailure (Feature), UPS.PowerConverter.Inverter.PresentStatus.InternalFailure (Input), UPS.PowerConverter.Output.OutputID (Feature), UPS.PowerConverter.Output.PresentStatus.ShortCircuit (Feature), UPS.PowerConverter.Output.PresentStatus.ShortCircuit (Input), UPS.PowerConverter.PowerConverterID (Feature), UPS.PowerConverter.Rectifier.PresentStatus.DCBusUnbalanced (Feature), UPS.PowerConverter.Rectifier.PresentStatus.DCBusUnbalanced (Input), UPS.PowerSummary.AudibleAlarmControl (Feature), UPS.PowerSummary.CapacityGranularity1 (Feature), UPS.PowerSummary.CapacityMode (Feature), UPS.PowerSummary.Country (Feature), UPS.PowerSummary.DesignCapacity (Feature), UPS.PowerSummary.FlowID (Feature), UPS.PowerSummary.FullChargeCapacity (Feature), UPS.PowerSummary.iManufacturer (Feature), UPS.PowerSummary.iModel (Feature), UPS.PowerSummary.iProduct (Feature), UPS.PowerSummary.iSerialNumber (Feature), UPS.PowerSummary.PowerSummaryID (Feature), UPS.PowerSummary.PresentStatus.CommunicationLost (Feature), UPS.PowerSummary.PresentStatus.CommunicationLost (Input), UPS.PowerSummary.RemainingCapacityLimit (Feature)

   6.374763     [D1] upsdrv_initups: 94 items are present in the report descriptor from HID UPS, but 15 of them have several Types named by same Path value, where at least one of the names was used and other(s) were not used by the mapping defined in the selected NUT subdriver MGE HID 1.56: UPS.BatterySystem.Charger.PresentStatus.VoltageTooHigh (Input), UPS.BatterySystem.Charger.PresentStatus.VoltageTooLow (Input), UPS.OutletSystem.Outlet.[2].PresentStatus.SwitchOn/Off (Input), UPS.OutletSystem.Outlet.[3].PresentStatus.SwitchOn/Off (Input), UPS.PowerSummary.PresentStatus.ACPresent (Input), UPS.PowerSummary.PresentStatus.BelowRemainingCapacityLimit (Input), UPS.PowerSummary.PresentStatus.Charging (Input), UPS.PowerSummary.PresentStatus.Discharging (Input), UPS.PowerSummary.PresentStatus.Good (Input), UPS.PowerSummary.PresentStatus.InternalFailure (Input), UPS.PowerSummary.PresentStatus.NeedReplacement (Input), UPS.PowerSummary.PresentStatus.Overload (Input), UPS.PowerSummary.PresentStatus.ShutdownImminent (Input), UPS.PowerSummary.RemainingCapacity (Input), UPS.PowerSummary.RunTimeToEmpty (Input)

   6.375414     [D5] upsdrv_initups: 235 mapping entries are defined, and 49 were actually used from USB HID report, in the selected NUT subdriver MGE HID 1.56

...
ups.status: OL CHRG
...
````

Not sure about the `*.[NUMBER].*` entries here, maybe there are templates for per-outlet etc. use-cases? At least some (like `SwitchOn/Off`) are seen as handled though. Not digging further at the moment.

For #3080, using a specially broken `mge-hid.c` (commented away lines with `ACPresent`), the sheer lack of `OL/OB` info in `ups.status` is reported better now:
````
   7.197814     [D2] Path: UPS.PowerSummary.PresentStatus.Discharging, Type: Feature, ReportID: 0x01, Offset: 4, Size: 1, Value: 0
   7.197917     [D5] ups_infoval_set: report descriptor mapping for 'UPS.PowerSummary.PresentStatus.Discharging' (Feature) was already set as handled

   7.198577     [D2] Path: UPS.PowerSummary.PresentStatus.Charging, Type: Feature, ReportID: 0x01, Offset: 2, Size: 1, Value: 1
   7.198666     [D5] ups_infoval_set: report descriptor mapping for 'UPS.PowerSummary.PresentStatus.Charging' (Feature) was already set as handled

   7.961940     [D1] ups_status_set: seems that UPS [eco650] does not report a power state

ups.status: CHRG
````

With "Charging" also neutered, the `ups.status` is reported but empty, and suggestion is posted visibly (via `upslogx()`) to try a more suitable sub-driver (would have helped in troubleshooting cases like #3061):
````
  13.431673     [D5] upsdrv_initups: 232 mapping entries are defined, and 47 were actually used from USB HID report, in the selected NUT subdriver MGE HID 1.56

  13.431847     upsdrv_initups: No flag bits for 'ups.status' were explicitly reported; it is possible a wrong 'subdriver' option was requested or detected (in case of problems with device data, consider testing with other explicit driver option 'subdriver' values)

  13.432061     [D1] upsdrv_initups: Optionally adjust some threshold values, if applicable and requested to...
  13.432730     [D1] upsdrv_initups: Optionally enable instant commands related to shutdown, if applicable...
  13.433375     [D5] send_to_all: ADDCMD load.off
...
  14.342367     [D1] ups_status_set: seems that UPS [eco650] does not report a power state

...
ups.serial: 000000000
ups.status:
ups.timer.shutdown: -1
...
````

Also, valgrind seems to be satisfied with running the code :)