### PR TITLE
`upssched`: Pass NOTIFYTYPE and UPSNAME into timer executions again, now with relevant values

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -56,6 +56,18 @@ https://github.com/networkupstools/nut/milestone/12
    * Updated `help()` and failure messages to suggest `-m '*,-'` for logging
      of all known local devices to stdout. [#3083]
 
+ - `upssched` tool updates:
+   * Previously in PR #2896 (NUT releases v2.8.3 and v2.8.4) the `UPSNAME` and
+     `NOTIFYTYPE` environment variables were neutered for the timer daemon,
+     since their values at the moment it first started were irrelevant when
+     actual timers fired. Lack of those values was however also against the
+     documented expectations. Now the values set when the `upssched` client
+     is called and ends up updating the timer daemon would be passed into
+     the timer. Also a `START-TIMER-SHARED` operation was added, to track a
+     single named timer for possibly many devices and/or event types -- in
+     this case they would be comma-separated in the environment variable
+     values. [issue #3092, PR #3097]
+
  - `configure` script options:
    * Introduced `--with-python{,2,3}-modules-dir` to specify PyNUT(Client)
      module installation location (for module-named dir to be created under

--- a/clients/upssched.c
+++ b/clients/upssched.c
@@ -19,7 +19,7 @@
 
 /* design notes for the curious:
  *
- * 1. we get called with a upsname and notifytype from upsmon
+ * 1. we get called with a ups_name and notify_type from upsmon
  * 2. the config file is searched for an AT condition that matches
  * 3. the conditions on any matching lines are parsed
  *
@@ -71,7 +71,7 @@ static conn_t	*connhead = NULL;
 static char	*cmdscript = NULL, *pipefn = NULL, *lockfn = NULL;
 
 /* ups name and notify type (string) as received from upsmon */
-static const	char	*upsname, *notify_type, *prog = NULL;
+static const	char	*ups_name, *notify_type, *prog = NULL;
 
 #ifdef WIN32
 static OVERLAPPED connect_overlapped;
@@ -1341,15 +1341,15 @@ static void parse_at(const char *ntype, const char *un, const char *cmd,
 		fatalx(EXIT_FAILURE, "LOCKFN must be set before any ATs in the config file!");
 	}
 
-	/* check upsname: does this apply to us? */
+	/* check ups_name: does this apply to us? */
 	upsdebugx(2, "%s: is '%s' in AT command the '%s' we were launched to process?",
-		__func__, un, upsname);
-	if (strcmp(upsname, un) != 0) {
+		__func__, un, ups_name);
+	if (strcmp(ups_name, un) != 0) {
 		if (strcmp(un, "*") != 0) {
 			upsdebugx(1, "%s: SKIP: '%s' in AT command "
 				"did not match the '%s' UPSNAME "
 				"we were launched to process",
-				__func__, un, upsname);
+				__func__, un, ups_name);
 			return;		/* not for us, and not the wildcard */
 		} else {
 			upsdebugx(1, "%s: this AT command is for a wildcard: matched", __func__);
@@ -1357,7 +1357,7 @@ static void parse_at(const char *ntype, const char *un, const char *cmd,
 	} else {
 		upsdebugx(1, "%s: '%s' in AT command matched the '%s' "
 			"UPSNAME we were launched to process",
-			__func__, un, upsname);
+			__func__, un, ups_name);
 	}
 
 	/* see if the current notify type matches the one from the .conf */
@@ -1579,10 +1579,10 @@ int main(int argc, char **argv)
 	open_syslog(prog);
 	syslogbit_set();
 
-	upsname = getenv("UPSNAME");
+	ups_name = getenv("UPSNAME");
 	notify_type = getenv("NOTIFYTYPE");
 
-	if ((!upsname) || (!notify_type)) {
+	if ((!ups_name) || (!notify_type)) {
 		printf("Error: environment variables UPSNAME and NOTIFYTYPE must be set.\n");
 		printf("This program should only be run from upsmon.\n");
 		exit(EXIT_FAILURE);

--- a/clients/upssched.c
+++ b/clients/upssched.c
@@ -247,11 +247,15 @@ static void cancel_timer(const char *name, const char *cname)
 			if (nut_debug_level)
 				upslogx(LOG_INFO, "Cancelling timer: %s", name);
 			removetimer(tmp);
+			/* TOTHINK: Don't we want to continue and cancel
+			 *  possibly many timers with this name? */
 			return;
 		}
 	}
 
-	/* this is not necessarily an error */
+	/* this is not necessarily an error: per docs,
+	 * if the timer has passed then pass the optional argument cmd to CMDSCRIPT.
+	 */
 	if (cname && cname[0]) {
 		if (nut_debug_level)
 			upslogx(LOG_INFO, "Cancel %s, event: %s", name, cname);
@@ -639,12 +643,13 @@ static TYPE_FD conn_add(TYPE_FD sockfd)
 
 static int sock_arg(conn_t *conn)
 {
+	/* "Server-side" listener for the timer daemon */
 	if (conn->ctx.numargs < 1)
 		return 0;
 
 	/* CANCEL <name> [<cmd>] */
 	if (!strcmp(conn->ctx.arglist[0], "CANCEL")) {
-
+		/* "cmd" may be present and empty, this is handled in the method */
 		if (conn->ctx.numargs < 3)
 			cancel_timer(conn->ctx.arglist[1], NULL);
 		else

--- a/conf/upssched.conf.sample.in
+++ b/conf/upssched.conf.sample.in
@@ -83,7 +83,9 @@ CMDSCRIPT @BINDIR@/upssched-cmd
 #
 #   Start a timer called <timername> that will trigger after <interval>
 #   seconds, calling your CMDSCRIPT with <timername> as the first
-#   argument.
+#   argument. Each invocation starts an independent timer, even if the
+#   <timername> was already registered and started (note this can mess
+#   up subsequent CANCEL-TIMER operations).
 #
 #   Example:
 #   1) Start a timer that will execute when communication with any UPS (*) has
@@ -95,6 +97,28 @@ CMDSCRIPT @BINDIR@/upssched-cmd
 #   on battery for 30 seconds
 #
 #   AT ONBATT * START-TIMER onbattwarn 30
+
+#   -----------------------------------------------------------------------
+#
+# - START-TIMER-SHARED <timername> <interval>
+#
+#   Start a timer called <timername> that will trigger after <interval>
+#   seconds, calling your CMDSCRIPT with <timername> as the first
+#   argument. Each invocation checks if the <timername> was already
+#   started, and if so -- appends the current event's `UPSNAME` and
+#   `NOTIFYTYPE` to the list of unique values it would report via
+#   environment variables (as a comma-separated string) when the
+#   timer does execute.
+#
+#   NOTE: Currently this updates the first seen instance with the
+#   <timername> (in case you managed to start many).
+#
+#   Example:
+#   1) Start or update a timer that will execute when communication
+#   with any UPS (*) has been gone for 10 seconds (since the first
+#   started and not yet elapsed timer named <upsgone>):
+#
+#   AT COMMBAD * START-TIMER upsgone 10
 
 #   -----------------------------------------------------------------------
 #

--- a/docs/man/upssched.conf.txt
+++ b/docs/man/upssched.conf.txt
@@ -69,7 +69,28 @@ and 'upsname' match the current activity.  Possible values for
 *START-TIMER* 'timername' 'interval';;
 Start a timer of 'interval' seconds.  When it triggers, it
 will pass the argument 'timername' as an argument to your
-CMDSCRIPT.
+CMDSCRIPT. Each invocation starts an independent timer, even
+if the 'timername' was already registered and started (note
+this can mess up subsequent CANCEL-TIMER operations).
++
+Example:
++
+Start a timer that will execute when any UPS (*) has been
+gone for 10 seconds
+
+	AT COMMBAD * START-TIMER upsgone 10
+
+*START-TIMER-SHARED* 'timername' 'interval';;
+Start a timer of 'interval' seconds.  When it triggers, it
+will pass the argument 'timername' as an argument to your
+CMDSCRIPT. Each invocation checks if the 'timername' was already
+started, and if so -- appends the current event's `UPSNAME` and
+`NOTIFYTYPE` to the list of unique values it would report via
+environment variables (as a comma-separated string) when the
+timer does execute.
++
+NOTE: Currently this updates the first seen instance with the
+'timername' (in case you managed to start many).
 +
 Example:
 +
@@ -82,6 +103,9 @@ gone for 10 seconds
 Cancel a running timer called 'timername', if possible.
 If the timer has passed then pass the optional argument
 'cmd' to CMDSCRIPT.
++
+NOTE: Currently this removes the first seen instance with the
+'timername' (in case you managed to start many).
 +
 Example:
 +


### PR DESCRIPTION
Closes: #3092
Follow-up from: PR #2896 and issue #2890

@kennethso168 : can you please check if this PR reasonably answers your woes from that issue? And also if it runs and does not crash/leak, and does utilize envvar values from each call that begins a timer? And that the new feature for `START-TIMER-SHARED` works and can pass several (comma-separated) values? (So far I only tested that it compiles, and than ran out of time) :)

CC @aquette @clepple @NUT-RogetPrice : does this make sense architecturally?