### PR TITLE
Fix building with a read-only nfs mounted source

### DIFF
--- a/scripts/python/module/Makefile.am
+++ b/scripts/python/module/Makefile.am
@@ -81,14 +81,14 @@ upload publish: @dotMAKE@
 			continue; \
 		fi; \
 		if test -s "$${B}" ; then \
-			cp -pf "$${B}" PyNUTClient/ || exit ; \
+			cp -f "$${B}" PyNUTClient/ || exit ; \
 			continue; \
 		fi ; \
 		sed -e "s,[@]PYTHON_DEFAULT[@],@PYTHON_DEFAULT@," < "$(srcdir)/$${B}.in" > "PyNUTClient/$${B}" || exit ; \
 		if test -x "$(srcdir)/$${B}.in" ; then chmod +x "PyNUTClient/$${B}"; fi ; \
 	 done ; \
-	 cp -pf "$(srcdir)/README.adoc" README.txt || exit ; \
-	 cp -pf "$(top_srcdir)/LICENSE-GPL3" . || exit ; \
+	 cp -f "$(srcdir)/README.adoc" README.txt || exit ; \
+	 cp -f "$(top_srcdir)/LICENSE-GPL3" . || exit ; \
 	 echo "from . import PyNUT" > PyNUTClient/__init__.py || exit
 	@touch '$@'
 

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -45,20 +45,20 @@ GENERATED_USB_FILES = nut-scanner/nutscan-usb.h
 # after such fundamental changes the project should better run `autogen.sh`.
 
 # Hotplug output file
-GENERATED_USB_OS_FILES = $(top_builddir)/scripts/hotplug/libhid.usermap
+GENERATED_USB_OS_FILES = $(abs_top_builddir)/scripts/hotplug/libhid.usermap
 
 # udev output file
-GENERATED_USB_OS_FILES += $(top_builddir)/scripts/udev/nut-usbups.rules.in
+GENERATED_USB_OS_FILES += $(abs_top_builddir)/scripts/udev/nut-usbups.rules.in
 
 # BSD devd output file
-GENERATED_USB_OS_FILES += $(top_builddir)/scripts/devd/nut-usb.conf.in
+GENERATED_USB_OS_FILES += $(abs_top_builddir)/scripts/devd/nut-usb.conf.in
 
 # FreeBSD quirks output file
-GENERATED_USB_OS_FILES += $(top_builddir)/scripts/devd/nut-usb.quirks
+GENERATED_USB_OS_FILES += $(abs_top_builddir)/scripts/devd/nut-usb.quirks
 
 # UPower output file
 # Note: unlike others above, this one is currently tracked in Git
-GENERATED_USB_OS_FILES += $(top_builddir)/scripts/upower/95-upower-hid.hwdb
+GENERATED_USB_OS_FILES += $(abs_top_builddir)/scripts/upower/95-upower-hid.hwdb
 
 CLEANFILES = $(GENERATED_SNMP_FILES) $(GENERATED_USB_FILES)
 # We do not clean away these files, some are even tracked in Git:
@@ -106,7 +106,7 @@ $(GENERATED_USB_OS_FILES): $(GENERATED_USB_FILES)
 	@$(MKDIR_P) "$(@D)"
 	@if test ! -s '$@' ; then \
 	    if test x"$(top_srcdir)" != x"$(top_builddir)" ; then \
-	        RELNAME="`echo '$@' | sed 's,^$(top_builddir)/*,,'`" ; \
+	        RELNAME="`echo '$@' | sed 's,^$(abs_top_builddir)/*,,'`" ; \
 	        SRCNAME="$(top_srcdir)/$${RELNAME}" ; \
 	        if test -s "$${SRCNAME}" ; then \
 	            echo "WARNING: GENERATED_USB_OS_FILES: using '$${SRCNAME}' for '$@'" >&2 ; \


### PR DESCRIPTION
First one had me very confused for a while. Couldn't figure out how it switched from the build directory to the source directory.

* Use full path for generated files
* Don't try to copy permissions
