### PR TITLE
Support exiting from `nut.exe -N` with Ctrl+C

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -114,6 +114,11 @@ https://github.com/networkupstools/nut/milestone/12
      operations. (Re-)registration of the "Network UPS Tools" service should
      now populate a nice description of it. The `-U` (uninstall) action should
      now also try to stop the service first. [PR #3235]
+   * Using `nut.exe -N` for testing and pressing 'Ctrl+C' should now cause the
+     started daemons to be killed off. Previously they would linger and e.g.
+     preclude subsequent experiments with the service wrapper. Console close
+     events are ignored, so there is a way to indefinitely keep the daemons
+     started by test-mode wrapper running (kill via Task Manager). [#3312]
    * Revised WIN32 `WSAStartup()` and registration of `atexit(WSACleanup)` to
      only be done once per program (and cleanups to be always registered); this
      impacts the C `libupsclient` and C++ `libnutclient` libraries (and so most

--- a/docs/man/nut.exe.txt
+++ b/docs/man/nut.exe.txt
@@ -99,6 +99,12 @@ Install as a Windows service called "Network UPS Tools". Does not start it.
 
 *-N*::
 Run once in non-service mode (for troubleshooting).
++
+Since NUT v2.8.5, using `nut.exe -N` for testing and pressing 'Ctrl+C' should
+cause the started daemons to be killed off.  Previously they would linger and
+e.g. preclude subsequent experiments with the service wrapper.  Console close
+events are ignored, so there is a way to indefinitely keep the daemons started
+by the test-mode wrapper running (kill later if needed via Task Manager).
 
 *start*::
 Install as a Windows service called "Network UPS Tools" (if not yet done),


### PR DESCRIPTION
Closes: #3312

Using `nut.exe -N` for testing and pressing `Ctrl+C` should now cause the started daemons to be killed off. Previously they would linger and e.g. preclude subsequent experiments with the service wrapper.

Console close  events are ignored, so there is a way to indefinitely keep the daemons  started by test-mode wrapper running (kill via Task Manager then).
