### PR TITLE
mge-hid: suppress CHRG on CC-mode devices when battery is fully charged

### DIFF
--- a/drivers/mge-hid.c
+++ b/drivers/mge-hid.c
@@ -558,6 +558,19 @@ static const char *eaton_abm_check_chrg_fun(double value)
 	if (advanced_battery_monitoring == ABM_UNKNOWN || advanced_battery_monitoring == ABM_DISABLED)
 	{
 		if (d_equal(value, 1)) {
+			/* UPS.PowerSummary.PresentStatus.Charging stays asserted in
+			 * float/maintenance mode on CC-mode devices (e.g. Eaton 5E series)
+			 * that do not expose the ABM HID path. Suppress CHRG once the
+			 * battery is fully charged so that ups.status does not show a
+			 * persistent OL CHRG at 100%. */
+			const char	*charge_str = dstate_getinfo("battery.charge");
+			if (charge_str != NULL) {
+				double	charge = strtod(charge_str, NULL);
+				if (charge >= 100.0) {
+					snprintf(mge_scratch_buf, sizeof(mge_scratch_buf), "%s", "!chrg");
+					return mge_scratch_buf;
+				}
+			}
 			snprintf(mge_scratch_buf, sizeof(mge_scratch_buf), "%s", "chrg");
 		}
 		else {


### PR DESCRIPTION
Fixes #3518

## Problem

On constant-charge (CC-mode) devices such as the Eaton 5E series, `UPS.PowerSummary.PresentStatus.Charging` stays asserted at 1 in float/maintenance mode. These devices do not expose `UPS.BatterySystem.Charger.ABMEnable`, so `advanced_battery_monitoring` remains `ABM_UNKNOWN` throughout the driver lifetime.

`eaton_abm_check_chrg_fun()` maps any `Charging=1` directly to `"chrg"` when `ABM_UNKNOWN`, with no mechanism to detect float mode. The result is `ups.status` stuck at `OL CHRG` indefinitely once the battery reaches 100%.

## Fix

When `ABM_UNKNOWN` or `ABM_DISABLED` and the UPS asserts `Charging=1`, consult `battery.charge` before publishing CHRG. If the battery is at 100% the charger is in float/maintenance mode, not actively charging, so return `!chrg` instead.

## Testing

Tested on:
- Eaton 5E 650i (vendor 0463, product ffff, subdriver MGE HID 1.58, firmware 01.04.0016): `ups.status` now shows `OL` at full charge
- Eaton 5E 650i (firmware 03.08.0018): same result

Both units previously showed persistent `OL CHRG` with `battery.charge: 100`. After this change both report `OL` as expected.
