### PR TITLE
drivers/nutdrv_qx_megatec.c: add QX_FLAG_ABSENT to "ups.firmware"…

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -58,6 +58,13 @@ https://github.com/networkupstools/nut/milestone/13
     * Only claim a USB device as "supported" during discovery out of the box
       if `subdriver_command` was assigned (`1A86:7523` is used by CH340/341
       USB chips not only in UPSes). [issue #3410]
+    * Modified `megatec` subdriver to allow `ups.firmware` with empty contents
+      (when a device returns all-spaces in that part of the `I` query response)
+      out of the box and not ignore the device as unsupported, by adding the
+      `QX_FLAG_ABSENT` in the mapping table. The practical effect should be
+      similar to specifying `novendor` in the `ups.conf` (except that the
+      option bypasses the check altogether, so driver instances handling well
+      behaved devices would also not show their manufacturer). [issue #3436]
 
  - `usbhid-ups` driver updates:
     * When reconnecting, report success more visibly (not only in debug), and

--- a/drivers/nutdrv_qx_megatec.c
+++ b/drivers/nutdrv_qx_megatec.c
@@ -25,7 +25,7 @@
 
 #include "nutdrv_qx_megatec.h"
 
-#define MEGATEC_VERSION "Megatec 0.09"
+#define MEGATEC_VERSION "Megatec 0.10"
 
 /* qx2nut lookup table */
 static item_t	megatec_qx2nut[] = {
@@ -100,7 +100,17 @@ static item_t	megatec_qx2nut[] = {
 	{ "ups.serial",			0,	NULL,	"I\r",	"",	38,	'#',	"",	8,	15,	"%s",	0,	NULL,	NULL,	NULL },	/* Megatec IC adds "ups.serial" support function */
 	{ "device.model",		0,	NULL,	"I\r",	"",	38,	'#',	"",	17,	21,	"%s",	QX_FLAG_STATIC | QX_FLAG_TRIM,	NULL,	NULL,	NULL },	/* Shorter field than in other dialects */
 	{ "battery.runtime",		0,	NULL,	"I\r",	"",	38,	'#',	"",	22,	26,	"%s",	QX_FLAG_TRIM,	NULL,	NULL,	NULL },	/* Megatec IC adds "ups.runtime" support function */
-	{ "ups.firmware",		0,	NULL,	"I\r",	"",	38,	'#',	"",	28,	0,	"%s",	QX_FLAG_STATIC | QX_FLAG_TRIM,	NULL,	NULL,	NULL },	/* Note: Per example above, this should end at 36 not 37 as in other dialects; we say 0 to go to end of line, wherever that is in fact */
+
+	/* Notes:
+	 * 1) Per example above, this should end at 36 not 37 as in other dialects;
+	 *    we say 0 to go to end of line, wherever that is in fact;
+	 * 2) The QX_FLAG_ABSENT allows the driver init to not ignore devices which
+	 *    return all-spaces here, and the driver trims that - and treats the
+	 *    absent version immediately as the lack of protocol support. The effect
+	 *    should be similar to specifying "novendor" which bypasses the query
+	 *    altogether. TOTHINK: Set a default like "UNKNOWN"? [#3436]
+	 */
+	{ "ups.firmware",		0,	NULL,	"I\r",	"",	38,	'#',	"",	28,	0,	"%s",	QX_FLAG_STATIC | QX_FLAG_TRIM | QX_FLAG_ABSENT,	NULL,	NULL,	NULL },
 
 	/* Instant commands */
 	{ "beeper.toggle",		0,	NULL,	"Q\r",		"",	0,	0,	"",	0,	0,	NULL,	QX_FLAG_CMD,	NULL,	NULL,	NULL },


### PR DESCRIPTION
…so devices with all-spaces in that field can still be recognized

Closes: #3436

An UPS returned a reply to the `I` query which the subdriver interpreted as lack of "ups.firmware" and discarded the device as unsupported, unless `novendor` was added into the settings (which needs an end-user to discover that this option exists and might help).

According to an experiment in that issue discussion, this change should not impact well-behaved devices which report a real manufacturer string here.

One point not decided yet is whether the NUT driver should stick with the returned value (all-spaces or trimmed-empty string), or stick some fallback like `UNKNOWN` in there?

Thanks @siravijbb