### PR TITLE
idowell-hid: fix bogus battery.runtime/battery.voltage on GoldenMate LiFePO4 (LLP64 Logical Maximum overflow)

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -145,6 +145,15 @@ https://github.com/networkupstools/nut/milestone/13
       Phoenixtec vendor ID (`0x06da`) is gated by device strings so the other
       devices on that ID still fall through to `liebert-hid` / `mge-hid`.
       [issue #3501, PR #3502]
+    * `idowell-hid` subdriver now repairs a firmware bug in those GoldenMate
+      LiFePO4 packs, which encode the four-byte Logical Maximum of
+      `UPS.PowerSummary.RunTimeToEmpty` with reversed byte order in report
+      0x02. The resulting value does not fit a signed 32-bit `long`, so on
+      platforms where `long` is 32-bit (notably Windows) it wrapped negative,
+      and the following `UPS.PowerSummary.Voltage` item inherited the same
+      broken maximum from HID global state. Both `battery.runtime` and
+      `battery.voltage` then read as nonsense; platforms with a 64-bit `long`
+      were unaffected. [PR #3555]
     * `mge-hid` subdriver updated to suppress `CHRG` status on constant-charge
       mode devices when battery is fully charged. [issue #3518, PR #3519]
 

--- a/drivers/idowell-hid.c
+++ b/drivers/idowell-hid.c
@@ -29,8 +29,9 @@
 #include "idowell-hid.h"
 #include "main.h"	/* for getval() */
 #include "usb-common.h"
+#include "hidparser.h" /* for FindObject_with_ID_Node() */
 
-#define IDOWELL_HID_VERSION	"iDowell HID 0.21"
+#define IDOWELL_HID_VERSION	"iDowell HID 0.22"
 /* FIXME: experimental flag to be put in upsdrv_info */
 /* v0.21 GoldenMate LiFePO4 packs reuse the shared Phoenixtec VID (0x06da):
  *       claim only those (by -BMS-/Smart-Battery firmware strings) and defer
@@ -206,6 +207,94 @@ static int idowell_claim(HIDDevice_t *hd)
 	}
 }
 
+/* idowell_fix_report_desc: correct a firmware bug in GoldenMate LiFePO4 packs.
+ *
+ * These devices declare the same data points twice: once as Feature items in
+ * ReportID 0x01 (with sane Logical Maximum values) and again as Input items in
+ * ReportID 0x02. In ReportID 0x02 the firmware encodes the 4-byte Logical
+ * Maximum for UPS.PowerSummary.RunTimeToEmpty with the bytes in the wrong
+ * order: it emits "27 ff ff ff fe" (0xFEFFFFFF) where 0xFFFFFFFE was intended.
+ *
+ * 0xFEFFFFFF does not fit a signed 32-bit long, so on LLP64 platforms (Windows,
+ * where long is 32-bit) the generic "LogMax < LogMin" recovery in HIDParse()
+ * stores it back as the negative value -16777217. Per the HID spec, Logical
+ * values persist in global state, so the following UPS.PowerSummary.Voltage
+ * Input item inherits the same broken maximum. Both readings then come out as
+ * nonsense (battery.runtime = -16777217, battery.voltage = -167772.2) while the
+ * ReportID 0x01 Feature copies of the very same usages read correctly.
+ *
+ * Rather than invent limits, we copy the values this device itself declares for
+ * the same usages in ReportID 0x01: 0x75FFFFFF for RunTimeToEmpty (32-bit) and
+ * 65535 for Voltage (16-bit).
+ */
+#define IDOWELL_RUNTIME_LOGMAX	0x75FFFFFFL
+#define IDOWELL_VOLTAGE_LOGMAX	65535L
+
+static int idowell_fix_report_desc(HIDDevice_t *pDev, HIDDesc_t *pDesc_arg) {
+	HIDData_t	*pData;
+	int	retval = 0;
+
+	int	vendorID = pDev->VendorID;
+	int	productID = pDev->ProductID;
+
+	if (!((vendorID == PHOENIXTEC_VENDORID && productID == 0xffff)
+	   || (vendorID == IDOWELL_VENDORID && productID == 0x0300))) {
+		upsdebugx(3, "NOT Attempting Report Descriptor fix for UPS: "
+			"Vendor: %04x, Product: %04x (vendor/product not matched)",
+			(unsigned int)vendorID, (unsigned int)productID);
+		return 0;
+	}
+
+	if (disable_fix_report_desc) {
+		upsdebugx(3, "NOT Attempting Report Descriptor fix for UPS: "
+			"Vendor: %04x, Product: %04x "
+			"(got disable_fix_report_desc in config)",
+			(unsigned int)vendorID, (unsigned int)productID);
+		return 0;
+	}
+
+	upsdebugx(3, "Attempting Report Descriptor fix for UPS: "
+		"Vendor: %04x, Product: %04x",
+		(unsigned int)vendorID, (unsigned int)productID);
+
+	/* Only touch items whose maximum is demonstrably broken (below the
+	 * minimum), so a firmware revision that encodes this correctly is
+	 * left alone. */
+	if ((pData = FindObject_with_ID_Node(pDesc_arg, 0x02,
+			USAGE_BAT_RUN_TIME_TO_EMPTY))) {
+		upsdebugx(4, "Original Report Descriptor: ReportID 0x02 "
+			"RunTimeToEmpty LogMin: %ld LogMax: %ld",
+			pData->LogMin, pData->LogMax);
+
+		if (pData->LogMax < pData->LogMin) {
+			pData->LogMax = IDOWELL_RUNTIME_LOGMAX;
+			pData->assumed_LogMax = true;
+			upsdebugx(3, "Fixing Report Descriptor: set ReportID 0x02 "
+				"RunTimeToEmpty LogMax = %ld",
+				(long)IDOWELL_RUNTIME_LOGMAX);
+			retval++;
+		}
+	}
+
+	if ((pData = FindObject_with_ID_Node(pDesc_arg, 0x02,
+			USAGE_POW_VOLTAGE))) {
+		upsdebugx(4, "Original Report Descriptor: ReportID 0x02 "
+			"Voltage LogMin: %ld LogMax: %ld",
+			pData->LogMin, pData->LogMax);
+
+		if (pData->LogMax < pData->LogMin) {
+			pData->LogMax = IDOWELL_VOLTAGE_LOGMAX;
+			pData->assumed_LogMax = true;
+			upsdebugx(3, "Fixing Report Descriptor: set ReportID 0x02 "
+				"Voltage LogMax = %ld",
+				(long)IDOWELL_VOLTAGE_LOGMAX);
+			retval++;
+		}
+	}
+
+	return retval;
+}
+
 subdriver_t idowell_subdriver = {
 	IDOWELL_HID_VERSION,
 	idowell_claim,
@@ -214,5 +303,5 @@ subdriver_t idowell_subdriver = {
 	idowell_format_model,
 	idowell_format_mfr,
 	idowell_format_serial,
-	fix_report_desc,
+	idowell_fix_report_desc,
 };


### PR DESCRIPTION
## Problem

On Windows, a GoldenMate 1500VA/1000W LiFePO4 pack (`0x06da:0xffff`, the device
added to `idowell-hid` in PR #3502) reports two nonsense values:

```
battery.runtime: -16777217
battery.voltage: -167772.2
```

The same usages read correctly from the device's own ReportID 0x01 Feature
copies (1740 s and 13.2 V), which is what made this traceable.

## Root cause

The device declares its data twice: as Feature items in ReportID 0x01 with sane
limits, and again as Input items in ReportID 0x02 — and NUT polls the latter.

In ReportID 0x02 the firmware emits the 4-byte Logical Maximum for
`UPS.PowerSummary.RunTimeToEmpty` **byte-reversed**:

```
09 68              Usage (RunTimeToEmpty)
75 20              Report Size (32)
15 00              Logical Minimum (0)
27 ff ff ff fe     Logical Maximum -> 0xFEFFFFFF     <-- 0xFFFFFFFE was intended
81 83              Input
```

`0xFEFFFFFF` is 4278190079, which does not fit a **signed 32-bit** `long`.
Windows is LLP64, so `long` is 32-bit, and the generic `LogMax < LogMin`
recovery in `HIDParse()` re-stores it with:

https://github.com/networkupstools/nut/blob/master/drivers/hidparser.c#L423

```c
pParser->Data.LogMax = (long) pParser->Value;
```

4278190079 wraps to exactly `-16777217`. From the driver log:

```
HIDParse: LogMax is less than LogMin. Vendor HID report descriptor may be incorrect;
  interpreting LogMax -16777217 as 4278190079 in ReportID: 0x02
```

Then, per the HID spec, Logical values persist in **global** item state. The very
next item, `UPS.PowerSummary.Voltage`, declares a new Report Size but no new
Logical Maximum, so it silently inherits the broken one:

```
05 84 09 30        Usage (Voltage)
67 21 d1 f0 00     Unit
55 05              Unit Exponent (5)
75 10              Report Size (16)
81 82              Input          <-- no Logical Maximum of its own
```

That is how a single firmware typo corrupts two unrelated readings.

**This is why CI won't catch it.** On LP64 platforms (Linux, the BSDs) `long` is
64-bit, 4278190079 fits comfortably, and the bug simply does not manifest. It
reproduces only on LLP64 — Windows.

## The fix

Adds `idowell_fix_report_desc()`, following the existing `cps-hid.c` /
`apc-hid.c` pattern, replacing the default no-op `fix_report_desc` in
`idowell_subdriver`.

Deliberate choices:

* **Gated** to `0x06da:0xffff` and `0x075d:0x0300` only.
* **Does not invent limits.** It uses the values *this device itself declares*
  for the same usages in ReportID 0x01 — `0x75FFFFFF` for RunTimeToEmpty (from
  descriptor bytes `27 ff ff ff 75`) and `65535` for Voltage (from
  `27 ff ff 00 00`).
* **Only corrects demonstrably broken items** (`LogMax < LogMin`), so a firmware
  revision that encodes this correctly is left untouched.
* **Honors `disable_fix_report_desc`.**

Also adds `#include "hidparser.h"` for `FindObject_with_ID_Node()` —
`usbhid-ups.h` -> `libhid.h` -> `hidtypes.h` provides the types but not the
prototype, so this is needed under `-Werror=implicit-function-declaration`.

Subdriver version bumped 0.21 -> 0.22.

## Testing

Built from this branch with MSYS2/mingw64 on Windows 11 (NUT 2.8.5 install,
`usbhid-ups` only), tested against the physical device.

Driver log with the fix applied:

```
Using subdriver: iDowell HID 0.22
Attempting Report Descriptor fix for UPS: Vendor: 06da, Product: ffff
Fixing Report Descriptor: set ReportID 0x02 RunTimeToEmpty LogMax = 1979711487
Fixing Report Descriptor: set ReportID 0x02 Voltage LogMax = 65535
Path: UPS.PowerSummary.RunTimeToEmpty, Type: Input, ReportID: 0x02, Value: 1740
Path: UPS.PowerSummary.Voltage,        Type: Input, ReportID: 0x02, Value: 13.2
```

The ReportID 0x02 Input values now agree exactly with the ReportID 0x01 Feature
values. Raw report 0x02 decodes cleanly:

```
02 b2 64 44 07 00 00 28 05
      |  |___________|  |___|
      |  0x744 = 1860 s  0x528 = 1320 -> 13.2 V
      0x64 = 100 %
```

`upsc` before / after:

| | before | after |
|---|---|---|
| `battery.runtime` | `-16777217` | `1740` |
| `battery.voltage` | `-167772.2` | `13.2` |

No change in behaviour on LP64 platforms: the guard is `LogMax < LogMin`, which
is never true there for this descriptor, so the function is a no-op.

## Notes

Happy to add a `NEWS.adoc` entry under the existing `usbhid-ups` /
`idowell-hid` bullet — will follow up on this PR shortly.

Two things about this device worth recording for anyone who finds this later:
it exposes only 25 usages, all under `UPS.PowerSummary.*`, with no
`PercentLoad`, no `Current`, and no `UPS.PowerConverter` / `UPS.Flow`
collections — so `ups.load` and the input/output voltage points are genuinely
unavailable rather than unmapped. It also declares a ReportID 0x06 with 32 bytes
of Input as Constant with no usages attached; in testing the device never sends
that report at all.
