### PR TITLE
Investigate issue #3302 driver behavior when upsd aborts

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -17,6 +17,14 @@ For a complete and more detailed list of changes, please refer to the
 ChangeLog file (generated for release archives), or to the Git version
 control history for "live" codebase.
 
+Release notes for NUT 2.8.6 - what's new since 2.8.5
+----------------------------------------------------
+
+https://github.com/networkupstools/nut/milestone/13
+
+ - common code:
+   * Revised 'dstate' machinery to track socket connections closed mid-way
+     through a call, to avoid access after `free()`. [#3302]
 
 PLANNED: Release notes for NUT 2.8.6 - what's new since 2.8.5
 -------------------------------------------------------------

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -17,15 +17,6 @@ For a complete and more detailed list of changes, please refer to the
 ChangeLog file (generated for release archives), or to the Git version
 control history for "live" codebase.
 
-Release notes for NUT 2.8.6 - what's new since 2.8.5
-----------------------------------------------------
-
-https://github.com/networkupstools/nut/milestone/13
-
- - common code:
-   * Revised 'dstate' machinery to track socket connections closed mid-way
-     through a call, to avoid access after `free()`. [#3302]
-
 PLANNED: Release notes for NUT 2.8.6 - what's new since 2.8.5
 -------------------------------------------------------------
 
@@ -71,6 +62,10 @@ https://github.com/networkupstools/nut/milestone/13
  - `usbhid-ups` driver updates:
     * When reconnecting, report success more visibly (not only in debug), and
       do not reset driver state to "quiet" when it will loop trying. [PR #3423]
+
+ - common code:
+   * Revised 'dstate' machinery to track socket connections closed mid-way
+     through a call, to avoid access after `free()`. [#3302]
 
  - NUT client libraries:
     * Complete support for actions documented in `docs/net-protocol.txt`

--- a/docs/config-prereqs.txt
+++ b/docs/config-prereqs.txt
@@ -185,10 +185,16 @@ metadata about recently published package revisions:
     ccache time \
     git perl curl \
     make autoconf automake libltdl-dev libtool binutils \
-    valgrind \
     cppcheck \
     pkg-config \
     gcc g++ clang
+
+# To trace memory, file descriptor and other resources usage/leakage
+# the valgrind tool is highly recommended. Its availability is however
+# very much CPU-dependent, so it may not be present in all distributions:
+:; apt-get install \
+    valgrind \
+    || true
 
 # To debug eventual core dump files, or trace programs with an IDE like
 # NetBeans (perhaps remotely), you may want the GNU Debugger program:
@@ -197,9 +203,11 @@ metadata about recently published package revisions:
 
 # NOTE: Older Debian-like distributions may lack a "libtool-bin"
 :; apt-get install \
-    libtool-bin
+    libtool-bin \
+    || true
 
 # See comments below, python version and package naming depends on distro
+# (e.g. newer ones only offer "python3" explicitly)
 :; apt-get install \
     python
 
@@ -216,7 +224,8 @@ metadata about recently published package revisions:
 #   :; apt-get install gettext
 #
 # To install the Python NUT-Monitor app, you may need some modules.
-# Ideally, they would be packaged, named according to major Python version:
+# Ideally, they would be packaged, named according to major Python version
+# (note this may pull in parts of X11, fonts, etc. as is reasonable for a GUI):
 #   :; apt-get install python3-pyqt5
 # or on newer (2025+) releases,
 #   :; apt-get install python3-pyqt6 pyqt6-dev-tools
@@ -232,10 +241,13 @@ metadata about recently published package revisions:
 :; apt-get install \
     aspell aspell-en
 
-# For other doc types (man-page, PDF, HTML) generation - massive packages
-# (TEX, X11):
+# For relatively light-weight docs (man-page, maybe HTML):
 :; apt-get install \
-    asciidoc source-highlight python3-pygments dblatex
+    asciidoc
+
+# For other doc types (PDF, HTML) generation - massive packages (TEX, X11):
+:; apt-get install \
+    source-highlight python3-pygments dblatex
 
 # For CGI graph generation - massive packages (X11):
 :; apt-get install \

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -238,11 +238,26 @@ static TYPE_FD sock_open(const char *fn)
 static void sock_disconnect(conn_t *conn)
 {
 #ifndef WIN32
+# if 0
+	if (VALID_FD(conn->fd)) {
+		FILE	*f = fdopen(conn->fd, 600);
+		if (f) {
+			upsdebugx(4, "%s: flushing socket %d", __func__, (int)conn->fd);
+			setvbuf(f, NULL, _IONBF, 0);
+			fflush(f);
+		}
+	}
+# endif
 	upsdebugx(3, "%s: disconnecting socket %d", __func__, (int)conn->fd);
 	close(conn->fd);
 #else	/* WIN32 */
 	/* FIXME NUT_WIN32_INCOMPLETE not sure if this is the right way to close a connection */
 	if (conn->read_overlapped.hEvent != INVALID_HANDLE_VALUE) {
+		if (VALID_FD(conn->fd)) {
+			upsdebugx(4, "%s: flushing named pipe handle %p", __func__, conn->fd);
+			FlushFileBuffers(conn->fd);
+		}
+		upsdebugx(4, "%s: closing not-invalid named pipe handle %p", __func__, conn->fd);
 		CloseHandle(conn->read_overlapped.hEvent);
 		conn->read_overlapped.hEvent = INVALID_HANDLE_VALUE;
 	}

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -194,6 +194,8 @@ static TYPE_FD sock_open(const char *fn)
 
 #else /* WIN32 */
 
+	upsdebugx(6, "%s: opening NAMED_PIPE for listening: '%s'",
+		__func__, fn);
 	fd = CreateNamedPipe(
 		fn,			/* pipe name */
 		PIPE_ACCESS_DUPLEX	/* read/write access */
@@ -208,6 +210,9 @@ static TYPE_FD sock_open(const char *fn)
 		NULL);			/* FIXME: default security attribute */
 
 	if (INVALID_FD(fd)) {
+		upsdebugx(1, "%s: Can't create a state socket "
+			"(windows named pipe) for listening: %s",
+			__func__, pipename);
 		fatal_with_errno(EXIT_FAILURE,
 			"Can't create a state socket (windows named pipe)");
 	}
@@ -599,6 +604,8 @@ static void sock_connect(TYPE_FD sock)
 	conn->fd = sock;
 
 	/* sockfd is the handle of the connection pending pipe */
+	upsdebugx(6, "%s: opening NAMED_PIPE for incoming data: '%s'",
+		__func__, pipename);
 	sockfd = CreateNamedPipe(
 		pipename,		/* pipe name */
 		PIPE_ACCESS_DUPLEX	/* read/write access */
@@ -613,6 +620,9 @@ static void sock_connect(TYPE_FD sock)
 		NULL);			/* FIXME: default security attribute */
 
 	if (INVALID_FD(sockfd)) {
+		upsdebugx(1, "%s: Can't open state socket "
+			"(windows named pipe) for incoming data: %s",
+			__func__, pipename);
 		fatal_with_errno(EXIT_FAILURE,
 			"Can't create a state socket (windows named pipe)");
 	}

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -328,6 +328,7 @@ static void send_to_all(const char *fmt, ...)
 		if (result == 0) {
 			upsdebugx(2, "%s: write failed on handle %p, disconnecting", __func__, conn->fd);
 			sock_disconnect(conn);
+			conn = NULL;
 			continue;
 		}
 		else {
@@ -348,6 +349,7 @@ static void send_to_all(const char *fmt, ...)
 			upsdebugx(6, "%s: failed write: %s", __func__, buf);
 
 			sock_disconnect(conn);
+			conn = NULL;
 
 			/* TOTHINK: Maybe fallback elsewhere in other cases? */
 			if (ret < 0 && errno == EAGAIN && do_synchronous == -1) {
@@ -474,6 +476,7 @@ static int send_to_one(conn_t *conn, const char *fmt, ...)
 #endif	/* WIN32 */
 		upsdebugx(6, "%s: failed write: %s", __func__, buf);
 		sock_disconnect(conn);
+		conn = NULL;
 
 		/* TOTHINK: Maybe fallback elsewhere in other cases? */
 		if (ret < 0 && errno == EAGAIN && do_synchronous == -1) {
@@ -1003,6 +1006,7 @@ static void sock_read(conn_t *conn)
 
 		default:
 			sock_disconnect(conn);
+			conn = NULL;
 			return;
 		}
 	}
@@ -1035,6 +1039,7 @@ static void sock_read(conn_t *conn)
 		if (is_closed) {
 			upsdebugx(1, "%s: it seems the other side has closed the connection", __func__);
 			sock_disconnect(conn);
+			conn = NULL;
 			return;
 		}
 	} else {
@@ -1048,6 +1053,7 @@ static void sock_read(conn_t *conn)
 	if (res == 0) {
 		upslogx(LOG_INFO, "Read error : %d", (int)GetLastError());
 		sock_disconnect(conn);
+		conn = NULL;
 		return;
 	}
 	ret = bytesRead;
@@ -1128,6 +1134,7 @@ static void sock_close(void)
 	for (conn = connhead; conn; conn = cnext) {
 		cnext = conn->next;
 		sock_disconnect(conn);
+		conn = NULL;
 	}
 
 	connhead = NULL;
@@ -1262,6 +1269,7 @@ int dstate_poll_fds(struct timeval timeout, TYPE_FD arg_extrafd)
 
 		if (conn->closing) {
 			sock_disconnect(conn);
+			conn = NULL;
 		}
 	}
 
@@ -1351,6 +1359,7 @@ int dstate_poll_fds(struct timeval timeout, TYPE_FD arg_extrafd)
 
 		if (conn->closing) {
 			sock_disconnect(conn);
+			conn = NULL;
 		}
 	}
 

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -242,6 +242,13 @@ static TYPE_FD sock_open(const char *fn)
 
 static void sock_disconnect(conn_t *conn)
 {
+	if (!conn) {
+		upsdebugx(3, "%s: WARNING: called after connection was closed?", __func__);
+		return;
+	}
+
+	conn->closing = 1;
+
 #ifndef WIN32
 # if 0
 	if (VALID_FD(conn->fd)) {
@@ -306,6 +313,10 @@ static void sock_disconnect(conn_t *conn)
 	free(conn);
 }
 
+/** Iterate all connections to post a formatted string on them.
+ *  Clean up any connections found to be aborted during this cycle.
+ *  No return code.
+ */
 static void send_to_all(const char *fmt, ...)
 {
 	ssize_t	ret;
@@ -363,8 +374,7 @@ static void send_to_all(const char *fmt, ...)
 		result = WriteFile(conn->fd, buf, buflen, &bytesWritten, NULL);
 		if (result == 0) {
 			upsdebugx(2, "%s: write failed on handle %p, disconnecting", __func__, conn->fd);
-			sock_disconnect(conn);
-			conn = NULL;
+			conn->closing = 1;
 			continue;
 		}
 		else {
@@ -384,8 +394,7 @@ static void send_to_all(const char *fmt, ...)
 #endif	/* WIN32 */
 			upsdebugx(6, "%s: failed write: %s", __func__, buf);
 
-			sock_disconnect(conn);
-			conn = NULL;
+			conn->closing = 1;
 
 			/* TOTHINK: Maybe fallback elsewhere in other cases? */
 			if (ret < 0 && errno == EAGAIN && do_synchronous == -1) {
@@ -395,6 +404,9 @@ static void send_to_all(const char *fmt, ...)
 				do_synchronous = 1;
 			}
 
+			/* Note: calls send_to_all() for connections alive
+			 *  at the moment (if any), so it was important to
+			 *  forget the failed one above: */
 			dstate_setinfo("driver.parameter.synchronous", "%s",
 				(do_synchronous==1)?"yes":((do_synchronous==0)?"no":"auto"));
 		} else {
@@ -403,8 +415,29 @@ static void send_to_all(const char *fmt, ...)
 				__func__, buflen, conn->fd, ret, buf);
 		}
 	}
+
+	for (conn = connhead; conn; conn = cnext) {
+		cnext = conn->next;
+
+		if (conn->closing) {
+			sock_disconnect(conn);
+			conn = NULL;
+		}
+	}
+
+	errno = 0;
 }
 
+/**
+ * Send a formatted string to one given connection.
+ *
+ * @param conn
+ * @param fmt
+ * @param ...
+ * @return	-2 and errno=ENOTCONN if connections was or became closed;
+ *		0 other failures (e.g. no memory for buffer);
+ *		1 for successful send (or no-op with empty formatting string)
+ */
 static int send_to_one(conn_t *conn, const char *fmt, ...)
 {
 	ssize_t	ret;
@@ -415,6 +448,12 @@ static int send_to_one(conn_t *conn, const char *fmt, ...)
 	DWORD bytesWritten = 0;
 	BOOL  result = FALSE;
 #endif	/* WIN32 */
+
+	if (!conn || conn->closing) {
+		upsdebugx(3, "%s: WARNING: called after connection was closed?", __func__);
+		errno = ENOTCONN;
+		return -2;	/* failed and freed */
+	}
 
 	va_start(ap, fmt);
 #ifdef HAVE_PRAGMAS_FOR_GCC_DIAGNOSTIC_IGNORED_FORMAT_NONLITERAL
@@ -447,6 +486,7 @@ static int send_to_one(conn_t *conn, const char *fmt, ...)
 	if (buflen >= SSIZE_MAX) {
 		/* Can't compare buflen to ret... though should not happen with ST_SOCK_BUF_LEN */
 		upslog_with_errno(LOG_NOTICE, "%s failed: buffered message too large", __func__);
+		errno = ENOMEM;
 		return 0;	/* failed */
 	}
 
@@ -463,7 +503,7 @@ static int send_to_one(conn_t *conn, const char *fmt, ...)
 #else	/* WIN32 */
 	result = WriteFile(conn->fd, buf, buflen, &bytesWritten, NULL);
 	if (result == 0) {
-		ret = 0;
+		ret = -1;	/* wait and retry below */
 	}
 	else {
 		ret = (ssize_t)bytesWritten;
@@ -489,7 +529,7 @@ static int send_to_one(conn_t *conn, const char *fmt, ...)
 #else	/* WIN32 */
 		result = WriteFile(conn->fd, buf, buflen, &bytesWritten, NULL);
 		if (result == 0) {
-			ret = 0;
+			ret = 0;	/* signal error */
 		}
 		else {
 			ret = (ssize_t)bytesWritten;
@@ -522,10 +562,14 @@ static int send_to_one(conn_t *conn, const char *fmt, ...)
 			do_synchronous = 1;
 		}
 
+		/* Note: calls send_to_all() for connections alive
+		 *  at the moment (if any), so it was important to
+		 *  forget the failed one above: */
 		dstate_setinfo("driver.parameter.synchronous", "%s",
 			(do_synchronous==1)?"yes":((do_synchronous==0)?"no":"auto"));
 
-		return 0;	/* failed */
+		errno = ENOTCONN;
+		return -2;	/* failed and freed */
 	} else {
 #ifndef WIN32
 		upsdebugx(6, "%s: write %" PRIuSIZE " bytes to socket %d succeeded "
@@ -682,34 +726,59 @@ static void sock_connect(TYPE_FD sock)
 
 }
 
+/**
+ * Send data from one state tree node into the given connection
+ * (value and possible enum/range/aux/type information).
+ *
+ * @param node
+ * @param conn
+ * @return	-2 and errno=ENOTCONN if connections was or became closed;
+ *		0 other failures (e.g. no memory for buffer);
+ *		1 for successful send (or no-op with empty/NULL nodes)
+ */
 static int st_tree_dump_conn_one_node(st_tree_t *node, conn_t *conn)
 {
 	enum_t	*etmp;
 	range_t	*rtmp;
+	int	send_ret;
 
-	if (!send_to_one(conn, "SETINFO %s \"%s\"\n", node->var, node->val)) {
-		return 0;	/* write failed, bail out */
+	if (!conn || conn->closing) {
+		upsdebugx(3, "%s: WARNING: called after connection was closed?", __func__);
+		errno = ENOTCONN;
+		return -2;
 	}
+
+	send_ret = send_to_one(conn, "SETINFO %s \"%s\"\n", node->var, node->val);
+	if (errno == ENOTCONN)
+		return -2;
+	if (!send_ret)
+		return 0;	/* write failed, bail out */
 
 	/* send any enums */
 	for (etmp = node->enum_list; etmp; etmp = etmp->next) {
-		if (!send_to_one(conn, "ADDENUM %s \"%s\"\n", node->var, etmp->val)) {
+		send_ret = send_to_one(conn, "ADDENUM %s \"%s\"\n", node->var, etmp->val);
+		if (errno == ENOTCONN)
+			return -2;
+		if (!send_ret)
 			return 0;
-		}
 	}
 
 	/* send any ranges */
 	for (rtmp = node->range_list; rtmp; rtmp = rtmp->next) {
-		if (!send_to_one(conn, "ADDRANGE %s %i %i\n", node->var, rtmp->min, rtmp->max)) {
+		send_ret = send_to_one(conn, "ADDRANGE %s %i %i\n", node->var, rtmp->min, rtmp->max);
+		if (errno == ENOTCONN)
+			return -2;
+		if (!send_ret)
 			return 0;
-		}
 	}
 
 	/* provide any auxiliary data */
 	if (node->aux) {
-		if (!send_to_one(conn, "SETAUX %s %ld\n", node->var, node->aux)) {
+		send_ret = send_to_one(conn, "SETAUX %s %ld\n", node->var, node->aux);
+		if (errno == ENOTCONN)
+			return -2;
+		if (!send_ret)
 			return 0;
-		}
 	}
 
 	/* finally report any flags */
@@ -729,64 +798,138 @@ static int st_tree_dump_conn_one_node(st_tree_t *node, conn_t *conn)
 			snprintfcat(flist, sizeof(flist), " NUMBER");
 		}
 
-		if (!send_to_one(conn, "SETFLAGS %s\n", flist)) {
+		send_ret = send_to_one(conn, "SETFLAGS %s\n", flist);
+		if (errno == ENOTCONN)
+			return -2;
+		if (!send_ret)
 			return 0;
-		}
 	}
 
 	return 1;	/* everything's OK here ... */
 }
 
+/**
+ * Dump the state tree into given connection, as a recursive tree walk
+ * and st_tree_dump_conn_one_node() calls for encountered nodes.
+ *
+ * @param node Starting point for left-right iteration walk
+ * @param conn
+ * @return	-2 and errno=ENOTCONN if connections was or became closed;
+ *		0 other failures (e.g. no memory for buffer);
+ *		1 for successful send (or no-op with empty/NULL nodes)
+ */
 static int st_tree_dump_conn(st_tree_t *node, conn_t *conn)
 {
-	int	ret;
+	int	send_ret;
+
+	if (!conn || conn->closing) {
+		upsdebugx(3, "%s: WARNING: called after connection was closed?", __func__);
+		errno = ENOTCONN;
+		return -2;
+	}
 
 	if (!node) {
 		return 1;	/* not an error */
 	}
 
 	if (node->left) {
-		ret = st_tree_dump_conn(node->left, conn);
-
-		if (!ret) {
+		send_ret = st_tree_dump_conn(node->left, conn);
+		if (errno == ENOTCONN)
+			return -2;
+		if (!send_ret) {
 			return 0;	/* write failed in the child */
 		}
 	}
 
-	if (!st_tree_dump_conn_one_node(node, conn))
+	send_ret = st_tree_dump_conn_one_node(node, conn);
+	if (errno == ENOTCONN)
+		return -2;
+	if (!send_ret)
 		return 0;	/* one of writes failed, bail out */
 
 	if (node->right) {
-		return st_tree_dump_conn(node->right, conn);
+		send_ret = st_tree_dump_conn(node->right, conn);
+		if (errno == ENOTCONN)
+			return -2;
+		return send_ret;
 	}
 
-	return 1;	/* everything's OK here ... */
+	return 1;	/* no right node; everything's OK here ... */
 }
 
+/**
+ * Report all known commands for this driver into the given connection.
+ *
+ * @param conn
+ * @return	-2 and errno=ENOTCONN if connections was or became closed;
+ *		0 if any send_to_one() failed otherwise;
+ *		1 for successful send of everything (or no-op with empty list)
+ */
 static int cmd_dump_conn(conn_t *conn)
 {
 	cmdlist_t	*cmd;
+	int	send_ret;
+
+	if (!conn || conn->closing) {
+		upsdebugx(3, "%s: WARNING: called after connection was closed?", __func__);
+		errno = ENOTCONN;
+		return -2;
+	}
 
 	for (cmd = cmdhead; cmd; cmd = cmd->next) {
-		if (!send_to_one(conn, "ADDCMD %s\n", cmd->name)) {
+		send_ret = send_to_one(conn, "ADDCMD %s\n", cmd->name);
+		if (errno == ENOTCONN)
+			return -2;
+		if (!send_ret)
 			return 0;
-		}
 	}
 
 	return 1;
 }
 
-
-static void send_tracking(conn_t *conn, const char *id, int value)
+/**
+ * Send an operation with a tracking ID.
+ * Returns same as send_to_one().
+ *
+ * @return	-2 and errno=ENOTCONN if connections was or became closed;
+ *		0 other failures (e.g. no memory for buffer);
+ *		1 for successful send (or no-op with empty formatting string)
+ */
+static int send_tracking(conn_t *conn, const char *id, int value)
 {
-	send_to_one(conn, "TRACKING %s %i\n", id, value);
+	if (!conn || conn->closing) {
+		upsdebugx(3, "%s: WARNING: called after connection was closed?", __func__);
+		errno = ENOTCONN;
+		return -2;
+	}
+
+	return send_to_one(conn, "TRACKING %s %i\n", id, value);
 }
 
+/**
+ * Called from sock_read() to handle command arg[0] (with possible arguments)
+ * for a given connection.
+ *
+ * @return	-3 command recognized but a send_to_one() returned 0;
+ *		-2 and errno=ENOTCONN if connections was or became closed;
+ *		0 other failures (e.g. insufficient numarg for a specific
+ *		  command, or unknown command overall);
+ *		1 for successful send (or no-op with empty formatting string)
+ *		2 for handled LOGOUT (connection may be already closed with
+ *		  errno=ENOTCONN raised, or will be soon)
+ */
 static int sock_arg(conn_t *conn, size_t numarg, char **arg)
 {
 #ifdef WIN32
 	char *sockfn = pipename;	/* Just for the report below; not a global var in WIN32 builds */
 #endif	/* WIN32 */
+	int	send_ret, send_errno;
+
+	if (!conn || conn->closing) {
+		upsdebugx(3, "%s: WARNING: called after connection was closed?", __func__);
+		errno = ENOTCONN;
+		return -2;
+	}
 
 	upsdebugx(6, "%s: Driver on %s is now handling %s with %" PRIuSIZE " args",
 		__func__, sockfn, numarg ? arg[0] : "<skipped: no command>", numarg);
@@ -796,40 +939,76 @@ static int sock_arg(conn_t *conn, size_t numarg, char **arg)
 	}
 
 	if (!strcasecmp(arg[0], "LOGOUT")) {
-		send_to_one(conn, "OK Goodbye\n");
+		/* NOTE: conn may be freed after send_to_one(),
+		 *  do not dereference it anymore */
+		TYPE_FD	conn_fd = conn->fd;
+		send_ret = send_to_one(conn, "OK Goodbye\n");
+		send_errno = errno;
+		upsdebugx(6, "%s: %s: send_to_one(OK Goodbye) returned %d",
+			__func__, arg[0], send_ret);
+
 #ifndef WIN32
-		upsdebugx(2, "%s: received LOGOUT on socket %d, will be disconnecting", __func__, (int)conn->fd);
+		upsdebugx(2, "%s: received LOGOUT on socket %d, will be disconnecting", __func__, (int)conn_fd);
 #else	/* WIN32 */
-		upsdebugx(2, "%s: received LOGOUT on handle %p, will be disconnecting", __func__, conn->fd);
+		upsdebugx(2, "%s: received LOGOUT on handle %p, will be disconnecting", __func__, conn_fd);
 #endif	/* WIN32 */
+
 		/* Let the system flush the reply somehow (or the other
 		 * side to just see it) before we drop the pipe */
 		usleep(1000000);
-		/* err on the safe side, and actually close/free conn separately */
-		conn->closing = 1;
+
+		/* err on the safe side, and actually close/free the conn
+		 *  separately, if not already discarded by send_to_one()
+		 *  e.g. due to aborted client side: */
+		if (send_errno != ENOTCONN)
+			conn->closing = 1;
 		upsdebugx(4, "%s: LOGOUT processing finished", __func__);
-		return 2;
+		return 2;	/* Special code for LOGOUT to be known by caller */
 	}
 
 	if (!strcasecmp(arg[0], "GETPID")) {
-		send_to_one(conn, "PID %" PRIiMAX "\n", (intmax_t)getpid());
-		return 1;
+		send_ret = send_to_one(conn, "PID %" PRIiMAX "\n", (intmax_t)getpid());
+		send_errno = errno;
+		upsdebugx(6, "%s: %s: send_to_one(PID) returned %d",
+			__func__, arg[0], send_ret);
+		if (send_errno == ENOTCONN)
+			return -2;
+		if (!send_ret)
+			return -3;	/* failed */
+		return send_ret;
 	}
 
 	if (!strcasecmp(arg[0], "DUMPALL") || !strcasecmp(arg[0], "DUMPSTATUS") || (!strcasecmp(arg[0], "DUMPVALUE") && numarg > 1)) {
 		/* first thing: the staleness flag (see also below) */
-		if ((stale == 1) && !send_to_one(conn, "DATASTALE\n")) {
-			return 1;
+		if (stale == 1) {
+			send_ret = send_to_one(conn, "DATASTALE\n");
+			send_errno = errno;
+			upsdebugx(6, "%s: %s: send_to_one(DATASTALE) returned %d",
+				__func__, arg[0], send_ret);
+			if (send_errno == ENOTCONN)
+				return -2;
+			if (!send_ret)
+				return -3;	/* failed */
 		}
 
 		if (!strcasecmp(arg[0], "DUMPALL")) {
-			if (!st_tree_dump_conn(dtree_root, conn)) {
-				return 1;
-			}
+			send_ret = st_tree_dump_conn(dtree_root, conn);
+			send_errno = errno;
+			upsdebugx(6, "%s: %s: st_tree_dump_conn() returned %d",
+				__func__, arg[0], send_ret);
+			if (send_errno == ENOTCONN)
+				return -2;
+			if (!send_ret)
+				return -3;	/* failed */
 
-			if (!cmd_dump_conn(conn)) {
-				return 1;
-			}
+			send_ret = cmd_dump_conn(conn);
+			send_errno = errno;
+			upsdebugx(6, "%s: %s: cmd_dump_conn() returned %d",
+				__func__, arg[0], send_ret);
+			if (send_errno == ENOTCONN)
+				return -2;
+			if (!send_ret)
+				return -3;	/* failed */
 		} else {
 			/* A cheaper version of the dump */
 			char	*varname = (!strcasecmp(arg[0], "DUMPSTATUS") ? "ups.status" : (numarg > 1 ? arg[1] : NULL));
@@ -839,22 +1018,51 @@ static int sock_arg(conn_t *conn, size_t numarg, char **arg)
 				upsdebugx(1, "%s: %s was requested but currently no %s is known",
 					__func__, arg[0], NUT_STRARG(varname));
 			} else {
-				if (!st_tree_dump_conn_one_node(sttmp, conn))
-					return 1;
+				send_ret = st_tree_dump_conn_one_node(sttmp, conn);
+				send_errno = errno;
+				upsdebugx(6, "%s: %s: st_tree_dump_conn_one_node() returned %d",
+					__func__, arg[0], send_ret);
+				if (send_errno == ENOTCONN)
+					return -2;
+				if (!send_ret)
+					return -3;	/* failed */
 			}
 		}
 
-		if ((stale == 0) && !send_to_one(conn, "DATAOK\n")) {
-			return 1;
+		if (stale == 0) {
+			send_ret = send_to_one(conn, "DATAOK\n");
+			send_errno = errno;
+			upsdebugx(6, "%s: %s: send_to_one(DATAOK) returned %d",
+				__func__, arg[0], send_ret);
+			if (send_errno == ENOTCONN)
+				return -2;
+			if (!send_ret)
+				return -3;	/* failed */
 		}
 
-		send_to_one(conn, "DUMPDONE\n");
-		return 1;
+		send_ret = send_to_one(conn, "DUMPDONE\n");
+		send_errno = errno;
+		upsdebugx(6, "%s: %s: send_to_one(DUMPDONE) returned %d",
+			__func__, arg[0], send_ret);
+		if (send_errno == ENOTCONN)
+			return -2;
+
+		upsdebugx(4, "%s: %s processing finished", __func__, arg[0]);
+		if (!send_ret)
+			return -3;	/* failed */
+		return send_ret;	/* one way or another, the command was handled */
 	}
 
 	if (!strcasecmp(arg[0], "PING")) {
-		send_to_one(conn, "PONG\n");
-		return 1;
+		send_ret = send_to_one(conn, "PONG\n");
+		send_errno = errno;
+		upsdebugx(6, "%s: %s: send_to_one(PONG) returned %d",
+			__func__, arg[0], send_ret);
+		if (send_errno == ENOTCONN)
+			return -2;
+		if (!send_ret)
+			return -3;	/* failed */
+		return send_ret;
 	}
 
 	if (!strcasecmp(arg[0], "NOBROADCAST")) {
@@ -927,11 +1135,20 @@ static int sock_arg(conn_t *conn, size_t numarg, char **arg)
 			 * not pass to driver-provided logic. */
 
 			/* send back execution result if requested */
-			if (cmdid)
-				send_tracking(conn, cmdid, ret);
+			send_ret = 1;
+			if (cmdid) {
+				send_ret = send_tracking(conn, cmdid, ret);
+				send_errno = errno;
+				upsdebugx(6, "%s: %s: send_tracking(shared INSTCMD) returned %d",
+					__func__, arg[0], send_ret);
+				if (send_errno == ENOTCONN)
+					return -2;
+				if (!send_ret)
+					return -3;	/* failed */
+			}
 
 			/* The command was handled, status is a separate consideration */
-			return 1;
+			return send_ret;
 		} /* else try other handler(s) */
 
 		/* try the driver-provided handler if present */
@@ -939,11 +1156,20 @@ static int sock_arg(conn_t *conn, size_t numarg, char **arg)
 			ret = upsh.instcmd(cmdname, cmdparam);
 
 			/* send back execution result if requested */
-			if (cmdid)
-				send_tracking(conn, cmdid, ret);
+			send_ret = 1;
+			if (cmdid) {
+				send_ret = send_tracking(conn, cmdid, ret);
+				send_errno = errno;
+				upsdebugx(6, "%s: %s: send_tracking(driver-provided INSTCMD) returned %d",
+					__func__, arg[0], send_ret);
+				if (send_errno == ENOTCONN)
+					return -2;
+				if (!send_ret)
+					return -3;	/* failed */
+			}
 
 			/* The command was handled, status is a separate consideration */
-			return 1;
+			return send_ret;
 		}
 
 		if (cmdparam) {
@@ -963,11 +1189,20 @@ static int sock_arg(conn_t *conn, size_t numarg, char **arg)
 		 * call stack, or returned by a driver's handler (for unknown
 		 * commands) just a bit above.
 		 */
-		if (cmdid)
-			send_tracking(conn, cmdid, ret);
+		send_ret = 1;
+		if (cmdid) {
+			send_ret = send_tracking(conn, cmdid, ret);
+			send_errno = errno;
+			upsdebugx(6, "%s: %s: send_tracking(other INSTCMD) returned %d",
+				__func__, arg[0], send_ret);
+			if (send_errno == ENOTCONN)
+				return -2;
+			if (!send_ret)
+				return -3;	/* failed */
+		}
 
 		/* The command was handled, status is a separate consideration */
-		return 1;
+		return send_ret;
 	}
 
 	if (numarg < 3) {
@@ -1001,11 +1236,20 @@ static int sock_arg(conn_t *conn, size_t numarg, char **arg)
 			 * not pass to driver-provided logic. */
 
 			/* send back execution result if requested */
-			if (setid)
-				send_tracking(conn, setid, ret);
+			send_ret = 1;
+			if (setid) {
+				send_ret = send_tracking(conn, setid, ret);
+				send_errno = errno;
+				upsdebugx(6, "%s: %s: send_tracking(shared SETVAR) returned %d",
+					__func__, arg[0], send_ret);
+				if (send_errno == ENOTCONN)
+					return -2;
+				if (!send_ret)
+					return -3;	/* failed */
+			}
 
 			/* The command was handled, status is a separate consideration */
-			return 1;
+			return send_ret;
 		} /* else try other handler(s) */
 
 		/* try the driver-provided handler if present */
@@ -1013,11 +1257,20 @@ static int sock_arg(conn_t *conn, size_t numarg, char **arg)
 			ret = upsh.setvar(arg[1], arg[2]);
 
 			/* send back execution result if requested */
-			if (setid)
-				send_tracking(conn, setid, ret);
+			send_ret = 1;
+			if (setid) {
+				send_ret = send_tracking(conn, setid, ret);
+				send_errno = errno;
+				upsdebugx(6, "%s: %s: send_tracking(driver-provided SETVAR) returned %d",
+					__func__, arg[0], send_ret);
+				if (send_errno == ENOTCONN)
+					return -2;
+				if (!send_ret)
+					return -3;	/* failed */
+			}
 
 			/* The command was handled, status is a separate consideration */
-			return 1;
+			return send_ret;
 		}
 
 		upslogx(LOG_SET_UNKNOWN, "Got SET, but driver lacks a handler");
@@ -1028,14 +1281,35 @@ static int sock_arg(conn_t *conn, size_t numarg, char **arg)
 	return 0;
 }
 
-static void sock_read(conn_t *conn)
+/**
+ * Reads incoming data into a buffer and parses them,
+ * to handle via sock_arg().
+ *
+ * @param conn
+ * @return	-2 and errno=ENOTCONN if connections was or became closed,
+ *                 including after LOGOUT handling;
+ *		-1 if read() yielded EINTR or EAGAIN (POSIX builds)
+ *                 or buffer parsing failed;
+ *		0 other failures (e.g. no memory for buffer);
+ *		1 for successful enough handling (no syntax or connection
+ *		  errors along the way; response sending may have failed
+ *		  or unknown commands may have been posted)
+ */
+static int sock_read(conn_t *conn)
 {
 	ssize_t	ret, i;
 	int	ret_arg = -1;
-
 #ifndef WIN32
 	char	buf[SMALLBUF];
+#endif
 
+	if (!conn || conn->closing) {
+		upsdebugx(3, "%s: WARNING: called after connection was closed?", __func__);
+		errno = ENOTCONN;
+		return -2;
+	}
+
+#ifndef WIN32
 	ret = read(conn->fd, buf, sizeof(buf));
 
 	if (ret < 0) {
@@ -1043,12 +1317,14 @@ static void sock_read(conn_t *conn)
 		{
 		case EINTR:
 		case EAGAIN:
-			return;
+			return -1;
 
+		case ENOTCONN:
 		default:
 			sock_disconnect(conn);
 			conn = NULL;
-			return;
+			errno = ENOTCONN;
+			return -2;
 		}
 	}
 
@@ -1081,7 +1357,8 @@ static void sock_read(conn_t *conn)
 			upsdebugx(1, "%s: it seems the other side has closed the connection", __func__);
 			sock_disconnect(conn);
 			conn = NULL;
-			return;
+			errno = ENOTCONN;
+			return -2;
 		}
 	} else {
 		conn->readzero = 0;
@@ -1090,19 +1367,25 @@ static void sock_read(conn_t *conn)
 	char *buf = conn->buf;
 	DWORD bytesRead;
 	BOOL res;
+
 	res = GetOverlappedResult(conn->fd, &conn->read_overlapped, &bytesRead, FALSE);
 	if (res == 0) {
 		upslogx(LOG_INFO, "Read error : %d", (int)GetLastError());
 		sock_disconnect(conn);
 		conn = NULL;
-		return;
+		errno = ENOTCONN;
+		return -2;
 	}
 	ret = bytesRead;
+
+	/* TODO: Make use of this for a retry loop like above? */
+	if (ret > 0)
+		conn->readzero = 0;
 
 	/* Special case for signals */
 	if (!strncmp(conn->buf, COMMAND_STOP, sizeof(COMMAND_STOP))) {
 		set_exit_flag(1);
-		return;
+		return 1;
 	}
 #endif	/* WIN32 */
 
@@ -1115,6 +1398,11 @@ static void sock_read(conn_t *conn)
 
 		case 1: /* try to use it, and complain about unknown commands */
 			ret_arg = sock_arg(conn, conn->ctx.numargs, conn->ctx.arglist);
+			if (errno == ENOTCONN) {
+				upsdebugx(1, "%s: socket was closed by sock_arg()", __func__);
+				return -2;
+			}
+
 			if (!ret_arg) {
 				size_t	arg;
 
@@ -1123,37 +1411,48 @@ static void sock_read(conn_t *conn)
 				for (arg = 0; arg < conn->ctx.numargs && arg < INT_MAX; arg++) {
 					upslogx(LOG_INFO, "arg %d: %s", (int)arg, conn->ctx.arglist[arg]);
 				}
+			} else if (ret_arg == -3) {
+				upslogx(LOG_INFO, "Failed to handle a recognized command on socket");
 			} else if (ret_arg == 2) {
-				/* closed by LOGOUT processing, conn is free()'d */
+				/* closed by LOGOUT processing, conn is free()'d
+				 * or soon will be (at least marked conn->closing=1) */
 				if (i < ret)
-					upsdebugx(1, "%s: returning early, socket may be not valid anymore", __func__);
-				return;
+					upsdebugx(1, "%s: returning early after LOGOUT, socket may be not valid anymore", __func__);
+				errno = ENOTCONN;
+				return -2;
 			}
 
 			continue;
 
 		default: /* nothing parsed */
 			upslogx(LOG_NOTICE, "Parse error on sock: %s", conn->ctx.errmsg);
-			return;
+			return -1;
 		}
 	}
 
 #ifdef WIN32
-	/* Restart async read */
-	memset(conn->buf, 0, sizeof(conn->buf));
-	ReadFile(
-		conn->fd,
-		conn->buf,
-		sizeof(conn->buf) - 1,	/* -1 to be sure to have a trailing 0 */
-		NULL,
-		&(conn->read_overlapped)
-	);
+	if (!conn->closing) {
+		/* Restart async read */
+		memset(conn->buf, 0, sizeof(conn->buf));
+		ReadFile(
+			conn->fd,
+			conn->buf,
+			sizeof(conn->buf) - 1,	/* -1 to be sure to have a trailing 0 */
+			NULL,
+			&(conn->read_overlapped)
+		);
+	}
 #endif	/* WIN32 */
+
+	return 1;	/* Handled without errors */
 }
 
+/** Dismantle the socket (or named pipe) and connections */
 static void sock_close(void)
 {
 	conn_t	*conn, *cnext;
+
+	upsdebugx(1, "%s: starting...", __func__);
 
 	if (VALID_FD(sockfd)) {
 #ifndef WIN32
@@ -1180,6 +1479,8 @@ static void sock_close(void)
 
 	connhead = NULL;
 	/* conntail = NULL; */
+
+	upsdebugx(1, "%s: finished", __func__);
 }
 
 /* interface */

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -251,18 +251,34 @@ static void sock_disconnect(conn_t *conn)
 	upsdebugx(3, "%s: disconnecting socket %d", __func__, (int)conn->fd);
 	close(conn->fd);
 #else	/* WIN32 */
-	/* FIXME NUT_WIN32_INCOMPLETE not sure if this is the right way to close a connection */
+	/* FIXME NUT_WIN32_INCOMPLETE not sure if this is the right
+	 *  way to close a connection, but was revised to match
+	 *  the wincompat::pipe_disconnect() implementation.
+	 * In practice at least dummy-ups tends to crash soon after
+	 * this with memory (re-)allocation troubles if send_to_one
+	 * failed (e.g. upsd killed at the right moment). May be an
+	 * MSYS2 platform problem though. */
+	if (conn->fd != INVALID_HANDLE_VALUE) {
+		upsdebugx(4, "%s: flushing named pipe handle %p", __func__, conn->fd);
+		FlushFileBuffers(conn->fd);
+	}
+
 	if (conn->read_overlapped.hEvent != INVALID_HANDLE_VALUE) {
-		if (VALID_FD(conn->fd)) {
-			upsdebugx(4, "%s: flushing named pipe handle %p", __func__, conn->fd);
-			FlushFileBuffers(conn->fd);
-		}
-		upsdebugx(4, "%s: closing not-invalid named pipe handle %p", __func__, conn->fd);
+		upsdebugx(4, "%s: closing not-invalid named pipe read_overlapped event handle %p",
+			__func__, conn->read_overlapped.hEvent);
 		CloseHandle(conn->read_overlapped.hEvent);
 		conn->read_overlapped.hEvent = INVALID_HANDLE_VALUE;
 	}
-	upsdebugx(3, "%s: disconnecting named pipe handle %p", __func__, conn->fd);
-	DisconnectNamedPipe(conn->fd);
+	if (conn->fd != INVALID_HANDLE_VALUE) {
+		upsdebugx(3, "%s: disconnecting named pipe handle %p", __func__, conn->fd);
+		if (DisconnectNamedPipe(conn->fd) == 0)
+			upsdebug_with_errno(3, "%s: DisconnectNamedPipe failed");
+		upsdebugx(4, "%s: closing named pipe handle %p", __func__, conn->fd);
+		CloseHandle(conn->fd);
+		conn->fd = INVALID_HANDLE_VALUE;
+	} else {
+		upsdebugx(3, "%s: NOT disconnecting named pipe handle %p: already invalid", __func__, conn->fd);
+	}
 #endif	/* WIN32 */
 
 	upsdebugx(5, "%s: finishing parsing context", __func__);

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -54,6 +54,7 @@ typedef struct {
 	pid_t	pid;
 #else	/* WIN32 */
 	int	pid;	/* for WIN32 used just as a flag that this UPS was started by this tool in this run */
+	PROCESS_INFORMATION	ProcessInformation;
 #endif	/* WIN32 */
 	void	*next;
 }	ups_t;
@@ -807,12 +808,24 @@ static void debugcmdline(int level, const char *msg, char *const argv[])
 }
 
 #ifndef WIN32
-static int forkexec_parent_analyze(pid_t waitret, int wstat, int *puexectimeout)
+static int forkexec_parent_analyze(pid_t waitret, int wstat, const ups_t *ups)
+#else
+static int forkexec_parent_analyze(DWORD res, const ups_t *ups)
+#endif
 {
+	/* work around const for this one... */
+#ifdef WIN32
+	int *pupid = (int *)&(ups->pid);
+#endif
+	int *puexectimeout = (int *)&(ups->exceeded_timeout);
+
+	*puexectimeout = 0;
+
+#ifndef WIN32
 	if (waitret == -1) {
 		upslogx(LOG_WARNING, "Startup timer elapsed, continuing...");
 		exec_timeout++;
-		if (puexectimeout) *puexectimeout = 1;
+		*puexectimeout = 1;
 		return 0;
 	}
 
@@ -838,10 +851,28 @@ static int forkexec_parent_analyze(pid_t waitret, int wstat, int *puexectimeout)
 		return -3;
 	}
 
-	if (puexectimeout) *puexectimeout = 0;
+#else	/* WIN32 */
+
+	if (res == WAIT_OBJECT_0) {
+		/* all ok, no-op */
+	} else
+	if (res == WAIT_TIMEOUT) {
+		upslogx(LOG_WARNING, "Startup timer elapsed, continuing...");
+		*pupid = 0;	/* For WIN32, just a flag (not "-1" has a meaning) */
+		*puexectimeout = 1;
+		return 0;
+	} else {
+		DWORD	exit_code = 0;
+		GetExitCodeProcess( ups->ProcessInformation.hProcess, &exit_code );
+		upslogx(LOG_WARNING, "Driver failed to start (exit status=%d)", exit_code);
+		exec_error++;
+		return -2;
+	}
+#endif	/* WIN32 */
+
+	upsdebugx(3, "%s: startup seems successful", __func__);
 	return 1;
 }
-#endif	/* WIN32 */
 
 static void forkexec(char *const argv[], const ups_t *ups)
 {
@@ -943,7 +974,7 @@ static void forkexec(char *const argv[], const ups_t *ups)
 			alarm(0);
 
 			/* Bump timeout or error counts if appropriate */
-			forkexec_parent_analyze(waitret, wstat, puexectimeout);
+			forkexec_parent_analyze(waitret, wstat, ups);
 
 			return;
 		}	/* end of pid != 0 (fork parent) part */
@@ -970,13 +1001,14 @@ static void forkexec(char *const argv[], const ups_t *ups)
 #else	/* WIN32 */
 	BOOL	ret;
 	DWORD	res;
-	DWORD	exit_code = 0;
 	char	commandline[LARGEBUF];
 	STARTUPINFO	StartupInfo;
-	PROCESS_INFORMATION	ProcessInformation;
+	/* work around const for this one... */
+	PROCESS_INFORMATION	*pProcessInformation = (PROCESS_INFORMATION*)&(ups->ProcessInformation);
 	int	i = 1, waited = 0;
 
 	memset(&StartupInfo, 0, sizeof(STARTUPINFO));
+	memset(pProcessInformation, 0, sizeof(PROCESS_INFORMATION));
 
 	/* the command line is made of the driver name followed by args */
 	if (strstr(argv[0], ups->driver)) {
@@ -1014,10 +1046,10 @@ static void forkexec(char *const argv[], const ups_t *ups)
 			NULL,
 			NULL,
 			&StartupInfo,
-			&ProcessInformation
+			pProcessInformation
 			);
 
-	if (ret == 0) {
+	if (!ret) {
 		fatal_with_errno(EXIT_FAILURE, "execv");
 	}
 
@@ -1035,7 +1067,7 @@ static void forkexec(char *const argv[], const ups_t *ups)
 				"to check that driver survived this long "
 				"(per device configuration section)",
 				__func__, (unsigned int)ups->maxstartdelay);
-			res = WaitForSingleObject(ProcessInformation.hProcess,
+			res = WaitForSingleObject(pProcessInformation->hProcess,
 				((unsigned int)ups->maxstartdelay) * 1000);
 			waited = 1;
 		}
@@ -1045,7 +1077,7 @@ static void forkexec(char *const argv[], const ups_t *ups)
 				"to check that driver survived this long "
 				"(per global configuration section)",
 				__func__, (unsigned int)maxstartdelay);
-			res = WaitForSingleObject(ProcessInformation.hProcess,
+			res = WaitForSingleObject(pProcessInformation->hProcess,
 				((unsigned int)maxstartdelay) * 1000);
 			waited = 1;
 		}
@@ -1056,22 +1088,11 @@ static void forkexec(char *const argv[], const ups_t *ups)
 			"to check that driver survived this long "
 			"(not required by global nor by device "
 			"configuration sections)", __func__);
-		res = WaitForSingleObject(ProcessInformation.hProcess,
+		res = WaitForSingleObject(pProcessInformation->hProcess,
 			0);
 	}
 
-	if (res != WAIT_TIMEOUT) {
-		GetExitCodeProcess( ProcessInformation.hProcess, &exit_code );
-		upslogx(LOG_WARNING, "Driver failed to start (exit status=%d)", ret);
-		exec_error++;
-		return;
-	} else {
-		/* work around const for this one... */
-		int *pupid = (int *)&(ups->pid);
-		int *puexectimeout = (int *)&(ups->exceeded_timeout);
-		*pupid = 0;	/* For WIN32, just a flag (not "-1" has a meaning) */
-		*puexectimeout = 1;
-	}
+	forkexec_parent_analyze(res, ups);
 
 	return;
 #endif	/* WIN32 */
@@ -1449,22 +1470,23 @@ static void start_driver(const ups_t *ups)
 		/* otherwise, retry if still needed */
 			if (drv_maxretry > 0)
 				if (drv_retrydelay >= 0) {
-#ifndef WIN32
-					int	*puexectimeout = (int *)&(ups->exceeded_timeout);
-#endif
-
 					upsdebugx(3, "%s: retrying after %u seconds",
 						__func__, (unsigned int)drv_retrydelay);
 					sleep ((unsigned int)drv_retrydelay);
 
+					if (upscount > 1 && ups->exceeded_timeout) {
+						/* Final checks, similar to those in forkexec() */
 #ifndef WIN32
-					if (upscount > 1 && *puexectimeout) {
 						int	wstat;
 						pid_t	waitret;
 
-						/* Final checks, similar to those in forkexec() */
 						waitret = waitpid(ups->pid, &wstat, WNOHANG);
-						if (forkexec_parent_analyze(waitret, wstat, puexectimeout) > 0) {
+						if (forkexec_parent_analyze(waitret, wstat, ups) > 0)
+#else
+						DWORD res = WaitForSingleObject(ups->ProcessInformation.hProcess, 0);
+						if (forkexec_parent_analyze(res, ups))
+#endif
+						{
 							upslogx(LOG_INFO, "%s: driver %s [%s] completed startup "
 								"while we were sleeping to retry", __func__,
 								ups->driver, ups->upsname);
@@ -1473,7 +1495,6 @@ static void start_driver(const ups_t *ups)
 							exec_timeout = initial_exec_timeout;
 						}
 					}
-#endif
 
 				}
 		}

--- a/drivers/upsdrvctl.c
+++ b/drivers/upsdrvctl.c
@@ -806,6 +806,43 @@ static void debugcmdline(int level, const char *msg, char *const argv[])
 	upsdebugx(level, "%s", cmdline);
 }
 
+#ifndef WIN32
+static int forkexec_parent_analyze(pid_t waitret, int wstat, int *puexectimeout)
+{
+	if (waitret == -1) {
+		upslogx(LOG_WARNING, "Startup timer elapsed, continuing...");
+		exec_timeout++;
+		if (puexectimeout) *puexectimeout = 1;
+		return 0;
+	}
+
+	if (WIFEXITED(wstat) == 0) {
+		upslogx(LOG_WARNING, "Driver exited abnormally");
+		exec_error++;
+		return -1;
+	}
+
+	/* the rest of checks only work when WIFEXITED is nonzero */
+
+	if (WEXITSTATUS(wstat) != 0) {
+		upslogx(LOG_WARNING, "Driver failed to start"
+			" (exit status=%d)", WEXITSTATUS(wstat));
+		exec_error++;
+		return -2;
+	}
+
+	if (WIFSIGNALED(wstat)) {
+		upslog_with_errno(LOG_WARNING, "Driver died after signal %d",
+			WTERMSIG(wstat));
+		exec_error++;
+		return -3;
+	}
+
+	if (puexectimeout) *puexectimeout = 0;
+	return 1;
+}
+#endif	/* WIN32 */
+
 static void forkexec(char *const argv[], const ups_t *ups)
 {
 #ifndef WIN32
@@ -906,33 +943,7 @@ static void forkexec(char *const argv[], const ups_t *ups)
 			alarm(0);
 
 			/* Bump timeout or error counts if appropriate */
-			if (waitret == -1) {
-				upslogx(LOG_WARNING, "Startup timer elapsed, continuing...");
-				exec_timeout++;
-				*puexectimeout = 1;
-				return;
-			}
-
-			if (WIFEXITED(wstat) == 0) {
-				upslogx(LOG_WARNING, "Driver exited abnormally");
-				exec_error++;
-				return;
-			}
-
-			/* the rest only work when WIFEXITED is nonzero */
-
-			if (WEXITSTATUS(wstat) != 0) {
-				upslogx(LOG_WARNING, "Driver failed to start"
-				" (exit status=%d)", WEXITSTATUS(wstat));
-				exec_error++;
-				return;
-			}
-
-			if (WIFSIGNALED(wstat)) {
-				upslog_with_errno(LOG_WARNING, "Driver died after signal %d",
-					WTERMSIG(wstat));
-				exec_error++;
-			}
+			forkexec_parent_analyze(waitret, wstat, puexectimeout);
 
 			return;
 		}	/* end of pid != 0 (fork parent) part */
@@ -1438,9 +1449,32 @@ static void start_driver(const ups_t *ups)
 		/* otherwise, retry if still needed */
 			if (drv_maxretry > 0)
 				if (drv_retrydelay >= 0) {
+#ifndef WIN32
+					int	*puexectimeout = (int *)&(ups->exceeded_timeout);
+#endif
+
 					upsdebugx(3, "%s: retrying after %u seconds",
 						__func__, (unsigned int)drv_retrydelay);
 					sleep ((unsigned int)drv_retrydelay);
+
+#ifndef WIN32
+					if (upscount > 1 && *puexectimeout) {
+						int	wstat;
+						pid_t	waitret;
+
+						/* Final checks, similar to those in forkexec() */
+						waitret = waitpid(ups->pid, &wstat, WNOHANG);
+						if (forkexec_parent_analyze(waitret, wstat, puexectimeout) > 0) {
+							upslogx(LOG_INFO, "%s: driver %s [%s] completed startup "
+								"while we were sleeping to retry", __func__,
+								ups->driver, ups->upsname);
+							drv_maxretry = 0;
+							exec_error = initial_exec_error;
+							exec_timeout = initial_exec_timeout;
+						}
+					}
+#endif
+
 				}
 		}
 	}

--- a/server/netssl.c
+++ b/server/netssl.c
@@ -976,6 +976,7 @@ void net_starttls(nut_ctype_t *client, size_t numarg, const char **arg)
 	if (status != SECSuccess) {
 		upslogx(LOG_ERR, "Can not initialize SSL connection");
 		nss_error("net_starttls / SSL_AuthCertificateHook");
+		send_err_extra(client, NUT_ERR_ACCESS_DENIED, "\"SSL trust failed\"");
 		return;
 	}
 
@@ -984,6 +985,7 @@ void net_starttls(nut_ctype_t *client, size_t numarg, const char **arg)
 	if (status != SECSuccess) {
 		upslogx(LOG_ERR, "Can not initialize SSL connection");
 		nss_error("net_starttls / SSL_BadCertHook");
+		send_err_extra(client, NUT_ERR_ACCESS_DENIED, "\"SSL trust failed\"");
 		return;
 	}
 
@@ -992,6 +994,7 @@ void net_starttls(nut_ctype_t *client, size_t numarg, const char **arg)
 	if (status != SECSuccess) {
 		upslogx(LOG_ERR, "Can not initialize SSL connection");
 		nss_error("net_starttls / SSL_HandshakeCallback");
+		send_err_extra(client, NUT_ERR_ACCESS_DENIED, "\"SSL init failed\"");
 		return;
 	}
 
@@ -1000,6 +1003,7 @@ void net_starttls(nut_ctype_t *client, size_t numarg, const char **arg)
 	if (status != SECSuccess) {
 		upslogx(LOG_ERR, "Can not initialize SSL connection");
 		nss_error("net_starttls / SSL_ConfigSecureServer");
+		send_err_extra(client, NUT_ERR_ACCESS_DENIED, "\"SSL init failed\"");
 		return;
 	}
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_CAST_FUNCTION_TYPE_STRICT)
@@ -1011,6 +1015,7 @@ void net_starttls(nut_ctype_t *client, size_t numarg, const char **arg)
 	if (status != SECSuccess) {
 		upslogx(LOG_ERR, "Can not initialize SSL connection");
 		nss_error("net_starttls / SSL_ResetHandshake");
+		send_err_extra(client, NUT_ERR_ACCESS_DENIED, "\"SSL handshake failed\"");
 		return;
 	}
 

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -653,6 +653,7 @@ int sendback(nut_ctype_t *client, const char *fmt, ...)
 	size_t	len;
 	char	ans[NUT_NET_ANSWER_MAX+1];
 	va_list	ap;
+	const char	*op = NULL;
 
 	if (!client) {
 		return 0;
@@ -671,20 +672,28 @@ int sendback(nut_ctype_t *client, const char *fmt, ...)
 
 #ifdef WITH_SSL
 	if (client->ssl) {
+		op = "ssl_write";
 		res = ssl_write(client, ans, len);
 	} else
 #endif /* WITH_SSL */
 	{
+		op = "write";
 		res = write(client->sock_fd, ans, len);
 	}
 
 	{ /* scoping */
-		char * s = str_rtrim(ans, '\n');
-		upsdebugx(2, "write: [destfd=%d] [len=%" PRIuSIZE "] [%s]", client->sock_fd, len, s);
+		char	*s = str_rtrim(ans, '\n');
+
+		upsdebugx(2, "%s: %s(): [destfd=%d] [len=%" PRIuSIZE "] ans=[%s]",
+			__func__, op, client->sock_fd, len, s);
 	}
 
 	if (res < 0 || len != (size_t)res) {
-		upslog_with_errno(LOG_NOTICE, "write() failed for %s", client->addr);
+		upslog_with_errno(LOG_NOTICE, "%s() failed for %s", op, client->addr);
+		upsdebugx(2, "%s: %s() failed for %s "
+			"(res=%" PRIiSIZE ", len=%" PRIuSIZE "), "
+			"setting client->last_heard=0",
+			__func__, op, client->addr, res, len);
 		client->last_heard = 0;
 		return 0;	/* failed */
 	}

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -704,6 +704,22 @@ int send_err(nut_ctype_t *client, const char *errtype)
 	return sendback(client, "ERR %s\n", errtype);
 }
 
+int send_err_extra(nut_ctype_t *client, const char *errtype, const char *extra)
+{
+	/* TOTHINK: Skip also empty `!*extra` strings? */
+	if (!extra) {
+		return send_err(client, errtype);
+	}
+
+	if (!client) {
+		return -1;
+	}
+
+	upsdebugx(4, "Sending error [%s] [%s] to client %s", errtype, extra, client->addr);
+
+	return sendback(client, "ERR %s %s\n", errtype, extra);
+}
+
 /* disconnect anyone logged into this UPS */
 void kick_login_clients(const char *upsname)
 {

--- a/server/upsd.h
+++ b/server/upsd.h
@@ -69,6 +69,7 @@ void kick_login_clients(const char *upsname);
 int sendback(nut_ctype_t *client, const char *fmt, ...)
 	__attribute__ ((__format__ (__printf__, 2, 3)));
 int send_err(nut_ctype_t *client, const char *errtype);
+int send_err_extra(nut_ctype_t *client, const char *errtype, const char *extra);
 
 void server_load(void);
 void server_free(void);


### PR DESCRIPTION
Start by poking `upsdrvctl` for both WIN32 and POSIX builds...

Includes code from PR #3367 to try reproducing the issue.

UPDATE: Maybe specific to `dummy-ups`, reproduced both for standalone starts of the driver program directly, one driver via `upsdrvctl` (note: the latter does not seem to propagate the exit-code and returns `0`, at least on Windows, probably should indicate an error), and a swarm of drivers via `upsdrvctl` (also exits with code `0` even if all drivers died abruptly). Sometimes it took several starts of `upsd` to be killed a few seconds later.

In all these cases the final words were like:

* upsd
```
   0.011162     Connected to UPS [UPS2]: dummy-ups-UPS2
   0.011473     Connected to UPS [UPS1]: dummy-ups-UPS1
   0.011641     Connected to UPS [dummy]: dummy-ups-dummy
   0.011762     Your system limits the maximum number of connections to 64
but you requested 348. The server may handle connections
in smaller groups, maybe affecting efficiency and response time.

   0.011989     [D1:6336:upsd.exe] poll_reload: (p)re-allocate 348 entries for polling FDs and handlers
   0.012186     Found 53 UPS defined in ups.conf
...
   0.186789     [D1:6336:upsd.exe] mainloop: UPS [UPSwarm43] driver is still not connected (FD -1)
   0.186938     [D1:6336:upsd.exe] mainloop: UPS [UPSwarm44] driver is not currently connected, trying to reconnect
   0.187080     [D1:6336:upsd.exe] mainloop: UPS [UPSwarm44] driver is still not connected (FD -1)
(end of log)
```
  * with a Ctrl+C at this point, there is even no clean-up logged (are signals set up later? shouldn't be...)
* a longer-living `upsd` sometimes logs the clean-up:
```
...
   1.842622     [D1:3404:upsd.exe] mainloop: UPS [UPSwarm50] driver is still not connected (FD -1)
   1.870824     [D1:3404:upsd.exe] upsd_cleanup: starting the end-game
   1.871082     [D1:3404:upsd.exe] driver_free: forgetting UPS [dummy] (FD 644)
   1.871209     [D1:3404:upsd.exe] driver_free: forgetting UPS [UPS1] (FD 636)
   1.871347     [D1:3404:upsd.exe] driver_free: forgetting UPS [UPS2] (FD 628)
   1.871459     [D1:3404:upsd.exe] driver_free: forgetting UPS [UPSwarm1] (FD -1)
   1.871547     [D1:3404:upsd.exe] driver_free: forgetting UPS [UPSwarm2] (FD -1)
...
   1.880913     [D1:3404:upsd.exe] driver_free: forgetting UPS [UPSwarm50] (FD -1)
   1.881051     [D1:3404:upsd.exe] upsd_cleanup: finished
```

* On the `dummy-ups` side it seems to always end with the same `entering parse_data_file()` call (and exit-code 127) after failing to write to the server:
```
...
   3.773319     [D5:16220:dummy-ups:UPSwarm11] send_to_one: SETAUX outlet.3.id 32
   3.787747     [D6:16220:dummy-ups:UPSwarm11] send_to_one: write 22 bytes to handle 000000000000011C succeeded (ret=22): SETAUX outlet.3.id 32

   3.787949     [D2:16220:dummy-ups:UPSwarm11] send_to_one: sending SETFLAGS outlet.3.id RW STRING
   3.788031     [D5:16220:dummy-ups:UPSwarm11] send_to_one: SETFLAGS outlet.3.id RW STRING
   3.788133     WARNING: send_to_one: write 31 bytes to handle 000000000000011C failed (ret=0), disconnecting.: No error [The pipe is being closed. ]
   3.788250     [D6:16220:dummy-ups:UPSwarm11] send_to_one: failed write: SETFLAGS outlet.3.id RW STRING

   3.788364     [D3:16220:dummy-ups:UPSwarm11] sock_disconnect: disconnecting named pipe handle 000000000000011C
   3.788502     [D5:16220:dummy-ups:UPSwarm11] sock_disconnect: finishing parsing context
   3.788591     [D5:16220:dummy-ups:UPSwarm11] sock_disconnect: relinking the chain of connections
   3.788667     [D5:16220:dummy-ups:UPSwarm11] sock_disconnect: freeing the conn object
   3.788755     [D5:16220:dummy-ups:UPSwarm11] send_to_all: SETINFO driver.state "updateinfo"
   3.788861     [D1:16220:dummy-ups:UPSwarm11] upsdrv_updateinfo...
   4.793998     [D1:16220:dummy-ups:UPSwarm11] entering parse_data_file()
(end of log)

$ echo $?
127
```

I don't think I've reproduced nor ruled out the problem on non-Windows builds yet.

Per GDB and added debug-logging traces, it seems to crash around `malloc()` calls, whether in PCONF context init or in `vupslog()` a bit before it gets there:
```
...
   8.255625     [D3:15120:dummy-ups:UPSwarm11] sock_connect: new connection on handle 0000000000000120
   8.255752     [D6:15120:dummy-ups:UPSwarm11] sock_arg: Driver on \\.\pipe\dummy-ups-UPSwarm11 is now handling DUMPALL with 1 args
   8.255874     [D2:15120:dummy-ups:UPSwarm11] send_to_one: sending SETINFO device.mfr "EATON | Powerware"
   8.256006     [D5:15120:dummy-ups:UPSwarm11] send_to_one: SETINFO device.mfr "EATON | Powerware"
   8.256165     WARNING: send_to_one: write 39 bytes to handle 0000000000000120 failed (ret=0), disconnecting.: No error [The pipe is being closed. ]
   8.256322     [D6:15120:dummy-ups:UPSwarm11] send_to_one: failed write: SETINFO device.mfr "EATON | Powerware"

   8.256457     [D3:15120:dummy-ups:UPSwarm11] sock_disconnect: disconnecting named pipe handle 0000000000000120
   8.256585     [D5:15120:dummy-ups:UPSwarm11] sock_disconnect: finishing parsing context
   8.256706     [D5:15120:dummy-ups:UPSwarm11] sock_disconnect: relinking the chain of connections
   8.256798     [D5:15120:dummy-ups:UPSwarm11] sock_disconnect: freeing the conn object

Thread 1 received signal SIGSEGV, Segmentation fault.
0x00007ffb8325d990 in ntdll!RtlAllocateHeap () from C:\Windows\SYSTEM32\ntdll.dll
(gdb) bt
#0  0x00007ffb8325d990 in ntdll!RtlAllocateHeap () from C:\Windows\SYSTEM32\ntdll.dll
#1  0x00007ffb8325b44d in ntdll!RtlAllocateHeap () from C:\Windows\SYSTEM32\ntdll.dll
#2  0x00007ffb83328a18 in ntdll!RtlRegisterSecureMemoryCacheCallback () from C:\Windows\SYSTEM32\ntdll.dll
#3  0x00007ffb8325d255 in ntdll!RtlAllocateHeap () from C:\Windows\SYSTEM32\ntdll.dll
#4  0x00007ffb8325b44d in ntdll!RtlAllocateHeap () from C:\Windows\SYSTEM32\ntdll.dll
#5  0x00007ffb8144a131 in realloc () from C:\Windows\System32\msvcrt.dll
#6  0x00007ffb81449c45 in msvcrt!calloc () from C:\Windows\System32\msvcrt.dll
#7  0x00007ff6b737f0a9 in xcalloc (number=<optimized out>, size=<optimized out>) at common.c:4760
#8  0x00007ff6b737f12e in vupslog (priority=2, fmt=0x5fed50 "[D5:15120:dummy-ups:UPSwarm11] %s: %.*s", va=0x5ff170 "", use_strerror=0) at common.c:3816
#9  0x00007ff6b737f8ce in s_upsdebugx (level=<optimized out>, level@entry=5, fmt=0x5fed50 "[D5:15120:dummy-ups:UPSwarm11] %s: %.*s",
    fmt@entry=0x7ff6b73a0e99 <__func__.16+681> "%s: %.*s") at common.c:4535
#10 0x00007ff6b7378591 in send_to_all (fmt=fmt@entry=0x7ff6b73a0f6b <__func__.16+891> "SETINFO %s \"%s\"\n") at dstate.c:305
#11 0x00007ff6b73786b0 in vdstate_setinfo (var=var@entry=0x7ff6b739cfbf <__func__.4+1047> "driver.state", fmt=fmt@entry=0x7ff6b73a08d1 <__func__.4+15657> "updateinfo",
    ap=ap@entry=0x5ff5a0 "d") at dstate.c:1386
#12 0x00007ff6b737715d in dstate_setinfo (var=var@entry=0x7ff6b739cfbf <__func__.4+1047> "driver.state", fmt=fmt@entry=0x7ff6b73a08d1 <__func__.4+15657> "updateinfo")
    at dstate.c:1412
#13 0x00007ff6b739aa7f in main (argc=<optimized out>, argv=<optimized out>) at main.c:3268
```