### PR TITLE
Improve debug tracing of strings and HID paths in USB driver

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -59,6 +59,8 @@ https://github.com/networkupstools/nut/milestone/12
      Length" values they could identify on some devices: sometimes the first
      (or otherwise preferred) option may be not the correct one, so try the
      other too. [issue #3136]
+   * Improved high-verbosity debug tracing of NUT `libhid` and `usbhid-ups`
+     to help make sense of data processing issues (HID paths, strings). [#3201]
    * For state tree methods, introduced `difftime_st_tree_timespec()` to
      abstract platform-dependent definitions of `st_tree_timespec_t`. [PR #3156]
    * Introduced global variables for last changed timestamp and value of

--- a/drivers/libhid.c
+++ b/drivers/libhid.c
@@ -559,6 +559,7 @@ int HIDGetItemValue(hid_dev_handle_t udev, const char *hidpath, double *Value, u
 char *HIDGetIndexString(hid_dev_handle_t udev, const int Index, char *buf, size_t buflen)
 {
 	usb_ctrl_strindex	idx;
+	int	ret;
 
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TYPE_LIMITS) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_CONSTANT_OUT_OF_RANGE_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_UNSIGNED_ZERO_COMPARE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_UNREACHABLE_CODE) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_TAUTOLOGICAL_TYPE_LIMIT_COMPARE) )
 # pragma GCC diagnostic push
@@ -626,8 +627,15 @@ char *HIDGetIndexString(hid_dev_handle_t udev, const int Index, char *buf, size_
 # pragma GCC diagnostic pop
 #endif
 
-	if (comm_driver->get_string(udev, idx, buf, (usb_ctrl_charbufsize)buflen) < 1)
+	ret = comm_driver->get_string(udev, idx, buf, (usb_ctrl_charbufsize)buflen);
+	upsdebugx(6, "%s: get_string() at index %d returned %d %s",
+		__func__, Index, ret,
+		ret < 0 ? "error code" : "useful bytes");
+	if (ret < 1)
 		buf[0] = '\0';
+	else
+		upsdebug_hex(6, "...into data buffer", buf,
+			((size_t)ret < buflen ? (size_t)ret : buflen));
 
 	return str_rtrim(buf, '\n');
 }

--- a/drivers/usb-common.c
+++ b/drivers/usb-common.c
@@ -484,6 +484,10 @@ int nut_usb_get_string(
 		return ret;
 	}
 
+	upsdebugx(6, "%s: from nut_usb_get_string_descriptor() got %d useful bytes", __func__, ret);
+	upsdebug_hex(6, "...into buffer, presumably in simple UTF-16LE encoding",
+		buffer, ((size_t)ret < sizeof(buffer) ? (size_t)ret : sizeof(buffer)));
+
 	/* translate simple UTF-16LE to 8-bit */
 	len = ret < (int)buflen ? ret : (int)buflen;
 	len = len / 2 - 1;	/* 16-bit characters, without header */
@@ -495,6 +499,11 @@ int nut_usb_get_string(
 			buf[i] = '?';	/* not decoded */
 	}
 	buf[i] = '\0';
+
+	/* "data bytes" because we have null terminator on top */
+	upsdebugx(6, "%s: converted into %d data bytes as: [%s]", __func__, len, buf);
+	upsdebug_hex(6, "...should be in 8-bit encoding", buf,
+		(len >= 0 && (size_t)len < buflen ? (size_t)len : buflen));
 
 	return len;
 }


### PR DESCRIPTION
Help investigate issues like #2685 and #3201.

Example updated output (around string processing that goes through the NUT USB handling stack, and in particular the `usbhid-ups` driver `stringid_conversion` helper to `HIDGetIndexString()` a value.

```
### Added clarity on where a data item handling starts in the wall of text. Sort of ends at "Path:"
### vvv Start of additions from this PR:
   4.621236     [D5] refresh_report_buffer: investigating path: 00840004.00840024.00850089
### ^^^ End of additions from this PR
   4.621243     [D4] Entering libusb_get_report
   4.674009     [D3] Report[get]: (7 bytes) => 10 05 01 03 02 04 06
   4.674024     [D5] PhyMax = 0, PhyMin = 0, LogMax = 255, LogMin = 0
   4.674032     [D5] Unit = 00000000, UnitExp = 0
   4.674039     [D5] Exponent = 0
   4.674047     [D5] hid_lookup_path: 00840004 -> UPS
   4.674054     [D5] hid_lookup_path: 00840024 -> PowerSummary
   4.674061     [D5] hid_lookup_path: 00850089 -> iDeviceChemistry
   4.674068     [D1] Path: UPS.PowerSummary.iDeviceChemistry, Type: Feature, ReportID: 0x10, Offset: 0, Size: 8, Value: 5

### Found along the way that one *get_report query can return a large buffer
### which we take several sips from later (note initial Report[get] vs Report[buf] later):
...
   4.674290     [D3] Report[buf]: (7 bytes) => 10 05 01 03 02 04 06
   4.674296     [D5] PhyMax = 0, PhyMin = 0, LogMax = 255, LogMin = 0
   4.674303     [D5] Unit = 00000000, UnitExp = 0
   4.674309     [D5] Exponent = 0
   4.674316     [D5] hid_lookup_path: 00840004 -> UPS
   4.674322     [D5] hid_lookup_path: 00840024 -> PowerSummary
   4.674329     [D5] hid_lookup_path: ffff00f1 -> iVersion
   4.674336     [D1] Path: UPS.PowerSummary.iVersion, Type: Feature, ReportID: 0x10, Offset: 40, Size: 8, Value: 6

### And on it goes to another device interaction and a Report[get]
   4.674352     [D5] refresh_report_buffer: investigating path: 00840004.00840024.00840035
   4.674382     [D4] Entering libusb_get_report
...
```

```
### Ultimately (per earlier PRs) it signs off finishing the initial RD investigation
### as used to identify the device and which subdriver wants to handle it,
### and goes to a walk over mapping tables to set NUT data points from that:

   4.999278     [D2] Report descriptor retrieved (Reportlen = 909)
   4.999284     [D2] Found HID device
   4.999292     [D3] Using default, detected or customized USB HID numbers: usb_config_index=0 usb_hid_rep_index=0 usb_hid_desc_index=0 usb_hid_ep_in=1 usb_hid_ep_out=1
   4.999307     [D1] Detected a UPS: EATON/Ellipse ECO 650
   4.999315     [D1] upsdrv_initups: finished
   4.999323     [D5] send_to_all: SETINFO driver.state "init.quiet"
   4.999330     [D5] send_to_all: SETINFO driver.version "2.8.4.903.3-906+g62b0e39b2"
   4.999338     [D5] send_to_all: SETINFO driver.version.internal "0.71"
   4.999351     [D5] send_to_all: SETINFO driver.name "usbhid-ups"
   4.999358     [D5] send_to_all: SETINFO driver.state "init.info"
   4.999365     [D1] upsdrv_initinfo...
   4.999372     [D5] send_to_all: SETINFO driver.version.data "MGE HID 1.57"
   4.999379     [D1] upsdrv_initinfo: Performing an initial UPS data walk with subdriver MGE HID 1.57...
...
```

```
### Eventually it hits the strings, including a firmware version - something we were interested in for the original issue:
   5.114868     [D5] hid_lookup_usage: UPS -> 00840004
   5.114874     [D5] hid_lookup_usage: PowerSummary -> 00840024
   5.114879     [D5] hid_lookup_usage: iVersion -> ffff00f1
   5.114885     [D4] string_to_path: depth = 3
   5.114891     [D3] Report[buf]: (7 bytes) => 10 05 01 03 02 04 06
   5.114898     [D5] PhyMax = 0, PhyMin = 0, LogMax = 255, LogMin = 0
   5.114905     [D5] Unit = 00000000, UnitExp = 0
   5.114913     [D5] Exponent = 0
   5.114921     [D2] Path: UPS.PowerSummary.iVersion, Type: Feature, ReportID: 0x10, Offset: 40, Size: 8, Value: 6
### vvv Start of additions from this PR:
   5.211003     [D6] nut_usb_get_string: from nut_usb_get_string_descriptor() got 6 useful bytes
   5.211019     [D6] ...into buffer, presumably in simple UTF-16LE encoding: (6 bytes) => 06 03 30
   5.211027     [D6]  00 32 00
   5.211034     [D6] nut_usb_get_string: converted into 2 data bytes as: [02]
   5.211041     [D6] ...should be in 8-bit encoding: (2 bytes) => 30 32
   5.211048     [D6] HIDGetIndexString: get_string() at index 6 returned 2 useful bytes
   5.211055     [D6] ...into data buffer: (2 bytes) => 30 32
### ^^^ End of additions from this PR
   5.211062     [D5] ups_infoval_set: setting report descriptor mapping for 'UPS.PowerSummary.iVersion' (Feature) as handled
   5.211070     [D5] send_to_all: SETINFO ups.firmware "02"
...
```

Note: the entries are split into two lines because:
* `upsdebugx()` allows for a formatting string and varargs to display debugged variable values, but `upsdebug_hex()` only dumps the specified buffer bytes after a fixed description string,
* also there's nothing to dump in case of error.

The report from `refresh_report_buffer()` prints the HID Path as a chain of raw HEX numbers partially because in that method we do not have access to `utab` with mapping to strings like we do in `HIDDumpTree()`; also it should be a bit faster (no `utab` walks) so less CPU stress from added tracing.