### PR TITLE
apc_modbus: increase default TCP response timeout to 2000 ms

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -47,6 +47,7 @@ https://github.com/networkupstools/nut/milestone/13
 
  - `apc_modbus` driver updates:
     * Fixed string join not doing zero termination. [PR #3413]
+    * Increased default TCP response timeout to 2000 ms. [PR #3418]
 
  - NUT client libraries:
     * Complete support for actions documented in `docs/net-protocol.txt`

--- a/drivers/apc_modbus.c
+++ b/drivers/apc_modbus.c
@@ -1961,7 +1961,7 @@ void upsdrv_makevartable(void)
 	addvar(VAR_VALUE, "porttype", "Modbus port type (serial, tcp, default=serial)");
 #endif /* defined NUT_MODBUS_HAS_USB */
 	addvar(VAR_VALUE, "slaveid", "Modbus slave id (default=1)");
-	addvar(VAR_VALUE, "response_timeout_ms", "Modbus response timeout in milliseconds");
+	addvar(VAR_VALUE, "response_timeout_ms", "Modbus response timeout in milliseconds (default=500, 2000 for TCP)");
 
 	/* Serial RTU parameters */
 	addvar(VAR_VALUE, "baudrate", "Modbus serial RTU communication speed in baud (default=9600)");
@@ -2181,7 +2181,7 @@ void upsdrv_initups(void)
 	int rtu_databits;
 	int rtu_stopbits;
 	int slaveid;
-	uint32_t response_timeout_ms;
+	uint32_t response_timeout_ms = 500;
 	char tcp_host[256];
 	char tcp_port[6];
 
@@ -2256,6 +2256,12 @@ void upsdrv_initups(void)
 			fatalx(EXIT_FAILURE, "failed to parse host/port");
 		}
 
+		/*
+		 * Increase the default for TCP
+		 * See https://github.com/networkupstools/nut/pull/3414#issuecomment-4243889805
+		 */
+		response_timeout_ms = 2000;
+
 		modbus_ctx = modbus_new_tcp_pi(tcp_host, tcp_port);
 	} else if (!strcasecmp(val, "serial")) {
 		val = getval("baudrate");
@@ -2292,13 +2298,18 @@ void upsdrv_initups(void)
 	val = getval("response_timeout_ms");
 	if (val != NULL) {
 		response_timeout_ms = (uint32_t)strtoul(val, NULL, 0);
+	}
+
+	if (response_timeout_ms < 100) {
+		upslogx(LOG_WARNING, "response_timeout_ms value %u ms is very low and may cause communication problems; consider increasing it", response_timeout_ms);
+	}
 
 #if (defined NUT_MODBUS_TIMEOUT_ARG_sec_usec_uint32) || (defined NUT_MODBUS_TIMEOUT_ARG_sec_usec_uint32_cast_timeval_fields)
-		r = modbus_set_response_timeout(modbus_ctx, response_timeout_ms / 1000, (response_timeout_ms % 1000) * 1000);
-		if (r < 0) {
-			modbus_free(modbus_ctx);
-			fatalx(EXIT_FAILURE, "modbus_set_response_timeout: error(%s)", modbus_strerror(errno));
-		}
+	r = modbus_set_response_timeout(modbus_ctx, response_timeout_ms / 1000, (response_timeout_ms % 1000) * 1000);
+	if (r < 0) {
+		modbus_free(modbus_ctx);
+		fatalx(EXIT_FAILURE, "modbus_set_response_timeout: error(%s)", modbus_strerror(errno));
+	}
 #elif (defined NUT_MODBUS_TIMEOUT_ARG_timeval_numeric_fields)
 	{	/* see comments above */
 		struct timeval to;
@@ -2309,7 +2320,6 @@ void upsdrv_initups(void)
 	}
 /* #elif (defined NUT_MODBUS_TIMEOUT_ARG_timeval) // some un-castable type in fields */
 #endif /* NUT_MODBUS_TIMEOUT_ARG_* */
-	}
 
 	if (modbus_connect(modbus_ctx) == -1) {
 		modbus_free(modbus_ctx);


### PR DESCRIPTION
The default 500ms timeout value is marginal for Modbus TCP, even on a fast local network. In tests with an APC UPS, we see timeouts because of this:

```
Apr 14 19:10:44 ares apc_modbus[2002143]: _apc_modbus_read_registers: Read of 0:27 failed: Connection timed out (192.168.0.102:502)
Apr 14 19:10:44 ares apc_modbus[2002143]: _apc_modbus_read_registers: Read of 0:27 failed: Invalid data (192.168.0.102:502)
Apr 14 19:10:44 ares apc_modbus[2002143]: _apc_modbus_close: Closing connection
Apr 14 19:10:47 ares apc_modbus[2002143]: Opened modbus successfully
```

Packet capture:

```
No.	Time	Source	Destination	Protocol	Length	Info
3636	2026-04-14 19:10:43.842072	192.168.0.40	192.168.0.102	Modbus/TCP	66	   Query: Trans: 12622; Unit:   1, Func:   3: Read Holding Registers
3637	2026-04-14 19:10:44.018369	192.168.0.102	192.168.0.40	TCP	60	502 → 40392 [ACK] Seq=70441 Ack=11905 Win=3660 Len=0
3638	2026-04-14 19:10:44.377723	192.168.0.40	192.168.0.102	Modbus/TCP	66	   Query: Trans: 12623; Unit:   1, Func:   3: Read Holding Registers
3639	2026-04-14 19:10:44.578103	192.168.0.102	192.168.0.40	TCP	60	502 → 40392 [ACK] Seq=70441 Ack=11917 Win=3648 Len=0
3640	2026-04-14 19:10:44.579449	192.168.0.102	192.168.0.40	Modbus/TCP	117	Response: Trans: 12622; Unit:   1, Func:   3: Read Holding Registers
3641	2026-04-14 19:10:44.579482	192.168.0.40	192.168.0.102	TCP	54	40392 → 502 [ACK] Seq=11917 Ack=70504 Win=63 Len=0
3642	2026-04-14 19:10:44.579604	192.168.0.40	192.168.0.102	TCP	54	40392 → 502 [FIN, ACK] Seq=11917 Ack=70504 Win=63 Len=0
```

3636 is the first read, 3638 is the retry after 500ms without response, both are ACKed. 3640 is the actual response to transaction 12622, which arrives 700ms after the initial packet. At this point we expect a response to transaction 12623, which is why we fail with "invalid data".

To fix this we increase the default TCP response timeout to 2000 ms, which seems to be more reasonable for a device that already can take 700 ms to respond under ideal conditions. I chose a bit higher value for users who might connect the device over a higher latency network.

<!-- Comment:
* Please revise the docs/developers.txt for coding style suggestions and
  other considerations applicable to NUT codebase contributions, as well
  as for which text documents to update. See also docs/developer-guide.txt
  for general points on NUT architecture and design.

* Please note that we require "Signed-Off-By" tags in each Git Commit
  message, to conform to the common DCO (Developer Certificate of Origin)
  as posted in LICENSE-DCO at root of NUT codebase as well as published
  at https://developercertificate.org/

* The checklist below is more of a reminder of steps to take and "dangers"
  to look out for. PRs to update this template are also welcome :)

* Local build iterations can be augmented with the ci_build.sh script.
  Note that if your system has both GCC and CLANG, they can expose different
  kinds of issues in their static analysis warnings, so incantations like
  `CC=clang CXX=clang++ ./ci_build.sh` or `BUILD_TYPE=fightwarn ./ci_build.sh`
  (to iterate a matrix of some build dependency combos and compilers) can
  be useful.
-->

## General points

- [x] Described the changes in the PR submission or a separate issue, e.g.
  known published or discovered protocols, applicable hardware (expected
  compatible and actually tested/developed against), limitations, etc.

- [x] There may be multiple commits in the PR, aligned and commented with
  a functional change. Notably, coding style changes better belong in a
  separate PR, but certainly in a dedicated commit to simplify reviews
  of "real" changes in the other commits. Similarly for typo fixes in
  comments or text documents.

- [x] Use of coding helper tools and AI should be disclosed in the commit
  or PR comments (it is interesting to know which ones do a decent job).
  As with other contributions, a human is responsible and thanked for the
  quality and content of the change, and is presumed to have the right to
  post that code to be published further under the project's license terms.

- [x] Please star NUT on GitHub, this helps with sponsorships! ;)

## Frequent "underwater rocks" for driver addition/update PRs

- [x] Revised existing driver families and added a sub-driver if applicable
  (`nutdrv_qx`, `usbhid-ups`...) or added a brand new driver in the other
  case.

- [x] Did not extend obsoleted drivers with new hardware support features
  (notably `blazer` and other single-device family drivers for Qx protocols,
  except the new `nutdrv_qx` which should cover them all).

- [x] For updated existing device drivers, bumped the `DRIVER_VERSION` macro
  or its equivalent.

<!-- Comment:
  Some sub-drivers have `SUBDRIVER_VERSION` or customized names like
  e.g. `MEGATEC_VERSION` in `drivers/nutdrv_qx_megatec.c`
-->

- [x] For USB devices (HID or not), revised that the driver uses unique
  VID/PID combinations, or raised discussions when this is not the case
  (several vendors do use same interface chips for unrelated protocols).

- [x] For new USB devices, built and committed the changes for the
  `scripts/upower/95-upower-hid.hwdb` file

- [x] Proposed NUT data mapping is aligned with existing `docs/nut-names.txt`
  file. If the device exposes useful data points not listed in the file, the
  `experimental.*` namespace can be used as documented there, and discussion
  should be raised on the NUT Developers mailing list to standardize the new
  concept.

- [x] Updated `data/driver.list.in` if applicable (new tested device info)
<!-- Comment:
Also note below, a point about PR posting for NUT DDL
-->

## Frequent "underwater rocks" for general C code PRs

- [x] Did not "blindly assume" default integer type sizes and value ranges,
  structure layout and alignment in memory, endianness (layout of bytes and
  bits in memory for multi-byte numeric types), or use of generic `int` where
  language or libraries dictate the use of `size_t` (or `ssize_t` sometimes).

<!-- Comment:
* NOTE: Casting and/or pragmas (support detected at compile time,
  see `m4/ax_c_pragmas.m4`) to silence warnings may be acceptable,
  but only if coupled with range checks or similar actions.
-->

- [x] Progress and errors are handled with `upsdebugx()`, `upslogx()`,
  `fatalx()` and related methods, not with direct `printf()` or `exit()`.
  Similarly, NUT helpers are used for error-checked memory allocation and
  string operations (except where customized error handling is needed,
  such as unlocking device ports, etc.)

- [x] Coding style (including whitespace for indentations) follows precedent
  in the code of the file, and examples/guide in `docs/developers.txt` file.

- [x] For newly added files, the `Makefile.am` recipes were updated and the
  `make distcheck` target passes.

## General documentation updates

- [x] Added a bullet point into `NEWS.adoc`, possibly also `UPGRADING.adoc`
  if there is something packagers or custom-build users should take into
  account (new driver categories, configuration options, dependencies...)

- [x] Updated `docs/acknowledgements.txt` (for vendor-backed device support)

- [x] Added or updated manual page information in `docs/man/*.txt` files
  and corresponding recipe lists in `docs/man/Makefile.am` for new pages

- [x] Passed `make spellcheck`, updated spell-checking dictionary in the
  `docs/nut.dict` file if needed (did not remove any words -- the `make`
  rule printout in case of changes suggests how to maintain it).

## Additional work may be needed after posting this PR

- [x] Propose a PR for NUT DDL with detailed device data dumps from tests
  against real hardware (the more models, the better).

- [x] Address NUT CI farm build failures for the PR: testing on numerous
  platforms and toolkits can expose issues not seen on just one system.

<!-- Comment:
* One frequent "offence" is the appearance of unexpected (not git-ignored)
  or modification during build of files tracked in Git.

* Another frequent issue is not tracking newly introduced file names in
  `EXTRA_DIST` of the `Makefile.am` (and for `*.in` templates -- of rules
  in the `configure.ac` script) so the `make distcheck` fails.

* Avoid using GNU-specific constructs in the `Makefile.am`, even if that
  means cumbersome ways to build a target. This should not happen in mere
  driver updates, however.

* Also some third-party libraries or OS headers and method argument types
  and counts can differ -- necessitating m4 code for `configure` script
  probing, and `ifdef`, `typedef`, etc. in C code to adapt to the build
  environment (precedents available in NUT codebase). In extreme cases,
  you may need to spin up a VM or container to reproduce those issues
  and iterate on a fix locally; see `docs/config-prereqs.txt` and
  `docs/ci-farm-lxc-setup.txt` for notes taken during preparation of
  the multi-platform NUT CI farm.
-->

- [x] Revise suggestions from LGTM.COM analysis about "new issues" with
  the changed codebase.

<!-- Comment:
  Take them with a grain of salt, especially with regard to things like
  architecture-dependent range checks, but many of the complaints from
  the tool are indeed useful.
-->
