### PR TITLE
drivers/libusb{0,1}.c: bound rdlens loop by element count, not sizeof

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -171,6 +171,8 @@ https://github.com/networkupstools/nut/milestone/13
       chunks populated only partially with bytes we intended. These buffers are
       now more diligently pre-zeroed as their siblings were in other code paths,
       to avoid sending host stack garbage to a device. [#3529]
+    * USB drivers: fixed an out-of-bounds read of the candidate HID report
+      descriptor lengths, which could cause a segmentation fault. [PR #3550]
 
  - NUT client libraries:
     * Complete support for actions documented in `docs/net-protocol.txt`

--- a/drivers/libusb0.c
+++ b/drivers/libusb0.c
@@ -651,7 +651,7 @@ static int nut_libusb_open(usb_dev_handle **udevp,
 				}
 			}
 
-			for (j = 0; j < sizeof(rdlens); j++) {
+			for (j = 0; j < SIZEOF_ARRAY(rdlens); j++) {
 				rdlen = rdlens[j];
 				if (rdlen < 0)
 					continue;
@@ -716,7 +716,7 @@ static int nut_libusb_open(usb_dev_handle **udevp,
 				break;
 			}
 
-			if (j >= sizeof(rdlens)) {
+			if (j >= SIZEOF_ARRAY(rdlens)) {
 				/* Ended the loop without success */
 				goto next_device;
 			}

--- a/drivers/libusb1.c
+++ b/drivers/libusb1.c
@@ -807,7 +807,7 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 			}
 		}
 
-		for (j = 0; j < sizeof(rdlens); j++) {
+		for (j = 0; j < SIZEOF_ARRAY(rdlens); j++) {
 			rdlen = rdlens[j];
 			if (rdlen < 0)
 				continue;
@@ -897,7 +897,7 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 			break;
 		}
 
-		if (j >= sizeof(rdlens)) {
+		if (j >= SIZEOF_ARRAY(rdlens)) {
 			/* Ended the loop without success */
 			goto next_device;
 		}


### PR DESCRIPTION
`nut_libusb_open()` iterates the two candidate HID report descriptor lengths:

```c
	int32_t rdlen1, rdlen2, rdlens[2];
	size_t j;
	...
	for (j = 0; j < sizeof(rdlens); j++) {
		rdlen = rdlens[j];
```

`sizeof(rdlens)` is the size in **bytes** (8), not the element count (2), so the loop reads `rdlens[2..7]` — 24 bytes past the end of the array — and uses that stack garbage as `rdlen`. The "ran out of candidates" test after the loop (`if (j >= sizeof(rdlens))`) has the same bug, so it never fires as intended either.

The out-of-range indices are only reached when neither real candidate satisfies the caller — i.e. exactly when a device is in a bad state and both descriptor reads fail, which is when you least want undefined behaviour. Garbage that happens to survive the `rdlen` sanity checks is then passed to `libusb_control_transfer()` and on to the HID parser callback, which is where it segfaults.

### How it showed up

`usbhid-ups` segfaulting against an EcoFlow DELTA 3 Plus (`3746:ffff`) on an NVIDIA Jetson Orin Nano (aarch64, NUT built from `v2.8.5`) after the device's USB connection had wedged. `usbreset` on the device cleared the wedge, and the crash went away with it — the descriptor reads then succeeded on the first candidate and the loop never ran past index 0.

### Fix

Use `SIZEOF_ARRAY()` from `include/common.h`, which both files already include. `drivers/libusb0.c` carries the identical defect in the same two places and is fixed the same way.

Regression from aba6f43544b17d2f16e69ca19f162c6c19748fc7 ("if the tried `rdlen` did not succeed, fall back to the other value we had in mind" [#3136]), first released in v2.8.5.

Happy to add a `NEWS.adoc` entry under the 2.8.6 section if you'd like one — I left it out to keep the diff to the fix, since the entry would want this PR's number.
