### PR TITLE
riello_usb, riello_ser: report NAK on RE as failure

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -125,6 +125,9 @@ https://github.com/networkupstools/nut/milestone/13
     * Completed support for NUT standard USB configuration options, and fixed
       some problems possible when iterating devices. [issue #1768, PR #3477]
 
+ - `riello_usb`, `riello_ser` driver updates:
+	* riello_usb, riello_ser: report NAK on RE as failure [issue #3546]
+
  - `usbhid-ups` driver updates:
     * When reconnecting, report success more visibly (not only in debug), and
       do not reset driver state to "quiet" when it will loop trying. [PR #3423]

--- a/drivers/riello_ser.c
+++ b/drivers/riello_ser.c
@@ -49,7 +49,7 @@
 #include "riello.h"
 
 #define DRIVER_NAME	"Riello serial driver"
-#define DRIVER_VERSION	"0.17"
+#define DRIVER_VERSION	"0.18"
 
 #define DEFAULT_OFFDELAY   5  /*!< seconds (max 0xFF) */
 #define DEFAULT_BOOTDELAY  5  /*!< seconds (max 0xFF) */
@@ -372,7 +372,7 @@ static int get_ups_extended(void)
 	/* optonal */
 	if (!wait_packet && foundnak) {
 		upsdebugx (3, "Get extended Ko: command not supported");
-		return 0;
+		return -1;
 	}
 
 	upsdebugx (3, "Get extended Ok: received byte %u", buf_ptr_length);

--- a/drivers/riello_usb.c
+++ b/drivers/riello_usb.c
@@ -36,7 +36,7 @@
 #include "riello.h"
 
 #define DRIVER_NAME	"Riello USB driver"
-#define DRIVER_VERSION	"0.18"
+#define DRIVER_VERSION	"0.19"
 
 #define DEFAULT_OFFDELAY   5  /*!< seconds (max 0xFF) */
 #define DEFAULT_BOOTDELAY  5  /*!< seconds (max 0xFF) */
@@ -600,7 +600,7 @@ static int get_ups_extended(void)
 	/* optional */
 	if (!wait_packet && foundnak) {
 		upsdebugx (3, "Get extended Ko: command not supported");
-		return 0;
+		return -1;
 	}
 
 	upsdebugx (3, "Get extended Ok: read byte: %d", recv);


### PR DESCRIPTION
Fixes #3546

## What

`get_ups_extended()` returns `0` both on success and when the UPS answers the
extended-data command (`RE`) with a NAK. `upsdrv_updateinfo()` therefore sets
`getextendedOK = 1` and publishes `output.L1.power`, `output.L1.realpower` and
`output.L1.current` (plus L2/L3 on three-phase) from `DevData` fields that were
never written. On a device that does not implement `RE`, these are reported as a
constant `0` for the lifetime of the driver -- indistinguishable from a genuine
zero-load reading.

The `/* optional */` comment marks the intent correctly: a NAK on `RE` must not
be treated as a comms failure. This PR keeps that, but makes the return value
also tell the caller that no data arrived, so the variables are simply not
published.

## How

Return `-1` instead of `0` on the NAK path in both drivers. `get_ups_extended()`
has exactly one caller in each driver and that caller only compares against `0`. 
Driver versions bumped.

## Hardware

Developed and tested against:

- RPS S.p.a. USV5, 800 VA / 480 W, firmware `SWM036-01-02`
- NUT 2.8.1 on Debian 13, driver `riello_usb`

Before the fix, every cycle logs `Get extended Ko: command not supported` (raw
`RE` reply is a 12-byte frame with command byte `0x15`, NAK) while `upsc` still
reports:

```
output.L1.current: 0
output.L1.power: 0
output.L1.realpower: 0
```

After the fix those three variables are absent, and every other variable is
unchanged (`input.voltage`, `input.frequency`, `output.voltage`,
`output.frequency`, `battery.voltage`, `ups.load`). 

`riello_ser.c` carries the identical pattern and the same single-caller
structure, so it is changed for symmetry. I have no serial Riello unit, so that
half is reviewed but **not** tested on hardware.

## AI disclosure

Claude Code was used to help analyse the driver flow and draft the
issue report. The frame decoding and the CRC check were verified by hand 
against the raw USB captures, the fix was reviewed and tested
on real hardware by me, and I take responsibility for the content of this
change.



