### PR TITLE
`nutdrv_qx`: add OMRON BN150T support

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -95,13 +95,21 @@ https://github.com/networkupstools/nut/milestone/13
       allowing the Megatec payload to be successfully reconstructed. [PR #3485]
     * Added an `omron` USB subdriver and an `omron` protocol subdriver for
       the OMRON BN150T, and registered its USB ID `0590:00b7`. The transport
-      matches `ippon` except that the control transfer carries a 16-byte HID
-      Output report. The polling data mapping follows `q1` but does not publish
+      is based on `ippon`, with a 16-byte HID Output report and stricter
+      handling of short transfers and of replies with no terminating CR.
+      The base `Q1` mapping follows `q1` but does not publish
       the third character (index 2) of the eight-character `Q1` status field,
-      which this hardware reports as always set and for which OMRON's own
-      driver has no active handling either; the shutdown commands are in
-      OMRON's form. Ported from the GPL driver source published by OMRON; only
-      the BN150T was tested, and only its polling path. [issue #3112]
+      which this hardware reported as set on every observed poll (on mains,
+      idle and unloaded) and for which OMRON's own driver has no active
+      handling either, nor the last character (index 7), which `q1` would
+      publish as the beeper status but OMRON's own driver does not read at
+      all; the shutdown commands are in OMRON's form. On top of that it adds
+      the OMRON extension queries for
+      battery charge, runtime and temperature, output frequency, firmware
+      (`ups.firmware` and `ups.firmware.aux`), serial number, battery date and
+      the nominal power and battery voltage ratings. Ported from the GPL driver
+      source published by OMRON; only the BN150T was tested, and only its
+      polling path. [issue #3112]
     * In `Voltronic-QS-Hex` subdriver, the format string sanity check added in
       recent NUT releases caught a mismatch in `ups.load` reading. [issue #3532]
     * Modified `voltronic-qs` subdriver to request the QI command, supplying

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -95,24 +95,21 @@ https://github.com/networkupstools/nut/milestone/13
       allowing the Megatec payload to be successfully reconstructed. [PR #3485]
     * Added an `omron` USB subdriver and an `omron` protocol subdriver for
       the OMRON BN150T, and registered its USB ID `0590:00b7`. The transport
-      is based on `ippon`, with a 16-byte HID Output report and stricter
-      handling of short transfers and of replies with no terminating CR.
-      The base `Q1` mapping follows `q1` but does not publish
-      the third character (index 2) of the eight-character `Q1` status field,
-      which this hardware reported as set during stable mains operation
-      (normally and in ECO mode) and clear while on battery, and for which
-      neither OMRON driver version has active handling, nor the last character
-      (index 7), which `q1` would
-      publish as the beeper status but neither OMRON driver version reads at
-      all; the shutdown commands are in OMRON's form. On top of that it adds
-      the OMRON extension queries for
+      uses a 16-byte HID Output report and validates transfer and reply
+      lengths. The base `Q1` mapping follows `q1` but omits two status
+      characters. Index 2 was set during stable operation on mains, both in
+      normal mode and in ECO mode, and was clear while on battery; neither OMRON
+      driver version handles it. Index 7, which `q1` would publish as the
+      beeper status, is not read by either OMRON driver version. The shutdown
+      commands use OMRON's form. The subdriver also adds extension queries for
       battery charge, runtime and temperature, output frequency, firmware
       (`ups.firmware` and `ups.firmware.aux`), serial number, battery date and
-      the nominal power and battery voltage ratings. Ported from OMRON-authored
-      GPL driver version 1.00 distributed in the Synology DSM 7.3-86009 GPL
-      sources and version 1.02 distributed in the QNAP QTS 5.2.3 GPL sources;
-      polling and the direct shutdown commands were verified on an unloaded
-      BN150T over USB; other OMRON models and serial connections are untested.
+      nominal power and battery voltage ratings. The implementation was ported
+      from OMRON-authored GPL driver version 1.00 distributed in the Synology
+      DSM 7.3-86009 GPL sources and version 1.02 distributed in the QNAP QTS
+      5.2.3 GPL sources. Polling and the direct shutdown commands were verified
+      on an unloaded BN150T over USB; other OMRON models and serial connections
+      are untested.
       [issue #3112]
     * In `Voltronic-QS-Hex` subdriver, the format string sanity check added in
       recent NUT releases caught a mismatch in `ups.load` reading. [issue #3532]

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -100,16 +100,17 @@ https://github.com/networkupstools/nut/milestone/13
       The base `Q1` mapping follows `q1` but does not publish
       the third character (index 2) of the eight-character `Q1` status field,
       which this hardware reported as set on every observed poll (on mains,
-      idle and unloaded) and for which OMRON's own driver has no active
-      handling either, nor the last character (index 7), which `q1` would
-      publish as the beeper status but OMRON's own driver does not read at
+      idle and unloaded) and for which neither OMRON driver version has active
+      handling, nor the last character (index 7), which `q1` would
+      publish as the beeper status but neither OMRON driver version reads at
       all; the shutdown commands are in OMRON's form. On top of that it adds
       the OMRON extension queries for
       battery charge, runtime and temperature, output frequency, firmware
       (`ups.firmware` and `ups.firmware.aux`), serial number, battery date and
-      the nominal power and battery voltage ratings. Ported from the GPL driver
-      source published by OMRON; only the BN150T was tested, and only its
-      polling path. [issue #3112]
+      the nominal power and battery voltage ratings. Ported from OMRON-authored
+      GPL driver version 1.00 distributed in the Synology DSM 7.3-86009 GPL
+      sources and version 1.02 distributed in the QNAP QTS 5.2.3 GPL sources;
+      only the BN150T was tested, and only its polling path. [issue #3112]
     * In `Voltronic-QS-Hex` subdriver, the format string sanity check added in
       recent NUT releases caught a mismatch in `ups.load` reading. [issue #3532]
     * Modified `voltronic-qs` subdriver to request the QI command, supplying

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -93,6 +93,15 @@ https://github.com/networkupstools/nut/milestone/13
       an initialization failure with certain UPS models (e.g., SVC
       VP-1250-LCD) that return a 7-byte report instead of the standard 6 bytes,
       allowing the Megatec payload to be successfully reconstructed. [PR #3485]
+    * Added an `omron` USB subdriver and an `omron` protocol subdriver for
+      the OMRON BN150T, and registered its USB ID `0590:00b7`. The transport
+      matches `ippon` except that the control transfer carries a 16-byte HID
+      Output report. The polling data mapping follows `q1` but does not publish
+      the third character (index 2) of the eight-character `Q1` status field,
+      which this hardware reports as always set and for which OMRON's own
+      driver has no active handling either; the shutdown commands are in
+      OMRON's form. Ported from the GPL driver source published by OMRON; only
+      the BN150T was tested, and only its polling path. [issue #3112]
     * In `Voltronic-QS-Hex` subdriver, the format string sanity check added in
       recent NUT releases caught a mismatch in `ups.load` reading. [issue #3532]
     * Modified `voltronic-qs` subdriver to request the QI command, supplying

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -99,9 +99,10 @@ https://github.com/networkupstools/nut/milestone/13
       handling of short transfers and of replies with no terminating CR.
       The base `Q1` mapping follows `q1` but does not publish
       the third character (index 2) of the eight-character `Q1` status field,
-      which this hardware reported as set on every observed poll (on mains,
-      idle and unloaded) and for which neither OMRON driver version has active
-      handling, nor the last character (index 7), which `q1` would
+      which this hardware reported as set during stable mains operation
+      (normally and in ECO mode) and clear while on battery, and for which
+      neither OMRON driver version has active handling, nor the last character
+      (index 7), which `q1` would
       publish as the beeper status but neither OMRON driver version reads at
       all; the shutdown commands are in OMRON's form. On top of that it adds
       the OMRON extension queries for
@@ -110,7 +111,9 @@ https://github.com/networkupstools/nut/milestone/13
       the nominal power and battery voltage ratings. Ported from OMRON-authored
       GPL driver version 1.00 distributed in the Synology DSM 7.3-86009 GPL
       sources and version 1.02 distributed in the QNAP QTS 5.2.3 GPL sources;
-      only the BN150T was tested, and only its polling path. [issue #3112]
+      polling and the direct shutdown commands were verified on an unloaded
+      BN150T over USB; other OMRON models and serial connections are untested.
+      [issue #3112]
     * In `Voltronic-QS-Hex` subdriver, the format string sanity check added in
       recent NUT releases caught a mismatch in `ups.load` reading. [issue #3532]
     * Modified `voltronic-qs` subdriver to request the QI command, supplying

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -1144,6 +1144,8 @@
 "NUT"	"ups"	"5"	"all supported NUT devices, through remote upsd"	""	"dummy-ups"
 "NUT"	"ups"	"5"	"Simulated devices"	""	"dummy-ups"
 
+"OMRON"	"ups"	"4"	"BN150T"	"USB (USB ID 0590:00b7)"	"nutdrv_qx port=auto vendorid=0590 productid=00b7 protocol=omron subdriver=omron"	# https://github.com/networkupstools/nut/issues/3112 ; ported from the GPL driver source published by OMRON. Only the polling path was verified on hardware.
+
 "Oneac"	"ups"	"1"	"ON400"	"advanced interface"	"oneac"
 "Oneac"	"ups"	"1"	"ON600"	"advanced interface"	"oneac"
 "Oneac"	"ups"	"1"	"ON900"	"advanced interface"	"oneac"

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -1144,7 +1144,7 @@
 "NUT"	"ups"	"5"	"all supported NUT devices, through remote upsd"	""	"dummy-ups"
 "NUT"	"ups"	"5"	"Simulated devices"	""	"dummy-ups"
 
-"OMRON"	"ups"	"4"	"BN150T"	"USB (USB ID 0590:00b7)"	"nutdrv_qx port=auto vendorid=0590 productid=00b7 protocol=omron subdriver=omron"	# https://github.com/networkupstools/nut/issues/3112 ; ported from OMRON-authored GPL driver version 1.00 distributed in the Synology DSM 7.3-86009 GPL sources and version 1.02 distributed in the QNAP QTS 5.2.3 GPL sources. Only the polling path was verified on hardware.
+"OMRON"	"ups"	"4"	"BN150T"	"USB (USB ID 0590:00b7)"	"nutdrv_qx port=auto vendorid=0590 productid=00b7 protocol=omron subdriver=omron"	# https://github.com/networkupstools/nut/issues/3112 ; ported from OMRON-authored GPL driver version 1.00 distributed in the Synology DSM 7.3-86009 GPL sources and version 1.02 distributed in the QNAP QTS 5.2.3 GPL sources. Polling and direct shutdown commands were verified on an unloaded BN150T over USB; other models are untested.
 
 "Oneac"	"ups"	"1"	"ON400"	"advanced interface"	"oneac"
 "Oneac"	"ups"	"1"	"ON600"	"advanced interface"	"oneac"

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -1144,7 +1144,7 @@
 "NUT"	"ups"	"5"	"all supported NUT devices, through remote upsd"	""	"dummy-ups"
 "NUT"	"ups"	"5"	"Simulated devices"	""	"dummy-ups"
 
-"OMRON"	"ups"	"4"	"BN150T"	"USB (USB ID 0590:00b7)"	"nutdrv_qx port=auto vendorid=0590 productid=00b7 protocol=omron subdriver=omron"	# https://github.com/networkupstools/nut/issues/3112 ; ported from the GPL driver source published by OMRON. Only the polling path was verified on hardware.
+"OMRON"	"ups"	"4"	"BN150T"	"USB (USB ID 0590:00b7)"	"nutdrv_qx port=auto vendorid=0590 productid=00b7 protocol=omron subdriver=omron"	# https://github.com/networkupstools/nut/issues/3112 ; ported from OMRON-authored GPL driver version 1.00 distributed in the Synology DSM 7.3-86009 GPL sources and version 1.02 distributed in the QNAP QTS 5.2.3 GPL sources. Only the polling path was verified on hardware.
 
 "Oneac"	"ups"	"1"	"ON400"	"advanced interface"	"oneac"
 "Oneac"	"ups"	"1"	"ON600"	"advanced interface"	"oneac"

--- a/docs/man/nutdrv_qx.txt
+++ b/docs/man/nutdrv_qx.txt
@@ -486,7 +486,7 @@ USB INTERFACE ONLY
 include::nut_usb_addvars.txt[]
 
 *subdriver =* 'string'::
-Select a serial-over-USB subdriver to use.
+Select a USB communication subdriver to use.
 You have a choice between *ablerex*, *armac*, *cypress*, *fabula*, *fuji*, *gtec*, *hunnox*, *ippon*, *krauler*, *omron*, *phoenix*, *phoenixtec*, *sgs* and *snr*.
 +
 Run the driver program with the `--help` option to see the exact list of

--- a/docs/man/nutdrv_qx.txt
+++ b/docs/man/nutdrv_qx.txt
@@ -220,31 +220,33 @@ Note that when changing *ups.id* (through linkman:upsrw[8]) the driver will cont
 OMRON PROTOCOL
 ~~~~~~~~~~~~~~
 
-This protocol is a variant of the 'q1' one, ported from the GPL driver source
-published by OMRON, and differs from 'q1' in the following ways.
+This protocol is a variant of the 'q1' one, ported from two OMRON-authored GPL
+driver sources: version 1.00 distributed in the Synology DSM 7.3-86009 GPL
+sources, and version 1.02 distributed in the QNAP QTS 5.2.3 GPL sources. It
+differs from 'q1' in the following ways.
 
 The third character (index 2) of the eight-character `Q1` status field, which
 'q1' maps to *BYPASS*, is not published at all. The tested device reports it as
-set continuously while running on mains, idle and unloaded. OMRON's own driver
-has no active handling for that character either: it does test it -- calling
+set continuously while running on mains, idle and unloaded. Neither OMRON
+driver version has active handling for that character. Both test it -- calling
 the same one `Bit5', counting from the other end -- but the body of that branch
-is commented out in both vendor releases. Its meaning on this hardware is not
-established.
+is commented out in both the 1.00 and 1.02 sources. Its meaning on this
+hardware is not established.
 
 The last character (index 7) of the status field, which 'q1' maps to
-*ups.beeper.status*, is not published either. OMRON's own driver never reads
-that character: it takes the beeper state from a different query, which this
-subdriver does not implement. In that query `0' means enabled, whereas 'q1'
-would map an index-7 `0' to disabled. Whether index 7 reports the beeper state
-on this hardware is not established.
+*ups.beeper.status*, is not published either. Neither OMRON driver version
+reads that character. Both take the beeper state from a different query, which
+this subdriver does not implement. In that query `0' means enabled, whereas
+'q1' would map an index-7 `0' to disabled. Whether index 7 reports the beeper
+state on this hardware is not established.
 
 Among the UPS-specific instant commands this protocol exposes only
-*shutdown.return*, *shutdown.stayoff* and *shutdown.stop*. OMRON's own driver
-has no equivalent of the 'q1' *load.on*, *load.off*, `test.battery.*` or
-*beeper.toggle* commands; what it defines instead is per-outlet load control
-and *beeper.enable* / *beeper.disable*, which this subdriver does not expose
-either. The driver core registers further commands of its own on top of the
-subdriver's, such as *shutdown.default* and *driver.killpower*.
+*shutdown.return*, *shutdown.stayoff* and *shutdown.stop*. Neither OMRON driver
+version has an equivalent of the 'q1' *load.on*, *load.off*, `test.battery.*`
+or *beeper.toggle* commands; both define per-outlet load control and
+*beeper.enable* / *beeper.disable* instead, which this subdriver does not
+expose either. The driver core registers further commands of its own on top of
+the subdriver's, such as *shutdown.default* and *driver.killpower*.
 
 Autodetection is restricted to OMRON's USB vendor ID, because the claim
 function of this protocol checks no more of the device than the 'q1' one does,
@@ -281,7 +283,7 @@ Where the battery readings come from, which is not the same for all of them:
 
 NOTE: Only the BN150T has been tested, over USB, and only its polling path.
 None of the shutdown commands has ever been sent to real hardware; they follow
-the vendor source. Other OMRON models are untested.
+the OMRON 1.00 and 1.02 driver sources. Other OMRON models are untested.
 
 *ondelay*::
 The acceptable range is +0..599940+ seconds.

--- a/docs/man/nutdrv_qx.txt
+++ b/docs/man/nutdrv_qx.txt
@@ -30,7 +30,7 @@ refers to this large family of similar dialects as the 'Megatec Q*' or
 
 The *nutdrv_qx* driver is known to work with various UPSes from
 'Armac', 'Blazer', 'Energy Sistem', 'Fenton Technologies', 'General Electric',
-'Gtec', 'Hunnox', 'Masterguard', 'Mustek', 'Powercool', 'Voltronic Power',
+'Gtec', 'Hunnox', 'Masterguard', 'Mustek', 'OMRON', 'Powercool', 'Voltronic Power',
 'SKE' (rebranded by many, many -- have I said many? -- others...
 
 Long story short: if your UPS came with a software called 'Viewpower',
@@ -88,7 +88,7 @@ If you set stayoff in linkman:ups.conf[5] when FSD arises the UPS will call a *s
 
 *protocol =* 'string'::
 Skip autodetection of the protocol to use and only use the one specified.
-Supported values: 'bestups', 'gtec', 'hunnox', 'innovart31', 'innovart33', 'innovatae', 'masterguard', 'mecer', 'megatec', 'megatec/old', 'mustek', 'q1', 'q2', 'q6', 'voltronic', 'voltronic-axpert', 'voltronic-qs', 'voltronic-qs-hex' and 'zinto'.
+Supported values: 'bestups', 'gtec', 'hunnox', 'innovart31', 'innovart33', 'innovatae', 'masterguard', 'mecer', 'megatec', 'megatec/old', 'mustek', 'omron', 'q1', 'q2', 'q6', 'voltronic', 'voltronic-axpert', 'voltronic-qs', 'voltronic-qs-hex' and 'zinto'.
 +
 Run the driver program with the `--help` option to see the exact list of
 `protocol` values it would currently recognize.
@@ -168,8 +168,8 @@ If not specified, the driver defaults to 10%.
 Only used if *runtimecal* is also specified.
 
 
-BESTUPS, INNOVART31, INNOVART33, INNOVATAE, MECER, MEGATEC, MEGATEC/OLD, MUSTEK, Q1, Q2, Q6, VOLTRONIC-QS, VOLTRONIC-QS-HEX, ZINTO PROTOCOLS
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BESTUPS, INNOVART31, INNOVART33, INNOVATAE, MECER, MEGATEC, MEGATEC/OLD, MUSTEK, OMRON, Q1, Q2, Q6, VOLTRONIC-QS, VOLTRONIC-QS-HEX, ZINTO PROTOCOLS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 *ignoresab*::
 Some UPSes incorrectly report the `Shutdown Active' bit as always on, consequently making the driver believe the UPS is nearing a shutdown (and, as a result, ups.status always contains +FSD+... and you know what this means).
@@ -215,6 +215,54 @@ MASTERGUARD PROTOCOL
 Make the claim function verify it's talking to the specified 'slave address' (*ups.id*).
 Safeguard against talking to the wrong one of several identical UPSes on the same USB bus.
 Note that when changing *ups.id* (through linkman:upsrw[8]) the driver will continue to talk to the UPS with the new 'slave address', but won't claim it again on restart until the *slave_addr* parameter is adjusted.
+
+
+OMRON PROTOCOL
+~~~~~~~~~~~~~~
+
+This protocol is a variant of the 'q1' one, ported from the GPL driver source
+published by OMRON, and differs from 'q1' in the following ways.
+
+The third character (index 2) of the eight-character `Q1` status field, which
+'q1' maps to *BYPASS*, is not published at all. The tested device reports it as
+set continuously while running on mains, idle and unloaded. OMRON's own driver
+has no active handling for that character either: it does test it -- calling
+the same one `Bit5', counting from the other end -- but the body of that branch
+is commented out in both vendor releases. Its meaning on this hardware is not
+established.
+
+Among the UPS-specific instant commands this protocol exposes only
+*shutdown.return*, *shutdown.stayoff* and *shutdown.stop*. OMRON's own driver
+has no equivalent of the 'q1' *load.on*, *load.off*, `test.battery.*` or
+*beeper.toggle* commands; what it defines instead is per-outlet load control
+and *beeper.enable* / *beeper.disable*, which this subdriver does not expose
+either. The driver core registers further commands of its own on top of the
+subdriver's, such as *shutdown.default* and *driver.killpower*.
+
+Autodetection additionally requires OMRON's USB vendor ID, because the claim
+function of this protocol checks no more of the device than the 'q1' one does,
+and would otherwise take over every device that the generic 'q1' fallback
+exists to serve. A device reached over a serial link therefore has to be given
+`protocol = omron` explicitly.
+
+Over USB this protocol is normally paired with the *omron* value of the
+*subdriver* option, which selects the matching transport; both were added for
+the same device. For the tested unit that is
+`protocol = omron`, `subdriver = omron`, `vendorid = 0590`, `productid = 00b7`.
+
+NOTE: Only the BN150T has been tested, over USB, and only its polling path.
+None of the shutdown commands has ever been sent to real hardware; they follow
+the vendor source. Other OMRON models are untested.
+
+*ondelay*::
+The acceptable range is +0..599940+ seconds.
+Note that OMRON's shutdown commands carry no return-delay field, so this
+setting does not reach the device.
+
+*offdelay*::
+The acceptable range is +12..600+ seconds.
+The value reaches the device in OMRON's own encoding: a six-second-step form
+below one minute, and a whole-minute form at one minute and above.
 
 
 INNOVART31, INNOVART33, INNOVATAE, Q1, Q2, Q6 PROTOCOLS
@@ -399,7 +447,7 @@ include::nut_usb_addvars.txt[]
 
 *subdriver =* 'string'::
 Select a serial-over-USB subdriver to use.
-You have a choice between *ablerex*, *armac*, *cypress*, *fabula*, *fuji*, *gtec*, *hunnox*, *ippon*, *krauler*, *phoenix*, *phoenixtec*, *sgs* and *snr*.
+You have a choice between *ablerex*, *armac*, *cypress*, *fabula*, *fuji*, *gtec*, *hunnox*, *ippon*, *krauler*, *omron*, *phoenix*, *phoenixtec*, *sgs* and *snr*.
 +
 Run the driver program with the `--help` option to see the exact list of
 `subdriver` values it would currently recognize.
@@ -513,6 +561,12 @@ Perform a quick (10 second) battery test.
 *test.battery.stop*::
 Stop a running battery test.
 (Not available on some hardware)
+
+NOTE: Of the commands above, the 'omron' protocol offers only
+*shutdown.return*, *shutdown.stayoff* and *shutdown.stop*; see
+<<_omron_protocol,OMRON PROTOCOL>> above for why the others are left out.
+Commands registered by the driver core rather than by a protocol subdriver,
+such as *shutdown.default*, are unaffected by that.
 
 
 BESTUPS, INNOVART31, INNOVART33, INNOVATAE, MECER, MEGATEC, MEGATEC/OLD, MUSTEK, Q1, Q2, Q6, ZINTO PROTOCOLS

--- a/docs/man/nutdrv_qx.txt
+++ b/docs/man/nutdrv_qx.txt
@@ -227,10 +227,11 @@ differs from 'q1' in the following ways.
 
 The third character (index 2) of the eight-character `Q1` status field, which
 'q1' maps to *BYPASS*, is not published at all. The tested device reports it as
-set continuously while running on mains, idle and unloaded. Neither OMRON
+set during stable mains operation, both normally and in ECO mode, and clear
+while on battery; it also varied during startup/calibration. Neither OMRON
 driver version has active handling for that character. Both test it -- calling
 the same one `Bit5', counting from the other end -- but the body of that branch
-is commented out in both the 1.00 and 1.02 sources. Its meaning on this
+is commented out in both the 1.00 and 1.02 sources. Its exact meaning on this
 hardware is not established.
 
 The last character (index 7) of the status field, which 'q1' maps to
@@ -281,9 +282,15 @@ Where the battery readings come from, which is not the same for all of them:
   the data as good. A stale reading is not distinguishable from a fresh one by
   a client.
 
-NOTE: Only the BN150T has been tested, over USB, and only its polling path.
-None of the shutdown commands has ever been sent to real hardware; they follow
-the OMRON 1.00 and 1.02 driver sources. Other OMRON models are untested.
+NOTE: Only the BN150T has been tested, over USB. Polling and all three direct
+shutdown commands were exercised with its output unloaded. *shutdown.return*
+was verified on battery, including automatic output recovery after utility
+returned; *shutdown.stayoff* kept the output off with utility present until
+manual recovery; and *shutdown.stop* cancelled pending 120-second shutdowns.
+The shared *shutdown.default*, *driver.killpower* and driver `-k' paths were not
+exercised; their pre-existing failure-reporting limitation is tracked in
+link:https://github.com/networkupstools/nut/issues/3553[issue #3553].
+Other OMRON models and serial connections are untested.
 
 *ondelay*::
 The acceptable range is +0..599940+ seconds.

--- a/docs/man/nutdrv_qx.txt
+++ b/docs/man/nutdrv_qx.txt
@@ -231,6 +231,13 @@ the same one `Bit5', counting from the other end -- but the body of that branch
 is commented out in both vendor releases. Its meaning on this hardware is not
 established.
 
+The last character (index 7) of the status field, which 'q1' maps to
+*ups.beeper.status*, is not published either. OMRON's own driver never reads
+that character: it takes the beeper state from a different query, which this
+subdriver does not implement. In that query `0' means enabled, whereas 'q1'
+would map an index-7 `0' to disabled. Whether index 7 reports the beeper state
+on this hardware is not established.
+
 Among the UPS-specific instant commands this protocol exposes only
 *shutdown.return*, *shutdown.stayoff* and *shutdown.stop*. OMRON's own driver
 has no equivalent of the 'q1' *load.on*, *load.off*, `test.battery.*` or
@@ -239,16 +246,38 @@ and *beeper.enable* / *beeper.disable*, which this subdriver does not expose
 either. The driver core registers further commands of its own on top of the
 subdriver's, such as *shutdown.default* and *driver.killpower*.
 
-Autodetection additionally requires OMRON's USB vendor ID, because the claim
+Autodetection is restricted to OMRON's USB vendor ID, because the claim
 function of this protocol checks no more of the device than the 'q1' one does,
 and would otherwise take over every device that the generic 'q1' fallback
-exists to serve. A device reached over a serial link therefore has to be given
-`protocol = omron` explicitly.
+exists to serve. The OMRON protocol is tried before command-based protocol
+probes; a non-OMRON USB device is rejected from this candidate without a
+transfer. A device reached over a serial link has no USB vendor ID and
+therefore has to be given `protocol = omron` explicitly.
 
 Over USB this protocol is normally paired with the *omron* value of the
 *subdriver* option, which selects the matching transport; both were added for
-the same device. For the tested unit that is
+the same device. The registered BN150T USB ID can select both automatically,
+but specifying both remains recommended for an unambiguous configuration. For
+the tested unit the explicit settings are
 `protocol = omron`, `subdriver = omron`, `vendorid = 0590`, `productid = 00b7`.
+
+Where the battery readings come from, which is not the same for all of them:
+
+- *battery.charge* and *battery.runtime* are normally read from the device
+  through OMRON extension queries of their own, so they do not depend on the
+  *runtimecal* guesswork described under
+  <<_battery_charge_guesstimation,BATTERY CHARGE GUESSTIMATION>>.
+- *battery.voltage.low* and *battery.voltage.high* are **not** device readings.
+  The device does not report those two thresholds at all. It reports a nominal
+  battery voltage, and the driver derives the pair from that, in the same way
+  it does for any other device that reports a nominal and no thresholds. The
+  current *battery.voltage* is a real reading, and comes from `Q1` rather than
+  from any of this.
+- If one of those queries fails during a poll, its variable falls back to the
+  driver's estimate for that cycle, or - for *battery.runtime* with no
+  *runtimecal* set - keeps its previous value while the driver still reports
+  the data as good. A stale reading is not distinguishable from a fresh one by
+  a client.
 
 NOTE: Only the BN150T has been tested, over USB, and only its polling path.
 None of the shutdown commands has ever been sent to real hardware; they follow

--- a/docs/man/nutdrv_qx.txt
+++ b/docs/man/nutdrv_qx.txt
@@ -220,19 +220,19 @@ Note that when changing *ups.id* (through linkman:upsrw[8]) the driver will cont
 OMRON PROTOCOL
 ~~~~~~~~~~~~~~
 
-This protocol is a variant of the 'q1' one, ported from two OMRON-authored GPL
-driver sources: version 1.00 distributed in the Synology DSM 7.3-86009 GPL
-sources, and version 1.02 distributed in the QNAP QTS 5.2.3 GPL sources. It
-differs from 'q1' in the following ways.
+This protocol is a variant of the 'q1' protocol. Its implementation is based
+on two OMRON-authored GPL driver sources: version 1.00 distributed in the
+Synology DSM 7.3-86009 GPL sources, and version 1.02 distributed in the QNAP
+QTS 5.2.3 GPL sources. It differs from 'q1' in the following ways.
 
 The third character (index 2) of the eight-character `Q1` status field, which
 'q1' maps to *BYPASS*, is not published at all. The tested device reports it as
-set during stable mains operation, both normally and in ECO mode, and clear
+set during stable mains operation, both in normal mode and in ECO mode, and clear
 while on battery; it also varied during startup/calibration. Neither OMRON
-driver version has active handling for that character. Both test it -- calling
-the same one `Bit5', counting from the other end -- but the body of that branch
-is commented out in both the 1.00 and 1.02 sources. Its exact meaning on this
-hardware is not established.
+driver version has active handling for that character. Both test the same
+character -- naming it `Bit5' when counting from the other end -- but the body
+of that branch is commented out in both the 1.00 and 1.02 sources. Its exact
+meaning on this hardware is not established.
 
 The last character (index 7) of the status field, which 'q1' maps to
 *ups.beeper.status*, is not published either. Neither OMRON driver version
@@ -245,50 +245,52 @@ Among the UPS-specific instant commands this protocol exposes only
 *shutdown.return*, *shutdown.stayoff* and *shutdown.stop*. Neither OMRON driver
 version has an equivalent of the 'q1' *load.on*, *load.off*, `test.battery.*`
 or *beeper.toggle* commands; both define per-outlet load control and
-*beeper.enable* / *beeper.disable* instead, which this subdriver does not
-expose either. The driver core registers further commands of its own on top of
-the subdriver's, such as *shutdown.default* and *driver.killpower*.
+*beeper.enable* / *beeper.disable* instead. This subdriver does not expose
+those commands. The driver core registers additional commands independently of
+the subdriver, such as *shutdown.default* and *driver.killpower*.
 
-Autodetection is restricted to OMRON's USB vendor ID, because the claim
-function of this protocol checks no more of the device than the 'q1' one does,
-and would otherwise take over every device that the generic 'q1' fallback
-exists to serve. The OMRON protocol is tried before command-based protocol
-probes; a non-OMRON USB device is rejected from this candidate without a
-transfer. A device reached over a serial link has no USB vendor ID and
-therefore has to be given `protocol = omron` explicitly.
+Autodetection is restricted to OMRON's USB vendor ID because this protocol's
+claim check is as permissive as the 'q1' check. Without the vendor-ID check,
+the subdriver could claim devices intended for the generic 'q1' fallback. The
+OMRON protocol is tried before command-based protocol probes; a non-OMRON USB
+device is rejected by this candidate without a transfer. A device reached over
+a serial link has no USB vendor ID and therefore must be configured with
+`protocol = omron` explicitly.
 
-Over USB this protocol is normally paired with the *omron* value of the
-*subdriver* option, which selects the matching transport; both were added for
-the same device. The registered BN150T USB ID can select both automatically,
-but specifying both remains recommended for an unambiguous configuration. For
-the tested unit the explicit settings are
+Over USB, this protocol is normally paired with the *omron* value of the
+*subdriver* option, which selects the matching transport. The protocol and
+transport were added together for this device. The registered BN150T USB ID
+can select both automatically, but specifying both remains recommended to make
+the configuration unambiguous. For the tested unit the explicit settings are
 `protocol = omron`, `subdriver = omron`, `vendorid = 0590`, `productid = 00b7`.
 
-Where the battery readings come from, which is not the same for all of them:
+The battery variables have different data sources:
 
-- *battery.charge* and *battery.runtime* are normally read from the device
-  through OMRON extension queries of their own, so they do not depend on the
+- *battery.charge* and *battery.runtime* are normally obtained from separate
+  OMRON extension queries, so they do not depend on the
   *runtimecal* guesswork described under
   <<_battery_charge_guesstimation,BATTERY CHARGE GUESSTIMATION>>.
 - *battery.voltage.low* and *battery.voltage.high* are **not** device readings.
   The device does not report those two thresholds at all. It reports a nominal
   battery voltage, and the driver derives the pair from that, in the same way
-  it does for any other device that reports a nominal and no thresholds. The
-  current *battery.voltage* is a real reading, and comes from `Q1` rather than
-  from any of this.
-- If one of those queries fails during a poll, its variable falls back to the
-  driver's estimate for that cycle, or - for *battery.runtime* with no
-  *runtimecal* set - keeps its previous value while the driver still reports
-  the data as good. A stale reading is not distinguishable from a fresh one by
-  a client.
+  it does for any other device that reports a nominal voltage but no
+  thresholds. The current *battery.voltage* is read directly from `Q1` and
+  does not use these derived thresholds.
+- If the charge or runtime query fails during a poll, the corresponding
+  variable falls back to the driver's estimate for that cycle. If the runtime
+  query fails and no *runtimecal* value is set, the driver retains the previous
+  *battery.runtime* value while continuing to mark the data as good. A client
+  cannot distinguish that stale reading from a fresh one.
 
-NOTE: Only the BN150T has been tested, over USB. Polling and all three direct
-shutdown commands were exercised with its output unloaded. *shutdown.return*
-was verified on battery, including automatic output recovery after utility
-returned; *shutdown.stayoff* kept the output off with utility present until
-manual recovery; and *shutdown.stop* cancelled pending 120-second shutdowns.
-The shared *shutdown.default*, *driver.killpower* and driver `-k' paths were not
-exercised; their pre-existing failure-reporting limitation is tracked in
+NOTE: Only the BN150T has been tested, and only over USB. Polling and all
+three direct shutdown commands were exercised with its output unloaded.
+*shutdown.return* was verified on battery, including automatic output recovery
+after utility returned; *shutdown.stayoff* kept the output off with utility
+present until manual recovery; and *shutdown.stop* cancelled pending
+120-second shutdowns.
+The shared *shutdown.default* and *driver.killpower* commands and the driver's
+`-k' path were not exercised. Their pre-existing failure-reporting limitation
+is tracked in
 link:https://github.com/networkupstools/nut/issues/3553[issue #3553].
 Other OMRON models and serial connections are untested.
 
@@ -603,8 +605,8 @@ Stop a running battery test.
 NOTE: Of the commands above, the 'omron' protocol offers only
 *shutdown.return*, *shutdown.stayoff* and *shutdown.stop*; see
 <<_omron_protocol,OMRON PROTOCOL>> above for why the others are left out.
-Commands registered by the driver core rather than by a protocol subdriver,
-such as *shutdown.default*, are unaffected by that.
+Commands registered independently by the driver core, such as
+*shutdown.default*, remain available.
 
 
 BESTUPS, INNOVART31, INNOVART33, INNOVATAE, MECER, MEGATEC, MEGATEC/OLD, MUSTEK, Q1, Q2, Q6, ZINTO PROTOCOLS

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3793 utf-8
+personal_ws-1.1 en 3795 utf-8
 AAC
 AAS
 ABI
@@ -899,6 +899,7 @@ OIDs
 OLHVT
 OMNIVS
 OMNIVSINT
+OMRON
 ONF
 ONV
 OO
@@ -2894,6 +2895,7 @@ oldmac
 oldmge
 oldnut
 omnios
+omron
 onbatt
 onbattery
 onbattwarn

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3795 utf-8
+personal_ws-1.1 en 3799 utf-8
 AAC
 AAS
 ABI
@@ -287,6 +287,7 @@ DS
 DSA
 DSHUTD
 DSL
+DSM
 DTE
 DTrace
 DUMPALL
@@ -900,6 +901,7 @@ OLHVT
 OMNIVS
 OMNIVSINT
 OMRON
+OMRON's
 ONF
 ONV
 OO
@@ -1098,6 +1100,7 @@ QLDL
 QMD
 QMF
 QMOD
+QNAP
 QOL
 QP
 QPAR
@@ -1355,6 +1358,7 @@ Sy
 Sycon
 Symmetra
 Symmetras
+Synology
 SyntaxWarning
 Sysgration
 SyslogIdentifier

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3799 utf-8
+personal_ws-1.1 en 3800 utf-8
 AAC
 AAS
 ABI
@@ -1108,6 +1108,7 @@ QPD
 QQ
 QQQ
 QRI
+QTS
 QVFW
 QWS
 QinHeng

--- a/docs/nutdrv_qx-subdrivers.txt
+++ b/docs/nutdrv_qx-subdrivers.txt
@@ -1190,6 +1190,7 @@ For more details, have a look at the currently available subdrivers:
 - +nutdrv_qx_megatec.+{+c+,+h+}
 - +nutdrv_qx_megatec-old.+{+c+,+h+}
 - +nutdrv_qx_mustek.+{+c+,+h+}
+- +nutdrv_qx_omron.+{+c+,+h+}
 - +nutdrv_qx_q1.+{+c+,+h+}
 - +nutdrv_qx_q2.+{+c+,+h+}
 - +nutdrv_qx_q6.+{+c+,+h+}

--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -520,7 +520,7 @@ NUTDRV_QX_SUBDRIVERS =	\
  nutdrv_qx_innovatae.c	\
  nutdrv_qx_masterguard.c	\
  nutdrv_qx_mecer.c nutdrv_qx_megatec.c nutdrv_qx_megatec-old.c	\
- nutdrv_qx_mustek.c nutdrv_qx_q1.c nutdrv_qx_q2.c nutdrv_qx_q6.c	\
+ nutdrv_qx_mustek.c nutdrv_qx_omron.c nutdrv_qx_q1.c nutdrv_qx_q2.c nutdrv_qx_q6.c	\
  nutdrv_qx_voltronic.c common_voltronic-crc.c	\
  nutdrv_qx_voltronic-axpert.c nutdrv_qx_voltronic-qs.c nutdrv_qx_voltronic-qs-hex.c	\
  nutdrv_qx_zinto.c	\
@@ -547,7 +547,7 @@ dist_noinst_HEADERS = \
  delta_ups-mib.h nutdrv_qx.h nutdrv_qx_bestups.h nutdrv_qx_blazer-common.h	\
  nutdrv_qx_gtec.h nutdrv_qx_innovart31.h nutdrv_qx_innovart33.h nutdrv_qx_innovatae.h	\
  nutdrv_qx_masterguard.h nutdrv_qx_mecer.h nutdrv_qx_ablerex.h	\
- nutdrv_qx_megatec.h nutdrv_qx_megatec-old.h nutdrv_qx_mustek.h nutdrv_qx_q1.h nutdrv_qx_q2.h nutdrv_qx_q6.h nutdrv_qx_hunnox.h	\
+ nutdrv_qx_megatec.h nutdrv_qx_megatec-old.h nutdrv_qx_mustek.h nutdrv_qx_omron.h nutdrv_qx_q1.h nutdrv_qx_q2.h nutdrv_qx_q6.h nutdrv_qx_hunnox.h	\
  nutdrv_qx.h common_voltronic-crc.h nutdrv_qx_voltronic.h	\
  nutdrv_qx_voltronic-axpert.h nutdrv_qx_voltronic-qs.h nutdrv_qx_voltronic-qs-hex.h \
  nutdrv_qx_zinto.h \

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -1173,7 +1173,7 @@ static int	omron_command(const char *cmd, size_t cmdlen, char *buf, size_t bufle
 
 	}
 
-	p = memchr(tmp, '\r', tmplen);
+	p = (char *)memchr(tmp, '\r', tmplen);
 	upsdebugx(3, "send: %.*s", (int)(p ? (size_t)(p - tmp) : tmplen), tmp);
 
 	/* Read the reply in one transfer of at most 64 bytes */
@@ -1207,7 +1207,7 @@ static int	omron_command(const char *cmd, size_t cmdlen, char *buf, size_t bufle
 	/* If no CR was received, use a NUL found within the received bytes;
 	 * otherwise treat every received byte as payload. */
 	if (!len) {
-		p = memchr(tmp, '\0', (size_t)ret);
+		p = (char *)memchr(tmp, '\0', (size_t)ret);
 		len = p ? (size_t)(p - tmp) : (size_t)ret;
 	}
 

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -58,7 +58,7 @@
 #	define DRIVER_NAME	"Generic Q* Serial driver"
 #endif	/* QX_USB */
 
-#define DRIVER_VERSION	"0.53"
+#define DRIVER_VERSION	"0.54"
 
 #ifdef QX_SERIAL
 #	include "serial.h"

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -2575,6 +2575,14 @@ static void	*ippon_subdriver(USBDevice_t *device)
 	return NULL;
 }
 
+static void	*omron_subdriver(USBDevice_t *device)
+{
+	NUT_UNUSED_VARIABLE(device);
+
+	subdriver_command = &omron_command;
+	return NULL;
+}
+
 static void	*krauler_subdriver(USBDevice_t *device)
 {
 	NUT_UNUSED_VARIABLE(device);
@@ -2658,6 +2666,9 @@ typedef struct {
 /* ST Microelectronics */
 #define STMICRO_VENDORID	0x0483
 
+/* OMRON Corporation */
+#define OMRON_VENDORID	0x0590
+
 /* Sysgration Ltd. */
 #define SYSGRATION_VENDORID	0x05b8
 
@@ -2699,6 +2710,7 @@ static qx_usb_device_id_t	qx_usb_id[] = {
 	{ USB_DEVICE(GE_VENDORID,	0x00c9),	NULL,		NULL,			&phoenix_subdriver },	/* GE EP series */
 	{ USB_DEVICE(QINHENG_VENDORID,	0x7523),	NULL,		NULL,			NULL },	/* NOTE: VID:PID may be used by non-UPS devices with CH340/341 chips! But also Ippon Innova TAE series, using QinHeng Electronics CH340 serial converter; no specific "USB subdriver" handler defined at the moment */
 	{ USB_DEVICE(STMICRO_VENDORID,	0x0035),	NULL,		NULL,			&sgs_subdriver },	/* TS Shara UPSes; vendor ID 0x0483 is from ST Microelectronics - with product IDs delegated to different OEMs */
+	{ USB_DEVICE(OMRON_VENDORID,	0x00b7),	NULL,		NULL,			&omron_subdriver },	/* OMRON BN150T */
 	{ USB_DEVICE(NONAME0001_VENDORID,	0x0000),	"MEC",		"MEC0003",		&fabula_subdriver },	/* Fideltronik/MEC LUPUS 500 USB */
 	{ USB_DEVICE(NONAME0001_VENDORID,	0x0000),	NULL,		"MEC0003",		&fabula_hunnox_subdriver },	/* Hunnox HNX 850, reported to also help support Powercool and some other devices; closely related to fabula with tweaks */
 	{ USB_DEVICE(NONAME0001_VENDORID,	0x0000),	"ATCL FOR UPS",	"ATCL FOR UPS",		&fuji_subdriver },	/* Fuji UPSes */

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -93,6 +93,8 @@
 
 /* Reference list of available non-USB subdrivers */
 static subdriver_t	*subdriver_list[] = {
+	/* Vendor-ID-gated before command-based protocol probes */
+	&omron_subdriver,
 	&voltronic_subdriver,
 	&voltronic_axpert_subdriver,
 	&voltronic_qs_subdriver,
@@ -112,7 +114,6 @@ static subdriver_t	*subdriver_list[] = {
 	&q2_subdriver,
 	&q6_subdriver,
 	&gtec_subdriver,
-	&omron_subdriver,
 	/* Fallback Q1 subdriver */
 	&q1_subdriver,
 	NULL
@@ -1115,9 +1116,12 @@ static int	ippon_command(const char *cmd, size_t cmdlen, char *buf, size_t bufle
 }
 
 /* OMRON communication subdriver
- * Same transport as ippon above, except that the control transfer carries a
- * 16-byte HID Output report, the size declared by the report descriptor of the
- * BN150T. Only that model has been tested. */
+ * Based on the ippon transport above, with three differences: the control
+ * transfer carries a 16-byte HID Output report, the size declared by the
+ * report descriptor of the BN150T; sending advances per report and treats a
+ * short transfer as an error; and the reply is searched for its end only
+ * within what was actually read, since tmp[] holds no terminating NUL when
+ * the device fills it. Only the BN150T has been tested. */
 #define	OMRON_REPORT_SIZE	16
 
 static int	omron_command(const char *cmd, size_t cmdlen, char *buf, size_t buflen)

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -1115,13 +1115,11 @@ static int	ippon_command(const char *cmd, size_t cmdlen, char *buf, size_t bufle
 	return (int)len;
 }
 
-/* OMRON communication subdriver
- * Based on the ippon transport above, with three differences: the control
- * transfer carries a 16-byte HID Output report, the size declared by the
- * report descriptor of the BN150T; sending advances per report and treats a
- * short transfer as an error; and the reply is searched for its end only
- * within what was actually read, since tmp[] holds no terminating NUL when
- * the device fills it. Only the BN150T has been tested. */
+/* OMRON USB transport
+ * The BN150T declares a 16-byte HID Output report. Each write sends one
+ * complete report and rejects a short transfer. Reply parsing searches for a
+ * terminator only within the bytes actually received because a full-length
+ * reply need not contain a terminating NUL. Only the BN150T has been tested. */
 #define	OMRON_REPORT_SIZE	16
 
 static int	omron_command(const char *cmd, size_t cmdlen, char *buf, size_t buflen)
@@ -1203,9 +1201,8 @@ static int	omron_command(const char *cmd, size_t cmdlen, char *buf, size_t bufle
 
 	}
 
-	/* Just in case there wasn't any '\r', fall back to the string length
-	 * within what was actually read: tmp[] holds no terminating NUL when
-	 * the device fills the whole buffer. */
+	/* If no CR was received, use a NUL found within the received bytes;
+	 * otherwise treat every received byte as payload. */
 	if (!len) {
 		p = memchr(tmp, '\0', (size_t)ret);
 		len = p ? (size_t)(p - tmp) : (size_t)ret;

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -1150,9 +1150,12 @@ static int	omron_command(const char *cmd, size_t cmdlen, char *buf, size_t bufle
 	 * report inside tmp[]. */
 	for (i = 0; i < tmplen; i += OMRON_REPORT_SIZE) {
 
+		/* The HID specification encodes Output report type 2 with report ID 0
+		 * as 0x0200. OMRON-authored driver versions 1.00 and 1.02 instead use
+		 * 0x0002, which was verified on the BN150T; preserve the tested value. */
 		ret = usb_control_msg(udev,
 			USB_ENDPOINT_OUT + USB_TYPE_CLASS + USB_RECIP_INTERFACE,
-			0x09, 0x2, 0, (usb_ctrl_charbuf)&tmp[i],
+			0x09, 0x0002, 0, (usb_ctrl_charbuf)&tmp[i],
 			OMRON_REPORT_SIZE, 1000);
 
 		if (ret <= 0) {

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -1112,6 +1112,125 @@ static int	ippon_command(const char *cmd, size_t cmdlen, char *buf, size_t bufle
 	return (int)len;
 }
 
+/* OMRON communication subdriver
+ * Same transport as ippon above, except that the control transfer carries a
+ * 16-byte HID Output report, the size declared by the report descriptor of the
+ * BN150T. Only that model has been tested. */
+#define	OMRON_REPORT_SIZE	16
+
+static int	omron_command(const char *cmd, size_t cmdlen, char *buf, size_t buflen)
+{
+	char	tmp[64];
+	char	*p;
+	size_t	tmplen;
+	int	ret;
+	size_t	i, len;
+
+	if (buflen > INT_MAX) {
+		upsdebugx(3, "%s: requested to read too much (%" PRIuSIZE "), "
+			"reducing buflen to (INT_MAX-1)",
+			__func__, buflen);
+		buflen = (INT_MAX - 1);
+	}
+
+	/* Send command
+	 * NOTE: the whole buffer is zeroed first, so that the padding sent
+	 * after a command shorter than the chunk length is defined. */
+	memset(tmp, 0, sizeof(tmp));
+	tmplen = cmdlen > sizeof(tmp) ? sizeof(tmp) : cmdlen;
+	memcpy(tmp, cmd, tmplen);
+
+	/* Advance by a whole report, not by the transferred count: a report is
+	 * only meaningful to the device as a unit, so a partial transfer cannot
+	 * be resumed at a byte offset. This also keeps &tmp[i] plus a full
+	 * report inside tmp[]. */
+	for (i = 0; i < tmplen; i += OMRON_REPORT_SIZE) {
+
+		ret = usb_control_msg(udev,
+			USB_ENDPOINT_OUT + USB_TYPE_CLASS + USB_RECIP_INTERFACE,
+			0x09, 0x2, 0, (usb_ctrl_charbuf)&tmp[i],
+			OMRON_REPORT_SIZE, 1000);
+
+		if (ret <= 0) {
+			upsdebugx(3, "send: %s (%d)",
+				(ret != LIBUSB_ERROR_TIMEOUT) ? nut_usb_strerror(ret) : "Connection timed out",
+				ret);
+			return ret;
+		}
+
+		if (ret != OMRON_REPORT_SIZE) {
+			upsdebugx(3, "send: short transfer (%d of %d bytes)",
+				ret, OMRON_REPORT_SIZE);
+			return -1;
+		}
+
+	}
+
+	p = memchr(tmp, '\r', tmplen);
+	upsdebugx(3, "send: %.*s", (int)(p ? (size_t)(p - tmp) : tmplen), tmp);
+
+	/* Read the reply in one transfer of at most 64 bytes */
+	ret = usb_interrupt_read(udev,
+		0x81,
+		(usb_ctrl_charbuf)tmp, sizeof(tmp), 1000);
+
+	/* Any errors here mean that we are unable to read a reply
+	 * (which will happen after successfully writing a command
+	 * to the UPS) */
+	if (ret <= 0) {
+		upsdebugx(3, "read: %s (%d)",
+			(ret != LIBUSB_ERROR_TIMEOUT) ? nut_usb_strerror(ret) : "Connection timed out",
+			ret);
+		return ret;
+	}
+
+	/* The transfer length is not the payload length: the reply is
+	 * terminated by 0x0D, so the payload has to be measured here. */
+
+	for (i = 0, len = 0; i < (size_t)ret; i++) {
+
+		if (tmp[i] != '\r')
+			continue;
+
+		len = ++i;
+		break;
+
+	}
+
+	/* Just in case there wasn't any '\r', fall back to the string length
+	 * within what was actually read: tmp[] holds no terminating NUL when
+	 * the device fills the whole buffer. */
+	if (!len) {
+		p = memchr(tmp, '\0', (size_t)ret);
+		len = p ? (size_t)(p - tmp) : (size_t)ret;
+	}
+
+	upsdebug_hex(5, "read", tmp, len);
+	upsdebugx(3, "read: %.*s",
+		(int)(len && tmp[len - 1] == '\r' ? len - 1 : len), tmp);
+
+	len = len < buflen ? len : buflen - 1;
+
+	memset(buf, 0, buflen);
+	memcpy(buf, tmp, len);
+
+	/* If the reply lacks the expected terminating CR, add it (if there's enough space) */
+	if (len && memchr(buf, '\r', len) == NULL) {
+		upsdebugx(4, "%s: the reply lacks the expected terminating CR.", __func__);
+		if (len < buflen - 1) {
+			upsdebugx(4, "%s: adding missing terminating CR.", __func__);
+			buf[len++] = '\r';
+			buf[len] = 0;
+		}
+	}
+
+	if (len > INT_MAX) {
+		upsdebugx(3, "%s: read too much (%" PRIuSIZE ")", __func__, len);
+		return -1;
+	}
+	return (int)len;
+}
+
 static int 	hunnox_protocol(int asking_for)
 {
 	char	buf[1030];
@@ -3240,6 +3359,7 @@ void	upsdrv_shutdown(void)
 			{ "phoenixtec", &phoenixtec_command },
 			{ "phoenix", &phoenix_command },
 			{ "ippon", &ippon_command },
+			{ "omron", &omron_command },
 			{ "krauler", &krauler_command },
 			{ "fabula", &fabula_command },
 			{ "hunnox", &hunnox_command },

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -78,6 +78,7 @@
 #include "nutdrv_qx_megatec.h"
 #include "nutdrv_qx_megatec-old.h"
 #include "nutdrv_qx_mustek.h"
+#include "nutdrv_qx_omron.h"
 #include "nutdrv_qx_q1.h"
 #include "nutdrv_qx_q2.h"
 #include "nutdrv_qx_q6.h"
@@ -111,6 +112,7 @@ static subdriver_t	*subdriver_list[] = {
 	&q2_subdriver,
 	&q6_subdriver,
 	&gtec_subdriver,
+	&omron_subdriver,
 	/* Fallback Q1 subdriver */
 	&q1_subdriver,
 	NULL
@@ -2575,7 +2577,8 @@ static void	*ippon_subdriver(USBDevice_t *device)
 	return NULL;
 }
 
-static void	*omron_subdriver(USBDevice_t *device)
+/* Note: the "omron_subdriver" name is taken by the subdriver_t structure */
+static void	*omron_usb_subdriver(USBDevice_t *device)
 {
 	NUT_UNUSED_VARIABLE(device);
 
@@ -2710,7 +2713,7 @@ static qx_usb_device_id_t	qx_usb_id[] = {
 	{ USB_DEVICE(GE_VENDORID,	0x00c9),	NULL,		NULL,			&phoenix_subdriver },	/* GE EP series */
 	{ USB_DEVICE(QINHENG_VENDORID,	0x7523),	NULL,		NULL,			NULL },	/* NOTE: VID:PID may be used by non-UPS devices with CH340/341 chips! But also Ippon Innova TAE series, using QinHeng Electronics CH340 serial converter; no specific "USB subdriver" handler defined at the moment */
 	{ USB_DEVICE(STMICRO_VENDORID,	0x0035),	NULL,		NULL,			&sgs_subdriver },	/* TS Shara UPSes; vendor ID 0x0483 is from ST Microelectronics - with product IDs delegated to different OEMs */
-	{ USB_DEVICE(OMRON_VENDORID,	0x00b7),	NULL,		NULL,			&omron_subdriver },	/* OMRON BN150T */
+	{ USB_DEVICE(OMRON_VENDORID,	0x00b7),	NULL,		NULL,			&omron_usb_subdriver },	/* OMRON BN150T */
 	{ USB_DEVICE(NONAME0001_VENDORID,	0x0000),	"MEC",		"MEC0003",		&fabula_subdriver },	/* Fideltronik/MEC LUPUS 500 USB */
 	{ USB_DEVICE(NONAME0001_VENDORID,	0x0000),	NULL,		"MEC0003",		&fabula_hunnox_subdriver },	/* Hunnox HNX 850, reported to also help support Powercool and some other devices; closely related to fabula with tweaks */
 	{ USB_DEVICE(NONAME0001_VENDORID,	0x0000),	"ATCL FOR UPS",	"ATCL FOR UPS",		&fuji_subdriver },	/* Fuji UPSes */

--- a/drivers/nutdrv_qx_omron.c
+++ b/drivers/nutdrv_qx_omron.c
@@ -1,0 +1,337 @@
+/* nutdrv_qx_omron.c - Subdriver for OMRON UPSes speaking the Q1 protocol
+ *
+ * Copyright (C)
+ *   2013 Daniele Pezzini <hyouko@gmail.com>	(nutdrv_qx_q1.c, on which this is based)
+ *   2026 Jun Kurihara <junkurihara@users.noreply.github.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * NOTE:
+ * This subdriver is the 'q1' subdriver plus the OMRON-specific corrections
+ * listed below. It has been tested on a BN150T (USB 0590:00b7) only; other
+ * OMRON models are untested. What was exercised on that unit is the reading
+ * side: Q1 polling and the capability queries. No instant command has ever
+ * been sent to it, so every command string below rests on the vendor source
+ * alone.
+ *
+ * Differences from 'q1':
+ *
+ * - The third status bit of the Q1 reply ("Bypass/Boost or Buck Active",
+ *   index 2 of the status field) is not published. On a BN150T running on
+ *   mains, idle and with nothing connected to its output, that bit reads 1 on
+ *   every poll, and 'q1' maps it unconditionally to the BYPASS status - which
+ *   in NUT means that protection has been bypassed, i.e. an abnormal state.
+ *   OMRON's own driver deliberately does not evaluate this bit either: the
+ *   block that would decide between TRIM/BYPASS/BOOST is commented out in its
+ *   entirety, identically in the 1.00 and 1.02 releases of the vendor source,
+ *   while every other status bit is handled. What the bit actually reports on
+ *   this hardware is unknown - resolving it needs an observed on-battery
+ *   event - so nothing is published for it.
+ *
+ * - The instant commands that OMRON's own driver does not implement are not
+ *   registered: test.battery.start, test.battery.start.deep,
+ *   test.battery.start.quick and test.battery.stop (the vendor source has no
+ *   T or TL command at all), load.on, load.off, and beeper.toggle (no Q
+ *   command; the vendor uses Bn/Bf to enable/disable the beeper instead).
+ *   Registering an instant command publishes it to NUT clients as something
+ *   the device can perform, so listing commands that may not exist is a defect
+ *   in its own right.
+ *
+ * - The shutdown commands use OMRON's own byte strings rather than the Megatec
+ *   ones, and shutdown.return / shutdown.stayoff are two transactions, not one:
+ *   the auto-restart flag is set first and its failure aborts the command. See
+ *   omron_start_auto() and omron_process_command() below.
+ *
+ * - A command accepted by the UPS is acknowledged with "OK", not with the "ACK"
+ *   that the Megatec-derived subdrivers expect.
+ *
+ * - The claim function additionally requires OMRON's USB vendor ID, see
+ *   omron_claim() below.
+ *
+ */
+
+#include "main.h"
+#include "nutdrv_qx.h"
+#include "nutdrv_qx_blazer-common.h"
+
+#include "nutdrv_qx_omron.h"
+
+#define OMRON_VERSION "Omron 0.01"
+
+/* OMRON's USB vendor ID, as published in 'ups.vendorid' by nutdrv_qx.
+ * Keep in sync with OMRON_VENDORID in nutdrv_qx.c */
+#define OMRON_USB_VENDORID	"0590"
+
+/* What the UPS answers to a command it accepted. The Megatec-derived
+ * subdrivers expect "ACK"; OMRON acknowledges with "OK" and its own driver
+ * tests it with strncmp(buf, "OK", 2). */
+#define OMRON_ACCEPTED		"OK"
+
+/* Set the UPS's auto-restart flag ahead of a shutdown command
+ *
+ * "An" enables restarting when mains returns, "Af" disables it. The vendor
+ * driver sends the matching one *before* the shutdown command itself, and
+ * abandons the instant command if the UPS answers it with anything other than
+ * "OK"; identical code in both releases. Without it, shutdown.return can leave
+ * a unit whose auto-restart flag happens to be off dead after mains returns.
+ *
+ * This is also NUT's documented convention, not just OMRON's: docs/nut-names.txt
+ * states that shutdown commands set ups.start.auto to the matching value first.
+ * nutdrv_qx implements that in the instcmd() fallback path, but the fallback
+ * only runs for commands *absent* from the subdriver table, so a subdriver that
+ * registers shutdown.return itself has to do this for itself.
+ *
+ * Divergence from the vendor, deliberate. The vendor has three outcomes: it
+ * skips the prologue entirely when its CF capability bitmap says the command
+ * is unsupported; it abandons the shutdown on an explicit non-"OK" answer; and
+ * it proceeds to shut down anyway when the transfer itself fails or nothing
+ * comes back, because the guard around the reply test has no else branch.
+ * This driver has no CF gating, and it abandons the shutdown in all three of
+ * transfer failure, no answer, and non-"OK" answer. A shutdown that did not
+ * happen is visible in the logs and reversible; a shutdown whose auto-restart
+ * state is unknown may need someone at the front panel. */
+static int	omron_start_auto(const int on)
+{
+	/* A throwaway item, deliberately not a row of omron_qx2nut[]: this
+	 * transaction happens inside the preprocessing of another item, and
+	 * qx_process() stores the reply in whichever item it is handed - it
+	 * must not be the one instcmd() is working on. answer_len 0 and
+	 * leading 0 accept any reply; the OMRON_ACCEPTED test below is the one
+	 * that decides. */
+	item_t	prologue = {
+		on ? "ups.start.auto (An)" : "ups.start.auto (Af)",
+		0,	NULL,
+		on ? "An\r" : "Af\r",
+		"",	0,	0,
+		"",	0,	0,
+		"%s",	QX_FLAG_NONUT,
+		NULL,	NULL,	NULL
+	};
+
+	/* A rejected query is also a -1 here, not an answer to compare against:
+	 * qx_process_answer() matches subdriver->rejected before anything else */
+	if (qx_process(&prologue, NULL)) {
+		upslogx(LOG_ERR, "%s: [%.*s] failed or was rejected", __func__,
+			(int)strcspn(prologue.command, "\r"), prologue.command);
+		return -1;
+	}
+
+	/* Covers an empty answer too: answer_len is 0, so a zero-length reply
+	 * reaches this point rather than being caught as a short one */
+	if (strcasecmp(prologue.value, OMRON_ACCEPTED)) {
+		upslogx(LOG_ERR, "%s: [%.*s] not acknowledged, answer was [%s]",
+			__func__,
+			(int)strcspn(prologue.command, "\r"), prologue.command,
+			prologue.value);
+		return -1;
+	}
+
+	dstate_setinfo("ups.start.auto", "%s", on ? "yes" : "no");
+
+	return 0;
+}
+
+/* Build the OMRON form of a shutdown command
+ *
+ * OMRON expresses the delay either in tenths of a minute (".n", i.e. 6-second
+ * steps) below one minute, or in whole minutes ("nn") from one minute up, and
+ * never appends the Megatec "R<mmmm>" return-delay field. It also spells
+ * "shut down and stay off" as a distinct "Sf<n>" command, where the Megatec
+ * form is "S<n>R0000". blazer_process_command() produces the Megatec form for
+ * both, and appends the R field as soon as ups.delay.start is non-zero, which
+ * it is by default - hence this replacement rather than a reuse of it.
+ *
+ * Mirrors on_shutdown_return() and on_shutdown_stayoff() of the vendor driver,
+ * which are identical in the 1.00 and 1.02 releases. ups.delay.start has no
+ * effect on these commands; it stays in the table because upsdrv_shutdown()
+ * looks it up before dispatching.
+ *
+ * The two-command shutdown sequence lives here as well: omron_start_auto()
+ * runs first, exactly as the vendor orders it, and its failure aborts the
+ * command before anything is sent to power the unit down.
+ *
+ * NOTE: no shutdown command has ever been sent to this hardware, and the
+ * byte strings below have not been confirmed by observation - only by reading
+ * the vendor source. Treat a first real shutdown as an experiment.
+ */
+static int	omron_process_command(item_t *item, char *value, const size_t valuelen)
+{
+	const char	*offdelay_str = dstate_getinfo("ups.delay.shutdown");
+	long		offdelay;
+	char		buf[SMALLBUF] = "";
+
+	if (!offdelay_str) {
+		upslogx(LOG_ERR, "%s: ups.delay.shutdown is not set",
+			item->info_type);
+		return -1;
+	}
+
+	offdelay = strtol(offdelay_str, NULL, 10);
+
+	if (offdelay < 0) {
+		upslogx(LOG_ERR, "%s: offdelay '%ld' should not be negative",
+			item->info_type, offdelay);
+		return -1;
+	}
+
+	if (offdelay < 60) {
+		snprintf(buf, sizeof(buf), ".%ld", offdelay / 6);
+	} else {
+		snprintf(buf, sizeof(buf), "%02ld", offdelay / 60);
+	}
+
+	/* Auto-restart flag first, and only then the power-down command */
+	if (!strcasecmp(item->info_type, "shutdown.return")) {
+
+		if (omron_start_auto(1)) {
+			/* Not a value-conversion failure: keep instcmd() from
+			 * reporting one because qx_process() left EINVAL behind */
+			errno = 0;
+			return -1;
+		}
+
+	} else if (!strcasecmp(item->info_type, "shutdown.stayoff")) {
+
+		if (omron_start_auto(0)) {
+			errno = 0;
+			return -1;
+		}
+
+	}
+
+	snprintf_dynamic(value, valuelen, item->command, "%s", buf);
+
+	return 0;
+}
+
+/* qx2nut lookup table */
+static item_t	omron_qx2nut[] = {
+
+	/*
+	 * > [Q1\r]
+	 * < [(102.5 000.0 102.4 000 49.9 54.5 22.7 00101000\r]
+	 *    01234567890123456789012345678901234567890123456
+	 *    0         1         2         3         4
+	 */
+
+	{ "input.voltage",		0,	NULL,	"Q1\r",	"",	47,	'(',	"",	1,	5,	"%.1f",	0,	NULL,	NULL,	NULL },
+	{ "input.voltage.fault",	0,	NULL,	"Q1\r",	"",	47,	'(',	"",	7,	11,	"%.1f",	0,	NULL,	NULL,	NULL },
+	{ "output.voltage",		0,	NULL,	"Q1\r",	"",	47,	'(',	"",	13,	17,	"%.1f",	0,	NULL,	NULL,	NULL },
+	{ "ups.load",			0,	NULL,	"Q1\r",	"",	47,	'(',	"",	19,	21,	"%.0f",	0,	NULL,	NULL,	NULL },
+	{ "input.frequency",		0,	NULL,	"Q1\r",	"",	47,	'(',	"",	23,	26,	"%.1f",	0,	NULL,	NULL,	NULL },
+	{ "battery.voltage",		0,	NULL,	"Q1\r",	"",	47,	'(',	"",	28,	31,	"%.2f",	0,	NULL,	NULL,	qx_multiply_battvolt },
+	{ "ups.temperature",		0,	NULL,	"Q1\r",	"",	47,	'(',	"",	33,	36,	"%.1f",	0,	NULL,	NULL,	NULL },
+	/* Status bits.
+	 * Index 2 of the status field ("Bypass/Boost or Buck Active") is
+	 * intentionally absent, see the note at the top of this file. */
+	{ "ups.status",			0,	NULL,	"Q1\r",	"",	47,	'(',	"",	38,	38,	NULL,	QX_FLAG_QUICK_POLL,	NULL,	NULL,	blazer_process_status_bits },	/* Utility Fail (Immediate) */
+	{ "ups.status",			0,	NULL,	"Q1\r",	"",	47,	'(',	"",	39,	39,	NULL,	QX_FLAG_QUICK_POLL,	NULL,	NULL,	blazer_process_status_bits },	/* Battery Low */
+	{ "ups.alarm",			0,	NULL,	"Q1\r",	"",	47,	'(',	"",	41,	41,	NULL,	0,			NULL,	NULL,	blazer_process_status_bits },	/* UPS Failed */
+	{ "ups.type",			0,	NULL,	"Q1\r",	"",	47,	'(',	"",	42,	42,	"%s",	QX_FLAG_STATIC,		NULL,	NULL,	blazer_process_status_bits },	/* UPS Type */
+	{ "ups.status",			0,	NULL,	"Q1\r",	"",	47,	'(',	"",	43,	43,	NULL,	QX_FLAG_QUICK_POLL,	NULL,	NULL,	blazer_process_status_bits },	/* Test in Progress */
+	{ "ups.status",			0,	NULL,	"Q1\r",	"",	47,	'(',	"",	44,	44,	NULL,	QX_FLAG_QUICK_POLL,	NULL,	NULL,	blazer_process_status_bits },	/* Shutdown Active */
+	{ "ups.beeper.status",		0,	NULL,	"Q1\r",	"",	47,	'(',	"",	45,	45,	"%s",	0,			NULL,	NULL,	blazer_process_status_bits },	/* Beeper status */
+
+	/* Instant commands */
+	{ "shutdown.return",		0,	NULL,	"S%s\r",	"",	0,	0,	"",	0,	0,	NULL,	QX_FLAG_CMD,	NULL,	NULL,	omron_process_command },
+	{ "shutdown.stayoff",		0,	NULL,	"Sf%s\r",	"",	0,	0,	"",	0,	0,	NULL,	QX_FLAG_CMD,	NULL,	NULL,	omron_process_command },
+	{ "shutdown.stop",		0,	NULL,	"C\r",		"",	0,	0,	"",	0,	0,	NULL,	QX_FLAG_CMD,	NULL,	NULL,	NULL },
+
+	/* Server-side settable vars */
+	{ "ups.delay.start",		ST_FLAG_RW,	blazer_r_ondelay,	NULL,	"",	0,	0,	"",	0,	0,	DEFAULT_ONDELAY,	QX_FLAG_ABSENT | QX_FLAG_SETVAR | QX_FLAG_RANGE,	NULL,	NULL,	blazer_process_setvar },
+	{ "ups.delay.shutdown",		ST_FLAG_RW,	blazer_r_offdelay,	NULL,	"",	0,	0,	"",	0,	0,	DEFAULT_OFFDELAY,	QX_FLAG_ABSENT | QX_FLAG_SETVAR | QX_FLAG_RANGE,	NULL,	NULL,	blazer_process_setvar },
+
+	/* End of structure. */
+	{ NULL,				0,	NULL,	NULL,		"",	0,	0,	"",	0,	0,	NULL,	0,	NULL,	NULL,	NULL }
+};
+
+/* Testing table
+ *
+ * The Q1 answer is a reply captured from a BN150T, not a hand-written one.
+ * The command answers are "OK\r" because that is what OMRON acknowledges with;
+ * an empty answer here would pass regardless of the 'accepted' string, since
+ * nutdrv_qx's instcmd() treats "no reply" as success.
+ *
+ * Both delay forms of each shutdown command are listed: ".n" for an
+ * ups.delay.shutdown below 60 seconds (the default, 30, gives ".5") and "nn"
+ * for one minute or more. A command absent from this table is answered with
+ * the 'rejected' string by the testing implementation, which is how the NAK
+ * path gets exercised. */
+#ifdef TESTING
+static testing_t	omron_testing[] = {
+	{ "Q1\r",	"(102.5 000.0 102.4 000 49.9 54.5 22.7 00101000\r",	-1 },
+	{ "An\r",	"OK\r",	-1 },
+	{ "Af\r",	"OK\r",	-1 },
+	{ "S.5\r",	"OK\r",	-1 },
+	{ "S02\r",	"OK\r",	-1 },
+	{ "Sf.5\r",	"OK\r",	-1 },
+	{ "Sf02\r",	"OK\r",	-1 },
+	{ "C\r",	"OK\r",	-1 },
+	{ NULL }
+};
+#endif	/* TESTING */
+
+/* Subdriver-specific claim
+ *
+ * This subdriver differs from 'q1' only in OMRON-specific details, so its
+ * protocol check is exactly as permissive as 'q1''s and would otherwise claim
+ * every device that the generic 'q1' fallback is meant to serve. Restrict
+ * auto-detection to OMRON's USB vendor ID, which nutdrv_qx's upsdrv_initups()
+ * publishes as 'ups.vendorid' before subdriver_matcher() runs. A user who
+ * names this protocol explicitly gets it either way: subdriver_matcher() skips
+ * every other subdriver before calling its claim, so reaching this function
+ * with 'protocol' set means it was set to ours. */
+static int	omron_claim(void)
+{
+	if (!getval("protocol")) {
+
+		const char	*vendorid = dstate_getinfo("ups.vendorid");
+
+		if (!vendorid || strcasecmp(vendorid, OMRON_USB_VENDORID)) {
+			upsdebugx(2, "%s: not an OMRON device (ups.vendorid: %s)",
+				__func__, vendorid ? vendorid : "unset");
+			return 0;
+		}
+
+	}
+
+	return blazer_claim_light();
+}
+
+/* Subdriver-specific initups */
+static void	omron_initups(void)
+{
+	blazer_initups_light(omron_qx2nut);
+}
+
+/* Subdriver interface */
+subdriver_t	omron_subdriver = {
+	OMRON_VERSION,
+	omron_claim,
+	omron_qx2nut,
+	omron_initups,
+	NULL,
+	blazer_makevartable_light,
+	OMRON_ACCEPTED,
+	/* Rejected: the vendor tests the first three characters only, so what
+	 * follows "NAK" on this hardware is unverified - no NAK has ever been
+	 * observed here, and nutdrv_qx compares the whole answer. A wrong guess
+	 * costs nothing: the answer then fails the ordinary length and format
+	 * checks instead, with the same result and a less specific log line. */
+	"NAK\r",
+#ifdef TESTING
+	omron_testing,
+#endif	/* TESTING */
+};

--- a/drivers/nutdrv_qx_omron.c
+++ b/drivers/nutdrv_qx_omron.c
@@ -21,25 +21,27 @@
  * NOTE:
  * This subdriver is the 'q1' subdriver plus the OMRON-specific corrections
  * listed below. It has been tested on a BN150T (USB 0590:00b7) only; other
- * OMRON models are untested. What was exercised on that unit is the reading
- * side: Q1 polling, the capability queries and the extension queries. No
- * instant command has ever been sent to it, so every instant-command byte
- * string below rests on the OMRON 1.00 and 1.02 driver sources alone. Version
+ * OMRON models are untested. Q1 polling, the capability and extension queries,
+ * and shutdown.stop/return/stayoff were exercised on that unit with its output
+ * unloaded. The observed command sequences and acknowledgements matched the
+ * OMRON 1.00 and 1.02 driver sources from which they were derived. Version
  * 1.00 was distributed in the Synology DSM 7.3-86009 GPL sources, and version
- * 1.02 in the QNAP QTS 5.2.3 GPL sources.
+ * 1.02 in the QNAP QTS 5.2.3 GPL sources. Only the direct instant commands were
+ * exercised; the shared shutdown.default, driver.killpower and driver -k paths were not.
  *
  * Differences from 'q1':
  *
  * - The third status bit of the Q1 reply ("Bypass/Boost or Buck Active",
- *   index 2 of the status field) is not published. On a BN150T running on
- *   mains, idle and with nothing connected to its output, that bit reads 1 on
- *   every poll, and 'q1' maps it unconditionally to the BYPASS status - which
- *   in NUT means that protection has been bypassed, i.e. an abnormal state.
+ *   index 2 of the status field) is not published. On stable mains operation,
+ *   including ECO mode, that bit reads 1; it read 0 while on battery, and also
+ *   varied during startup/calibration. 'q1' maps it unconditionally to the
+ *   BYPASS status. In NUT that means protection has been bypassed, i.e. an
+ *   abnormal state.
  *   Neither OMRON driver version evaluates this bit: the block that would
  *   decide between TRIM/BYPASS/BOOST is commented out in its entirety,
  *   identically in the 1.00 and 1.02 sources.
- *   What the bit actually reports on this hardware is unknown - resolving it
- *   needs an observed on-battery event - so nothing is published for it.
+ *   What the bit actually reports on this hardware remains unknown, so nothing
+ *   is published for it.
  *
  * - The instant commands that neither OMRON driver version implements are not
  *   registered: test.battery.start, test.battery.start.deep,
@@ -186,9 +188,11 @@ static int	omron_start_auto(const int on)
  * runs first, exactly as both OMRON sources order it, and its failure aborts
  * the command before anything is sent to power the unit down.
  *
- * NOTE: no shutdown command has ever been sent to this hardware, and the byte
- * strings below have not been confirmed by observation - only by reading the
- * OMRON 1.00 and 1.02 sources. Treat a first real shutdown as an experiment.
+ * The two delay encodings and all three direct shutdown operations have been
+ * confirmed on an unloaded BN150T: An/S.2 and Af/Sf.2 performed 12-second
+ * shutdowns, An/S02 and Af/Sf02 were scheduled and cancelled with C, and every
+ * transaction was acknowledged with "OK". The byte strings were originally
+ * derived from the OMRON 1.00 and 1.02 sources.
  */
 static int	omron_process_command(item_t *item, char *value, const size_t valuelen)
 {
@@ -622,13 +626,14 @@ static item_t	omron_qx2nut[] = {
 
 /* Testing table
  *
- * The query answers are replies captured from BN150T hardware runs. The
- * instant-command answers are synthetic fixtures: no instant command has ever
- * been sent to real hardware, so no instant-command reply has been observed.
- * The OMRON 1.00 and 1.02 drivers accept a reply whose first two bytes are
- * "OK". That is the test omron_command_answer() applies to the shutdown rows
- * and An/Af prologue item alike. "OK\r" is the plain form, while "OKn\r" is
- * a synthetic prefix-acceptance case, not an observed reply.
+ * The query answers are replies captured from BN150T hardware runs. Plain
+ * "OK\r" replies were also observed for An, Af, C, S02, Sf02, S.2 and Sf.2.
+ * The table uses S.5/Sf.5 for the default 30-second delay; those exact command
+ * strings were not sent to hardware, but the same short-delay form was
+ * observed with .2. The OMRON 1.00 and 1.02 drivers accept a reply whose first
+ * two bytes are "OK". That is the test omron_command_answer() applies to the
+ * shutdown rows and An/Af prologue item alike. "OKn\r" remains a synthetic
+ * prefix-acceptance case, not an observed reply.
  *
  * Both delay forms of each shutdown command are listed: ".n" for an
  * ups.delay.shutdown below 60 seconds (the default, 30, gives ".5") and "nn"

--- a/drivers/nutdrv_qx_omron.c
+++ b/drivers/nutdrv_qx_omron.c
@@ -22,9 +22,9 @@
  * This subdriver is the 'q1' subdriver plus the OMRON-specific corrections
  * listed below. It has been tested on a BN150T (USB 0590:00b7) only; other
  * OMRON models are untested. What was exercised on that unit is the reading
- * side: Q1 polling and the capability queries. No instant command has ever
- * been sent to it, so every command string below rests on the vendor source
- * alone.
+ * side: Q1 polling, the capability queries and the extension queries. No
+ * instant command has ever been sent to it, so every instant-command byte
+ * string below rests on the vendor source alone.
  *
  * Differences from 'q1':
  *
@@ -35,10 +35,9 @@
  *   in NUT means that protection has been bypassed, i.e. an abnormal state.
  *   OMRON's own driver deliberately does not evaluate this bit either: the
  *   block that would decide between TRIM/BYPASS/BOOST is commented out in its
- *   entirety, identically in the 1.00 and 1.02 releases of the vendor source,
- *   while every other status bit is handled. What the bit actually reports on
- *   this hardware is unknown - resolving it needs an observed on-battery
- *   event - so nothing is published for it.
+ *   entirety, identically in the 1.00 and 1.02 releases of the vendor source.
+ *   What the bit actually reports on this hardware is unknown - resolving it
+ *   needs an observed on-battery event - so nothing is published for it.
  *
  * - The instant commands that OMRON's own driver does not implement are not
  *   registered: test.battery.start, test.battery.start.deep,
@@ -57,8 +56,9 @@
  * - A command accepted by the UPS is acknowledged with "OK", not with the "ACK"
  *   that the Megatec-derived subdrivers expect.
  *
- * - The claim function additionally requires OMRON's USB vendor ID, see
- *   omron_claim() below.
+ * - Autodetection is restricted to OMRON's USB vendor ID and this protocol is
+ *   tried before command-based probes. An explicit 'protocol = omron' skips
+ *   the vendor-ID check. See omron_claim() below.
  *
  */
 
@@ -78,6 +78,34 @@
  * subdrivers expect "ACK"; OMRON acknowledges with "OK" and its own driver
  * tests it with strncmp(buf, "OK", 2). */
 #define OMRON_ACCEPTED		"OK"
+
+/* Answer preprocess for the instant commands and the An/Af prologue
+ *
+ * The vendor tests exactly the first two bytes of the reply against "OK", for
+ * An/Af and for the shutdown commands alike. nutdrv_qx's instcmd() differs on
+ * both sides of that test: it treats an empty reply as success, which would
+ * report a shutdown as accepted when nothing acknowledged it, and it then
+ * compares the whole extracted reply against 'accepted', which would fail an
+ * acknowledgement the vendor accepts, such as "OKn". Enforce the vendor's
+ * test here, and normalise the answer to the acknowledgement alone so that
+ * the exact compares downstream see the reply they expect. */
+static int	omron_command_answer(item_t *item, const int len)
+{
+	if (len < 2 || strncmp(item->answer, OMRON_ACCEPTED, 2)) {
+		upsdebugx(2, "%s: %s: not acknowledged, answer was [%.*s]",
+			__func__, item->info_type,
+			(int)strcspn(item->answer, "\r"), item->answer);
+		/* A rejection, not a value-conversion failure. Best effort:
+		 * logging between here and instcmd()'s errno test may leave
+		 * another value behind. */
+		errno = 0;
+		return -1;
+	}
+
+	snprintf(item->answer, sizeof(item->answer), "%s\r", OMRON_ACCEPTED);
+
+	return (int)strlen(item->answer);
+}
 
 /* Set the UPS's auto-restart flag ahead of a shutdown command
  *
@@ -108,8 +136,9 @@ static int	omron_start_auto(const int on)
 	 * transaction happens inside the preprocessing of another item, and
 	 * qx_process() stores the reply in whichever item it is handed - it
 	 * must not be the one instcmd() is working on. answer_len 0 and
-	 * leading 0 accept any reply; the OMRON_ACCEPTED test below is the one
-	 * that decides. */
+	 * leading 0 accept any reply; the acknowledgement is enforced by
+	 * omron_command_answer() on this item, the same test the shutdown
+	 * command rows carry. */
 	item_t	prologue = {
 		on ? "ups.start.auto (An)" : "ups.start.auto (Af)",
 		0,	NULL,
@@ -117,24 +146,16 @@ static int	omron_start_auto(const int on)
 		"",	0,	0,
 		"",	0,	0,
 		"%s",	QX_FLAG_NONUT,
-		NULL,	NULL,	NULL
+		NULL,	omron_command_answer,	NULL
 	};
 
-	/* A rejected query is also a -1 here, not an answer to compare against:
-	 * qx_process_answer() matches subdriver->rejected before anything else */
+	/* Everything lands here as a -1: a transfer failure fails qx_process()
+	 * itself, and an empty answer, a NAK and any reply that is not the "OK"
+	 * acknowledgement fail omron_command_answer() */
 	if (qx_process(&prologue, NULL)) {
-		upslogx(LOG_ERR, "%s: [%.*s] failed or was rejected", __func__,
-			(int)strcspn(prologue.command, "\r"), prologue.command);
-		return -1;
-	}
-
-	/* Covers an empty answer too: answer_len is 0, so a zero-length reply
-	 * reaches this point rather than being caught as a short one */
-	if (strcasecmp(prologue.value, OMRON_ACCEPTED)) {
-		upslogx(LOG_ERR, "%s: [%.*s] not acknowledged, answer was [%s]",
+		upslogx(LOG_ERR, "%s: [%.*s] failed or was not acknowledged",
 			__func__,
-			(int)strcspn(prologue.command, "\r"), prologue.command,
-			prologue.value);
+			(int)strcspn(prologue.command, "\r"), prologue.command);
 		return -1;
 	}
 
@@ -216,6 +237,308 @@ static int	omron_process_command(item_t *item, char *value, const size_t valuele
 	return 0;
 }
 
+/* Answer preprocess for ups.serial
+ *
+ * The serial number is the one reply whose characters are unconstrained, so it
+ * is also the one place a rejected query could be published as data: the Q1
+ * rows require a leading '(', the parsed extension rows exclude the letters
+ * of "NAK" by character set or template, but a NAK-plus-padding reply of
+ * sufficient length would pass for a serial number. The core's 'rejected'
+ * test cannot catch that, being a whole-answer compare against one guessed
+ * form. */
+static int	omron_reject_nak(item_t *item, const int len)
+{
+	if (len >= 3 && !strncmp(item->answer, "NAK", 3)) {
+		upsdebugx(2, "%s: %s: query rejected by the UPS",
+			__func__, item->info_type);
+		return -1;
+	}
+
+	return len;
+}
+
+/* Check a whole reply against the characters it may contain
+ *
+ * The core's own guard is skipped for any item with a preprocess, so a reply
+ * of acceptable length that is otherwise corrupt would reach dstate as a
+ * plausible value. Every OMRON extension below that publishes a parsed reading
+ * therefore validates its whole reply before converting any of it: through
+ * this function, against the character set the vendor uses for that command,
+ * except for the UN rows, which match a positional template instead.
+ * ups.serial is the exception: the vendor accepts any character in that reply,
+ * and the only check made here is omron_reject_nak(). */
+static int	omron_check_charset(item_t *item, const char *accept)
+{
+	if (item->value[0] == '\0'
+	||  strspn(item->value, accept) != strlen(item->value)
+	) {
+		upsdebugx(2, "%s: %s: unexpected characters in [%s]",
+			__func__, item->info_type, item->value);
+		return -1;
+	}
+
+	return 0;
+}
+
+/* Parse a whole reply as one decimal number
+ *
+ * The character set is the vendor's for that command, which also keeps
+ * strtod() away from "nan", "inf" and exponent notation; on top of it the
+ * conversion has to consume the entire value and stay in range. */
+static int	omron_strict_decimal(item_t *item, const char *accept, double *reading)
+{
+	char	*end = NULL;
+
+	if (omron_check_charset(item, accept))
+		return -1;
+
+	errno = 0;
+	*reading = strtod(item->value, &end);
+
+	if (end == item->value || *end != '\0' || errno == ERANGE) {
+		upsdebugx(2, "%s: %s: unparsable reading [%s]",
+			__func__, item->info_type, item->value);
+		return -1;
+	}
+
+	return 0;
+}
+
+/* Normalise a signed decimal reading
+ *
+ * TPb answers with an explicit sign, e.g. "+22.5". It is validated as a signed
+ * decimal and republished at one decimal place, which also removes the leading
+ * '+' that no other reading in this table carries. The vendor publishes the
+ * reply as it arrives. */
+static int	omron_process_signed(item_t *item, char *value, const size_t valuelen)
+{
+	double	reading;
+
+	if (omron_strict_decimal(item, "0123456789.+-", &reading))
+		return -1;
+
+	snprintf(value, valuelen, "%.1f", reading);
+
+	return 0;
+}
+
+/* battery.charge out of the Bl ? reply
+ *
+ * Vendor character set for this command: digits only, no sign and no decimal
+ * point. A percentage outside 0..100 is a corrupt reply, not a reading. */
+static int	omron_process_charge(item_t *item, char *value, const size_t valuelen)
+{
+	double	reading;
+
+	if (omron_strict_decimal(item, "0123456789", &reading))
+		return -1;
+
+	if (reading < 0 || reading > 100) {
+		upsdebugx(2, "%s: %s: charge out of range [%s]",
+			__func__, item->info_type, item->value);
+		return -1;
+	}
+
+	snprintf(value, valuelen, "%.1f", reading);
+
+	return 0;
+}
+
+/* output.frequency out of the Lf ? reply
+ *
+ * Vendor character set for this command: digits and '.', so no sign either. */
+static int	omron_process_frequency(item_t *item, char *value, const size_t valuelen)
+{
+	double	reading;
+
+	if (omron_strict_decimal(item, "0123456789.", &reading))
+		return -1;
+
+	snprintf(value, valuelen, "%.1f", reading);
+
+	return 0;
+}
+
+/* The three nominal ratings out of the UN reply
+ *
+ * The value this is handed has already been cut to a from/to window, so it
+ * says nothing about whether the rest of the reply survived. The whole answer
+ * is matched against a positional template first - exact field widths, every
+ * separator and unit in place, nothing after the last one - which is what makes
+ * the fixed offsets safe to use. The nominal battery voltage is published
+ * without the leading zero the vendor prints. */
+static int	omron_process_un(item_t *item, char *value, const size_t valuelen)
+{
+	/* 'd' stands for a digit, everything else is itself */
+	static const char	shape[] = "ddddW/ddddVA/dddV/dddW/dddW";
+	const char		*answer = item->answer;
+	size_t			i;
+
+	for (i = 0; i < sizeof(shape) - 1; i++) {
+
+		if (shape[i] == 'd') {
+			if (answer[i] < '0' || answer[i] > '9')
+				break;
+			continue;
+		}
+
+		if (answer[i] != shape[i])
+			break;
+	}
+
+	if (i < sizeof(shape) - 1
+	||  (answer[i] != '\0' && answer[i] != '\r')
+	) {
+		upsdebugx(2, "%s: %s: reply does not match [%s]: [%s]",
+			__func__, item->info_type, shape, answer);
+		return -1;
+	}
+
+	/* The window is all digits by the check above */
+	snprintf(value, valuelen, "%ld", strtol(item->value, NULL, 10));
+
+	return 0;
+}
+
+/* battery.runtime out of the RTS reply
+ *
+ * RTS answers in whole minutes and NUT wants seconds, so the reply is parsed
+ * strictly and converted here rather than through qx_multiply_m2s(), which
+ * accepts any numeric prefix. */
+static int	omron_process_runtime(item_t *item, char *value, const size_t valuelen)
+{
+	char	*end = NULL;
+	long	minutes;
+
+	if (omron_check_charset(item, "0123456789"))
+		return -1;
+
+	errno = 0;
+	minutes = strtol(item->value, &end, 10);
+
+	if (end == item->value || *end != '\0' || errno == ERANGE
+	||  minutes < 0 || minutes > LONG_MAX / 60
+	) {
+		upsdebugx(2, "%s: %s: unusable runtime [%s]",
+			__func__, item->info_type, item->value);
+		return -1;
+	}
+
+	snprintf(value, valuelen, "%ld", minutes * 60);
+
+	return 0;
+}
+
+/* battery.date out of the BRR reply
+ *
+ * The reply is eight digits, YYYYMMDD. It is checked for being exactly that
+ * and for forming a date that exists, then published as ISO rather than in the
+ * vendor's MM/DD/YY, which drops the century. The variable is QX_FLAG_STATIC,
+ * so a wrong value published once is never refreshed. */
+static int	omron_process_batt_date(item_t *item, char *value, const size_t valuelen)
+{
+	static const int	monthlen[12] = {
+		31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31
+	};
+	const char		*answer = item->value;
+	int			year, month, day, len;
+
+	if (omron_check_charset(item, "0123456789"))
+		return -1;
+
+	if (strlen(answer) != 8) {
+		upsdebugx(2, "%s: %s: expected eight digits, got [%s]",
+			__func__, item->info_type, answer);
+		return -1;
+	}
+
+	year  = (answer[0] - '0') * 1000 + (answer[1] - '0') * 100
+	      + (answer[2] - '0') * 10 + (answer[3] - '0');
+	month = (answer[4] - '0') * 10 + (answer[5] - '0');
+	day   = (answer[6] - '0') * 10 + (answer[7] - '0');
+
+	if (month < 1 || month > 12) {
+		upsdebugx(2, "%s: %s: month out of range in [%s]",
+			__func__, item->info_type, answer);
+		return -1;
+	}
+
+	len = monthlen[month - 1];
+	if (month == 2 && !(year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)))
+		len = 28;
+
+	if (day < 1 || day > len) {
+		upsdebugx(2, "%s: %s: day out of range in [%s]",
+			__func__, item->info_type, answer);
+		return -1;
+	}
+
+	snprintf(value, valuelen, "%04d-%02d-%02d", year, month, day);
+
+	return 0;
+}
+
+/* ups.firmware, and ups.firmware.aux alongside it, out of the FWV reply
+ *
+ * The reply is two delimited versions, "M:0.17(S:2.00)". The auxiliary one is
+ * published from here rather than from a row of its own because the fields are
+ * delimited rather than at fixed offsets. Neither is published until both
+ * parse: the variable is QX_FLAG_STATIC, so a wrong value published once would
+ * never be refreshed. */
+static int	omron_process_firmware(item_t *item, char *value, const size_t valuelen)
+{
+	const char	*answer = item->value;
+	const char	*open, *close;
+	char		*end = NULL;
+	double		main_version, aux_version;
+
+	if (omron_check_charset(item, "0123456789MS.:() "))
+		return -1;
+
+	open = strchr(answer, '(');
+	close = strchr(answer, ')');
+
+	/* Both tags are checked, not just the shape, so that the two versions
+	 * cannot be published the wrong way round. Only spaces are tolerated
+	 * after the closing bracket. */
+	if (open == NULL || close == NULL || close < open + 4 || open < answer + 3
+	||  strncmp(answer, "M:", 2) != 0
+	||  open[1] != 'S' || open[2] != ':'
+	||  strchr(open + 1, '(') != NULL
+	||  strchr(close + 1, ')') != NULL
+	||  strspn(close + 1, " ") != strlen(close + 1)
+	) {
+		upsdebugx(2, "%s: %s: unexpected shape [%s]",
+			__func__, item->info_type, answer);
+		return -1;
+	}
+
+	/* Both versions start two characters into their half, past a "M:"/"S:"
+	 * style tag, and have to run up to their delimiter with nothing left */
+	errno = 0;
+	main_version = strtod(answer + 2, &end);
+
+	if (end != open || errno == ERANGE) {
+		upsdebugx(2, "%s: %s: unparsable main version in [%s]",
+			__func__, item->info_type, answer);
+		return -1;
+	}
+
+	errno = 0;
+	aux_version = strtod(open + 3, &end);
+
+	if (end != close || errno == ERANGE) {
+		upsdebugx(2, "%s: %s: unparsable auxiliary version in [%s]",
+			__func__, item->info_type, answer);
+		return -1;
+	}
+
+	snprintf(value, valuelen, "%.2f", main_version);
+	dstate_setinfo("ups.firmware.aux", "%.2f", aux_version);
+
+	return 0;
+}
+
 /* qx2nut lookup table */
 static item_t	omron_qx2nut[] = {
 
@@ -235,19 +558,56 @@ static item_t	omron_qx2nut[] = {
 	{ "ups.temperature",		0,	NULL,	"Q1\r",	"",	47,	'(',	"",	33,	36,	"%.1f",	0,	NULL,	NULL,	NULL },
 	/* Status bits.
 	 * Index 2 of the status field ("Bypass/Boost or Buck Active") is
-	 * intentionally absent, see the note at the top of this file. */
+	 * intentionally absent, see the note at the top of this file. So is
+	 * index 7, which 'q1' publishes as ups.beeper.status: OMRON's own
+	 * parser never reads that character, and takes the beeper state from
+	 * a different query, in which '0' means enabled - while
+	 * blazer_process_status_bits() maps an index-7 '0' to disabled. */
 	{ "ups.status",			0,	NULL,	"Q1\r",	"",	47,	'(',	"",	38,	38,	NULL,	QX_FLAG_QUICK_POLL,	NULL,	NULL,	blazer_process_status_bits },	/* Utility Fail (Immediate) */
 	{ "ups.status",			0,	NULL,	"Q1\r",	"",	47,	'(',	"",	39,	39,	NULL,	QX_FLAG_QUICK_POLL,	NULL,	NULL,	blazer_process_status_bits },	/* Battery Low */
 	{ "ups.alarm",			0,	NULL,	"Q1\r",	"",	47,	'(',	"",	41,	41,	NULL,	0,			NULL,	NULL,	blazer_process_status_bits },	/* UPS Failed */
 	{ "ups.type",			0,	NULL,	"Q1\r",	"",	47,	'(',	"",	42,	42,	"%s",	QX_FLAG_STATIC,		NULL,	NULL,	blazer_process_status_bits },	/* UPS Type */
 	{ "ups.status",			0,	NULL,	"Q1\r",	"",	47,	'(',	"",	43,	43,	NULL,	QX_FLAG_QUICK_POLL,	NULL,	NULL,	blazer_process_status_bits },	/* Test in Progress */
 	{ "ups.status",			0,	NULL,	"Q1\r",	"",	47,	'(',	"",	44,	44,	NULL,	QX_FLAG_QUICK_POLL,	NULL,	NULL,	blazer_process_status_bits },	/* Shutdown Active */
-	{ "ups.beeper.status",		0,	NULL,	"Q1\r",	"",	47,	'(',	"",	45,	45,	"%s",	0,			NULL,	NULL,	blazer_process_status_bits },	/* Beeper status */
+
+	/* OMRON extensions
+	 *
+	 * Commands and reply lengths are the vendor's own. Its lengths are
+	 * minimums, not the exact lengths this hardware returns.
+	 *
+	 * All eight read commands, the shape of their replies and the values this
+	 * table publishes from them have been exercised on a BN150T. The reply
+	 * validation is the exception: this hardware has never returned a
+	 * malformed reply, so only the accepting side of it has ever run.
+	 *
+	 * None carries QX_FLAG_QUICK_POLL: a QUICK_POLL item that fails aborts
+	 * qx_ups_walk() before QX_FLAG_SKIP can be set, which during
+	 * initialisation stops the driver from starting at all. */
+	{ "battery.charge",		0,	NULL,	"Bl ?\r",	"",	4,	0,	"",	0,	0,	"%.1f",	0,			NULL,	NULL,	omron_process_charge },
+	{ "battery.runtime",		0,	NULL,	"RTS\r",	"",	4,	0,	"",	0,	0,	"%.0f",	0,			NULL,	NULL,	omron_process_runtime },
+	{ "battery.temperature",	0,	NULL,	"TPb\r",	"",	5,	0,	"",	0,	0,	"%s",	0,			NULL,	NULL,	omron_process_signed },
+	{ "output.frequency",		0,	NULL,	"Lf ?\r",	"",	4,	0,	"",	0,	0,	"%.1f",	0,			NULL,	NULL,	omron_process_frequency },
+	{ "ups.serial",			0,	NULL,	"PSNR\r",	"",	17,	0,	"",	0,	0,	"%s",	QX_FLAG_STATIC | QX_FLAG_TRIM,	NULL,	omron_reject_nak,	NULL },	/* Trim '#' and space padding */
+	{ "ups.firmware",		0,	NULL,	"FWV\r",	"",	15,	0,	"",	0,	0,	"%s",	QX_FLAG_STATIC,		NULL,	NULL,	omron_process_firmware },
+	{ "battery.date",		0,	NULL,	"BRR\r",	"",	9,	0,	"",	0,	0,	"%s",	QX_FLAG_STATIC,		NULL,	NULL,	omron_process_batt_date },
+	/*
+	 * > [UN\r]
+	 * < [1125W/1125VA/048V/160W/020W\r]
+	 *    0123456789012345678901234567
+	 *    0         1         2
+	 * Keep these three adjacent: qx_ups_walk() reuses the previous item's
+	 * answer when the command matches, so one transfer serves all three.
+	 * OMRON 1.00 and 1.02 publish the first two fields as current power;
+	 * use nominal NUT variables here because UN reports the UPS ratings.
+	 */
+	{ "ups.realpower.nominal",	0,	NULL,	"UN\r",		"",	27,	0,	"",	0,	3,	"%.0f",	QX_FLAG_STATIC,		NULL,	NULL,	omron_process_un },
+	{ "ups.power.nominal",		0,	NULL,	"UN\r",		"",	27,	0,	"",	6,	9,	"%.0f",	QX_FLAG_STATIC,		NULL,	NULL,	omron_process_un },
+	{ "battery.voltage.nominal",	0,	NULL,	"UN\r",		"",	27,	0,	"",	13,	15,	"%.0f",	QX_FLAG_STATIC,		NULL,	NULL,	omron_process_un },
 
 	/* Instant commands */
-	{ "shutdown.return",		0,	NULL,	"S%s\r",	"",	0,	0,	"",	0,	0,	NULL,	QX_FLAG_CMD,	NULL,	NULL,	omron_process_command },
-	{ "shutdown.stayoff",		0,	NULL,	"Sf%s\r",	"",	0,	0,	"",	0,	0,	NULL,	QX_FLAG_CMD,	NULL,	NULL,	omron_process_command },
-	{ "shutdown.stop",		0,	NULL,	"C\r",		"",	0,	0,	"",	0,	0,	NULL,	QX_FLAG_CMD,	NULL,	NULL,	NULL },
+	{ "shutdown.return",		0,	NULL,	"S%s\r",	"",	0,	0,	"",	0,	0,	NULL,	QX_FLAG_CMD,	NULL,	omron_command_answer,	omron_process_command },
+	{ "shutdown.stayoff",		0,	NULL,	"Sf%s\r",	"",	0,	0,	"",	0,	0,	NULL,	QX_FLAG_CMD,	NULL,	omron_command_answer,	omron_process_command },
+	{ "shutdown.stop",		0,	NULL,	"C\r",		"",	0,	0,	"",	0,	0,	NULL,	QX_FLAG_CMD,	NULL,	omron_command_answer,	NULL },
 
 	/* Server-side settable vars */
 	{ "ups.delay.start",		ST_FLAG_RW,	blazer_r_ondelay,	NULL,	"",	0,	0,	"",	0,	0,	DEFAULT_ONDELAY,	QX_FLAG_ABSENT | QX_FLAG_SETVAR | QX_FLAG_RANGE,	NULL,	NULL,	blazer_process_setvar },
@@ -259,10 +619,14 @@ static item_t	omron_qx2nut[] = {
 
 /* Testing table
  *
- * The Q1 answer is a reply captured from a BN150T, not a hand-written one.
- * The command answers are "OK\r" because that is what OMRON acknowledges with;
- * an empty answer here would pass regardless of the 'accepted' string, since
- * nutdrv_qx's instcmd() treats "no reply" as success.
+ * The query answers are replies captured from BN150T hardware runs. The
+ * instant-command answers are synthetic fixtures: no instant command has ever
+ * been sent to real hardware, so no instant-command reply has ever been
+ * observed. The vendor drivers accept a reply whose first two bytes are "OK",
+ * which is the test omron_command_answer() applies for the shutdown command
+ * rows and the An/Af prologue item alike; "OK\r" is the plain form of that,
+ * and the "OKn\r" entry is a synthetic prefix-acceptance case, not an observed
+ * reply.
  *
  * Both delay forms of each shutdown command are listed: ".n" for an
  * ups.delay.shutdown below 60 seconds (the default, 30, gives ".5") and "nn"
@@ -272,10 +636,18 @@ static item_t	omron_qx2nut[] = {
 #ifdef TESTING
 static testing_t	omron_testing[] = {
 	{ "Q1\r",	"(102.5 000.0 102.4 000 49.9 54.5 22.7 00101000\r",	-1 },
+	{ "Bl ?\r",	"100\r",	-1 },
+	{ "RTS\r",	"0699\r",	-1 },
+	{ "TPb\r",	"+22.5\r",	-1 },
+	{ "Lf ?\r",	"49.9\r",	-1 },
+	{ "PSNR\r",	"A0Z25110005109G \r",	-1 },
+	{ "FWV\r",	"M:0.17(S:2.00)\r",	-1 },
+	{ "BRR\r",	"20260730\r",	-1 },
+	{ "UN\r",	"1125W/1125VA/048V/160W/020W\r",	-1 },
 	{ "An\r",	"OK\r",	-1 },
 	{ "Af\r",	"OK\r",	-1 },
 	{ "S.5\r",	"OK\r",	-1 },
-	{ "S02\r",	"OK\r",	-1 },
+	{ "S02\r",	"OKn\r",	-1 },
 	{ "Sf.5\r",	"OK\r",	-1 },
 	{ "Sf02\r",	"OK\r",	-1 },
 	{ "C\r",	"OK\r",	-1 },
@@ -289,10 +661,12 @@ static testing_t	omron_testing[] = {
  * protocol check is exactly as permissive as 'q1''s and would otherwise claim
  * every device that the generic 'q1' fallback is meant to serve. Restrict
  * auto-detection to OMRON's USB vendor ID, which nutdrv_qx's upsdrv_initups()
- * publishes as 'ups.vendorid' before subdriver_matcher() runs. A user who
- * names this protocol explicitly gets it either way: subdriver_matcher() skips
- * every other subdriver before calling its claim, so reaching this function
- * with 'protocol' set means it was set to ours. */
+ * publishes as 'ups.vendorid' before subdriver_matcher() runs. The OMRON entry
+ * precedes command-based protocol probes: non-OMRON devices are rejected here
+ * without a transfer, while a known OMRON device goes directly to the Q1
+ * check. A user who names this protocol explicitly gets it either way:
+ * subdriver_matcher() skips every other subdriver before calling its claim, so
+ * reaching this function with 'protocol' set means it was set to ours. */
 static int	omron_claim(void)
 {
 	if (!getval("protocol")) {
@@ -325,11 +699,11 @@ subdriver_t	omron_subdriver = {
 	NULL,
 	blazer_makevartable_light,
 	OMRON_ACCEPTED,
-	/* Rejected: the vendor tests the first three characters only, so what
-	 * follows "NAK" on this hardware is unverified - no NAK has ever been
-	 * observed here, and nutdrv_qx compares the whole answer. A wrong guess
-	 * costs nothing: the answer then fails the ordinary length and format
-	 * checks instead, with the same result and a less specific log line. */
+	/* Rejected: no NAK has ever been observed from this hardware, and the
+	 * vendor tests the first three characters only, so the exact form
+	 * guessed here is unverified while nutdrv_qx compares the whole answer.
+	 * The places where a wrong guess could matter carry a prefix test of
+	 * their own: omron_reject_nak() and omron_command_answer(). */
 	"NAK\r",
 #ifdef TESTING
 	omron_testing,

--- a/drivers/nutdrv_qx_omron.c
+++ b/drivers/nutdrv_qx_omron.c
@@ -24,7 +24,9 @@
  * OMRON models are untested. What was exercised on that unit is the reading
  * side: Q1 polling, the capability queries and the extension queries. No
  * instant command has ever been sent to it, so every instant-command byte
- * string below rests on the vendor source alone.
+ * string below rests on the OMRON 1.00 and 1.02 driver sources alone. Version
+ * 1.00 was distributed in the Synology DSM 7.3-86009 GPL sources, and version
+ * 1.02 in the QNAP QTS 5.2.3 GPL sources.
  *
  * Differences from 'q1':
  *
@@ -33,25 +35,26 @@
  *   mains, idle and with nothing connected to its output, that bit reads 1 on
  *   every poll, and 'q1' maps it unconditionally to the BYPASS status - which
  *   in NUT means that protection has been bypassed, i.e. an abnormal state.
- *   OMRON's own driver deliberately does not evaluate this bit either: the
- *   block that would decide between TRIM/BYPASS/BOOST is commented out in its
- *   entirety, identically in the 1.00 and 1.02 releases of the vendor source.
+ *   Neither OMRON driver version evaluates this bit: the block that would
+ *   decide between TRIM/BYPASS/BOOST is commented out in its entirety,
+ *   identically in the 1.00 and 1.02 sources.
  *   What the bit actually reports on this hardware is unknown - resolving it
  *   needs an observed on-battery event - so nothing is published for it.
  *
- * - The instant commands that OMRON's own driver does not implement are not
+ * - The instant commands that neither OMRON driver version implements are not
  *   registered: test.battery.start, test.battery.start.deep,
- *   test.battery.start.quick and test.battery.stop (the vendor source has no
- *   T or TL command at all), load.on, load.off, and beeper.toggle (no Q
- *   command; the vendor uses Bn/Bf to enable/disable the beeper instead).
+ *   test.battery.start.quick and test.battery.stop (neither source has a T or
+ *   TL command), load.on, load.off, and beeper.toggle (no Q command; both
+ *   sources use Bn/Bf to enable/disable the beeper instead).
  *   Registering an instant command publishes it to NUT clients as something
  *   the device can perform, so listing commands that may not exist is a defect
  *   in its own right.
  *
- * - The shutdown commands use OMRON's own byte strings rather than the Megatec
- *   ones, and shutdown.return / shutdown.stayoff are two transactions, not one:
- *   the auto-restart flag is set first and its failure aborts the command. See
- *   omron_start_auto() and omron_process_command() below.
+ * - The shutdown commands use the byte strings implemented by the OMRON 1.00
+ *   and 1.02 drivers rather than the Megatec ones. shutdown.return and
+ *   shutdown.stayoff are two transactions, not one: the auto-restart flag is
+ *   set first and its failure aborts the command. See omron_start_auto() and
+ *   omron_process_command() below.
  *
  * - A command accepted by the UPS is acknowledged with "OK", not with the "ACK"
  *   that the Megatec-derived subdrivers expect.
@@ -75,20 +78,20 @@
 #define OMRON_USB_VENDORID	"0590"
 
 /* What the UPS answers to a command it accepted. The Megatec-derived
- * subdrivers expect "ACK"; OMRON acknowledges with "OK" and its own driver
- * tests it with strncmp(buf, "OK", 2). */
+ * subdrivers expect "ACK"; OMRON acknowledges with "OK", and driver versions
+ * 1.00 and 1.02 both test it with strncmp(buf, "OK", 2). */
 #define OMRON_ACCEPTED		"OK"
 
 /* Answer preprocess for the instant commands and the An/Af prologue
  *
- * The vendor tests exactly the first two bytes of the reply against "OK", for
- * An/Af and for the shutdown commands alike. nutdrv_qx's instcmd() differs on
- * both sides of that test: it treats an empty reply as success, which would
- * report a shutdown as accepted when nothing acknowledged it, and it then
- * compares the whole extracted reply against 'accepted', which would fail an
- * acknowledgement the vendor accepts, such as "OKn". Enforce the vendor's
- * test here, and normalise the answer to the acknowledgement alone so that
- * the exact compares downstream see the reply they expect. */
+ * Both OMRON sources test exactly the first two bytes of the reply against
+ * "OK", for An/Af and for the shutdown commands alike. nutdrv_qx's instcmd()
+ * differs on both sides of that test: it treats an empty reply as success,
+ * which would report a shutdown as accepted when nothing acknowledged it, and
+ * it then compares the whole extracted reply against "accepted", which would
+ * fail an acknowledgement both OMRON sources accept, such as "OKn". Enforce
+ * that shared test here, and normalise the answer to the acknowledgement alone
+ * so that the exact compares downstream see the reply they expect. */
 static int	omron_command_answer(item_t *item, const int len)
 {
 	if (len < 2 || strncmp(item->answer, OMRON_ACCEPTED, 2)) {
@@ -107,29 +110,29 @@ static int	omron_command_answer(item_t *item, const int len)
 	return (int)strlen(item->answer);
 }
 
-/* Set the UPS's auto-restart flag ahead of a shutdown command
+/* Set the UPS auto-restart flag ahead of a shutdown command
  *
- * "An" enables restarting when mains returns, "Af" disables it. The vendor
- * driver sends the matching one *before* the shutdown command itself, and
- * abandons the instant command if the UPS answers it with anything other than
- * "OK"; identical code in both releases. Without it, shutdown.return can leave
- * a unit whose auto-restart flag happens to be off dead after mains returns.
+ * "An" enables restarting when mains returns, "Af" disables it. Both OMRON
+ * driver versions send the matching one *before* the shutdown command itself,
+ * and abandon the instant command if the UPS answers with anything other than
+ * "OK". Without it, shutdown.return can leave a unit whose auto-restart flag
+ * happens to be off dead after mains returns.
  *
- * This is also NUT's documented convention, not just OMRON's: docs/nut-names.txt
- * states that shutdown commands set ups.start.auto to the matching value first.
- * nutdrv_qx implements that in the instcmd() fallback path, but the fallback
- * only runs for commands *absent* from the subdriver table, so a subdriver that
- * registers shutdown.return itself has to do this for itself.
+ * This is also the documented NUT convention: docs/nut-names.txt states that
+ * shutdown commands set ups.start.auto to the matching value first. nutdrv_qx
+ * implements that in the instcmd() fallback path, but the fallback only runs
+ * for commands *absent* from the subdriver table, so a subdriver that registers
+ * shutdown.return itself has to do this for itself.
  *
- * Divergence from the vendor, deliberate. The vendor has three outcomes: it
- * skips the prologue entirely when its CF capability bitmap says the command
- * is unsupported; it abandons the shutdown on an explicit non-"OK" answer; and
- * it proceeds to shut down anyway when the transfer itself fails or nothing
- * comes back, because the guard around the reply test has no else branch.
- * This driver has no CF gating, and it abandons the shutdown in all three of
- * transfer failure, no answer, and non-"OK" answer. A shutdown that did not
- * happen is visible in the logs and reversible; a shutdown whose auto-restart
- * state is unknown may need someone at the front panel. */
+ * This implementation deliberately diverges from both OMRON sources. Their
+ * shared implementation has three outcomes: it skips the prologue when its CF
+ * capability bitmap says the command is unsupported; it abandons the shutdown
+ * on an explicit non-"OK" answer; and it proceeds to shut down when the
+ * transfer itself fails or nothing comes back, because the guard around the
+ * reply test has no else branch. This driver has no CF gating and abandons the
+ * shutdown in all three cases. A shutdown that did not happen is visible in
+ * the logs and reversible; a shutdown whose auto-restart state is unknown may
+ * need someone at the front panel. */
 static int	omron_start_auto(const int on)
 {
 	/* A throwaway item, deliberately not a row of omron_qx2nut[]: this
@@ -174,18 +177,18 @@ static int	omron_start_auto(const int on)
  * both, and appends the R field as soon as ups.delay.start is non-zero, which
  * it is by default - hence this replacement rather than a reuse of it.
  *
- * Mirrors on_shutdown_return() and on_shutdown_stayoff() of the vendor driver,
- * which are identical in the 1.00 and 1.02 releases. ups.delay.start has no
+ * Mirrors on_shutdown_return() and on_shutdown_stayoff() in the OMRON 1.00 and
+ * 1.02 sources; their implementations are identical. ups.delay.start has no
  * effect on these commands; it stays in the table because upsdrv_shutdown()
  * looks it up before dispatching.
  *
  * The two-command shutdown sequence lives here as well: omron_start_auto()
- * runs first, exactly as the vendor orders it, and its failure aborts the
- * command before anything is sent to power the unit down.
+ * runs first, exactly as both OMRON sources order it, and its failure aborts
+ * the command before anything is sent to power the unit down.
  *
- * NOTE: no shutdown command has ever been sent to this hardware, and the
- * byte strings below have not been confirmed by observation - only by reading
- * the vendor source. Treat a first real shutdown as an experiment.
+ * NOTE: no shutdown command has ever been sent to this hardware, and the byte
+ * strings below have not been confirmed by observation - only by reading the
+ * OMRON 1.00 and 1.02 sources. Treat a first real shutdown as an experiment.
  */
 static int	omron_process_command(item_t *item, char *value, const size_t valuelen)
 {
@@ -259,14 +262,14 @@ static int	omron_reject_nak(item_t *item, const int len)
 
 /* Check a whole reply against the characters it may contain
  *
- * The core's own guard is skipped for any item with a preprocess, so a reply
- * of acceptable length that is otherwise corrupt would reach dstate as a
- * plausible value. Every OMRON extension below that publishes a parsed reading
- * therefore validates its whole reply before converting any of it: through
- * this function, against the character set the vendor uses for that command,
- * except for the UN rows, which match a positional template instead.
- * ups.serial is the exception: the vendor accepts any character in that reply,
- * and the only check made here is omron_reject_nak(). */
+ * The core guard is skipped for any item with a preprocess, so a reply of
+ * acceptable length that is otherwise corrupt would reach dstate as a plausible
+ * value. Every OMRON extension below that publishes a parsed reading therefore
+ * validates its whole reply before converting it. This function uses the
+ * character set defined for that command in the corresponding OMRON source;
+ * the UN rows instead match a positional template. ups.serial is the exception:
+ * both OMRON sources accept any character in that reply, so its only check here
+ * is omron_reject_nak(). */
 static int	omron_check_charset(item_t *item, const char *accept)
 {
 	if (item->value[0] == '\0'
@@ -282,9 +285,9 @@ static int	omron_check_charset(item_t *item, const char *accept)
 
 /* Parse a whole reply as one decimal number
  *
- * The character set is the vendor's for that command, which also keeps
- * strtod() away from "nan", "inf" and exponent notation; on top of it the
- * conversion has to consume the entire value and stay in range. */
+ * The OMRON-source character set for each command also keeps strtod() away from
+ * "nan", "inf" and exponent notation. The conversion must additionally consume
+ * the entire value and stay in range. */
 static int	omron_strict_decimal(item_t *item, const char *accept, double *reading)
 {
 	char	*end = NULL;
@@ -308,8 +311,8 @@ static int	omron_strict_decimal(item_t *item, const char *accept, double *readin
  *
  * TPb answers with an explicit sign, e.g. "+22.5". It is validated as a signed
  * decimal and republished at one decimal place, which also removes the leading
- * '+' that no other reading in this table carries. The vendor publishes the
- * reply as it arrives. */
+ * "+" that no other reading in this table carries. Both OMRON sources publish
+ * the reply as it arrives. */
 static int	omron_process_signed(item_t *item, char *value, const size_t valuelen)
 {
 	double	reading;
@@ -324,8 +327,8 @@ static int	omron_process_signed(item_t *item, char *value, const size_t valuelen
 
 /* battery.charge out of the Bl ? reply
  *
- * Vendor character set for this command: digits only, no sign and no decimal
- * point. A percentage outside 0..100 is a corrupt reply, not a reading. */
+ * The OMRON-source character set for this command allows digits only, with no
+ * sign or decimal point. A value outside 0..100 is corrupt, not a reading. */
 static int	omron_process_charge(item_t *item, char *value, const size_t valuelen)
 {
 	double	reading;
@@ -346,7 +349,7 @@ static int	omron_process_charge(item_t *item, char *value, const size_t valuelen
 
 /* output.frequency out of the Lf ? reply
  *
- * Vendor character set for this command: digits and '.', so no sign either. */
+ * The OMRON-source character set allows digits and ".", with no sign. */
 static int	omron_process_frequency(item_t *item, char *value, const size_t valuelen)
 {
 	double	reading;
@@ -366,7 +369,7 @@ static int	omron_process_frequency(item_t *item, char *value, const size_t value
  * is matched against a positional template first - exact field widths, every
  * separator and unit in place, nothing after the last one - which is what makes
  * the fixed offsets safe to use. The nominal battery voltage is published
- * without the leading zero the vendor prints. */
+ * without the leading zero the OMRON sources print. */
 static int	omron_process_un(item_t *item, char *value, const size_t valuelen)
 {
 	/* 'd' stands for a digit, everything else is itself */
@@ -431,10 +434,10 @@ static int	omron_process_runtime(item_t *item, char *value, const size_t valuele
 
 /* battery.date out of the BRR reply
  *
- * The reply is eight digits, YYYYMMDD. It is checked for being exactly that
- * and for forming a date that exists, then published as ISO rather than in the
- * vendor's MM/DD/YY, which drops the century. The variable is QX_FLAG_STATIC,
- * so a wrong value published once is never refreshed. */
+ * The reply is eight digits, YYYYMMDD. It is checked for being exactly that and
+ * for forming a date that exists, then published as ISO rather than the
+ * MM/DD/YY form used by the OMRON sources, which drops the century. The variable
+ * is QX_FLAG_STATIC, so a wrong value published once is never refreshed. */
 static int	omron_process_batt_date(item_t *item, char *value, const size_t valuelen)
 {
 	static const int	monthlen[12] = {
@@ -572,8 +575,8 @@ static item_t	omron_qx2nut[] = {
 
 	/* OMRON extensions
 	 *
-	 * Commands and reply lengths are the vendor's own. Its lengths are
-	 * minimums, not the exact lengths this hardware returns.
+	 * Commands and reply lengths come from the corresponding OMRON source. The
+	 * specified lengths are minimums, not exact hardware reply lengths.
 	 *
 	 * All eight read commands, the shape of their replies and the values this
 	 * table publishes from them have been exercised on a BN150T. The reply
@@ -621,12 +624,11 @@ static item_t	omron_qx2nut[] = {
  *
  * The query answers are replies captured from BN150T hardware runs. The
  * instant-command answers are synthetic fixtures: no instant command has ever
- * been sent to real hardware, so no instant-command reply has ever been
- * observed. The vendor drivers accept a reply whose first two bytes are "OK",
- * which is the test omron_command_answer() applies for the shutdown command
- * rows and the An/Af prologue item alike; "OK\r" is the plain form of that,
- * and the "OKn\r" entry is a synthetic prefix-acceptance case, not an observed
- * reply.
+ * been sent to real hardware, so no instant-command reply has been observed.
+ * The OMRON 1.00 and 1.02 drivers accept a reply whose first two bytes are
+ * "OK". That is the test omron_command_answer() applies to the shutdown rows
+ * and An/Af prologue item alike. "OK\r" is the plain form, while "OKn\r" is
+ * a synthetic prefix-acceptance case, not an observed reply.
  *
  * Both delay forms of each shutdown command are listed: ".n" for an
  * ups.delay.shutdown below 60 seconds (the default, 30, gives ".5") and "nn"
@@ -699,11 +701,11 @@ subdriver_t	omron_subdriver = {
 	NULL,
 	blazer_makevartable_light,
 	OMRON_ACCEPTED,
-	/* Rejected: no NAK has ever been observed from this hardware, and the
-	 * vendor tests the first three characters only, so the exact form
-	 * guessed here is unverified while nutdrv_qx compares the whole answer.
-	 * The places where a wrong guess could matter carry a prefix test of
-	 * their own: omron_reject_nak() and omron_command_answer(). */
+	/* Rejected: no NAK has ever been observed from this hardware. Both OMRON
+	 * sources test only the first three characters, so the exact form guessed
+	 * here is unverified while nutdrv_qx compares the whole answer. The places
+	 * where a wrong guess could matter carry their own prefix test:
+	 * omron_reject_nak() and omron_command_answer(). */
 	"NAK\r",
 #ifdef TESTING
 	omron_testing,

--- a/drivers/nutdrv_qx_omron.c
+++ b/drivers/nutdrv_qx_omron.c
@@ -19,24 +19,25 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  *
  * NOTE:
- * This subdriver is the 'q1' subdriver plus the OMRON-specific corrections
+ * This subdriver extends 'q1' with the OMRON-specific corrections
  * listed below. It has been tested on a BN150T (USB 0590:00b7) only; other
  * OMRON models are untested. Q1 polling, the capability and extension queries,
  * and shutdown.stop/return/stayoff were exercised on that unit with its output
  * unloaded. The observed command sequences and acknowledgements matched the
  * OMRON 1.00 and 1.02 driver sources from which they were derived. Version
  * 1.00 was distributed in the Synology DSM 7.3-86009 GPL sources, and version
- * 1.02 in the QNAP QTS 5.2.3 GPL sources. Only the direct instant commands were
- * exercised; the shared shutdown.default, driver.killpower and driver -k paths were not.
+ * 1.02 in the QNAP QTS 5.2.3 GPL sources. Only the direct instant commands
+ * were exercised; the shared shutdown.default and driver.killpower commands
+ * and the driver's -k path were not.
  *
  * Differences from 'q1':
  *
  * - The third status bit of the Q1 reply ("Bypass/Boost or Buck Active",
- *   index 2 of the status field) is not published. On stable mains operation,
- *   including ECO mode, that bit reads 1; it read 0 while on battery, and also
- *   varied during startup/calibration. 'q1' maps it unconditionally to the
- *   BYPASS status. In NUT that means protection has been bypassed, i.e. an
- *   abnormal state.
+ *   index 2 of the status field) is not published. During stable operation on
+ *   mains in both normal and ECO modes, that bit was 1; it was 0 while on
+ *   battery and also varied during startup/calibration. 'q1' maps it
+ *   unconditionally to the BYPASS status. In NUT that means protection has
+ *   been bypassed, i.e. an abnormal state.
  *   Neither OMRON driver version evaluates this bit: the block that would
  *   decide between TRIM/BYPASS/BOOST is commented out in its entirety,
  *   identically in the 1.00 and 1.02 sources.
@@ -79,21 +80,20 @@
  * Keep in sync with OMRON_VENDORID in nutdrv_qx.c */
 #define OMRON_USB_VENDORID	"0590"
 
-/* What the UPS answers to a command it accepted. The Megatec-derived
+/* Accepted-command acknowledgement. The Megatec-derived
  * subdrivers expect "ACK"; OMRON acknowledges with "OK", and driver versions
  * 1.00 and 1.02 both test it with strncmp(buf, "OK", 2). */
 #define OMRON_ACCEPTED		"OK"
 
 /* Answer preprocess for the instant commands and the An/Af prologue
  *
- * Both OMRON sources test exactly the first two bytes of the reply against
- * "OK", for An/Af and for the shutdown commands alike. nutdrv_qx's instcmd()
- * differs on both sides of that test: it treats an empty reply as success,
- * which would report a shutdown as accepted when nothing acknowledged it, and
- * it then compares the whole extracted reply against "accepted", which would
- * fail an acknowledgement both OMRON sources accept, such as "OKn". Enforce
- * that shared test here, and normalise the answer to the acknowledgement alone
- * so that the exact compares downstream see the reply they expect. */
+ * Both OMRON sources accept replies whose first two bytes are "OK", for An/Af
+ * and the shutdown commands alike. nutdrv_qx's instcmd() instead treats an
+ * empty reply as success and otherwise compares the complete extracted reply
+ * with "accepted". The former would report an unacknowledged shutdown as
+ * accepted, while the latter would reject a reply accepted by both OMRON
+ * sources, such as "OKn". Enforce the OMRON test here and normalise the answer
+ * so that downstream exact comparisons see the expected acknowledgement. */
 static int	omron_command_answer(item_t *item, const int len)
 {
 	if (len < 2 || strncmp(item->answer, OMRON_ACCEPTED, 2)) {
@@ -117,14 +117,14 @@ static int	omron_command_answer(item_t *item, const int len)
  * "An" enables restarting when mains returns, "Af" disables it. Both OMRON
  * driver versions send the matching one *before* the shutdown command itself,
  * and abandon the instant command if the UPS answers with anything other than
- * "OK". Without it, shutdown.return can leave a unit whose auto-restart flag
- * happens to be off dead after mains returns.
+ * "OK". Without it, shutdown.return may leave the unit powered off after mains
+ * returns if auto-restart is disabled.
  *
  * This is also the documented NUT convention: docs/nut-names.txt states that
  * shutdown commands set ups.start.auto to the matching value first. nutdrv_qx
  * implements that in the instcmd() fallback path, but the fallback only runs
  * for commands *absent* from the subdriver table, so a subdriver that registers
- * shutdown.return itself has to do this for itself.
+ * shutdown.return must set it explicitly.
  *
  * This implementation deliberately diverges from both OMRON sources. Their
  * shared implementation has three outcomes: it skips the prologue when its CF
@@ -137,13 +137,12 @@ static int	omron_command_answer(item_t *item, const int len)
  * need someone at the front panel. */
 static int	omron_start_auto(const int on)
 {
-	/* A throwaway item, deliberately not a row of omron_qx2nut[]: this
-	 * transaction happens inside the preprocessing of another item, and
-	 * qx_process() stores the reply in whichever item it is handed - it
-	 * must not be the one instcmd() is working on. answer_len 0 and
-	 * leading 0 accept any reply; the acknowledgement is enforced by
-	 * omron_command_answer() on this item, the same test the shutdown
-	 * command rows carry. */
+	/* A temporary item, deliberately not a row of omron_qx2nut[]: this
+	 * transaction happens while another item is being preprocessed.
+	 * qx_process() stores the reply in the item passed to it, so using the
+	 * item handled by instcmd() would overwrite that item. Setting answer_len
+	 * and leading to 0 accepts any reply; omron_command_answer() then enforces
+	 * the same acknowledgement test used by the shutdown command rows. */
 	item_t	prologue = {
 		on ? "ups.start.auto (An)" : "ups.start.auto (Af)",
 		0,	NULL,
@@ -154,9 +153,9 @@ static int	omron_start_auto(const int on)
 		NULL,	omron_command_answer,	NULL
 	};
 
-	/* Everything lands here as a -1: a transfer failure fails qx_process()
-	 * itself, and an empty answer, a NAK and any reply that is not the "OK"
-	 * acknowledgement fail omron_command_answer() */
+	/* All failure modes return -1: qx_process() handles transfer failures,
+	 * while omron_command_answer() rejects an empty answer, a NAK or any reply
+	 * other than the "OK" acknowledgement. */
 	if (qx_process(&prologue, NULL)) {
 		upslogx(LOG_ERR, "%s: [%.*s] failed or was not acknowledged",
 			__func__,
@@ -171,20 +170,20 @@ static int	omron_start_auto(const int on)
 
 /* Build the OMRON form of a shutdown command
  *
- * OMRON expresses the delay either in tenths of a minute (".n", i.e. 6-second
- * steps) below one minute, or in whole minutes ("nn") from one minute up, and
- * never appends the Megatec "R<mmmm>" return-delay field. It also spells
- * "shut down and stay off" as a distinct "Sf<n>" command, where the Megatec
- * form is "S<n>R0000". blazer_process_command() produces the Megatec form for
- * both, and appends the R field as soon as ups.delay.start is non-zero, which
- * it is by default - hence this replacement rather than a reuse of it.
+ * OMRON encodes delays below one minute in tenths of a minute (".n", six-second
+ * steps) and delays of one minute or more in whole minutes ("nn"). It never
+ * appends the Megatec "R<mmmm>" return-delay field. It also spells "shut down
+ * and stay off" as a distinct "Sf<n>" command, where the Megatec form is
+ * "S<n>R0000". blazer_process_command() produces the Megatec form for both and
+ * appends the R field whenever ups.delay.start is non-zero, which it is by
+ * default. This driver therefore cannot reuse that function.
  *
- * Mirrors on_shutdown_return() and on_shutdown_stayoff() in the OMRON 1.00 and
- * 1.02 sources; their implementations are identical. ups.delay.start has no
- * effect on these commands; it stays in the table because upsdrv_shutdown()
- * looks it up before dispatching.
+ * This mirrors on_shutdown_return() and on_shutdown_stayoff() in the OMRON
+ * 1.00 and 1.02 sources; their implementations are identical.
+ * ups.delay.start has no effect on these commands; it stays in the table because
+ * upsdrv_shutdown() looks it up before dispatching.
  *
- * The two-command shutdown sequence lives here as well: omron_start_auto()
+ * The two-command shutdown sequence is also implemented here: omron_start_auto()
  * runs first, exactly as both OMRON sources order it, and its failure aborts
  * the command before anything is sent to power the unit down.
  *
@@ -246,13 +245,12 @@ static int	omron_process_command(item_t *item, char *value, const size_t valuele
 
 /* Answer preprocess for ups.serial
  *
- * The serial number is the one reply whose characters are unconstrained, so it
- * is also the one place a rejected query could be published as data: the Q1
- * rows require a leading '(', the parsed extension rows exclude the letters
- * of "NAK" by character set or template, but a NAK-plus-padding reply of
- * sufficient length would pass for a serial number. The core's 'rejected'
- * test cannot catch that, being a whole-answer compare against one guessed
- * form. */
+ * The serial-number reply is the only one whose characters are unconstrained,
+ * so it is also the one place a rejected query could be published as data. Q1
+ * rows require a leading '(', and the parsed extension rows exclude the letters
+ * of "NAK" by character set or template, but a sufficiently long NAK reply with
+ * padding would pass for a serial number. The core's 'rejected' test cannot
+ * catch that because it compares the whole answer with one guessed form. */
 static int	omron_reject_nak(item_t *item, const int len)
 {
 	if (len >= 3 && !strncmp(item->answer, "NAK", 3)) {
@@ -266,14 +264,14 @@ static int	omron_reject_nak(item_t *item, const int len)
 
 /* Check a whole reply against the characters it may contain
  *
- * The core guard is skipped for any item with a preprocess, so a reply of
- * acceptable length that is otherwise corrupt would reach dstate as a plausible
- * value. Every OMRON extension below that publishes a parsed reading therefore
- * validates its whole reply before converting it. This function uses the
- * character set defined for that command in the corresponding OMRON source;
- * the UN rows instead match a positional template. ups.serial is the exception:
- * both OMRON sources accept any character in that reply, so its only check here
- * is omron_reject_nak(). */
+ * The core guard is skipped for any item with a preprocess callback, so a
+ * reply of acceptable length that is otherwise corrupt would reach dstate as a
+ * plausible value. Every OMRON extension below that publishes a parsed reading
+ * therefore validates its whole reply before converting it. This function uses
+ * the character set defined for the matching command in the OMRON sources;
+ * the UN rows instead match a positional template. ups.serial is the
+ * exception: both OMRON sources accept any character in that reply, so its only
+ * check here is omron_reject_nak(). */
 static int	omron_check_charset(item_t *item, const char *accept)
 {
 	if (item->value[0] == '\0'
@@ -289,9 +287,9 @@ static int	omron_check_charset(item_t *item, const char *accept)
 
 /* Parse a whole reply as one decimal number
  *
- * The OMRON-source character set for each command also keeps strtod() away from
- * "nan", "inf" and exponent notation. The conversion must additionally consume
- * the entire value and stay in range. */
+ * The character set from the OMRON sources also keeps strtod() away from "nan",
+ * "inf" and exponent notation. The conversion must additionally consume the
+ * entire value and stay in range. */
 static int	omron_strict_decimal(item_t *item, const char *accept, double *reading)
 {
 	char	*end = NULL;
@@ -313,7 +311,7 @@ static int	omron_strict_decimal(item_t *item, const char *accept, double *readin
 
 /* Normalise a signed decimal reading
  *
- * TPb answers with an explicit sign, e.g. "+22.5". It is validated as a signed
+ * TPb returns an explicit sign, e.g. "+22.5". It is validated as a signed
  * decimal and republished at one decimal place, which also removes the leading
  * "+" that no other reading in this table carries. Both OMRON sources publish
  * the reply as it arrives. */
@@ -331,8 +329,8 @@ static int	omron_process_signed(item_t *item, char *value, const size_t valuelen
 
 /* battery.charge out of the Bl ? reply
  *
- * The OMRON-source character set for this command allows digits only, with no
- * sign or decimal point. A value outside 0..100 is corrupt, not a reading. */
+ * The OMRON sources permit only digits for this command, with no sign or
+ * decimal point. A value outside 0..100 is corrupt, not a reading. */
 static int	omron_process_charge(item_t *item, char *value, const size_t valuelen)
 {
 	double	reading;
@@ -353,7 +351,7 @@ static int	omron_process_charge(item_t *item, char *value, const size_t valuelen
 
 /* output.frequency out of the Lf ? reply
  *
- * The OMRON-source character set allows digits and ".", with no sign. */
+ * The OMRON sources permit digits and ".", with no sign. */
 static int	omron_process_frequency(item_t *item, char *value, const size_t valuelen)
 {
 	double	reading;
@@ -368,11 +366,11 @@ static int	omron_process_frequency(item_t *item, char *value, const size_t value
 
 /* The three nominal ratings out of the UN reply
  *
- * The value this is handed has already been cut to a from/to window, so it
- * says nothing about whether the rest of the reply survived. The whole answer
+ * The value passed here has already been sliced to the item's from/to window,
+ * so it does not show whether the rest of the reply was valid. The whole answer
  * is matched against a positional template first - exact field widths, every
- * separator and unit in place, nothing after the last one - which is what makes
- * the fixed offsets safe to use. The nominal battery voltage is published
+ * separator and unit in place, and no trailing data - which is what makes the
+ * fixed offsets safe to use. The nominal battery voltage is published
  * without the leading zero the OMRON sources print. */
 static int	omron_process_un(item_t *item, char *value, const size_t valuelen)
 {
@@ -438,8 +436,8 @@ static int	omron_process_runtime(item_t *item, char *value, const size_t valuele
 
 /* battery.date out of the BRR reply
  *
- * The reply is eight digits, YYYYMMDD. It is checked for being exactly that and
- * for forming a date that exists, then published as ISO rather than the
+ * The reply is eight digits, YYYYMMDD. It is checked for exactly that format
+ * and for a valid calendar date, then published as ISO rather than the
  * MM/DD/YY form used by the OMRON sources, which drops the century. The variable
  * is QX_FLAG_STATIC, so a wrong value published once is never refreshed. */
 static int	omron_process_batt_date(item_t *item, char *value, const size_t valuelen)
@@ -485,13 +483,13 @@ static int	omron_process_batt_date(item_t *item, char *value, const size_t value
 	return 0;
 }
 
-/* ups.firmware, and ups.firmware.aux alongside it, out of the FWV reply
+/* Parse ups.firmware and ups.firmware.aux from the FWV reply
  *
- * The reply is two delimited versions, "M:0.17(S:2.00)". The auxiliary one is
- * published from here rather than from a row of its own because the fields are
- * delimited rather than at fixed offsets. Neither is published until both
- * parse: the variable is QX_FLAG_STATIC, so a wrong value published once would
- * never be refreshed. */
+ * The reply contains two delimited versions, "M:0.17(S:2.00)". The auxiliary
+ * version is published from here rather than from a row of its own because the
+ * fields are delimited rather than at fixed offsets. Neither is published
+ * unless both parse successfully. The main row is QX_FLAG_STATIC, so a wrong
+ * value published once would never be refreshed. */
 static int	omron_process_firmware(item_t *item, char *value, const size_t valuelen)
 {
 	const char	*answer = item->value;
@@ -506,8 +504,8 @@ static int	omron_process_firmware(item_t *item, char *value, const size_t valuel
 	close = strchr(answer, ')');
 
 	/* Both tags are checked, not just the shape, so that the two versions
-	 * cannot be published the wrong way round. Only spaces are tolerated
-	 * after the closing bracket. */
+	 * cannot be published in reverse order. Only spaces are tolerated after
+	 * the closing bracket. */
 	if (open == NULL || close == NULL || close < open + 4 || open < answer + 3
 	||  strncmp(answer, "M:", 2) != 0
 	||  open[1] != 'S' || open[2] != ':'
@@ -520,8 +518,8 @@ static int	omron_process_firmware(item_t *item, char *value, const size_t valuel
 		return -1;
 	}
 
-	/* Both versions start two characters into their half, past a "M:"/"S:"
-	 * style tag, and have to run up to their delimiter with nothing left */
+	/* Both versions start after an "M:" or "S:" tag and must end exactly at
+	 * their respective delimiters. */
 	errno = 0;
 	main_version = strtod(answer + 2, &end);
 
@@ -579,13 +577,13 @@ static item_t	omron_qx2nut[] = {
 
 	/* OMRON extensions
 	 *
-	 * Commands and reply lengths come from the corresponding OMRON source. The
-	 * specified lengths are minimums, not exact hardware reply lengths.
+	 * Command strings come from the OMRON sources. The specified reply lengths
+	 * are minimums, not exact hardware lengths.
 	 *
-	 * All eight read commands, the shape of their replies and the values this
-	 * table publishes from them have been exercised on a BN150T. The reply
-	 * validation is the exception: this hardware has never returned a
-	 * malformed reply, so only the accepting side of it has ever run.
+	 * All eight read commands, the shapes of their replies, and the values this
+	 * table publishes from them have been exercised on a BN150T. Because the
+	 * device returned no malformed replies, only the validation success paths
+	 * were exercised.
 	 *
 	 * None carries QX_FLAG_QUICK_POLL: a QUICK_POLL item that fails aborts
 	 * qx_ups_walk() before QX_FLAG_SKIP can be set, which during
@@ -626,13 +624,13 @@ static item_t	omron_qx2nut[] = {
 
 /* Testing table
  *
- * The query answers are replies captured from BN150T hardware runs. Plain
+ * The query answers are replies captured during BN150T hardware runs. Plain
  * "OK\r" replies were also observed for An, Af, C, S02, Sf02, S.2 and Sf.2.
  * The table uses S.5/Sf.5 for the default 30-second delay; those exact command
- * strings were not sent to hardware, but the same short-delay form was
+ * strings were not sent to hardware, but the same short-delay encoding was
  * observed with .2. The OMRON 1.00 and 1.02 drivers accept a reply whose first
- * two bytes are "OK". That is the test omron_command_answer() applies to the
- * shutdown rows and An/Af prologue item alike. "OKn\r" remains a synthetic
+ * two bytes are "OK". omron_command_answer() applies that test to the
+ * shutdown rows and the An/Af prologue item. "OKn\r" remains a synthetic
  * prefix-acceptance case, not an observed reply.
  *
  * Both delay forms of each shutdown command are listed: ".n" for an
@@ -665,15 +663,16 @@ static testing_t	omron_testing[] = {
 /* Subdriver-specific claim
  *
  * This subdriver differs from 'q1' only in OMRON-specific details, so its
- * protocol check is exactly as permissive as 'q1''s and would otherwise claim
- * every device that the generic 'q1' fallback is meant to serve. Restrict
- * auto-detection to OMRON's USB vendor ID, which nutdrv_qx's upsdrv_initups()
+ * protocol check is just as permissive as the 'q1' check and could otherwise
+ * claim every device intended for the generic 'q1' fallback. Restrict
+ * autodetection to OMRON's USB vendor ID, which nutdrv_qx's upsdrv_initups()
  * publishes as 'ups.vendorid' before subdriver_matcher() runs. The OMRON entry
  * precedes command-based protocol probes: non-OMRON devices are rejected here
  * without a transfer, while a known OMRON device goes directly to the Q1
- * check. A user who names this protocol explicitly gets it either way:
- * subdriver_matcher() skips every other subdriver before calling its claim, so
- * reaching this function with 'protocol' set means it was set to ours. */
+ * check. Explicit protocol selection bypasses the vendor-ID gate:
+ * subdriver_matcher() skips every other subdriver before calling this claim,
+ * so reaching this function with 'protocol' set means that 'omron' was
+ * requested. */
 static int	omron_claim(void)
 {
 	if (!getval("protocol")) {
@@ -706,10 +705,10 @@ subdriver_t	omron_subdriver = {
 	NULL,
 	blazer_makevartable_light,
 	OMRON_ACCEPTED,
-	/* Rejected: no NAK has ever been observed from this hardware. Both OMRON
-	 * sources test only the first three characters, so the exact form guessed
-	 * here is unverified while nutdrv_qx compares the whole answer. The places
-	 * where a wrong guess could matter carry their own prefix test:
+	/* Rejected: no NAK response has been observed from this hardware.
+	 * Both OMRON sources test only the first three characters. The configured
+	 * form is unverified, while nutdrv_qx compares the whole answer. The code
+	 * paths where a mismatch could matter perform their own prefix checks in
 	 * omron_reject_nak() and omron_command_answer(). */
 	"NAK\r",
 #ifdef TESTING

--- a/drivers/nutdrv_qx_omron.h
+++ b/drivers/nutdrv_qx_omron.h
@@ -1,0 +1,30 @@
+/* nutdrv_qx_omron.h - Subdriver for OMRON UPSes speaking the Q1 protocol
+ *
+ * Copyright (C)
+ *   2013 Daniele Pezzini <hyouko@gmail.com>	(nutdrv_qx_q1.h, on which this is based)
+ *   2026 Jun Kurihara <junkurihara@users.noreply.github.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ */
+
+#ifndef NUTDRV_QX_OMRON_H
+#define NUTDRV_QX_OMRON_H
+
+#include "nutdrv_qx.h"
+
+extern subdriver_t	omron_subdriver;
+
+#endif /* NUTDRV_QX_OMRON_H */


### PR DESCRIPTION
## Key Changes

- Add an `omron` USB transport for OMRON BN150T (`0590:00b7`). It uses the device's 16-byte HID Output report size, rejects short writes, and bounds reply parsing and debug output by the number of bytes actually received.
- Add an `omron` protocol subdriver based on the Q1 family, with OMRON-specific status handling, strict validation, extension queries, and automatic USB selection guarded by OMRON's vendor ID.
- Publish the observed OMRON extension data, including battery charge, runtime and temperature, output frequency, firmware revisions, serial number, battery date, nominal power, and nominal battery voltage.
- Add the OMRON forms of `shutdown.stop`, `shutdown.return`, and `shutdown.stayoff`, including the required `An`/`Af` auto-restart prologue and `OK` acknowledgement handling.
- Document the protocol, transport, tested hardware scope, source provenance, and known limitations in the manual, NEWS, subdriver list, spell-check dictionary, and hardware compatibility list. Bump the `nutdrv_qx` driver version to 0.54.

## Testing

- Built with `make -j2 -C drivers -W nutdrv_qx_omron.c nutdrv_qx`: exit 0, no warnings.
- Compiled `nutdrv_qx_omron.c` with `-DTESTING -fsyntax-only` and the project warning flags: exit 0, no warnings.
- Ran `git diff --check 26177060b`: exit 0, no output.
- Exercised protocol claiming, Q1 polling, and all eight OMRON extension queries on an OMRON BN150T over USB.
- Verified explicit OMRON transport/protocol selection, protocol autodetection with the OMRON USB transport selected explicitly, and automatic selection of both transport and protocol with the device constrained to USB `0590:00b7`. All three paths selected `Omron 0.01`; autodetection sent no other protocol probes.
- Ran the driver continuously for about 62 hours. The archived debug-level-1 log contains 22,372 completed updates (5,605 full and 16,767 quick). Automated checks found no stale-data, NAK, timeout, short-transfer, overflow, USB-loss, or communication-loss/failure events.
- On the completely unloaded BN150T, exercised `shutdown.stop`, `shutdown.return`, and `shutdown.stayoff`, including 120-second schedule/cancel checks and actual 12-second shutdowns. The observed command sequences and acknowledgements matched `C`, `An` then `S.2`/`S02`, and `Af` then `Sf.2`/`Sf02` as expected.
- Verified `shutdown.return` while on battery and automatic output recovery after utility restoration. Verified that `shutdown.stayoff` held the output off with utility present until manual front-panel recovery.
- The UPS output was unloaded throughout: every output receptacle was empty and only the USB data cable was connected. OB was observed; LB, serial connections, other OMRON models, and other OMRON USB IDs were not tested.
- After hardware testing, only comments and documentation were changed to record and clarify the observed results; driver logic remained unchanged.
- Did not exercise `shutdown.default`, `upsdrvctl shutdown`, the driver `-k` path, or `driver.killpower` because of the separately reported shared-core failure-masking issue (#3553).
- Ran `make distcheck`: exit 0. This covered the distribution archive, an all-features configured build, checks, and normal and `DESTDIR` install/uninstall passes, including the new subdriver files.
- Ran NUT's source non-ASCII check and an added-line byte scan over the complete PR diff: both passed with no findings.
- Regenerated the USB metadata with `tools/nut-usbinfo.pl`. The BN150T appears in the generated udev, devd, hotplug and nut-scanner data. The tracked `scripts/upower/95-upower-hid.hwdb` is unchanged because that generator emits entries there only for `usbhid-ups` and `apc_modbus` devices.
- Ran `make spellcheck` with `aspell` and its English dictionary: exit 0, with no findings after adding `OMRON's`, `DSM`, `QNAP`, and `Synology` to `docs/nut.dict`.

## Related Tasks

- Related to #3112. That issue requests BN75T support over a serial connection; this PR adds and tests BN150T support over USB, so it does not close #3112.
- #3553 tracks the pre-existing failure-reporting limitation in shared `shutdown.default` and driver `-k` handling encountered while reviewing shutdown behavior. This PR intentionally does not modify `drivers/main.c`.
- A separate pre-existing concern in another transport was reported through the repository's private security advisory process before this PR. Technical  details are intentionally omitted pending maintainer triage; this PR does not modify that transport.

## Other

- The protocol implementation was derived from OMRON-authored GPL driver version 1.00 distributed in the Synology DSM 7.3-86009 GPL sources and version 1.02 distributed in the QNAP QTS 5.2.3 GPL sources.
- The device does not expose an independent readback of `ups.start.auto`. Automatic recovery after a non-cancelled `An` shutdown was physically verified, but preservation of the final `An` setting across `C` remains an inference rather than a device readback.
- AI assistance from Claude and OpenAI Codex was used during implementation, review, test planning, and drafting. The human contributor reviewed the resulting code, documentation, hardware observations, and submission text and remains responsible for the contribution.

---
Below is a checklist from the PR template.

## General points

- [x] Described the changes in the PR submission or a separate issue, e.g. known published or discovered protocols, applicable hardware (expected compatible and actually tested/developed against), limitations, etc.

- [x] There may be multiple commits in the PR, aligned and commented with a functional change. Notably, coding style changes better belong in a separate PR, but certainly in a dedicated commit to simplify reviews of "real" changes in the other commits. Similarly for typo fixes in comments or text documents.

- [x] Use of coding helper tools and AI should be disclosed in the commit or PR comments (it is interesting to know which ones do a decent job). As with other contributions, a human is responsible and thanked for the quality and content of the change, and is presumed to have the right to post that code to be published further under the project's license terms.

- [x] Especially with involvement of AI, including modern IDE coding aid, please be sure to revise that proposed code and documentation changes follow NUT code style guide -- this helps portability across the decades worth of supported systems. Notably, avoid Unicode characters where ASCII text is expected (C sources and headers, manual pages and other `acsiidoc`  inputs). Particularly AI is keen on adding `mdash` characters instead of plain ASCII double-dash (which renders into the long dash where applicable).

- [x] Please star NUT on GitHub, this helps with sponsorships! ;)

## Frequent "underwater rocks" for driver addition/update PRs

- [x] Revised existing driver families and added a sub-driver if applicable (`nutdrv_qx`, `usbhid-ups`...) or added a brand new driver in the other case.

- [x] Did not extend obsoleted drivers with new hardware support features (notably `blazer` and other single-device family drivers for Qx protocols, except the new `nutdrv_qx` which should cover them all).

- [x] For updated existing device drivers, bumped the `DRIVER_VERSION` macro or its equivalent.

- [x] For USB devices (HID or not), revised that the driver uses unique VID/PID combinations, or raised discussions when this is not the case (several vendors do use same interface chips for unrelated protocols).

- [x] For new USB devices, built and committed the changes for the `scripts/upower/95-upower-hid.hwdb` file

  -> N/A for this `nutdrv_qx` device: `tools/nut-usbinfo.pl` was run and produced no change to that file because its UPower output includes only `usbhid-ups` and `apc_modbus` devices.

- [x] Proposed NUT data mapping is aligned with existing `docs/nut-names.txt` file. If the device exposes useful data points not listed in the file, the `experimental.*` namespace can be used as documented there, and discussion should be raised on the NUT Developers mailing list to standardize the new concept.

- [x] Updated `data/driver.list.in` if applicable (new tested device info)

## Frequent "underwater rocks" for general C code PRs

- [x] Did not "blindly assume" default integer type sizes and value ranges, structure layout and alignment in memory, endianness (layout of bytes and bits in memory for multi-byte numeric types), or use of generic `int` where language or libraries dictate the use of `size_t` (or `ssize_t` sometimes).

- [x] Progress and errors are handled with `upsdebugx()`, `upslogx()`, `fatalx()` and related methods, not with direct `printf()` or `exit()`. Similarly, NUT helpers are used for error-checked memory allocation and string operations (except where customized error handling is needed, such as unlocking device ports, etc.)

- [x] Coding style (including whitespace for indentations) follows precedent in the code of the file, and examples/guide in `docs/developers.txt` file.

- [x] For newly added files, the `Makefile.am` recipes were updated and the `make distcheck` target passes.

## General documentation updates

- [x] Added a bullet point into `NEWS.adoc`, possibly also `UPGRADING.adoc` if there is something packagers or custom-build users should take into account (new driver categories, configuration options, dependencies...)

  -> `UPGRADING.adoc` is not applicable because this adds no dependency, incompatible configuration change, or packaging migration.

- [x] Updated `docs/acknowledgements.txt` (for vendor-backed device support)

  -> N/A: the implementation uses published GPL sources, but there was no vendor-backed contribution or claim of current official support.

- [x] Added or updated manual page information in `docs/man/*.txt` files and corresponding recipe lists in `docs/man/Makefile.am` for new pages

  -> The existing `docs/man/nutdrv_qx.txt` page was updated; no new manual page or recipe was added.

- [x] Passed `make spellcheck`, updated spell-checking dictionary in the `docs/nut.dict` file if needed (did not remove any words -- the `make` rule printout in case of changes suggests how to maintain it).

## Additional work may be needed after posting this PR

- [ ] Propose a PR for NUT DDL with detailed device data dumps from tests against real hardware (the more models, the better).

- [ ] Address NUT CI farm build failures for the PR: testing on numerous platforms and toolkits can expose issues not seen on just one system.

- [ ] Revise suggestions from LGTM.COM analysis about "new issues" with the changed codebase.
