### PR TITLE
drivers: nhs_ser: do not force CRTSCTS (breaks CDC-ACM and 3-wire ser…

### DIFF
--- a/drivers/nhs_ser.c
+++ b/drivers/nhs_ser.c
@@ -595,7 +595,7 @@ static int openfd(const char * portarg, int BAUDRATE) {
 	tty.c_cflag |= CS8;		/* 8 bits per byte */
 
 	/* CTS / RTS */
-	tty.c_cflag |= CRTSCTS;	/* Enable hardware flow control */
+    tty.c_cflag &= ~CRTSCTS;	/* NHS serial / CDC-ACM has no RTS/CTS flow control */
 
 	/* Enable Read and disable modem control */
 	/* // tty.c_cflag |= (CLOCAL | CREAD); */


### PR DESCRIPTION
Disables the hardcoded CRTSCTS in nhs_ser openfd(), which blocks
   communication on NHS UPSes with no RTS/CTS lines (USB/CDC-ACM and the
   official 3-wire serial cable).

   Full diagnosis, raw packet captures and device details: Refs #3510 