### PR TITLE
Handle `upsmon` NOTIFYCMD and `upssched` CMDSCRIPT values strictly as paths

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -185,6 +185,14 @@ https://github.com/networkupstools/nut/milestone/13
       success of SSL initialization with both backends is more diligently
       tracked) should now not cause exit of the client if secure connection
       is not required by its configuration in the first place. [#3420]
+    * Potentially a breaking change for existing deployments with `upsmon` and
+      `upssched` integration: the `CMDSCRIPT` and `NOTIFYCMD` definitions were
+      revised to mean an exact program name (possibly with spaces in the value),
+      not a shell scriptlet. Documentation in earlier NUT releases implied that
+      arguments could be passed here -- this is no longer true. If you need to
+      pass special arguments to a notification program, please write a small
+      script to do so and specify its path here. The `SHUTDOWNCMD` is still
+      a scriptlet, as far as specifying command arguments is concerned. [#3499]
 
  - `NUT-Monitor` Python GUI client:
     * Fixed Qt tray tooltips to render in plain text, not rich text which

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -202,6 +202,9 @@ https://github.com/networkupstools/nut/milestone/13
       ended up as literal HTML on KDE Plasma 6; now that rich text formatting
       is only used for main window status labels. [PR #3430]
 
+ - `upssched` client/tool updates:
+    * Added a `clean_exit()` handler similar to that in `upsmon`. [PR #3499]
+
  - `upsd` data server updates:
     * If we hit "Too many open files" during configuration reload, close
       the oldest client connection and retry. [issue #3365]

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -187,12 +187,15 @@ https://github.com/networkupstools/nut/milestone/13
       is not required by its configuration in the first place. [#3420]
     * Potentially a breaking change for existing deployments with `upsmon` and
       `upssched` integration: the `CMDSCRIPT` and `NOTIFYCMD` definitions were
-      revised to mean an exact program name (possibly with spaces in the value),
-      not a shell scriptlet. Documentation in earlier NUT releases implied that
-      arguments could be passed here -- this is no longer true. If you need to
-      pass special arguments to a notification program, please write a small
-      script to do so and specify its path here. The `SHUTDOWNCMD` is still
-      a scriptlet, as far as specifying command arguments is concerned. [#3499]
+      revised for the first token to mean an exact program name (possibly with
+      spaces in the value), not a shell scriptlet. Documentation in earlier
+      NUT releases implied that arguments could be passed here -- this is no
+      longer true. If you need to pass special arguments to a notification
+      program, please use additional separately quoted tokens, or write a
+      small helper script to do so and specify its path here.
+      The `SHUTDOWNCMD` is still a scriptlet, as far as specifying command
+      arguments is concerned, but it also newly supports parsing multiple
+      tokens as additional arguments. [PR #3499]
 
  - `NUT-Monitor` Python GUI client:
     * Fixed Qt tray tooltips to render in plain text, not rich text which

--- a/UPGRADING.adoc
+++ b/UPGRADING.adoc
@@ -46,6 +46,14 @@ Changes from 2.8.5 to 2.8.6
   if the requested value is larger than what is allowed (minus some reserve
   for configuration files and other use-cases). [issue #3365]
 
+- Potentially a breaking change for existing deployments with `upsmon` and
+  `upssched` integration: the `CMDSCRIPT` and `NOTIFYCMD` definitions were
+  revised to mean an exact program name (possibly with spaces in the value),
+  not a shell scriptlet. Documentation in earlier NUT releases implied that
+  arguments could be passed here -- this is no longer true. If you need to
+  pass special arguments to a notification program, please write a small
+  script to do so and specify its path here. The `SHUTDOWNCMD` is still
+  a scriptlet, as far as specifying command arguments is concerned. [#3499]
 
 Changes from 2.8.4 to 2.8.5
 ---------------------------

--- a/UPGRADING.adoc
+++ b/UPGRADING.adoc
@@ -48,12 +48,14 @@ Changes from 2.8.5 to 2.8.6
 
 - Potentially a breaking change for existing deployments with `upsmon` and
   `upssched` integration: the `CMDSCRIPT` and `NOTIFYCMD` definitions were
-  revised to mean an exact program name (possibly with spaces in the value),
-  not a shell scriptlet. Documentation in earlier NUT releases implied that
-  arguments could be passed here -- this is no longer true. If you need to
-  pass special arguments to a notification program, please write a small
-  script to do so and specify its path here. The `SHUTDOWNCMD` is still
-  a scriptlet, as far as specifying command arguments is concerned. [#3499]
+  revised for the first token to mean an exact program name (possibly with
+  spaces in the value), not a shell scriptlet. Documentation in earlier NUT
+  releases implied that arguments could be passed here -- this is no longer
+  true. If you need to pass special arguments to a notification program,
+  please use additional separately quoted tokens, or write a small helper
+  script to do so and specify its path here. The `SHUTDOWNCMD` is still a
+  scriptlet, as far as specifying command arguments is concerned, but it also
+  newly supports parsing multiple tokens as additional arguments. [PR #3499]
 
 Changes from 2.8.4 to 2.8.5
 ---------------------------

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -47,7 +47,15 @@
 #define builtin_setproctag(x)	setproctag(x)
 #define setproctag(x)	do { builtin_setproctag(x); upscli_upslog_setproctag(x, nut_common_cookie()); } while(0)
 
-static	char	*shutdowncmd = NULL, *notifycmd = NULL;
+/* Argument array for respective program, where [0] is the program name,
+ * followed by (argc-1) possible command-line argument tokens, with a
+ * NULL value in the end as the [argc]'th entry. Overall (argc+1) items
+ * if at all populated, minimum 2 for the program name and NULL sentinel.
+ * Concatenated value of NOTIFYCMD is also stored to ease debug logging,
+ * but is not used directly for program calls (value of SHUTDOWNCMD is
+ * currently passed to system() as concatenated, not as an array). */
+static	char	**shutdowncmd_argv = NULL, **notifycmd_argv = NULL, *shutdowncmd_concat = NULL, *notifycmd_concat = NULL;
+static	size_t	shutdowncmd_argc = 0, notifycmd_argc = 0;
 static	char	*powerdownflag = NULL, *configfile = NULL;
 
 static	unsigned int	minsupplies = 1, sleepval = 5;
@@ -264,7 +272,6 @@ typedef struct async_notify_s {
 
 static unsigned __stdcall async_notify(LPVOID param)
 {
-	char	*argv[3];
 	int	ret;
 
 	/* the following code is a copy of the content of the NOT WIN32 part of
@@ -280,22 +287,28 @@ static unsigned __stdcall async_notify(LPVOID param)
 	}
 
 	if (flag_isset(data->flags, NOTIFY_EXEC)) {
-		if (notifycmd != NULL) {
-			upsdebugx(6, "%s: Calling NOTIFYCMD: %s with notice: %s",
-				__func__, notifycmd, NUT_STRARG(data->notice));
+		if (notifycmd_argc > 0) {
+			/* We will add one argument, plus one NULL sentinel, after argc original entries */
+			char	**argv = (char**)xcalloc(notifycmd_argc + 2, sizeof(char *));
+
+			/* For logging note that notifycmd_concat is quoted as appropriate */
+			upsdebugx(6, "%s: Calling NOTIFYCMD as %s with notice: %s",
+				__func__, NUT_STRARG(notifycmd_concat), NUT_STRARG(data->notice));
 			if (data->upsname)
 				setenv("UPSNAME", data->upsname, 1);
 			else
 				setenv("UPSNAME", "", 1);
 
 			setenv("NOTIFYTYPE", data->ntype, 1);
-			argv[0] = notifycmd;
-			argv[1] = data->notice;
-			argv[2] = NULL;
-			ret = _spawnvp(_P_WAIT, notifycmd, (const char * const *)argv);
+			/* Copy entries [0]..[argc-1] */
+			memcpy(argv, notifycmd_argv, notifycmd_argc * sizeof(char *));
+			argv[notifycmd_argc] = data->notice;
+			argv[notifycmd_argc + 1] = NULL;
+			ret = _spawnvp(_P_WAIT, notifycmd_argv[0], (const char * const *)argv);
 			if (ret == -1) {
 				upslog_with_errno(LOG_ERR, "%s: _spawnvp failed", __func__);
 			}
+			free(argv);
 		}
 	}
 
@@ -348,16 +361,20 @@ static void notify(const char *notice, unsigned int flags, const char *ntype,
 		__func__, use_pipe ? "grand" : "");
 
 	if (flag_isset(flags, NOTIFY_WALL)) {
-		upsdebugx(6, "%s (%schild): NOTIFY_WALL", __func__, use_pipe ? "grand" : "");
+		upsdebugx(6, "%s (%schild): NOTIFY_WALL",
+			__func__, use_pipe ? "grand" : "");
 		wall(notice);
 	}
 
 	if (flag_isset(flags, NOTIFY_EXEC)) {
-		if (notifycmd != NULL) {
-			char	*argv[3];
+		if (notifycmd_argc > 0) {
+			/* We will add one argument, plus one NULL sentinel, after argc original entries */
+			char	**argv = (char**)xcalloc(notifycmd_argc + 2, sizeof(char *));
 
-			upsdebugx(6, "%s (%schild): NOTIFY_EXEC: calling NOTIFYCMD as '%s' with notice: '%s'",
-				__func__, use_pipe ? "grand" : "", notifycmd, NUT_STRARG(notice));
+			/* For logging note that notifycmd_concat is quoted as appropriate */
+			upsdebugx(6, "%s (%schild): NOTIFY_EXEC: calling NOTIFYCMD as %s with notice: '%s'",
+				__func__, use_pipe ? "grand" : "",
+				NUT_STRARG(notifycmd_concat), NUT_STRARG(notice));
 
 			if (upsname)
 				setenv("UPSNAME", upsname, 1);
@@ -365,19 +382,24 @@ static void notify(const char *notice, unsigned int flags, const char *ntype,
 				setenv("UPSNAME", "", 1);
 
 			setenv("NOTIFYTYPE", ntype, 1);
-			argv[0] = (char *)notifycmd;
-			argv[1] = (char *)notice;
-			argv[2] = NULL;
-			execvp(notifycmd, argv);
+			/* Copy entries [0]..[argc-1] */
+			memcpy(argv, notifycmd_argv, notifycmd_argc * sizeof(char *));
+			argv[notifycmd_argc] = notice;
+			argv[notifycmd_argc + 1] = NULL;
+			execvp(notifycmd_argv[0], argv);
 			/* execvp() only returns on error */
-			upslog_with_errno(LOG_ERR, "%s: execvp(%s) failed", __func__, notifycmd);
+			upslog_with_errno(LOG_ERR, "%s: execvp(%s) failed",
+				__func__, NUT_STRARG(notifycmd_concat));
+			free(argv);
 			exit(EXIT_FAILURE);
 		} else {
-			upsdebugx(6, "%s (%schild): NOTIFY_EXEC: no NOTIFYCMD was configured", __func__, use_pipe ? "grand" : "");
+			upsdebugx(6, "%s (%schild): NOTIFY_EXEC: no NOTIFYCMD was configured",
+				__func__, use_pipe ? "grand" : "");
 		}
 	}
 
-	upsdebugx(6, "%s (%schild): exiting after notifications", __func__, use_pipe ? "grand" : "");
+	upsdebugx(6, "%s (%schild): exiting after notifications",
+		__func__, use_pipe ? "grand" : "");
 
 	exit(EXIT_SUCCESS);
 #else	/* WIN32 */
@@ -1049,13 +1071,19 @@ static void doshutdown(void)
 		}
 #endif	/* WIN32 */
 
+		/* NOTE: Unlike NOTIFYCMD whose arg[0] MUST be a program path name
+		 *  (so we can pass additional args safely), we do not currently
+		 *  require that of the SHUTDOWNCMD whose one string may contain
+		 *  further arguments right away. We, however, do support multi-token
+		 *  syntax for that directive too.
+		 */
 		upsdebugx(1, "%s: upsmon mono-process: Calling shutdown command: %s",
-			__func__, shutdowncmd);
-		sret = system(shutdowncmd);
+			__func__, NUT_STRARG(shutdowncmd_concat));
+		sret = system(shutdowncmd_concat);
 
 		if (sret != 0)
 			upslogx(LOG_ERR, "Unable to call shutdown command: %s",
-				shutdowncmd);
+				shutdowncmd_concat);
 	}
 
 	/* code below runs in the child (or only) process */
@@ -2316,12 +2344,95 @@ static int parse_conf_arg(size_t numargs, char **arg)
 	if (numargs < 2)
 		return 0;
 
-	/* SHUTDOWNCMD <cmd> */
-	if (!strcmp(arg[0], "SHUTDOWNCMD")) {
-		checkmode(arg[0], shutdowncmd, arg[1], reload_flag);
+	/* NOTIFYCMD <cmd> [<arg1> [<arg2>...]] */
+	if (!strcmp(arg[0], "NOTIFYCMD")) {
+		size_t	i, l = 0;
 
-		free(shutdowncmd);
-		shutdowncmd = xstrdup(arg[1]);
+		/* -1: the arg[0] is the configuration token */
+		notifycmd_argc = numargs - 1;
+
+		/* +1: the notifycmd_argv[notifycmd_argc] is the NULL sentinel */
+		free(notifycmd_argv);
+		notifycmd_argv = (char**)xcalloc(notifycmd_argc + 1, sizeof(char *));
+		for (i = 1; i < numargs; i++) {
+			/* +1: either a space follows, or '\0'
+			 * +2: surrounding quotes
+			 */
+			l += strlen(arg[i]) + 3;
+			notifycmd_argv[i - 1] = xstrdup(arg[i]);
+			strcpy(notifycmd_argv[i - 1], arg[i]);
+		}
+		notifycmd_argv[notifycmd_argc] = NULL;
+
+		free(notifycmd_concat);
+		notifycmd_concat = (char*)xcalloc(l + 2, sizeof(char));
+		for (i = 1; i < numargs; i++) {
+			snprintfcat(notifycmd_concat, l + 1, "'%s'%s",
+				arg[i], i == numargs - 1 ? "" : " ");
+		}
+
+		upsdebugx(1, "%s: collected %s with %" PRIuSIZE " tokens: %s",
+			__func__, arg[0], notifycmd_argc, NUT_STRARG(notifycmd_concat));
+
+		if (notifycmd_argc > 0 && strchr(notifycmd_argv[0], ' ')) {
+			/* NOTE: this may also be a path with spaces, more prominent on Windows or MacOS, probably */
+			upslogx(LOG_WARNING, "%s: command '%s' contains spaces, be sure to pass any arguments as separately quoted tokens!",
+				arg[0], notifycmd_argv[0]);
+		}
+
+		/* Handled OK */
+		return 1;
+	}
+
+	/* SHUTDOWNCMD <cmd> [<arg1> [<arg2>...]] */
+	if (!strcmp(arg[0], "SHUTDOWNCMD")) {
+		/* Similar to NOTIFYCMD handling, but while there the first
+		 * arg token MUST be the command/path name, here we allow
+		 * arguments inside the single-token definition (or as some
+		 * follow-up tokens). This impacts the shutdowncmd_concat
+		 * value by NOT quoting the first (possibly only) token. */
+		char	*shutdowncmd_concat_new = NULL;
+		size_t	i, l = 0;
+
+		/* -1: the arg[0] is the configuration token */
+		shutdowncmd_argc = numargs - 1;
+
+		/* +1: the shutdowncmd_argv[shutdowncmd_argc] is the NULL sentinel */
+		free(shutdowncmd_argv);
+		shutdowncmd_argv = (char**)xcalloc(shutdowncmd_argc + 1, sizeof(char *));
+		for (i = 1; i < numargs; i++) {
+			/* +1: either a space follows, or '\0'
+			 * +2: surrounding quotes
+			 */
+			l += strlen(arg[i]) + 3;
+			shutdowncmd_argv[i - 1] = xstrdup(arg[i]);
+			strcpy(shutdowncmd_argv[i - 1], arg[i]);
+		}
+		shutdowncmd_argv[shutdowncmd_argc] = NULL;
+
+		/* For SHUTDOWNCMD we do not quote first (possibly only)
+		 * token that may have a full command line scriptlet */
+		shutdowncmd_concat_new = (char*)xcalloc(l + 2, sizeof(char));
+		snprintf(shutdowncmd_concat_new, l + 1, "%s%s",
+			shutdowncmd_argv[0], numargs == 2 ? "" : " ");
+		for (i = 2; i < numargs; i++) {
+			snprintfcat(shutdowncmd_concat_new, l + 1, "'%s'%s",
+				arg[i], i == numargs - 1 ? "" : " ");
+		}
+
+		/* First check whether the old value is same as new and
+		 * remains known to the other process, if appropriate;
+		 * only then release the memory and replace the pointer.
+		 */
+		checkmode(arg[0], shutdowncmd_concat, shutdowncmd_concat_new, reload_flag);
+
+		free(shutdowncmd_concat);
+		shutdowncmd_concat = shutdowncmd_concat_new;
+
+		upsdebugx(1, "%s: collected %s with %" PRIuSIZE " tokens: %s",
+			__func__, arg[0], shutdowncmd_argc, NUT_STRARG(shutdowncmd_concat));
+
+		/* Handled OK */
 		return 1;
 	}
 
@@ -2362,13 +2473,6 @@ static int parse_conf_arg(size_t numargs, char **arg)
 			upslogx(LOG_INFO, "Using power down flag file %s",
 				arg[1]);
 
-		return 1;
-	}
-
-	/* NOTIFYCMD <cmd> */
-	if (!strcmp(arg[0], "NOTIFYCMD")) {
-		free(notifycmd);
-		notifycmd = xstrdup(arg[1]);
 		return 1;
 	}
 
@@ -2775,7 +2879,7 @@ static void ups_free(utype_t *ups)
 
 static void upsmon_cleanup(void)
 {
-	int	i;
+	size_t	i;
 	utype_t	*utmp, *unext;
 
 	/* Flush *our* output before possibly failing in third-party code
@@ -2796,10 +2900,24 @@ static void upsmon_cleanup(void)
 	}
 
 	free(run_as_user);
-	free(shutdowncmd);
-	free(notifycmd);
+	free(shutdowncmd_concat);
+	free(notifycmd_concat);
 	free(powerdownflag);
 	free(configfile);
+
+	if (shutdowncmd_argv) {
+		for (i = 0; i < shutdowncmd_argc; i++) {
+			free(shutdowncmd_argv[i]);
+		}
+		free(shutdowncmd_argv);
+	}
+
+	if (notifycmd_argv) {
+		for (i = 0; i < notifycmd_argc; i++) {
+			free(notifycmd_argv[i]);
+		}
+		free(notifycmd_argv);
+	}
 
 	for (i = 0; notifylist[i].name != NULL; i++) {
 		free(notifylist[i].msg);
@@ -3560,12 +3678,12 @@ static void runparent(int fd)
 	set_pdflag();
 
 	upsdebugx(1, "%s: upsmon parent: Calling shutdown command: %s",
-		__func__, shutdowncmd);
-	sret = system(shutdowncmd);
+		__func__, shutdowncmd_concat);
+	sret = system(shutdowncmd_concat);
 
 	if (sret != 0)
 		upslogx(LOG_ERR, "upsmon parent: Unable to call shutdown command: %s",
-			shutdowncmd);
+			shutdowncmd_concat);
 
 	if (shutdownexitdelay) {
 		/* make sure the child is still alive - inverse of check_parent() */
@@ -3578,7 +3696,7 @@ static void runparent(int fd)
 			"after %s (%i) shutdown command: %s",
 			exit_flag, (intmax_t)pid_pipechild,
 			(sret == 0 ? "calling" : "trying to call"),
-			sret, shutdowncmd);
+			sret, shutdowncmd_concat);
 		upsnotify(NOTIFY_STATE_EXTEND_TIMEOUT, "Parent: waiting for child to exit");
 
 		do {
@@ -3617,7 +3735,7 @@ static void runparent(int fd)
 	close(fd);
 	upslogx(LOG_WARNING, "upsmon parent: Exiting after %s (%i) shutdown command: %s",
 		(sret == 0 ? "calling" : "trying to call"),
-		sret, shutdowncmd);
+		sret, shutdowncmd_concat);
 	exit(EXIT_SUCCESS);
 }
 #endif	/* !WIN32 */
@@ -4137,21 +4255,23 @@ int main(int argc, char *argv[])
 	if (checking_flag)
 		exit(check_pdflag());
 
-	if (shutdowncmd == NULL) {
+	if (shutdowncmd_argc == 0) {
 		printf("Warning: no shutdown command defined%s\n",
 			(minsupplies < 1)
 			? ", but that is OK for a monitoring-only client."
 			: "!");
 		fflush(stdout);
 	} else {
-		upsdebugx(1, "will use a shutdown command (SHUTDOWNCMD): '%s'", shutdowncmd);
+		upsdebugx(1, "will use a shutdown command (SHUTDOWNCMD): '%s'",
+			NUT_STRARG(shutdowncmd_concat));
 	}
 
-	if (notifycmd == NULL) {
+	if (notifycmd_argc == 0) {
 		printf("Warning: no custom notification command defined, just so you know\n");
 		fflush(stdout);
 	} else {
-		upsdebugx(1, "will use custom notification command (NOTIFYCMD): '%s'", notifycmd);
+		upsdebugx(1, "will use custom notification command (NOTIFYCMD): '%s'",
+			NUT_STRARG(notifycmd_concat));
 	}
 
 	/* we may need to get rid of a flag from a previous shutdown */

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -4648,6 +4648,7 @@ end_loop_cycle:
 
 	upslogx(LOG_INFO, "Signal %d: exiting", exit_flag);
 	upsnotify(NOTIFY_STATE_STOPPING, "Signal %d: exiting", exit_flag);
+	/* TOTHINK: use atexit() instead, to handle any code path? */
 	upsmon_cleanup();
 
 	upsdebugx(1, "Finally exiting due to signal %d", exit_flag);

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -2900,16 +2900,31 @@ static void upsmon_cleanup(void)
 	}
 
 	free(run_as_user);
+	run_as_user = NULL;
 	free(shutdowncmd_concat);
+	shutdowncmd_concat = NULL;
 	free(notifycmd_concat);
+	notifycmd_concat = NULL;
 	free(powerdownflag);
+	powerdownflag = NULL;
 	free(configfile);
+	configfile = NULL;
+
+	free(certpath);
+	certpath = NULL;
+	free(certname);
+	certname = NULL;
+	free(certpasswd);
+	certpasswd = NULL;
+	free(certfile);
+	certfile = NULL;
 
 	if (shutdowncmd_argv) {
 		for (i = 0; i < shutdowncmd_argc; i++) {
 			free(shutdowncmd_argv[i]);
 		}
 		free(shutdowncmd_argv);
+		shutdowncmd_argv = NULL;
 	}
 
 	if (notifycmd_argv) {
@@ -2917,10 +2932,12 @@ static void upsmon_cleanup(void)
 			free(notifycmd_argv[i]);
 		}
 		free(notifycmd_argv);
+		notifycmd_argv = NULL;
 	}
 
 	for (i = 0; notifylist[i].name != NULL; i++) {
 		free(notifylist[i].msg);
+		notifylist[i].msg = NULL;
 	}
 
 	fflush(stdout);

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -302,7 +302,7 @@ static unsigned __stdcall async_notify(LPVOID param)
 			setenv("NOTIFYTYPE", data->ntype, 1);
 			/* Copy entries [0]..[argc-1] */
 			memcpy(argv, notifycmd_argv, notifycmd_argc * sizeof(char *));
-			argv[notifycmd_argc] = data->notice;
+			argv[notifycmd_argc] = (char*)(data->notice);
 			argv[notifycmd_argc + 1] = NULL;
 			ret = _spawnvp(_P_WAIT, notifycmd_argv[0], (const char * const *)argv);
 			if (ret == -1) {
@@ -384,7 +384,7 @@ static void notify(const char *notice, unsigned int flags, const char *ntype,
 			setenv("NOTIFYTYPE", ntype, 1);
 			/* Copy entries [0]..[argc-1] */
 			memcpy(argv, notifycmd_argv, notifycmd_argc * sizeof(char *));
-			argv[notifycmd_argc] = notice;
+			argv[notifycmd_argc] = (char*)notice;
 			argv[notifycmd_argc + 1] = NULL;
 			execvp(notifycmd_argv[0], argv);
 			/* execvp() only returns on error */

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -238,25 +238,18 @@ static void wall(const char *text)
 	pclose(wf);
 #else	/* WIN32 */
 #	define MESSAGE_CMD "message.exe"
-	char	*command;
+	char	*argv[3];
+	int	ret;
 
-	/* first +1 is for the space between message and text
-	 * second +1 is for trailing 0
-	 * +2 is for ""
-	 */
-	size_t	commandsz = strlen(MESSAGE_CMD) + 1 + 2 + strlen(text) + 1;
+	argv[0] = MESSAGE_CMD;
+	argv[1] = (char *)text;
+	argv[2] = NULL;
 
-	command = malloc (commandsz);
-	if (command == NULL) {
-		upslog_with_errno(LOG_NOTICE, "Not enough memory for wall");
-		return;
+	upsdebugx(6, "%s: executing %s with message: %s", __func__, MESSAGE_CMD, NUT_STRARG(text));
+	ret = _spawnvp(_P_WAIT, MESSAGE_CMD, (const char * const *)argv);
+	if (ret != 0) {
+		upslog_with_errno(LOG_NOTICE, "Can't invoke wall (status: %d)", ret);
 	}
-
-	snprintf(command, commandsz, "%s \"%s\"", MESSAGE_CMD, text);
-	if (system(command) != 0) {
-		upslog_with_errno(LOG_NOTICE, "Can't invoke wall");
-	}
-	free(command);
 #endif	/* WIN32 */
 }
 
@@ -271,32 +264,37 @@ typedef struct async_notify_s {
 
 static unsigned __stdcall async_notify(LPVOID param)
 {
-	char	exec[LARGEBUF];
-	char	notice[LARGEBUF];
+	char	*argv[3];
+	int	ret;
 
 	/* the following code is a copy of the content of the NOT WIN32 part of
-	"notify" function below */
+	 * "notify" function below */
 
 	async_notify_t *data = (async_notify_t *)param;
 
 	if (flag_isset(data->flags, NOTIFY_WALL)) {
-		snprintf(notice,LARGEBUF,"%s: %s", data->date, data->notice);
+		char	notice[LARGEBUF];
+
+		snprintf(notice, sizeof(notice), "%s: %s", data->date, data->notice);
 		wall(notice);
 	}
 
 	if (flag_isset(data->flags, NOTIFY_EXEC)) {
 		if (notifycmd != NULL) {
-			snprintf(exec, sizeof(exec), "%s \"%s\"", notifycmd, data->notice);
-
-			upsdebugx(6, "%s: Calling NOTIFYCMD: %s", __func__, exec);
+			upsdebugx(6, "%s: Calling NOTIFYCMD: %s with notice: %s",
+				__func__, notifycmd, NUT_STRARG(data->notice));
 			if (data->upsname)
 				setenv("UPSNAME", data->upsname, 1);
 			else
 				setenv("UPSNAME", "", 1);
 
 			setenv("NOTIFYTYPE", data->ntype, 1);
-			if (system(exec) == -1) {
-				upslog_with_errno(LOG_ERR, "%s", __func__);
+			argv[0] = notifycmd;
+			argv[1] = data->notice;
+			argv[2] = NULL;
+			ret = _spawnvp(_P_WAIT, notifycmd, (const char * const *)argv);
+			if (ret == -1) {
+				upslog_with_errno(LOG_ERR, "%s: _spawnvp failed", __func__);
 			}
 		}
 	}
@@ -314,12 +312,11 @@ static void notify(const char *notice, unsigned int flags, const char *ntype,
 			const char *upsname)
 {
 #ifndef WIN32
-	char	exec[LARGEBUF];
 	int	ret;
 #endif	/* !WIN32 */
 
 	upsdebugx(6, "%s: sending notification for [%s]: type %s with flags 0x%04x: %s",
-		__func__, upsname ? upsname : "upsmon itself", ntype, flags, notice);
+		__func__, upsname ? upsname : "upsmon itself", ntype, flags, NUT_STRARG(notice));
 
 	if (flag_isset(flags, NOTIFY_IGNORE)) {
 		upsdebugx(6, "%s: NOTIFY_IGNORE", __func__);
@@ -328,7 +325,7 @@ static void notify(const char *notice, unsigned int flags, const char *ntype,
 
 	if (flag_isset(flags, NOTIFY_SYSLOG)) {
 		upsdebugx(6, "%s: NOTIFY_SYSLOG (as LOG_NOTICE)", __func__);
-		upslogx(LOG_NOTICE, "%s", notice);
+		upslogx(LOG_NOTICE, "%s", NUT_STRARG(notice));
 	}
 
 #ifndef WIN32
@@ -357,10 +354,10 @@ static void notify(const char *notice, unsigned int flags, const char *ntype,
 
 	if (flag_isset(flags, NOTIFY_EXEC)) {
 		if (notifycmd != NULL) {
-			upsdebugx(6, "%s (%schild): NOTIFY_EXEC: calling NOTIFYCMD as '%s \"%s\"'",
-				__func__, use_pipe ? "grand" : "", notifycmd, notice);
+			char	*argv[3];
 
-			snprintf(exec, sizeof(exec), "%s \"%s\"", notifycmd, notice);
+			upsdebugx(6, "%s (%schild): NOTIFY_EXEC: calling NOTIFYCMD as '%s' with notice: '%s'",
+				__func__, use_pipe ? "grand" : "", notifycmd, NUT_STRARG(notice));
 
 			if (upsname)
 				setenv("UPSNAME", upsname, 1);
@@ -368,9 +365,13 @@ static void notify(const char *notice, unsigned int flags, const char *ntype,
 				setenv("UPSNAME", "", 1);
 
 			setenv("NOTIFYTYPE", ntype, 1);
-			if (system(exec) == -1) {
-				upslog_with_errno(LOG_ERR, "%s", __func__);
-			}
+			argv[0] = (char *)notifycmd;
+			argv[1] = (char *)notice;
+			argv[2] = NULL;
+			execvp(notifycmd, argv);
+			/* execvp() only returns on error */
+			upslog_with_errno(LOG_ERR, "%s: execvp(%s) failed", __func__, notifycmd);
+			exit(EXIT_FAILURE);
 		} else {
 			upsdebugx(6, "%s (%schild): NOTIFY_EXEC: no NOTIFYCMD was configured", __func__, use_pipe ? "grand" : "");
 		}

--- a/clients/upssched.c
+++ b/clients/upssched.c
@@ -2256,6 +2256,83 @@ static void checkconf(void)
 	pconf_finish(&ctx);
 }
 
+static void clean_exit(void)
+{
+	ttype_t	*tcurr, *tnext;
+	conn_t	*ccurr, *cnext;
+	size_t	i;
+
+	/* Flush *our* output before possibly failing in third-party code
+	 * (e.g. SSL libs), so client consumers have a chance to see it */
+	fflush(stdout);
+	fflush(stderr);
+
+	upsdebugx(1, "%s: starting", __func__);
+
+	/* Free timers */
+	tcurr = thead;
+	while (tcurr) {
+		tnext = tcurr->next;
+
+		free(tcurr->name);
+
+		if (tcurr->upsnames) {
+			for (i = 0; tcurr->upsnames[i]; i++) {
+				free(tcurr->upsnames[i]);
+			}
+			free(tcurr->upsnames);
+		}
+
+		if (tcurr->notifytypes) {
+			for (i = 0; tcurr->notifytypes[i]; i++) {
+				free(tcurr->notifytypes[i]);
+			}
+			free(tcurr->notifytypes);
+		}
+
+		if (tcurr->notifymsgs) {
+			for (i = 0; tcurr->notifymsgs[i]; i++) {
+				free(tcurr->notifymsgs[i]);
+			}
+			free(tcurr->notifymsgs);
+		}
+
+		free(tcurr);
+		tcurr = tnext;
+	}
+	thead = NULL;
+
+	/* Free connections */
+	ccurr = connhead;
+	while (ccurr) {
+		cnext = ccurr->next;
+		pconf_finish(&ccurr->ctx);
+		free(ccurr);
+		ccurr = cnext;
+	}
+	connhead = NULL;
+
+	/* Free strings and arrays */
+	if (cmdscript_argv) {
+		for (i = 0; i < cmdscript_argc; i++) {
+			free(cmdscript_argv[i]);
+		}
+		free(cmdscript_argv);
+		cmdscript_argv = NULL;
+	}
+
+	free(cmdscript_concat);
+	cmdscript_concat = NULL;
+
+	free(pipefn);
+	pipefn = NULL;
+
+	free(lockfn);
+	lockfn = NULL;
+
+	upsdebugx(1, "%s: finished, exiting", __func__);
+}
+
 static void help(const char *arg_progname)
 	__attribute__((noreturn));
 
@@ -2350,20 +2427,19 @@ int main(int argc, char **argv)
 	else
 		upsdebugx(1, "Did not get any NOTIFYMSG from command line");
 
-	/* see if this matches anything in the config file */
+	/* Whenever a process exits, do carefully free any resources it
+	 * has (maybe by parent, from before forking some notifier etc.) */
+	atexit(clean_exit);
+
+	setproctag("cli");
+
+	/* See if this request matches anything in the config file */
 	/* This is actually the processing loop:
 	 * checkconf -> conf_arg -> parse_at -> sendcmd -> daemon if needed
 	 *  -> start_daemon -> conn_add(pipefd) or sock_read(conn)
 	 */
-	setproctag("cli");
 	checkconf();
 
 	upsdebugx(1, "Exiting upssched (CLI process)");
-
-	/* Flush *our* output before possibly failing in third-party code
-	 * (e.g. SSL libs), so client consumers have a chance to see it */
-	fflush(stdout);
-	fflush(stderr);
-
 	exit(EXIT_SUCCESS);
 }

--- a/clients/upssched.c
+++ b/clients/upssched.c
@@ -105,32 +105,71 @@ static OVERLAPPED connect_overlapped;
 
 static void exec_cmd(const char *cmd)
 {
-	int	err;
-	char	buf[LARGEBUF];
-
-	snprintf(buf, sizeof(buf), "%s %s", cmdscript, cmd);
-
-	upsdebugx(4, "%s: calling: %s", __func__, buf);
-	err = system(buf);
-	upsdebugx(3, "%s(%s): returned %d", __func__, buf, err);
 #ifndef WIN32
-	if (WIFEXITED(err)) {
-		if (WEXITSTATUS(err)) {
-			upslogx(LOG_INFO, "exec_cmd(%s) returned %d", buf, WEXITSTATUS(err));
+	int	waitstatus = 0;
+	pid_t	pid, waitret;
+#else
+	int	err = 0;
+#endif
+	char	*argv[3];
+
+	if (cmdscript == NULL) {
+		upslogx(LOG_ERR, "No CMDSCRIPT defined, cannot execute command: %s", NUT_STRARG(cmd));
+		return;
+	}
+
+	argv[0] = cmdscript;
+	argv[1] = (char *)cmd;
+	argv[2] = NULL;
+
+	upsdebugx(4, "%s: calling: %s %s", __func__, cmdscript, NUT_STRARG(cmd));
+
+#ifndef WIN32
+	pid = fork();
+	if (pid < 0) {
+		upslog_with_errno(LOG_ERR, "fork() failed in exec_cmd");
+		return;
+	}
+
+	if (pid == 0) {
+		/* child process */
+		execvp(cmdscript, argv);
+		/* execvp() only returns on error */
+		upslog_with_errno(LOG_ERR, "execvp(%s) failed", cmdscript);
+		exit(EXIT_FAILURE);
+	}
+
+	/* parent process - wait for child */
+	waitret = waitpid(pid, &waitstatus, 0);
+	if (waitret < 0) {
+		upslog_with_errno(LOG_ERR, "waitpid(%d) failed", (int)pid);
+		return;
+	}
+
+	if (WIFEXITED(waitstatus)) {
+		if (WEXITSTATUS(waitstatus)) {
+			upslogx(LOG_INFO, "exec_cmd(%s %s) returned %d",
+				cmdscript, NUT_STRARG(cmd), WEXITSTATUS(waitstatus));
 		}
 	} else {
-		if (WIFSIGNALED(err)) {
-			upslogx(LOG_WARNING, "exec_cmd(%s) terminated with signal %d", buf, WTERMSIG(err));
+		if (WIFSIGNALED(waitstatus)) {
+			upslogx(LOG_WARNING, "exec_cmd(%s %s) terminated with signal %d",
+				cmdscript, NUT_STRARG(cmd), WTERMSIG(waitstatus));
 		} else {
-			upslogx(LOG_ERR, "Execute command failure: %s", buf);
+			upslogx(LOG_ERR, "Execute command failure: %s %s",
+				cmdscript, NUT_STRARG(cmd));
 		}
 	}
+
+	upsdebugx(3, "%s: returned status %d", __func__, waitstatus);
 #else	/* WIN32 */
-	if(err != -1) {
-		upslogx(LOG_INFO, "Execute command \"%s\" OK", buf);
-	}
-	else {
-		upslogx(LOG_ERR, "Execute command failure : %s", buf);
+	/* Use _spawnvp for Windows */
+	err = _spawnvp(_P_WAIT, cmdscript, (const char * const *)argv);
+	if (err != -1) {
+		upslogx(LOG_INFO, "Execute command \"%s %s\" OK", cmdscript, NUT_STRARG(cmd));
+		upsdebugx(3, "%s: returned status %d", __func__, err);
+	} else {
+		upslog_with_errno(LOG_ERR, "Execute command \"%s %s\" failure", cmdscript, NUT_STRARG(cmd));
 	}
 #endif	/* WIN32 */
 

--- a/clients/upssched.c
+++ b/clients/upssched.c
@@ -81,7 +81,15 @@ typedef struct ttype_s {
 
 static ttype_t	*thead = NULL;
 static conn_t	*connhead = NULL;
-static char	*cmdscript = NULL, *pipefn = NULL, *lockfn = NULL;
+static char	*pipefn = NULL, *lockfn = NULL;
+/* Argument array for respective program, where [0] is the program name,
+ * followed by (argc-1) possible command-line argument tokens, with a
+ * NULL value in the end as the [argc]'th entry. Overall (argc+1) items
+ * if at all populated, minimum 2 for the program name and NULL sentinel.
+ * Concatenated value is also stored to ease debug logging, but is not
+ * used directly for program calls. */
+static char	**cmdscript_argv = NULL, *cmdscript_concat = NULL;
+static size_t	cmdscript_argc = 0;
 static int	nut_debug_level_args = 0, nut_debug_level_env = 0, nut_debug_level_conf = 0;
 static int	list_timers = 0;
 
@@ -111,18 +119,15 @@ static void exec_cmd(const char *cmd)
 #else
 	int	err = 0;
 #endif
-	char	*argv[3];
+	char	**argv = NULL;
 
-	if (cmdscript == NULL) {
+	if (cmdscript_argc == 0) {
 		upslogx(LOG_ERR, "No CMDSCRIPT defined, cannot execute command: %s", NUT_STRARG(cmd));
 		return;
 	}
 
-	argv[0] = cmdscript;
-	argv[1] = (char *)cmd;
-	argv[2] = NULL;
-
-	upsdebugx(4, "%s: calling: %s %s", __func__, cmdscript, NUT_STRARG(cmd));
+	/* For logging note that cmdscript_concat is quoted as appropriate */
+	upsdebugx(4, "%s: calling: %s \"%s\"", __func__, NUT_STRARG(cmdscript_concat), NUT_STRARG(cmd));
 
 #ifndef WIN32
 	pid = fork();
@@ -131,49 +136,60 @@ static void exec_cmd(const char *cmd)
 		return;
 	}
 
-	if (pid == 0) {
-		/* child process */
-		execvp(cmdscript, argv);
-		/* execvp() only returns on error */
-		upslog_with_errno(LOG_ERR, "execvp(%s) failed", cmdscript);
-		exit(EXIT_FAILURE);
-	}
+	if (pid > 0) {
+		/* parent process - wait for child */
+		waitret = waitpid(pid, &waitstatus, 0);
+		if (waitret < 0) {
+			upslog_with_errno(LOG_ERR, "waitpid(%d) failed", (int)pid);
+			return;
+		}
 
-	/* parent process - wait for child */
-	waitret = waitpid(pid, &waitstatus, 0);
-	if (waitret < 0) {
-		upslog_with_errno(LOG_ERR, "waitpid(%d) failed", (int)pid);
+		if (WIFEXITED(waitstatus)) {
+			if (WEXITSTATUS(waitstatus)) {
+				upslogx(LOG_INFO, "exec_cmd(%s '%s') returned %d",
+					NUT_STRARG(cmdscript_concat), NUT_STRARG(cmd), WEXITSTATUS(waitstatus));
+			}
+		} else {
+			if (WIFSIGNALED(waitstatus)) {
+				upslogx(LOG_WARNING, "exec_cmd(%s '%s') terminated with signal %d",
+					NUT_STRARG(cmdscript_concat), NUT_STRARG(cmd), WTERMSIG(waitstatus));
+			} else {
+				upslogx(LOG_ERR, "Execute command failure: %s '%s'",
+					NUT_STRARG(cmdscript_concat), NUT_STRARG(cmd));
+			}
+		}
+
+		upsdebugx(3, "%s: returned status %d", __func__, waitstatus);
 		return;
 	}
+#endif	/* !WIN32 */
 
-	if (WIFEXITED(waitstatus)) {
-		if (WEXITSTATUS(waitstatus)) {
-			upslogx(LOG_INFO, "exec_cmd(%s %s) returned %d",
-				cmdscript, NUT_STRARG(cmd), WEXITSTATUS(waitstatus));
-		}
-	} else {
-		if (WIFSIGNALED(waitstatus)) {
-			upslogx(LOG_WARNING, "exec_cmd(%s %s) terminated with signal %d",
-				cmdscript, NUT_STRARG(cmd), WTERMSIG(waitstatus));
-		} else {
-			upslogx(LOG_ERR, "Execute command failure: %s %s",
-				cmdscript, NUT_STRARG(cmd));
-		}
-	}
+	/* Only deal with argv for child or mono-process */
+	/* We will add one argument, plus one NULL sentinel, after argc original entries */
+	argv = (char**)xcalloc(cmdscript_argc + 2, sizeof(char *));
+	/* Copy entries [0]..[argc-1] */
+	memcpy(argv, cmdscript_argv, cmdscript_argc * sizeof(char *));
+	argv[cmdscript_argc] = (char *)cmd;
+	argv[cmdscript_argc + 1] = NULL;
 
-	upsdebugx(3, "%s: returned status %d", __func__, waitstatus);
+#ifndef WIN32
+	/* child process */
+	execvp(cmdscript_argv[0], argv);
+	/* execvp() only returns on error */
+	upslog_with_errno(LOG_ERR, "execvp(%s) failed", NUT_STRARG(cmdscript_concat));
+	free(argv);
+	exit(EXIT_FAILURE);
 #else	/* WIN32 */
 	/* Use _spawnvp for Windows */
-	err = _spawnvp(_P_WAIT, cmdscript, (const char * const *)argv);
+	err = _spawnvp(_P_WAIT, cmdscript_argv[0], (const char * const *)argv);
 	if (err != -1) {
-		upslogx(LOG_INFO, "Execute command \"%s %s\" OK", cmdscript, NUT_STRARG(cmd));
+		upslogx(LOG_INFO, "Execute command %s \"%s\" OK", NUT_STRARG(cmdscript_concat), NUT_STRARG(cmd));
 		upsdebugx(3, "%s: returned status %d", __func__, err);
 	} else {
-		upslog_with_errno(LOG_ERR, "Execute command \"%s %s\" failure", cmdscript, NUT_STRARG(cmd));
+		upslog_with_errno(LOG_ERR, "Execute command %s \"%s\" failure", NUT_STRARG(cmdscript_concat), NUT_STRARG(cmd));
 	}
+	free(argv);
 #endif	/* WIN32 */
-
-	return;
 }
 
 /* Collect the list of strings into a "sep" (e.g. comma) separated string.
@@ -1973,7 +1989,7 @@ static void parse_at(const char *ntype, const char *un, const char *cmd,
 {
 	/* complain both ways in case we don't have a tty */
 
-	if (!cmdscript) {
+	if (!cmdscript_argc) {
 		printf("CMDSCRIPT must be set before any ATs in the config file!\n");
 		fatalx(EXIT_FAILURE, "CMDSCRIPT must be set before any ATs in the config file!");
 	}
@@ -2074,9 +2090,43 @@ static int conf_arg(size_t numargs, char **arg)
 	if (numargs < 2)
 		return 0;
 
-	/* CMDSCRIPT <scriptname> */
+	/* CMDSCRIPT <scriptname> [<arg1> [<arg2>...]] */
 	if (!strcmp(arg[0], "CMDSCRIPT")) {
-		cmdscript = xstrdup(arg[1]);
+		size_t	i, l = 0;
+
+		/* -1: the arg[0] is the configuration token */
+		cmdscript_argc = numargs - 1;
+
+		/* +1: the cmdscript_argv[cmdscript_argc] is the NULL sentinel */
+		free(cmdscript_argv);
+		cmdscript_argv = (char**)xcalloc(cmdscript_argc + 1, sizeof(char *));
+		for (i = 1; i < numargs; i++) {
+			/* +1: either a space follows, or '\0'
+			 * +2: surrounding quotes
+			 */
+			l += strlen(arg[i]) + 3;
+			cmdscript_argv[i - 1] = xstrdup(arg[i]);
+			strcpy(cmdscript_argv[i - 1], arg[i]);
+		}
+		cmdscript_argv[cmdscript_argc] = NULL;
+
+		free(cmdscript_concat);
+		cmdscript_concat = (char*)xcalloc(l + 2, sizeof(char));
+		for (i = 1; i < numargs; i++) {
+			snprintfcat(cmdscript_concat, l + 1, "'%s'%s",
+				arg[i], i == numargs - 1 ? "" : " ");
+		}
+
+		upsdebugx(1, "%s: collected %s with %" PRIuSIZE " tokens: %s",
+			__func__, arg[0], cmdscript_argc, NUT_STRARG(cmdscript_concat));
+
+		if (cmdscript_argc > 0 && strchr(cmdscript_argv[0], ' ')) {
+			/* NOTE: this may also be a path with spaces, more prominent on Windows or MacOS, probably */
+			upslogx(LOG_WARNING, "%s: command '%s' contains spaces, be sure to pass any arguments as separately quoted tokens!",
+				arg[0], cmdscript_argv[0]);
+		}
+
+		/* Handled OK */
 		return 1;
 	}
 

--- a/conf/upsmon.conf.sample.in
+++ b/conf/upsmon.conf.sample.in
@@ -147,12 +147,19 @@
 MINSUPPLIES 1
 
 # --------------------------------------------------------------------------
-# SHUTDOWNCMD "<command>"
+# SHUTDOWNCMD "<command>" ["<arg1>" "<arg2>" ...]
 #
 # upsmon runs this command when the system needs to be brought down.
 #
 # This should work just about everywhere ... if it doesn't, well, change it,
 # perhaps to a more complicated custom script.
+#
+# Unlike some others, this directive still allows to pass both the command
+# and its arguments as a single quoted token. It also supports a multi-token
+# syntax to pass each argument as a separate token:
+# SHUTDOWNCMD "/sbin/shutdown -h +0"
+# SHUTDOWNCMD "/sbin/shutdown" "-h" "+0"
+# SHUTDOWNCMD /sbin/shutdown -h +0
 #
 # Note that while you experiment with the initial setup and want to test how
 # your configuration reacts to power state changes and ultimately when power
@@ -206,15 +213,16 @@ SHUTDOWNCMD "/sbin/shutdown -h +0"
 #SHUTDOWNEXIT yes
 
 # --------------------------------------------------------------------------
-# NOTIFYCMD <command>
+# NOTIFYCMD <command> ["<arg1>" "<arg2>" ...]
 #
 # upsmon calls this to send messages when things happen
 #
-# The value is interpreted as a complete path to an externally stored
-# executable script (e.g. not an inline scriptlet) or program file without
-# further arguments (this is a change from NUT v2.8.5 and older releases).
+# The first (possibly only) token of the value is interpreted as a complete
+# path to an externally stored executable script (e.g. not an inline scriptlet)
+# or program file without further arguments (which may be passed in explicitly
+# quoted separate tokens). This is a change from NUT v2.8.5 and older releases.
 # This command is called with the full text of the message (from NOTIFYMSG)
-# as one argument.
+# as one last argument, with further details passed as environment variables.
 #
 # The environment string NOTIFYTYPE will contain the type string of
 # whatever caused this event to happen.

--- a/conf/upsmon.conf.sample.in
+++ b/conf/upsmon.conf.sample.in
@@ -210,6 +210,9 @@ SHUTDOWNCMD "/sbin/shutdown -h +0"
 #
 # upsmon calls this to send messages when things happen
 #
+# The value is interpreted as a complete path to an externally stored
+# executable script (e.g. not an inline scriptlet) or program file without
+# further arguments (this is a change from NUT v2.8.5 and older releases).
 # This command is called with the full text of the message (from NOTIFYMSG)
 # as one argument.
 #

--- a/conf/upssched.conf.sample.in
+++ b/conf/upssched.conf.sample.in
@@ -21,6 +21,9 @@
 # CMDSCRIPT <scriptname>
 #
 # This script gets called to invoke commands for timers that trigger.
+# The value is interpreted as a complete path to an externally stored
+# executable script (e.g. not an inline scriptlet) or program file without
+# further arguments (this is a change from NUT v2.8.5 and older releases).
 # It is given a single argument - the <timername> in your
 # AT ... START-TIMER defines.
 #

--- a/conf/upssched.conf.sample.in
+++ b/conf/upssched.conf.sample.in
@@ -18,13 +18,16 @@
 
 # ============================================================================
 #
-# CMDSCRIPT <scriptname>
+# CMDSCRIPT <scriptname> ["<arg1>" "<arg2>" ...]
 #
 # This script gets called to invoke commands for timers that trigger.
-# The value is interpreted as a complete path to an externally stored
-# executable script (e.g. not an inline scriptlet) or program file without
-# further arguments (this is a change from NUT v2.8.5 and older releases).
-# It is given a single argument - the <timername> in your
+#
+# The first (possibly only) token of the value is interpreted as a complete
+# path to an externally stored executable script (e.g. not an inline scriptlet)
+# or program file without further arguments (which may be passed in explicitly
+# quoted separate tokens). This is a change from NUT v2.8.5 and older releases.
+#
+# It is given a single last argument - the <timername> in your
 # AT ... START-TIMER defines.
 #
 # *** This must be defined *before* the first AT line.  Otherwise the

--- a/docs/man/upsmon.conf.txt
+++ b/docs/man/upsmon.conf.txt
@@ -213,11 +213,11 @@ same as when `max=1`), and a zero value means to never repeat the message
 Note that this throttle only applies to one latest-active error state per
 monitored device.
 
-*NOTIFYCMD* 'command'::
+*NOTIFYCMD* 'command' ['arg1' 'arg2' ...]::
 
 upsmon calls this to send messages when things happen.
 +
-This command is called with the full text of the message as one
+This command is called with the full text of the message as one last
 argument.  The environment string NOTIFYTYPE will contain the type
 string of whatever caused this event to happen.
 +
@@ -230,18 +230,22 @@ NOTIFYFLAG.  See NOTIFYFLAG below for more details.
 Making this some sort of shell script might not be a bad idea.  For
 more information and ideas, see docs/scheduling.txt
 +
-The value is interpreted as a complete path to an externally stored
-executable script (e.g. not an inline scriptlet) or program file without
-further arguments (this is a change from NUT v2.8.5 and older releases).
+The first (possibly only) token of the value is interpreted as a complete
+path to an externally stored executable script (e.g. not an inline scriptlet)
+or program file without further arguments (which may be passed in explicitly
+# quoted separate tokens). This is a change from NUT v2.8.5 and older releases.
 Remember, this command also needs to be one element in the configuration
 file, so if your command path has spaces, then wrap it in quotes.
 +
-+NOTIFYCMD "/path to/script"+
+------
+NOTIFYCMD "/path to/script"
+NOTIFYCMD "/path to/script" "--debug" "-v"
+------
 +
-This script is run in the background--that is, upsmon forks before it
-calls out to start it.  This means that your NOTIFYCMD may have multiple
-instances running simultaneously if a lot of stuff happens all at once.
-Keep this in mind when designing complicated notifiers.
+This script is run in the background -- that is, linkman:upsmon[8] normally
+forks before it calls out to start it.  This means that your NOTIFYCMD may
+have multiple instances running simultaneously if a lot of stuff happens all
+at once. Keep this in mind when designing complicated notifiers.
 
 *NOTIFYMSG* 'type' 'message'::
 
@@ -539,7 +543,7 @@ powered off, at just the time you need it here), and is not available on
 all platforms -- so such setups are something users explore on their own
 so far (we would welcome posts on NUT Wiki or links to blogs though).
 
-*SHUTDOWNCMD* 'command'::
+*SHUTDOWNCMD* 'command' ['arg1' 'arg2' ...]::
 
 upsmon runs this command when the system needs to be brought down.  If
 it is a secondary, it will do that immediately whenever the current
@@ -548,11 +552,24 @@ overall power value drops below the MINSUPPLIES value above.
 When upsmon is a primary, it will allow any secondaries to log out before
 starting the local shutdown procedure.
 +
-Note that the command needs to be one element in the config file.  If
-your shutdown command includes spaces, then put it in quotes to keep it
-together, i.e.:
-
+Note that historically (before NUT v2.8.6 release) the command needed to
+be one element in the config file.  If your shutdown command included spaces,
+then you should have put it in quotes to keep it together, i.e.:
++
+------
 	SHUTDOWNCMD "/sbin/shutdown -h +0"
+------
++
+Now unlike some others, this directive still allows to pass both the command
+and its arguments as a single quoted token, but it also supports a multi-token
+syntax to pass each argument as a separate token.
+These lines should be equivalent with NUT v2.8.6 or newer:
++
+------
+SHUTDOWNCMD "/sbin/shutdown -h +0"
+SHUTDOWNCMD "/sbin/shutdown" "-h" "+0"
+SHUTDOWNCMD /sbin/shutdown -h +0
+------
 
 *SHUTDOWNEXIT* 'boolean|number'::
 

--- a/docs/man/upsmon.conf.txt
+++ b/docs/man/upsmon.conf.txt
@@ -230,10 +230,13 @@ NOTIFYFLAG.  See NOTIFYFLAG below for more details.
 Making this some sort of shell script might not be a bad idea.  For
 more information and ideas, see docs/scheduling.txt
 +
-Remember, this command also needs to be one element in the configuration file,
-so if your command has spaces, then wrap it in quotes.
+The value is interpreted as a complete path to an externally stored
+executable script (e.g. not an inline scriptlet) or program file without
+further arguments (this is a change from NUT v2.8.5 and older releases).
+Remember, this command also needs to be one element in the configuration
+file, so if your command path has spaces, then wrap it in quotes.
 +
-+NOTIFYCMD "/path/to/script --foo --bar"+
++NOTIFYCMD "/path to/script"+
 +
 This script is run in the background--that is, upsmon forks before it
 calls out to start it.  This means that your NOTIFYCMD may have multiple

--- a/docs/man/upsmon.txt
+++ b/docs/man/upsmon.txt
@@ -258,7 +258,12 @@ Example:
  - `NOTIFYCMD "/usr/local/bin/notifyme"`
 
 Remember to wrap the path in "double quotes" if it contains any spaces.
-It should probably not rely on receiving any command-line arguments.
+It should not rely on receiving any command-line arguments: the value of
+this directive is interpreted as a complete path to an externally stored
+executable script (e.g. not an inline scriptlet) or program file without
+further arguments (this is a change from NUT v2.8.5 and older releases).
+If you need to pass special arguments to a notification program, please
+write a small script to do so and specify its path here.
 
 The program you run as your NOTIFYCMD can use the environment variables
 NOTIFYTYPE and UPSNAME to know what has happened and on which UPS.  It

--- a/docs/man/upssched.conf.txt
+++ b/docs/man/upssched.conf.txt
@@ -42,14 +42,15 @@ Example:
 
 	DEBUG_MIN 6
 
-*CMDSCRIPT* 'scriptname'::
+*CMDSCRIPT* 'scriptname' ['arg1' 'arg2' ...]::
 Required.  This must be above any AT lines.  This script is used to
 invoke commands when your timers are triggered.  It receives a single
-argument which is the name of the timer that caused it to trigger.
+last argument which is the name of the timer that caused it to trigger.
 +
-The value is interpreted as a complete path to an externally stored
-executable script (e.g. not an inline scriptlet) or program file without
-further arguments (this is a change from NUT v2.8.5 and older releases).
+The first (possibly only) token of the value is interpreted as a complete
+path to an externally stored executable script (e.g. not an inline scriptlet)
+or program file without further arguments (which may be passed in explicitly
+quoted separate tokens). This is a change from NUT v2.8.5 and older releases.
 
 *PIPEFN* 'filename'::
 Required.  This sets the file name of the socket which will be used for

--- a/docs/man/upssched.conf.txt
+++ b/docs/man/upssched.conf.txt
@@ -46,6 +46,10 @@ Example:
 Required.  This must be above any AT lines.  This script is used to
 invoke commands when your timers are triggered.  It receives a single
 argument which is the name of the timer that caused it to trigger.
++
+The value is interpreted as a complete path to an externally stored
+executable script (e.g. not an inline scriptlet) or program file without
+further arguments (this is a change from NUT v2.8.5 and older releases).
 
 *PIPEFN* 'filename'::
 Required.  This sets the file name of the socket which will be used for

--- a/docs/man/upssched.txt
+++ b/docs/man/upssched.txt
@@ -98,9 +98,16 @@ EARLY SHUTDOWNS
 ---------------
 
 To shut down the system early, define a timer that starts due to an ONBATT
-condition.  When it triggers, make your CMDSCRIPT call your shutdown
-routine.  It should finish by calling `upsmon -c fsd` so that upsmon gets
-to shut down the slaves in a controlled manner.
+condition.  When it triggers, make your `CMDSCRIPT` call your shutdown
+routine, especially if you have to prioritize something to stop first,
+or have subsystems that can take longer to gracefully stop than the normal
+OS shutdown patience allows (some systems might `kill` remaining processes
+after a hard-coded timeout).
+
+Your `CMDSCRIPT` should finish by calling `upsmon -c fsd`, so that your
+primary instance of linkman:upsmon[8] gets to shut down the secondary
+systems in a controlled manner (note the primary instance would also run
+its local definition of `SHUTDOWNCMD` in the end).
 
 Be sure you cancel the timer if power returns (ONLINE).
 

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3783 utf-8
+personal_ws-1.1 en 3784 utf-8
 AAC
 AAS
 ABI
@@ -3191,6 +3191,7 @@ schuko
 scm
 screenshot
 screenshots
+scriptlet
 scriptname
 sd
 sdcmd

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -2266,7 +2266,11 @@ generatecfg_upsmon_trivial() {
 
         NOTIFYTGT=""
         if [ -x "${TOP_SRCDIR-}/scripts/misc/notifyme-debug" ] ; then
-            echo "NOTIFYCMD \"TEMPDIR='${NUT_STATEPATH}' ${TOP_SRCDIR-}/scripts/misc/notifyme-debug\"" >> "$NUT_CONFPATH/upsmon.conf" || exit
+            (echo "#!/bin/sh" ; echo "TEMPDIR='${NUT_STATEPATH}' ${TOP_SRCDIR-}/scripts/misc/notifyme-debug \"\$@\"") > "$NUT_CONFPATH/upsmon-notify.sh" \
+            && chmod +x "$NUT_CONFPATH/upsmon-notify.sh" \
+            || exit
+
+            echo "NOTIFYCMD \"$NUT_CONFPATH/upsmon-notify.sh\"" >> "$NUT_CONFPATH/upsmon.conf" || exit
 
             # NOTE: "SYSLOG" typically ends up in console log of the NIT run and
             # "EXEC" goes to a log file like tests/NIT/tmp/run/notifyme-399.log

--- a/tests/NIT/upssched.conf.in
+++ b/tests/NIT/upssched.conf.in
@@ -8,7 +8,7 @@
 
 #DEBUG_MIN 4
 
-CMDSCRIPT @TOP_BUILDDIR@/clients/upssched-cmd
+CMDSCRIPT @TOP_SRCDIR@/clients/upssched-cmd
 
 PIPEFN @NUT_STATEPATH@/upssched.pipe
 LOCKFN @NUT_STATEPATH@/upssched.lock


### PR DESCRIPTION
Documentation was vague about this, and implementation used `system()` which modern guidelines frown upon. Fix this to mean a single token with an exact path name (or a program in `PATH`) without arguments, inline scriptlets, etc.

NOTE: `SHUTDOWNCMD` should not be impacted by this change, and can still take arguments as is often does (e.g. `shutdown -t now`).