### PR TITLE
nutdrv_qx: Fix armac subdriver failing on 7-byte interrupt reads

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -73,7 +73,7 @@ https://github.com/networkupstools/nut/milestone/13
       8 bytes per read instead of strictly requiring 6 bytes. This resolves
       an initialization failure with certain UPS models (e.g., SVC
       VP-1250-LCD) that return a 7-byte report instead of the standard 6 bytes,
-      allowing the Megatec payload to be successfully reconstructed.
+      allowing the Megatec payload to be successfully reconstructed. [PR #3485]
 
  - `usbhid-ups` driver updates:
     * When reconnecting, report success more visibly (not only in debug), and

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -69,6 +69,11 @@ https://github.com/networkupstools/nut/milestone/13
       similar to specifying `novendor` in the `ups.conf` (except that the
       option bypasses the check altogether, so driver instances handling well
       behaved devices would also not show their manufacturer). [issue #3436]
+    * Modified `armac` subdriver's USB interrupt read logic to request up to
+      8 bytes per read instead of strictly requiring 6 bytes. This resolves
+      an initialization failure with certain UPS models (e.g., SVC
+      VP-1250-LCD) that return a 7-byte report instead of the standard 6 bytes,
+      allowing the Megatec payload to be successfully reconstructed.
 
  - `usbhid-ups` driver updates:
     * When reconnecting, report success more visibly (not only in debug), and

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -1408,6 +1408,8 @@
 
 "SuperPower"	"ups"	"2"	"HP360, Hope-550"	""	"blazer_ser"
 
+"SVC"	"ups"	"2"	"VP-1250-LCD 1250VA"	"(USB ID 0925:1234, armac subdriver, megatec protocol)"	"nutdrv_qx"	# https://github.com/networkupstools/nut/pull/3485
+
 "SVEN"	"ups"	"2"	"Power Pro+ series"	"USB"	"blazer_usb (USB ID ffff:0000)"
 "SVEN"	"ups"	"2"	"Power Pro+ series"	"USB"	"blazer_usb (USB ID 05b8:0000)"
 "SVEN"	"ups"	"1"	"Power Pro+ series"	"USB"	"richcomm_usb (USB ID 0925:1234)"

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -58,7 +58,7 @@
 #	define DRIVER_NAME	"Generic Q* Serial driver"
 #endif	/* QX_USB */
 
-#define DRIVER_VERSION	"0.50"
+#define DRIVER_VERSION	"0.51"
 
 #ifdef QX_SERIAL
 #	include "serial.h"
@@ -2200,8 +2200,14 @@ static void load_armac_endpoint_cache(void)
  * software, which doesn't seem to be Armac specific. The banner is: "2004
  * Richcomm Technologies, Inc. Dec 27 2005 ver 1.1." Maybe other Richcomm UPSes
  * would work with this - better than with the richcomm_usb driver.
+ *
+ * NOTE: ARMAC_READ_SIZE_FOR_CONTROL is set to 8. While some Armac devices
+ * return exactly 6 bytes per interrupt read (1 control byte + 5 data bytes),
+ * others return 7 bytes (1 control byte + 6 data bytes). Requesting 8 bytes
+ * safely accommodates these variations (up to endpoint MaxPacketSize) without
+ * dropping trailing bytes or timing out.
  */
-#define ARMAC_READ_SIZE_FOR_CONTROL 6
+#define ARMAC_READ_SIZE_FOR_CONTROL 8
 #define ARMAC_READ_SIZE_FOR_INTERRUPT 64
 static int	armac_command(const char *cmd, size_t cmdlen, char *buf, size_t buflen)
 {
@@ -2282,8 +2288,8 @@ static int	armac_command(const char *cmd, size_t cmdlen, char *buf, size_t bufle
 		/* Cleanup buffer before sending a new command */
 		for (i = 0; i < 10; i++) {
 			ret = usb_interrupt_read(udev, 0x81,
-				(usb_ctrl_charbuf)tmpbuf, ARMAC_READ_SIZE_FOR_CONTROL, 100);
-			if (ret != ARMAC_READ_SIZE_FOR_CONTROL) {
+				(usb_ctrl_charbuf)tmpbuf, read_size, 100);
+			if (ret <= 0) {
 				/* Timeout - buffer is clean. */
 				break;
 			}
@@ -2322,14 +2328,14 @@ static int	armac_command(const char *cmd, size_t cmdlen, char *buf, size_t bufle
 	while (bufpos + read_size + 1 < buflen) {
 		size_t bytes_available;
 
-		/* Read data in 6-byte chunks */
+		/* Read data in chunks (read_size handles both 8-byte control and 64-byte interrupt cases) */
 		ret = usb_interrupt_read(udev, use_interrupt ? armac_endpoint_cache.in_endpoint_address : 0x81,
 			(usb_ctrl_charbuf)tmpbuf, read_size, 1000);
 
 		/* Any errors here mean that we are unable to read a reply
 		 * (which will happen after successfully writing a command
 		 * to the UPS) */
-		if (ret != read_size) {
+		if (ret <= 0) {
 			/* NOTE: If end condition is invalid for particular UPS we might make one
 			 * request more and get this error. If bufpos > (say) 10 this could be ignored
 			 * and the reply correctly read. */
@@ -2360,9 +2366,9 @@ static int	armac_command(const char *cmd, size_t cmdlen, char *buf, size_t bufle
 			break;
 		}
 
-		if (bytes_available > (unsigned)read_size - 1) {
-			/* Single interrupt transfer has 1 control + 5 data bytes */
-			bytes_available = read_size - 1;
+		if (bytes_available > (unsigned)ret - 1) {
+			/* Do not read past what we actually received */
+			bytes_available = ret - 1;
 		}
 
 		/* Copy bytes into the final buffer while detecting end of line - \r */


### PR DESCRIPTION
Fixes https://github.com/networkupstools/nut/issues/3484

## Description

This PR fixes an issue in the `nutdrv_qx` driver (specifically the `armac` subdriver) that prevented it from communicating with some specific UPS devices.

Previously, the `armac_command` loop strictly checked if the number of bytes returned by `usb_interrupt_read` was exactly `6` (`ARMAC_READ_SIZE_FOR_CONTROL`). However, looks like some hardware implementations of this USB interface return a 7-byte report. 

Because `ret` was `7` and `read_size` was `6`, the driver would hit `if (ret != read_size)`, treat it as an error, and abort. This caused the driver to fail entirely during initialization.

## Changes Made

1. Changed `ARMAC_READ_SIZE_FOR_CONTROL` from `6` to `8`. Requesting 8 bytes ensures the read operation can accommodate both 6-byte and 7-byte reports.
2. Replaced the strict `if (ret != read_size)` check with `if (ret <= 0)` in both `armac_command` read loops. This allows the driver to proceed if the report is successfully read.

Since the first byte of the report acts as a header that contains the actual length of the payload (extracted via `tmpbuf[0] & 0x3F`), the parsing logic itself doesn't need any changes. The driver will safely extract the correct number of Megatec string characters, whether it received a 6-byte or a 7-byte report.

## Testing Performed

Tested with the SVC VP-1250-LCD UPS on Windows.
- Before patch: Driver fails immediately with `[D1:test] interrupt read error: Other error (7)`.
- After patch: Driver correctly parses the full Megatec string and correctly claims the `Megatec 0.10` protocol. All sensors (Input Voltage, Output Voltage, Battery, Load, Frequency) are correctly populated.
