### PR TITLE
`upssched` and other NUT daemons: fix Windows state pipe permissions

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -187,6 +187,10 @@ https://github.com/networkupstools/nut/milestone/13
       tracked) should now not cause exit of the client if secure connection
       is not required by its configuration in the first place. [#3420]
 
+ - `upssched` client/tool updates:
+    * Fixed handling of `NOTIFYMSG` from command line if other arguments are
+      present (e.g. debugging with `-DDDDDD`). [issues #3105, #3525, PR #3527]
+
  - `NUT-Monitor` Python GUI client:
     * Fixed Qt tray tooltips to render in plain text, not rich text which
       ended up as literal HTML on KDE Plasma 6; now that rich text formatting

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -131,6 +131,7 @@ https://github.com/networkupstools/nut/milestone/13
       `connect()` to ensure a timeout if something does not respond. [PR #3456]
     * Windows driver state named pipes now use explicit security attributes
       instead of relying on default settings from the launch context. [PR #3479]
+    * Likewise for named pipes in other NUT daemons and `upssched`. [PR #3527]
     * Drivers with libusb-1.0 code path, and `nutdrv_qx` in particular: revise
       to fix per-close `libusb_exit()` deadlock, and escalate a persistent
       `LIBUSB_ERROR_OVERFLOW` state to USB reset handling. [PR #3448]

--- a/clients/upssched.c
+++ b/clients/upssched.c
@@ -708,19 +708,23 @@ static TYPE_FD open_sock(void)
 	set_close_on_exec(fd);
 
 #else /* WIN32 */
+	SECURITY_ATTRIBUTES	pipe_sa;
+	SECURITY_DESCRIPTOR	pipe_sd;
+
+	init_pipe_security(&pipe_sa, &pipe_sd);
 
 	fd = CreateNamedPipe(
-			pipefn, /* pipe name */
-			PIPE_ACCESS_DUPLEX | /* read/write access */
-			FILE_FLAG_OVERLAPPED, /* async IO */
+			pipefn,		/* pipe name */
+			PIPE_ACCESS_DUPLEX |	/* read/write access */
+			FILE_FLAG_OVERLAPPED,	/* async IO */
 			PIPE_TYPE_BYTE |
 			PIPE_READMODE_BYTE |
 			PIPE_WAIT,
-			PIPE_UNLIMITED_INSTANCES, /* max. instances */
-			BUF_LEN, /* output buffer size */
-			BUF_LEN, /* input buffer size */
-			0, /* client time-out */
-			NULL); /* FIXME: default security attributes */
+			PIPE_UNLIMITED_INSTANCES,	/* max. instances */
+			BUF_LEN,	/* output buffer size */
+			BUF_LEN,	/* input buffer size */
+			0,		/* client time-out */
+			&pipe_sa);	/* default security attributes */
 
 	if (INVALID_FD(fd)) {
 		fatal_with_errno(EXIT_FAILURE,
@@ -943,25 +947,29 @@ static TYPE_FD conn_add(TYPE_FD sockfd)
 #else /* WIN32 */
 
 	conn_t	*conn, *tmp, *last;
+	SECURITY_ATTRIBUTES	pipe_sa;
+	SECURITY_DESCRIPTOR	pipe_sd;
 
 	/* We have detected a connection on the opened pipe. So we start
 	 * by saving its handle and creating a new pipe for future connection */
 	conn = xcalloc(1, sizeof(*conn));
 	conn->fd = sockfd;
 
+	init_pipe_security(&pipe_sa, &pipe_sd);
+
 	/* sock is the handle of the connection pending pipe */
 	acc = CreateNamedPipe(
-			pipefn, /* pipe name */
-			PIPE_ACCESS_DUPLEX |  /* read/write access */
-			FILE_FLAG_OVERLAPPED, /* async IO */
+			pipefn,		/* pipe name */
+			PIPE_ACCESS_DUPLEX |	/* read/write access */
+			FILE_FLAG_OVERLAPPED,	/* async IO */
 			PIPE_TYPE_BYTE |
 			PIPE_READMODE_BYTE |
 			PIPE_WAIT,
-			PIPE_UNLIMITED_INSTANCES, /* max. instances */
-			BUF_LEN, /* output buffer size */
-			BUF_LEN, /* input buffer size */
-			0, /* client time-out */
-			NULL); /* FIXME: default security attribute */
+			PIPE_UNLIMITED_INSTANCES,	/* max. instances */
+			BUF_LEN,	/* output buffer size */
+			BUF_LEN,	/* input buffer size */
+			0,		/* client time-out */
+			&pipe_sa);	/* default security attribute */
 
 	if (INVALID_FD(acc)) {
 		fatal_with_errno(EXIT_FAILURE,

--- a/clients/upssched.c
+++ b/clients/upssched.c
@@ -2194,7 +2194,7 @@ static void help(const char *arg_progname)
 
 	nut_report_config_flags();
 
-	printf("\n%s", suggest_doc_links(arg_progname, "upsmon.conf"));
+	printf("\n%s", suggest_doc_links(arg_progname, "upssched.conf"));
 
 	exit(EXIT_SUCCESS);
 }

--- a/clients/upssched.c
+++ b/clients/upssched.c
@@ -715,11 +715,12 @@ static TYPE_FD open_sock(void)
 
 	fd = CreateNamedPipe(
 			pipefn,		/* pipe name */
-			PIPE_ACCESS_DUPLEX |	/* read/write access */
-			FILE_FLAG_OVERLAPPED,	/* async IO */
-			PIPE_TYPE_BYTE |
-			PIPE_READMODE_BYTE |
-			PIPE_WAIT,
+			PIPE_ACCESS_DUPLEX	/* read/write access */
+			| FILE_FLAG_OVERLAPPED,	/* async IO */
+			PIPE_TYPE_BYTE
+			| PIPE_READMODE_BYTE
+			| PIPE_REJECT_REMOTE_CLIENTS	/* local host only */
+			| PIPE_WAIT,
 			PIPE_UNLIMITED_INSTANCES,	/* max. instances */
 			BUF_LEN,	/* output buffer size */
 			BUF_LEN,	/* input buffer size */
@@ -960,11 +961,12 @@ static TYPE_FD conn_add(TYPE_FD sockfd)
 	/* sock is the handle of the connection pending pipe */
 	acc = CreateNamedPipe(
 			pipefn,		/* pipe name */
-			PIPE_ACCESS_DUPLEX |	/* read/write access */
-			FILE_FLAG_OVERLAPPED,	/* async IO */
-			PIPE_TYPE_BYTE |
-			PIPE_READMODE_BYTE |
-			PIPE_WAIT,
+			PIPE_ACCESS_DUPLEX	/* read/write access */
+			| FILE_FLAG_OVERLAPPED,	/* async IO */
+			PIPE_TYPE_BYTE
+			| PIPE_READMODE_BYTE
+			| PIPE_REJECT_REMOTE_CLIENTS	/* local host only */
+			| PIPE_WAIT,
 			PIPE_UNLIMITED_INSTANCES,	/* max. instances */
 			BUF_LEN,	/* output buffer size */
 			BUF_LEN,	/* input buffer size */

--- a/clients/upssched.c
+++ b/clients/upssched.c
@@ -2201,13 +2201,12 @@ static void help(const char *arg_progname)
 
 int main(int argc, char **argv)
 {
-	int	opt_ret, argn = 0;
+	int	opt_ret;
 
 	/* Here this is a global variable, used also in start_daemon() */
 	prog = getprogname_argv0_default(argc > 0 ? argv[0] : NULL, "upssched");
 
 	while ((opt_ret = getopt(argc, argv, optstring)) != -1) {
-		argn++;
 		switch (opt_ret) {
 			case 'D':
 				nut_debug_level_args++;
@@ -2253,9 +2252,9 @@ int main(int argc, char **argv)
 
 	ups_name = getenv("UPSNAME");
 	notify_type = getenv("NOTIFYTYPE");
-	upsdebugx(2, "Remaining argn=%d of argc=%d", argn, argc);
-	if (argc > argn + 1 && *argv[argn + 1])
-		notify_msg = argv[argn + 1];
+	upsdebugx(2, "Handled optind=%d CLI tokens of argc=%d", optind - 1, argc);
+	if (argc > optind && *argv[optind])
+		notify_msg = argv[optind];
 
 	if ((!list_timers) && ((!ups_name) || (!notify_type))) {
 		printf("Error: environment variables UPSNAME and NOTIFYTYPE must be set.\n");

--- a/common/wincompat.c
+++ b/common/wincompat.c
@@ -534,6 +534,8 @@ void pipe_create(const char * pipe_name)
 {
 	BOOL	ret;
 	char	pipe_full_name[NUT_PATH_MAX + 1];
+	SECURITY_ATTRIBUTES	pipe_sa;
+	SECURITY_DESCRIPTOR	pipe_sd;
 
 	/* save pipe name for further use in pipe_connect */
 	if (pipe_name == NULL) {
@@ -552,6 +554,8 @@ void pipe_create(const char * pipe_name)
 		CloseHandle(pipe_connection_overlapped.hEvent);
 	}
 	memset(&pipe_connection_overlapped, 0, sizeof(pipe_connection_overlapped));
+	init_pipe_security(&pipe_sa, &pipe_sd);
+
 	upsdebugx(2, "%s: creating NAMED_PIPE (listener): '%s'", __func__, pipe_full_name);
 	pipe_connection_handle = CreateNamedPipe(
 		pipe_full_name,
@@ -564,7 +568,7 @@ void pipe_create(const char * pipe_name)
 		LARGEBUF,		/* output buffer size */
 		LARGEBUF,		/* input buffer size */
 		0,			/* client time-out */
-		NULL);			/* FIXME: default security attribute */
+		&pipe_sa);		/* default security attribute */
 
 	if (pipe_connection_handle == INVALID_HANDLE_VALUE) {
 		upslogx(LOG_ERR, "Error creating named pipe");

--- a/common/wincompat.c
+++ b/common/wincompat.c
@@ -579,6 +579,7 @@ void pipe_create(const char * pipe_name)
 		| FILE_FLAG_OVERLAPPED,	/* async IO */
 		PIPE_TYPE_MESSAGE
 		| PIPE_READMODE_MESSAGE
+		| PIPE_REJECT_REMOTE_CLIENTS	/* local host only */
 		| PIPE_WAIT,
 		PIPE_UNLIMITED_INSTANCES,	/* max. instances */
 		LARGEBUF,		/* output buffer size */

--- a/common/wincompat.c
+++ b/common/wincompat.c
@@ -454,7 +454,7 @@ void syslog(int priority, const char *fmt, ...)
 	/* At least while this is not configurable, can be static to speed up;
 	 * see https://github.com/networkupstools/nut/issues/3375
 	 */
-	static char	pipe_full_name[] = "\\\\.\\pipe\\"EVENTLOG_PIPE_NAME;
+	static char	pipe_full_name[] = "\\\\.\\pipe\\"EVENTLOG_PIPE_NAME, reported_no_pipe = 0;
 	char	buf1[LARGEBUF + sizeof(DWORD)];
 	char	buf2[LARGEBUF];
 	va_list	ap;
@@ -490,12 +490,18 @@ void syslog(int priority, const char *fmt, ...)
 		NULL);			/* no template file */
 
 	if (pipe == INVALID_HANDLE_VALUE) {
-		upsdebug_with_errno(1,
+		upsdebug_with_errno(reported_no_pipe ? 7 : 1,
 			"%s: SKIP: can't open existing event log NAMED_PIPE: '%s'",
 			__func__, pipe_full_name);
 
+		reported_no_pipe = 1;
 		return;
 	}
+
+	if (reported_no_pipe)
+		upsdebugx(1, "%s: opened existing event log NAMED_PIPE which we failed to use earlier: '%s'",
+			__func__, pipe_full_name);
+	reported_no_pipe = 0;
 
 	WriteFile(pipe, buf1, strlen(buf2) + sizeof(DWORD), &bytesWritten, NULL);
 

--- a/common/wincompat.c
+++ b/common/wincompat.c
@@ -454,7 +454,7 @@ void syslog(int priority, const char *fmt, ...)
 	/* At least while this is not configurable, can be static to speed up;
 	 * see https://github.com/networkupstools/nut/issues/3375
 	 */
-	static char	pipe_full_name[] = "\\\\.\\pipe\\"EVENTLOG_PIPE_NAME, reported_no_pipe = 0;
+	static char	pipe_full_name[] = "\\\\.\\pipe\\"EVENTLOG_PIPE_NAME, reported_no_pipe = 0, reentered = 0;
 	char	buf1[LARGEBUF + sizeof(DWORD)];
 	char	buf2[LARGEBUF];
 	va_list	ap;
@@ -464,6 +464,13 @@ void syslog(int priority, const char *fmt, ...)
 	if (EventLogName == NULL) {
 		return;
 	}
+
+	/* Could an upsdebugx() below cause re-syslog?.. */
+	if (reentered) {
+		return;
+	}
+
+	reentered = 1;
 
 	/* Format message */
 	va_start(ap, fmt);
@@ -495,6 +502,7 @@ void syslog(int priority, const char *fmt, ...)
 			__func__, pipe_full_name);
 
 		reported_no_pipe = 1;
+		reentered = 0;
 		return;
 	}
 
@@ -510,6 +518,8 @@ void syslog(int priority, const char *fmt, ...)
 	 * loop */
 	upsdebugx(6, "%s: closing event log NAMED_PIPE", __func__);
 	CloseHandle(pipe);
+
+	reentered = 0;
 }
 
 /* Signal emulation via NamedPipe */

--- a/common/wincompat.c
+++ b/common/wincompat.c
@@ -515,6 +515,21 @@ static const char	*named_pipe_name=NULL;
 OVERLAPPED		pipe_connection_overlapped;
 pipe_conn_t		*pipe_connhead = NULL;
 
+void init_pipe_security(SECURITY_ATTRIBUTES *sa, SECURITY_DESCRIPTOR *sd)
+{
+	if (!InitializeSecurityDescriptor(sd, SECURITY_DESCRIPTOR_REVISION)) {
+		fatal_with_errno(EXIT_FAILURE, "InitializeSecurityDescriptor failed");
+	}
+
+	if (!SetSecurityDescriptorDacl(sd, TRUE, NULL, FALSE)) {
+		fatal_with_errno(EXIT_FAILURE, "SetSecurityDescriptorDacl failed");
+	}
+
+	sa->nLength = sizeof(*sa);
+	sa->lpSecurityDescriptor = sd;
+	sa->bInheritHandle = FALSE;
+}
+
 void pipe_create(const char * pipe_name)
 {
 	BOOL	ret;

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -66,23 +66,6 @@
 	double			previous_battery_charge_value = -1.0;
 	st_tree_timespec_t	previous_battery_charge_timestamp;
 
-#ifdef WIN32
-static void init_pipe_security(SECURITY_ATTRIBUTES *sa, SECURITY_DESCRIPTOR *sd)
-{
-	if (!InitializeSecurityDescriptor(sd, SECURITY_DESCRIPTOR_REVISION)) {
-		fatal_with_errno(EXIT_FAILURE, "InitializeSecurityDescriptor failed");
-	}
-
-	if (!SetSecurityDescriptorDacl(sd, TRUE, NULL, FALSE)) {
-		fatal_with_errno(EXIT_FAILURE, "SetSecurityDescriptorDacl failed");
-	}
-
-	sa->nLength = sizeof(*sa);
-	sa->lpSecurityDescriptor = sd;
-	sa->bInheritHandle = FALSE;
-}
-#endif	/* WIN32 */
-
 #ifndef WIN32
 /* this may be a frequent stumbling point for new users, so be verbose here */
 static void sock_fail(const char *fn)

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -206,6 +206,7 @@ static TYPE_FD sock_open(const char *fn)
 		| FILE_FLAG_OVERLAPPED,	/* async IO */
 		PIPE_TYPE_BYTE
 		| PIPE_READMODE_BYTE
+		| PIPE_REJECT_REMOTE_CLIENTS	/* local host only */
 		| PIPE_WAIT,
 		PIPE_UNLIMITED_INSTANCES,	/* max. instances */
 		ST_SOCK_BUF_LEN,	/* output buffer size */
@@ -664,6 +665,7 @@ static void sock_connect(TYPE_FD sock)
 		| FILE_FLAG_OVERLAPPED,	/* async IO */
 		PIPE_TYPE_BYTE
 		| PIPE_READMODE_BYTE
+		| PIPE_REJECT_REMOTE_CLIENTS	/* local host only */
 		| PIPE_WAIT,
 		PIPE_UNLIMITED_INSTANCES,	/* max. instances */
 		ST_SOCK_BUF_LEN,	/* output buffer size */

--- a/include/wincompat.h
+++ b/include/wincompat.h
@@ -157,6 +157,7 @@ typedef struct pipe_conn_s {
 extern pipe_conn_t *pipe_connhead;
 extern OVERLAPPED pipe_connection_overlapped;
 void pipe_create(const char * pipe_name);
+void init_pipe_security(SECURITY_ATTRIBUTES *sa, SECURITY_DESCRIPTOR *sd);
 void pipe_connect();
 void pipe_disconnect(pipe_conn_t *conn);
 int pipe_ready(pipe_conn_t *conn);

--- a/include/wincompat.h
+++ b/include/wincompat.h
@@ -1,6 +1,3 @@
-#ifndef NUT_WINCOMPAT_H
-#define NUT_WINCOMPAT_H 1
-
 /*
    Copyright (C)
 	2001	Andrew Delpha (delpha@computer.org)
@@ -28,6 +25,9 @@
    This header is provided to map Windows system calls to be compatible
    with the NUT code.
 */
+
+#ifndef NUT_WINCOMPAT_H
+#define NUT_WINCOMPAT_H 1
 
 #include "common.h"
 #include <limits.h>


### PR DESCRIPTION
Generalize the fix from PR #3479, hoping it would help with issue #3525.

CC @mbv06 : a cursory review would be welcome :) Also, as I've just asked in your PR trail - would similar fixes be useful in "client" side of the connections (`CreateFile`)?

CC @alexdruqn-cpu : when/if Appveyor CI produces a build of this PR (in roughly an hour if all goes well; it should post a link in a comment below), a practical test would be welcome to see if this change impacts the issue you've seen on your system.