### PR TITLE
Fix NSS bundling for Windows clients, do not abort `upsmon` if SSL was not required (and we failed to set it up)

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -103,6 +103,11 @@ https://github.com/networkupstools/nut/milestone/13
  - `upsmon` client updates:
     * Introduced support for `CERTFILE` option, so the client can identify
       itself to the data server also in OpenSSL builds. [issue #3331]
+    * Failure of SSL connection setup (e.g. due to inability to load the
+      NSS library, a practical regression since NUT v2.8.4 release, now that
+      success of SSL initialization with both backends is more diligently
+      tracked) should now not cause exit of the client if secure connection
+      is not required by its configuration in the first place. [#3420]
 
  - Introduced `ci_build.sh` settings and respective CI workflow settings
    to optionally re-use a `config.cache` file from older runs, and similar

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -4188,8 +4188,12 @@ int main(int argc, char *argv[])
 	}
 
 	if (upscli_init2(certverify, certpath, certname, certpasswd, certfile) < 0) {
-		upsnotify(NOTIFY_STATE_STOPPING, "Failed upscli_init2()");
-		exit(EXIT_FAILURE);
+		if (certverify || certpath || certname || certpasswd || certfile) {
+			upslogx(LOG_WARNING, "Failed upscli_init2() while SSL was required");
+			upsnotify(NOTIFY_STATE_STOPPING, "Failed upscli_init2() while SSL was required");
+			exit(EXIT_FAILURE);
+		}
+		upslogx(LOG_WARNING, "Failed upscli_init2() but SSL ability was not required");
 	}
 
 	/* prep our signal handlers */

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -266,17 +266,26 @@ do_dlllddrec() (
 	done
 )
 
+TEMPFILE_REC=''
+TEMPFILE_REC_MADEBY=''
 dlllddrec() {
-	TEMPFILE_REC="`mktemp`" || TEMPFILE_REC=""
-	if [ -n "$TEMPFILE_REC" ] ; then
-		trap 'rm -f "$TEMPFILE_REC"' 0 1 2 3 15
+	if [ -z "$TEMPFILE_REC" ] ; then
+		TEMPFILE_REC="`mktemp`" || TEMPFILE_REC=""
+		if [ -n "$TEMPFILE_REC" ] ; then
+			TEMPFILE_REC_MADEBY='dlllddrec'
+			trap 'rm -f "$TEMPFILE_REC"' 0 1 2 3 15
+			echo "=== Tracking visited files in '${TEMPFILE_REC}' made by '${TEMPFILE_REC_MADEBY}'" >&2
+		fi
 	fi
 
 	# Recurse to find the (mingw-provided) tree of dependencies for one file
+	SEARCH_DLL_PATH="${SEARCH_DLL_PATH}:`dirname \"$1\"`" \
 	do_dlllddrec "$1" | sort | uniq
 
-	rm -f "$TEMPFILE_REC"
-	trap - 0 1 2 3 15
+	if [ x"$TEMPFILE_REC_MADEBY" = x'dlllddrec' ]; then
+		rm -f "$TEMPFILE_REC"
+		trap - 0 1 2 3 15
+	fi
 }
 
 # Alas, can't rely on having BASH, and dash fails to parse its syntax
@@ -310,6 +319,15 @@ dllldddir() (
 		trap "rm -f '$TMP1' '$TMP2'" 0 1 2 3 15
 	#fi
 
+	if [ -z "$TEMPFILE_REC" ] ; then
+		TEMPFILE_REC="`mktemp`" || TEMPFILE_REC=""
+		if [ -n "$TEMPFILE_REC" ] ; then
+			TEMPFILE_REC_MADEBY='dllldddir'
+			trap "rm -f '$TEMPFILE_REC' '$TMP1' '$TMP2'" 0 1 2 3 15
+			echo "=== Tracking visited files in '${TEMPFILE_REC}' made by '${TEMPFILE_REC_MADEBY}'" >&2
+		fi
+	fi
+
 	NEXTDLLS="$SEENDLLS"
 	while [ -n "$NEXTDLLS" ] ; do
 		MOREDLLS="`dllldd $NEXTDLLS | sort | uniq`"
@@ -327,6 +345,10 @@ dllldddir() (
 			SEENDLLS="`( echo \"$SEENDLLS\" ; echo \"$NEXTDLLS\" ) | sort | uniq`"
 		fi
 	done
+
+	if [ x"$TEMPFILE_REC_MADEBY" = x'dllldddir' ]; then
+		rm -f "$TEMPFILE_REC"
+	fi
 
 	if [ -z "$BASH_VERSION" ] ; then
 		rm -f "$TMP1" "$TMP2"
@@ -346,12 +368,26 @@ dllldddir_pedantic() (
 		return
 	fi
 
+	if [ -z "$TEMPFILE_REC" ] ; then
+		TEMPFILE_REC="`mktemp`" || TEMPFILE_REC=""
+		if [ -n "$TEMPFILE_REC" ] ; then
+			TEMPFILE_REC_MADEBY='dllldddir_pedantic'
+			trap "rm -f '$TEMPFILE_REC'" 0 1 2 3 15
+			echo "=== Tracking visited files in '${TEMPFILE_REC}' made by '${TEMPFILE_REC_MADEBY}'" >&2
+		fi
+	fi
+
 	# Two passes: one finds direct dependencies of all EXE/DLL under the
 	# specified location(s); then trims this list to be unique, and then
 	# the second pass recurses those libraries for their dependencies:
 	find "$@" -type f | ${EGREP} -i '\.(exe|dll)$' \
 	| while read E ; do dllldd "$E" ; done | sort | uniq \
 	| while read D ; do echo "$D"; dlllddrec "$D" ; done | sort | uniq
+
+	if [ x"$TEMPFILE_REC_MADEBY" = x'dlllddrec_pedantic' ]; then
+		rm -f "$TEMPFILE_REC"
+		trap - 0 1 2 3 15
+	fi
 )
 
 if [ x"${DLLLDD_SOURCED-}" != xtrue ] ; then

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -64,7 +64,7 @@ discover_COMPILER_PATHS() {
 discover_COMPILER_PATHS
 
 filter_away_system_DLLs() {
-	${EGREP} -v -i '^(/.*/)?(msvcrt|userenv|bcrypt|rpcrt4|usp10|ntdll|api-ms-win-[^ ]*|(advapi|kernel|user|wsock|ws2_|gdi|ole|shell)(32|64))\.dll$'
+	${EGREP} -v -i '^(/.*/)?(msvcrt|userenv|bcrypt|dnsapi|iphlpapi|mswsock|shlwapi|winmm|rpcrt4|usp10|ntdll|api-ms-win-[^ ]*|(advapi|crypt|kernel|user|wsock|ws2_|gdi|ole|shell)(32|64))\.dll$'
 }
 
 filter_away_NUT_DLLs() {

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -83,6 +83,27 @@ dllldd_with_tools() (
 	LC_ALL=C
 	export LANG LC_ALL
 
+	SEARCH_INPUT_PATH="`for F in \"$@\" ; do dirname \"$F\" ; done | sort | uniq | tr '\n' ':' | sed s',:*$,,'`" \
+	&& [ -n "$SEARCH_INPUT_PATH" ] \
+	&& echo "$SEARCH_INPUT_PATH" | ${EGREP} '[^:]' >/dev/null \
+	|| SEARCH_INPUT_PATH=""
+
+	if [ -n "$SEARCH_INPUT_PATH" ] ; then
+		# Here add (our buld products) last in path,
+		# so as to not corrupt real programs' work
+		SEARCH_DLL_PATH="${SEARCH_DLL_PATH}:${SEARCH_INPUT_PATH}"
+	fi
+
+	# Consider the location of investigated input EXE/DLL(s) too:
+	PATH="${SEARCH_DLL_PATH}"
+	export PATH
+	if [ -n "${LD_LIBRARY_PATH}" ] ; then
+		LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${SEARCH_DLL_PATH}"
+	else
+		LD_LIBRARY_PATH="${SEARCH_DLL_PATH}"
+	fi
+	export LD_LIBRARY_PATH
+
 	# Otherwise try objdump, if ARCH is known (linux+mingw builds) or not (MSYS2 builds)
 	SEEN=0
 	if [ -n "${ARCH-}${MINGW_PREFIX-}${MSYSTEM_PREFIX-}" ] ; then
@@ -96,6 +117,14 @@ dllldd_with_tools() (
 				if [ -n "$DESTDIR" -a -d "${DESTDIR}" ] ; then
 					OUT="`find \"$DESTDIR\" -type f -name \"$F\" \! -size 0 2>/dev/null | head -1`" \
 					&& [ -n "$OUT" ] && { echo "$OUT" ; SEEN="`expr $SEEN + 1`" ; continue ; }
+				fi
+				if [ -n "$SEARCH_INPUT_PATH" ] ; then
+					SEEN_INPUT=false
+					for D in `echo "${SEARCH_INPUT_PATH}" | tr ':' '\n'` ; do
+						OUT="`find \"$D\" -type f -name \"$F\" \! -size 0 2>/dev/null | head -1`" \
+						&& [ -n "$OUT" ] && { echo "$OUT" ; SEEN_INPUT=true ; break ; }
+					done
+					$SEEN_INPUT && { SEEN="`expr $SEEN + 1`" ; continue ; }
 				fi
 				if [ -n "$ARCH" -a -d "/usr/${ARCH}" ] ; then
 					OUT="`ls -1 \"/usr/${ARCH}/bin/$F\" \"/usr/${ARCH}/lib/$F\" 2>/dev/null || true`" \
@@ -161,6 +190,15 @@ dllldd() (
 	OUT_TOOLS="`dllldd_with_tools \"$@\"`" && [ -n "${OUT_TOOLS}" ] || RES=$?
 	OUT_STRINGS="`dllldd_with_strings \"$@\" | filter_away_NUT_DLLs`" && [ -n "${OUT_STRINGS}" ] && RES=0
 	( # Subshell to sort results in the end
+	SEARCH_INPUT_PATH="`for F in \"$@\" ; do dirname \"$F\" ; done | sort | uniq | tr '\n' ':' | sed s',:*$,,'`" \
+	&& [ -n "$SEARCH_INPUT_PATH" ] \
+	&& echo "$SEARCH_INPUT_PATH" | ${EGREP} '[^:]' >/dev/null \
+	|| SEARCH_INPUT_PATH=""
+
+	if [ -n "$SEARCH_INPUT_PATH" ] ; then
+		SEARCH_DLL_PATH="${SEARCH_INPUT_PATH}:${SEARCH_DLL_PATH}"
+	fi
+
 	if [ -n "${OUT_TOOLS}" ] ; then
 		echo "${OUT_TOOLS}"
 	fi

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -67,6 +67,12 @@ filter_away_system_DLLs() {
 	${EGREP} -v -i '^(/.*/)?(msvcrt|userenv|bcrypt|rpcrt4|usp10|ntdll|api-ms-win-[^ ]*|(advapi|kernel|user|wsock|ws2_|gdi|ole|shell)(32|64))\.dll$'
 }
 
+filter_away_NUT_DLLs() {
+	# Only use this in search via `strings|grep` (and if coupled with
+	# a tools-based search)
+	${EGREP} -v -i '^(/.*/)?lib(nut|ups)[^ ]*\.dll$'
+}
+
 dllldd_with_tools() (
 	# Traverse an EXE or DLL file for DLLs it needs directly,
 	# which are provided in the cross-build env (not system ones).
@@ -153,7 +159,7 @@ dllldd() (
 	# Did at least one method not-fail and return something?
 	RES=0
 	OUT_TOOLS="`dllldd_with_tools \"$@\"`" && [ -n "${OUT_TOOLS}" ] || RES=$?
-	OUT_STRINGS="`dllldd_with_strings \"$@\"`" && [ -n "${OUT_STRINGS}" ] && RES=0
+	OUT_STRINGS="`dllldd_with_strings \"$@\" | filter_away_NUT_DLLs`" && [ -n "${OUT_STRINGS}" ] && RES=0
 	( # Subshell to sort results in the end
 	if [ -n "${OUT_TOOLS}" ] ; then
 		echo "${OUT_TOOLS}"

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -6,7 +6,7 @@
 # for Windows, bundled with open-source dependencies.
 #
 # Copyright (C)
-#   2022-2025  Jim Klimov <jimklimov+nut@gmail.com>
+#   2022-2026  Jim Klimov <jimklimov+nut@gmail.com>
 
 # tools
 [ -n "${GREP}" ] || { GREP="`command -v grep`" && [ x"${GREP}" != x ] || { echo "$0: FAILED to locate GREP tool" >&2 ; exit 1 ; } ; }
@@ -14,7 +14,25 @@
 
 REGEX_WS="`printf '[\t ]'`"
 REGEX_NOT_WS="`printf '[^\t ]'`"
-dllldd() (
+
+cherrypick_MSYS_DLL_PATH() {
+	echo "${PATH}:${LD_LIBRARY_PATH}" | tr ':' '\n' | \
+	while read D ; do
+		case "$D" in
+			""|/?/*|*/Windows*|*/System*|*/Progra*) continue ;;
+			"${MSYS_HOME}"/*|/mingw*/*|/usr/*|/clang*/*|/?bin/*|/ucrt*/*|/opt/*|/home/*|/var/*|/tmp/*)
+				[ -d "$D" ] && printf '%s:' "$D"
+				;;
+		esac
+	done | sed 's/:*$//'
+}
+SEARCH_DLL_PATH="`cherrypick_MSYS_DLL_PATH`"
+
+filter_away_system_DLLs() {
+	${EGREP} -v -i '^(/.*/)?(msvcrt|userenv|bcrypt|rpcrt4|usp10|ntdll|api-ms-win-[^ ]*|(advapi|kernel|user|wsock|ws2_|gdi|ole|shell)(32|64))\.dll$'
+}
+
+dllldd_with_tools() (
 	# Traverse an EXE or DLL file for DLLs it needs directly,
 	# which are provided in the cross-build env (not system ones).
 	# Assume no whitespaces in paths and filenames of interest.
@@ -30,7 +48,7 @@ dllldd() (
 		for OD in objdump "$ARCH-objdump" ; do
 			(command -v "$OD" >/dev/null 2>/dev/null) || continue
 
-			ODOUT="`$OD -x \"$@\" 2>/dev/null | ${EGREP} -i \"DLL Name:\" | awk '{print $NF}' | sort | uniq | ${EGREP} -v -i '^(/.*/)?(msvcrt|userenv|bcrypt|rpcrt4|usp10|(advapi|kernel|user|wsock|ws2_|gdi|ole||shell)(32|64))\.dll$'`" \
+			ODOUT="`$OD -x \"$@\" 2>/dev/null | ${EGREP} -i \"DLL Name:\" | awk '{print $NF}' | sort | uniq | filter_away_system_DLLs`" \
 			&& [ -n "$ODOUT" ] || continue
 
 			for F in $ODOUT ; do
@@ -90,7 +108,7 @@ dllldd() (
 					done
 				fi
 
-				echo "WARNING: '$F' was not found in searched locations (system paths)!" >&2
+				echo "WARNING: '$F' was not found in searched locations (system paths) by tools matcher ($OD)!" >&2
 			done
 		done
 		if [ "$SEEN" != 0 ] ; then
@@ -105,16 +123,102 @@ dllldd() (
 	OUT="`ldd \"$@\" 2>/dev/null | ${EGREP} -i '\.dll' | ${EGREP} '/(bin|lib)/' | sed \"s,^${REGEX_WS}*\(${REGEX_NOT_WS}${REGEX_NOT_WS}*\)${REGEX_WS}${REGEX_WS}*=>${REGEX_WS}${REGEX_WS}*\(${REGEX_NOT_WS}${REGEX_NOT_WS}*\)${REGEX_WS}.*\$,\2,\" | sort | uniq | ${EGREP} -i '\.dll$'`" \
 	&& [ -n "$OUT" ] && { echo "$OUT" ; return 0 ; }
 
+	echo "WARNING: no suitable DLLs were found in $@ by tools matcher (ldd)!" >&2
 	return 1
 )
 
-dlllddrec() (
-	# Recurse to find the (mingw-provided) tree of dependencies
-	dllldd "$1" | while read D ; do
-		echo "$D"
-		dlllddrec "$D"
-	done | sort | uniq
+dllldd_with_strings() (
+	strings "$@" | ${EGREP} -i '..*\.dll$' | sort | uniq | filter_away_system_DLLs | \
+	while read DLL ; do (
+		# Avoid looping on at least self-reference in a file
+		for S in "$@" ; do
+			# echo "=== Compare '$DLL' to '$S'" >&2
+			case "$DLL" in
+				"$S"|*/"$S") exit ;;
+			esac
+			case "$S" in
+				*/"$DLL") exit ;;
+			esac
+		done
+		# echo "=== '$DLL' not in '$@'" >&2
+		echo "$DLL"
+	) ; done
 )
+
+dllldd() (
+	# Did at least one method not-fail and return something?
+	RES=0
+	OUT_TOOLS="`dllldd_with_tools \"$@\"`" && [ -n "${OUT_TOOLS}" ] || RES=$?
+	OUT_STRINGS="`dllldd_with_strings \"$@\"`" && [ -n "${OUT_STRINGS}" ] && RES=0
+	( # Subshell to sort results in the end
+	if [ -n "${OUT_TOOLS}" ] ; then
+		echo "${OUT_TOOLS}"
+	fi
+	if [ -n "${OUT_STRINGS}" ] ; then
+		OUT_STRINGS_FULL="`echo \"${OUT_STRINGS}\" | ${EGREP} '[/\\]'`" || OUT_STRINGS_FULL=""
+		if [ -n "${OUT_STRINGS_FULL}" ] ; then
+			echo "${OUT_STRINGS_FULL}"
+			OUT_STRINGS="`echo \"${OUT_STRINGS}\" | ${EGREP} -v '[/\\]'`"
+		fi
+
+		for S in ${OUT_STRINGS} ; do
+			if (echo "${OUT_STRINGS_FULL}"; echo "${OUT_TOOLS}") | ${GREP} -i '[/\\]'"$S"'$' ; then
+				# Already a full path name (reported via grep to stdout above)
+				continue
+			fi
+
+			# Something new (e.g. something listed for dynamic loading)...
+
+			# Is it simply in PATH (and deemed executable)?
+			# WARNING: Can return things in system path
+			# command -v "$S" && continue
+
+			echo "${SEARCH_DLL_PATH}" | tr ':' '\n' | {
+				while read D ; do
+					if [ -s "$D/$S" ]; then
+						echo "$D/$S"
+						exit
+					fi
+				done
+
+				echo "WARNING: '$S' was not found in searched locations (system paths) by strings matcher!" >&2
+			}
+		done
+	fi
+	) | sort | uniq
+	return $RES
+)
+
+do_dlllddrec() (
+	# Skip out if we already reported this file
+	if [ -n "$TEMPFILE_REC" ] ; then
+		if ${EGREP} '^'"$1"'$' "$TEMPFILE_REC" >/dev/null 2>/dev/null ; then
+			exit
+		fi
+	fi
+
+	# Recurse to find the (mingw-provided) tree of dependencies - implem
+	echo "=== Recursing into '$1'..." >&2
+	echo "$1" >> "$TEMPFILE_REC"
+	dllldd "$1" | while read DLL_HIT ; do
+		[ -n "$DLL_HIT" ] || continue
+		echo "$DLL_HIT"
+		do_dlllddrec "$DLL_HIT"
+	done
+)
+
+dlllddrec() {
+	TEMPFILE_REC="`mktemp`" || TEMPFILE_REC=""
+	if [ -n "$TEMPFILE_REC" ] ; then
+		trap 'rm -f "$TEMPFILE_REC"' 0 1 2 3 15
+	fi
+
+	# Recurse to find the (mingw-provided) tree of dependencies for one file
+	do_dlllddrec "$1" | sort | uniq
+
+	rm -f "$TEMPFILE_REC"
+	trap - 0 1 2 3 15
+}
 
 # Alas, can't rely on having BASH, and dash fails to parse its syntax
 # even if hidden by conditionals or separate method like this (might
@@ -198,7 +302,13 @@ if [ x"${DLLLDD_SOURCED-}" != xtrue ] ; then
 			cat << EOF
 Tool to find DLLs needed by an EXE or another DLL
 
-Directly used libraries:
+Directly used libraries, search with "proper tools":
+	$0 dllldd_with_tools ONEFILE.EXE
+
+Directly used libraries, search with "strings" and "grep":
+	$0 dllldd_with_strings ONEFILE.EXE
+
+Directly used libraries, combine the two methods above (default):
 	$0 dllldd ONEFILE.EXE
 
 Recursively used libraries:
@@ -210,7 +320,7 @@ and list their set of required DLLs
 	$0 dllldddir_pedantic [DIRNAME...]
 EOF
 			;;
-		dlllddrec|dllldd|dllldddir|dllldddir_pedantic) "$@" ;;
+		dlllddrec|dllldd|dllldd_with_tools|dllldd_with_strings|dllldddir|dllldddir_pedantic) "$@" ;;
 		*) dlllddrec "$1" ;;
 	esac
 

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -178,8 +178,10 @@ dllldd_with_tools() (
 )
 
 dllldd_with_strings() (
-	strings "$@" | ${EGREP} -i '..*\.dll$' | sort | uniq | filter_away_system_DLLs | \
-	while read DLL ; do (
+	strings "$@" | tr ' ' '\n' | tr '&' '\n' \
+	| ${EGREP} -i '..*\.dll$' | sort | uniq \
+	| filter_away_system_DLLs | ${EGREP} -vi '^%s\.dll$' \
+	| while read DLL ; do (
 		# Avoid looping on at least self-reference in a file
 		for S in "$@" ; do
 			# echo "=== Compare '$DLL' to '$S'" >&2

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -106,11 +106,12 @@ dllldd_with_tools() (
 
 	# Otherwise try objdump, if ARCH is known (linux+mingw builds) or not (MSYS2 builds)
 	SEEN=0
+	NOTSEEN_OD=""
 	if [ -n "${ARCH-}${MINGW_PREFIX-}${MSYSTEM_PREFIX-}" ] ; then
 		for OD in objdump "$ARCH-objdump" ; do
 			(command -v "$OD" >/dev/null 2>/dev/null) || continue
 
-			ODOUT="`$OD -x \"$@\" 2>/dev/null | ${EGREP} -i \"DLL Name:\" | awk '{print $NF}' | sort | uniq | filter_away_system_DLLs`" \
+			ODOUT="`$OD -x \"$@\" 2>/dev/null | ${EGREP} -i 'DLL Name:' | awk '{print $NF}' | sort | uniq | filter_away_system_DLLs`" \
 			&& [ -n "$ODOUT" ] || continue
 
 			for F in $ODOUT ; do
@@ -148,21 +149,31 @@ dllldd_with_tools() (
 				fi
 
 				echo "WARNING: '$F' was not found in searched locations (system paths) by tools matcher ($OD)!" >&2
+				NOTSEEN_OD="${NOTSEEN_OD} ${F}"
 			done
 		done
-		if [ "$SEEN" != 0 ] ; then
+		if [ "$SEEN" != 0 ] && [ -z "${NOTSEEN_OD}" ]; then
 			return 0
 		fi
+	else
+		NOTSEEN_OD="$*"
 	fi
 
 	# if `ldd` handles Windows PE (e.g. on MSYS2), we are lucky:
 	#         libiconv-2.dll => /mingw64/bin/libiconv-2.dll (0x7ffd26c90000)
 	# but it tends to say "not a dynamic executable"
 	# or that file type is not supported
-	OUT="`ldd \"$@\" 2>/dev/null | ${EGREP} -i '\.dll' | ${EGREP} '/(bin|lib)/' | sed \"s,^${REGEX_WS}*\(${REGEX_NOT_WS}${REGEX_NOT_WS}*\)${REGEX_WS}${REGEX_WS}*=>${REGEX_WS}${REGEX_WS}*\(${REGEX_NOT_WS}${REGEX_NOT_WS}*\)${REGEX_WS}.*\$,\2,\" | sort | uniq | ${EGREP} -i '\.dll$'`" \
-	&& [ -n "$OUT" ] && { echo "$OUT" ; return 0 ; }
+	if [ -n "${NOTSEEN_OD}" ] ; then
+		# TOTHINK: Tack SEARCH_INPUT_PATH and/or "NOTSEEN"
+		#  into these investigations, for "not found" files
+		#  which may be our own libraries:
+		#    libnutprivate-2_8_5-common-all-1.dll => not found
+		#  Especially if we did not have/run an objdump above.
+		OUT="`ldd \"${NOTSEEN_OD}\" 2>/dev/null | ${EGREP} -i '\.dll' | ${EGREP} '/(bin|lib)/' | sed \"s,^${REGEX_WS}*\(${REGEX_NOT_WS}${REGEX_NOT_WS}*\)${REGEX_WS}${REGEX_WS}*=>${REGEX_WS}${REGEX_WS}*\(${REGEX_NOT_WS}${REGEX_NOT_WS}*\)${REGEX_WS}.*\$,\2,\" | sort | uniq | ${EGREP} -i '\.dll$'`" \
+		&& [ -n "$OUT" ] && { echo "$OUT" ; return 0 ; }
+		echo "WARNING: no suitable DLLs were found in ${NOTSEEN_OD} by tools matcher (ldd)!" >&2
+	fi
 
-	echo "WARNING: no suitable DLLs were found in $@ by tools matcher (ldd)!" >&2
 	return 1
 )
 

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -28,6 +28,41 @@ cherrypick_MSYS_DLL_PATH() {
 }
 SEARCH_DLL_PATH="`cherrypick_MSYS_DLL_PATH`"
 
+discover_COMPILER_PATHS() {
+	# Look for compiler-provided libraries, e.g. in cross-builds on linux+mingw
+	# we have a selection of such C++ required artifacts as:
+	#   /usr/lib/gcc/x86_64-w64-mingw32/9.3-win32/libgcc_s_seh-1.dll
+	#   /usr/lib/gcc/x86_64-w64-mingw32/9.3-win32/libstdc++-6.dll
+	#   /usr/lib/gcc/x86_64-w64-mingw32/9.3-posix/libgcc_s_seh-1.dll
+	#   /usr/lib/gcc/x86_64-w64-mingw32/9.3-posix/libstdc++-6.dll
+	#   /usr/lib/gcc/i686-w64-mingw32/9.3-win32/libstdc++-6.dll
+	#   /usr/lib/gcc/i686-w64-mingw32/9.3-posix/libstdc++-6.dll
+	# while on MSYS2 there is one in standard path matched above:
+	#   /mingw64/bin/libstdc++-6.dll
+	# A clumsy alternative would be to link deliverable C++ libs/bins
+	# statically with "-static-libgcc -static-libstdc++" options.
+	COMPILER_PATHS=""
+	if [ -n "$CC" ] ; then
+		# gcc and clang support this option:
+		COMPILER_PATHS="`$CC --print-search-dirs | ${GREP} libraries: | sed 's,^libraries: *=/,/,'`"
+	else
+		# FIXME: Try to look up in config.log first?
+		if [ -n "$ARCH" ] && (command -v "${ARCH}-gcc") 2>/dev/null >/dev/null ; then
+			COMPILER_PATHS="`\"${ARCH}-gcc\" --print-search-dirs | ${GREP} libraries: | sed 's,^libraries: *=/,/,'`"
+		fi
+	fi
+	if [ -n "$CXX" ] ; then
+		# g++ and clang support this option:
+		COMPILER_PATHS="`$CXX --print-search-dirs | ${GREP} libraries: | sed 's,^libraries: *=/,/,'`:${COMPILER_PATHS}"
+	else
+		# FIXME: Try to look up in config.log first?
+		if [ -n "$ARCH" ] && (command -v "${ARCH}-g++") 2>/dev/null >/dev/null ; then
+			COMPILER_PATHS="`\"${ARCH}-g++\" --print-search-dirs | ${GREP} libraries: | sed 's,^libraries: *=/,/,'`"
+		fi
+	fi
+}
+discover_COMPILER_PATHS
+
 filter_away_system_DLLs() {
 	${EGREP} -v -i '^(/.*/)?(msvcrt|userenv|bcrypt|rpcrt4|usp10|ntdll|api-ms-win-[^ ]*|(advapi|kernel|user|wsock|ws2_|gdi|ole|shell)(32|64))\.dll$'
 }
@@ -69,37 +104,6 @@ dllldd_with_tools() (
 					&& [ -n "$OUT" ] && { echo "$OUT" ; SEEN="`expr $SEEN + 1`" ; continue ; }
 				fi
 
-				# Look for compiler-provided libraries, e.g. in cross-builds on linux+mingw
-				# we have a selection of such C++ required artifacts as:
-				#   /usr/lib/gcc/x86_64-w64-mingw32/9.3-win32/libgcc_s_seh-1.dll
-				#   /usr/lib/gcc/x86_64-w64-mingw32/9.3-win32/libstdc++-6.dll
-				#   /usr/lib/gcc/x86_64-w64-mingw32/9.3-posix/libgcc_s_seh-1.dll
-				#   /usr/lib/gcc/x86_64-w64-mingw32/9.3-posix/libstdc++-6.dll
-				#   /usr/lib/gcc/i686-w64-mingw32/9.3-win32/libstdc++-6.dll
-				#   /usr/lib/gcc/i686-w64-mingw32/9.3-posix/libstdc++-6.dll
-				# while on MSYS2 there is one in standard path matched above:
-				#   /mingw64/bin/libstdc++-6.dll
-				# A clumsy alternative would be to link deliverable C++ libs/bins
-				# statically with "-static-libgcc -static-libstdc++" options.
-				COMPILER_PATHS=""
-				if [ -n "$CC" ] ; then
-					# gcc and clang support this option:
-					COMPILER_PATHS="`$CC --print-search-dirs | ${GREP} libraries: | sed 's,^libraries: *=/,/,'`"
-				else
-					# FIXME: Try to look up in config.log first?
-					if [ -n "$ARCH" ] && (command -v "${ARCH}-gcc") 2>/dev/null >/dev/null ; then
-						COMPILER_PATHS="`\"${ARCH}-gcc\" --print-search-dirs | ${GREP} libraries: | sed 's,^libraries: *=/,/,'`"
-					fi
-				fi
-				if [ -n "$CXX" ] ; then
-					# g++ and clang support this option:
-					COMPILER_PATHS="`$CXX --print-search-dirs | ${GREP} libraries: | sed 's,^libraries: *=/,/,'`:${COMPILER_PATHS}"
-				else
-					# FIXME: Try to look up in config.log first?
-					if [ -n "$ARCH" ] && (command -v "${ARCH}-g++") 2>/dev/null >/dev/null ; then
-						COMPILER_PATHS="`\"${ARCH}-g++\" --print-search-dirs | ${GREP} libraries: | sed 's,^libraries: *=/,/,'`"
-					fi
-				fi
 				if [ -n "$COMPILER_PATHS" ] ; then
 					COMPILER_PATHS="`echo \"$COMPILER_PATHS\" | tr ':' '\n'`"
 					for P in $COMPILER_PATHS ; do


### PR DESCRIPTION
Closes: #3420

* Windows: The 7-zip archive from AppVeyor (and proto area made by our Makefile) did not deliver some libraries apparently needed by `nss3.dll` but not referenced from it in a way visible to `objdump`, `ldd` and similar tools. Hopefully `strings | grep` would fare better to catch such cases.
* All platforms: we no check more diligently for (in)ability to set up SSL, so even the `NoDB` mode in NSS builds failed if the library could not load (due to trouble above). Currently `upsmon` aborted the start-up if it could not initialize SSL (also in older releases), but now this happened with runs that did not require the SSL at all.
  * The method did `return -1` in some failure cases earlier too, so this is not a newly introduced change of behavior. Just there is now more abilities and more error-checking inside.