### PR TITLE
scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in: remove "Sourcing conf file.." message [#3194]

### DIFF
--- a/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
+++ b/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
@@ -151,7 +151,6 @@ SVCNAME_SMF="svc:/system/power/nut-driver"
     NUT_DRIVER_ENUMERATOR_CONF="${NUT_CONFPATH}/nut-driver-enumerator.conf"
 
 [ -s "${NUT_DRIVER_ENUMERATOR_CONF}" ] && \
-    echo "Sourcing config file: ${NUT_DRIVER_ENUMERATOR_CONF}" && \
     . "${NUT_DRIVER_ENUMERATOR_CONF}"
 
 [ -z "${UPSCONF-}" ] && \


### PR DESCRIPTION
If "NUT_DRIVER_ENUMERATOR_CONF" variable in `nut-driver-enumerator.sh` is not empty, an informational message is printed about sourcing the config file. However the systemd `nut-driver@.service` script expects only the device ID output and fails when extra messages appear.
