### PR TITLE
Fix suggestion of user password in NUT-Monitor from NUT authconf data, revise parsers in bindings

### DIFF
--- a/clients/nutclient.cpp
+++ b/clients/nutclient.cpp
@@ -2321,6 +2321,7 @@ static int splitaddr(const std::string& buf, std::string& hostname, uint16_t& po
 		colon = tmp.find(':');
 		if (colon != std::string::npos) {
 			hostname = tmp.substr(0, colon);
+			if (hostname.empty()) hostname = "localhost";
 		} else {
 			hostname = tmp;
 			port = NUT_PORT;
@@ -3809,7 +3810,7 @@ void TcpClient::connect(const AuthConf& ac)
 	std::string hostname;
 	uint16_t portnum = NUT_PORT;
 	if (splitaddr(ac.section, hostname, portnum) == 0) {
-		_host = !hostname.empty() ? hostname : "localhost";
+		_host = hostname;
 		_port = portnum;
 	}
 

--- a/clients/nutclient.cpp
+++ b/clients/nutclient.cpp
@@ -2148,6 +2148,7 @@ static void set_authconf_val(AuthConf& conf, const std::string& var, const std::
 }
 
 static int parse_authconf_file(const std::string& filename, int fatal_errors, bool global_scope, std::list<AuthConf>& authconf_list, AuthConf*& global_defaults);
+static bool normalize_section(const std::string& section, std::string& normalized_name, std::string& user);
 
 static void handle_authconf_args(size_t numargs, char **arg, AuthConf*& current_section, bool global_scope, std::list<AuthConf>& authconf_list, AuthConf*& global_defaults)
 {
@@ -2158,13 +2159,19 @@ static void handle_authconf_args(size_t numargs, char **arg, AuthConf*& current_
 		std::string sectname = arg[0];
 		sectname = sectname.substr(1, sectname.length() - 2);
 
-		if (sectname == "_global_defaults" || sectname.empty()) {
+		if (sectname == "_global_defaults" || sectname.empty() || sectname == "*") {
 			if (!global_defaults) {
 				authconf_list.emplace_back("");
 				global_defaults = &authconf_list.back();
 			}
 			current_section = global_defaults;
 		} else {
+			std::string normalized_name;
+			std::string section_user;
+			if (!normalize_section(sectname, normalized_name, section_user)) {
+				throw nut::IOException("Invalid authconf section: " + sectname);
+			}
+			sectname = normalized_name;
 			/* Check if section already exists */
 			current_section = nullptr;
 			for (auto& ac : authconf_list) {
@@ -2181,7 +2188,7 @@ static void handle_authconf_args(size_t numargs, char **arg, AuthConf*& current_
 
 		size_t at = current_section->section.find('@');
 		if (at != std::string::npos && at > 0) {
-			current_section->user = current_section->section.substr(0, at - 1);
+			current_section->user = current_section->section.substr(0, at);
 		}
 
 		return;
@@ -2354,12 +2361,17 @@ static void normalize_parts(std::string& normalized_name, std::string& user, std
 		char portbuf[16];
 		snprintf(portbuf, sizeof(portbuf), "%u", static_cast<unsigned int>(NUT_PORT));
 		port = portbuf;
+	} else if (port.find_first_not_of("0123456789") != std::string::npos) {
+		struct servent* service = getservbyname(port.c_str(), "tcp");
+		if (service) {
+			char portbuf[16];
+			snprintf(portbuf, sizeof(portbuf), "%u",
+				static_cast<unsigned int>(ntohs(static_cast<uint16_t>(service->s_port))));
+			port = portbuf;
+		}
 	}
 
-	normalized_name = "";
-	if (!user.empty()) {
-		normalized_name += user + "@";
-	}
+	normalized_name = user + "@";
 
 	if ((host.find(':') != std::string::npos || host.find('[') != std::string::npos || host.find(']') != std::string::npos)
 		&& host.front() != '[') {
@@ -2369,6 +2381,41 @@ static void normalize_parts(std::string& normalized_name, std::string& user, std
 	}
 
 	normalized_name += ":" + port;
+}
+
+static bool normalize_section(const std::string& section, std::string& normalized_name, std::string& user)
+{
+	std::string addr = section;
+	size_t at = section.find('@');
+	if (at != std::string::npos) {
+		user = section.substr(0, at);
+		addr = section.substr(at + 1);
+	} else {
+		user.clear();
+	}
+
+	std::string host;
+	std::string port;
+	if (!addr.empty() && addr.front() == '[') {
+		size_t close = addr.find(']');
+		if (close == std::string::npos) return false;
+		host = addr.substr(1, close - 1);
+		if (close + 1 < addr.size()) {
+			if (addr[close + 1] != ':') return false;
+			port = addr.substr(close + 2);
+		}
+	} else {
+		size_t colon = addr.find(':');
+		if (colon == std::string::npos) {
+			host = addr;
+		} else {
+			host = addr.substr(0, colon);
+			port = addr.substr(colon + 1);
+		}
+	}
+
+	normalize_parts(normalized_name, user, host, port);
+	return true;
 }
 
 void AuthConf::merge(const AuthConf& source)
@@ -2382,7 +2429,10 @@ void AuthConf::merge(const AuthConf& source)
 		/* Section title strictly defines a user name */
 		user = section.substr(0, at);
 	} else if (at == 0) {
-		/* Section starts with @, so no user in title */
+		/* Userless host section: USER may be supplied by this section or defaults. */
+		if (user.empty() && !source.user.empty()) {
+			user = source.user;
+		}
 	} else {
 		/* No '@' in target section title */
 		if (user.empty() && !source.user.empty()) {

--- a/clients/upsclient.c
+++ b/clients/upsclient.c
@@ -1404,6 +1404,9 @@ void upscli_add_host_cert(const char* hostname, const char* certname, int certve
 		snprintf(host,
 			MIN(sizeof(host) - 1, (size_t)(substr_port - substr_host + 1)),
 			"%s", substr_host);
+		if (!host[0]) {
+			snprintf(host, sizeof(host), "%s", "localhost");
+		}
 
 		if (substr_port[1]) {
 			port = get_port_from_string(substr_port + 1);

--- a/scripts/perl/UPS/Nut.pm.in
+++ b/scripts/perl/UPS/Nut.pm.in
@@ -1573,16 +1573,52 @@ sub getDebug {
     return $debug;
 }
 
+sub normalizeSection {
+    my ($class, $section) = @_;
+    my ($user, $addr) = (undef, $section);
+    if ($section =~ /@/) {
+        ($user, $addr) = split(/@/, $section, 2);
+    }
+
+    my ($host, $port) = ($addr, undef);
+    if (substr($addr, 0, 1) eq '[') {
+        my $close = index($addr, ']');
+        die "Invalid authconf section: '$section'" if $close < 0;
+        $host = substr($addr, 1, $close - 1);
+        my $suffix = substr($addr, $close + 1);
+        if ($suffix ne '') {
+            die "Invalid authconf section: '$section'" unless substr($suffix, 0, 1) eq ':';
+            $port = substr($suffix, 1);
+        }
+    } elsif ($addr =~ /:/) {
+        ($host, $port) = split(/:/, $addr, 2);
+    }
+
+    $host = 'localhost' if !defined($host) || $host eq '';
+    $port = '3493' if !defined($port) || $port eq '';
+    if ($port !~ /^\d+$/) {
+        my $service_port = getservbyname($port, 'tcp');
+        $port = $service_port if defined $service_port;
+    }
+    my $host_part = $host =~ /:/ ? "[$host]" : $host;
+    my $fixed_user = defined($user) && $user ne '' ? $user : undef;
+    return ((defined($fixed_user) ? $fixed_user : '') . "\@$host_part:$port", $fixed_user);
+}
+
 sub new {
     my $class = shift;
     my $section = shift || "";
 
-    $section =~ s/^\[//;
-    $section =~ s/\]$//;
+    if ($section =~ /^\[(.*)\]$/) {
+        my $inner = $1;
+        $section = $inner if $inner =~ /@/ || $inner !~ /:/ || substr($inner, 0, 1) eq '[';
+    }
+    my $section_user;
+    ($section, $section_user) = $class->normalizeSection($section) if $section ne '';
 
     my $self = {
         section     => $section,  # [@host:port] or [user@host:port], or NULL for global
-        user        => undef,
+        user        => $section_user,
         pass        => undef,
         certpath    => undef,     # Path to trusted CA certificates; in case of NSS, this is the path to location of the NSS DB files used for all purposes
         certfile    => undef,     # (OpenSSL only) Client certificate file for authentication to the server (client cert, CA chain, client key)
@@ -1685,6 +1721,7 @@ sub readAuthConfFile {
                 }
                 $current_ac = $global_defaults_ref;
             } else {
+                ($sectname) = $class->normalizeSection($sectname);
                 # Check if section already exists
                 $current_ac = undef;
                 foreach my $ac (@authconf_list) {
@@ -1809,13 +1846,13 @@ sub getAuthConf {
         $host_part = "[$host_part]";
     }
 
-    my $target_user_host_port = "";
-    $target_user_host_port .= "$user\@" if defined $user;
-    $target_user_host_port .= $host_part;
+    my $target_user_host_port = (defined($user) ? $user : '') . "\@$host_part";
     $target_user_host_port .= ":$norm_port" if defined $norm_port;
+    ($target_user_host_port) = $class->normalizeSection($target_user_host_port);
 
     my $target_host_port = "\@$host_part";
     $target_host_port .= ":$norm_port" if defined $norm_port;
+    ($target_host_port) = $class->normalizeSection($target_host_port);
 
     my $res = UPS::Nut::AuthConf->new("[$target_user_host_port]");
 
@@ -1872,10 +1909,9 @@ sub findAuthConf {
         $host_part = "[$host_part]";
     }
 
-    my $target = "";
-    $target .= "$user\@" if defined $user;
-    $target .= $host_part;
+    my $target = (defined($user) ? $user : '') . "\@$host_part";
     $target .= ":$norm_port" if defined $norm_port;
+    ($target) = $class->normalizeSection($target);
 
     my $star_match;
     $class->_debug("findAuthConf(): Looking for user [" . ($user || "undef") . "], host [" . ($host || "undef") . "]=>[$norm_host], port [" . ($port || "undef") . "]");

--- a/scripts/perl/UPS/Nut.pm.in
+++ b/scripts/perl/UPS/Nut.pm.in
@@ -1935,6 +1935,7 @@ sub to_nut_args {
         }
     } elsif ($sect =~ /:/) {
         ($host, $port) = split(/:/, $sect, 2);
+        $host = 'localhost' if !defined($host) || $host eq '';
     } elsif ($sect ne "") {
         $host = $sect;
     }
@@ -1996,4 +1997,3 @@ sub isValid {
 
 1;
 __END__
-

--- a/scripts/python/app/NUT-Monitor-py2gtk2.in
+++ b/scripts/python/app/NUT-Monitor-py2gtk2.in
@@ -1371,5 +1371,18 @@ if __name__ == "__main__" :
          module.bindtextdomain( APP, DIR )
          module.textdomain( APP )
 
+    nut_debug_level = os.getenv("NUT_DEBUG_LEVEL", 0)
+    try:
+        nut_debug_level = int(nut_debug_level)
+    except ValueError:
+        nut_debug_level = 0
+    except TypeError:
+        nut_debug_level = 0
+
+    if nut_debug_level > 0:
+        PyNUT.debug = True
+        if nut_debug_level > 5:
+            PyNUT.AuthConf.setDebug(True)
+
     gui = interface()
     gtk.main()

--- a/scripts/python/app/NUT-Monitor-py2gtk2.in
+++ b/scripts/python/app/NUT-Monitor-py2gtk2.in
@@ -130,6 +130,8 @@ class interface :
     __password_manually_edited       = False
     __login_suggested                = False
     __password_suggested             = False
+    __auth_check_suggested           = False
+    __auth_suggestions_suppressed    = False
 
     def __init__( self ) :
 
@@ -328,8 +330,9 @@ class interface :
                 self.__password_manually_edited = False
                 self.__password_suggested = True
 
-            self.__widgets["ups_authentication_check"].set_active(self.__login_suggested or self.__password_suggested)
-            self.__set_suggested_style( self.__widgets["ups_authentication_check"], self.__widgets["ups_authentication_check"].get_active() )
+            self.__auth_check_suggested = self.__login_suggested and self.__password_suggested
+            self.__widgets["ups_authentication_check"].set_active(self.__auth_check_suggested)
+            self.__set_suggested_style( self.__widgets["ups_authentication_check"], self.__auth_check_suggested )
 
         self.gui_status_message( _("Welcome to NUT Monitor") )
 
@@ -369,16 +372,24 @@ class interface :
         self.__check_gui_fields()
 
     def __on_auth_check_changed( self, widget=None ) :
+        self.__auth_check_suggested = False
         checked = self.__widgets["ups_authentication_check"].get_active()
+        self.__auth_suggestions_suppressed = not checked
         if not checked :
             # If user unchecks, we clear suggestions so it doesn't immediately re-check
             if self.__login_suggested :
                 self.__login_suggested = False
+                self.__widgets["ups_authentication_login"].handler_block_by_func(self.__on_login_changed)
                 self.__widgets["ups_authentication_login"].set_text("")
+                self.__widgets["ups_authentication_login"].handler_unblock_by_func(self.__on_login_changed)
+                self.__login_manually_edited = False
                 self.__set_suggested_style( self.__widgets["ups_authentication_login"], False )
             if self.__password_suggested :
                 self.__password_suggested = False
+                self.__widgets["ups_authentication_password"].handler_block_by_func(self.__on_password_changed)
                 self.__widgets["ups_authentication_password"].set_text("")
+                self.__widgets["ups_authentication_password"].handler_unblock_by_func(self.__on_password_changed)
+                self.__password_manually_edited = False
                 self.__set_suggested_style( self.__widgets["ups_authentication_password"], False )
         self.__check_gui_fields()
 
@@ -396,67 +407,92 @@ class interface :
         except:
             port = 3493
 
-        # If not manually edited and was suggested, check if it still matches authconf for current host/port
-        if not self.__login_manually_edited and not self.__password_manually_edited:
-            ac = PyNUT.AuthConf.getAuthConf(host=host, port=port)
-            if self.__login_suggested:
-                if not ac or not ac.user:
-                    self.__widgets["ups_authentication_login"].set_text("")
-                    self.__set_suggested_style( self.__widgets["ups_authentication_login"], False )
+        login = self.__widgets["ups_authentication_login"].get_text()
+        ac_no_user = PyNUT.AuthConf.getAuthConf(host=host, port=port)
 
-                    # (Re-)Set these AFTER on*changed handlers might
-                    # by default assume the field was edited by user!
+        # If not manually edited and was suggested, check if it still matches authconf for current host/port/user
+        if not self.__login_manually_edited and not self.__auth_suggestions_suppressed:
+            if self.__login_suggested:
+                if not ac_no_user or not ac_no_user.user:
+                    self.__widgets["ups_authentication_login"].handler_block_by_func(self.__on_login_changed)
+                    self.__widgets["ups_authentication_login"].set_text("")
+                    self.__widgets["ups_authentication_login"].handler_unblock_by_func(self.__on_login_changed)
+                    self.__set_suggested_style( self.__widgets["ups_authentication_login"], False )
                     self.__login_manually_edited = False
                     self.__login_suggested = False
-                elif ac.user != self.__widgets["ups_authentication_login"].get_text():
-                    # Re-populate if it matches a different entry for this host/port
-                    self.__widgets["ups_authentication_login"].set_text(ac.user)
+                elif ac_no_user.user != self.__widgets["ups_authentication_login"].get_text():
+                    self.__widgets["ups_authentication_login"].handler_block_by_func(self.__on_login_changed)
+                    self.__widgets["ups_authentication_login"].set_text(ac_no_user.user)
+                    self.__widgets["ups_authentication_login"].handler_unblock_by_func(self.__on_login_changed)
                     self.__set_suggested_style( self.__widgets["ups_authentication_login"], True )
                     self.__login_manually_edited = False
                     self.__login_suggested = True
-            elif ac and ac.user:
-                # Re-populate if it matches a different entry for this host/port
-                self.__widgets["ups_authentication_login"].set_text(ac.user)
+            elif ac_no_user and ac_no_user.user:
+                self.__widgets["ups_authentication_login"].handler_block_by_func(self.__on_login_changed)
+                self.__widgets["ups_authentication_login"].set_text(ac_no_user.user)
+                self.__widgets["ups_authentication_login"].handler_unblock_by_func(self.__on_login_changed)
                 self.__set_suggested_style( self.__widgets["ups_authentication_login"], True )
                 self.__login_manually_edited = False
                 self.__login_suggested = True
 
-            if self.__password_suggested:
-                if not ac or not ac.password:
+        # Now re-evaluate password suggestion based on potentially updated login
+        login = self.__widgets["ups_authentication_login"].get_text()
+        ac = PyNUT.AuthConf.getAuthConf(user=login, host=host, port=port)
+        # Look for direct hits
+        ac_user_match = PyNUT.AuthConf.findAuthConf(user=login, host=host, port=port)
+        if not ((ac_no_user and ac_no_user.user == login) or
+                (ac_user_match and ac_user_match.section == ac.section)):
+            ac = None
+
+        # Ensure that if the entered username doesn't match anything, we clear suggested password
+        # (even if login itself was manually edited)
+        if not self.__password_manually_edited and not self.__auth_suggestions_suppressed:
+            if not ac or not ac.password:
+                if self.__password_suggested:
+                    self.__widgets["ups_authentication_password"].handler_block_by_func(self.__on_password_changed)
                     self.__widgets["ups_authentication_password"].set_text("")
+                    self.__widgets["ups_authentication_password"].handler_unblock_by_func(self.__on_password_changed)
                     self.__set_suggested_style( self.__widgets["ups_authentication_password"], False )
                     self.__password_manually_edited = False
                     self.__password_suggested = False
-                elif ac.password != self.__widgets["ups_authentication_password"].get_text():
-                    # Re-populate if it matches a different entry for this host/port
-                    self.__widgets["ups_authentication_password"].set_text(ac.password)
-                    self.__set_suggested_style( self.__widgets["ups_authentication_password"], True )
-                    self.__password_manually_edited = False
-                    self.__password_suggested = True
-            elif ac and ac.password:
-                # Re-populate if it matches a different entry for this host/port
+            elif self.__password_suggested and ac.password != self.__widgets["ups_authentication_password"].get_text():
+                # If it was suggested but now matches a different password (e.g. for a different user)
+                self.__widgets["ups_authentication_password"].handler_block_by_func(self.__on_password_changed)
                 self.__widgets["ups_authentication_password"].set_text(ac.password)
+                self.__widgets["ups_authentication_password"].handler_unblock_by_func(self.__on_password_changed)
+                self.__set_suggested_style( self.__widgets["ups_authentication_password"], True )
+                self.__password_manually_edited = False
+                self.__password_suggested = True
+            elif not self.__password_suggested and ac and ac.password:
+                # If not suggested yet but we found a match
+                self.__widgets["ups_authentication_password"].handler_block_by_func(self.__on_password_changed)
+                self.__widgets["ups_authentication_password"].set_text(ac.password)
+                self.__widgets["ups_authentication_password"].handler_unblock_by_func(self.__on_password_changed)
                 self.__set_suggested_style( self.__widgets["ups_authentication_password"], True )
                 self.__password_manually_edited = False
                 self.__password_suggested = True
 
-            # Only programmatically change checkbox if we HAVE a suggestion
-            if self.__login_suggested or self.__password_suggested:
+
+        # Automatically select authentication only for a complete credential suggestion.
+        if (self.__login_suggested and self.__password_suggested and
+                not self.__widgets["ups_authentication_check"].get_active()):
+            self.__widgets["ups_authentication_check"].handler_block_by_func(self.__on_auth_check_changed)
+            self.__widgets["ups_authentication_check"].set_active(True)
+            self.__widgets["ups_authentication_check"].handler_unblock_by_func(self.__on_auth_check_changed)
+            self.__auth_check_suggested = True
+
+        # Only retract an automatic selection. Editing either credential transfers
+        # control to the user and keeps authentication selected.
+        if self.__auth_check_suggested and not (self.__login_suggested and self.__password_suggested):
+            if self.__login_manually_edited or self.__password_manually_edited:
+                self.__auth_check_suggested = False
+            else:
                 self.__widgets["ups_authentication_check"].handler_block_by_func(self.__on_auth_check_changed)
-                self.__widgets["ups_authentication_check"].set_active(True)
+                self.__widgets["ups_authentication_check"].set_active(False)
                 self.__widgets["ups_authentication_check"].handler_unblock_by_func(self.__on_auth_check_changed)
+                self.__auth_check_suggested = False
 
-            # If we had suggestions but they are now gone,
-            # and user didn't manually edit anything, we
-            # should also uncheck the "Use authentication" box
-            if not self.__login_suggested and not self.__password_suggested:
-                if self.__widgets["ups_authentication_check"].get_active():
-                    self.__widgets["ups_authentication_check"].handler_block_by_func(self.__on_auth_check_changed)
-                    self.__widgets["ups_authentication_check"].set_active(False)
-                    self.__widgets["ups_authentication_check"].handler_unblock_by_func(self.__on_auth_check_changed)
-
-        # Only highlight the checkbox as suggested if it was all suggested
-        self.__set_suggested_style( self.__widgets["ups_authentication_check"], self.__login_suggested and self.__password_suggested )
+        self.__set_suggested_style( self.__widgets["ups_authentication_check"], self.__auth_check_suggested )
 
         # If UPS list contains something, clear it
         if self.__widgets["ups_list_combo"].get_active() != -1 :
@@ -551,8 +587,9 @@ class interface :
                         self.__password_manually_edited = False
                         self.__password_suggested = True
 
-                    self.__widgets["ups_authentication_check"].set_active(self.__login_suggested or self.__password_suggested)
-                    self.__set_suggested_style( self.__widgets["ups_authentication_check"], self.__widgets["ups_authentication_check"].get_active() )
+                    self.__widgets["ups_authentication_check"].set_active(self.__login_suggested and self.__password_suggested)
+                    self.__auth_check_suggested = self.__login_suggested and self.__password_suggested
+                    self.__set_suggested_style( self.__widgets["ups_authentication_check"], self.__auth_check_suggested )
 
         if self.__widgets["ups_authentication_check"].get_active() :
             login    = self.__widgets["ups_authentication_login"].get_text()
@@ -1336,4 +1373,3 @@ if __name__ == "__main__" :
 
     gui = interface()
     gtk.main()
-

--- a/scripts/python/app/NUT-Monitor-py3qt5.in
+++ b/scripts/python/app/NUT-Monitor-py3qt5.in
@@ -1430,5 +1430,18 @@ if __name__ == "__main__" :
          module.bindtextdomain( APP, DIR )
          module.textdomain( APP )
 
+    nut_debug_level = os.getenv("NUT_DEBUG_LEVEL", 0)
+    try:
+        nut_debug_level = int(nut_debug_level)
+    except ValueError:
+        nut_debug_level = 0
+    except TypeError:
+        nut_debug_level = 0
+
+    if nut_debug_level > 0:
+        PyNUT.debug = True
+        if nut_debug_level > 5:
+            PyNUT.AuthConf.setDebug(True)
+
     gui = interface(sys.argv)
     gui.exec()

--- a/scripts/python/app/NUT-Monitor-py3qt5.in
+++ b/scripts/python/app/NUT-Monitor-py3qt5.in
@@ -142,6 +142,8 @@ class interface :
     __password_manually_edited       = False
     __login_suggested                = False
     __password_suggested             = False
+    __auth_check_suggested           = False
+    __auth_suggestions_suppressed    = False
 
     def __init__( self, argv ) :
 
@@ -290,8 +292,9 @@ class interface :
                 self.__password_manually_edited = False
                 self.__password_suggested = True
 
-            self.__widgets["ups_authentication_check"].setChecked(self.__login_suggested or self.__password_suggested)
-            self.__set_suggested_style( self.__widgets["ups_authentication_check"], self.__widgets["ups_authentication_check"].isChecked() )
+            self.__auth_check_suggested = self.__login_suggested and self.__password_suggested
+            self.__widgets["ups_authentication_check"].setChecked(self.__auth_check_suggested)
+            self.__set_suggested_style( self.__widgets["ups_authentication_check"], self.__auth_check_suggested )
 
         if ( cmd_opts.hidden != True ) :
             self.__widgets["main_window"].show()
@@ -387,15 +390,23 @@ class interface :
         self.__check_gui_fields()
 
     def __on_auth_check_changed( self, checked ) :
+        self.__auth_check_suggested = False
+        self.__auth_suggestions_suppressed = not checked
         if not checked :
             # If user unchecks, we clear suggestions so it doesn't immediately re-check
             if self.__login_suggested :
                 self.__login_suggested = False
+                self.__widgets["ups_authentication_login"].blockSignals(True)
                 self.__widgets["ups_authentication_login"].setText("")
+                self.__widgets["ups_authentication_login"].blockSignals(False)
+                self.__login_manually_edited = False
                 self.__set_suggested_style( self.__widgets["ups_authentication_login"], False )
             if self.__password_suggested :
                 self.__password_suggested = False
+                self.__widgets["ups_authentication_password"].blockSignals(True)
                 self.__widgets["ups_authentication_password"].setText("")
+                self.__widgets["ups_authentication_password"].blockSignals(False)
+                self.__password_manually_edited = False
                 self.__set_suggested_style( self.__widgets["ups_authentication_password"], False )
         self.__check_gui_fields()
 
@@ -407,67 +418,92 @@ class interface :
         except:
             port = 3493
 
-        # If not manually edited and was suggested, check if it still matches authconf for current host/port
-        if not self.__login_manually_edited and not self.__password_manually_edited:
-            ac = PyNUT.AuthConf.getAuthConf(host=host, port=port)
-            if self.__login_suggested:
-                if not ac or not ac.user:
-                    self.__widgets["ups_authentication_login"].setText("")
-                    self.__set_suggested_style( self.__widgets["ups_authentication_login"], False )
+        login = self.__widgets["ups_authentication_login"].text()
+        ac_no_user = PyNUT.AuthConf.getAuthConf(host=host, port=port)
 
-                    # (Re-)Set these AFTER on*changed handlers might
-                    # by default assume the field was edited by user!
+        # If not manually edited and was suggested, check if it still matches authconf for current host/port/user
+        if not self.__login_manually_edited and not self.__auth_suggestions_suppressed:
+            if self.__login_suggested:
+                if not ac_no_user or not ac_no_user.user:
+                    self.__widgets["ups_authentication_login"].blockSignals(True)
+                    self.__widgets["ups_authentication_login"].setText("")
+                    self.__widgets["ups_authentication_login"].blockSignals(False)
+                    self.__set_suggested_style( self.__widgets["ups_authentication_login"], False )
                     self.__login_manually_edited = False
                     self.__login_suggested = False
-                elif ac.user != self.__widgets["ups_authentication_login"].text():
-                    # Re-populate if it matches a different entry for this host/port
-                    self.__widgets["ups_authentication_login"].setText(ac.user)
+                elif ac_no_user.user != self.__widgets["ups_authentication_login"].text():
+                    self.__widgets["ups_authentication_login"].blockSignals(True)
+                    self.__widgets["ups_authentication_login"].setText(ac_no_user.user)
+                    self.__widgets["ups_authentication_login"].blockSignals(False)
                     self.__set_suggested_style( self.__widgets["ups_authentication_login"], True )
                     self.__login_manually_edited = False
                     self.__login_suggested = True
-            elif ac and ac.user:
-                # Re-populate if it matches a different entry for this host/port
-                self.__widgets["ups_authentication_login"].setText(ac.user)
+            elif ac_no_user and ac_no_user.user:
+                self.__widgets["ups_authentication_login"].blockSignals(True)
+                self.__widgets["ups_authentication_login"].setText(ac_no_user.user)
+                self.__widgets["ups_authentication_login"].blockSignals(False)
                 self.__set_suggested_style( self.__widgets["ups_authentication_login"], True )
                 self.__login_manually_edited = False
                 self.__login_suggested = True
 
-            if self.__password_suggested:
-                if not ac or not ac.password:
+        # Now re-evaluate password suggestion based on potentially updated login
+        login = self.__widgets["ups_authentication_login"].text()
+        ac = PyNUT.AuthConf.getAuthConf(user=login, host=host, port=port)
+        # Look for direct hits
+        ac_user_match = PyNUT.AuthConf.findAuthConf(user=login, host=host, port=port)
+        if not ((ac_no_user and ac_no_user.user == login) or
+                (ac_user_match and ac_user_match.section == ac.section)):
+            ac = None
+
+        # Ensure that if the entered username doesn't match anything, we clear suggested password
+        # (even if login itself was manually edited)
+        if not self.__password_manually_edited and not self.__auth_suggestions_suppressed:
+            if not ac or not ac.password:
+                if self.__password_suggested:
+                    self.__widgets["ups_authentication_password"].blockSignals(True)
                     self.__widgets["ups_authentication_password"].setText("")
+                    self.__widgets["ups_authentication_password"].blockSignals(False)
                     self.__set_suggested_style( self.__widgets["ups_authentication_password"], False )
                     self.__password_manually_edited = False
                     self.__password_suggested = False
-                elif ac.password != self.__widgets["ups_authentication_password"].text():
-                    # Re-populate if it matches a different entry for this host/port
-                    self.__widgets["ups_authentication_password"].setText(ac.password)
-                    self.__set_suggested_style( self.__widgets["ups_authentication_password"], True )
-                    self.__password_manually_edited = False
-                    self.__password_suggested = True
-            elif ac and ac.password:
-                # Re-populate if it matches a different entry for this host/port
+            elif self.__password_suggested and ac.password != self.__widgets["ups_authentication_password"].text():
+                # If it was suggested but now matches a different password (e.g. for a different user)
+                self.__widgets["ups_authentication_password"].blockSignals(True)
                 self.__widgets["ups_authentication_password"].setText(ac.password)
+                self.__widgets["ups_authentication_password"].blockSignals(False)
+                self.__set_suggested_style( self.__widgets["ups_authentication_password"], True )
+                self.__password_manually_edited = False
+                self.__password_suggested = True
+            elif not self.__password_suggested and ac and ac.password:
+                # If not suggested yet but we found a match
+                self.__widgets["ups_authentication_password"].blockSignals(True)
+                self.__widgets["ups_authentication_password"].setText(ac.password)
+                self.__widgets["ups_authentication_password"].blockSignals(False)
                 self.__set_suggested_style( self.__widgets["ups_authentication_password"], True )
                 self.__password_manually_edited = False
                 self.__password_suggested = True
 
-            # Only programmatically change checkbox if we HAVE a suggestion
-            if self.__login_suggested or self.__password_suggested:
+
+        # Automatically select authentication only for a complete credential suggestion.
+        if (self.__login_suggested and self.__password_suggested and
+                not self.__widgets["ups_authentication_check"].isChecked()):
+            self.__widgets["ups_authentication_check"].blockSignals(True)
+            self.__widgets["ups_authentication_check"].setChecked(True)
+            self.__widgets["ups_authentication_check"].blockSignals(False)
+            self.__auth_check_suggested = True
+
+        # Only retract an automatic selection. Editing either credential transfers
+        # control to the user and keeps authentication selected.
+        if self.__auth_check_suggested and not (self.__login_suggested and self.__password_suggested):
+            if self.__login_manually_edited or self.__password_manually_edited:
+                self.__auth_check_suggested = False
+            else:
                 self.__widgets["ups_authentication_check"].blockSignals(True)
-                self.__widgets["ups_authentication_check"].setChecked(True)
+                self.__widgets["ups_authentication_check"].setChecked(False)
                 self.__widgets["ups_authentication_check"].blockSignals(False)
+                self.__auth_check_suggested = False
 
-            # If we had suggestions but they are now gone,
-            # and user didn't manually edit anything, we
-            # should also uncheck the "Use authentication" box
-            if not self.__login_suggested and not self.__password_suggested:
-                if self.__widgets["ups_authentication_check"].isChecked():
-                    self.__widgets["ups_authentication_check"].blockSignals(True)
-                    self.__widgets["ups_authentication_check"].setChecked(False)
-                    self.__widgets["ups_authentication_check"].blockSignals(False)
-
-        # Only highlight the checkbox as suggested if it was all suggested
-        self.__set_suggested_style( self.__widgets["ups_authentication_check"], self.__login_suggested and self.__password_suggested )
+        self.__set_suggested_style( self.__widgets["ups_authentication_check"], self.__auth_check_suggested )
 
         # If UPS list contains something, clear it
         if self.__widgets["ups_list_combo"].currentIndex() != -1 :
@@ -560,8 +596,9 @@ class interface :
                         self.__password_manually_edited = False
                         self.__password_suggested = True
 
-                    self.__widgets["ups_authentication_check"].setChecked(self.__login_suggested or self.__password_suggested)
-                    self.__set_suggested_style( self.__widgets["ups_authentication_check"], self.__widgets["ups_authentication_check"].isChecked() )
+                    self.__widgets["ups_authentication_check"].setChecked(self.__login_suggested and self.__password_suggested)
+                    self.__auth_check_suggested = self.__login_suggested and self.__password_suggested
+                    self.__set_suggested_style( self.__widgets["ups_authentication_check"], self.__auth_check_suggested )
 
         if self.__widgets["ups_authentication_check"].isChecked() :
             login    = self.__widgets["ups_authentication_login"].text()

--- a/scripts/python/app/NUT-Monitor-py3qt6.in
+++ b/scripts/python/app/NUT-Monitor-py3qt6.in
@@ -1456,5 +1456,18 @@ if __name__ == "__main__" :
          module.bindtextdomain( APP, DIR )
          module.textdomain( APP )
 
+    nut_debug_level = os.getenv("NUT_DEBUG_LEVEL", 0)
+    try:
+        nut_debug_level = int(nut_debug_level)
+    except ValueError:
+        nut_debug_level = 0
+    except TypeError:
+        nut_debug_level = 0
+
+    if nut_debug_level > 0:
+        PyNUT.debug = True
+        if nut_debug_level > 5:
+            PyNUT.AuthConf.setDebug(True)
+
     gui = interface(sys.argv)
     gui.exec()

--- a/scripts/python/app/NUT-Monitor-py3qt6.in
+++ b/scripts/python/app/NUT-Monitor-py3qt6.in
@@ -145,6 +145,8 @@ class interface :
     __password_manually_edited       = False
     __login_suggested                = False
     __password_suggested             = False
+    __auth_check_suggested           = False
+    __auth_suggestions_suppressed    = False
 
     def __init__( self, argv ) :
 
@@ -293,8 +295,9 @@ class interface :
                 self.__password_manually_edited = False
                 self.__password_suggested = True
 
-            self.__widgets["ups_authentication_check"].setChecked(self.__login_suggested or self.__password_suggested)
-            self.__set_suggested_style( self.__widgets["ups_authentication_check"], self.__widgets["ups_authentication_check"].isChecked() )
+            self.__auth_check_suggested = self.__login_suggested and self.__password_suggested
+            self.__widgets["ups_authentication_check"].setChecked(self.__auth_check_suggested)
+            self.__set_suggested_style( self.__widgets["ups_authentication_check"], self.__auth_check_suggested )
 
         if ( cmd_opts.hidden != True ) :
             self.__widgets["main_window"].show()
@@ -390,15 +393,23 @@ class interface :
         self.__check_gui_fields()
 
     def __on_auth_check_changed( self, checked ) :
+        self.__auth_check_suggested = False
+        self.__auth_suggestions_suppressed = not checked
         if not checked :
             # If user unchecks, we clear suggestions so it doesn't immediately re-check
             if self.__login_suggested :
                 self.__login_suggested = False
+                self.__widgets["ups_authentication_login"].blockSignals(True)
                 self.__widgets["ups_authentication_login"].setText("")
+                self.__widgets["ups_authentication_login"].blockSignals(False)
+                self.__login_manually_edited = False
                 self.__set_suggested_style( self.__widgets["ups_authentication_login"], False )
             if self.__password_suggested :
                 self.__password_suggested = False
+                self.__widgets["ups_authentication_password"].blockSignals(True)
                 self.__widgets["ups_authentication_password"].setText("")
+                self.__widgets["ups_authentication_password"].blockSignals(False)
+                self.__password_manually_edited = False
                 self.__set_suggested_style( self.__widgets["ups_authentication_password"], False )
         self.__check_gui_fields()
 
@@ -410,67 +421,95 @@ class interface :
         except:
             port = 3493
 
-        # If not manually edited and was suggested, check if it still matches authconf for current host/port
-        if not self.__login_manually_edited and not self.__password_manually_edited:
-            ac = PyNUT.AuthConf.getAuthConf(host=host, port=port)
-            if self.__login_suggested:
-                if not ac or not ac.user:
-                    self.__widgets["ups_authentication_login"].setText("")
-                    self.__set_suggested_style( self.__widgets["ups_authentication_login"], False )
+        login = self.__widgets["ups_authentication_login"].text()
+        ac_no_user = PyNUT.AuthConf.getAuthConf(host=host, port=port)
+        ''' Merged result of authconf lookup without requesting a particular username.
+         This can still contain some user/pass data, if there
+         is some default for that host, or a global default '''
 
-                    # (Re-)Set these AFTER on*changed handlers might
-                    # by default assume the field was edited by user!
+        # If not manually edited and was suggested, check if it still matches authconf for current host/port/user
+        if not self.__login_manually_edited and not self.__auth_suggestions_suppressed:
+            if self.__login_suggested:
+                if not ac_no_user or not ac_no_user.user:
+                    self.__widgets["ups_authentication_login"].blockSignals(True)
+                    self.__widgets["ups_authentication_login"].setText("")
+                    self.__widgets["ups_authentication_login"].blockSignals(False)
+                    self.__set_suggested_style( self.__widgets["ups_authentication_login"], False )
                     self.__login_manually_edited = False
                     self.__login_suggested = False
-                elif ac.user != self.__widgets["ups_authentication_login"].text():
-                    # Re-populate if it matches a different entry for this host/port
-                    self.__widgets["ups_authentication_login"].setText(ac.user)
+                elif ac_no_user.user != self.__widgets["ups_authentication_login"].text():
+                    self.__widgets["ups_authentication_login"].blockSignals(True)
+                    self.__widgets["ups_authentication_login"].setText(ac_no_user.user)
+                    self.__widgets["ups_authentication_login"].blockSignals(False)
                     self.__set_suggested_style( self.__widgets["ups_authentication_login"], True )
                     self.__login_manually_edited = False
                     self.__login_suggested = True
-            elif ac and ac.user:
-                # Re-populate if it matches a different entry for this host/port
-                self.__widgets["ups_authentication_login"].setText(ac.user)
+            elif ac_no_user and ac_no_user.user:
+                self.__widgets["ups_authentication_login"].blockSignals(True)
+                self.__widgets["ups_authentication_login"].setText(ac_no_user.user)
+                self.__widgets["ups_authentication_login"].blockSignals(False)
                 self.__set_suggested_style( self.__widgets["ups_authentication_login"], True )
                 self.__login_manually_edited = False
                 self.__login_suggested = True
 
-            if self.__password_suggested:
-                if not ac or not ac.password:
+        # Now re-evaluate password suggestion based on potentially updated login
+        login = self.__widgets["ups_authentication_login"].text()
+        ac = PyNUT.AuthConf.getAuthConf(user=login, host=host, port=port)
+        # Look for direct hits
+        ac_user_match = PyNUT.AuthConf.findAuthConf(user=login, host=host, port=port)
+        if not ((ac_no_user and ac_no_user.user == login) or
+                (ac_user_match and ac_user_match.section == ac.section)):
+            ac = None
+
+        # Ensure that if the entered username doesn't match anything, we clear suggested password
+        # (even if login itself was manually edited)
+        if not self.__password_manually_edited and not self.__auth_suggestions_suppressed:
+            if not ac or not ac.password:
+                if self.__password_suggested:
+                    self.__widgets["ups_authentication_password"].blockSignals(True)
                     self.__widgets["ups_authentication_password"].setText("")
+                    self.__widgets["ups_authentication_password"].blockSignals(False)
                     self.__set_suggested_style( self.__widgets["ups_authentication_password"], False )
                     self.__password_manually_edited = False
                     self.__password_suggested = False
-                elif ac.password != self.__widgets["ups_authentication_password"].text():
-                    # Re-populate if it matches a different entry for this host/port
-                    self.__widgets["ups_authentication_password"].setText(ac.password)
-                    self.__set_suggested_style( self.__widgets["ups_authentication_password"], True )
-                    self.__password_manually_edited = False
-                    self.__password_suggested = True
-            elif ac and ac.password:
-                # Re-populate if it matches a different entry for this host/port
+            elif self.__password_suggested and ac.password != self.__widgets["ups_authentication_password"].text():
+                # If it was suggested but now matches a different password (e.g. for a different user)
+                self.__widgets["ups_authentication_password"].blockSignals(True)
                 self.__widgets["ups_authentication_password"].setText(ac.password)
+                self.__widgets["ups_authentication_password"].blockSignals(False)
+                self.__set_suggested_style( self.__widgets["ups_authentication_password"], True )
+                self.__password_manually_edited = False
+                self.__password_suggested = True
+            elif not self.__password_suggested and ac and ac.password:
+                # If not suggested yet but we found a match
+                self.__widgets["ups_authentication_password"].blockSignals(True)
+                self.__widgets["ups_authentication_password"].setText(ac.password)
+                self.__widgets["ups_authentication_password"].blockSignals(False)
                 self.__set_suggested_style( self.__widgets["ups_authentication_password"], True )
                 self.__password_manually_edited = False
                 self.__password_suggested = True
 
-            # Only programmatically change checkbox if we HAVE a suggestion
-            if self.__login_suggested or self.__password_suggested:
+
+        # Automatically select authentication only for a complete credential suggestion.
+        if (self.__login_suggested and self.__password_suggested and
+                not self.__widgets["ups_authentication_check"].isChecked()):
+            self.__widgets["ups_authentication_check"].blockSignals(True)
+            self.__widgets["ups_authentication_check"].setChecked(True)
+            self.__widgets["ups_authentication_check"].blockSignals(False)
+            self.__auth_check_suggested = True
+
+        # Only retract an automatic selection. Editing either credential transfers
+        # control to the user and keeps authentication selected.
+        if self.__auth_check_suggested and not (self.__login_suggested and self.__password_suggested):
+            if self.__login_manually_edited or self.__password_manually_edited:
+                self.__auth_check_suggested = False
+            else:
                 self.__widgets["ups_authentication_check"].blockSignals(True)
-                self.__widgets["ups_authentication_check"].setChecked(True)
+                self.__widgets["ups_authentication_check"].setChecked(False)
                 self.__widgets["ups_authentication_check"].blockSignals(False)
+                self.__auth_check_suggested = False
 
-            # If we had suggestions but they are now gone,
-            # and user didn't manually edit anything, we
-            # should also uncheck the "Use authentication" box
-            if not self.__login_suggested and not self.__password_suggested:
-                if self.__widgets["ups_authentication_check"].isChecked():
-                    self.__widgets["ups_authentication_check"].blockSignals(True)
-                    self.__widgets["ups_authentication_check"].setChecked(False)
-                    self.__widgets["ups_authentication_check"].blockSignals(False)
-
-        # Only highlight the checkbox as suggested if it was all suggested
-        self.__set_suggested_style( self.__widgets["ups_authentication_check"], self.__login_suggested and self.__password_suggested )
+        self.__set_suggested_style( self.__widgets["ups_authentication_check"], self.__auth_check_suggested )
 
         # If UPS list contains something, clear it
         if self.__widgets["ups_list_combo"].currentIndex() != -1 :
@@ -565,8 +604,9 @@ class interface :
                         self.__password_manually_edited = False
                         self.__password_suggested = True
 
-                    self.__widgets["ups_authentication_check"].setChecked(self.__login_suggested or self.__password_suggested)
-                    self.__set_suggested_style( self.__widgets["ups_authentication_check"], self.__widgets["ups_authentication_check"].isChecked() )
+                    self.__widgets["ups_authentication_check"].setChecked(self.__login_suggested and self.__password_suggested)
+                    self.__auth_check_suggested = self.__login_suggested and self.__password_suggested
+                    self.__set_suggested_style( self.__widgets["ups_authentication_check"], self.__auth_check_suggested )
 
         if self.__widgets["ups_authentication_check"].isChecked() :
             login    = self.__widgets["ups_authentication_login"].text()

--- a/scripts/python/module/PyNUT.py.in
+++ b/scripts/python/module/PyNUT.py.in
@@ -140,10 +140,14 @@ class AuthConf:
         AuthConf.__global_defaults = None
 
     def __init__(self, section=""):
-        self.section = section
+        self.section = AuthConf.normalizeSection(section) if section else section
         ''' `@host:port` or `user@host:port`, or None for global; note that host may be an IPv6 address enclosed in brackets '''
 
         self.user = None
+        if self.section and '@' in self.section:
+            section_user = self.section.split('@', 1)[0]
+            if section_user:
+                self.user = section_user
         self.password = None
 
         self.certpath = None
@@ -169,6 +173,49 @@ class AuthConf:
 
         self.forcessl = -1
         ''' -1 = unset, 0 = off, 1 = on '''
+
+    @staticmethod
+    def normalizeSection(section):
+        """Return the canonical user@host:port spelling of an authconf section."""
+        if section.startswith('[') and section.endswith(']'):
+            inner = section[1:-1]
+            if '@' in inner or ':' not in inner or inner.startswith('['):
+                section = inner
+        user = None
+        addr = section
+        if '@' in section:
+            user, addr = section.split('@', 1)
+
+        host = addr
+        port = None
+        if addr.startswith('['):
+            close_bracket = addr.find(']')
+            if close_bracket < 0:
+                raise PyNUTError("Invalid authconf section: '%s'" % section)
+            host = addr[1:close_bracket]
+            suffix = addr[close_bracket + 1:]
+            if suffix:
+                if not suffix.startswith(':'):
+                    raise PyNUTError("Invalid authconf section: '%s'" % section)
+                port = suffix[1:]
+        elif ':' in addr:
+            host, port = addr.split(':', 1)
+
+        if not host:
+            host = 'localhost'
+        if not port:
+            port = '3493'
+        elif not port.isdigit():
+            try:
+                port = str(socket.getservbyname(port, 'tcp'))
+            except socket.error:
+                pass
+
+        host_part = host
+        if ':' in host and not (host.startswith('[') and host.endswith(']')):
+            host_part = '[%s]' % host
+
+        return "%s@%s:%s" % (user if user else '', host_part, port)
 
     def __str__(self):
         sb = []
@@ -260,6 +307,7 @@ class AuthConf:
                                 AuthConf.__authconf_list.append(AuthConf.__global_defaults)
                             current_ac = AuthConf.__global_defaults
                         else:
+                            sectname = AuthConf.normalizeSection(sectname)
                             # Check if section already exists
                             current_ac = None
                             for ac in AuthConf.__authconf_list:
@@ -405,13 +453,13 @@ class AuthConf:
         if (':' in host_part or '[' in host_part or ']' in host_part) and not host_part.startswith('['):
             host_part = "[%s]" % host_part
 
-        target_user_host_port = ""
-        if user: target_user_host_port += "%s@" % user
-        target_user_host_port += host_part
+        target_user_host_port = "%s@%s" % (user if user else '', host_part)
         if norm_port: target_user_host_port += ":%s" % str(norm_port)
+        target_user_host_port = AuthConf.normalizeSection(target_user_host_port)
 
         target_host_port = "@%s" % host_part
         if norm_port: target_host_port += ":%s" % str(norm_port)
+        target_host_port = AuthConf.normalizeSection(target_host_port)
 
         res = AuthConf(target_user_host_port)
 
@@ -487,10 +535,9 @@ class AuthConf:
                 print ("[DEBUG] findAuthConf(): Processing section: [%s]" % (section))
 
             # 1. Exact match user@host:port
-            target = ""
-            if user: target += "%s@" % user
-            target += host_part
+            target = "%s@%s" % (user if user else '', host_part)
             if norm_port: target += ":%s" % str(norm_port)
+            target = AuthConf.normalizeSection(target)
 
             if section == target:
                 if AuthConf.__debug:

--- a/scripts/python/module/PyNUT.py.in
+++ b/scripts/python/module/PyNUT.py.in
@@ -473,10 +473,18 @@ class AuthConf:
         if (':' in host_part or '[' in host_part or ']' in host_part) and not host_part.startswith('['):
             host_part = "[%s]" % host_part
 
+        if AuthConf.__debug:
+            print ("[DEBUG] findAuthConf(): looking for user [%s], host [%s]=>[%s], port [%s]" % (
+                str(user), str(host), str(host_part), str(port)
+            ))
+
         # Try to match [user@host:port], then [host:port], then [host], then [*]
         # This is a simplified version of the C logic
         for ac in auth_configs:
             section = ac.section
+
+            if AuthConf.__debug:
+                print ("[DEBUG] findAuthConf(): Processing section: [%s]" % (section))
 
             # 1. Exact match user@host:port
             target = ""
@@ -485,16 +493,25 @@ class AuthConf:
             if norm_port: target += ":%s" % str(norm_port)
 
             if section == target:
+                if AuthConf.__debug:
+                    print ("[DEBUG] findAuthConf(): hit exact match user@host:port by section name [%s]" % (target))
                 return ac
 
             # 2. Match host:port
-            if not user and section == ("%s:%s" % (host_part, str(norm_port))):
+            target = ("%s:%s" % (host_part, str(norm_port)))
+            if not user and section == target:
+                if AuthConf.__debug:
+                    print ("[DEBUG] findAuthConf(): hit host:port by section name [%s]" % (target))
                 return ac
 
             # 3. Match host
             if not user and not norm_port and section == host_part:
+                if AuthConf.__debug:
+                    print ("[DEBUG] findAuthConf(): hit host by section name [%s]" % (host_part))
                 return ac
 
+        if AuthConf.__debug:
+            print ("[DEBUG] findAuthConf(): return global_defaults")
         return AuthConf.__global_defaults
 
 class PyNUTError( Exception ) :

--- a/scripts/python/module/PyNUT.py.in
+++ b/scripts/python/module/PyNUT.py.in
@@ -508,7 +508,7 @@ class PyNUTClient :
     def from_authconf(cls, authconf, **kwargs):
         """ Create a PyNUTClient from an AuthConf object """
         # Extract host and port from authconf.section if possible
-        host = "127.0.0.1"
+        host = "localhost"
         port = 3493
 
         # Simple split, could be more robust
@@ -536,6 +536,8 @@ class PyNUTClient :
                     host = addr_part # Should not happen in well-formed authconf
             elif ':' in addr_part:
                 host, port_str = addr_part.split(':', 1)
+                if not host:
+                    host = "localhost"
                 try:
                     port = int(port_str)
                 except ValueError:

--- a/tests/test_authconf.c
+++ b/tests/test_authconf.c
@@ -62,6 +62,12 @@ int main(int argc, char **argv)
 	fprintf(f, "[admin@localhost:12345]\n");
 	fprintf(f, "  PASS = adminpass\n");
 	fprintf(f, "  FORCESSL = 1\n");
+
+	expected_sections++;
+	/* localhost should get defaulted here: */
+	fprintf(f, "[bigadmin@:12345]\n");
+	fprintf(f, "  PASS = adminpass\n");
+	fprintf(f, "  FORCESSL = 1\n");
 	fclose(f);
 
 	f = fopen(include_conf, "w");
@@ -549,7 +555,39 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	/* 31. Expected printout 3 */
+	/* 31. Empty hostname [bigadmin@:12345] should be saved by parser with "localhost" */
+	printf("Checking empty hostname in address section becomes localhost\n");
+	ac = upscli_find_authconf_item("bigadmin", "localhost", "12345");
+	if (ac) {
+		if (ac->section && !strcmp(ac->section, "bigadmin@localhost:12345")) {
+			printf("ok %d - got expected user, address and port as the section name\n", ++testnum);
+		} else {
+			printf("not ok %d - did not get expected user, address and port as the section name\n", ++testnum);
+			upscli_dump_authconf_item(NULL, ac, 1, 1);
+			return 1;
+		}
+	} else {
+		printf("not ok %d - did not get any section by expected user, address and port\n", ++testnum);
+		return 1;
+	}
+
+	/* 32. Empty hostname [bigadmin@:12345] */
+	printf("Checking empty hostname in address section becomes localhost\n");
+	ac = upscli_find_authconf_item("bigadmin", "", "12345");
+	if (ac) {
+		if (ac->section && !strcmp(ac->section, "bigadmin@localhost:12345")) {
+			printf("ok %d - got expected user, address (normalized from empty) and port as the section name\n", ++testnum);
+		} else {
+			printf("not ok %d - did not get expected user, address (normalized from empty) and port as the section name\n", ++testnum);
+			upscli_dump_authconf_item(NULL, ac, 1, 1);
+			return 1;
+		}
+	} else {
+		printf("not ok %d - did not get any section by expected user, address (normalized from empty) and port\n", ++testnum);
+		return 1;
+	}
+
+	/* 33. Expected printout 3 */
 	printf("=== Parsed configuration (production view) after several 'get' operations with results caching:\n");
 	/* Not "for_debug", but how would this info look in a config file */
 	num_sections = upscli_dump_authconf_list(NULL, 0, 1);


### PR DESCRIPTION
Apply common logic to authconf parsers (empty host part means localhost, resolve NUT port from possible string via OS service naming) so data in memory is stored under normalized section names - follows up from #3329 etc.

Fix NUT-Monitor suggestion of passwords if the user name is being edited - follows up from #3533, tested with all 3 implementation variants.