### PR TITLE
snmp-ups: map more xppc readings for Phoenixtec UPS cards

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -83,6 +83,12 @@ https://github.com/networkupstools/nut/milestone/13
     * When reconnecting, report success more visibly (not only in debug), and
       do not reset driver state to "quiet" when it will loop trying. [PR #3423]
 
+ - `snmp-ups` driver updates:
+    * Extended the XPPC-MIB subdriver (enterprise 935) to expose
+      `battery.runtime`, `battery.voltage`, `input.frequency`,
+      `output.voltage.nominal` and `ups.firmware.aux` from Phoenixtec
+      based UPS cards that already answer the rest of the subtree. [#2608]
+
  - common code:
     * Revised 'dstate' machinery to track socket connections closed mid-way
       through a call, to avoid access after `free()`. [#3302]

--- a/drivers/xppc-mib.c
+++ b/drivers/xppc-mib.c
@@ -24,7 +24,7 @@
 
 #include "xppc-mib.h"
 
-#define XPPC_MIB_VERSION  "0.40"
+#define XPPC_MIB_VERSION  "0.41"
 
 #define XPPC_SYSOID       ".1.3.6.1.4.1.935"
 
@@ -109,14 +109,22 @@ static snmp_info_t xppc_mib[] = {
 
 	/* upsBaseIdentModel.0 = STRING: "Intelligent" */
 	snmp_info_default("ups.model", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.935.1.1.1.1.1.1.0", "Generic Phoenixtec SNMP device", SU_FLAG_OK, NULL),
+	/* upsSmartIdentAgentFirmwareRevision.0 = STRING: "11105200-1.44.00" */
+	snmp_info_default("ups.firmware.aux", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.935.1.1.1.1.2.4.0", NULL, SU_FLAG_OK, NULL),
 	/* upsBaseBatteryStatus.0 = INTEGER: batteryNormal(2) */
 	snmp_info_default("ups.status", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.935.1.1.1.2.1.1.0", "", SU_STATUS_BATT | SU_TYPE_INT | SU_FLAG_OK, xpcc_onbatt_info),
 	/* upsSmartBatteryCapacity.0 = INTEGER: 100 */
 	snmp_info_default("battery.charge", 0, 1, ".1.3.6.1.4.1.935.1.1.1.2.2.1.0", NULL, SU_TYPE_INT | SU_FLAG_OK, NULL),
+	/* upsSmartBatteryVoltage.0 = INTEGER: 809 */
+	snmp_info_default("battery.voltage", 0, 0.1, ".1.3.6.1.4.1.935.1.1.1.2.2.2.0", NULL, SU_TYPE_INT | SU_FLAG_OK, NULL),
 	/* upsSmartBatteryTemperature.0 = INTEGER: 260 */
 	snmp_info_default("ups.temperature", 0, 0.1, ".1.3.6.1.4.1.935.1.1.1.2.2.3.0", NULL, SU_TYPE_INT | SU_FLAG_OK, NULL),
+	/* upsSmartBatteryRunTimeRemaining.0 = INTEGER: 4800 */
+	snmp_info_default("battery.runtime", 0, 1.0, ".1.3.6.1.4.1.935.1.1.1.2.2.4.0", NULL, SU_TYPE_INT | SU_FLAG_OK, NULL),
 	/* upsSmartInputLineVoltage.0 = INTEGER: 1998 */
 	snmp_info_default("input.voltage", 0, 0.1, ".1.3.6.1.4.1.935.1.1.1.3.2.1.0", NULL, SU_TYPE_INT | SU_FLAG_OK, NULL),
+	/* upsSmartInputFrequency.0 = INTEGER: 499 */
+	snmp_info_default("input.frequency", 0, 0.1, ".1.3.6.1.4.1.935.1.1.1.3.2.4.0", NULL, SU_TYPE_INT | SU_FLAG_OK, NULL),
 	/* upsBaseOutputStatus.0 = INTEGER: onLine(2) */
 	snmp_info_default("ups.status", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.935.1.1.1.4.1.1.0", "", SU_TYPE_INT | SU_STATUS_PWR, xpcc_power_info),
 	/* upsSmartOutputVoltage.0 = INTEGER: 2309 */
@@ -125,6 +133,8 @@ static snmp_info_t xppc_mib[] = {
 	snmp_info_default("output.frequency", 0, 0.1, ".1.3.6.1.4.1.935.1.1.1.4.2.2.0", NULL, SU_TYPE_INT | SU_FLAG_OK, NULL),
 	/* upsSmartOutputLoad.0 = INTEGER: 7 */
 	snmp_info_default("ups.load", 0, 1, ".1.3.6.1.4.1.935.1.1.1.4.2.3.0", NULL, SU_TYPE_INT | SU_FLAG_OK, NULL),
+	/* upsSmartConfigRatedOutputVoltage.0 = INTEGER: 2200 */
+	snmp_info_default("output.voltage.nominal", 0, 0.1, ".1.3.6.1.4.1.935.1.1.1.5.2.1.0", NULL, SU_TYPE_INT | SU_FLAG_OK, NULL),
 
 	/* end of structure. */
 	snmp_info_sentinel


### PR DESCRIPTION
## What this does

The `xppc` subdriver (XPPC-MIB, enterprise 935) currently maps only a handful of data points. This adds five readings that the cards already answer in the same subtree but that NUT was throwing away:

- `battery.runtime` from `.1.3.6.1.4.1.935.1.1.1.2.2.4.0`
- `battery.voltage` from `.1.3.6.1.4.1.935.1.1.1.2.2.2.0`
- `input.frequency` from `.1.3.6.1.4.1.935.1.1.1.3.2.4.0`
- `output.voltage.nominal` from `.1.3.6.1.4.1.935.1.1.1.5.2.1.0`
- `ups.firmware.aux` from `.1.3.6.1.4.1.935.1.1.1.1.2.4.0`

`XPPC_MIB_VERSION` is bumped to 0.41 and a `NEWS.adoc` entry is added.

## Why

`battery.runtime` is the big one. Before this change `upsc` reported no remaining runtime for these cards even though the value is right there in the MIB. The other four round out battery voltage, line frequency, rated output voltage and the agent firmware string.

## Device and evidence

The card identifies as device.description "UPS Agent", device.mfr "Tripp Lite / Phoenixtec", sysObjectID `.1.3.6.1.4.1.935.1.1.1`. This is the Phoenixtec XPPC-MIB that the `xppc` subdriver already targets. The runtime OID maps to the same structural slot (`.2.2.4.0`) that `cyberpower-mib.c` reads as `battery.runtime` with scale 1.0 in seconds, which matched the observed value of about 83 minutes at light load.

This is the same family of card discussed in issue #2608, where the reporter had to give up because the hardware was no longer available to test against.

## Verified on real hardware

```
$ upsc myups
battery.charge: 100
battery.runtime: 5760
battery.voltage: 81.10
device.mfr: Tripp Lite / Phoenixtec
device.type: ups
driver.name: snmp-ups
driver.parameter.mibs: xppc
driver.parameter.snmp_version: v2c
driver.version: 2.8.4
input.frequency: 49.90
input.voltage: 217.50
output.frequency: 49.90
output.voltage: 219.70
output.voltage.nominal: 220
ups.firmware.aux: 11105200-1.44.00
ups.load: 9
ups.status: OL
ups.temperature: 32.80
```

The five readings this change adds are `battery.runtime`, `battery.voltage`, `input.frequency`, `output.voltage.nominal` and `ups.firmware.aux`. All five show up above on a live card.

## How to reproduce the dump

```
snmpwalk -v2c -c <community> <ups-ip> .1.3.6.1.4.1.935 > xppc-snmpwalk.log
```

I can attach the full walk if you want it for the DDL.

Closes part of #2608.
