### PR TITLE
scripts: Avoid `tail -n +/-NUM` syntax as less portable than `tail +/-NUM`

### DIFF
--- a/ci_build.sh
+++ b/ci_build.sh
@@ -1354,7 +1354,11 @@ consider_cleanup_shortcut() {
     if [ -s "${CI_BUILDDIR}"/configure ] ; then
         # FIXME: Consider CONFIG_SHELL, maybe from script shebang,
         #  here - like autogen.sh does
-        if sh -n "${CI_BUILDDIR}"/configure 2>/dev/null ; then
+        USE_CONFIG_SHELL=sh
+        if [ -n "${CONFIG_SHELL-}" ]; then
+            USE_CONFIG_SHELL="${CONFIG_SHELL}"
+        fi
+        if ${USE_CONFIG_SHELL} -n "${CI_BUILDDIR}"/configure 2>/dev/null ; then
             true
         else
             echo "=== Starting initial clean-up (from old build products): TAKING SHORTCUT because current configure script syntax is broken"

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -1512,7 +1512,7 @@ if [ -z "$BUILD_TYPE" ] ; then
             fi
             ;;
 
-        *) echo "WARNING: Command-line argument '$1' wsa not recognized as a BUILD_TYPE alias" >&2 ;;
+        *) echo "WARNING: Command-line argument '$1' was not recognized as a BUILD_TYPE alias" >&2 ;;
     esac
 fi
 

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -1336,17 +1336,17 @@ consider_cleanup_shortcut() {
         DO_REGENERATE=true
     fi
 
-    if [ -s Makefile ]; then
-        if [ -n "`find "${SCRIPTDIR}" -name configure.ac -newer "${CI_BUILDDIR}"/configure`" ] \
-        || [ -n "`find "${SCRIPTDIR}" -name '*.m4' -newer "${CI_BUILDDIR}"/configure`" ] \
-        || [ -n "`find "${SCRIPTDIR}" -name Makefile.am -newer "${CI_BUILDDIR}"/Makefile`" ] \
-        || [ -n "`find "${SCRIPTDIR}" -name Makefile.in -newer "${CI_BUILDDIR}"/Makefile`" ] \
-        || [ -n "`find "${SCRIPTDIR}" -name Makefile.am -newer "${CI_BUILDDIR}"/Makefile.in`" ] \
-        ; then
-            # Avoid reconfiguring just for the sake of distclean
-            echo "=== Starting initial clean-up (from old build products): TAKING SHORTCUT because recipes changed"
-            DO_REGENERATE=true
-        fi
+    if ( [ -s Makefile ] && (
+            [ -n "`find "${SCRIPTDIR}" -name Makefile.am -newer "${CI_BUILDDIR}"/Makefile`" ] \
+        ||  [ -n "`find "${SCRIPTDIR}" -name Makefile.in -newer "${CI_BUILDDIR}"/Makefile`" ] \
+        ||  [ -n "`find "${SCRIPTDIR}" -name Makefile.am -newer "${CI_BUILDDIR}"/Makefile.in`" ] ) ) \
+    || ( [ -s configure ] && (
+            [ -n "`find "${SCRIPTDIR}" -name configure.ac -newer "${CI_BUILDDIR}"/configure`" ] \
+        ||  [ -n "`find "${SCRIPTDIR}" -name '*.m4' -newer "${CI_BUILDDIR}"/configure`" ] ) ) \
+    ; then
+        # Avoid reconfiguring just for the sake of distclean
+        echo "=== Starting initial clean-up (from old build products): TAKING SHORTCUT because recipes changed"
+        DO_REGENERATE=true
     fi
 
     # When iterating configure.ac or m4 sources, we can end up with an

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -55,7 +55,7 @@ case "$BUILD_TYPE" in
             echo "SKIPPING BUILD_TYPE=fightwarn-clang: compiler not found" >&2
         fi
         if $TRIED_BUILD ; then true
-	else
+        else
             echo "FAILED to run: no default-named compilers were found" >&2
             exit 1
         fi
@@ -2754,16 +2754,16 @@ bindings)
     esac
 
     if [ "${_EXPORT_FLAGS}" = true ] ; then
-            [ -z "${CFLAGS}" ]   || export CFLAGS
-            [ -z "${CXXFLAGS}" ] || export CXXFLAGS
-            [ -z "${CPPFLAGS}" ] || export CPPFLAGS
-            [ -z "${LDFLAGS}" ]  || export LDFLAGS
+        [ -z "${CFLAGS}" ]   || export CFLAGS
+        [ -z "${CXXFLAGS}" ] || export CXXFLAGS
+        [ -z "${CPPFLAGS}" ] || export CPPFLAGS
+        [ -z "${LDFLAGS}" ]  || export LDFLAGS
     else
-            # NOTE: Passing via CONFIG_OPTS also fails
-            [ -z "${CFLAGS}" ]   || echo "WARNING: SKIP: On '${CI_OS_NAME}' with ccache used, can not export CFLAGS='${CFLAGS}'" >&2
-            [ -z "${CXXFLAGS}" ] || echo "WARNING: SKIP: On '${CI_OS_NAME}' with ccache used, can not export CXXFLAGS='${CXXFLAGS}'" >&2
-            [ -z "${CPPFLAGS}" ] || echo "WARNING: SKIP: On '${CI_OS_NAME}' with ccache used, can not export CPPFLAGS='${CPPFLAGS}'" >&2
-            [ -z "${LDFLAGS}" ]  || echo "WARNING: SKIP: On '${CI_OS_NAME}' with ccache used, can not export LDFLAGS='${LDFLAGS}'" >&2
+        # NOTE: Passing via CONFIG_OPTS also fails
+        [ -z "${CFLAGS}" ]   || echo "WARNING: SKIP: On '${CI_OS_NAME}' with ccache used, can not export CFLAGS='${CFLAGS}'" >&2
+        [ -z "${CXXFLAGS}" ] || echo "WARNING: SKIP: On '${CI_OS_NAME}' with ccache used, can not export CXXFLAGS='${CXXFLAGS}'" >&2
+        [ -z "${CPPFLAGS}" ] || echo "WARNING: SKIP: On '${CI_OS_NAME}' with ccache used, can not export CPPFLAGS='${CPPFLAGS}'" >&2
+        [ -z "${LDFLAGS}" ]  || echo "WARNING: SKIP: On '${CI_OS_NAME}' with ccache used, can not export LDFLAGS='${LDFLAGS}'" >&2
     fi
 
     PATH="`echo "${PATH}" | normalize_path`"

--- a/configure.ac
+++ b/configure.ac
@@ -6782,6 +6782,7 @@ AC_CONFIG_FILES([
  scripts/hotplug/libhidups
  scripts/HP-UX/nut.psf
  scripts/installer/Makefile
+ scripts/misc/nut.bash_completion
  scripts/python/Makefile
  scripts/python/module/Makefile
  scripts/python/module/PyNUT.py

--- a/configure.ac
+++ b/configure.ac
@@ -242,7 +242,7 @@ AS_IF([test x"${nut_enable_configure_debug}" = xyes], [
 AC_MSG_CHECKING(for autoconf macro to enable system extensions)
 m4_version_prereq(2.61, [
 	AC_MSG_RESULT(yes)
-        dnl Causes calls to ac_prog stuff, so dittoed below if "no"
+	dnl Causes calls to ac_prog stuff, so dittoed below if "no"
 	AC_USE_SYSTEM_EXTENSIONS
 ], [
 	AC_MSG_RESULT(no)

--- a/configure.ac
+++ b/configure.ac
@@ -314,6 +314,36 @@ AC_SUBST(NUT_AM_MAKE_CAN_EXPORT)
 dnl Some systems have older autotools without direct macro support for PKG_CONF*
 NUT_CHECK_PKGCONFIG
 
+dnl Nowadays both `tail -n +3` and `tail +3` work almost everywhere
+dnl * CentOS7 tail can not do `tail +3` -- no such file
+dnl * Classic Solaris tooling (even in Solaris 11) can not do `tail -n` -- no such option
+AC_MSG_CHECKING([how to "tail" starting from Nth line])
+dnl Requires autoconf 2.62 or newer; for even older systems consider
+dnl an adapted implementation of the logic below. For more details see
+dnl https://www.gnu.org/software/autoconf/manual/autoconf-2.68/html_node/Generic-Programs.html
+TAIL_ARGS_FROM_NTH_LINE=""
+ac_path_TAIL_found=""
+AC_PATH_PROGS_FEATURE_CHECK([TAIL], [tail gtail],
+	[_TAIL_OUT="`(echo "1"; echo "2"; echo "3"; echo "4"; echo "5"; echo "6"; echo "7") | $ac_path_TAIL +3`" || _TAIL_OUT=""
+	 AS_IF([(test x"${_TAIL_OUT}" != x && echo "${_TAIL_OUT}" | ${GREP} 3 && echo "${_TAIL_OUT}" | ${GREP} 7) >/dev/null],
+		[AS_IF([(echo "${_TAIL_OUT}" | ${GREP} 1 || echo "${_TAIL_OUT}" | ${GREP} 2) >/dev/null], [],
+			[ac_path_TAIL_found=:
+				 ac_cv_path_TAIL="${ac_path_TAIL}"])
+		])
+	 AS_IF([test x"${ac_path_TAIL_found}" != x:],
+		[_TAIL_OUT="`(echo "1"; echo "2"; echo "3"; echo "4"; echo "5"; echo "6"; echo "7") | $ac_path_TAIL -n +3`" || _TAIL_OUT=""
+		 AS_IF([(test x"${_TAIL_OUT}" != x && echo "${_TAIL_OUT}" | ${GREP} 3 && echo "${_TAIL_OUT}" | ${GREP} 7) >/dev/null],
+			[AS_IF([(echo "${_TAIL_OUT}" | ${GREP} 1 || echo "${_TAIL_OUT}" | ${GREP} 2) >/dev/null], [],
+				[ac_path_TAIL_found=:
+				 ac_cv_path_TAIL="${ac_path_TAIL}"
+				 TAIL_ARGS_FROM_NTH_LINE="-n"])
+			])
+		])
+	], [AC_MSG_ERROR([could not find tail that supports starting a listing from Nth line])]
+)
+AC_MSG_RESULT([$ac_cv_path_TAIL $TAIL_ARGS_FROM_NTH_LINE +NUM_FIRST_LINE])
+AC_SUBST([TAIL], [$ac_cv_path_TAIL])
+AC_SUBST([TAIL_ARGS_FROM_NTH_LINE], [$TAIL_ARGS_FROM_NTH_LINE])
 
 dnl Various version related processing
 dnl ----------------------------------

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -10,7 +10,7 @@ EXTRA_DIST = \
     HP-UX/nut-upsmon \
     HP-UX/nut-upsmon.sh \
     logrotate/nutlogd \
-    misc/nut.bash_completion \
+    misc/nut.bash_completion.in \
     misc/osd-notify \
     perl/Nut.pm \
     RedHat/halt.patch \
@@ -55,5 +55,7 @@ spellcheck spellcheck-interactive spellcheck-sortdict:
 	+$(MAKE) $(AM_MAKEFLAGS) -f $(top_builddir)/docs/Makefile MKDIR_P="$(MKDIR_P)" builddir="$(builddir)" srcdir="$(srcdir)" top_builddir="$(top_builddir)" top_srcdir="$(top_srcdir)" SPELLCHECK_SRC="$(SPELLCHECK_SRC)" SPELLCHECK_SRCDIR="$(srcdir)" SPELLCHECK_BUILDDIR="$(builddir)" $@
 
 CLEANFILES = *-spellchecked RedHat/*-spellchecked usb_resetter/*-spellchecked
+
+DISTCLEANFILES = misc/nut.bash_completion
 
 MAINTAINERCLEANFILES = Makefile.in .dirstamp

--- a/scripts/Solaris/postinstall.in
+++ b/scripts/Solaris/postinstall.in
@@ -5,6 +5,17 @@
 NUT_DIR="@prefix@"
 prefix="@prefix@" # expanded as part of some autoconf macros below
 
+# Operations with upsdrvctl below should not warn about running
+# directly on an SMF-capable system (note it currently acts as
+# set/unset, e.g. there is no meaningful "false" value handling):
+NUT_QUIET_INIT_NDE_WARNING=true
+export NUT_QUIET_INIT_NDE_WARNING
+
+# Possibly tweak the defaults here (or in a calling session) to
+# troubleshoot package installation:
+[ -n "${NUT_DEBUG_LEVEL-}" ] || NUT_DEBUG_LEVEL=0
+export NUT_DEBUG_LEVEL
+
 # TODO/FIXME : Should "/var/run" be a configure variable?
 # Note that "/var/run" is transient tmpfs, so upgrade has to be done during same uptime.
 ACTIVE_ENUMERATOR_FMRI_FILE="/var/run/nut-driver-enumerator-fmri.prev"
@@ -72,7 +83,7 @@ if test -x /usr/sbin/svcadm && test -x /usr/sbin/svccfg && test -x /usr/bin/svcs
 	if test -s "@CONFPATH@/ups.conf" ; then
 		echo "Stopping NUT drivers, if any (in case of upgrade)..."
 		@SBINDIR@/upsdrvsvcctl stop
-		@SBINDIR@/upsdrvctl -DDDDD stop
+		@SBINDIR@/upsdrvctl stop
 		sleep 5
 		echo "(Re-)register NUT drivers (if any)..."
 		REPORT_RESTART_42=no AUTO_START=no "@NUT_LIBEXECDIR@/nut-driver-enumerator.sh" --reconfigure

--- a/scripts/Solaris/postinstall.in
+++ b/scripts/Solaris/postinstall.in
@@ -125,9 +125,10 @@ if test -x /usr/sbin/svcadm && test -x /usr/sbin/svccfg && test -x /usr/bin/svcs
 	echo "Enable NUT umbrella service..."
 	/usr/sbin/svcadm enable -s nut
 else
-	echo "Put init script in /etc/init.d..."
+	echo "Put legacy init script in /etc/init.d..."
 	cp -pf "@NUT_DATADIR@/solaris-init/nut" /etc/init.d
 	chown root:bin /etc/init.d/nut
+	# Not 755, so only root may run it:
 	chmod 744 /etc/init.d/nut
 
 	ln -s ../init.d/nut /etc/rc3.d/S90nut > /dev/null 2>&1
@@ -135,7 +136,7 @@ else
 
 	# Start nut services
 
-	#echo "Starting nut services"
+	#echo "Starting legacy NUT services"
 	#$NUT_DIR/sbin/upsdrvctl start #> /dev/null 2>&1
 	#$NUT_DIR/sbin/upsd #> /dev/null 2>&1
 	#$NUT_DIR/sbin/upsmon #> /dev/null 2>&1

--- a/scripts/Solaris/preremove.in
+++ b/scripts/Solaris/preremove.in
@@ -7,6 +7,17 @@
 NUT_DIR="@prefix@"
 prefix="@prefix@" # expanded as part of some autoconf macros below
 
+# Operations with upsdrvctl below should not warn about running
+# directly on an SMF-capable system (note it currently acts as
+# set/unset, e.g. there is no meaningful "false" value handling):
+NUT_QUIET_INIT_NDE_WARNING=true
+export NUT_QUIET_INIT_NDE_WARNING
+
+# Possibly tweak the defaults here (or in a calling session) to
+# troubleshoot package installation:
+[ -n "${NUT_DEBUG_LEVEL-}" ] || NUT_DEBUG_LEVEL=0
+export NUT_DEBUG_LEVEL
+
 # TODO/FIXME : Should "/var/run" be a configure variable?
 # Note that "/var/run" is transient tmpfs, so upgrade has to be done during same uptime.
 ACTIVE_ENUMERATOR_FMRI_FILE="/var/run/nut-driver-enumerator-fmri.prev"
@@ -39,7 +50,7 @@ if test -x /usr/sbin/svcadm && test -x /usr/sbin/svccfg && test -x /usr/bin/svcs
 	done
 	echo "Stopping NUT drivers, if any..."
 	@SBINDIR@/upsdrvsvcctl stop
-	@SBINDIR@/upsdrvctl -DDDDD stop
+	@SBINDIR@/upsdrvctl stop
 	sleep 5
 	for S in `/usr/bin/svcs -H -o fmri '*/nut-driver:*'` `/usr/bin/svcs -H -o fmri '*/nut-driver-enumerator:*'` ; do
 		echo "Stopping NUT service: $S..."

--- a/scripts/Solaris/reset-ups-usb-solaris.sh.sample
+++ b/scripts/Solaris/reset-ups-usb-solaris.sh.sample
@@ -58,7 +58,7 @@ cfgadm -lv "${CFGADM_APID}"
 if $DO_SVC ; then svcadm enable "$DEVICE" ; fi
 svcadm clear "$DEVICE" 2>/dev/null
 
-dmesg | tail -n 20
+dmesg | tail -20
 date
 svcs -p "$DEVICE" ; upsc "$DEVICE" || { \
     COUNT=60

--- a/scripts/misc/.gitignore
+++ b/scripts/misc/.gitignore
@@ -1,0 +1,1 @@
+/nut.bash_completion

--- a/scripts/misc/nut.bash_completion
+++ b/scripts/misc/nut.bash_completion
@@ -80,7 +80,7 @@ _nut_upscmd_completion()
 
     # Get the list of commands from the UPS named in the previous word:
     local cmds
-    cmds=$(upscmd -l $prev 2>/dev/null | tail -n +3 | sed 's/ - .*//' )
+    cmds=$(upscmd -l $prev 2>/dev/null | tail +3 | sed 's/ - .*//' )
     COMPREPLY=( $(compgen -W "$cmds" -- ${cur}) )
 
     return 0

--- a/scripts/misc/nut.bash_completion.in
+++ b/scripts/misc/nut.bash_completion.in
@@ -62,12 +62,12 @@ _nut_upscmd_completion()
     case "$prev" in
         -u|-p) # TODO: match against upsd.users, if readable.
             COMPREPLY=( ) ; return 0 ;;
-	-l) 
+        -l)
             upses="$(_nut_upses)"
             COMPREPLY=( $(compgen -W "$upses" -- ${cur}) ) ; return 0 ;;
-	upscmd)
-	    upses="$(_nut_upses)"
-	    COMPREPLY=( $(compgen -W "$options $upses" -- ${cur}) ) ; return 0 ;;
+        upscmd)
+            upses="$(_nut_upses)"
+            COMPREPLY=( $(compgen -W "$options $upses" -- ${cur}) ) ; return 0 ;;
     esac
 
     # If the user starts to type an option, then only offer options for that word:
@@ -100,9 +100,9 @@ _nut_upsd_completion()
     options="-c -D -f -h -r -u -V -4 -6"
 
     case "$prev" in
-	-c) # commands:
+        -c) # commands:
             COMPREPLY=( $(compgen -W "reload stop" -- ${cur}) ) ; return 0 ;;
-	-r) # chroot:
+        -r) # chroot:
             COMPREPLY=( $(compgen -A directory -- ${cur}) ) ; return 0 ;;
         -u) # system user, not in upsd.users
             COMPREPLY=( $(compgen -u -- ${cur}) ) ; return 0 ;;
@@ -128,13 +128,13 @@ _nut_upsdrvctl_completion()
     options="-h -r -t -u -D"
 
     case "$prev" in
-	-r) # chroot:
+        -r) # chroot:
             COMPREPLY=( $(compgen -A directory -- ${cur}) ) ; return 0 ;;
         -u) # system user, not in upsd.users
             COMPREPLY=( $(compgen -u -- ${cur}) ) ; return 0 ;;
-	start|stop|shutdown)
-    	     upses="$(_nut_local_upses)"
-	     COMPREPLY=( $(compgen -W "$upses" -- ${cur}) ) ; return 0 ;;
+        start|stop|shutdown)
+            upses="$(_nut_local_upses)"
+            COMPREPLY=( $(compgen -W "$upses" -- ${cur}) ) ; return 0 ;;
     esac
 
     # If the user starts to type an option, then only offer options for that word:
@@ -162,7 +162,7 @@ _nut_upsmon_completion()
     options="-c -D -h -K -u -4 -6"
 
     case "$prev" in
-	-c) # commands:
+        -c) # commands:
             COMPREPLY=( $(compgen -W "fsd reload stop" -- ${cur}) ) ; return 0 ;;
         -u) # system user, not in upsd.users
             COMPREPLY=( $(compgen -u -- ${cur}) ) ; return 0 ;;
@@ -192,7 +192,7 @@ _nut_upsrw_completion()
     case "$prev" in
         -u|-p) # TODO: match against upsd.users, if readable.
             COMPREPLY=( ) ; return 0 ;;
-	-l)
+        -l)
             COMPREPLY=( $(compgen -W "$upses" -- ${cur}) ) ; return 0 ;;
     esac
 

--- a/scripts/misc/nut.bash_completion.in
+++ b/scripts/misc/nut.bash_completion.in
@@ -80,7 +80,7 @@ _nut_upscmd_completion()
 
     # Get the list of commands from the UPS named in the previous word:
     local cmds
-    cmds=$(upscmd -l $prev 2>/dev/null | tail +3 | sed 's/ - .*//' )
+    cmds=$(upscmd -l $prev 2>/dev/null | @TAIL@ @TAIL_ARGS_FROM_NTH_LINE@ +3 | sed 's/ - .*//' )
     COMPREPLY=( $(compgen -W "$cmds" -- ${cur}) )
 
     return 0

--- a/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
+++ b/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
@@ -668,7 +668,7 @@ upsconf_getDriverMedia() {
 
 upsconf_getMedia() {
     _DRVMED="`upsconf_getDriverMedia "$1"`" || return
-    echo "${_DRVMED}" | tail +2
+    echo "${_DRVMED}" | @TAIL@ @TAIL_ARGS_FROM_NTH_LINE@ +2
     return 0
 }
 

--- a/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
+++ b/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
@@ -668,7 +668,7 @@ upsconf_getDriverMedia() {
 
 upsconf_getMedia() {
     _DRVMED="`upsconf_getDriverMedia "$1"`" || return
-    echo "${_DRVMED}" | tail -n +2
+    echo "${_DRVMED}" | tail +2
     return 0
 }
 


### PR DESCRIPTION
Addresses part of issue #3099