### PR TITLE
upsmon et al: introduce NOTIFY_SUSPEND_TIMEJUMP_UNEXPECTED

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -185,6 +185,10 @@ https://github.com/networkupstools/nut/milestone/13
       success of SSL initialization with both backends is more diligently
       tracked) should now not cause exit of the client if secure connection
       is not required by its configuration in the first place. [#3420]
+    * Introduced a new notification type for unexpected clock change which
+      is specially handled (data re-initialization), whether due to sleep
+      and wake-up, or NTP/RTC clock changes during boot, or severe delays
+      on a stressed system (to name a few practical cases). [issue #3405]
 
  - `NUT-Monitor` Python GUI client:
     * Fixed Qt tray tooltips to render in plain text, not rich text which

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -4501,11 +4501,17 @@ int main(int argc, char *argv[])
 		 * without NUT direct support for suspend/inhibit */
 		dt = difftimeval(end, start);
 		if (dt > (sleepval + sleep_overhead_tolerance)) {
-			upslogx(LOG_WARNING, "It seems we have slept without warning or the system clock was changed by %.06f seconds", dt);
+			char	dtstr[SMALLBUF];
+			snprintf(dtstr, sizeof(dtstr), "%.06f seconds", dt);
+			upslogx(LOG_WARNING, "It seems we have slept without warning or the system clock was changed by %s", dtstr);
+			do_notify(ups, NOTIFY_SUSPEND_TIMEJUMP_UNEXPECTED, dtstr);
 			if (sleep_inhibitor_status < 0)
 				sleep_inhibitor_status = 0;	/* behave as woken up */
 		} else if (dt < 0) {
-			upslogx(LOG_WARNING, "It seems the system clock was changed into the past by %.06f seconds", dt);
+			char	dtstr[SMALLBUF];
+			snprintf(dtstr, sizeof(dtstr), "%.06f seconds", dt);
+			upslogx(LOG_WARNING, "It seems the system clock was changed into the past by %s", dtstr);
+			do_notify(ups, NOTIFY_SUSPEND_TIMEJUMP_UNEXPECTED, dtstr);
 			if (sleep_inhibitor_status < 0)
 				sleep_inhibitor_status = 0;	/* behave as woken up */
 		}

--- a/clients/upsmon.h
+++ b/clients/upsmon.h
@@ -136,6 +136,8 @@ typedef struct {
 
 #define NOTIFY_SHUTDOWN_HOSTSYNC	26	/* Shutdown initiated; primary system is waiting for secondaries to log out or time out */
 
+#define NOTIFY_SUSPEND_TIMEJUMP_UNEXPECTED	27	/* Clock jumped unexpectedly by X.Y sec */
+
 /* Special handling below */
 #define NOTIFY_OTHER	28	/* UPS has at least one unclassified status token */
 #define NOTIFY_NOTOTHER	29	/* UPS has no unclassified status tokens anymore */
@@ -212,6 +214,8 @@ static struct {
 	/* Reported when status_tokens tree becomes empty */
 	{ NOTIFY_NOTOTHER, "NOTOTHER", NULL, "UPS %s has no unclassified status tokens anymore", NOTIFY_DEFAULT },
 
+	/* NOTE: Stringify the time value as argument, e.g. `%g seconds` */
+	{ NOTIFY_SUSPEND_TIMEJUMP_UNEXPECTED, "SUSPEND_TIMEJUMP_UNEXPECTED", NULL, "Unexpected clock change by %s, treating as wake up from sleep", NOTIFY_DEFAULT },
 	{ NOTIFY_SUSPEND_STARTING, "SUSPEND_STARTING", NULL, "OS is entering sleep/suspend/hibernate mode", NOTIFY_DEFAULT },
 	{ NOTIFY_SUSPEND_FINISHED, "SUSPEND_FINISHED", NULL, "OS just finished sleep/suspend/hibernate mode, de-activating obsolete UPS readings to avoid an unfortunate shutdown", NOTIFY_DEFAULT },
 

--- a/common/nutconf.cpp
+++ b/common/nutconf.cpp
@@ -5,7 +5,7 @@
 
         Author: Emilien Kia <emilien.kia@gmail.com>
 
-    Copyright (C) 2024-2025 NUT Community
+    Copyright (C) 2024-2026 NUT Community
 
         Author: Jim Klimov  <jimklimov+nut@gmail.com>
 
@@ -1362,6 +1362,8 @@ UpsmonConfiguration::NotifyType UpsmonConfiguration::NotifyTypeFromString(const 
 		return NOTIFY_SUSPEND_STARTING;
 	else if(str=="SUSPEND_FINISHED")
 		return NOTIFY_SUSPEND_FINISHED;
+	else if(str=="SUSPEND_TIMEJUMP_UNEXPECTED")
+		return NOTIFY_SUSPEND_TIMEJUMP_UNEXPECTED;
 	else
 		return NOTIFY_TYPE_MAX;
 }

--- a/common/nutwriter.cpp
+++ b/common/nutwriter.cpp
@@ -5,7 +5,7 @@
 
         Author: Vaclav Krpec  <VaclavKrpec@Eaton.com>
 
-    Copyright (C) 2024-2025 NUT Community
+    Copyright (C) 2024-2026 NUT Community
 
         Author: Jim Klimov  <jimklimov+nut@gmail.com>
 
@@ -421,6 +421,7 @@ const NotifyFlagsStrings::TypeStrings NotifyFlagsStrings::type_str = {
 	"NOTBOOST",	// NOTIFY_NOTBOOST
 	"OTHER",	// NOTIFY_OTHER
 	"NOTOTHER",	// NOTIFY_NOTOTHER
+	"SUSPEND_TIMEJUMP_UNEXPECTED",	// NOTIFY_SUSPEND_TIMEJUMP_UNEXPECTED
 	"SUSPEND_STARTING",	// NOTIFY_SUSPEND_STARTING
 	"SUSPEND_FINISHED",	// NOTIFY_SUSPEND_FINISHED
 };

--- a/configure.ac
+++ b/configure.ac
@@ -5207,6 +5207,8 @@ dnl Note: Currently there is no reliable automatic detection -
 dnl users have to ask they want systemd units installed, or
 dnl risk auto-detection like seen below.
 dnl FIXME: Add a toggle like "--with(out)-systemd" to disable these probes too
+AC_PATH_PROG([SYSTEMD_SYSTEMCTL_PROGRAM], [systemctl], [/usr/bin/systemctl])
+
 AC_MSG_CHECKING(whether to install systemd unit files)
 NUT_ARG_WITH([systemdsystemunitdir], [(DIRPATH|yes|no|auto)], [Directory for systemd service files], [auto])
 systemdsystemunitdir="${nut_with_systemdsystemunitdir}"
@@ -5219,12 +5221,16 @@ case "${systemdsystemunitdir}" in
 			[def_systemdsystemunitdir=""])
 
 		AS_IF([test x"${def_systemdsystemunitdir}" = x], [
+			def_msgerr="--with-systemdsystemunitdir=${systemdsystemunitdir} was requested, but PKG_CONFIG could not be queried for the system settings. Please double-check that you have {lib,}systemd-dev{,el} installed as appropriate for your OS distribution!"
 			AS_IF([test "${systemdsystemunitdir}" = yes],
-				[AC_MSG_ERROR([--with-systemdsystemunitdir=${systemdsystemunitdir} was requested, but PKG_CONFIG could not be queried for the system settings])])
+				[AC_MSG_ERROR([${def_msgerr}])])
+			AS_IF([test x"${SYSTEMD_SYSTEMCTL_PROGRAM}" != x -a -x "${SYSTEMD_SYSTEMCTL_PROGRAM}"],
+				[AC_MSG_WARN([${SYSTEMD_SYSTEMCTL_PROGRAM} is present and ${def_msgerr}])])
 			systemdsystemunitdir=""
+			AS_UNSET(def_msgerr)
 			], [systemdsystemunitdir="${def_systemdsystemunitdir}"])
 
-		unset def_systemdsystemunitdir
+		AS_UNSET(def_systemdsystemunitdir)
 		;;
 	no)
 		systemdsystemunitdir=""
@@ -5251,8 +5257,6 @@ NUT_REPORT_FEATURE([consider basic systemd support], [${have_systemd}], [],
 dnl This option is only provided so that make distcheck can override it,
 dnl otherwise we ask pkg-config whenever --with-systemdsystemunitdir is
 dnl given
-
-AC_PATH_PROG([SYSTEMD_SYSTEMCTL_PROGRAM], [systemctl], [/usr/bin/systemctl])
 
 dnl Similarly for presets (list of svcs enabled/disabled by default)
 AC_MSG_CHECKING(whether to install systemd preset files)

--- a/include/nutconf.hpp
+++ b/include/nutconf.hpp
@@ -5,7 +5,7 @@
 
         Author: Emilien Kia <emilien.kia@gmail.com>
 
-    Copyright (C) 2024-2025 NUT Community
+    Copyright (C) 2024-2026 NUT Community
 
         Author: Jim Klimov  <jimklimov+nut@gmail.com>
 
@@ -1553,6 +1553,8 @@ public:
 		NOTIFY_NOTBOOST,
 
 		NOTIFY_SHUTDOWN_HOSTSYNC,
+
+		NOTIFY_SUSPEND_TIMEJUMP_UNEXPECTED,
 
 		NOTIFY_OTHER = 28,
 		NOTIFY_NOTOTHER,


### PR DESCRIPTION
Addresses: #3405

We have reports of various OS platforms reporting that they awoke from hibernation when none such happened. This may be in fact due to unified handling of unexpected time jumps, e.g. when a system is under such heavy load that it spends much more than `upsmon` loop delay between actual runs of the loop cycles, or clock jumps due to NTP vs. RTC, etc.

Either way, for a few recent NUT releases `upsmon` tries to handle this gracefully by re-querying UPS status before issuing FSD right away. The possibly misleading messages about awakening with little further explanation are however annoying. This PR adds an explicit notification to help make sense of these events.