### PR TITLE
Rework client password input

### DIFF
--- a/clients/Makefile.am
+++ b/clients/Makefile.am
@@ -125,9 +125,9 @@ endif WITH_CGI
 upsc_SOURCES = upsc.c upsclient.h
 upsc_LDADD = $(LDADD_CLIENT) $(top_builddir)/common/libcommonstrjson.la
 
-upscmd_SOURCES = upscmd.c upsclient.h
+upscmd_SOURCES = upscmd.c upsclient.h common-clients.c common-clients.h
 
-upsrw_SOURCES = upsrw.c upsclient.h
+upsrw_SOURCES = upsrw.c upsclient.h common-clients.c common-clients.h
 
 upslog_SOURCES = upslog.c upsclient.h upslog.h
 upslog_LDADD = $(LDADD_FULL)

--- a/clients/common-clients.c
+++ b/clients/common-clients.c
@@ -3,6 +3,14 @@
 #endif
 
 #include "common-clients.h"
+#include "proto.h"
+#ifdef WIN32
+#include "wincompat.h"
+#endif	/* WIN32 */
+
+#include <ctype.h>
+#include <stdio.h>
+#include <string.h>
 
 #if defined(HAVE_BSD_READPASSPHRASE_H)
 # include <bsd/readpassphrase.h>
@@ -30,4 +38,32 @@ char * read_password(char *buffer, size_t buffer_size)
     memset(pwtmp, 0, strlen(pwtmp));
     return buffer;
 #endif
+}
+
+
+char * read_passwordfile(const char *filename, char *buffer, size_t buffer_size)
+{
+    FILE *fp;
+    char *p;
+
+    fp = fopen(filename, "r");
+    if (fp == NULL)
+        return NULL;
+
+    p = fgets(buffer, buffer_size, fp);
+    if (p)
+    {
+        /* trim trailing spaces & newlines */
+        char *end = buffer + strlen(buffer) - 1;
+        while (end > buffer && isspace(*end))
+            --end;
+
+        *++end = '\0';
+        /* fail if buffer now empty */
+        if (*buffer == '\0')
+            p = NULL;
+    }
+
+    fclose(fp);
+    return p;
 }

--- a/clients/common-clients.c
+++ b/clients/common-clients.c
@@ -1,0 +1,33 @@
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#include "common-clients.h"
+
+#if defined(HAVE_BSD_READPASSPHRASE_H)
+# include <bsd/readpassphrase.h>
+#elif defined(HAVE_READPASSPHRASE_H)
+# include <readpassphrase.h>
+#elif !defined(WIN32) && defined(HAVE_UNISTD_H)
+# include <unistd.h>	/* getpass */
+#endif
+
+
+char * read_password(char *buffer, size_t buffer_size)
+{
+#if defined(HAVE_READPASSPHRASE_H) || defined(HAVE_BSD_READPASSPHRASE_H)
+    return readpassphrase("Password: ", buffer, buffer_size, RPP_ECHO_OFF);
+#else
+    /* fallback to getpass, win32 has a version in wincompat.c */
+
+	char *pwtmp = GETPASS("Password: ");
+    if (pwtmp == NULL)
+        return NULL;
+
+    strncpy(buffer, pwtmp, buffer_size);
+    buffer[buffer_size - 1] = '\0';
+
+    memset(pwtmp, 0, strlen(pwtmp));
+    return buffer;
+#endif
+}

--- a/clients/common-clients.h
+++ b/clients/common-clients.h
@@ -1,0 +1,22 @@
+#ifndef COMMON_CLIENT_H_SEEN
+#define COMMON_CLIENT_H_SEEN 1
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+/* *INDENT-OFF* */
+extern "C" {
+/* *INDENT-ON* */
+#endif
+
+
+char * read_password(char *buffer, size_t buffer_size);
+
+
+#ifdef __cplusplus
+/* *INDENT-OFF* */
+}
+/* *INDENT-ON* */
+#endif
+
+#endif /* COMMON_CLIENT_H_SEEN */

--- a/clients/common-clients.h
+++ b/clients/common-clients.h
@@ -11,6 +11,7 @@ extern "C" {
 
 
 char * read_password(char *buffer, size_t buffer_size);
+char * read_passwordfile(const char *filename, char *buffer, size_t buffer_size);
 
 
 #ifdef __cplusplus

--- a/clients/upscmd.c
+++ b/clients/upscmd.c
@@ -35,6 +35,7 @@
 
 #include "nut_stdint.h"
 #include "upsclient.h"
+#include "common-clients.h"
 
 /* name-swap in libupsclient consumer to simplify the look of code base */
 #define builtin_setproctag(x)	setproctag(x)
@@ -488,17 +489,10 @@ int main(int argc, char **argv)
 		}
 	}
 
-	/* getpass leaks slightly - use -p when testing in valgrind */
 	if (!have_pw) {
-		/* using getpass or getpass_r might not be a
-		 * good idea here (marked obsolete in POSIX) */
-		char	*pwtmp = GETPASS("Password: ");
-
-		if (!pwtmp) {
-			fatalx(EXIT_FAILURE, "getpass failed: %s", strerror(errno));
+		if (!read_password(password, sizeof(password))) {
+			fatalx(EXIT_FAILURE, "Failure reading password: %s", strerror(errno));
 		}
-
-		snprintf(password, sizeof(password), "%s", pwtmp);
 	}
 
 	snprintf(buf, sizeof(buf), "USERNAME %s\n", username);

--- a/clients/upscmd.c
+++ b/clients/upscmd.c
@@ -55,7 +55,7 @@ struct list_t {
 };
 
 /* For getopt loops; should match usage documented below: */
-static const char	optstring[] = "+Dlhu:p:t:wVW:";
+static const char	optstring[] = "+Dlhu:p:P:t:wVW:";
 
 static void help(const char *prog)
 {
@@ -64,11 +64,12 @@ static void help(const char *prog)
 
 	printf("\nusage: %s [-h]\n", prog);
 	printf("       %s [-l <ups>]\n", prog);
-	printf("       %s [-u <username>] [-p <password>] [-w] [-t <timeout>] <ups> <command> [<value>]\n\n", prog);
+	printf("       %s [-u <username>] [-p <password>] [-P <passfile>] [-w] [-t <timeout>] <ups> <command> [<value>]\n\n", prog);
 	printf("\n");
 	printf("  -l <ups>	show available commands on UPS <ups>\n");
 	printf("  -u <username>	set username for command authentication\n");
 	printf("  -p <password>	set password for command authentication\n");
+	printf("  -P <passfile>	read password for command authentication from file\n");
 	printf("  -w            wait for the completion of command by the driver\n");
 	printf("                and return its actual result from the device\n");
 	printf("  -t <timeout>	set a timeout when using -w (in seconds, default: %d)\n", DEFAULT_TRACKING_TIMEOUT);
@@ -388,6 +389,13 @@ int main(int argc, char **argv)
 		case 'p':
 			snprintf(password, sizeof(password), "%s", optarg);
 			have_pw = 1;
+			break;
+
+		case 'P':
+			if (read_passwordfile(optarg, password, sizeof(password)))
+				have_pw = 1;
+			else
+				fatal_with_errno(EXIT_FAILURE, "Error: failed to read password from: %s", optarg);
 			break;
 
 		case 't':

--- a/clients/upsrw.c
+++ b/clients/upsrw.c
@@ -35,6 +35,7 @@
 #include "nut_stdint.h"
 #include "upsclient.h"
 #include "extstate.h"
+#include "common-clients.h"
 
 /* name-swap in libupsclient consumer to simplify the look of code base */
 #define builtin_setproctag(x)	setproctag(x)
@@ -229,7 +230,7 @@ static void do_set(const char *varname, const char *newval)
 
 static void do_setvar(const char *varname, char *uin, const char *pass)
 {
-	char	newval[SMALLBUF], temp[SMALLBUF * 2], user[SMALLBUF], *ptr;
+	char	newval[SMALLBUF], temp[SMALLBUF * 2], user[SMALLBUF], pass_buf[512], *ptr;
 	struct passwd	*pw;
 
 	if (uin) {
@@ -261,12 +262,11 @@ static void do_setvar(const char *varname, char *uin, const char *pass)
 		}
 	}
 
-	/* leaks - use -p when running in valgrind */
 	if (!pass) {
-		pass = GETPASS("Password: " );
+		pass = read_password(pass_buf, sizeof(pass_buf));
 
 		if (!pass) {
-			fatal_with_errno(EXIT_FAILURE, "getpass failed");
+			fatal_with_errno(EXIT_FAILURE, "Failure reading password");
 		}
 	}
 

--- a/clients/upsrw.c
+++ b/clients/upsrw.c
@@ -55,7 +55,7 @@ struct list_t {
 };
 
 /* For getopt loops; should match usage documented below: */
-static const char	optstring[] = "+Dhls:p:t:u:wVW:";
+static const char	optstring[] = "+Dhls:p:P:t:u:wVW:";
 
 static void help(const char *prog)
 {
@@ -63,13 +63,14 @@ static void help(const char *prog)
 	printf("NUT administration client program to set variables within UPS hardware.\n");
 
 	printf("\nusage: %s [-h]\n", prog);
-	printf("       %s [-s <variable>] [-u <username>] [-p <password>] [-w] [-t <timeout>] <ups>\n\n", prog);
+	printf("       %s [-s <variable>] [-u <username>] [-p <password>] [-P <passfile>] [-w] [-t <timeout>] <ups>\n\n", prog);
 	printf("\n");
 	printf("  -s <variable>	specify variable to be changed\n");
 	printf("		use -s VAR=VALUE to avoid prompting for value\n");
 	printf("  -l            show all possible read/write variables.\n");
 	printf("  -u <username> set username for command authentication\n");
 	printf("  -p <password> set password for command authentication\n");
+	printf("  -P <passfile> read password for command authentication from file\n");
 	printf("  -w            wait for the completion of setting by the driver\n");
 	printf("                and return its actual result from the device\n");
 	printf("  -t <timeout>	set a timeout when using -w (in seconds, default: %d)\n", DEFAULT_TRACKING_TIMEOUT);
@@ -683,7 +684,7 @@ int main(int argc, char **argv)
 	uint16_t	port;
 	const char	*prog = getprogname_argv0_default(argc > 0 ? argv[0] : NULL, "upsrw");
 	const char	*net_connect_timeout = NULL;
-	char	*password = NULL, *username = NULL, *setvar = NULL;
+	char	*password = NULL, *username = NULL, *setvar = NULL, pass_buf[512];
 
 	NUT_UNUSED_VARIABLE(upslog_start_tmp);
 	upscli_upslog_setprocname(xstrdup(getmyprocname()), nut_common_cookie());
@@ -744,6 +745,12 @@ int main(int argc, char **argv)
 			break;
 		case 'p':
 			password = optarg;
+			break;
+		case 'P':
+			if (read_passwordfile(optarg, pass_buf, sizeof(pass_buf)))
+				password = pass_buf;
+			else
+				fatal_with_errno(EXIT_FAILURE, "Error: failed to read password from: %s", optarg);
 			break;
 		case 't':
 			if (!str_to_uint(optarg, &timeout, 10))

--- a/configure.ac
+++ b/configure.ac
@@ -1454,6 +1454,9 @@ AC_CHECK_FUNCS(seteuid setsid getpassphrase)
 AC_CHECK_FUNCS(on_exit setlogmask)
 AC_CHECK_DECLS(LOG_UPTO, [], [], [#include <syslog.h>])
 
+AC_SEARCH_LIBS([readpassphrase], [bsd])
+AC_CHECK_HEADERS([bsd/readpassphrase.h readpassphrase.h])
+
 dnl These common routines are not available in strict C standard library
 dnl compilation modes (not part of ANSI or later standard), only in GNU,
 dnl POSIX or other extension modes. Note that on modern systems they are

--- a/docs/man/upscmd.txt
+++ b/docs/man/upscmd.txt
@@ -45,6 +45,10 @@ you will be prompted for this when invoking a command if -u is not used.
 Set the password to authenticate to the server.  This is also optional
 like -u, and you will be prompted for it if necessary.
 
+*-P* 'pass-file'::
+Set the password from file to authenticate to the server.  This is also
+optional like -u, and you will be prompted for it if necessary.
+
 *-w*::
 Wait for the completion of command execution by the driver and return its
 actual result from the device. Note that this feature requires that both

--- a/docs/man/upsrw.txt
+++ b/docs/man/upsrw.txt
@@ -62,6 +62,10 @@ linkman:upsd.users[5], and are not linked to system usernames.
 Set the password to authenticate to the server.  This is also optional
 like -u, and you will be prompted for it if necessary.
 
+*-P* 'pass-file'::
+Set the password from file to authenticate to the server.  This is also
+optional like -u, and you will be prompted for it if necessary.
+
 *-w*::
 Wait for the completion of setting execution by the driver and return its
 actual result from the device. Note that this feature requires that both


### PR DESCRIPTION
Couple simple changes to password handling for the clients, mainly because I don't want to specify the password on a command line for my weekly battery tests. Cleaned up the usage of deprecated `getpass()` while I was at it.

* clients: Use `readpassphrase()` if available
* clients: Add option to read password from a file
