### PR TITLE
Fix minor issues to compile on AIX

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -137,13 +137,13 @@ install-fanout-cleanup: install-recursive @dotMAKE@
 touch-include-all-nut_version-generated.timestamp:
 	@[ -s include/nut_version.h ]
 	@touch -r include/nut_version.h -d '-10 seconds' include/.all.nut_version-generated.timestamp 2>/dev/null && exit ; \
-	 touch -d '1970-01-01T00:00:00' include/.all.nut_version-generated.timestamp && exit ; \
+	 touch -t '197001010000.00' include/.all.nut_version-generated.timestamp && exit ; \
 	 touch include/.all.nut_version-generated.timestamp
 
 touch-clients-all-libupsclient_version-generated.timestamp:
 	@[ -s clients/libupsclient-version.h ]
 	@touch -r clients/libupsclient-version.h -d '-10 seconds' clients/.all.libupsclient_version-generated.timestamp 2>/dev/null && exit ; \
-	 touch -d '1970-01-01T00:00:00' clients/.all.libupsclient_version-generated.timestamp && exit ; \
+	 touch -t '197001010000.00' clients/.all.libupsclient_version-generated.timestamp && exit ; \
 	 touch clients/.all.libupsclient_version-generated.timestamp
 
 touch-docs-man-all-linkman-generated.timestamp:
@@ -153,7 +153,7 @@ touch-docs-man-all-linkman-generated.timestamp:
 	 else \
 	    touch -r docs/man/linkman-driver-names.txt -d '-10 seconds' docs/man/.all.nut_linkman-generated.timestamp 2>/dev/null && exit ; \
 	 fi ; \
-	 touch -d '1970-01-01T00:00:00' docs/man/.all.nut_linkman-generated.timestamp && exit ; \
+	 touch -t '197001010000.00' docs/man/.all.nut_linkman-generated.timestamp && exit ; \
 	 touch docs/man/.all.nut_linkman-generated.timestamp
 
 # Verbosity for fanout rule tracing; 0/1 (or "default" that may auto-set

--- a/clients/upsc.c
+++ b/clients/upsc.c
@@ -549,6 +549,9 @@ int main(int argc, char **argv)
 /* Formal do_upsconf_args implementation to satisfy linker on AIX */
 #if (defined NUT_PLATFORM_AIX)
 void do_upsconf_args(char *upsname, char *var, char *val) {
+	NUT_UNUSED_VARIABLE(upsname);
+	NUT_UNUSED_VARIABLE(var);
+	NUT_UNUSED_VARIABLE(val);
 	fatalx(EXIT_FAILURE, "INTERNAL ERROR: formal do_upsconf_args called");
 }
 #endif  /* end of #if (defined NUT_PLATFORM_AIX) */

--- a/clients/upscmd.c
+++ b/clients/upscmd.c
@@ -559,6 +559,9 @@ int main(int argc, char **argv)
 /* Formal do_upsconf_args implementation to satisfy linker on AIX */
 #if (defined NUT_PLATFORM_AIX)
 void do_upsconf_args(char *upsname, char *var, char *val) {
+	NUT_UNUSED_VARIABLE(upsname);
+	NUT_UNUSED_VARIABLE(var);
+	NUT_UNUSED_VARIABLE(val);
 	fatalx(EXIT_FAILURE, "INTERNAL ERROR: formal do_upsconf_args called");
 }
 #endif  /* end of #if (defined NUT_PLATFORM_AIX) */

--- a/clients/upslog.c
+++ b/clients/upslog.c
@@ -1095,6 +1095,9 @@ int main(int argc, char **argv)
 /* Formal do_upsconf_args implementation to satisfy linker on AIX */
 #if (defined NUT_PLATFORM_AIX)
 void do_upsconf_args(char *upsname, char *var, char *val) {
+	NUT_UNUSED_VARIABLE(upsname);
+	NUT_UNUSED_VARIABLE(var);
+	NUT_UNUSED_VARIABLE(val);
 	fatalx(EXIT_FAILURE, "INTERNAL ERROR: formal do_upsconf_args called");
 }
 #endif  /* end of #if (defined NUT_PLATFORM_AIX) */

--- a/clients/upsrw.c
+++ b/clients/upsrw.c
@@ -817,6 +817,9 @@ int main(int argc, char **argv)
 /* Formal do_upsconf_args implementation to satisfy linker on AIX */
 #if (defined NUT_PLATFORM_AIX)
 void do_upsconf_args(char *upsname, char *var, char *val) {
+	NUT_UNUSED_VARIABLE(upsname);
+	NUT_UNUSED_VARIABLE(var);
+	NUT_UNUSED_VARIABLE(val);
 	fatalx(EXIT_FAILURE, "INTERNAL ERROR: formal do_upsconf_args called");
 }
 #endif  /* end of #if (defined NUT_PLATFORM_AIX) */

--- a/configure.ac
+++ b/configure.ac
@@ -1703,12 +1703,13 @@ AC_CACHE_CHECK([for %zu as PRIuSIZE],
     [ac_cv_printfmt_zu],
     [AX_RUN_OR_LINK_IFELSE(
         [AC_LANG_PROGRAM([$CODE_STRINGINCL
+#include <stdio.h>
 #include <stdlib.h>
 ],
             [[size_t n = 123;
 char buf[64];
 snprintf(buf, sizeof(buf), "%zu", n);
-return !strcmp(buf, "123");
+return strcmp(buf, "123");
 ]])],
         [ac_cv_printfmt_zu=yes], [ac_cv_printfmt_zu=no]
     )])

--- a/configure.ac
+++ b/configure.ac
@@ -525,6 +525,7 @@ AS_IF([test ! -d "${PIDPATH}" -o -h "${PIDPATH}" && test -d "/run" -a ! -h "/run
 
 AC_CHECK_PROGS([GETENT], [getent], [])
 AC_CHECK_PROGS([ID], [id], [])
+AC_CHECK_PROGS([LSGROUP], [lsgroup], [])
 
 PROBE_OS_USER="false"
 PROBE_OS_GROUP="false"
@@ -534,20 +535,24 @@ AS_IF([test x"${GETENT}" != x], [
 	],[
 	AS_IF([test x"${ID}" != x], [
 		PROBE_OS_USER="${ID} -u "
-		AS_IF([test -r "/etc/groups"], [
-			dnl FIXME: For command prefix usage like used in this
-			dnl  script, we might be better off defining a shell
-			dnl  function and referring to it. Grep would catch
-			dnl  also user names that have a group as secondary!
-			PROBE_OS_GROUP="cat /etc/groups | ${GREP} -w "
+		AS_IF([test x"${LSGROUP}" != x], [
+			PROBE_OS_GROUP="${LSGROUP} "
 			], [
-			dnl This shows groups of a USER with specified name!
-			dnl But to probe for cases where string names are
-			dnl same (e.g. "nut" or "ups") this might be good
-			dnl enough.
-			PROBE_OS_GROUP="${ID} -g "
+			AS_IF([test -r "/etc/groups"], [
+				dnl FIXME: For command prefix usage like used in this
+				dnl  script, we might be better off defining a shell
+				dnl  function and referring to it. Grep would catch
+				dnl  also user names that have a group as secondary!
+				PROBE_OS_GROUP="cat /etc/groups | ${GREP} -w "
+				], [
+				dnl This shows groups of a USER with specified name!
+				dnl But to probe for cases where string names are
+				dnl same (e.g. "nut" or "ups") this might be good
+				dnl enough.
+				PROBE_OS_GROUP="${ID} -g "
+				])
+			AC_MSG_WARN([Can not PROPERLY check existence of group accounts on this system, but can try best-effort])
 			])
-		AC_MSG_WARN([Can not PROPERLY check existence of group accounts on this system, but can try best-effort])
 		],[
 		AC_MSG_WARN([Can not check existence of user and group accounts on this system])
 		])

--- a/drivers/powervar_cx_ser.c
+++ b/drivers/powervar_cx_ser.c
@@ -142,16 +142,20 @@ void upsdrv_initups(void)
 			ser_set_speed(upsfd, device_path, B38400);
 			upsdebugx (4, "Serial baud set to 38400.");
 		}
+#if defined(B57600)
 		else if (ulBaud == 57600)
 		{
 			ser_set_speed(upsfd, device_path, B57600);
 			upsdebugx (4, "Serial baud set to 57600.");
 		}
+#endif
+#if defined(B115200)
 		else if (ulBaud == 115200)	/* The only other baud known to be available. */
 		{
 			ser_set_speed(upsfd, device_path, B115200);
 			upsdebugx (4, "Serial baud set to 115200.");
 		}
+#endif
 		else
 		{
 			upsdebugx (4, "Serial baud not set!! (%" PRIu32 ").", ulBaud);

--- a/include/common.h
+++ b/include/common.h
@@ -38,7 +38,7 @@
 #endif	/* WIN32 */
 
 /* Need this on AIX when using xlc to get alloca */
-#ifdef _AIX
+#if defined(_AIX) && defined(__IBMC__)
 #pragma alloca
 #endif /* _AIX */
 

--- a/include/timehead.h
+++ b/include/timehead.h
@@ -81,6 +81,7 @@ static inline struct tm *gmtime_r( const time_t *timer, struct tm *buf ) {
 #  define timegm(tm) _mkgmtime(tm)
 # else
 #  ifdef WANT_TIMEGM_FALLBACK
+time_t timegm_fallback(struct tm const* t);
 	/* use an implementation from fallbacks in NUT codebase */
 #   define timegm(tm) timegm_fallback(tm)
 #  else

--- a/m4/nut_compiler_family.m4
+++ b/m4/nut_compiler_family.m4
@@ -111,6 +111,10 @@ dnl NOTE: this option should not be passed via the fourth argument of the macro,
 dnl or it ends up in the flags too, possibly during the "pop"; have to use the
 dnl GOOD_FLAG instead :\
     COMPILERFLAG="$1"
+dnl GCC will silently accept warning disable options, but then if there is an issue, warn about the option, i.e.
+dnl "cc1: note: unrecognized command-line option '-Wno-unknown-warning-option' may have been intended to silence earlier diagnostics"
+dnl Instead try the enable option to check if it is valid
+    COMPILERTESTFLAG="`echo $1 | sed 's/^-Wno-/-W/'`"
 
 dnl We also try to run an actual build since tools called from that might
 dnl complain if they are forwarded unknown flags accepted by the front-end.
@@ -119,14 +123,22 @@ dnl complain if they are forwarded unknown flags accepted by the front-end.
     AC_MSG_NOTICE([Starting check compile flag for '${COMPILERFLAG}'; now CFLAGS='${CFLAGS}' and CXXFLAGS='${CXXFLAGS}'])
 
     AC_LANG_PUSH([C])
+dnl Use a simple program with out previous #defines so we don't cause errors on clang with -Wreserved-identifier
+    m4_pushdef([AC_LANG_CONFTEST(C)], [m4_ifdef([AC_LANG_DEFINES_PROVIDED], [AC_LANG_DEFINES_PROVIDED])
+cat << _ACEOF > conftest.$ac_ext
+int main(void) { return 0; }
+_ACEOF
+    ])
     GOOD_FLAG=no
-    AX_CHECK_COMPILE_FLAG([${COMPILERFLAG}],
+    # CFLAGS="-Werror $CFLAGS"
+    AX_CHECK_COMPILE_FLAG([${COMPILERTESTFLAG}],
         [CFLAGS="-Werror $NUT_SAVED_CFLAGS ${COMPILERFLAG}"
          AC_MSG_CHECKING([whether the flag '${COMPILERFLAG}' is still supported in CC linker mode])
          AX_RUN_OR_LINK_IFELSE([AC_LANG_PROGRAM([],[])],
             [GOOD_FLAG=yes],[])
          AC_MSG_RESULT([${GOOD_FLAG}])
         ], [], [])
+    m4_popdef([AC_LANG_CONFTEST(C)])
     AC_LANG_POP([C])
     AS_IF([test x"${GOOD_FLAG}" = xyes],
         [CFLAGS="$NUT_SAVED_CFLAGS ${COMPILERFLAG}"],
@@ -135,14 +147,22 @@ dnl complain if they are forwarded unknown flags accepted by the front-end.
     AC_MSG_NOTICE([${GOOD_FLAG} for C '${COMPILERFLAG}'; now CFLAGS=${CFLAGS}])
 
     AC_LANG_PUSH([C++])
+dnl Use a simple program with out previous #defines so we don't cause errors on clang with -Wreserved-identifier
+    m4_pushdef([AC_LANG_CONFTEST(C++)], [m4_ifdef([AC_LANG_DEFINES_PROVIDED], [AC_LANG_DEFINES_PROVIDED])
+cat << _ACEOF > conftest.$ac_ext
+int main(void) { return 0; }
+_ACEOF
+    ])
     GOOD_FLAG=no
-    AX_CHECK_COMPILE_FLAG([${COMPILERFLAG}],
+    # CXXFLAGS="-Werror $CXXFLAGS"
+    AX_CHECK_COMPILE_FLAG([${COMPILERTESTFLAG}],
         [CXXFLAGS="-Werror $NUT_SAVED_CXXFLAGS ${COMPILERFLAG}"
          AC_MSG_CHECKING([whether the flag '${COMPILERFLAG}' is still supported in CXX linker mode])
          AX_RUN_OR_LINK_IFELSE([AC_LANG_PROGRAM([],[])],
             [GOOD_FLAG=yes],[])
          AC_MSG_RESULT([${GOOD_FLAG}])
         ], [], [])
+    m4_popdef([AC_LANG_CONFTEST(C++)])
     AC_LANG_POP([C++])
     AS_IF([test x"${GOOD_FLAG}" = xyes],
         [CXXFLAGS="$NUT_SAVED_CXXFLAGS ${COMPILERFLAG}"],

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -1910,7 +1910,7 @@ static void mainloop(void)
 
 		if (fds[i].revents & (POLLHUP|POLLERR|POLLNVAL)) {
 
-			upsdebug_with_errno(3, "%s: Disconnect %s [%s%sFD %d] due to%s%s%s",
+			upsdebug_with_errno(3, "%s: Disconnect %s [%s%sFD %ld] due to%s%s%s",
 				__func__,
 				(handler[i].type==DRIVER ? "DRIVER" :
 				(handler[i].type==CLIENT ? "CLIENT" :
@@ -1921,7 +1921,7 @@ static void mainloop(void)
 				(handler[i].type==SERVER ? "" :
 				""))),
 				(handler[i].type==DRIVER || handler[i].type==CLIENT ? ", " : ""),
-				fds[i].fd,
+				(long int)fds[i].fd,
 				(fds[i].revents & POLLHUP ? " POLLHUP" : ""),
 				(fds[i].revents & POLLERR ? " POLLERR" : ""),
 				(fds[i].revents & POLLNVAL ? " POLLNVAL" : "")
@@ -1975,7 +1975,7 @@ static void mainloop(void)
 
 		if (fds[i].revents & POLLIN) {
 
-			upsdebugx(3, "%s: Incoming %s from %s [%s%sFD %d]",
+			upsdebugx(3, "%s: Incoming %s from %s [%s%sFD %ld]",
 				__func__,
 				(handler[i].type==SERVER ? "connection" : "data"),
 				(handler[i].type==DRIVER ? "DRIVER" :
@@ -1987,7 +1987,7 @@ static void mainloop(void)
 				(handler[i].type==SERVER ? "" :
 				""))),
 				(handler[i].type==DRIVER || handler[i].type==CLIENT ? ", " : ""),
-				fds[i].fd
+				(long int)fds[i].fd
 				);
 
 			switch(handler[i].type)

--- a/tools/nut-scanner/scan_eaton_serial.c
+++ b/tools/nut-scanner/scan_eaton_serial.c
@@ -28,11 +28,6 @@
 #include "nut-scan.h"
 #include "nut_stdint.h"
 
-/* Need this on AIX when using xlc to get alloca */
-#ifdef _AIX
-# pragma alloca
-#endif /* _AIX */
-
 #include <fcntl.h>
 #include <stdio.h>
 #if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP) && (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_STRICT_PROTOTYPES)


### PR DESCRIPTION
Just for fun I've been playing with getting it to compile on my 7.2 install under QEMU. Mainly minor changes, compiles clients & drivers before failing trying to write to the source directory (mounted read only).

* Add check for older IBM compilers.
* Check enable version of warnings to see if valid
* Use lsgroup on AIX to check for valid groups
* Fix %zu format check
* Switch to using -t to specify date as -d not always availble
* Ignore unused parameters
* AIX doesn't provide defines for those speeds.
* Provide function declaration when needed
