### PR TITLE
NUT4WIN: Allow 7-zip to store hard-links, allow `make` to create them

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1684,10 +1684,10 @@ install-win-bundle-thirdparty: @dotMAKE@
 	    | while read D ; do \
 	        BD="`basename \"$$D\"`" ; \
 	        if test -e './$(bindir)/'"$$BD" && diff './$(bindir)/'"$$BD" "$$D" 2>/dev/null >/dev/null ; then \
-	            echo "   DLL->bin       $$D : skip (already installed there)" 2>&1 ; \
+	            echo "   DLL->bin	SKIP	$$D : skip (already installed there)" 2>&1 ; \
 	            continue ; \
 	        fi ; \
-	        echo "   DLL->bin       $$D" 2>&1 ; \
+	        echo "   DLL->bin	COPY	$$D" 2>&1 ; \
 	        cp -pf "$$D" './$(bindir)/' ; \
 	    done ; \
 	 ) || exit ; \
@@ -1696,7 +1696,7 @@ install-win-bundle-thirdparty: @dotMAKE@
 	    GREP='$(GREP)' EGREP='$(EGREP)' \
 	    '$(abs_top_srcdir)/scripts/Windows/dllldd.sh' dllldddir . \
 	    | while read D ; do \
-	        echo "   DLL->sbin      $$D (symlink from bindir)" 2>&1 ; \
+	        echo "   DLL->sbin	LINK	$$D (symlink from bindir)" 2>&1 ; \
 	        ln -f '$(DESTDIR)/$(bindir)'/"`basename \"$$D\"`" ./ ; \
 	    done ; \
 	 ) || exit ; \
@@ -1706,7 +1706,7 @@ install-win-bundle-thirdparty: @dotMAKE@
 	    GREP='$(GREP)' EGREP='$(EGREP)' \
 	    '$(abs_top_srcdir)/scripts/Windows/dllldd.sh' dllldddir . \
 	    | while read D ; do \
-	        echo "   DLL->drv       $$D (symlink from bindir)" 2>&1 ; \
+	        echo "   DLL->drv	LINK	$$D (symlink from bindir)" 2>&1 ; \
 	        ln -f '$(DESTDIR)/$(bindir)'/"`basename \"$$D\"`" ./ ; \
 	    done ; \
 	 ) || exit ; \
@@ -1718,7 +1718,7 @@ install-win-bundle-thirdparty: @dotMAKE@
 	    GREP='$(GREP)' EGREP='$(EGREP)' \
 	    '$(abs_top_srcdir)/scripts/Windows/dllldd.sh' dllldddir . \
 	    | while read D ; do \
-	        echo "   DLL->cgi       $$D (symlink from bindir)" 2>&1 ; \
+	        echo "   DLL->cgi	LINK	$$D (symlink from bindir)" 2>&1 ; \
 	        ln -f '$(DESTDIR)/$(bindir)'/"`basename \"$$D\"`" ./ ; \
 	    done ; \
 	 ) || exit ; \
@@ -1730,7 +1730,7 @@ install-win-bundle-thirdparty: @dotMAKE@
 	    GREP='$(GREP)' EGREP='$(EGREP)' \
 	    '$(abs_top_srcdir)/scripts/Windows/dllldd.sh' dllldddir . \
 	    | while read D ; do \
-	        echo "   DLL->libexec   $$D (symlink from bindir)" 2>&1 ; \
+	        echo "   DLL->libexec	LINK	$$D (symlink from bindir)" 2>&1 ; \
 	        ln -f '$(DESTDIR)/$(bindir)'/"`basename \"$$D\"`" ./ ; \
 	    done ; \
 	 ) || exit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,9 @@
 #
 # Network UPS Tools: AppVeyor CI build recipe: NUT for Windows with MSYS2/MinGW x64
 #
+# Copyright (C) 2022-2026	Jim Klimov <jimklimov+nut@gmail.com>
+#
+# Inspired by docs:
 # https://www.msys2.org/docs/ci/
 # https://www.appveyor.com/docs/appveyor-yml/
 # https://www.appveyor.com/docs/build-configuration/
@@ -29,6 +32,7 @@ environment:
   CCACHE_DIR: /home/appveyor/.ccache
   DO_CLEAN_NUTCI_CACHE: no
   DO_USE_NUTCI_CACHE: yes
+  MSYS: "winsymlinks:nativestrict"
 
 # Customize GH notification message template
 # TODO: for repetitive commits in a PR consider a clean-up GHA like
@@ -172,7 +176,8 @@ after_test:
         C:\msys64\usr\bin\bash -lc 'date -u; set -e ; rm -rf ./.inst/NUT-for-Windows-x86_64-SNAPSHOT || true ; ln -fs "NUT-for-Windows-x86_64-SNAPSHOT-%APPVEYOR_BUILD_VERSION%" ./.inst/NUT-for-Windows-x86_64-SNAPSHOT ; ( cd .inst/NUT-for-Windows-x86_64-SNAPSHOT ; find . -ls ; )'
         C:\msys64\usr\bin\bash -lc 'date -u'
         cd .inst
-        7z a ../NUT-for-Windows-x86_64-SNAPSHOT-%APPVEYOR_BUILD_VERSION%.7z NUT*
+        REM 7z -snh: hoping for a version that can save hardlinks as such, and in 7z format to boot:
+        7z a -snh ../NUT-for-Windows-x86_64-SNAPSHOT-%APPVEYOR_BUILD_VERSION%.7z NUT*
 
   # Consider APPVEYOR_PULL_REQUEST_HEAD_COMMIT (PR) vs APPVEYOR_REPO_COMMIT (target branch, or ephemeral)
   - ps: |

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -71,7 +71,7 @@ discover_COMPILER_PATHS() {
 discover_COMPILER_PATHS
 
 filter_away_system_DLLs() {
-	${EGREP} -v -i '^(/.*/)?(msvcrt|userenv|bcrypt|dnsapi|dwrite|iphlpapi|mswsock|shlwapi|winmm|rpcrt4|usp10|ntdll|api-ms-win-[^ ]*|(advapi|crypt|kernel|user|wsock|ws2_|gdi|ole|shell)(32|64))'"${DLLEXT_REGEX_EOL}"
+	${EGREP} -v -i '^(/.*/)?(msvcrt|userenv|bcrypt|bcryptprimitives|dnsapi|dwrite|iphlpapi|kernelbase|mswsock|shlwapi|winmm|rpcrt4|usp10|ntdll|api-ms-win-[^ ]*|(advapi|crypt|kernel|user|wsock|ws2_|gdi|ole|shell)(32|64))'"${DLLEXT_REGEX_EOL}"
 }
 
 filter_away_NUT_DLLs() {

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -109,14 +109,15 @@ dllldd_with_tools() (
 	fi
 	export LD_LIBRARY_PATH
 
-	# Otherwise try objdump, if ARCH is known (linux+mingw builds) or not (MSYS2 builds)
+	# First try objdump, if ARCH is known (linux+mingw builds)
+	# or not (MSYS2 builds)
 	SEEN=0
 	NOTSEEN_OD=""
 	if [ -n "${ARCH-}${MINGW_PREFIX-}${MSYSTEM_PREFIX-}" ] ; then
 		for OD in objdump "$ARCH-objdump" ; do
 			(command -v "$OD" >/dev/null 2>/dev/null) || continue
 
-			ODOUT="`$OD -x \"$@\" 2>/dev/null | ${EGREP} -i 'DLL Name:' | awk '{print $NF}' | sort | uniq | filter_away_system_DLLs`" \
+			ODOUT="`$OD -x \"$@\" 2>/dev/null | ${EGREP} -i '(DLL Name:|^'"${REGEX_WS}"'*NEEDED)' | awk '{print $NF}' | sort | uniq | filter_away_system_DLLs`" \
 			&& [ -n "$ODOUT" ] || continue
 
 			for F in $ODOUT ; do

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -186,7 +186,8 @@ dllldd_with_tools() (
 dllldd_with_strings() (
 	strings "$@" | tr ' ' '\n' | tr '&' '\n' \
 	| ${EGREP} -i '..*'"${DLLEXT_REGEX_EOL}" | sort | uniq \
-	| filter_away_system_DLLs | ${EGREP} -vi '^%s'"${DLLEXT_REGEX_EOL}" \
+	| filter_away_system_DLLs \
+	| ${EGREP} -vi '^(lib)*%s'"${DLLEXT_REGEX_EOL}" \
 	| while read DLL ; do (
 		# Avoid looping on at least self-reference in a file
 		for S in "$@" ; do

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -262,6 +262,11 @@ dllldd() (
 	return $RES
 )
 
+# If present, this file tracks DLL/EXE names we have already recursed into,
+# so we reduce work done and avoid potential infinite looping. Created and
+# later cleaned up by whatever call below happens to be first.
+TEMPFILE_REC=''
+TEMPFILE_REC_MADEBY=''
 do_dlllddrec() (
 	# Skip out if we already reported this file
 	if [ -n "$TEMPFILE_REC" ] ; then
@@ -280,8 +285,6 @@ do_dlllddrec() (
 	done
 )
 
-TEMPFILE_REC=''
-TEMPFILE_REC_MADEBY=''
 dlllddrec() {
 	if [ -z "$TEMPFILE_REC" ] ; then
 		TEMPFILE_REC="`mktemp`" || TEMPFILE_REC=""

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -15,6 +15,11 @@
 REGEX_WS="`printf '[\t ]'`"
 REGEX_NOT_WS="`printf '[^\t ]'`"
 
+# Case-insensitive
+# To test on non-Windows, e.g.:  export DLLEXT_REGEX='\.so(\..*)*'
+[ -n "${DLLEXT_REGEX}" ] || DLLEXT_REGEX='\.dll'
+[ -n "${DLLEXT_REGEX_EOL}" ] || DLLEXT_REGEX_EOL="${DLLEXT_REGEX}"'$'
+
 cherrypick_MSYS_DLL_PATH() {
 	echo "${PATH}:${LD_LIBRARY_PATH}" | tr ':' '\n' | \
 	while read D ; do
@@ -64,13 +69,13 @@ discover_COMPILER_PATHS() {
 discover_COMPILER_PATHS
 
 filter_away_system_DLLs() {
-	${EGREP} -v -i '^(/.*/)?(msvcrt|userenv|bcrypt|dnsapi|iphlpapi|mswsock|shlwapi|winmm|rpcrt4|usp10|ntdll|api-ms-win-[^ ]*|(advapi|crypt|kernel|user|wsock|ws2_|gdi|ole|shell)(32|64))\.dll$'
+	${EGREP} -v -i '^(/.*/)?(msvcrt|userenv|bcrypt|dnsapi|iphlpapi|mswsock|shlwapi|winmm|rpcrt4|usp10|ntdll|api-ms-win-[^ ]*|(advapi|crypt|kernel|user|wsock|ws2_|gdi|ole|shell)(32|64))'"${DLLEXT_REGEX_EOL}"
 }
 
 filter_away_NUT_DLLs() {
 	# Only use this in search via `strings|grep` (and if coupled with
 	# a tools-based search)
-	${EGREP} -v -i '^(/.*/)?lib(nut|ups)[^ ]*\.dll$'
+	${EGREP} -v -i '^(/.*/)?lib(nut|ups)[^ ]*'"${DLLEXT_REGEX_EOL}"
 }
 
 dllldd_with_tools() (
@@ -169,7 +174,7 @@ dllldd_with_tools() (
 		#  which may be our own libraries:
 		#    libnutprivate-2_8_5-common-all-1.dll => not found
 		#  Especially if we did not have/run an objdump above.
-		OUT="`ldd \"${NOTSEEN_OD}\" 2>/dev/null | ${EGREP} -i '\.dll' | ${EGREP} '/(bin|lib)/' | sed \"s,^${REGEX_WS}*\(${REGEX_NOT_WS}${REGEX_NOT_WS}*\)${REGEX_WS}${REGEX_WS}*=>${REGEX_WS}${REGEX_WS}*\(${REGEX_NOT_WS}${REGEX_NOT_WS}*\)${REGEX_WS}.*\$,\2,\" | sort | uniq | ${EGREP} -i '\.dll$'`" \
+		OUT="`ldd \"${NOTSEEN_OD}\" 2>/dev/null | ${EGREP} -i "${DLLEXT_REGEX}" | ${EGREP} '/(bin|lib)/' | sed \"s,^${REGEX_WS}*\(${REGEX_NOT_WS}${REGEX_NOT_WS}*\)${REGEX_WS}${REGEX_WS}*=>${REGEX_WS}${REGEX_WS}*\(${REGEX_NOT_WS}${REGEX_NOT_WS}*\)${REGEX_WS}.*\$,\2,\" | sort | uniq | ${EGREP} -i "${DLLEXT_REGEX_EOL}"`" \
 		&& [ -n "$OUT" ] && { echo "$OUT" ; return 0 ; }
 		echo "WARNING: no suitable DLLs were found in ${NOTSEEN_OD} by tools matcher (ldd)!" >&2
 	fi
@@ -179,8 +184,8 @@ dllldd_with_tools() (
 
 dllldd_with_strings() (
 	strings "$@" | tr ' ' '\n' | tr '&' '\n' \
-	| ${EGREP} -i '..*\.dll$' | sort | uniq \
-	| filter_away_system_DLLs | ${EGREP} -vi '^%s\.dll$' \
+	| ${EGREP} -i '..*'"${DLLEXT_REGEX_EOL}" | sort | uniq \
+	| filter_away_system_DLLs | ${EGREP} -vi '^%s'"${DLLEXT_REGEX_EOL}" \
 	| while read DLL ; do (
 		# Avoid looping on at least self-reference in a file
 		for S in "$@" ; do
@@ -306,7 +311,7 @@ dllldddir() (
 	fi
 
 	# Assume no whitespace in built/MSYS/MinGW paths...
-	ORIGFILES="`find \"$@\" -type f | ${EGREP} -i '\.(exe|dll)$'`" || return
+	ORIGFILES="`find \"$@\" -type f | ${EGREP} -i '(\.exe|'"${DLLEXT_REGEX}"')$'`" || return
 
 	# Quick OK, nothing here?
 	[ -n "$ORIGFILES" ] || return 0
@@ -382,7 +387,7 @@ dllldddir_pedantic() (
 	# Two passes: one finds direct dependencies of all EXE/DLL under the
 	# specified location(s); then trims this list to be unique, and then
 	# the second pass recurses those libraries for their dependencies:
-	find "$@" -type f | ${EGREP} -i '\.(exe|dll)$' \
+	find "$@" -type f | ${EGREP} -i '(\.exe|'"${DLLEXT_REGEX}"')$' \
 	| while read E ; do dllldd "$E" ; done | sort | uniq \
 	| while read D ; do echo "$D"; dlllddrec "$D" ; done | sort | uniq
 

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -174,7 +174,7 @@ dllldd_with_tools() (
 		#  which may be our own libraries:
 		#    libnutprivate-2_8_5-common-all-1.dll => not found
 		#  Especially if we did not have/run an objdump above.
-		OUT="`ldd \"${NOTSEEN_OD}\" 2>/dev/null | ${EGREP} -i "${DLLEXT_REGEX}" | ${EGREP} '/(bin|lib)/' | sed \"s,^${REGEX_WS}*\(${REGEX_NOT_WS}${REGEX_NOT_WS}*\)${REGEX_WS}${REGEX_WS}*=>${REGEX_WS}${REGEX_WS}*\(${REGEX_NOT_WS}${REGEX_NOT_WS}*\)${REGEX_WS}.*\$,\2,\" | sort | uniq | ${EGREP} -i "${DLLEXT_REGEX_EOL}"`" \
+		OUT="`ldd \"${NOTSEEN_OD}\" 2>/dev/null | ${EGREP} -i "${DLLEXT_REGEX}" | ${EGREP} '/(bin|lib)/' | sed \"s,^${REGEX_WS}*\(${REGEX_NOT_WS}${REGEX_NOT_WS}*\)${REGEX_WS}${REGEX_WS}*=>${REGEX_WS}${REGEX_WS}*\(${REGEX_NOT_WS}${REGEX_NOT_WS}*\)\(${REGEX_WS}.*\)*\$,\2,\" | sort | uniq | ${EGREP} -i "${DLLEXT_REGEX_EOL}"`" \
 		&& [ -n "$OUT" ] && { echo "$OUT" ; return 0 ; }
 		echo "WARNING: no suitable DLLs were found in ${NOTSEEN_OD} by tools matcher (ldd)!" >&2
 	fi

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -22,6 +22,12 @@ REGEX_NOT_WS="`printf '[^\t ]'`"
 [ -n "${DLLEXT_REGEX}" ] || DLLEXT_REGEX='\.dll'
 [ -n "${DLLEXT_REGEX_EOL}" ] || DLLEXT_REGEX_EOL="${DLLEXT_REGEX}"'$'
 
+# If present, this file tracks DLL/EXE names we have already recursed into,
+# so we reduce work done and avoid potential infinite looping. Created and
+# later cleaned up by whatever call below happens to be first.
+TEMPFILE_REC=''
+TEMPFILE_REC_MADEBY=''
+
 cherrypick_MSYS_DLL_PATH() {
 	echo "${PATH}:${LD_LIBRARY_PATH}" | tr ':' '\n' | \
 	while read D ; do
@@ -254,6 +260,11 @@ dllldd() (
 				continue
 			fi
 
+			# Skip out if we already reported this file
+			if [ -n "$TEMPFILE_REC" ] && ${EGREP} '^(/.*/)*'"$S"'$' "$TEMPFILE_REC" >/dev/null 2>/dev/null ; then
+				continue
+			fi
+
 			# Something new (e.g. something listed for dynamic loading)...
 
 			# Is it simply in PATH (and deemed executable)?
@@ -274,17 +285,17 @@ dllldd() (
 			fi
 
 			echo "WARNING: '$S' was not found in searched locations (system paths) by strings matcher!" >&2
+
+			if [ -n "$TEMPFILE_REC" ] ; then
+				# Do not drill into this file name in vain, if seen again:
+				echo "$S" >> "$TEMPFILE_REC"
+			fi
 		done
 	fi
 	) | sort | uniq
 	return $RES
 )
 
-# If present, this file tracks DLL/EXE names we have already recursed into,
-# so we reduce work done and avoid potential infinite looping. Created and
-# later cleaned up by whatever call below happens to be first.
-TEMPFILE_REC=''
-TEMPFILE_REC_MADEBY=''
 do_dlllddrec() (
 	# Skip out if we already reported this file
 	if [ -n "$TEMPFILE_REC" ] ; then

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -71,7 +71,7 @@ discover_COMPILER_PATHS() {
 discover_COMPILER_PATHS
 
 filter_away_system_DLLs() {
-	${EGREP} -v -i '^(/.*/)?(msvcrt|userenv|bcrypt|dnsapi|iphlpapi|mswsock|shlwapi|winmm|rpcrt4|usp10|ntdll|api-ms-win-[^ ]*|(advapi|crypt|kernel|user|wsock|ws2_|gdi|ole|shell)(32|64))'"${DLLEXT_REGEX_EOL}"
+	${EGREP} -v -i '^(/.*/)?(msvcrt|userenv|bcrypt|dnsapi|dwrite|iphlpapi|mswsock|shlwapi|winmm|rpcrt4|usp10|ntdll|api-ms-win-[^ ]*|(advapi|crypt|kernel|user|wsock|ws2_|gdi|ole|shell)(32|64))'"${DLLEXT_REGEX_EOL}"
 }
 
 filter_away_NUT_DLLs() {

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -208,7 +208,15 @@ dllldd_with_strings() (
 	| while read DLL ; do (
 		# Skip out if we already reported this file
 		# (The for/case loop below is surprisingly expensive on MSYS2)
+
+		if [ -n "${OUT_TOOLS}" ] && echo "${OUT_TOOLS}" | ${EGREP} '^(/[^ ]*/)*'"$DLL( .*)*$" >/dev/null 2>/dev/null ; then
+			# Skip dllldd_with_strings() findings already seen by dllldd_with_tools()
+			exit
+		fi
+
+
 		if [ -n "$TEMPFILE_REC" ] && ${EGREP} '^(/.*/)*'"$DLL"'$' "$TEMPFILE_REC" >/dev/null 2>/dev/null ; then
+			# Skip older findings made in this process
 			exit
 		fi
 
@@ -232,6 +240,7 @@ dllldd() (
 	# Did at least one method not-fail and return something?
 	RES=0
 	OUT_TOOLS="`dllldd_with_tools \"$@\"`" && [ -n "${OUT_TOOLS}" ] || RES=$?
+	export OUT_TOOLS
 	OUT_STRINGS="`dllldd_with_strings \"$@\" | filter_away_NUT_DLLs`" && [ -n "${OUT_STRINGS}" ] && RES=0
 
 	( # Subshell to sort results in the end
@@ -294,7 +303,10 @@ dllldd() (
 			echo "WARNING: '$S' was not found in searched locations (system paths) by strings matcher!" >&2
 
 			if [ -n "$TEMPFILE_REC" ] ; then
-				# Do not drill into this file name in vain, if seen again:
+				# Do not drill into this file name in vain, if seen again;
+				# only log failures at this point -- do not log successes,
+				# to not preclude iterating into them later if we are part
+				# of dlllddrec() or similar.
 				echo "$S" >> "$TEMPFILE_REC"
 			fi
 		done

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -214,8 +214,9 @@ dllldd_with_strings() (
 			exit
 		fi
 
-
-		if [ -n "$TEMPFILE_REC" ] && ${EGREP} '^(/.*/)*'"$DLL"'$' "$TEMPFILE_REC" >/dev/null 2>/dev/null ; then
+		if [ -n "$TEMPFILE_REC" ] && [ -s "$TEMPFILE_REC" ] \
+		&& ${EGREP} '^(/.*/)*'"$DLL"'$' "$TEMPFILE_REC" >/dev/null 2>/dev/null \
+		; then
 			# Skip older findings made in this process
 			exit
 		fi
@@ -277,7 +278,9 @@ dllldd() (
 			fi
 
 			# Skip out if we already reported this file
-			if [ -n "$TEMPFILE_REC" ] && ${EGREP} '^(/.*/)*'"$S"'$' "$TEMPFILE_REC" >/dev/null 2>/dev/null ; then
+			if [ -n "$TEMPFILE_REC" ] && [ -s "$TEMPFILE_REC" ] \
+			&& ${EGREP} '^(/.*/)*'"$S"'$' "$TEMPFILE_REC" >/dev/null 2>/dev/null \
+			; then
 				continue
 			fi
 
@@ -317,10 +320,10 @@ dllldd() (
 
 do_dlllddrec() (
 	# Skip out if we already reported this file
-	if [ -n "$TEMPFILE_REC" ] ; then
-		if ${EGREP} '^'"$1"'$' "$TEMPFILE_REC" >/dev/null 2>/dev/null ; then
-			exit
-		fi
+	if [ -n "$TEMPFILE_REC" ] && [ -s "$TEMPFILE_REC" ] \
+	&& ${EGREP} '^'"$1"'$' "$TEMPFILE_REC" >/dev/null 2>/dev/null \
+	; then
+		exit
 	fi
 
 	# Recurse to find the (mingw-provided) tree of dependencies - implem

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -67,6 +67,11 @@ discover_COMPILER_PATHS() {
 			COMPILER_PATHS="`\"${ARCH}-g++\" --print-search-dirs | ${GREP} libraries: | sed 's,^libraries: *=/,/,'`"
 		fi
 	fi
+
+	COMPILER_PATHS_MULTILINE=""
+	if [ -n "${COMPILER_PATHS}" ] ; then
+		COMPILER_PATHS_MULTILINE="`echo \"${COMPILER_PATHS}\" | tr ':' '\n'`"
+	fi
 }
 discover_COMPILER_PATHS
 
@@ -91,10 +96,14 @@ dllldd_with_tools() (
 	export LANG LC_ALL
 
 	# Assume forward-slash separated path components:
-	SEARCH_INPUT_PATH="`for F in \"$@\" ; do echo \"$F\" ; done | sed -e 's,^\(.*\)/[^/]*$,\1,' | sort | uniq | tr '\n' ':' | sed s',:*$,,'`" \
-	&& [ -n "$SEARCH_INPUT_PATH" ] \
-	&& echo "$SEARCH_INPUT_PATH" | ${EGREP} '[^:]' >/dev/null \
-	|| SEARCH_INPUT_PATH=""
+	SEARCH_INPUT_PATH=""
+	SEARCH_INPUT_PATH_MULTILINE="`for F in \"$@\" ; do echo \"$F\" ; done | sed -e 's,^\(.*\)/[^/]*$,\1,' | sort | uniq`" \
+	&& [ -n "${SEARCH_INPUT_PATH_MULTILINE}" ] \
+	&& {
+		SEARCH_INPUT_PATH="`echo \"${SEARCH_INPUT_PATH_MULTILINE}\" | tr '\n' ':' | sed s',:*$,,'`" \
+		&& echo "$SEARCH_INPUT_PATH" | ${EGREP} '[^:]' >/dev/null \
+		|| SEARCH_INPUT_PATH=""
+	}
 
 	if [ -n "$SEARCH_INPUT_PATH" ] ; then
 		# Here add (our buld products) last in path,
@@ -130,7 +139,7 @@ dllldd_with_tools() (
 				fi
 				if [ -n "$SEARCH_INPUT_PATH" ] ; then
 					SEEN_INPUT=false
-					for D in `echo "${SEARCH_INPUT_PATH}" | tr ':' '\n'` ; do
+					for D in ${SEARCH_INPUT_PATH_MULTILINE} ; do
 						OUT="`find \"$D\" -type f -name \"$F\" \! -size 0 2>/dev/null | head -1`" \
 						&& [ -n "$OUT" ] && { echo "$OUT" ; SEEN_INPUT=true ; break ; }
 					done
@@ -149,9 +158,8 @@ dllldd_with_tools() (
 					&& [ -n "$OUT" ] && { echo "$OUT" ; SEEN="`expr $SEEN + 1`" ; continue ; }
 				fi
 
-				if [ -n "$COMPILER_PATHS" ] ; then
-					COMPILER_PATHS="`echo \"$COMPILER_PATHS\" | tr ':' '\n'`"
-					for P in $COMPILER_PATHS ; do
+				if [ -n "${COMPILER_PATHS_MULTILINE}" ] ; then
+					for P in ${COMPILER_PATHS_MULTILINE} ; do
 						OUT="`ls -1 \"${P}/$F\" 2>/dev/null || true`" \
 						&& [ -n "$OUT" ] && { echo "$OUT" ; SEEN="`expr $SEEN + 1`" ; continue 2 ; }
 					done
@@ -212,6 +220,7 @@ dllldd() (
 	RES=0
 	OUT_TOOLS="`dllldd_with_tools \"$@\"`" && [ -n "${OUT_TOOLS}" ] || RES=$?
 	OUT_STRINGS="`dllldd_with_strings \"$@\" | filter_away_NUT_DLLs`" && [ -n "${OUT_STRINGS}" ] && RES=0
+
 	( # Subshell to sort results in the end
 	SEARCH_INPUT_PATH="`for F in \"$@\" ; do  echo \"$F\" ; done | sed -e 's,^\(.*\)/[^/]*$,\1,' | sort | uniq | tr '\n' ':' | sed s',:*$,,'`" \
 	&& [ -n "$SEARCH_INPUT_PATH" ] \
@@ -222,14 +231,19 @@ dllldd() (
 		SEARCH_DLL_PATH="${SEARCH_INPUT_PATH}:${SEARCH_DLL_PATH}"
 	fi
 
+	SEARCH_DLL_PATH_MULTILINE="`echo \"${SEARCH_DLL_PATH}\" | tr ':' '\n'`"
+
 	if [ -n "${OUT_TOOLS}" ] ; then
+		# Report (presumed fully-qualified) findings from objdump/ldd
 		echo "${OUT_TOOLS}"
 	fi
+
 	if [ -n "${OUT_STRINGS}" ] ; then
 		# NOTE: Strings built into binaries might have Windows back-slashes,
 		# so just in case - cater for them too here:
 		OUT_STRINGS_FULL="`echo \"${OUT_STRINGS}\" | ${EGREP} '[/\\]'`" || OUT_STRINGS_FULL=""
 		if [ -n "${OUT_STRINGS_FULL}" ] ; then
+			# Report full names right away, iterate only those that remain
 			echo "${OUT_STRINGS_FULL}"
 			OUT_STRINGS="`echo \"${OUT_STRINGS}\" | ${EGREP} -v '[/\\]'`"
 		fi
@@ -246,16 +260,20 @@ dllldd() (
 			# WARNING: Can return things in system path
 			# command -v "$S" && continue
 
-			echo "${SEARCH_DLL_PATH}" | tr ':' '\n' | {
-				while read D ; do
-					if [ -s "$D/$S" ]; then
-						echo "$D/$S"
-						exit
-					fi
-				done
+			SEEN_INPUT=false
+			for D in ${SEARCH_DLL_PATH_MULTILINE} ; do
+				if [ -s "$D/$S" ]; then
+					echo "$D/$S"
+					SEEN_INPUT=true
+					break
+				fi
+			done
 
-				echo "WARNING: '$S' was not found in searched locations (system paths) by strings matcher!" >&2
-			}
+			if $SEEN_INPUT ; then
+				continue
+			fi
+
+			echo "WARNING: '$S' was not found in searched locations (system paths) by strings matcher!" >&2
 		done
 	fi
 	) | sort | uniq

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -423,7 +423,12 @@ and list their set of required DLLs
 EOF
 			;;
 		dlllddrec|dllldd|dllldd_with_tools|dllldd_with_strings|dllldddir|dllldddir_pedantic) "$@" ;;
-		*) dlllddrec "$1" ;;
+		*)	if [ -d "$1" ] ; then
+				dllldddir "$1"
+			else
+				dlllddrec "$1"
+			fi
+			;;
 	esac
 
 	exit 0

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -328,7 +328,7 @@ dlllddrec() {
 	SEARCH_DLL_PATH="${SEARCH_DLL_PATH}:`dirname \"$1\"`" \
 	do_dlllddrec "$1" | sort | uniq
 
-	if [ x"$TEMPFILE_REC_MADEBY" = x'dlllddrec' ]; then
+	if [ x"$TEMPFILE_REC_MADEBY" = x'dlllddrec' ] && [ -n "$TEMPFILE_REC" ]; then
 		rm -f "$TEMPFILE_REC"
 		trap - 0 1 2 3 15
 	fi
@@ -355,24 +355,33 @@ dllldddir() (
 	# Quick OK, nothing here?
 	[ -n "$ORIGFILES" ] || return 0
 
-	# Loop until we see nothing new:
-	SEENDLLS="`dllldd $ORIGFILES | sort | uniq`"
-	[ -n "$SEENDLLS" ] || return 0
-
-	#if [ -z "$BASH_VERSION" ] ; then
-		TMP1="`mktemp`"
-		TMP2="`mktemp`"
-		trap "rm -f '$TMP1' '$TMP2'" 0 1 2 3 15
-	#fi
-
 	if [ -z "$TEMPFILE_REC" ] ; then
 		TEMPFILE_REC="`mktemp`" || TEMPFILE_REC=""
 		if [ -n "$TEMPFILE_REC" ] ; then
 			TEMPFILE_REC_MADEBY='dllldddir'
-			trap "rm -f '$TEMPFILE_REC' '$TMP1' '$TMP2'" 0 1 2 3 15
+			trap "rm -f '$TEMPFILE_REC'" 0 1 2 3 15
 			echo "=== Tracking visited files in '${TEMPFILE_REC}' made by '${TEMPFILE_REC_MADEBY}'" >&2
 		fi
 	fi
+
+	# Loop until we see nothing new:
+	SEENDLLS="`dllldd $ORIGFILES | sort | uniq`"
+	[ -n "$SEENDLLS" ] || {
+		if [ x"$TEMPFILE_REC_MADEBY" = x'dllldddir' ] && [ -n "$TEMPFILE_REC" ] ; then
+			rm -f "$TEMPFILE_REC"
+		fi
+		return 0
+	}
+
+	#if [ -z "$BASH_VERSION" ] ; then
+		TMP1="`mktemp`"
+		TMP2="`mktemp`"
+		if [ -n "$TEMPFILE_REC" ] ; then
+			trap "rm -f '$TEMPFILE_REC' '$TMP1' '$TMP2'" 0 1 2 3 15
+		else
+			trap "rm -f '$TMP1' '$TMP2'" 0 1 2 3 15
+		fi
+	#fi
 
 	NEXTDLLS="$SEENDLLS"
 	while [ -n "$NEXTDLLS" ] ; do
@@ -392,7 +401,7 @@ dllldddir() (
 		fi
 	done
 
-	if [ x"$TEMPFILE_REC_MADEBY" = x'dllldddir' ]; then
+	if [ x"$TEMPFILE_REC_MADEBY" = x'dllldddir' ] && [ -n "$TEMPFILE_REC" ]; then
 		rm -f "$TEMPFILE_REC"
 	fi
 
@@ -430,7 +439,7 @@ dllldddir_pedantic() (
 	| while read E ; do dllldd "$E" ; done | sort | uniq \
 	| while read D ; do echo "$D"; dlllddrec "$D" ; done | sort | uniq
 
-	if [ x"$TEMPFILE_REC_MADEBY" = x'dlllddrec_pedantic' ]; then
+	if [ x"$TEMPFILE_REC_MADEBY" = x'dlllddrec_pedantic' ] && [ -n "$TEMPFILE_REC" ]; then
 		rm -f "$TEMPFILE_REC"
 		trap - 0 1 2 3 15
 	fi

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -206,6 +206,12 @@ dllldd_with_strings() (
 	| filter_away_system_DLLs \
 	| ${EGREP} -vi '^(lib)*%s'"${DLLEXT_REGEX_EOL}" \
 	| while read DLL ; do (
+		# Skip out if we already reported this file
+		# (The for/case loop below is surprisingly expensive on MSYS2)
+		if [ -n "$TEMPFILE_REC" ] && ${EGREP} '^(/.*/)*'"$DLL"'$' "$TEMPFILE_REC" >/dev/null 2>/dev/null ; then
+			exit
+		fi
+
 		# Avoid looping on at least self-reference in a file
 		for S in "$@" ; do
 			# echo "=== Compare '$DLL' to '$S'" >&2
@@ -216,6 +222,7 @@ dllldd_with_strings() (
 				*/"$DLL") exit ;;
 			esac
 		done
+
 		# echo "=== '$DLL' not in '$@'" >&2
 		echo "$DLL"
 	) ; done

--- a/scripts/Windows/dllldd.sh
+++ b/scripts/Windows/dllldd.sh
@@ -5,6 +5,8 @@
 # environment. It can do so recursively, to facilitate installation of NUT
 # for Windows, bundled with open-source dependencies.
 #
+# Assumes no whitespace in dir/file names, and forward slash as separator.
+#
 # Copyright (C)
 #   2022-2026  Jim Klimov <jimklimov+nut@gmail.com>
 
@@ -88,7 +90,8 @@ dllldd_with_tools() (
 	LC_ALL=C
 	export LANG LC_ALL
 
-	SEARCH_INPUT_PATH="`for F in \"$@\" ; do dirname \"$F\" ; done | sort | uniq | tr '\n' ':' | sed s',:*$,,'`" \
+	# Assume forward-slash separated path components:
+	SEARCH_INPUT_PATH="`for F in \"$@\" ; do echo \"$F\" ; done | sed -e 's,^\(.*\)/[^/]*$,\1,' | sort | uniq | tr '\n' ':' | sed s',:*$,,'`" \
 	&& [ -n "$SEARCH_INPUT_PATH" ] \
 	&& echo "$SEARCH_INPUT_PATH" | ${EGREP} '[^:]' >/dev/null \
 	|| SEARCH_INPUT_PATH=""
@@ -210,7 +213,7 @@ dllldd() (
 	OUT_TOOLS="`dllldd_with_tools \"$@\"`" && [ -n "${OUT_TOOLS}" ] || RES=$?
 	OUT_STRINGS="`dllldd_with_strings \"$@\" | filter_away_NUT_DLLs`" && [ -n "${OUT_STRINGS}" ] && RES=0
 	( # Subshell to sort results in the end
-	SEARCH_INPUT_PATH="`for F in \"$@\" ; do dirname \"$F\" ; done | sort | uniq | tr '\n' ':' | sed s',:*$,,'`" \
+	SEARCH_INPUT_PATH="`for F in \"$@\" ; do  echo \"$F\" ; done | sed -e 's,^\(.*\)/[^/]*$,\1,' | sort | uniq | tr '\n' ':' | sed s',:*$,,'`" \
 	&& [ -n "$SEARCH_INPUT_PATH" ] \
 	&& echo "$SEARCH_INPUT_PATH" | ${EGREP} '[^:]' >/dev/null \
 	|| SEARCH_INPUT_PATH=""
@@ -223,6 +226,8 @@ dllldd() (
 		echo "${OUT_TOOLS}"
 	fi
 	if [ -n "${OUT_STRINGS}" ] ; then
+		# NOTE: Strings built into binaries might have Windows back-slashes,
+		# so just in case - cater for them too here:
 		OUT_STRINGS_FULL="`echo \"${OUT_STRINGS}\" | ${EGREP} '[/\\]'`" || OUT_STRINGS_FULL=""
 		if [ -n "${OUT_STRINGS_FULL}" ] ; then
 			echo "${OUT_STRINGS_FULL}"


### PR DESCRIPTION
This should optimize the NUT for Windows installed footprint a bit, and speed up builds (link not copy the library files), see #2800.

The archive part may however be subject to un-availability of the feature in 7zip tool/format until the sunny day they implement their side.

An alternate space-saving measure could be to `configure` the NUT for Windows builds dump all programs and DLLs into one `bin` directory (which may be deemed potentially unsafe with CGI; less of a problem with `sbin` and `libexec`)...