### PR TITLE
nutdrv_qx: fix Cypress 0665:5161 replies

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -86,6 +86,12 @@ https://github.com/networkupstools/nut/milestone/13
     * Only claim a USB device as "supported" during discovery out of the box
       if `subdriver_command` was assigned (`1A86:7523` is used by CH340/341
       USB chips not only in UPSes). [issue #3410]
+    * Added a `cypress_0665_5161_subdriver` initialization method for devices
+      with USB ID `0665:5161` (Belkin, Voltronic, VOLT Polska) which enables
+      a quirk to drain stale bytes from USB buffers of the device before our
+      driver sends queries, and use a longer timeout. If this change breaks
+      your device, please add `cypress_drain_quirk = 0` in your `ups.conf`
+      and let us know. [issue #2534, PR #3563]
     * Modified `megatec` subdriver to allow `ups.firmware` with empty contents
       (when a device returns all-spaces in that part of the `I` query response)
       out of the box and not ignore the device as unsupported, by adding the

--- a/UPGRADING.adoc
+++ b/UPGRADING.adoc
@@ -79,6 +79,15 @@ The new `-A filename` option defaults to trying to use a `nutauth.conf` file
   This was revised to follow the new common setting `reconnect_max_tries`,
   which defaults to trying indefinitely now. [#3541]
 
+- Deployments using `nutdrv_qx` driver with `cypress` subdriver may be impacted
+  by a fix which added a `cypress_0665_5161_subdriver` initialization method for
+  devices with USB ID `0665:5161` (Belkin, Voltronic, VOLT Polska) which enables
+  a special quirk to drain stale bytes from USB buffers of the device before our
+  driver sends queries, and use a longer timeout. If this change breaks your
+  device, please add `cypress_drain_quirk = 0` in your `ups.conf` and let us
+  know. [issue #2534, PR #3563]
+
+
 Changes from 2.8.4 to 2.8.5
 ---------------------------
 

--- a/data/driver.list.in
+++ b/data/driver.list.in
@@ -1682,6 +1682,7 @@
 
 "Vivaldi"	"ups"	"1"	"EA200 LED"	"USB"	"richcomm_usb"
 
+"VOLT Polska"	"ups"	"2"	"RackUPS 1200VA/720W 2x7Ah"	"USB (USB ID 0665:5161)"	"nutdrv_qx"	# https://github.com/networkupstools/nut/issues/2534
 "Voltronic Power"	"ups"	"2"	"Apex 1KVA"	"Serial"	"nutdrv_qx"
 "Voltronic Power"	"ups"	"2"	"Apex 1KVA"	"USB"	"nutdrv_qx"
 "Voltronic Power"	"ups"	"2"	"Frigate TX 1KVA"	"Serial"	"nutdrv_qx"

--- a/docs/man/nutdrv_qx.txt
+++ b/docs/man/nutdrv_qx.txt
@@ -503,6 +503,15 @@ You must provide *value* (+0x409+ or +0x4095+), according to your device entry i
 *noscanlangid*::
 If this flag is set, don't autoscan valid range for langid.
 
+*cypress_drain_quirk =* 'value'::
+Some devices using the `cypress` subdriver, e.g. VOLT Polska identified as Cypress
+USB ID `0665:5161`, were seen to retain stale bytes in their USB buffer, returning
+old "garbage" as response to new queries and so corrupting discovery attempts.
+The `nutdrv_qx` driver can drain the USB buffer and use longer timeouts to communicate
+with such devices, but such a change may potentially misfire on other devices with
+same USB ID (Belkin, Voltronic).  This option allows to explicitly enable or disable
+this behavior; by default it is chosen according to device self-identification.
+
 
 IMPLEMENTATION NOTES
 ^^^^^^^^^^^^^^^^^^^^

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3800 utf-8
+personal_ws-1.1 en 3801 utf-8
 AAC
 AAS
 ABI
@@ -1030,6 +1030,7 @@ PnP
 Poettering
 Pohle
 PointBre
+Polska
 Pos
 Potrans
 Poush

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -3752,6 +3752,7 @@ void	upsdrv_initups(void)
 	char	*subdrv;
 # endif
 #endif
+	const char	*val;
 
 	upsdebugx(1, "%s...", __func__);
 
@@ -3813,7 +3814,6 @@ void	upsdrv_initups(void)
 		};
 
 		int		i;
-		const char	*val;
 		struct termios	tio;
 
 		/* Open and lock the serial port and set the speed to 2400 baud. */

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -730,12 +730,20 @@ static int				langid_fix = -1;
 
 static int	(*subdriver_command)(const char *cmd, size_t cmdlen, char *buf, size_t buflen) = NULL;
 
+static bool_t	cypress_0665_5161_quirk = FALSE;
+
+#define CYPRESS_0665_5161_FLUSH_REPORTS	10
+#define CYPRESS_0665_5161_FLUSH_TIMEOUT	25
+#define CYPRESS_REPLY_TIMEOUT			1000
+#define CYPRESS_0665_5161_REPLY_TIMEOUT	3000
+
 /* Cypress communication subdriver */
 static int	cypress_command(const char *cmd, size_t cmdlen, char *buf, size_t buflen)
 {
 	char	tmp[SMALLBUF];
 	size_t	tmplen;
 	int	ret = 0;
+	int	reply_timeout = CYPRESS_REPLY_TIMEOUT;
 	size_t	i;
 
 	if (buflen > INT_MAX) {
@@ -743,6 +751,36 @@ static int	cypress_command(const char *cmd, size_t cmdlen, char *buf, size_t buf
 			"reducing buflen to (INT_MAX-1)",
 			__func__, buflen);
 		buflen = (INT_MAX - 1);
+	}
+
+	/* Some USB devices with Cypress 0665:5161 can leave a reply from a previous
+	 * command queued on the interrupt endpoint. Do not apply this device quirk
+	 * to other Cypress-based UPSes.
+	 */
+	if (cypress_0665_5161_quirk) {
+		reply_timeout = CYPRESS_0665_5161_REPLY_TIMEOUT;
+
+		/* Read once more than the number of reports we accept, so a timeout
+		 * confirms that the endpoint is empty. Do not send a command if it
+		 * remains busy: its reply could not be associated reliably.
+		 */
+		for (i = 0; i <= CYPRESS_0665_5161_FLUSH_REPORTS; i++) {
+			ret = usb_interrupt_read(udev, 0x81,
+				(usb_ctrl_charbuf)tmp, 8, CYPRESS_0665_5161_FLUSH_TIMEOUT);
+
+			if (ret == LIBUSB_ERROR_TIMEOUT)
+				break;
+
+			if (ret <= 0)
+				return ret;
+
+			if (i == CYPRESS_0665_5161_FLUSH_REPORTS) {
+				upsdebugx(1, "cypress: input endpoint stayed busy before %s", cmd);
+				return LIBUSB_ERROR_BUSY;
+			}
+
+			upsdebugx(3, "cypress: discarded stale input report before %s", cmd);
+		}
 	}
 
 	/* Send command */
@@ -779,7 +817,7 @@ static int	cypress_command(const char *cmd, size_t cmdlen, char *buf, size_t buf
 		/* ret = usb->get_interrupt(udev, (unsigned char *)&buf[i], 8, 1000); */
 		ret = usb_interrupt_read(udev,
 			0x81,
-			(usb_ctrl_charbuf)&buf[i], 8, 1000);
+			(usb_ctrl_charbuf)&buf[i], 8, reply_timeout);
 
 		/* Any errors here mean that we are unable to read a reply
 		 * (which will happen after successfully writing a command
@@ -2561,6 +2599,16 @@ static void	*cypress_subdriver(USBDevice_t *device)
 {
 	NUT_UNUSED_VARIABLE(device);
 
+	cypress_0665_5161_quirk = FALSE;
+	subdriver_command = &cypress_command;
+	return NULL;
+}
+
+static void	*cypress_0665_5161_subdriver(USBDevice_t *device)
+{
+	NUT_UNUSED_VARIABLE(device);
+
+	cypress_0665_5161_quirk = TRUE;
 	subdriver_command = &cypress_command;
 	return NULL;
 }
@@ -2705,7 +2753,7 @@ static qx_usb_device_id_t	qx_usb_id[] = {
 	{ USB_DEVICE(SYSGRATION_VENDORID,	0x0000),	NULL,		NULL,			&cypress_subdriver },	/* Agiler UPS */
 	{ USB_DEVICE(NONAMEFFFF_VENDORID,	0x0000),	NULL,		NULL,			&ablerex_subdriver_fun },	/* Ablerex 625L USB (Note: earlier best-fit was "krauler_subdriver" before PR #1135) */
 	{ USB_DEVICE(LEGRAND_VENDORID,	0x0035),	NULL,		NULL,			&krauler_subdriver },	/* Legrand Daker DK / DK Plus */
-	{ USB_DEVICE(CYPRESS_VENDORID,	0x5161),	NULL,		NULL,			&cypress_subdriver },	/* Belkin F6C1200-UNV/Voltronic Power UPSes */
+	{ USB_DEVICE(CYPRESS_VENDORID,	0x5161),	NULL,		NULL,			&cypress_0665_5161_subdriver },	/* Belkin F6C1200-UNV/Voltronic Power UPSes */
 	{ USB_DEVICE(PHOENIXTEC_VENDORID,	0x0002),	"Phoenixtec Power","USB Cable (V2.00)",	&phoenixtec_subdriver },/* Masterguard A Series */
 	{ USB_DEVICE(PHOENIXTEC_VENDORID,	0x0002),	NULL,		NULL,			&cypress_subdriver },	/* Online Yunto YQ450 */
 	{ USB_DEVICE(PHOENIXTEC_VENDORID,	0x0003),	NULL,		NULL,			&ippon_subdriver },	/* Mustek Powermust */

--- a/drivers/nutdrv_qx.c
+++ b/drivers/nutdrv_qx.c
@@ -58,7 +58,7 @@
 #	define DRIVER_NAME	"Generic Q* Serial driver"
 #endif	/* QX_USB */
 
-#define DRIVER_VERSION	"0.54"
+#define DRIVER_VERSION	"0.55"
 
 #ifdef QX_SERIAL
 #	include "serial.h"
@@ -730,6 +730,8 @@ static int				langid_fix = -1;
 
 static int	(*subdriver_command)(const char *cmd, size_t cmdlen, char *buf, size_t buflen) = NULL;
 
+/* -1: let the driver guess by USB ID; 0/1: explicit disable/enable */
+static int	cypress_drain_quirk_setting = -1;
 static bool_t	cypress_0665_5161_quirk = FALSE;
 
 #define CYPRESS_0665_5161_FLUSH_REPORTS	10
@@ -2599,7 +2601,11 @@ static void	*cypress_subdriver(USBDevice_t *device)
 {
 	NUT_UNUSED_VARIABLE(device);
 
-	cypress_0665_5161_quirk = FALSE;
+	switch (cypress_drain_quirk_setting) {
+		case 0: cypress_0665_5161_quirk = FALSE; break;
+		case 1: cypress_0665_5161_quirk = TRUE; break;
+		default: cypress_0665_5161_quirk = FALSE;
+	}
 	subdriver_command = &cypress_command;
 	return NULL;
 }
@@ -2608,7 +2614,11 @@ static void	*cypress_0665_5161_subdriver(USBDevice_t *device)
 {
 	NUT_UNUSED_VARIABLE(device);
 
-	cypress_0665_5161_quirk = TRUE;
+	switch (cypress_drain_quirk_setting) {
+		case 0: cypress_0665_5161_quirk = FALSE; break;
+		case 1: cypress_0665_5161_quirk = TRUE; break;
+		default: cypress_0665_5161_quirk = TRUE;
+	}
 	subdriver_command = &cypress_command;
 	return NULL;
 }
@@ -3554,6 +3564,10 @@ void	upsdrv_makevartable(void)
 		"Apply the language ID workaround to the krauler subdriver "
 		"(0x409 or 0x4095)");
 	addvar(VAR_FLAG, "noscanlangid", "Don't autoscan valid range for langid");
+
+	addvar(VAR_VALUE, "cypress_drain_quirk",
+		"Enable or disable USB buffer drain from stale data for devices "
+		"with cypress subdriver (default: enabled for 0665:5161)");
 #endif	/* QX_USB */
 
 #ifdef QX_SERIAL
@@ -3753,7 +3767,8 @@ void	upsdrv_initups(void)
 		getval("product") ||
 		getval("serial") ||
 		getval("bus") ||
-		getval("langid_fix")
+		getval("langid_fix") ||
+		getval("cypress_drain_quirk")
 # if (defined WITH_USB_BUSPORT) && (WITH_USB_BUSPORT)
 		|| getval("busport")
 # endif
@@ -3890,6 +3905,21 @@ void	upsdrv_initups(void)
 				upsdebugx(2,
 					"Language ID workaround enabled (using '0x%x')",
 					(unsigned int)langid_fix);
+			}
+		}
+
+		if ((val = getval("cypress_drain_quirk"))) {
+			if (!strcmp(val, "1") || !strcasecmp(val, "on") || !strcasecmp(val, "yes") || !strcasecmp(val, "true")) {
+				upsdebugx(2, "cypress_drain_quirk explicitly enabled: %s", val);
+				cypress_drain_quirk_setting = 1;
+			} else if (!strcmp(val, "0") || !strcasecmp(val, "off") || !strcasecmp(val, "no") || !strcasecmp(val, "false")) {
+				upsdebugx(2, "cypress_drain_quirk explicitly disabled: %s", val);
+				cypress_drain_quirk_setting = 0;
+			} else if (!strcmp(val, "-1") || !strcasecmp(val, "null")) {
+				upsdebugx(2, "cypress_drain_quirk ignored (driver will choose by USB ID): %s", val);
+				cypress_drain_quirk_setting = -1;
+			} else {
+				upslogx(LOG_NOTICE, "Error enabling cypress_drain_quirk: unsupported value, ignored");
 			}
 		}
 


### PR DESCRIPTION
Fix handling of stale interrupt reports for the Cypress 0665:5161 USB transport.

The device can keep replies from prior commands queued on its interrupt endpoint,
which can break Qx protocol autodetection. Drain a bounded number of stale
reports before sending a command and use a longer reply timeout for this USB ID.

Verified with a VOLT Polska RackUPS 1200VA/720W (USB ID 0665:5161).
The driver autodetects the Voltronic-QS protocol and reports live UPS data.

Related to #2534.

Scope note: USB ID 0665:5161 is already shared by Belkin F6C1200-UNV and
Voltronic Power UPSes in `qx_usb_id[]`. The tested device is a VOLT Polska
RackUPS rebadge; its USB manufacturer and product strings are empty, so no
reliable finer-grained USB match is available. The quirk is therefore scoped
to this existing Cypress transport entry. Testing on a Belkin device would be
welcome.

Implementation and documentation were prepared with assistance from OpenAI
Codex; the contributor reviewed and tested the changes on the hardware
described above.

<!-- Comment:
* Please revise the docs/developers.txt for coding style suggestions and
  other considerations applicable to NUT codebase contributions, as well
  as for which text documents to update. See also docs/developer-guide.txt
  for general points on NUT architecture and design.

* Please note that we require "Signed-Off-By" tags in each Git Commit
  message, to conform to the common DCO (Developer Certificate of Origin)
  as posted in LICENSE-DCO at root of NUT codebase as well as published
  at https://developercertificate.org/

* The checklist below is more of a reminder of steps to take and "dangers"
  to look out for. PRs to update this template are also welcome :)

* Local build iterations can be augmented with the ci_build.sh script.
  Note that if your system has both GCC and CLANG, they can expose different
  kinds of issues in their static analysis warnings, so incantations like
  `CC=clang CXX=clang++ ./ci_build.sh` or `BUILD_TYPE=fightwarn ./ci_build.sh`
  (to iterate a matrix of some build dependency combos and compilers) can
  be useful.
-->

## General points

- [x] Described the changes in the PR submission or a separate issue, e.g.
  known published or discovered protocols, applicable hardware (expected
  compatible and actually tested/developed against), limitations, etc.

- [ ] There may be multiple commits in the PR, aligned and commented with
  a functional change. Notably, coding style changes better belong in a
  separate PR, but certainly in a dedicated commit to simplify reviews
  of "real" changes in the other commits. Similarly for typo fixes in
  comments or text documents.

- [x] Use of coding helper tools and AI should be disclosed in the commit
  or PR comments (it is interesting to know which ones do a decent job).
  As with other contributions, a human is responsible and thanked for the
  quality and content of the change, and is presumed to have the right to
  post that code to be published further under the project's license terms.

- [x] Especially with involvement of AI, including modern IDE coding aid,
  please be sure to revise that proposed code and documentation changes
  follow NUT code style guide -- this helps portability across the decades
  worth of supported systems. Notably, avoid Unicode characters where ASCII
  text is expected (C sources and headers, manual pages and other `acsiidoc`
  inputs). Particularly AI is keen on adding `mdash` characters instead of
  plain ASCII double-dash (which renders into the long dash where applicable).

- [ ] Please star NUT on GitHub, this helps with sponsorships! ;)

## Frequent "underwater rocks" for driver addition/update PRs

- [x] Revised existing driver families and added a sub-driver if applicable
  (`nutdrv_qx`, `usbhid-ups`...) or added a brand new driver in the other
  case.

- [x] Did not extend obsoleted drivers with new hardware support features
  (notably `blazer` and other single-device family drivers for Qx protocols,
  except the new `nutdrv_qx` which should cover them all).

- [ ] For updated existing device drivers, bumped the `DRIVER_VERSION` macro
  or its equivalent.

<!-- Comment:
  Some sub-drivers have `SUBDRIVER_VERSION` or customized names like
  e.g. `MEGATEC_VERSION` in `drivers/nutdrv_qx_megatec.c`
-->

- [ ] For USB devices (HID or not), revised that the driver uses unique
  VID/PID combinations, or raised discussions when this is not the case
  (several vendors do use same interface chips for unrelated protocols).

- [ ] For new USB devices, built and committed the changes for the
  `scripts/upower/95-upower-hid.hwdb` file

- [ ] Proposed NUT data mapping is aligned with existing `docs/nut-names.txt`
  file. If the device exposes useful data points not listed in the file, the
  `experimental.*` namespace can be used as documented there, and discussion
  should be raised on the NUT Developers mailing list to standardize the new
  concept.

- [x] Updated `data/driver.list.in` if applicable (new tested device info)
<!-- Comment:
Also note below, a point about PR posting for NUT DDL
-->

## Frequent "underwater rocks" for general C code PRs

- [ ] Did not "blindly assume" default integer type sizes and value ranges,
  structure layout and alignment in memory, endianness (layout of bytes and
  bits in memory for multi-byte numeric types), or use of generic `int` where
  language or libraries dictate the use of `size_t` (or `ssize_t` sometimes).

<!-- Comment:
* NOTE: Casting and/or pragmas (support detected at compile time,
  see `m4/ax_c_pragmas.m4`) to silence warnings may be acceptable,
  but only if coupled with range checks or similar actions.
-->

- [x] Progress and errors are handled with `upsdebugx()`, `upslogx()`,
  `fatalx()` and related methods, not with direct `printf()` or `exit()`.
  Similarly, NUT helpers are used for error-checked memory allocation and
  string operations (except where customized error handling is needed,
  such as unlocking device ports, etc.)

- [ ] Coding style (including whitespace for indentations) follows precedent
  in the code of the file, and examples/guide in `docs/developers.txt` file.

- [ ] For newly added files, the `Makefile.am` recipes were updated and the
  `make distcheck` target passes.

## General documentation updates

- [ ] Added a bullet point into `NEWS.adoc`, possibly also `UPGRADING.adoc`
  if there is something packagers or custom-build users should take into
  account (new driver categories, configuration options, dependencies...)

- [ ] Updated `docs/acknowledgements.txt` (for vendor-backed device support)

- [ ] Added or updated manual page information in `docs/man/*.txt` files
  and corresponding recipe lists in `docs/man/Makefile.am` for new pages

- [ ] Passed `make spellcheck`, updated spell-checking dictionary in the
  `docs/nut.dict` file if needed (did not remove any words -- the `make`
  rule printout in case of changes suggests how to maintain it).

## Additional work may be needed after posting this PR

- [ ] Propose a PR for NUT DDL with detailed device data dumps from tests
  against real hardware (the more models, the better).

- [ ] Address NUT CI farm build failures for the PR: testing on numerous
  platforms and toolkits can expose issues not seen on just one system.

<!-- Comment:
* One frequent "offence" is the appearance of unexpected (not git-ignored)
  or modification during build of files tracked in Git.

* Another frequent issue is not tracking newly introduced file names in
  `EXTRA_DIST` of the `Makefile.am` (and for `*.in` templates -- of rules
  in the `configure.ac` script) so the `make distcheck` fails.

* Avoid using GNU-specific constructs in the `Makefile.am`, even if that
  means cumbersome ways to build a target. This should not happen in mere
  driver updates, however.

* Also some third-party libraries or OS headers and method argument types
  and counts can differ -- necessitating m4 code for `configure` script
  probing, and `ifdef`, `typedef`, etc. in C code to adapt to the build
  environment (precedents available in NUT codebase). In extreme cases,
  you may need to spin up a VM or container to reproduce those issues
  and iterate on a fix locally; see `docs/config-prereqs.txt` and
  `docs/ci-farm-lxc-setup.txt` for notes taken during preparation of
  the multi-platform NUT CI farm.
-->

- [ ] Revise suggestions from LGTM.COM analysis about "new issues" with
  the changed codebase.

<!-- Comment:
  Take them with a grain of salt, especially with regard to things like
  architecture-dependent range checks, but many of the complaints from
  the tool are indeed useful.
-->
