### PR TITLE
blazer_usb, nutdrv_qx: play safer with temporary buffers, pre-zero some more

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -134,6 +134,10 @@ https://github.com/networkupstools/nut/milestone/13
     * Drivers with libusb-1.0 code path, and `nutdrv_qx` in particular: revise
       to fix per-close `libusb_exit()` deadlock, and escalate a persistent
       `LIBUSB_ERROR_OVERFLOW` state to USB reset handling. [PR #3448]
+    * Some driver code paths used buffers sent via USB transfers as fixed-size
+      chunks populated only partially with bytes we intended. These buffers are
+      now more diligently pre-zeroed as their siblings were in other code paths,
+      to avoid sending host stack garbage to a device. [#3529]
 
  - NUT client libraries:
     * Complete support for actions documented in `docs/net-protocol.txt`

--- a/drivers/blazer_usb.c
+++ b/drivers/blazer_usb.c
@@ -37,7 +37,7 @@
 #endif	/* WIN32 */
 
 #define DRIVER_NAME	"Megatec/Q1 protocol USB driver"
-#define DRIVER_VERSION	"0.24"
+#define DRIVER_VERSION	"0.25"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -150,6 +150,8 @@ static int phoenix_command(const char *cmd, char *buf, size_t buflen)
 	int	ret;
 	size_t	i;
 
+	memset(tmp, 0, sizeof(tmp));
+
 	for (i = 0; i < 8; i++) {
 
 		/* Read data in 8-byte chunks */
@@ -234,6 +236,7 @@ static int ippon_command(const char *cmd, char *buf, size_t buflen)
 	int	ret, len;
 	size_t	i;
 
+	memset(tmp, 0, sizeof(tmp));
 	snprintf(tmp, sizeof(tmp), "%s", cmd);
 
 	for (i = 0; i < strlen(tmp); i += (size_t)ret) {

--- a/drivers/nutdrv_atcl_usb.c
+++ b/drivers/nutdrv_atcl_usb.c
@@ -28,7 +28,7 @@
 
 /* driver version */
 #define DRIVER_NAME	"'ATCL FOR UPS' USB driver"
-#define DRIVER_VERSION	"1.23"
+#define DRIVER_VERSION	"1.24"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -608,7 +608,7 @@ void upsdrv_initinfo(void)
 
 void upsdrv_updateinfo(void)
 {
-	char	reply[STATUS_PACKETSIZE];
+	char	reply[STATUS_PACKETSIZE] = {0};
 	int	ret;
 
 	if (!udev) {
@@ -682,8 +682,11 @@ int instcmd(const char *cmdname, const char *extra)
 
 		/* Not "const" because this mismatches arg type
 		 * of usb_interrupt_write() */
-		char	shutdown_packet[SHUTDOWN_PACKETSIZE] = { 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+		char	shutdown_packet[SHUTDOWN_PACKETSIZE];
 		int ret;
+
+		memset(shutdown_packet, 0, sizeof(shutdown_packet));
+		shutdown_packet[0] = 0x01;
 
 		upslogx(LOG_DEBUG,
 			"%s: attempting to call usb_interrupt_write(01 00 00 00 00 00 00 00)",

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -58,7 +58,7 @@
 #	define DRIVER_NAME	"Generic Q* Serial driver"
 #endif	/* QX_USB */
 
-#define DRIVER_VERSION	"0.51"
+#define DRIVER_VERSION	"0.52"
 
 #ifdef QX_SERIAL
 #	include "serial.h"
@@ -913,6 +913,8 @@ static int	phoenix_command(const char *cmd, size_t cmdlen, char *buf, size_t buf
 	int	ret;
 	size_t	i;
 
+	memset(tmp, 0, sizeof(tmp));
+
 	if (buflen > INT_MAX) {
 		upsdebugx(3, "%s: requested to read too much (%" PRIuSIZE "), "
 			"reducing buflen to (INT_MAX-1)",
@@ -1640,6 +1642,7 @@ static int	fuji_command(const char *cmd, size_t cmdlen, char *buf, size_t buflen
 	/* Send command */
 
 	/* Remove the CR */
+	memset(command, 0, sizeof(command));
 	snprintf(command, sizeof(command), "%.*s", (int)strcspn(cmd, "\r"), cmd);
 
 	/* Length of the command that will be sent to the UPS can be
@@ -1947,6 +1950,8 @@ static int ablerex_command(const char *cmd, size_t cmdlen, char *buf, size_t buf
 		int	ret;
 
 		memset(buf, 0, buflen);
+		memset(tmp, 0, sizeof(tmp));
+
 		tmp[0] = 0x05;
 		tmp[1] = 0;
 		tmp[2] = 1 + (char)strcspn(cmd, "\r");

--- a/drivers/powercom-hid.c
+++ b/drivers/powercom-hid.c
@@ -28,7 +28,7 @@
 
 #include <ctype.h>	/* isdigit() */
 
-#define POWERCOM_HID_VERSION	"PowerCOM HID 0.74"
+#define POWERCOM_HID_VERSION	"PowerCOM HID 0.75"
 /* FIXME: experimental flag to be put in upsdrv_info */
 
 /* PowerCOM */
@@ -448,6 +448,8 @@ static const char *powercom_hack_voltage(double value)
 		/* Retry up to 5 times (approx 0.5s) */
 		max_retries = 5;
 	}
+
+	memset(data, 0, sizeof(data));
 
 	for (retry = 0; retry < max_retries; retry++) {
 		/* Portable read of Report 0xa4 (Feature) using NUT's wrapper */

--- a/drivers/richcomm_usb.c
+++ b/drivers/richcomm_usb.c
@@ -30,7 +30,7 @@
 
 /* driver version */
 #define DRIVER_NAME	"Richcomm dry-contact to USB driver"
-#define DRIVER_VERSION	"0.18"
+#define DRIVER_VERSION	"0.19"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info = {
@@ -807,6 +807,8 @@ void upsdrv_updateinfo(void)
 		}
 		dstate_setinfo("driver.state", "reconnect.updateinfo");
 	}
+
+	memset(reply, 0, sizeof(reply));
 
 	ret = query_ups(reply);
 

--- a/drivers/riello_usb.c
+++ b/drivers/riello_usb.c
@@ -36,7 +36,7 @@
 #include "riello.h"
 
 #define DRIVER_NAME	"Riello USB driver"
-#define DRIVER_VERSION	"0.17"
+#define DRIVER_VERSION	"0.18"
 
 #define DEFAULT_OFFDELAY   5  /*!< seconds (max 0xFF) */
 #define DEFAULT_BOOTDELAY  5  /*!< seconds (max 0xFF) */
@@ -129,6 +129,8 @@ static int Send_USB_Packet(uint8_t *send_str, uint16_t numbytes)
 
 	size = 7;
 
+	memset(USB_buff_pom, 0, sizeof(USB_buff_pom));
+
 	/* routine which parse report into 4-bytes packet */
 	for (i=0; i<(numbytes/size); i++) {
 		USB_buff_pom[0] = 0x37;
@@ -190,6 +192,8 @@ static int Get_USB_Packet(uint8_t *buffer)
 
 	/* note: this function stop until some byte(s) is not arrived */
 	size = 8;
+
+	memset(inBuf, 0, sizeof(inBuf));
 
 	/* Note: depending on libusb API version, size is either int or uint16_t
 	 * either way, likely less than size_t limit. But we don't assign much.

--- a/drivers/tripplite_usb.c
+++ b/drivers/tripplite_usb.c
@@ -137,7 +137,7 @@
 #include "usb-common.h"
 
 #define DRIVER_NAME	"Tripp Lite OMNIVS / SMARTPRO driver"
-#define DRIVER_VERSION	"0.44"
+#define DRIVER_VERSION	"0.45"
 
 /* driver description structure */
 upsdrv_info_t	upsdrv_info = {
@@ -811,6 +811,7 @@ static void debug_message(const char *msg, size_t len)
 	unsigned char tmp_value[9];
 	char var_name[20], err_msg[80];
 
+	memset(tmp_value, 0, sizeof(tmp_value));
 	snprintf(var_name, sizeof(var_name), "ups.debug.%c", *msg);
 
 	ret = send_cmd((const unsigned char *)msg, len, tmp_value, sizeof(tmp_value));


### PR DESCRIPTION
Avoid sending host stack garbage to devices.