### PR TITLE
nut-driver-enumerator: classify ragtech as serial media

### DIFF
--- a/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
+++ b/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
@@ -664,6 +664,10 @@ upsconf_getDriverMedia() {
                     printf '%s\n%s\n' "$CURR_DRV" "" ; return ;;
             esac
             ;;
+        ragtech)
+            # Serial protocol carried over a USB CDC-ACM device node
+            # (/dev/ttyACM*); needs the same udev settling as a serial port.
+            printf '%s\n%s\n' "$CURR_DRV" "serial" ; return ;;
         *usb*)
             printf '%s\n%s\n' "$CURR_DRV" "usb" ; return ;;
         nutdrv_qx) # May be direct serial or USB

--- a/tests/nut-driver-enumerator-test--ups.conf
+++ b/tests/nut-driver-enumerator-test--ups.conf
@@ -29,6 +29,10 @@ synchronous=no
 driverflag
 	port = /dev/ttyS1 # some path
 
+[ragtech-serial]
+	driver = ragtech
+	port = /dev/ttyACM0
+
 
 [dummy-proxy]
 driver = "dummy-ups  "

--- a/tests/nut-driver-enumerator-test.sh
+++ b/tests/nut-driver-enumerator-test.sh
@@ -198,6 +198,7 @@ epdu-2-snmp
 qx-serial
 qx-usb1
 qx-usb2
+ragtech-serial
 sectionWithComment
 sectionWithCommentWhitespace
 serial.4
@@ -232,6 +233,9 @@ port=auto
 driver=serial-ups
 driverflag
 port=/dev/ttyS1 # some path
+[ragtech-serial]
+driver=ragtech
+port=/dev/ttyACM0
 [dummy-proxy]
 driver="dummy-ups  "
 port=remoteUPS@RemoteHost.local
@@ -280,6 +284,7 @@ INST: 9a5561464ff8c78dd7cb544740ce2adc~[epdu-2-snmp]: DRV='snmp-ups' PORT='172.1
 INST: 16adbdafb22d9fdff1d09038520eb32e~[qx-serial]: DRV='nutdrv_qx' PORT='/dev/ttyb' MEDIA='serial' SECTIONMD5='e3e6e586fbe5b3c0a89432f4b993f4ad'
 INST: a21bd2b786228b9619f6adba6db8fa83~[qx-usb1]: DRV='nutdrv_qx' PORT='auto' MEDIA='usb' SECTIONMD5='a6139c5da35bef89dc5b96e2296f5369'
 INST: 0066605e07c66043a17eccecbeea1ac5~[qx-usb2]: DRV='nutdrv_qx' PORT='/dev/usb/8' MEDIA='usb' SECTIONMD5='5722dd9c21d07a1f5bcb516dbc458deb'
+INST: b377c8ec5f35b3c3df361686627e1625~[ragtech-serial]: DRV='ragtech' PORT='/dev/ttyACM0' MEDIA='serial' SECTIONMD5='bd2de13822ec93bde2aeeeca450fc228'
 INST: 1280a731e03116f77290e51dd2a2f37e~[sectionWithComment]: DRV='nutdrv_qx#comment' PORT='/dev/usb/8' MEDIA='' SECTIONMD5='be30e15e17d0579c85eecaf176b4a064'
 INST: 770abd5659061a29ed3ae4f7c0b00915~[sectionWithCommentWhitespace]: DRV='nutdrv_qx	# comment' PORT='/dev/usb/8 #	comment' MEDIA='' SECTIONMD5='c757822a331521cdc97310d0241eba28'
 INST: efdb1b4698215fdca36b9bc06d24661d~[serial.4]: DRV='serial-ups' PORT='/dev/ttyS1 # some path' MEDIA='' SECTIONMD5='9c485f733aa6d6c85c1724f162929443'


### PR DESCRIPTION
As discussed in #3500: teach `nut-driver-enumerator` that the `ragtech` driver uses serial media.

## Why

`ragtech` talks to a USB CDC-ACM device node (`/dev/ttyACM*`) through the serial layer. Until now the enumerator left it unclassified (the default for serial-only drivers), so the auto-generated `nut-driver@<ups>` service got no media dependency. Classifying it as `serial` makes the generated unit depend on `systemd-udevd` / `nut-udev-settle` (same as the existing serial/USB cases — both map to `DEPSVC_*_SYSTEMD="systemd-udevd.service nut-udev-settle.service"`), so the driver waits for the device node to be published by udev before starting, instead of racing the enumeration at boot.

This came out of a user whose hand-rolled unit was fighting the enumerator-generated one on a Raspberry Pi (#3500); @jimklimov suggested extending the script for `ragtech`.

## What

- `scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in`: add a `ragtech)` case returning `serial` media.
- `tests/nut-driver-enumerator-test--ups.conf`: add a `[ragtech-serial]` fixture section.
- `tests/nut-driver-enumerator-test.sh`: add the matching entries to the three expected outputs that enumerate all sections (device-name listing, config dump, and the MEDIA/checksum listing).

## Test

Ran the enumerator self-test against this change — all pass:

```
Test suite for nut-driver-enumerator has completed with 0 failed cases and 104 good cases
```

Happy to add a `NEWS.adoc` line or fold this into the broader NDE work in #3322 if you'd prefer — kept it minimal and focused for now.
