### PR TITLE
server/sstate.c, NEWS.adoc: wait a second before declaring UPS data stale

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -161,6 +161,13 @@ https://github.com/networkupstools/nut/milestone/12
      of the existing mappings. Suggest how user can help improve the driver
      if too few data points were seen. [#3082, #3095]
 
+ - `upsd` data server updates:
+   * Sometimes "Data for UPS [X] is stale" and "UPS [X] data is no longer
+     stale" messages were logged in the same second, especially no busy
+     systems. Now we allow one more second on top of `MAXAGE` setting to
+     declare the device dead, just in case fractional/whole second rounding
+     comes into play and breaks things. [issue #661]
+
  - `upsdrvctl` tool updates:
    * Make use of `setproctag()` and `getproctag()` to report parent/child
      process names. [#3084]


### PR DESCRIPTION
Addresses one guess for issue #661 (fractional/whole second rounding maybe being the problem with inter-process communications, so we wait for `MAXAGE+1` now before declaring data stale).

That situation may have other driver/device specific reasons when the stale/OK status flips because the driver explicitly says so (not due to timeout of comms between driver and data server, or total lack of updates for too long), as detailed in recent posts to that issue.