### PR TITLE
apc_modbus: simplify error handling with read retries

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -47,6 +47,8 @@ https://github.com/networkupstools/nut/milestone/13
 
  - `apc_modbus` driver updates:
     * Fixed string join not doing zero termination. [PR #3413]
+    * Added `modbus_retries` option to configure the number of read retry
+      attempts on timeout errors, simplifying error recovery. [PR #3414]
 
  - NUT client libraries:
     * Complete support for actions documented in `docs/net-protocol.txt`

--- a/docs/man/apc_modbus.txt
+++ b/docs/man/apc_modbus.txt
@@ -84,6 +84,11 @@ Set the Modbus slave id. The default slave id is 1.
 Set the Modbus response timeout. The default timeout is set by libmodbus. It can
 be good to set a higher timeout on TCP connections with high latency.
 
+*modbus_retries*='num'::
+Set the number of retries for Modbus register reads on timeout errors.
+The default is 3 retries. After exhausting retries (or on non-timeout errors),
+the connection is closed and will be re-established on the next update cycle.
+
 BUGS
 ----
 

--- a/drivers/apc_modbus.c
+++ b/drivers/apc_modbus.c
@@ -1100,7 +1100,7 @@ static int _apc_modbus_read_registers(modbus_t *ctx, int addr, int nb, uint16_t 
 
 		upslogx(LOG_ERR, "%s: Read of %d:%d failed: %s (%s)", __func__, addr, addr + nb, modbus_strerror(saved_errno), device_path);
 
-		if (saved_errno != ETIMEDOUT){
+		if (saved_errno != ETIMEDOUT) {
 			break;
 		}
 	}
@@ -1939,6 +1939,7 @@ void upsdrv_makevartable(void)
 #endif /* defined NUT_MODBUS_HAS_USB */
 	addvar(VAR_VALUE, "slaveid", "Modbus slave id (default=1)");
 	addvar(VAR_VALUE, "response_timeout_ms", "Modbus response timeout in milliseconds");
+	addvar(VAR_VALUE, "modbus_retries", "Number of retries for Modbus register reads on timeout errors (default=3)");
 
 	/* Serial RTU parameters */
 	addvar(VAR_VALUE, "baudrate", "Modbus serial RTU communication speed in baud (default=9600)");

--- a/drivers/apc_modbus.c
+++ b/drivers/apc_modbus.c
@@ -96,6 +96,7 @@ static int is_open = 0;
 static double power_nominal;
 static double realpower_nominal;
 static int64_t last_send_time = 0;
+static int modbus_retries = 3;
 
 /* Function declarations */
 static int _apc_modbus_read_inventory(void);
@@ -988,6 +989,7 @@ static apc_modbus_register_t* _apc_modbus_find_register_variable(const char *nut
 static void _apc_modbus_close(int free_modbus)
 {
 	if (modbus_ctx != NULL) {
+		upslogx(LOG_INFO, "%s: Closing connection", __func__);
 		modbus_close(modbus_ctx);
 		if (free_modbus) {
 			modbus_free(modbus_ctx);
@@ -1080,58 +1082,32 @@ interframe_delay_exit:
 	last_send_time = current_time;
 }
 
-static void _apc_modbus_handle_error(modbus_t *ctx)
-{
-	static int flush_retries = 0;
-	int flush = 0;
-#ifdef WIN32
-	int wsa_error;
-#endif /* WIN32 */
-
-	/*
-	 * We could enable MODBUS_ERROR_RECOVERY_LINK but that would just get stuck
-	 * in libmodbus until recovery. The only indication of this is that the
-	 * program is stuck and debug prints by libmodbus, which we don't want to
-	 * enable on release.
-	 *
-	 * Instead we detect timout errors and do a sleep + flush, on every other
-	 * error or when flush didn't work we do a reconnect.
-	 */
-
-#ifdef WIN32
-	wsa_error = WSAGetLastError();
-	if (wsa_error == WSAETIMEDOUT) {
-		flush = 1;
-	}
-#else	/* !WIN32 */
-	if (errno == ETIMEDOUT) {
-		flush = 1;
-	}
-#endif /* !WIN32 */
-
-	if (flush > 0 && flush_retries++ < 5) {
-		usleep(1000000);
-		modbus_flush(ctx);
-	} else {
-		flush_retries = 0;
-		upslogx(LOG_ERR, "%s: Closing connection", __func__);
-		/* Close without free, will retry connection on next update */
-		_apc_modbus_close(0);
-	}
-}
-
 static int _apc_modbus_read_registers(modbus_t *ctx, int addr, int nb, uint16_t *dest)
 {
-	_apc_modbus_interframe_delay();
+	int res;
+	int retries = modbus_retries;
+	int saved_errno;
 
-	if (modbus_read_registers(ctx, addr, nb, dest) > 0) {
+	while (retries-- > 0) {
+		_apc_modbus_interframe_delay();
+
+		res = modbus_read_registers(ctx, addr, nb, dest);
+		saved_errno = errno;
 		_apc_modbus_interframe_delay_reset();
-		return 1;
-	} else {
-		upslogx(LOG_ERR, "%s: Read of %d:%d failed: %s (%s)", __func__, addr, addr + nb, modbus_strerror(errno), device_path);
-		_apc_modbus_handle_error(ctx);
-		return 0;
+		if (res > 0) {
+			return 1;
+		}
+
+		upslogx(LOG_ERR, "%s: Read of %d:%d failed: %s (%s)", __func__, addr, addr + nb, modbus_strerror(saved_errno), device_path);
+
+		if (saved_errno != ETIMEDOUT){
+			break;
+		}
 	}
+
+	_apc_modbus_close(0);
+
+	return 0;
 }
 
 static int _apc_modbus_update_value(apc_modbus_register_t *regs_info, const uint16_t *regs, const size_t regs_len)
@@ -1499,7 +1475,7 @@ static int _apc_modbus_handle_outlet_cmd(const char *nut_cmdname, const char *ex
 	if (modbus_write_registers(modbus_ctx, APC_MODBUS_OUTLETCOMMAND_BF_REG, 2, value) < 0) {
 		upslogx(LOG_ERR, "%s: Write of outlet command failed: %s (%s)",
 			__func__, modbus_strerror(errno), device_path);
-		_apc_modbus_handle_error(modbus_ctx);
+		_apc_modbus_close(0);
 		*result = STAT_INSTCMD_FAILED;
 		return 1;
 	}
@@ -1681,7 +1657,7 @@ static int _apc_modbus_setvar(const char *nut_varname, const char *str_value)
 	nb = apc_value->modbus_len;
 	if (modbus_write_registers(modbus_ctx, addr, nb, reg_value) < 0) {
 		upslogx(LOG_ERR, "%s: Write of %d:%d failed: %s (%s)", __func__, addr, addr + nb - 1, modbus_strerror(errno), device_path);
-		_apc_modbus_handle_error(modbus_ctx);
+		_apc_modbus_close(0);
 		return STAT_SET_FAILED;
 	}
 
@@ -1760,7 +1736,7 @@ static int _apc_modbus_instcmd(const char *nut_cmdname, const char *extra)
 	upslog_INSTCMD_POWERSTATE_CHECKED(nut_cmdname, extra);
 	if (modbus_write_registers(modbus_ctx, addr, nb, value) < 0) {
 		upslogx(LOG_INSTCMD_FAILED, "%s: Write of %d:%d failed: %s (%s)", __func__, addr, addr + nb, modbus_strerror(errno), device_path);
-		_apc_modbus_handle_error(modbus_ctx);
+		_apc_modbus_close(0);
 		return STAT_INSTCMD_FAILED;
 	}
 
@@ -1801,6 +1777,7 @@ void upsdrv_updateinfo(void)
 			dstate_datastale();
 			return;
 		}
+		upslogx(LOG_INFO, "Opened modbus successfully");
 	}
 
 	alarm_init();
@@ -2309,6 +2286,15 @@ void upsdrv_initups(void)
 	}
 /* #elif (defined NUT_MODBUS_TIMEOUT_ARG_timeval) // some un-castable type in fields */
 #endif /* NUT_MODBUS_TIMEOUT_ARG_* */
+	}
+
+	val = getval("modbus_retries");
+	if (val != NULL) {
+		modbus_retries = atoi(val);
+		if (modbus_retries < 1) {
+			modbus_free(modbus_ctx);
+			fatalx(EXIT_FAILURE, "modbus_retries needs to be at least 1");
+		}
 	}
 
 	if (modbus_connect(modbus_ctx) == -1) {


### PR DESCRIPTION
Replace the complex `_apc_modbus_handle_error` function with a simpler retry mechanism built into `_apc_modbus_read_registers`.

The new approach:
- Retries register reads on `ETIMEDOUT` errors up to `modbus_retries` times (configurable, default 3)
- On non-timeout errors or after retry exhaustion, closes the connection for reconnection on the next update cycle
- Removes the platform-specific (WIN32/POSIX) timeout detection and the flush-based recovery that didn't work anyway (flush is already done in `_apc_modbus_reopen` upon reconnection)

Also adds a `modbus_retries` driver option to configure the number of read retry attempts, and improves logging for connection open/close events.

This change was inspired by a patch by @marcan to do the same and from testing the behaviour of `apcupsd`, noticing that on my USB unit it times out on read and only succeeds on the first retry.

<!-- Comment:
* Please revise the docs/developers.txt for coding style suggestions and
  other considerations applicable to NUT codebase contributions, as well
  as for which text documents to update. See also docs/developer-guide.txt
  for general points on NUT architecture and design.

* Please note that we require "Signed-Off-By" tags in each Git Commit
  message, to conform to the common DCO (Developer Certificate of Origin)
  as posted in LICENSE-DCO at root of NUT codebase as well as published
  at https://developercertificate.org/

* The checklist below is more of a reminder of steps to take and "dangers"
  to look out for. PRs to update this template are also welcome :)

* Local build iterations can be augmented with the ci_build.sh script.
  Note that if your system has both GCC and CLANG, they can expose different
  kinds of issues in their static analysis warnings, so incantations like
  `CC=clang CXX=clang++ ./ci_build.sh` or `BUILD_TYPE=fightwarn ./ci_build.sh`
  (to iterate a matrix of some build dependency combos and compilers) can
  be useful.
-->

## General points

- [x] Described the changes in the PR submission or a separate issue, e.g.
  known published or discovered protocols, applicable hardware (expected
  compatible and actually tested/developed against), limitations, etc.

- [x] There may be multiple commits in the PR, aligned and commented with
  a functional change. Notably, coding style changes better belong in a
  separate PR, but certainly in a dedicated commit to simplify reviews
  of "real" changes in the other commits. Similarly for typo fixes in
  comments or text documents.

- [x] Use of coding helper tools and AI should be disclosed in the commit
  or PR comments (it is interesting to know which ones do a decent job).
  As with other contributions, a human is responsible and thanked for the
  quality and content of the change, and is presumed to have the right to
  post that code to be published further under the project's license terms.

- [x] Please star NUT on GitHub, this helps with sponsorships! ;)

## Frequent "underwater rocks" for driver addition/update PRs

- [x] Revised existing driver families and added a sub-driver if applicable
  (`nutdrv_qx`, `usbhid-ups`...) or added a brand new driver in the other
  case.

- [x] Did not extend obsoleted drivers with new hardware support features
  (notably `blazer` and other single-device family drivers for Qx protocols,
  except the new `nutdrv_qx` which should cover them all).

- [x] For updated existing device drivers, bumped the `DRIVER_VERSION` macro
  or its equivalent.

<!-- Comment:
  Some sub-drivers have `SUBDRIVER_VERSION` or customized names like
  e.g. `MEGATEC_VERSION` in `drivers/nutdrv_qx_megatec.c`
-->

- [x] For USB devices (HID or not), revised that the driver uses unique
  VID/PID combinations, or raised discussions when this is not the case
  (several vendors do use same interface chips for unrelated protocols).

- [x] For new USB devices, built and committed the changes for the
  `scripts/upower/95-upower-hid.hwdb` file

- [x] Proposed NUT data mapping is aligned with existing `docs/nut-names.txt`
  file. If the device exposes useful data points not listed in the file, the
  `experimental.*` namespace can be used as documented there, and discussion
  should be raised on the NUT Developers mailing list to standardize the new
  concept.

- [x] Updated `data/driver.list.in` if applicable (new tested device info)
<!-- Comment:
Also note below, a point about PR posting for NUT DDL
-->

## Frequent "underwater rocks" for general C code PRs

- [x] Did not "blindly assume" default integer type sizes and value ranges,
  structure layout and alignment in memory, endianness (layout of bytes and
  bits in memory for multi-byte numeric types), or use of generic `int` where
  language or libraries dictate the use of `size_t` (or `ssize_t` sometimes).

<!-- Comment:
* NOTE: Casting and/or pragmas (support detected at compile time,
  see `m4/ax_c_pragmas.m4`) to silence warnings may be acceptable,
  but only if coupled with range checks or similar actions.
-->

- [x] Progress and errors are handled with `upsdebugx()`, `upslogx()`,
  `fatalx()` and related methods, not with direct `printf()` or `exit()`.
  Similarly, NUT helpers are used for error-checked memory allocation and
  string operations (except where customized error handling is needed,
  such as unlocking device ports, etc.)

- [x] Coding style (including whitespace for indentations) follows precedent
  in the code of the file, and examples/guide in `docs/developers.txt` file.

- [x] For newly added files, the `Makefile.am` recipes were updated and the
  `make distcheck` target passes.

## General documentation updates

- [x] Added a bullet point into `NEWS.adoc`, possibly also `UPGRADING.adoc`
  if there is something packagers or custom-build users should take into
  account (new driver categories, configuration options, dependencies...)

- [x] Updated `docs/acknowledgements.txt` (for vendor-backed device support)

- [x] Added or updated manual page information in `docs/man/*.txt` files
  and corresponding recipe lists in `docs/man/Makefile.am` for new pages

- [x] Passed `make spellcheck`, updated spell-checking dictionary in the
  `docs/nut.dict` file if needed (did not remove any words -- the `make`
  rule printout in case of changes suggests how to maintain it).

## Additional work may be needed after posting this PR

- [x] Propose a PR for NUT DDL with detailed device data dumps from tests
  against real hardware (the more models, the better).

- [ ] Address NUT CI farm build failures for the PR: testing on numerous
  platforms and toolkits can expose issues not seen on just one system.

<!-- Comment:
* One frequent "offence" is the appearance of unexpected (not git-ignored)
  or modification during build of files tracked in Git.

* Another frequent issue is not tracking newly introduced file names in
  `EXTRA_DIST` of the `Makefile.am` (and for `*.in` templates -- of rules
  in the `configure.ac` script) so the `make distcheck` fails.

* Avoid using GNU-specific constructs in the `Makefile.am`, even if that
  means cumbersome ways to build a target. This should not happen in mere
  driver updates, however.

* Also some third-party libraries or OS headers and method argument types
  and counts can differ -- necessitating m4 code for `configure` script
  probing, and `ifdef`, `typedef`, etc. in C code to adapt to the build
  environment (precedents available in NUT codebase). In extreme cases,
  you may need to spin up a VM or container to reproduce those issues
  and iterate on a fix locally; see `docs/config-prereqs.txt` and
  `docs/ci-farm-lxc-setup.txt` for notes taken during preparation of
  the multi-platform NUT CI farm.
-->

- [ ] Revise suggestions from LGTM.COM analysis about "new issues" with
  the changed codebase.

<!-- Comment:
  Take them with a grain of salt, especially with regard to things like
  architecture-dependent range checks, but many of the complaints from
  the tool are indeed useful.
-->
