### PR TITLE
tripplite_usb: fix unit_id default value

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -144,6 +144,8 @@ https://github.com/networkupstools/nut/milestone/12
  - `tripplite_usb` driver updates:
    * Added support for Tripplite protocol 3017 (mostly ASCII). [issue #2258,
      PR #3093]
+   * Fixed default `unit_id`, apparently broken by changes in NUT v2.8.1.
+     [issue #3191, PR #3192]
 
  - `usbhid-ups` driver updates:
    * Declared support for APC with USB ID `051d:0005` (details may evolve

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -137,7 +137,7 @@
 #include "usb-common.h"
 
 #define DRIVER_NAME	"Tripp Lite OMNIVS / SMARTPRO driver"
-#define DRIVER_VERSION	"0.42"
+#define DRIVER_VERSION	"0.43"
 
 /* driver description structure */
 upsdrv_info_t	upsdrv_info = {


### PR DESCRIPTION
Use correct value (`DEFAULT_UPSID`) for the actual `unit_id` default value instead of a "32-bit -1" value (via arch-dependent "long").   `DEFAULT_UPSID` is `65535`, or a "16-bit -1" value.

Closes: #3191