### PR TITLE
win32: return partial serial data on timeout

### DIFF
--- a/common/wincompat.c
+++ b/common/wincompat.c
@@ -898,6 +898,15 @@ int w32_serial_read(serial_handler_t *sh, void *ptr, size_t ulen, DWORD timeout)
 							errno = 0;
 							return 0;
 						}
+						CancelIo(sh->handle);
+						sh->overlapped_armed = 0;
+						ResetEvent(sh->io_status.hEvent);
+						upsdebugx(4,
+							"w32_serial_read : timeout after receiving %d characters, returning partial data",
+							tot);
+						SetLastError(ERROR_SUCCESS);
+						errno = 0;
+						return tot;
 					default:
 						goto err;
 				}


### PR DESCRIPTION
## Summary

Fix the Win32 serial read wrapper so that data already accumulated before a
timeout is returned to the caller instead of being discarded as an I/O error.

When `nutdrv_qx` receives a complete Q1 response over a Windows COM port, the
subsequent timeout currently falls through to the generic error path even
though valid bytes were already received.

This change cancels the pending overlapped operation, resets its state, clears
the Win32 error status and returns the accumulated byte count when the timeout
occurs after receiving data.

Fixes #3452.

## Testing

Tested on Windows x86_64 with a UPSBrasil 3 kVA UPS using:

- `nutdrv_qx`
- Q1 protocol
- USB-to-serial adapter on COM4
- NUT 2.8.5 plus the current development branch

Verified:

- the complete Q1 response is accepted without the previous EIO failure;
- continuous polling remains stable;
- `upsd`, `upsc` and `upsmon` receive the UPS data;
- the Windows NUT service starts automatically after reboot;
- communication recovers after disconnecting and reconnecting the USB serial
  adapter without restarting the driver process;
- UPS status changes between `OL` and `OL BYPASS` are reported correctly.

The broader `ci_build.sh` run stopped on an unrelated GCC 16 `-Werror` warning
in `nut-scanner`, after the affected driver and libraries had compiled.

## AI disclosure

ChatGPT was used to assist with diagnosing the Win32 timeout behavior,
reviewing the proposed change, and drafting the issue and pull request text.

The submitted change was manually reviewed, compiled and tested against real
hardware by the contributor.

## General points

- [x] Described the changes in the PR submission or a separate issue, e.g.
  known published or discovered protocols, applicable hardware (expected
  compatible and actually tested/developed against), limitations, etc.

- [x] There may be multiple commits in the PR, aligned and commented with
  a functional change. Notably, coding style changes better belong in a
  separate PR, but certainly in a dedicated commit to simplify reviews
  of "real" changes in the other commits. Similarly for typo fixes in
  comments or text documents.

- [x] Use of coding helper tools and AI should be disclosed in the commit
  or PR comments (it is interesting to know which ones do a decent job).
  As with other contributions, a human is responsible and thanked for the
  quality and content of the change, and is presumed to have the right to
  post that code to be published further under the project's license terms.

- [x] Especially with involvement of AI, including modern IDE coding aid,
  please be sure to revise that proposed code and documentation changes
  follow NUT code style guide -- this helps portability across the decades
  worth of supported systems. Notably, avoid Unicode characters where ASCII
  text is expected.

- [x] Please star NUT on GitHub, this helps with sponsorships! ;)

## Frequent "underwater rocks" for driver addition/update PRs

- [ ] Revised existing driver families and added a sub-driver if applicable
  (`nutdrv_qx`, `usbhid-ups`...) or added a brand new driver in the other
  case.

- [ ] Did not extend obsoleted drivers with new hardware support features
  (notably `blazer` and other single-device family drivers for Qx protocols,
  except the new `nutdrv_qx` which should cover them all).

- [ ] For updated existing device drivers, bumped the `DRIVER_VERSION` macro
  or its equivalent.

- [ ] For USB devices (HID or not), revised that the driver uses unique
  VID/PID combinations, or raised discussions when this is not the case.

- [ ] For new USB devices, built and committed the changes for the
  `scripts/upower/95-upower-hid.hwdb` file.

- [ ] Proposed NUT data mapping is aligned with existing
  `docs/nut-names.txt` file.

- [ ] Updated `data/driver.list.in` if applicable.

## Frequent "underwater rocks" for general C code PRs

- [x] Did not "blindly assume" default integer type sizes and value ranges,
  structure layout and alignment in memory, endianness, or use of generic
  `int` where language or libraries dictate the use of `size_t` or
  `ssize_t`.

- [x] Progress and errors are handled with `upsdebugx()`, `upslogx()`,
  `fatalx()` and related methods, not with direct `printf()` or `exit()`.

- [x] Coding style, including whitespace for indentations, follows precedent
  in the code of the file and the guidance in `docs/developers.txt`.

- [ ] For newly added files, the `Makefile.am` recipes were updated and the
  `make distcheck` target passes.

## General documentation updates

- [ ] Added a bullet point into `NEWS.adoc`, possibly also `UPGRADING.adoc`
  if there is something packagers or custom-build users should take into
  account.

- [ ] Updated `docs/acknowledgements.txt`.

- [ ] Added or updated manual page information in `docs/man/*.txt` files and
  corresponding recipe lists in `docs/man/Makefile.am`.

- [ ] Passed `make spellcheck` and updated `docs/nut.dict` if needed.

## Additional work may be needed after posting this PR

- [ ] Propose a PR for NUT DDL with detailed device data dumps from tests
  against real hardware.

- [ ] Address NUT CI farm build failures for the PR.

- [ ] Revise suggestions from LGTM.COM analysis about new issues.