### PR TITLE
idowell-hid: add GoldenMate 1000VA/800W LiFePO4 (USB ID 06da:ffff)

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -82,6 +82,12 @@ https://github.com/networkupstools/nut/milestone/13
  - `usbhid-ups` driver updates:
     * When reconnecting, report success more visibly (not only in debug), and
       do not reset driver state to "quiet" when it will loop trying. [PR #3423]
+    * `idowell-hid` subdriver now also supports GoldenMate 1000VA/800W LiFePO4
+      battery packs (`0x06da:0xffff`), which carry the same `-BMS-` firmware and
+      HID descriptor as the existing `0x075d:0x0300` device. The shared
+      Phoenixtec vendor ID (`0x06da`) is gated by device strings so the other
+      devices on that ID still fall through to `liebert-hid` / `mge-hid`.
+      [issue #3501, PR #3502]
 
  - common code:
     * Revised 'dstate' machinery to track socket connections closed mid-way

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -545,7 +545,8 @@
 
 "Gemini"	"ups"	"1"	"UPS625/UPS1000"	""	"safenet"
 
-"GoldenMate"	"ups"	"1"	"UPS 1000VA Pro"	"USB"	"usbhid-ups"
+"GoldenMate"	"ups"	"2"	"UPS 1000VA Pro (USB ID 075d:0300)"	"USB"	"usbhid-ups"	# https://github.com/networkupstools/nut/issues/3015
+"GoldenMate"	"ups"	"2"	"1000VA/800W LiFePO4 (USB ID 06da:ffff)"	"USB"	"usbhid-ups"	# https://github.com/networkupstools/nut/issues/3501
 
 "Grafenthal"	"ups"	"3"	"PR-3000-HS"	"SNMP/Web Minislot card (ref 149G0006)"	"snmp-ups"	# http://grafenthal.de/produkte/usv/online/pr-hs-serie/pr-3000-hs/?L=3et8
 

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3780 utf-8
+personal_ws-1.1 en 3782 utf-8
 AAC
 AAS
 ABI
@@ -99,6 +99,7 @@ BD
 BKnnnnM
 BKxxxM
 BMC
+BMS
 BNT
 BOH
 BP
@@ -2362,6 +2363,7 @@ idProduct
 idVendor
 ident
 idleload
+idowell
 ie
 ietf
 ifdef

--- a/drivers/idowell-hid.c
+++ b/drivers/idowell-hid.c
@@ -30,17 +30,29 @@
 #include "main.h"	/* for getval() */
 #include "usb-common.h"
 
-#define IDOWELL_HID_VERSION	"iDowell HID 0.20"
+#define IDOWELL_HID_VERSION	"iDowell HID 0.21"
 /* FIXME: experimental flag to be put in upsdrv_info */
+/* v0.21 GoldenMate LiFePO4 packs reuse the shared Phoenixtec VID (0x06da):
+ *       claim only those (by -BMS-/Smart-Battery firmware strings) and defer
+ *       everything else on that VID to liebert-hid / mge-hid */
 /* v0.20 Goldenmate also uses the same vendorID and productID so added additional HID2NUT lookup values */
 
 /* iDowell, Goldenmate */
 #define IDOWELL_VENDORID	0x075d
 
+/* Phoenixtec Power Co., Ltd; this VID is shared with liebert-hid (the default
+ * sink for 0x06da) and mge-hid (AEG PROTECT NAS). GoldenMate 1000VA/800W
+ * LiFePO4 packs reuse 0x06da:0xffff with the same iDowell-style -BMS- firmware
+ * and HID descriptor as 0x075d:0x0300, so the table match is gated by device
+ * strings in idowell_claim() to avoid hijacking the other 0x06da devices. */
+#define PHOENIXTEC_VENDORID	0x06da
+
 /* USB IDs device table */
 static usb_device_id_t idowell_usb_device_table[] = {
 	/* iDowell, Goldenmate */
 	{ USB_DEVICE(IDOWELL_VENDORID, 0x0300), NULL },
+	/* GoldenMate 1000VA/800W LiFePO4; claim gated by strings, see idowell_claim() */
+	{ USB_DEVICE(PHOENIXTEC_VENDORID, 0xffff), NULL },
 
 	/* Terminating entry */
 	{ 0, 0, NULL }
@@ -147,6 +159,23 @@ static const char *idowell_format_serial(HIDDevice_t *hd) {
 	return hd->Serial;
 }
 
+/* The Phoenixtec vendor ID (0x06da) is shared between several subdrivers:
+ * liebert-hid is the default sink, mge-hid grabs AEG PROTECT NAS, and we want
+ * only the GoldenMate LiFePO4 packs. They carry the same iDowell-style BMS
+ * firmware as the 0x075d:0x0300 device, reporting manufacturer "-BMS-" and
+ * product "Smart-Battery". Match on those strings so the other 0x06da devices
+ * fall through to liebert-hid / mge-hid. */
+static int idowell_is_goldenmate(HIDDevice_t *hd)
+{
+	if (hd->Vendor && strstr(hd->Vendor, "BMS")) {
+		return 1;
+	}
+	if (hd->Product && strstr(hd->Product, "Smart-Battery")) {
+		return 1;
+	}
+	return 0;
+}
+
 /* this function allows the subdriver to "claim" a device: return 1 if
  * the device is supported by this subdriver, else 0. */
 static int idowell_claim(HIDDevice_t *hd)
@@ -164,6 +193,11 @@ static int idowell_claim(HIDDevice_t *hd)
 		return 0;
 
 	case SUPPORTED:
+		/* On the shared Phoenixtec VID, only claim GoldenMate; let
+		 * liebert-hid (default sink) and mge-hid (AEG) handle the rest. */
+		if (hd->VendorID == PHOENIXTEC_VENDORID && !idowell_is_goldenmate(hd)) {
+			return 0;
+		}
 		return 1;
 
 	case NOT_SUPPORTED:


### PR DESCRIPTION
## Summary

GoldenMate ships the same `-BMS-` firmware with an identical 291-byte HID descriptor across multiple USB vendor/product IDs. The `075d:0300` variant was already added to this subdriver in #3015. This PR adds `06da:ffff` (Phoenixtec VID), which was previously falling through to the generic Phoenixtec/Liebert HID subdriver.

**Device:** GoldenMate 1000VA/800W Sinewave UPS with LiFePO4 Battery (230Wh), USB ID `06da:ffff`, manufacturer string `-BMS-`, product string `Smart-Battery`.

**Problem:** Without this change the device matches `Phoenixtec/Liebert HID 0.41` and reports `battery.runtime = 599940` seconds — a firmware placeholder value. The iDowell subdriver mappings (which were already extended for the identical `075d:0300` firmware) handle this device correctly.

**Evidence that HID descriptors are identical:** Both devices report the same 291-byte report descriptor (`05 84 09 04 a1 01 ...`), the same 28 HID objects, and the same `LogMax < LogMin` quirks in ReportID 0x01 and 0x02.

Tracked in #3501.

## Changes

- `drivers/idowell-hid.c`: add `06da:ffff` to the USB device table
- `data/driver.list.in`: split GoldenMate entry into two lines with correct model names, USB IDs, support level 2, and issue links