### PR TITLE
apc-hid: map shutdown.return for APC Back-UPS BX*MI units [#2683]

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -162,6 +162,18 @@ https://github.com/networkupstools/nut/milestone/13
  - `usbhid-ups` driver updates:
     * When reconnecting, report success more visibly (not only in debug), and
       do not reset driver state to "quiet" when it will loop trying. [PR #3423]
+    * `apc-hid` subdriver: mapped `shutdown.return` to
+      `UPS.APCGeneralCollection.APCDelayBeforeReboot` with value "1", for
+      newer APC Back-UPS devices (e.g. Back-UPS BX750MI) where that usage
+      is the only shutdown-capable one. Their firmware accepts but never
+      executes the value "10" written by the previously only matching
+      command `shutdown.reboot`, so the built-in shutdown sequence reported
+      success without ever powering the load off. The value "1" is what APC
+      PowerChute writes (confirmed by decoding USB captures of the vendor
+      software, and by live tests on another unit): the load is cycled after
+      a fixed ~2 minute grace, the command is executed only while on battery,
+      and output returns when wall power is present, even if AC came back
+      during the grace period. [issue #2683, PR #3566]
     * `idowell-hid` subdriver now also supports GoldenMate 1000VA/800W LiFePO4
       battery packs (`0x06da:0xffff`), which carry the same `-BMS-` firmware and
       HID descriptor as the existing `0x075d:0x0300` device. The shared

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3800 utf-8
+personal_ws-1.1 en 3801 utf-8
 AAC
 AAS
 ABI
@@ -1050,6 +1050,7 @@ PowerPC
 PowerPS
 PowerPal
 PowerPanel
+PowerChute
 PowerShare
 PowerShell
 PowerShield

--- a/drivers/apc-hid.c
+++ b/drivers/apc-hid.c
@@ -457,6 +457,13 @@ static hid_info_t apc_hid2nut[] = {
 	{ "load.on.delay", 0, 0, "UPS.APCGeneralCollection.APCDelayBeforeStartup", NULL, DEFAULT_ONDELAY, HU_TYPE_CMD, NULL },
 	{ "shutdown.stop", 0, 0, "UPS.APCGeneralCollection.APCDelayBeforeShutdown", NULL, "-1", HU_TYPE_CMD, NULL },
 	{ "shutdown.reboot", 0, 0, "UPS.APCGeneralCollection.APCDelayBeforeReboot", NULL, "10", HU_TYPE_CMD, NULL },
+	/* used by APC Back-UPS BX series (e.g. BX750MI), where this usage is the
+	 * only shutdown-capable one: value "1" is what APC PowerChute writes
+	 * (fixed ~2 min grace, executed only while on battery, output returns
+	 * when wall power is present, even if AC came back during the grace);
+	 * the "10" written by shutdown.reboot above is ACKed but never executed
+	 * by that firmware. See issue #2683. */
+	{ "shutdown.return", 0, 0, "UPS.APCGeneralCollection.APCDelayBeforeReboot", NULL, "1", HU_TYPE_CMD, NULL },
 	/* used by APC BackUPS CS */
 	{ "shutdown.return", 0, 0, "UPS.Output.APCDelayBeforeReboot", NULL, "1", HU_TYPE_CMD, NULL },
 


### PR DESCRIPTION

Closes the practical side of #2683 (and matches the empirical conclusion of #2666): on newer APC Back-UPS units such as the BX750MI, the built-in `upsdrvctl shutdown` / `usbhid-ups -k` sequence reports success but never powers the load off.

**Why:** on these units the only shutdown-capable HID usage is `UPS.APCGeneralCollection.APCDelayBeforeReboot`. The only command previously mapped to that path, `shutdown.reboot`, writes its default value "10" — which this firmware ACKs at the USB level but never executes. The shutdown chain then stops at that first "successful" command.

**Fix (one table line):** map `shutdown.return` to the same usage with value "1" — the exact write APC's own PowerChute Serial Shutdown performs (single `SET_REPORT(Feature, 0x40) = 01`, decoded from the USBPcap captures archived in #2683). With it, the driver-default chain (`shutdown.return,shutdown.reboot,load.off.delay,shutdown.stayoff`) succeeds on its first command with a write that actually works. This mirrors the existing "Back-UPS CS" `shutdown.return` entry, which uses the same value "1" on the `UPS.Output` path.

**Semantics of the write, per our bench work on a 2025-11 BX750MI-GR unit (051d:0002)** — complementing the PowerChute captures in #2683, which came from the original reporter's 2024-build unit:
- Fixed ~2 minute internal grace; the value is not a seconds count on this firmware.
- Executes only while on battery; race-immune — the cycle completes even if AC returns during the grace (matching PowerChute pcap capture `11-14-2` and our live retest).
- Output re-energizes when wall power is present — proper `shutdown.return` behavior.

**Verification of this patch (2026-08-12, BX750MI-GR, macOS/arm64 bench, libusb 1.0.30):**
- On battery: `usbhid-ups -a ups4 -k -u root` → chain used `shutdown.return` via `UPS.APCGeneralCollection.APCDelayBeforeReboot`, `Report[set]: (2 bytes) => 40 01`, "Shutdown successful with 'shutdown.return'". Output cut 2 min 2 s after the write; replugging the wall re-energized the output within seconds. Full debug logs available.
- On line (the "checking if wall power is on/off" question from #2683): same command with AC present throughout → the write is ACKed identically (`40 01` on the same path, driver reports success) but is **silently dropped by the firmware**: no output cut within 8 minutes, a subsequent register read showed `ups.timer.reboot: 0` (disarmed — an armed timer holds `1`), and a battery transition several minutes after the write produced no delayed fire either. So on this family no on-line/on-battery conditional command logic is needed: the write only ever does anything when issued on battery, and there it is race-immune. The unconditional default chain is safe on both sides of the power race.

**Review point worth flagging:** older Back-UPS ES devices also expose the `APCGeneralCollection` path. Previously `shutdown.return` did not match on them at all, and the default chain used `shutdown.reboot` (value "10"). With this patch the chain will prefer `shutdown.return` (value "1") on those units too. If their firmware honors the value as a seconds delay, this shortens the pre-cut delay from 10 s to 1 s; we could not test an ES unit. If that is a concern, the entry could be gated by product string instead — happy to rework it that way.

The NEWS.adoc entry currently references issue #2683; I can amend it with this PR's number once known (or per your preference).

**Transparency, as discussed in #2683:** I am not a programmer — the analysis, this patch, and this PR text were authored by an AI assistant (Claude / Fable 5, via Claude Code) under my direction; I performed the hardware tests on my BX750MI unit. Maintainer OK for AI-assisted contribution: [#2683 comment](https://github.com/networkupstools/nut/issues/2683#issuecomment-5263626668) follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQEAfDBxtHupEdAcv3Bgz2
