### PR TITLE
CI: Fix RPATH for illumos and related OSes

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -166,6 +166,8 @@ https://github.com/networkupstools/nut/milestone/13
       PRs #3429, #3432]
     * Updated a NUT CI farm worker to FreeBSD 15 and updated the recipes and
       documentation according to problems that were found along the way. [#3453]
+    * Various recipe portability fixes for AIX, NetBSD and OmniOS at least.
+      [#3489, #3495, #3498]
     * Jenkins used as the NUT CI farm core has bumped JDK requirements for its
       controllers and build agents, `docs/config-prereqs.txt` revised.
 

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -949,7 +949,7 @@ detect_platform_PKG_CONFIG_PATH_and_FLAGS() {
                             # assumed only useful if we use it via pkgconfig
                             case "${D}" in
                                 /usr/lib) ;;
-                                *) LDFLAGS="${LDFLAGS} -R${D}/${_BITS}" ;;
+                                *) LDFLAGS="${LDFLAGS} -Wl,-R${D}/${_BITS}" ;;
                             esac
                         else
                             if [ -d "${D}/pkgconfig" ] ; then
@@ -964,7 +964,7 @@ detect_platform_PKG_CONFIG_PATH_and_FLAGS() {
                             SYS_PKG_CONFIG_PATH="${SYS_PKG_CONFIG_PATH}:${D}/${_ARCH}/pkgconfig"
                             case "${D}" in
                                 /usr/lib) ;;
-                                *) LDFLAGS="${LDFLAGS} -R${D}/${_ARCH}" ;;
+                                *) LDFLAGS="${LDFLAGS} -Wl,-R${D}/${_ARCH}" ;;
                             esac
                         else
                             if [ -d "${D}/pkgconfig" ] ; then
@@ -997,7 +997,7 @@ detect_platform_PKG_CONFIG_PATH_and_FLAGS() {
                         SYS_PKG_CONFIG_PATH="${SYS_PKG_CONFIG_PATH}:${D}/pkgconfig"
                         case "${D}" in
                             /usr/lib) ;;
-                            *) LDFLAGS="${LDFLAGS} -R${D}" ;;
+                            *) LDFLAGS="${LDFLAGS} -Wl,-R${D}" ;;
                         esac
                     fi
                 fi

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -1078,7 +1078,7 @@ detect_platform_PKG_CONFIG_PATH_and_FLAGS() {
             # linking well. For more details see
             # https://github.com/networkupstools/nut/pull/2870#issuecomment-2768590518
             if [ -d "/usr/pkg/lib" -a -d "/usr/pkg/include" ] ; then
-                LDFLAGS="${LDFLAGS-} -R/usr/pkg/lib"
+                LDFLAGS="${LDFLAGS-} -Wl,-R/usr/pkg/lib"
                 CFLAGS="${CFLAGS-} -I/usr/pkg/include"
                 CXXFLAGS="${CXXFLAGS-} -I/usr/pkg/include"
             fi

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -1334,7 +1334,7 @@ the compiler flags that are needed.
 
 	--with-ssl-libs, --with-usb-libs, --with-snmp-libs,
 	--with-neon-libs, --with-libltdl-libs
-	--with-powerman-libs="-L/foo/bar -R/foo/bar -labcd -lxyz"
+	--with-powerman-libs="-L/foo/bar -Wl,-R/foo/bar -labcd -lxyz"
 
 If system doesn't have `pkg-config` or it fails to provides hints for
 some of the settings that are needed to set it up properly and the


### PR DESCRIPTION
Builds upon findings from #3495 (kudos to @dougnazar)

Use the more correct wording of LDFLAGS aimed at the linker but not compiler.