### PR TITLE
Make NUT OpenSSL dialogs more reliable

### DIFF
--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -920,8 +920,9 @@ case "${WITH_SSL_CLIENT}${WITH_SSL_SERVER}" in
                         # OpenSSL CA trust "database" should include hashes
                         # of CA PEM certificates as symlinks to actual files:
                         CERTHASH="`openssl x509 -subject_hash -in rootca.pem | head -1`"
-                        ln -s rootca.pem "${CERTHASH}".0
-                        ln -s rootca.pem "${CERTHASH}"
+                        # NOTE: Symlinking may be prohibited or not implemented on some platforms (e.g. Windows) or file systems
+                        ln -fs rootca.pem "${CERTHASH}".0 || ln -f rootca.pem "${CERTHASH}".0 || cp -f rootca.pem "${CERTHASH}".0
+                        ln -fs rootca.pem "${CERTHASH}" || ln -f rootca.pem "${CERTHASH}" || cp -f rootca.pem "${CERTHASH}"
                         ls -l "${TESTCERT_PATH_ROOTCA}"/rootca.pem "${TESTCERT_PATH_ROOTCA}/${CERTHASH}"*
                         ;;
                     *)


### PR DESCRIPTION
Follow-up to #3344, this PR applies similar logic of retrying (in case of `SSL_ERROR_WANT_WRITE` or `SSL_ERROR_WANT_READ` return codes) to read and write commands during the normal protocol dialog, not just during handshake.

Without this, `make check-NIT` failed on Windows at least with OpenSSL builds - `upsc` established the connection but failed actual queries (possibly it broke at the moment of sending/reading the `"OK STARTTLS"` confirmation). Apparently it fared better on all other NUT CI farm systems, regardless of their performance (some builders are co-located on quite congested hosts).

CC @clepple : this picks up the trick from your `ssl_accept_nbio` branch, of `return 0` from `ssl_error()` methods in case of these retryable return codes. The rest of non-blockable support (is it needed or not, toxic or not, after progress made in recent PRs) remains questionable to me. For some clarity, I'll bump the `ssl_accept_nbio_v285` branch after merging this PR (if it passes) to see how it fares in CI.

Also FYI CC @aquette - with this, SSL support should be at least functional on various platforms. Previously much of it happened to work if conditions were just right, and crashed elsewhere. Converging OpenSSL and NSS code to behave similarly, so it is a preference and not a choice driven by technical constraints, is a separate matter (#3331).

UPDATE: Huh, after a series of refactors into different smaller PRs and rebases, the big description here remained attached to a small change for tests in that area.