### PR TITLE
Add ARES AR630 to HCL

### DIFF
--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -135,6 +135,7 @@
 "Appro"	"pdu"	"1"	"SWPDU"	"48 outlets"	"powerman-pdu (experimental)"
 
 "ARES"	"ups"	"2"	"AR265i"	"USB"	"nutdrv_qx port=auto vendorid=0001 productid=0000 protocol=hunnox langid_fix=0x0409 novendor noscanlangid"	# https://github.com/networkupstools/nut/pull/638 did not explicitly mention the driver parameters, but other reports in the discussion did
+"ARES"	"ups"	"2"	"AR630"	"USB"	"nutdrv_qx port=auto vendorid=0001 productid=0000 protocol=hunnox langid_fix=0x0409 novendor noscanlangid"
 
 "ARTronic"	"ups"	"2"	"ARTon Millenium 1/2/3/6/10 kVA"	"Serial"	"blazer_ser"
 "ARTronic"	"ups"	"2"	"ARTon Millenium 3.1 10/15/20 kVA"	"Serial"	"blazer_ser"


### PR DESCRIPTION
## Summary

Adds the ARES AR630 UPS to `data/driver.list.in` with the same `nutdrv_qx`/`hunnox` USB parameters already used by the ARES AR265i entry.

## Field report

Tested on an ARES AR630 connected over USB on Ubuntu 22.04.5 LTS.

USB enumeration:

```text
Bus 001 Device 007: ID 0001:0000 Fry's Electronics
bInterfaceClass 3 Human Interface Device
```

Working `ups.conf` entry:

```ini
[ares630]
    driver = nutdrv_qx
    port = auto
    vendorid = 0001
    productid = 0000
    protocol = hunnox
    langid_fix = 0x0409
    novendor
    noscanlangid
```

Representative `upsc` values on line power:

```text
driver.name: nutdrv_qx
driver.version.data: Hunnox 0.02
battery.charge: 100
battery.voltage: 54.2
input.voltage: 229.0
output.voltage: 230.0
ups.load: 5
ups.status: OL
ups.temperature: 22.0
```

Mains-loss validation:

```text
OL -> OB when utility power was unplugged
input.voltage: 0.0
output.voltage: 219.0
ups.status: OB
```

Recovery validation:

```text
OB -> OL when utility power returned
input.voltage: 228-229.0
output.voltage: 229-230.0
ups.status: OL
```

FSD validation:

```text
upsmon -c fsd
ups.status: FSD OL
upsmon: Executing automatic power-fail shutdown
```

After manual power-on, NUT services started normally and the UPS returned to `OL` monitoring.

## Notes

`nut-scanner -U` initially suggested `nutdrv_atcl_usb`, but that driver could not retrieve status from this device in testing. `nutdrv_qx protocol=hunnox` worked and tracked online/on-battery state correctly.