### PR TITLE
drivers/usbhid-ups.c: reconnect_ups(): report success more visibly

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -60,6 +60,10 @@ https://github.com/networkupstools/nut/milestone/13
       if `subdriver_command` was assigned (`1A86:7523` is used by CH340/341
       USB chips not only in UPSes). [issue #3410]
 
+ - `usbhid-ups` driver updates:
+    * When reconnecting, report success more visibly (not only in debug), and
+      do not reset driver state to "quiet" when it will loop trying. [PR #3423]
+
  - NUT client libraries:
     * Complete support for actions documented in `docs/net-protocol.txt`
       was implemented in C++, Python and PERL bindings in-tree, and for Java

--- a/drivers/usbhid-ups.c
+++ b/drivers/usbhid-ups.c
@@ -6,7 +6,7 @@
  *   2005-2006 Peter Selinger <selinger@users.sourceforge.net>
  *   2007-2009 Arjen de Korte <adkorte-guest@alioth.debian.org>
  *   2016      Eaton / Arnaud Quette <ArnaudQuette@Eaton.com>
- *   2020-2025 Jim Klimov <jimklimov+nut@gmail.com>
+ *   2020-2026 Jim Klimov <jimklimov+nut@gmail.com>
  *
  * This program was sponsored by MGE UPS SYSTEMS, and now Eaton
  *
@@ -29,7 +29,7 @@
  */
 
 #define DRIVER_NAME	"Generic HID driver"
-#define DRIVER_VERSION	"0.71"
+#define DRIVER_VERSION	"0.72"
 
 #define HU_VAR_WAITBEFORERECONNECT "waitbeforereconnect"
 
@@ -2564,10 +2564,12 @@ static int reconnect_ups(void)
 	ret = comm_driver->open_dev(&udev, &curDevice, subdriver_matcher, NULL);
 	upsdebugx(4, "Opening comm_driver returns ret=%i", ret);
 	if (ret > 0) {
+		upsdebugx(0, "Device has been reconnected");
+		dstate_setinfo("driver.state", "quiet");
 		return 1;
 	}
 
-	dstate_setinfo("driver.state", "quiet");
+	upsdebugx(1, "Device has not been reconnected");
 	return 0;
 }
 


### PR DESCRIPTION
Also fix setting "quiet" driver status when we actualy remain in reconnecting state (or rather will soon re-enter it because the situation is not fixed).

Tested by re-plugging the USB cable and watching debug logs.