### PR TITLE
nutdrv_qx: Voltronic-QS: Add QI command

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -81,6 +81,9 @@ https://github.com/networkupstools/nut/milestone/13
       allowing the Megatec payload to be successfully reconstructed. [PR #3485]
     * In `Voltronic-QS-Hex` subdriver, the format string sanity check added in
       recent NUT releases caught a mismatch in `ups.load` reading. [issue #3532]
+    * Modified `voltronic-qs` subdriver to request the QI command, supplying
+      NUT with battery charge, runtime, input frequency, output current, and
+      input transfer low/high values.
 
  - Introduced a new NUT driver named `ragtech` which provides support for the
    Ragtech "Easy Pro" family of line-interactive UPS units (also sold under

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -83,7 +83,8 @@ https://github.com/networkupstools/nut/milestone/13
       recent NUT releases caught a mismatch in `ups.load` reading. [issue #3532]
     * Modified `voltronic-qs` subdriver to request the QI command, supplying
       NUT with battery charge, runtime, input frequency, output current, and
-      input transfer low/high values.
+      input transfer low/high values on devices which support it (`H`, `I`, `J`
+      protocols, e.g. Powershield PSDR800). [#3521]
 
  - Introduced a new NUT driver named `ragtech` which provides support for the
    Ragtech "Easy Pro" family of line-interactive UPS units (also sold under

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -1233,6 +1233,7 @@
 "Powermatic"	"ups"	"2"	"Cleanline L-1000C"	"USB"	"nutdrv_qx"	# https://alioth-lists.debian.net/pipermail/nut-upsdev/2024-September/008015.html
 
 "PowerShield"	"ups"	"2"	"Defender 1200VA"	"USB"	"blazer_usb"
+"PowerShield"	"ups"	"2"	"PSDR800"	"USB"	"nutdrv_qx protocol=voltronic-qs"
 
 "PowerTech"	"ups"	"1"	"Comp1000"	"DTR cable power"	"genericups upstype=3"
 "PowerTech"	"ups"	"2"	"SMK-800"	""	"blazer_ser"

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3789 utf-8
+personal_ws-1.1 en 3790 utf-8
 AAC
 AAS
 ABI
@@ -1088,6 +1088,7 @@ QFRE
 QGR
 QGS
 QHE
+QI
 QID
 QLDL
 QMD

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3790 utf-8
+personal_ws-1.1 en 3792 utf-8
 AAC
 AAS
 ABI
@@ -984,6 +984,7 @@ PROTVER
 PRs
 PSA
 PSD
+PSDR
 PSF
 PSFn
 PSGPSER
@@ -1057,6 +1058,7 @@ PowerWalker
 PowerWare
 Powerchute
 Powercool
+Powershield
 Powervar
 Powervar's
 Powerwell

--- a/drivers/nutdrv_qx_voltronic-qs.c
+++ b/drivers/nutdrv_qx_voltronic-qs.c
@@ -25,7 +25,7 @@
 
 #include "nutdrv_qx_voltronic-qs.h"
 
-#define VOLTRONIC_QS_VERSION "Voltronic-QS 0.10"
+#define VOLTRONIC_QS_VERSION "Voltronic-QS 0.11"
 
 /* Support functions */
 static int	voltronic_qs_claim(void);

--- a/drivers/nutdrv_qx_voltronic-qs.c
+++ b/drivers/nutdrv_qx_voltronic-qs.c
@@ -100,6 +100,20 @@ static item_t	voltronic_qs_qx2nut[] = {
 	{ "battery.voltage.nominal",	0,	NULL,	"F\r",	"",	22,	'#',	"",	11,	15,	"%.1f",	QX_FLAG_STATIC,	NULL,	NULL,	NULL },
 	{ "output.frequency.nominal",	0,	NULL,	"F\r",	"",	22,	'#',	"",	17,	20,	"%.0f",	QX_FLAG_STATIC,	NULL,	NULL,	NULL },
 
+	/* Query UPS for charge and runtime
+	 * > [QI\r]
+	 * < [(100 00979 50.0 000.3 177 290 0 0000010000112000\r]
+	 *    0123456789012345678901234567890123456789012345678
+	 *    0         1         2         3         4
+	 */
+
+	{ "battery.charge",		0,	NULL,	"QI\r",	"",	49,	'(',	"",	1,	3,	"%.0f",	0,		NULL,	NULL,	NULL },
+	{ "battery.runtime",		0,	NULL,	"QI\r",	"",	49,	'(',	"",	5,	9,	"%.0f",	0,		NULL,	NULL,	NULL },
+	{ "input.frequency",		0,	NULL,	"QI\r",	"",	49,	'(',	"",	11,	14,	"%.1f",	0,		NULL,	NULL,	NULL },
+	{ "output.current",		0,	NULL,	"QI\r",	"",	49,	'(',	"",	16,	20,	"%.1f",	0,		NULL,	NULL,	NULL },
+	{ "input.transfer.low",		0,	NULL,	"QI\r",	"",	49,	'(',	"",	22,	24,	"%.0f",	QX_FLAG_STATIC,	NULL,	NULL,	NULL },
+	{ "input.transfer.high",	0,	NULL,	"QI\r",	"",	49,	'(',	"",	26,	28,	"%.0f",	QX_FLAG_STATIC,	NULL,	NULL,	NULL },
+
 	/* Instant commands */
 	{ "beeper.toggle",		0,	NULL,	"Q\r",		"",	0,	0,	"",	1,	3,	NULL,	QX_FLAG_CMD,	NULL,	NULL,	NULL },
 	{ "load.off",			0,	NULL,	"S00R0000\r",	"",	0,	0,	"",	1,	3,	NULL,	QX_FLAG_CMD,	NULL,	NULL,	NULL },
@@ -123,6 +137,7 @@ static item_t	voltronic_qs_qx2nut[] = {
 static testing_t	voltronic_qs_testing[] = {
 	{ "QS\r",	"(215.0 195.0 230.0 014 49.0 22.7 30.0 00000000\r",	-1 },
 	{ "F\r",	"#220.0 003 12.00 50.0\r",	-1 },
+	{ "QI\r",	"(100 00979 50.0 000.3 177 290 0 0000010000112000\r", -1}
 	{ "M\r",	"V\r",	-1 },
 	{ "Q\r",	"",	-1 },
 	{ "C\r",	"",	-1 },


### PR DESCRIPTION
Hi, this PR adds the `QI` command for battery charge, runtime, input frequency, output current, and input transfer low/high values to the Voltronic-QS driver.

I am unsure of the consequences of using this with an unsupported UPS, hence marking this PR as a draft. A decompilation of Voltronic's ViewPower software shows this is only used for `H`/`I`/`J` protocols only. I am hoping someone can test this on a `V` protocol UPS, but otherwise let me know if there's a way to disable this for the `V` protocol, or if it's fine anyway.

I found this command while collecting a USB packet capture of a Powershield PSDR800 while using the manufacturer's NetGuard software, which seems to be based off of Voltronic's ViewPower.

Thanks,
Steve