### PR TITLE
Fix hang in gen-snmp-subdriver.sh

### DIFF
--- a/scripts/subdriver/gen-snmp-subdriver.sh
+++ b/scripts/subdriver/gen-snmp-subdriver.sh
@@ -487,8 +487,8 @@ done
 
 # remove blank and "End of MIB" lines
 TABCHAR="`printf '\t'`"
-${EGREP} "^[ ${TABCHAR}]?\$" | ${GREP} "End of MIB" | ${GREP} -v "${NUMWALKFILE}" > "${TMP_NUMWALKFILE}"
-${EGREP} "^[ ${TABCHAR}]?\$" | ${GREP} "End of MIB" | ${GREP} -v "${STRWALKFILE}" > "${TMP_STRWALKFILE}"
+${EGREP} -v "^[ ${TABCHAR}]?\$" "${NUMWALKFILE}" | ${GREP} -v "End of MIB" > "${TMP_NUMWALKFILE}"
+${EGREP} -v "^[ ${TABCHAR}]?\$" "${STRWALKFILE}" | ${GREP} -v "End of MIB" > "${TMP_STRWALKFILE}"
 NUMWALKFILE="${TMP_NUMWALKFILE}"
 STRWALKFILE="${TMP_STRWALKFILE}"
 


### PR DESCRIPTION
Fix an issue introduced in commit 8b038f4 (PR #3107) whereby `grep-snmp-subdriver.sh` hangs indefinitely.

Closes: #3308