### PR TITLE
Rename autoconf variable PORT to NUT_PORT

### DIFF
--- a/UPGRADING.adoc
+++ b/UPGRADING.adoc
@@ -63,6 +63,12 @@ Changes from 2.8.4 to 2.8.5
   usually override `--with-pidpath` anyway to provide a dedicated location
   for NUT `root`-owned daemon PID files. [#3099]
 
+- The autoconf managed macro for `--with-port` option was renamed from plain
+  `PORT` to less ambiguous `NUT_PORT` to avoid potential conflicts with any
+  third-party code.  If anyone did use this macro in their custom builds or
+  integrations, some renaming (or stubbed definitions to the effect of
+  `PORT=NUT_PORT`) may be needed. [#3238]
+
 - In drivers using the common `main.c` and `main.h` framework, introduced
   a `void upsdrv_tweak_prognames(void)` required method (may be no-op) to
   optionally tweak `prognames[]` entries now that there is certain support

--- a/clients/nutclient.cpp
+++ b/clients/nutclient.cpp
@@ -794,7 +794,7 @@ bool Client::hasFeature(const Feature& feature)
 TcpClient::TcpClient():
 Client(),
 _host("localhost"),
-_port(PORT),
+_port(NUT_PORT),
 _timeout(0),
 _socket(new internal::Socket)
 {

--- a/clients/nutclient.h
+++ b/clients/nutclient.h
@@ -40,8 +40,8 @@
  * if that is included earlier by the program code.
  * If not - got a fallback here:
  */
-#ifndef PORT
-# define PORT 3493
+#ifndef NUT_PORT
+# define NUT_PORT 3493
 #endif
 
 namespace nut
@@ -397,7 +397,7 @@ public:
 	 * \param host Server host name.
 	 * \param port Server port.
 	 */
-	TcpClient(const std::string& host, uint16_t port = PORT);
+	TcpClient(const std::string& host, uint16_t port = NUT_PORT);
 	~TcpClient() override;
 
 	/**
@@ -405,7 +405,7 @@ public:
 	 * \param host Server host name.
 	 * \param port Server port.
 	 */
-	void connect(const std::string& host, uint16_t port = PORT);
+	void connect(const std::string& host, uint16_t port = NUT_PORT);
 
 	/**
 	 * Connect to the server.

--- a/clients/upsclient.c
+++ b/clients/upsclient.c
@@ -1696,7 +1696,7 @@ int upscli_splitname(const char *buf, char **upsname, char **hostname, uint16_t 
 			return -1;
 		}
 
-		*port = PORT;
+		*port = NUT_PORT;
 		return 0;
 	}
 
@@ -1752,7 +1752,7 @@ int upscli_splitaddr(const char *buf, char **hostname, uint16_t *port)
 
 		/* no port specified, use default */
 		if (((s = strtok_r(NULL, "\0", &last)) == NULL) || (*s != ':')) {
-			*port = PORT;
+			*port = NUT_PORT;
 			return 0;
 		}
 	} else {
@@ -1765,7 +1765,7 @@ int upscli_splitaddr(const char *buf, char **hostname, uint16_t *port)
 
 		/* no port specified, use default */
 		if (s == NULL) {
-			*port = PORT;
+			*port = NUT_PORT;
 			return 0;
 		}
 	}

--- a/configure.ac
+++ b/configure.ac
@@ -4700,11 +4700,11 @@ AC_MSG_CHECKING(network port number)
 NUT_ARG_WITH([port], [PORTNUM], [port for network communications], [3493])
 
 AS_IF([(test 0 -lt "${nut_with_port}" && test 65536 -gt "${nut_with_port}") 2>/dev/null],
-	[PORT="${nut_with_port}"],
+	[NUT_PORT="${nut_with_port}"],
 	[AC_MSG_ERROR(invalid option --with(out)-port - see docs/configure.txt)]
 )
-AC_MSG_RESULT(${PORT})
-AC_DEFINE_UNQUOTED(PORT, ${PORT}, [Port for network communications])
+AC_MSG_RESULT(${NUT_PORT})
+AC_DEFINE_UNQUOTED(NUT_PORT, ${NUT_PORT}, [Port for NUT network communications])
 
 dnl ---------------------------------------------------------------------
 AC_MSG_CHECKING(facility for syslog)
@@ -6142,7 +6142,7 @@ AC_SUBST(LDFLAGS_NUT_RPATH)
 AC_SUBST(LDFLAGS_NUT_RPATH_CXX)
 AC_SUBST(DRVPATH)
 AC_SUBST(SBINDIR)
-AC_SUBST(PORT)
+AC_SUBST(NUT_PORT)
 AC_SUBST(RUN_AS_USER)
 AC_SUBST(RUN_AS_GROUP)
 AC_SUBST(SUN_LIBUSB)

--- a/scripts/obs/nut.spec
+++ b/scripts/obs/nut.spec
@@ -492,9 +492,9 @@ sh autogen.sh
 ### via Make now ### (cd tools; python nut-snmpinfo.py)
 
 make %{?_smp_mflags}
-PORT=$(sed -n 's/#define PORT //p' config.log)
-if test "$PORT" = 3493 ; then
-    PORT=nut
+NUT_PORT=$(sed -n 's/#define NUT_PORT //p' config.log)
+if test "$NUT_PORT" = 3493 ; then
+    NUT_PORT=nut
 fi
 
 %check

--- a/server/conf.c
+++ b/server/conf.c
@@ -318,7 +318,7 @@ static int parse_upsd_conf_args(size_t numargs, char **arg)
 	/* LISTEN <address> [<port>] */
 	if (!strcmp(arg[0], "LISTEN")) {
 		if (numargs < 3)
-			listen_add(arg[1], string_const(PORT));
+			listen_add(arg[1], string_const(NUT_PORT));
 		else
 			listen_add(arg[1], arg[2]);
 		return 1;

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -934,12 +934,12 @@ void server_load(void)
 		/* Note: default opt_af==AF_UNSPEC so not constrained to only one protocol */
 		if (opt_af != AF_INET) {
 			upsdebugx(1, "%s: No LISTEN configuration provided, will try IPv6 localhost", __func__);
-			listen_add("::1", string_const(PORT));
+			listen_add("::1", string_const(NUT_PORT));
 		}
 
 		if (opt_af != AF_INET6) {
 			upsdebugx(1, "%s: No LISTEN configuration provided, will try IPv4 localhost", __func__);
-			listen_add("127.0.0.1", string_const(PORT));
+			listen_add("127.0.0.1", string_const(NUT_PORT));
 		}
 	}
 

--- a/tools/nut-scanner/scan_avahi.c
+++ b/tools/nut-scanner/scan_avahi.c
@@ -304,7 +304,7 @@ static void update_device(const char * host_name, const char *ip, uint16_t port,
 				nutscan_add_option_to_device(dev, "desc", "IPv6");
 			}
 
-			if (port != PORT) {
+			if (port != NUT_PORT) {
 				/* +5+1+1+1 is for :
 				 - port number (max 65535 so 5 characters),
 				 - '@' and ':' characters
@@ -359,7 +359,7 @@ static void update_device(const char * host_name, const char *ip, uint16_t port,
 			if (proto == AVAHI_PROTO_INET6) {
 				nutscan_add_option_to_device(dev, "desc", "IPv6");
 			}
-			if (port != PORT) {
+			if (port != NUT_PORT) {
 				/*+1+1 is for ':' character and terminating 0 */
 				/*buf is the string containing the port number*/
 				buf_size = strlen(host_name) + strlen(buf) + 1 + 1;

--- a/tools/nut-scanner/scan_nut.c
+++ b/tools/nut-scanner/scan_nut.c
@@ -238,7 +238,7 @@ static void * list_nut_devices_thready(void * arg)
 		 * around the host name:
 		 */
 		buf_size = strlen(answer[1]) + strlen(hostname) + 1 + 1 + 1 + 1;
-		if (port != PORT) {
+		if (port != NUT_PORT) {
 			/* colon and up to 5 digits */
 			buf_size += 6;
 		}
@@ -254,7 +254,7 @@ static void * list_nut_devices_thready(void * arg)
 			if (*hostname == '[')
 				hostname_colon = NULL;
 
-			if (port != PORT) {
+			if (port != NUT_PORT) {
 				if (hostname_colon) {
 					snprintf(dev->port, buf_size, "%s@[%s]:%" PRIu16,
 						answer[1], hostname, port);


### PR DESCRIPTION
Use a less ambiguous `NUT_PORT` macro for this internally known value. Collisions on plain `PORT` seem likely with third-party code trying to use the bindings...

Also fix a non-use of `configure`'d `PORT` value in C++ client bindings.