### PR TITLE
Update data/driver.list.in: add Accurat Flux 850 (Richcomm V2.0, USB ID 0925:1234)

### DIFF
--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -56,6 +56,8 @@
 "Ablerex"	"ups"	"2"	"GRs Plus series"	"USB"	"nutdrv_qx"
 "Ablerex"	"ups"	"1"	"(various)"	"Serial"	"nutdrv_hashx"	# https://www.ablerex.eu/download/
 
+"Accurat"	"ups"	"2"	"Flux 850"	"(USB ID 0925:1234, Richcomm V2.0, armac subdriver, megatec protocol)"	"nutdrv_qx"	# https://github.com/networkupstools/nut/issues/2738, https://github.com/networkupstools/nut/pull/3323
+
 "ActivePower"	"ups"	"2"	"400VA"	""	"blazer_ser"
 "ActivePower"	"ups"	"2"	"1400VA"	""	"blazer_ser"
 "ActivePower"	"ups"	"2"	"2000VA"	""	"blazer_ser"
@@ -64,7 +66,6 @@
 "Advice"	"ups"	"2"	"Top V Pro 6-10K"	"USB"	"blazer_usb"	# https://www.advice.co.il/en/advice-products/ups-systems/ups-online-systems/one-phase-ups-5k-10k/%D7%90%D7%9C-%D7%A4%D7%A1%D7%A7-%D7%90%D7%95%D7%9F-%D7%9C%D7%99%D7%99%D7%9F-top-v-pro-6-10k-detail https://github.com/networkupstools/nut/issues/744
 "Advice"	"ups"	"2"	"PRS850"	"USB"	"blazer_usb"
 "Advice"	"ups"	"2"	"PRV700 Pro"	"USB"	"blazer_usb"
-"Accurat"	"ups"	"2"	"Flux 850"	"(USB ID 0925:1234, Richcomm V2.0, armac subdriver, megatec protocol)"	"nutdrv_qx"	# https://github.com/networkupstools/nut/issues/2738
 
 "AEC"	"ups"	"1"	"MiniGuard UPS 700"	"Megatec M2501 cable"	"genericups upstype=21"
 


### PR DESCRIPTION
## Summary
   
   Adds Accurat Flux 850 to the Hardware Compatibility List.
   
   ## Device Details
   
   | Property | Value |
   |----------|-------|
   | Manufacturer | Accurat (batterium GmbH, Germany) |
   | Model | Flux 850 |
   | Type | Line-Interactive, AVR |
   | Rating | 850VA / 510W |
   | USB ID | `0925:1234` (Lakeview Research / Richcomm V2.0) |
   | Firmware | V2.63 |
   | Driver | `nutdrv_qx` |
   | Subdriver | `armac` |
   | Protocol | `megatec` |
   | NUT version tested | v2.8.5-rc4 (git master) |
   | OS | Debian Bookworm (OpenMediaVault 7.x), amd64 |
   
   ## Context
   
   The Accurat Flux series is a budget UPS line sold primarily on Amazon in the EU market. It uses the same Richcomm V2.0 USB chipset (`0925:1234`) as the Vultech UPS2000VA-PRO documented in #2738.
   
   The standard NUT 2.8.0 Debian package does not support this device. Building from git master (>= 2.8.2) with `nutdrv_qx`, `subdriver=armac`, and `protocol=megatec` works correctly.
   
   All standard monitoring values (voltage, load, battery, temperature, frequency) are reported. Shutdown commands and battery tests are functional.
   
   DDL dump submitted: https://github.com/networkupstools/nut-ddl/issues/58
   
   ## Related
   
   - #2738 (Vultech UPS2000VA-PRO, same chipset – includes my confirmation comment)
   - #2153 (Armac O/850E/PSW)
   - #2219 (Vultech UPS1400VA-LFP)

**Complete setup scripts (driver build + master/client configuration):**
https://gist.github.com/lvl47/a280c7d1a0a8a489c084c83b8f28f054