### PR TITLE
Support checking for program names including optional aliases

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -40,11 +40,13 @@ https://github.com/networkupstools/nut/milestone/12
    to patterns defined in link:docs/nut-names.txt[]
 
  - common code:
-   * extended with plural `checkprocnames()` and `compareprocnames()`,
+   * Extended with plural `checkprocnames()` and `compareprocnames()`,
      as well as `sendsignalpidaliases()` and `sendsignalfnaliases()`, for
      binaries that expect to have one of several names at the moment (e.g.
      when renaming a program to "*-old" or promoting a "*-new" into the
-     stable name as a default implementation). [PR #3101]
+     stable name as a default implementation). Drivers united by `main.c`
+     framework introduced a `upsdrv_tweak_prognames()` hook method to let
+     them manipulate the array of `prognames[]` aliases. [PR #3101]
 
  - `nutdrv_qx` driver updates:
    * Define an internal `QX_FLAG_MAPPING_HANDLED` to check if the subdriver

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -39,6 +39,12 @@ https://github.com/networkupstools/nut/milestone/12
  - (expected) CI automation for use of data points in drivers that conform
    to patterns defined in link:docs/nut-names.txt[]
 
+ - common code:
+   * extended with plural `checkprocnames()` and `compareprocnames()` for
+     binaries that expect to have one of several names at the moment (e.g.
+     when renaming a program to "*-old" or promoting a "*-new" into the
+     stable name as a default implementation). [PR #3101]
+
  - `nutdrv_qx` driver updates:
    * Define an internal `QX_FLAG_MAPPING_HANDLED` to check if the subdriver
      code (mapping table) and the data found from device walk sit together

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -40,7 +40,8 @@ https://github.com/networkupstools/nut/milestone/12
    to patterns defined in link:docs/nut-names.txt[]
 
  - common code:
-   * extended with plural `checkprocnames()` and `compareprocnames()` for
+   * extended with plural `checkprocnames()` and `compareprocnames()`,
+     as well as `sendsignalpidaliases()` and `sendsignalfnaliases()`, for
      binaries that expect to have one of several names at the moment (e.g.
      when renaming a program to "*-old" or promoting a "*-new" into the
      stable name as a default implementation). [PR #3101]

--- a/UPGRADING.adoc
+++ b/UPGRADING.adoc
@@ -26,6 +26,16 @@ Changes from 2.8.4 to 2.8.5
 
 - PLANNED: Keep track of any further API clean-up?
 
+- In drivers using the common `main.c` and `main.h` framework, introduced
+  a `void upsdrv_tweak_prognames(void)` required method (may be no-op) to
+  optionally tweak `prognames[]` entries now that there is certain support
+  to accept program name aliases, not just one hard-coded string value.
+  Any third-party drivers may require rebuilding to extend with this method.
+  Any drivers that would undergo promotion with renaming can take advantage
+  of this new facility to keep working under both old and new file names.
+  [#3101]
+
+
 Changes from 2.8.3 to 2.8.4
 ---------------------------
 

--- a/common/common.c
+++ b/common/common.c
@@ -1810,6 +1810,9 @@ int sendsignalpidaliases(pid_t pid, int sig, const char **prognames, int check_c
 		}
 		/* NULL sentinel of the non-NULL prognames[] array */
 		total_prognames++;
+
+		upsdebugx(4, "%s: collected %" PRIuSIZE " aliases (with NULL sentinel): %s",
+			__func__, total_prognames, all_prognames);
 	}
 
 	/* if (cpn1 == -3) => NUT_IGNORE_CHECKPROCNAME=true */
@@ -2070,12 +2073,13 @@ int sendsignalfnaliases(const char *pidfn, int sig, const char **prognames, int 
 #else	/* => WIN32 */
 
 int sendsignalfn(const char *pidfn, const char * sig, const char *progname_ignored, int check_current_progname_ignored)
+{
 	const char	*arr[2];
 
-	arr[0] = progname;
+	arr[0] = progname_ignored;
 	arr[1] = NULL;
 
-	return sendsignalfnaliases(pidfn, sig, arr, check_current_progname);
+	return sendsignalfnaliases(pidfn, sig, arr, check_current_progname_ignored);
 }
 
 int sendsignalfnaliases(const char *pidfn, const char * sig, const char **prognames_ignored, int check_current_progname_ignored)

--- a/docs/new-drivers.txt
+++ b/docs/new-drivers.txt
@@ -110,6 +110,10 @@ This information is currently used for the startup banner printing and tests.
 Essential functions
 -------------------
 
+For a full current list of functions expected in this context, please see the
+`drivers/main.h` file in NUT sources.  Some more methods may be required by
+driver structure, even if in the common case they have no-op implementations.
+
 upsdrv_initups
 ~~~~~~~~~~~~~~
 

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3552 utf-8
+personal_ws-1.1 en 3553 utf-8
 AAC
 AAS
 ABI
@@ -2867,6 +2867,7 @@ proc
 productid
 prog
 progname
+prognames
 progs
 proxied
 prtconf

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3550 utf-8
+personal_ws-1.1 en 3552 utf-8
 AAC
 AAS
 ABI
@@ -3028,7 +3028,9 @@ sendline
 sendmail
 sendsignal
 sendsignalfn
+sendsignalfnaliases
 sendsignalpid
+sendsignalpidaliases
 senoidal
 sequentialized
 ser

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3548 utf-8
+personal_ws-1.1 en 3550 utf-8
 AAC
 AAS
 ABI
@@ -1767,6 +1767,7 @@ cgroupsv
 changelog
 chargetime
 charset
+checkprocnames
 checkruntime
 checksum
 checksums
@@ -1810,6 +1811,7 @@ command's
 commandlen
 committer
 comms
+compareprocnames
 compat
 compilerPath
 conf

--- a/drivers/adelsystem_cbi.c
+++ b/drivers/adelsystem_cbi.c
@@ -34,7 +34,7 @@
 #endif
 
 #define DRIVER_NAME	"NUT ADELSYSTEM DC-UPS CB/CBI driver (libmodbus link type: " NUT_MODBUS_LINKTYPE_STR ")"
-#define DRIVER_VERSION	"0.05"
+#define DRIVER_VERSION	"0.06"
 
 /* variables */
 static modbus_t *mbctx = NULL;							/* modbus memory context */
@@ -494,6 +494,11 @@ void upsdrv_shutdown(void)
 
 /* print driver usage info */
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/al175.c
+++ b/drivers/al175.c
@@ -52,7 +52,7 @@ typedef	uint8_t byte_t;
 
 
 #define DRIVER_NAME	"Eltek AL175/COMLI driver"
-#define DRIVER_VERSION	"0.17"
+#define DRIVER_VERSION	"0.18"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -1324,6 +1324,11 @@ static int instcmd(const char *cmdname, const char *extra)
 
 /* no help */
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/apc_modbus.c
+++ b/drivers/apc_modbus.c
@@ -44,7 +44,7 @@
 #endif
 
 #define DRIVER_NAME	"NUT APC Modbus driver " DRIVER_NAME_NUT_MODBUS_HAS_USB_WITH_STR " USB support (libmodbus link type: " NUT_MODBUS_LINKTYPE_STR ")"
-#define DRIVER_VERSION	"0.16"
+#define DRIVER_VERSION	"0.17"
 
 #if defined NUT_MODBUS_HAS_USB
 
@@ -1591,6 +1591,11 @@ void upsdrv_shutdown(void)
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/apcsmart-old.c
+++ b/drivers/apcsmart-old.c
@@ -25,7 +25,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"APC Smart protocol driver (old)"
-#define DRIVER_VERSION	"2.35"
+#define DRIVER_VERSION	"2.36"
 
 static upsdrv_info_t table_info = {
 	"APC command table",
@@ -1487,6 +1487,11 @@ void upsdrv_initups(void)
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/apcsmart.c
+++ b/drivers/apcsmart.c
@@ -37,7 +37,7 @@
 #include "apcsmart_tabs.h"
 
 #define DRIVER_NAME	"APC Smart protocol driver"
-#define DRIVER_VERSION	"3.36"
+#define DRIVER_VERSION	"3.37"
 
 #ifdef WIN32
 # ifndef ECANCELED
@@ -2152,6 +2152,11 @@ void upsdrv_makevartable(void)
 	addvar(VAR_VALUE, "sdtype", "simple shutdown method");
 	addvar(VAR_VALUE, "advorder", "advanced shutdown control");
 	addvar(VAR_VALUE, "cshdelay", "CS hack delay");
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
+{
 }
 
 void upsdrv_help(void)

--- a/drivers/apcupsd-ups.c
+++ b/drivers/apcupsd-ups.c
@@ -57,7 +57,7 @@ typedef struct pollfd {
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"apcupsd network client UPS driver"
-#define DRIVER_VERSION	"0.73"
+#define DRIVER_VERSION	"0.74"
 
 #define POLL_INTERVAL_MIN 10
 
@@ -361,6 +361,11 @@ void upsdrv_shutdown(void)
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/asem.c
+++ b/drivers/asem.c
@@ -67,7 +67,7 @@
 #endif
 
 #define DRIVER_NAME	"ASEM"
-#define DRIVER_VERSION	"0.15"
+#define DRIVER_VERSION	"0.16"
 
 /* Valid on ASEM PB1300 UPS */
 #define BQ2060_ADDRESS	0x0B
@@ -354,6 +354,11 @@ void upsdrv_help(void)
 	printf(" HIGH/low battery thresholds\n");
 	printf("  lb = " __XSTR__(LOW_BATTERY_THRESHOLD) " (battery is low under this level)\n");
 	printf("  hb = " __XSTR__(HIGH_BATTERY_THRESHOLD) " (battery is high above this level)\n");
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
+{
 }
 
 /* list flags and values that you want to receive via -x */

--- a/drivers/bcmxcp.c
+++ b/drivers/bcmxcp.c
@@ -116,7 +116,7 @@ TODO List:
 #include "bcmxcp.h"
 
 #define DRIVER_NAME	"BCMXCP UPS driver"
-#define DRIVER_VERSION	"0.38"
+#define DRIVER_VERSION	"0.39"
 
 #define MAX_NUT_NAME_LENGTH 128
 #define NUT_OUTLET_POSITION   7
@@ -2218,6 +2218,11 @@ static int decode_instcmd_exec(const ssize_t res, const unsigned char exec_statu
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/belkin.c
+++ b/drivers/belkin.c
@@ -29,7 +29,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"Belkin Smart protocol driver"
-#define DRIVER_VERSION	"0.29"
+#define DRIVER_VERSION	"0.30"
 
 static ssize_t init_communication(void);
 static ssize_t get_belkin_reply(char *buf);
@@ -483,6 +483,11 @@ static int instcmd(const char *cmdname, const char *extra)
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/belkinunv.c
+++ b/drivers/belkinunv.c
@@ -94,7 +94,7 @@
 #include "serial.h"
 
 #define DRIVER_NAME	"Belkin 'Universal UPS' driver"
-#define DRIVER_VERSION	"0.12"
+#define DRIVER_VERSION	"0.13"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -1355,6 +1355,11 @@ void upsdrv_help(void)
 	printf(" ups.beeper.status: enabled, disabled, muted\n");
 	printf(" input.transfer.low: (in V)\n");
 	printf(" input.transfer.high: (in V)\n");
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
+{
 }
 
 /* list flags and values that you want to receive via -x */

--- a/drivers/bestfcom.c
+++ b/drivers/bestfcom.c
@@ -45,7 +45,7 @@
 #include "serial.h"
 
 #define DRIVER_NAME	"Best Ferrups/Fortress driver"
-#define DRIVER_VERSION	"0.17"
+#define DRIVER_VERSION	"0.18"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -509,6 +509,11 @@ void upsdrv_makevartable(void)
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/bestfortress.c
+++ b/drivers/bestfortress.c
@@ -35,7 +35,7 @@
 #endif
 
 #define DRIVER_NAME     "Best Fortress UPS driver"
-#define DRIVER_VERSION  "0.13"
+#define DRIVER_VERSION  "0.14"
 
 /* driver description structure */
 upsdrv_info_t   upsdrv_info = {
@@ -570,6 +570,11 @@ static int instcmd (const char *cmdname, const char *extra)
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/bestuferrups.c
+++ b/drivers/bestuferrups.c
@@ -33,7 +33,7 @@
 #include "serial.h"
 
 #define DRIVER_NAME	"Best Ferrups Series ME/RE/MD driver"
-#define DRIVER_VERSION	"0.08"
+#define DRIVER_VERSION	"0.09"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -408,6 +408,11 @@ void upsdrv_makevartable(void)
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/bestups.c
+++ b/drivers/bestups.c
@@ -29,7 +29,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"Best UPS driver"
-#define DRIVER_VERSION	"1.11"
+#define DRIVER_VERSION	"1.12"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -437,6 +437,11 @@ void upsdrv_updateinfo(void)
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/bicker_ser.c
+++ b/drivers/bicker_ser.c
@@ -108,7 +108,7 @@
 #include "serial.h"
 
 #define DRIVER_NAME	"Bicker serial protocol"
-#define DRIVER_VERSION	"0.04"
+#define DRIVER_VERSION	"0.05"
 
 #define BICKER_SOH	0x01
 #define BICKER_EOT	0x04
@@ -885,6 +885,11 @@ void upsdrv_shutdown(void)
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/blazer_ser.c
+++ b/drivers/blazer_ser.c
@@ -31,7 +31,7 @@
 #include "blazer.h"
 
 #define DRIVER_NAME	"Megatec/Q1 protocol serial driver"
-#define DRIVER_VERSION	"1.64"
+#define DRIVER_VERSION	"1.65"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -105,6 +105,12 @@ ssize_t blazer_command(const char *cmd, char *buf, size_t buflen)
 
 
 void upsdrv_help(void)
+{
+}
+
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/blazer_usb.c
+++ b/drivers/blazer_usb.c
@@ -37,7 +37,7 @@
 #endif	/* WIN32 */
 
 #define DRIVER_NAME	"Megatec/Q1 protocol USB driver"
-#define DRIVER_VERSION	"0.23"
+#define DRIVER_VERSION	"0.24"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -579,6 +579,12 @@ void upsdrv_help(void)
 	}
 	printf("\n\n");
 #endif	/* TESTING */
+}
+
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
+{
 }
 
 

--- a/drivers/clone-outlet.c
+++ b/drivers/clone-outlet.c
@@ -31,7 +31,7 @@
 #endif	/* !WIN32 */
 
 #define DRIVER_NAME	"Clone outlet UPS driver"
-#define DRIVER_VERSION	"0.08"
+#define DRIVER_VERSION	"0.09"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -525,6 +525,12 @@ void upsdrv_shutdown(void)
 
 
 void upsdrv_help(void)
+{
+}
+
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/clone.c
+++ b/drivers/clone.c
@@ -34,7 +34,7 @@
 #endif	/* !WIN32 */
 
 #define DRIVER_NAME	"Clone UPS driver"
-#define DRIVER_VERSION	"0.08"
+#define DRIVER_VERSION	"0.09"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -750,6 +750,12 @@ void upsdrv_shutdown(void)
 
 
 void upsdrv_help(void)
+{
+}
+
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/dummy-ups.c
+++ b/drivers/dummy-ups.c
@@ -48,7 +48,7 @@
 #include "dummy-ups.h"
 
 #define DRIVER_NAME	"Device simulation and repeater driver"
-#define DRIVER_VERSION	"0.22"
+#define DRIVER_VERSION	"0.23"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info =
@@ -414,6 +414,11 @@ static int instcmd(const char *cmdname, const char *extra)
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/etapro.c
+++ b/drivers/etapro.c
@@ -55,7 +55,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"ETA PRO driver"
-#define DRIVER_VERSION	"0.09"
+#define DRIVER_VERSION	"0.10"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -360,6 +360,12 @@ upsdrv_shutdown(void)
 
 void
 upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void
+upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/everups.c
+++ b/drivers/everups.c
@@ -21,7 +21,7 @@
 #include "serial.h"
 
 #define DRIVER_NAME	"Ever UPS driver (serial)"
-#define DRIVER_VERSION	"0.08"
+#define DRIVER_VERSION	"0.09"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -219,6 +219,11 @@ void upsdrv_shutdown(void)
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/failover.c
+++ b/drivers/failover.c
@@ -27,7 +27,7 @@
 #include "upsdrvquery.h"
 
 #define DRIVER_NAME      "UPS Failover Driver"
-#define DRIVER_VERSION   "0.01"
+#define DRIVER_VERSION   "0.02"
 
 upsdrv_info_t upsdrv_info = {
 	DRIVER_NAME,
@@ -233,7 +233,11 @@ void upsdrv_shutdown(void)
 
 void upsdrv_help(void)
 {
+}
 
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
+{
 }
 
 void upsdrv_makevartable(void)

--- a/drivers/gamatronic.c
+++ b/drivers/gamatronic.c
@@ -33,7 +33,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"Gamatronic UPS driver"
-#define DRIVER_VERSION	"0.08"
+#define DRIVER_VERSION	"0.09"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -383,6 +383,11 @@ int instcmd(const char *cmdname, const char *extra)
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/generic_gpio_common.c
+++ b/drivers/generic_gpio_common.c
@@ -491,6 +491,11 @@ void upsdrv_help(void)
 {
 }
 
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
+{
+}
+
 /* list flags and values that you want to receive via -x */
 void upsdrv_makevartable(void)
 {

--- a/drivers/generic_gpio_libgpiod.c
+++ b/drivers/generic_gpio_libgpiod.c
@@ -31,7 +31,7 @@
 #endif
 
 #define DRIVER_NAME	"GPIO UPS driver (API " WITH_LIBGPIO_VERSION_STR ")"
-#define DRIVER_VERSION	"1.04"
+#define DRIVER_VERSION	"1.05"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/generic_modbus.c
+++ b/drivers/generic_modbus.c
@@ -31,7 +31,7 @@
 #endif
 
 #define DRIVER_NAME	"NUT Generic Modbus driver (libmodbus link type: " NUT_MODBUS_LINKTYPE_STR ")"
-#define DRIVER_VERSION	"0.07"
+#define DRIVER_VERSION	"0.08"
 
 /* variables */
 static modbus_t *mbctx = NULL;                             /* modbus memory context */
@@ -347,6 +347,11 @@ void upsdrv_shutdown(void)
 
 /* print driver usage info */
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/genericups.c
+++ b/drivers/genericups.c
@@ -31,7 +31,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"Generic contact-closure UPS driver"
-#define DRIVER_VERSION	"1.41"
+#define DRIVER_VERSION	"1.42"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -406,6 +406,11 @@ void upsdrv_shutdown(void)
 void upsdrv_help(void)
 {
 	listtypes();
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
+{
 }
 
 void upsdrv_makevartable(void)

--- a/drivers/huawei-ups2000.c
+++ b/drivers/huawei-ups2000.c
@@ -55,7 +55,7 @@
 #endif
 
 #define DRIVER_NAME	"NUT Huawei UPS2000 (1kVA-3kVA) RS-232 Modbus driver (libmodbus link type: " NUT_MODBUS_LINKTYPE_STR ")"
-#define DRIVER_VERSION	"0.10"
+#define DRIVER_VERSION	"0.11"
 
 #define CHECK_BIT(var,pos) ((var) & (1<<(pos)))
 #define MODBUS_SLAVE_ID 1
@@ -1826,6 +1826,12 @@ void upsdrv_shutdown(void)
 
 
 void upsdrv_help(void)
+{
+}
+
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/hwmon_ina219.c
+++ b/drivers/hwmon_ina219.c
@@ -37,7 +37,7 @@
 #define BATTERY_CHARGE_LOW                  15
 
 #define DRIVER_NAME                         "hwmon-INA219 UPS driver"
-#define DRIVER_VERSION                      "0.03"
+#define DRIVER_VERSION                      "0.04"
 
 upsdrv_info_t upsdrv_info = {
 	DRIVER_NAME,
@@ -475,6 +475,11 @@ void upsdrv_shutdown(void)
 void upsdrv_help(void)
 {
 	/* No special options in this driver (vars/flags are auto-documented) */
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
+{
 }
 
 void upsdrv_cleanup(void)

--- a/drivers/isbmex.c
+++ b/drivers/isbmex.c
@@ -27,7 +27,7 @@
 #include <string.h>
 
 #define DRIVER_NAME	"ISBMEX UPS driver"
-#define DRIVER_VERSION	"0.12"
+#define DRIVER_VERSION	"0.13"
 
 /* driver description structure */
 upsdrv_info_t	upsdrv_info = {
@@ -418,6 +418,11 @@ void upsdrv_shutdown(void)
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/ivtscd.c
+++ b/drivers/ivtscd.c
@@ -25,7 +25,7 @@
 #include "attribute.h"
 
 #define DRIVER_NAME	"IVT Solar Controller driver"
-#define DRIVER_VERSION	"0.07"
+#define DRIVER_VERSION	"0.08"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -214,6 +214,11 @@ void upsdrv_shutdown(void)
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/liebert-esp2.c
+++ b/drivers/liebert-esp2.c
@@ -28,7 +28,7 @@
 #define IsBitSet(val, bit) ((val) & (1 << (bit)))
 
 #define DRIVER_NAME	"Liebert ESP-II serial UPS driver"
-#define DRIVER_VERSION	"0.09"
+#define DRIVER_VERSION	"0.10"
 
 #define UPS_SHUTDOWN_DELAY 12 /* it means UPS will be shutdown 120 sec */
 #define SHUTDOWN_CMD_LEN  8
@@ -571,6 +571,11 @@ static int setvar(const char *varname, const char *val)
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/liebert-gxe.c
+++ b/drivers/liebert-gxe.c
@@ -24,7 +24,7 @@
 #include "ydn23.h"
 
 #define DRIVER_NAME	"Liebert GXE Series UPS driver"
-#define DRIVER_VERSION	"0.04"
+#define DRIVER_VERSION	"0.05"
 
 #define PROBE_RETRIES	3
 #define DEFAULT_STALE_RETRIES	3
@@ -494,6 +494,11 @@ void upsdrv_initinfo(void)
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/liebert.c
+++ b/drivers/liebert.c
@@ -27,7 +27,7 @@
 #include "attribute.h"
 
 #define DRIVER_NAME	"Liebert MultiLink UPS driver"
-#define DRIVER_VERSION	"1.06"
+#define DRIVER_VERSION	"1.07"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -176,6 +176,11 @@ void upsdrv_makevartable(void)
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/macosx-ups.c
+++ b/drivers/macosx-ups.c
@@ -29,7 +29,7 @@
 #include "IOKit/ps/IOPSKeys.h"
 
 #define DRIVER_NAME	"Mac OS X UPS meta-driver"
-#define DRIVER_VERSION	"1.43"
+#define DRIVER_VERSION	"1.44"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -338,6 +338,11 @@ static int setvar(const char *varname, const char *val)
 */
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -2700,9 +2700,9 @@ int main(int argc, char **argv)
 			int cmdret = -1;
 			/* Send a signal to older copy of the driver, if any */
 			if (oldpid < 0) {
-				cmdret = sendsignalfn(pidfnbuf, cmd, progname, 1);
+				cmdret = sendsignalfnaliases(pidfnbuf, cmd, prognames, 1);
 			} else {
-				cmdret = sendsignalpid(oldpid, cmd, progname, 1);
+				cmdret = sendsignalpidaliases(oldpid, cmd, prognames, 1);
 			}
 
 			switch (cmdret) {
@@ -2797,9 +2797,9 @@ int main(int argc, char **argv)
 
 			upslogx(LOG_WARNING, "Duplicate driver instance detected (PID file %s exists)! Terminating other driver!", pidfnbuf);
 
-			if ((sigret = sendsignalfn(pidfnbuf, SIGTERM, progname, 1) != 0)) {
+			if ((sigret = sendsignalfnaliases(pidfnbuf, SIGTERM, prognames, 1) != 0)) {
 				upsdebug_with_errno(1, "Can't send signal to PID, assume invalid PID file %s; "
-					"sendsignalfn() returned %d", pidfnbuf, sigret);
+					"sendsignalfnaliases() returned %d", pidfnbuf, sigret);
 				break;
 			}
 
@@ -2814,9 +2814,9 @@ int main(int argc, char **argv)
 			struct stat	st;
 			if (stat(pidfnbuf, &st) == 0) {
 				upslogx(LOG_WARNING, "Duplicate driver instance is still alive (PID file %s exists) after several termination attempts! Killing other driver!", pidfnbuf);
-				if (sendsignalfn(pidfnbuf, SIGKILL, progname, 1) == 0) {
+				if (sendsignalfnaliases(pidfnbuf, SIGKILL, prognames, 1) == 0) {
 					sleep(5);
-					if (sendsignalfn(pidfnbuf, 0, progname, 1) == 0) {
+					if (sendsignalfnaliases(pidfnbuf, 0, prognames, 1) == 0) {
 						upslogx(LOG_WARNING, "Duplicate driver instance is still alive (could signal the process)");
 						/* TODO: Should we writepid() below in this case?
 						 * Or if driver init fails, restore the old content

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -43,7 +43,15 @@ TYPE_FD	upsfd = ERROR_FD;
  * during their assignment when reading program parameters
  * from CLI or config file. */
 char		*device_path = NULL, *device_sdcommands = NULL;
-const char	*progname = NULL, *upsname = NULL, *device_name = NULL;
+const char	*upsname = NULL, *device_name = NULL;
+
+/* We allow for aliases to certain program names (e.g. when renaming a driver
+ * between "old" and "new" and default implementations, it should accept both
+ * or more names it can be called by).
+ * The [0] entry is used to set up stuff like pipe names, man page links, etc.
+ */
+const char	*prognames[MAX_PROGNAMES];
+char	prognames_should_free[MAX_PROGNAMES];
 
 /* may be set by the driver to wake up while in dstate_poll_fds */
 TYPE_FD	extrafd = ERROR_FD;
@@ -331,6 +339,7 @@ static
 void storeval(const char *var, char *val)
 {
 	vartab_t	*tmp, *last;
+	const char	**pprogname;
 
 	/* NOTE: (FIXME?) The override and default mechanisms here
 	 * effectively bypass both VAR_SENSITIVE protections and
@@ -402,33 +411,37 @@ void storeval(const char *var, char *val)
 	printf("Look in the man page or call this driver with -h for a list of\n");
 	printf("valid variable names and flags.\n");
 
-	if (!strcmp(progname, "nutdrv_qx")) {
-		/* First many entries are from nut_usb_addvars() implementations;
-		 * the latter two (about langid) are from nutdrv_qx.c
-		 */
-		if (!strcmp(var, "vendor")
-		||  !strcmp(var, "product")
-		||  !strcmp(var, "serial")
-		||  !strcmp(var, "vendorid")
-		||  !strcmp(var, "productid")
-		||  !strcmp(var, "bus")
-		||  !strcmp(var, "device")
-		||  !strcmp(var, "busport")
-		||  !strcmp(var, "usb_set_altinterface")
-		||  !strcmp(var, "usb_config_index")
-		||  !strcmp(var, "usb_hid_rep_index")
-		||  !strcmp(var, "usb_hid_desc_index")
-		||  !strcmp(var, "usb_hid_ep_in")
-		||  !strcmp(var, "usb_hid_ep_out")
-		||  !strcmp(var, "allow_duplicates")
-		||  !strcmp(var, "langid_fix")
-		||  !strcmp(var, "noscanlangid")
-		) {
-			printf("\nNOTE: for driver '%s', options like '%s' are only available\n"
-				"if it was built with USB support. If you are running a custom build of NUT,\n"
-				"please check results of the `configure` checks, and consider an explicit\n"
-				"`--with-usb` option. Also make sure that both libusb library and headers\n"
-				"are installed in your build environment.\n\n", progname, var);
+	/* FIXME: find a way to separate this logic from main.c */
+	for (pprogname = prognames; *pprogname != NULL; pprogname++) {
+		if (!strcmp(*pprogname, "nutdrv_qx")) {
+			/* First many entries are from nut_usb_addvars() implementations;
+			 * the latter two (about langid) are from nutdrv_qx.c
+			 */
+			if (!strcmp(var, "vendor")
+			||  !strcmp(var, "product")
+			||  !strcmp(var, "serial")
+			||  !strcmp(var, "vendorid")
+			||  !strcmp(var, "productid")
+			||  !strcmp(var, "bus")
+			||  !strcmp(var, "device")
+			||  !strcmp(var, "busport")
+			||  !strcmp(var, "usb_set_altinterface")
+			||  !strcmp(var, "usb_config_index")
+			||  !strcmp(var, "usb_hid_rep_index")
+			||  !strcmp(var, "usb_hid_desc_index")
+			||  !strcmp(var, "usb_hid_ep_in")
+			||  !strcmp(var, "usb_hid_ep_out")
+			||  !strcmp(var, "allow_duplicates")
+			||  !strcmp(var, "langid_fix")
+			||  !strcmp(var, "noscanlangid")
+			) {
+				printf("\nNOTE: for driver '%s', options like '%s' are only available\n"
+					"if it was built with USB support. If you are running a custom build of NUT,\n"
+					"please check results of the `configure` checks, and consider an explicit\n"
+					"`--with-usb` option. Also make sure that both libusb library and headers\n"
+					"are installed in your build environment.\n\n", progname, var);
+				break;
+			}
 		}
 	}
 
@@ -1596,41 +1609,69 @@ void do_upsconf_args(char *confupsname, char *var, char *val)
 	 * reload should not allow changes here, but would report
 	 */
 	if (!strcmp(var, "driver")) {
-		int do_handle;
+		int	do_handle = -2, good_hits = 0, bad_hits = 0;
+		const char	**pprogname;
+		char	all_prognames[LARGEBUF];
+		size_t	i;
 
 		upsdebugx(5, "%s: this is a 'driver' setting, may we proceed?", __func__);
-		do_handle = testval_reloadable(var, progname, val, 0);
+		for (pprogname = prognames; *pprogname != NULL; pprogname++) {
+			do_handle = testval_reloadable(var, prognames[0], val, 0);
 
-		if (do_handle == -1) {
-			upsdebugx(5, "%s: 'driver' setting already applied with this value", __func__);
-			return;
-		}
-
-		/* Acceptable progname is only set once during start-up
-		 * val is from ups.conf
-		 */
-		if (!reload_flag || do_handle > 0) {
-			/* Accomodate for libtool wrapped developer iterations
-			 * running e.g. `drivers/.libs/lt-dummy-ups` filenames
-			 */
-			size_t tmplen = strlen("lt-");
-			if (strncmp("lt-", progname, tmplen) == 0
-			&&  strcmp(val, progname + tmplen) == 0) {
-				/* debug level may be not initialized yet, and situation
-				 * should not happen in end-user builds, so ok to yell: */
-				upsdebugx(0, "Seems this driver binary %s is a libtool "
-					"wrapped build for driver %s", progname, val);
-				/* progname points to xbasename(argv[0]) in-place;
-				 * roll the pointer forward a bit, we know we can:
-				 */
-				progname = progname + tmplen;
+			if (do_handle == -1) {
+				upsdebugx(5, "%s: 'driver' setting already applied with this value", __func__);
+				return;
 			}
 		}
 
-		if (strcmp(val, progname) != 0) {
-			fatalx(EXIT_FAILURE, "Error: UPS [%s] is for driver %s, but I'm %s!\n",
-				confupsname, val, progname);
+		memset(all_prognames, 0, sizeof(all_prognames));
+		/* Acceptable progname is only set once during start-up
+		 * val is from ups.conf
+		 */
+		i = 0;
+		for (pprogname = prognames; *pprogname != NULL; pprogname++) {
+			if (!reload_flag || do_handle > 0) {
+				/* Accomodate for libtool wrapped developer iterations
+				 * running e.g. `drivers/.libs/lt-dummy-ups` filenames
+				 */
+				size_t	tmplen = strlen("lt-");
+				if (strncmp("lt-", *pprogname, tmplen) == 0
+				&&  strcmp(val, *pprogname + tmplen) == 0) {
+					/* debug level may be not initialized yet, and situation
+					 * should not happen in end-user builds, so ok to yell: */
+					upsdebugx(0, "Seems this driver binary %s is a libtool "
+						"wrapped build for driver %s", *pprogname, val);
+					if (prognames_should_free[i]) {
+						char	*newpn = xstrdup(*pprogname + tmplen);
+						free((char*)*pprogname);
+						*pprogname = newpn;
+					} else {
+						/* *pprogname points to xbasename(argv[0]) in-place;
+						 * roll the pointer forward a bit, we know we can */
+						*pprogname = *pprogname + tmplen;
+					}
+				}
+			}
+
+			snprintfcat(all_prognames, sizeof(all_prognames), "%s'%s'",
+				all_prognames[0] ? "/" : "", *pprogname);
+
+			if (strcmp(val, *pprogname) != 0) {
+				bad_hits++;
+			} else {
+				good_hits++;
+			}
+
+			i++;
 		}
+
+		upsdebugx(3, "%s: collected %d bad hits and %d good hits for '%s' in %s",
+			__func__, bad_hits, good_hits, val, all_prognames);
+		if (!good_hits) {
+			fatalx(EXIT_FAILURE, "Error: UPS [%s] is for driver '%s', but I'm %s!\n",
+				confupsname, val, all_prognames);
+		}
+
 		return;
 	}
 
@@ -1859,6 +1900,8 @@ static void exit_upsdrv_cleanup(void)
 
 static void exit_cleanup(void)
 {
+	size_t	i;
+
 	dstate_setinfo("driver.state", "cleanup.exit");
 
 	if (!dump_data && !help_only) {
@@ -1893,6 +1936,16 @@ static void exit_cleanup(void)
 		CloseHandle(mutex);
 	}
 #endif	/* WIN32 */
+
+	for (i = 0; i < MAX_PROGNAMES; i++) {
+		/* Some prognames[] may be allocated statically,
+		 * e.g. can be a pointer to part of argv[0];
+		 * others come from strdup() and friends.
+		 */
+		if (prognames_should_free[i] && *(prognames[i])) {
+			free((char*)(prognames[i]));
+		}
+	}
 }
 #endif /* DRIVERS_MAIN_WITHOUT_MAIN */
 
@@ -2125,21 +2178,26 @@ int main(int argc, char **argv)
 	/* pick up a default from configure --with-group */
 	group = xstrdup(RUN_AS_GROUP);	/* xstrdup: this gets freed at exit */
 
-	progname = xbasename(argv[0]);
+	memset(prognames, 0, sizeof(prognames));
+	memset(prognames_should_free, 0, sizeof(prognames_should_free));
+	prognames[0] = xbasename(argv[0]);
 
 #ifdef WIN32
-	drv_name = xbasename(argv[0]);
+	drv_name = prognames[0];
 	/* remove trailing .exe */
 	dot = strrchr(drv_name,'.');
 	if (dot != NULL) {
 		if (strcasecmp(dot, ".exe") == 0) {
-			progname = strdup(drv_name);
-			char * t = strrchr(progname,'.');
+			char	*fixed_progname = strdup(drv_name);
+			char	*t = strrchr(fixed_progname,'.');
 			*t = 0;
+			prognames[0] = fixed_progname;
+			prognames_should_free[0] = 1;
 		}
 	}
 	else {
-		progname = strdup(drv_name);
+		prognames[0] = strdup(drv_name);
+		prognames_should_free[0] = 1;
 	}
 #endif	/* WIN32 */
 

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -2201,6 +2201,8 @@ int main(int argc, char **argv)
 	}
 #endif	/* WIN32 */
 
+	upsdrv_tweak_prognames();
+
 	open_syslog(progname);
 
 	if (!banner_is_disabled()) {

--- a/drivers/main.h
+++ b/drivers/main.h
@@ -29,6 +29,7 @@ extern char	prognames_should_free[MAX_PROGNAMES];
 #define	progname	(prognames[0])
 
 /* functions & variables required in each driver */
+void upsdrv_tweak_prognames(void);	/* optionally add aliases and/or set preferred name into [0] (for pipe name etc.); called just after populating prognames[0] and prognames_should_free[] entries */
 void upsdrv_initups(void);	/* open connection to UPS, fail if not found */
 void upsdrv_initinfo(void);	/* prep data, settings for UPS monitoring */
 void upsdrv_updateinfo(void);	/* update state data if possible */

--- a/drivers/main.h
+++ b/drivers/main.h
@@ -11,12 +11,22 @@
 #endif	/* WIN32 */
 
 /* public functions & variables from main.c, documented in detail there */
-extern const char	*progname, *upsname, *device_name;
+extern const char	*upsname, *device_name;
 extern char		*device_path, *device_sdcommands;
 extern int		broken_driver, experimental_driver,
 			do_lock_port, exit_flag, handling_upsdrv_shutdown;
 extern TYPE_FD		upsfd, extrafd;
 extern time_t		poll_interval;
+
+/* We allow for aliases to certain program names (e.g. when renaming a driver
+ * between "old" and "new" and default implementations, it should accept both
+ * or more names it can be called by).
+ * The [0] entry is used to set up stuff like pipe names, man page links, etc.
+ */
+#define	MAX_PROGNAMES	4
+extern const char	*prognames[MAX_PROGNAMES];
+extern char	prognames_should_free[MAX_PROGNAMES];
+#define	progname	(prognames[0])
 
 /* functions & variables required in each driver */
 void upsdrv_initups(void);	/* open connection to UPS, fail if not found */

--- a/drivers/masterguard.c
+++ b/drivers/masterguard.c
@@ -31,7 +31,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"MASTERGUARD UPS driver"
-#define DRIVER_VERSION	"0.29"
+#define DRIVER_VERSION	"0.30"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -446,6 +446,17 @@ static ssize_t ups_ident( void )
  *
  ********************************************************************/
 void upsdrv_help( void )
+{
+
+}
+
+/********************************************************************
+ *
+ *
+ * optionally tweak prognames[] entries
+ *
+ ********************************************************************/
+void upsdrv_tweak_prognames(void)
 {
 
 }

--- a/drivers/metasys.c
+++ b/drivers/metasys.c
@@ -28,7 +28,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"Metasystem UPS driver"
-#define DRIVER_VERSION	"0.12"
+#define DRIVER_VERSION	"0.13"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -1099,6 +1099,11 @@ static int instcmd(const char *cmdname, const char *extra)
 
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/mge-utalk.c
+++ b/drivers/mge-utalk.c
@@ -69,7 +69,7 @@
 /* --------------------------------------------------------------- */
 
 #define DRIVER_NAME	"MGE UPS SYSTEMS/U-Talk driver"
-#define DRIVER_VERSION	"0.99"
+#define DRIVER_VERSION	"0.100"
 
 
 /* driver description structure */
@@ -531,6 +531,11 @@ void upsdrv_shutdown(void)
 /* --------------------------------------------------------------- */
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/microdowell.c
+++ b/drivers/microdowell.c
@@ -44,7 +44,7 @@
 #define MAX_SHUTDOWN_DELAY_LEN 5
 
 #define DRIVER_NAME	"MICRODOWELL UPS driver"
-#define DRIVER_VERSION	"0.06"
+#define DRIVER_VERSION	"0.07"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -1030,6 +1030,11 @@ void upsdrv_shutdown(void)
 
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/microsol-apc.c
+++ b/drivers/microsol-apc.c
@@ -35,7 +35,7 @@
 #include "microsol-apc.h"
 
 #define DRIVER_NAME	"APC Back-UPS BR series UPS driver"
-#define DRIVER_VERSION	"0.72"
+#define DRIVER_VERSION	"0.73"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {

--- a/drivers/microsol-common.c
+++ b/drivers/microsol-common.c
@@ -794,6 +794,11 @@ void upsdrv_help(void)
 	printf(" These are valid only if prgshut = 2 or 3\n");
 }
 
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
+{
+}
+
 void upsdrv_makevartable(void)
 {
 	addvar(VAR_VALUE, "battext", "Battery extension (0-80AH)");

--- a/drivers/netxml-ups.c
+++ b/drivers/netxml-ups.c
@@ -42,7 +42,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"network XML UPS"
-#define DRIVER_VERSION	"0.48"
+#define DRIVER_VERSION	"0.49"
 
 /** *_OBJECT query multi-part body boundary */
 #define FORM_POST_BOUNDARY "NUT-NETXML-UPS-OBJECTS"
@@ -554,6 +554,11 @@ static int setvar(const char *varname, const char *val) {
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/nhs_ser.c
+++ b/drivers/nhs_ser.c
@@ -43,7 +43,7 @@
 #include <math.h>
 
 #define DRIVER_NAME	"NHS Nobreak Drivers"
-#define DRIVER_VERSION	"0.02"
+#define DRIVER_VERSION	"0.03"
 #define MANUFACTURER	"NHS Sistemas Eletronicos LTDA"
 
 #define DEFAULTBAUD	2400
@@ -2470,4 +2470,9 @@ void upsdrv_makevartable(void) {
 }
 
 void upsdrv_help(void) {
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
+{
 }

--- a/drivers/nut-ipmipsu.c
+++ b/drivers/nut-ipmipsu.c
@@ -27,7 +27,7 @@
 #include "nut-ipmi.h"
 
 #define DRIVER_NAME	"IPMI PSU driver"
-#define DRIVER_VERSION	"0.35"
+#define DRIVER_VERSION	"0.36"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -201,6 +201,11 @@ static int setvar(const char *varname, const char *val)
 */
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/nutdrv_atcl_usb.c
+++ b/drivers/nutdrv_atcl_usb.c
@@ -28,7 +28,7 @@
 
 /* driver version */
 #define DRIVER_NAME	"'ATCL FOR UPS' USB driver"
-#define DRIVER_VERSION	"1.21"
+#define DRIVER_VERSION	"1.22"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -735,6 +735,11 @@ void upsdrv_shutdown(void)
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/nutdrv_hashx.c
+++ b/drivers/nutdrv_hashx.c
@@ -36,7 +36,7 @@
 #define IGNCHARS	""
 
 #define DRIVER_NAME	"Generic #* Serial driver"
-#define DRIVER_VERSION	"0.02"
+#define DRIVER_VERSION	"0.03"
 
 #define SESSION_ID	"OoNUTisAMAZINGoO"
 #define SESSION_HASH	"74279F35A48F5F13"
@@ -641,6 +641,11 @@ void upsdrv_shutdown(void)
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -58,7 +58,7 @@
 #	define DRIVER_NAME	"Generic Q* Serial driver"
 #endif	/* QX_USB */
 
-#define DRIVER_VERSION	"0.46"
+#define DRIVER_VERSION	"0.47"
 
 #ifdef QX_SERIAL
 #	include "serial.h"
@@ -3247,6 +3247,11 @@ void	upsdrv_help(void)
 	}
 	printf("\n");
 #endif	/* TESTING */
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
+{
 }
 
 /* Adding flags/vars */

--- a/drivers/nutdrv_siemens_sitop.c
+++ b/drivers/nutdrv_siemens_sitop.c
@@ -56,7 +56,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"Siemens SITOP UPS500 series driver"
-#define DRIVER_VERSION	"0.07"
+#define DRIVER_VERSION	"0.08"
 
 #define RX_BUFFER_SIZE 100
 
@@ -266,6 +266,11 @@ void upsdrv_shutdown(void) {
 
 
 void upsdrv_help(void) {
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
+{
 }
 
 /* list flags and values that you want to receive via -x */

--- a/drivers/oneac.c
+++ b/drivers/oneac.c
@@ -51,7 +51,7 @@ int setcmd(const char* varname, const char* setvalue);
 int instcmd(const char *cmdname, const char *extra);
 
 #define DRIVER_NAME	"Oneac EG/ON/OZ/OB UPS driver"
-#define DRIVER_VERSION	"0.85"
+#define DRIVER_VERSION	"0.86"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -835,6 +835,11 @@ void upsdrv_help(void)
 {
 	printf("\n---------\nNOTE:\n");
 	printf("You must set the UPS interface card DIP switch to 9600 BPS\n");
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
+{
 }
 
 void upsdrv_cleanup(void)

--- a/drivers/optiups.c
+++ b/drivers/optiups.c
@@ -28,7 +28,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"Opti-UPS driver"
-#define DRIVER_VERSION	"1.08"
+#define DRIVER_VERSION	"1.09"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -602,6 +602,11 @@ void upsdrv_shutdown(void)
 void upsdrv_help(void)
 {
 	printf(HELP);
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
+{
 }
 
 /* list flags and values that you want to receive via -x */

--- a/drivers/phoenixcontact_modbus.c
+++ b/drivers/phoenixcontact_modbus.c
@@ -32,7 +32,7 @@
 #endif
 
 #define DRIVER_NAME	"NUT PhoenixContact Modbus driver (libmodbus link type: " NUT_MODBUS_LINKTYPE_STR ")"
-#define DRIVER_VERSION	"0.09"
+#define DRIVER_VERSION	"0.10"
 
 #define CHECK_BIT(var,pos) ((var) & (1<<(pos)))
 #define MODBUS_SLAVE_ID 192
@@ -802,6 +802,11 @@ void upsdrv_help(void)
 		"\ninput.voltage.low.critical\tThreshold [V] to switch to battery mode"
 		"\ninput.voltage.high.critical\tThreshold [V] to return to mains mode"
 		"\n");
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
+{
 }
 
 /* list flags and values that you want to receive via -x */

--- a/drivers/pijuice.c
+++ b/drivers/pijuice.c
@@ -23,7 +23,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME                         "PiJuice UPS driver"
-#define DRIVER_VERSION                      "0.15"
+#define DRIVER_VERSION                      "0.16"
 
 /*
  * Linux I2C userland is a bit of a mess until distros refresh to
@@ -862,6 +862,11 @@ void upsdrv_help(void)
 {
 	printf("\nThe default I2C address is 20 [0x14]\n");
 	printf("\n");
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
+{
 }
 
 void upsdrv_makevartable(void)

--- a/drivers/powercom.c
+++ b/drivers/powercom.c
@@ -86,7 +86,7 @@
 #include "nut_float.h"
 
 #define DRIVER_NAME	"PowerCom protocol UPS driver"
-#define DRIVER_VERSION	"0.25"
+#define DRIVER_VERSION	"0.26"
 
 /* driver description structure */
 upsdrv_info_t	upsdrv_info = {
@@ -1163,6 +1163,11 @@ void upsdrv_help(void)
 	printf("#   voltage = {2.0000,0.0000,2.0000,0.0000}\n");
 	printf("    nobt\n");
 	return;
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
+{
 }
 
 /* initialize information */

--- a/drivers/powerman-pdu.c
+++ b/drivers/powerman-pdu.c
@@ -23,7 +23,7 @@
 #include <libpowerman.h>	/* pm_err_t and other beasts */
 
 #define DRIVER_NAME	"Powerman PDU client driver"
-#define DRIVER_VERSION	"0.16"
+#define DRIVER_VERSION	"0.17"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -181,6 +181,11 @@ static int setvar(const char *varname, const char *val)
 */
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/powerpanel.c
+++ b/drivers/powerpanel.c
@@ -36,7 +36,7 @@ static subdriver_t *subdriver[] = {
 };
 
 #define DRIVER_NAME	"CyberPower text/binary protocol UPS driver"
-#define DRIVER_VERSION	"0.30"
+#define DRIVER_VERSION	"0.31"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -183,6 +183,11 @@ void upsdrv_initups(void)
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/powervar_cx_ser.c
+++ b/drivers/powervar_cx_ser.c
@@ -39,7 +39,7 @@
 #include "powervar_cx.h"	/* Common driver defines, variables, and functions */
 
 #define DRIVER_NAME	"Powervar-CUSSP UPS driver (Serial)"
-#define DRIVER_VERSION	"1.00"
+#define DRIVER_VERSION	"1.01"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -194,6 +194,12 @@ void upsdrv_help(void)
 {
 	printf("\n---------\nNOTE:\n");
 	printf("This driver is for connecting to a Powervar UPS serial port at 9600 BPS.\n");
+}
+
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
+{
 }
 
 

--- a/drivers/powervar_cx_usb.c
+++ b/drivers/powervar_cx_usb.c
@@ -45,7 +45,7 @@
 #include "powervar_cx.h"	/* Common driver variables and functions */
 
 #define DRIVER_NAME	"Powervar-CUSSP UPS driver (USB)"
-#define DRIVER_VERSION	"1.00"
+#define DRIVER_VERSION	"1.01"
 
 /* USB comm stuff here */
 #define USB_RESPONSE_SIZE	8
@@ -451,6 +451,11 @@ void upsdrv_help(void)
 {
 	printf("\n---------\nNOTE:\n");
 	printf("This driver is for connecting to a Powervar UPS USB port.\n");
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
+{
 }
 
 void upsdrv_cleanup(void)

--- a/drivers/rhino.c
+++ b/drivers/rhino.c
@@ -38,7 +38,7 @@
 #include "timehead.h"
 
 #define DRIVER_NAME	"Microsol Rhino UPS driver"
-#define DRIVER_VERSION	"0.56"
+#define DRIVER_VERSION	"0.57"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -782,6 +782,11 @@ void upsdrv_shutdown(void)
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/richcomm_usb.c
+++ b/drivers/richcomm_usb.c
@@ -30,7 +30,7 @@
 
 /* driver version */
 #define DRIVER_NAME	"Richcomm dry-contact to USB driver"
-#define DRIVER_VERSION	"0.15"
+#define DRIVER_VERSION	"0.16"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -794,6 +794,11 @@ void upsdrv_shutdown(void)
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/riello_ser.c
+++ b/drivers/riello_ser.c
@@ -48,7 +48,7 @@
 #include "riello.h"
 
 #define DRIVER_NAME	"Riello serial driver"
-#define DRIVER_VERSION	"0.15"
+#define DRIVER_VERSION	"0.16"
 
 #define DEFAULT_OFFDELAY   5  /*!< seconds (max 0xFF) */
 #define DEFAULT_BOOTDELAY  5  /*!< seconds (max 0xFF) */
@@ -1243,6 +1243,11 @@ static int setvar(const char *varname, const char *val)
 */
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/riello_usb.c
+++ b/drivers/riello_usb.c
@@ -36,7 +36,7 @@
 #include "riello.h"
 
 #define DRIVER_NAME	"Riello USB driver"
-#define DRIVER_VERSION	"0.15"
+#define DRIVER_VERSION	"0.16"
 
 #define DEFAULT_OFFDELAY   5  /*!< seconds (max 0xFF) */
 #define DEFAULT_BOOTDELAY  5  /*!< seconds (max 0xFF) */
@@ -862,9 +862,12 @@ static int start_ups_comm(void)
 
 void upsdrv_help(void)
 {
-
 }
 
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
+{
+}
 
 void upsdrv_makevartable(void)
 {

--- a/drivers/safenet.c
+++ b/drivers/safenet.c
@@ -41,7 +41,7 @@
 #include "safenet.h"
 
 #define DRIVER_NAME	"Generic SafeNet UPS driver"
-#define DRIVER_VERSION	"1.83"
+#define DRIVER_VERSION	"1.84"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -470,6 +470,11 @@ void upsdrv_shutdown(void)
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/skel.c
+++ b/drivers/skel.c
@@ -22,7 +22,7 @@
 /* #define IGNCHARS	""	*/
 
 #define DRIVER_NAME	"Skeleton UPS driver"
-#define DRIVER_VERSION	"0.07"
+#define DRIVER_VERSION	"0.08"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -163,7 +163,13 @@ static int setvar(const char *varname, const char *val)
 }
 */
 
+/* print driver-specific usage info */
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/sms_ser.c
+++ b/drivers/sms_ser.c
@@ -31,7 +31,7 @@
 #define ENDCHAR '\r'
 
 #define DRIVER_NAME	"SMS Brazil UPS driver"
-#define DRIVER_VERSION	"1.03"
+#define DRIVER_VERSION	"1.04"
 
 #define QUERY_SIZE 7
 #define BUFFER_SIZE 18
@@ -570,6 +570,11 @@ void upsdrv_shutdown(void) {
 }
 
 void upsdrv_help(void) {
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
+{
 }
 
 /* list flags and values that you want to receive via -x */

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -1309,6 +1309,11 @@ static struct snmp_pdu **nut_snmp_walk(const char *OID, int max_iteration)
 	while( nb_iteration < max_iteration ) {
 		struct snmp_pdu	**new_ret_array;
 
+		/* Check if we are asked to stop (reactivity++) */
+		if (exit_flag != 0) {
+			fatalx(EXIT_FAILURE, "Aborting because exit_flag was set");
+		}
+
 		/* Going to a shorter OID means we are outside our sub-tree */
 		if( current_name_len < name_len ) {
 			break;
@@ -2204,6 +2209,11 @@ bool_t load_mib2nut(const char *mib)
 			__func__, mib);
 		/* Retry at most 3 times, to maximise chances */
 		for (i = 0; i < 3 ; i++) {
+			/* Check if we are asked to stop (reactivity++) */
+			if (exit_flag != 0) {
+				fatalx(EXIT_FAILURE, "Aborting because exit_flag was set");
+			}
+
 			upsdebugx(3, "%s: trying the new match_sysoid() method: attempt #%d",
 				__func__, (i+1));
 			if ((m2n = match_sysoid()) != NULL)

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -543,6 +543,11 @@ void upsdrv_help(void)
 	upsdebugx(1, "entering %s", __func__);
 }
 
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
+{
+}
+
 /* list flags and values that you want to receive via -x */
 void upsdrv_makevartable(void)
 {

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -546,6 +546,33 @@ void upsdrv_help(void)
 /* optionally tweak prognames[] entries */
 void upsdrv_tweak_prognames(void)
 {
+	upsdebugx(1, "entering %s", __func__);
+
+	/* If executed via an accepted alias, move it down in prognames[] stack */
+	if (!strcmp(prognames[0], "snmp-ups-old")) {
+		upsdebugx(3, "%s: marking program name '%s' as an alias for '%s'",
+			__func__, prognames[0], "snmp-ups");
+
+		if (prognames_should_free[1] && prognames[1])
+			free((char*)prognames[1]);
+		prognames[1] = prognames[0];
+		prognames_should_free[1] = prognames_should_free[0];
+
+		if (prognames_should_free[0])
+			free((char*)prognames[0]);
+		prognames[0] = xstrdup("snmp-ups");
+		prognames_should_free[0] = 1;
+	} else {
+		if (!strcmp(prognames[0], "snmp-ups")) {
+			upsdebugx(3, "%s: marking program name '%s' as an alias for '%s'",
+				__func__, "snmp-ups-old", prognames[0]);
+
+			if (prognames_should_free[1])
+				free((char*)prognames[1]);
+			prognames[1] = xstrdup("snmp-ups-old");
+			prognames_should_free[1] = 1;
+		}
+	}
 }
 
 /* list flags and values that you want to receive via -x */

--- a/drivers/socomec_jbus.c
+++ b/drivers/socomec_jbus.c
@@ -35,7 +35,7 @@
 #endif
 
 #define DRIVER_NAME	"Socomec jbus driver (libmodbus link type: " NUT_MODBUS_LINKTYPE_STR ")"
-#define DRIVER_VERSION	"0.09"
+#define DRIVER_VERSION	"0.10"
 
 #define CHECK_BIT(var,pos) ((var) & (1<<(pos)))
 #define MODBUS_SLAVE_ID 1
@@ -442,6 +442,11 @@ void upsdrv_shutdown(void)
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/solis.c
+++ b/drivers/solis.c
@@ -48,7 +48,7 @@
 #include "timehead.h"
 
 #define DRIVER_NAME	"Microsol Solis UPS driver"
-#define DRIVER_VERSION	"0.72"
+#define DRIVER_VERSION	"0.73"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -1003,6 +1003,11 @@ void upsdrv_help(void) {
 	printf(" where houron is power-on hour and houroff is shutdown and power-off hour\n");
 	printf(" Uses daysweek and houron to programming and save UPS power on/off\n");
 	printf(" These are valid only if prgshut = 2 or 3\n");
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
+{
 }
 
 void upsdrv_makevartable(void) {

--- a/drivers/tripplite.c
+++ b/drivers/tripplite.c
@@ -117,7 +117,7 @@
 #include <ctype.h>
 
 #define DRIVER_NAME	"Tripp-Lite SmartUPS driver"
-#define DRIVER_VERSION	"0.98"
+#define DRIVER_VERSION	"0.99"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -616,6 +616,11 @@ void upsdrv_updateinfo(void)
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -137,7 +137,7 @@
 #include "usb-common.h"
 
 #define DRIVER_NAME	"Tripp Lite OMNIVS / SMARTPRO driver"
-#define DRIVER_VERSION	"0.41"
+#define DRIVER_VERSION	"0.42"
 
 /* driver description structure */
 upsdrv_info_t	upsdrv_info = {
@@ -1678,6 +1678,11 @@ void upsdrv_updateinfo(void)
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/tripplitesu.c
+++ b/drivers/tripplitesu.c
@@ -126,7 +126,7 @@
 #include "nut_stdint.h"
 
 #define DRIVER_NAME	"Tripp Lite SmartOnline driver"
-#define DRIVER_VERSION	"0.10"
+#define DRIVER_VERSION	"0.11"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -878,6 +878,11 @@ void upsdrv_shutdown(void)
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/upscode2.c
+++ b/drivers/upscode2.c
@@ -43,7 +43,7 @@
 #include "nut_float.h"
 
 #define DRIVER_NAME	"UPScode II UPS driver"
-#define DRIVER_VERSION	"0.94"
+#define DRIVER_VERSION	"0.95"
 
 /* driver description structure */
 upsdrv_info_t	upsdrv_info = {
@@ -460,6 +460,10 @@ void upsdrv_help(void)
 {
 }
 
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
+{
+}
 
 void upsdrv_initups(void)
 {

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -1210,7 +1210,7 @@ static void start_driver(const ups_t *ups)
 	}
 }
 
-static void help(const char *progname)
+static void help(const char *arg_progname)
 	__attribute__((noreturn));
 
 static void help(const char *arg_progname)

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -29,7 +29,7 @@
  */
 
 #define DRIVER_NAME	"Generic HID driver"
-#define DRIVER_VERSION	"0.68"
+#define DRIVER_VERSION	"0.69"
 
 #define HU_VAR_WAITBEFORERECONNECT "waitbeforereconnect"
 
@@ -1280,6 +1280,11 @@ void upsdrv_help(void)
 		printf("\"%s\"", subdriver_list[i]->name);
 	}
 	printf("\n");
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
+{
 }
 
 void upsdrv_makevartable(void)

--- a/drivers/ve-direct.c
+++ b/drivers/ve-direct.c
@@ -22,7 +22,7 @@
 #include "serial.h"
 
 #define DRIVER_NAME	"Victron Energy Direct UPS and solar controller driver"
-#define DRIVER_VERSION	"0.22"
+#define DRIVER_VERSION	"0.23"
 
 #define VE_GET	7
 #define VE_SET	8
@@ -285,6 +285,11 @@ void upsdrv_shutdown(void)
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/drivers/victronups.c
+++ b/drivers/victronups.c
@@ -32,7 +32,7 @@
 #include "serial.h"
 
 #define DRIVER_NAME	"GE/IMV/Victron UPS driver"
-#define DRIVER_VERSION	"0.25"
+#define DRIVER_VERSION	"0.26"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -518,6 +518,11 @@ void upsdrv_shutdown(void)
 }
 
 void upsdrv_help(void)
+{
+}
+
+/* optionally tweak prognames[] entries */
+void upsdrv_tweak_prognames(void)
 {
 }
 

--- a/include/common.h
+++ b/include/common.h
@@ -309,14 +309,20 @@ size_t parseprogbasename(char *buf, size_t buflen, const char *progname, size_t 
  *	0	Process name identified, does not seem to match
  *	1+	Process name identified, and seems to match with
  *		varying precision
- * Generally speaking, if (checkprocname(...)) then ok to proceed
+ * Generally speaking, if (checkprocname(...)) then ok to proceed.
+ * Singular for programs with a single expected executable name,
+ * plural for programs with expected aliases (e.g. "old"/new" migrations).
  */
 int checkprocname(pid_t pid, const char *progname);
-/* compareprocname() does the bulk of work for checkprocname()
- * and returns same values. The "pid" argument is used for logging.
- * Generally speaking, if (compareprocname(...)) then ok to proceed
+int checkprocnames(pid_t pid, const char **prognames);
+/* compareprocname*() methods do the bulk of work for checkprocname*()
+ * and return same values. The "pid" argument is used for logging.
+ * Generally speaking, if (compareprocname(...)) then ok to proceed.
+ * Singular for programs with a single expected executable name,
+ * plural for programs with expected aliases (e.g. "old"/new" migrations).
  */
 int compareprocname(pid_t pid, const char *procname, const char *progname);
+int compareprocnames(pid_t pid, const char *procname, const char **prognames);
 /* Helper for the above methods and some others. If it returns true (1),
  * work about PID-name comparison should be quickly skipped.
  */

--- a/include/common.h
+++ b/include/common.h
@@ -382,6 +382,7 @@ pid_t get_max_pid_t(void);
 /* send sig to pid after some sanity checks, returns
  * -1 for error, or zero for a successfully sent signal */
 int sendsignalpid(pid_t pid, int sig, const char *progname, int check_current_progname);
+int sendsignalpidaliases(pid_t pid, int sig, const char **prognames, int check_current_progname);
 
 /* open <pidfn> and get the pid
  * returns zero or more for successfully retrieved value,
@@ -406,9 +407,11 @@ pid_t parsepidfile(const char *pidfn);
  * named driver programs does not request it)
  */
 int sendsignalfn(const char *pidfn, int sig, const char *progname, int check_current_progname);
+int sendsignalfnaliases(const char *pidfn, int sig, const char **prognames, int check_current_progname);
 #else	/* WIN32 */
 /* No progname here - communications via named pipe */
 int sendsignalfn(const char *pidfn, const char * sig, const char *progname_ignored, int check_current_progname_ignored);
+int sendsignalfnaliases(const char *pidfn, const char * sig, const char **prognames_ignored, int check_current_progname_ignored);
 #endif	/* WIN32 */
 
 const char *xbasename(const char *file);


### PR DESCRIPTION
Used e.g. when sending signals (is the passed PID for an expected program?) or checking for `driver.name` values.

Practically useful for renaming of drivers like using some "old"/"new" suffixes as default implementations change.

Expected useful for merging FTY/DMF branch, which currently juggles `snmp-ups-dmf` and `snmp-ups-old` which are both acceptable implementations of `snmp-ups` and hard-coding some one `progname` as we do today was a bit unwieldy in 42ity project practice. The PR offers such aliasing in `snmp-ups` to illustrate and test the feature also on `master` branch.

Also fixes optional `free`'ing of `progname` in drivers, where it even previously could have been a pointer to someone else's memory (e.g. a position inside `argv[0]`) or a dedicated block (via `xstrdup` etc). Now this origin is tracked and handled accordingly.