### PR TITLE
`nut-scanner`: fix mutex release in failure code path

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -41,6 +41,11 @@ https://github.com/networkupstools/nut/milestone/13
  - (expected) CI automation for use of data points in drivers that conform
    to patterns defined in link:docs/nut-names.txt[]
 
+ - Fix fallout of development in NUT v2.8.0 through v2.8.5:
+    * `nut-scanner` tool updates:
+      - Mutexes used in parallelized scans were not properly released on
+        failure code paths (impacts likely all 2.8.x until now). [PR #3551]
+
  - Second-level bullet points listed in this file will now use 4 spaces
    (not 3 like before) for easier initial indentation of new entries.
 

--- a/docs/config-prereqs.txt
+++ b/docs/config-prereqs.txt
@@ -908,7 +908,10 @@ below.
     valgrind \
     cppcheck \
     pkgconf \
-    gcc clang
+    gcc
+
+# Name for LLVM CLANG compiler may vary on old and new systems:
+:; pkg install -y clang || pkg install -y llvm
 
 # To debug eventual core dump files, or trace programs with an IDE like
 # NetBeans (perhaps remotely), you may want the GNU Debugger program:
@@ -947,7 +950,6 @@ below.
     cppunit \
     nss \
     augeas \
-    libusb \
     glib \
     libmodbus \
     neon \
@@ -955,6 +957,10 @@ below.
     powerman \
     freeipmi \
     avahi
+
+# libusb may be not available, or not under that name.
+# Maybe not at all, being part of core system:
+:; pkg install libusb || true
 
 # NOTE: At least on FreeBSD 12, system-provided crypto exists and is used
 # by libnetsnmp, libneon, etc. - but is not marked as a package. Conversely,

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3792 utf-8
+personal_ws-1.1 en 3793 utf-8
 AAC
 AAS
 ABI
@@ -802,6 +802,7 @@ Mozilla
 Msg
 MultiLink
 Multiplug
+Mutexes
 MyCompany
 MyPasSw
 MyState

--- a/tools/nut-scanner/scan_eaton_serial.c
+++ b/tools/nut-scanner/scan_eaton_serial.c
@@ -562,6 +562,9 @@ nutscan_device_t * nutscan_scan_eaton_serial(const char* ports_range)
 					thread_count * sizeof(nutscan_thread_t));
 				if (new_thread_array == NULL) {
 					upsdebugx(1, "%s: Failed to realloc thread array", __func__);
+# ifdef HAVE_PTHREAD_TRYJOIN
+					pthread_mutex_unlock(&threadcount_mutex);
+# endif /* HAVE_PTHREAD_TRYJOIN */
 					break;
 				}
 				else {

--- a/tools/nut-scanner/scan_ipmi.c
+++ b/tools/nut-scanner/scan_ipmi.c
@@ -995,6 +995,9 @@ nutscan_device_t * nutscan_scan_ip_range_ipmi(nutscan_ip_range_list_t * irl, nut
 						thread_count * sizeof(nutscan_thread_t));
 					if (new_thread_array == NULL) {
 						upsdebugx(1, "%s: Failed to realloc thread array", __func__);
+# ifdef HAVE_PTHREAD_TRYJOIN
+						pthread_mutex_unlock(&threadcount_mutex);
+# endif /* HAVE_PTHREAD_TRYJOIN */
 						break;
 					}
 					else {

--- a/tools/nut-scanner/scan_nut.c
+++ b/tools/nut-scanner/scan_nut.c
@@ -969,6 +969,9 @@ nutscan_device_t * nutscan_scan_ip_range_nut_authconf(nutscan_ip_range_list_t * 
 					thread_count * sizeof(nutscan_thread_t));
 				if (new_thread_array == NULL) {
 					upsdebugx(1, "%s: Failed to realloc thread array", __func__);
+# ifdef HAVE_PTHREAD_TRYJOIN
+					pthread_mutex_unlock(&threadcount_mutex);
+# endif /* HAVE_PTHREAD_TRYJOIN */
 					break;
 				}
 				else {

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -1366,6 +1366,9 @@ nutscan_device_t * nutscan_scan_ip_range_snmp(
 					thread_count * sizeof(nutscan_thread_t));
 				if (new_thread_array == NULL) {
 					upsdebugx(1, "%s: Failed to realloc thread array", __func__);
+# ifdef HAVE_PTHREAD_TRYJOIN
+					pthread_mutex_unlock(&threadcount_mutex);
+# endif /* HAVE_PTHREAD_TRYJOIN */
 					break;
 				}
 				else {

--- a/tools/nut-scanner/scan_xml_http.c
+++ b/tools/nut-scanner/scan_xml_http.c
@@ -738,6 +738,9 @@ nutscan_device_t * nutscan_scan_ip_range_xml_http(nutscan_ip_range_list_t * irl,
 						thread_count * sizeof(nutscan_thread_t));
 					if (new_thread_array == NULL) {
 						upsdebugx(1, "%s: Failed to realloc thread array", __func__);
+# ifdef HAVE_PTHREAD_TRYJOIN
+						pthread_mutex_unlock(&threadcount_mutex);
+# endif /* HAVE_PTHREAD_TRYJOIN */
 						break;
 					}
 					else {


### PR DESCRIPTION
Caught by `clang-19` and `clang-22` static analysis on FreeBSD 15.1, confirmed and fixed by Copilot in GitHub codespaces.
Impacts probably all 2.8.x releases until latest 2.8.5.