### PR TITLE
Prefer complete HID descriptor for EcoFlow devices

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -49,6 +49,11 @@ https://github.com/networkupstools/nut/milestone/13
       descriptor lengths, which could cause a segmentation fault (regression
       added in NUT v2.8.5 release). [PR #3550]
 
+ - USB drivers now prefer the longer of conflicting HID report descriptor
+   lengths for EcoFlow devices using USB ID `3746:ffff`. This makes the
+   complete descriptor available on affected River 3 Plus firmware while
+   retaining the shorter length as a fallback.
+
  - Windows serial compatibility: fixed timeout handling to return data
    already received as a successful short read, while safely canceling
    and completing pending overlapped I/O before reusing its state.

--- a/drivers/libusb0.c
+++ b/drivers/libusb0.c
@@ -48,7 +48,7 @@
 #include "strcasestr-static.h"
 
 #define USB_DRIVER_NAME		"USB communication driver (libusb 0.1)"
-#define USB_DRIVER_VERSION	"0.53"
+#define USB_DRIVER_VERSION	"0.54"
 
 /* driver description structure */
 upsdrv_info_t comm_upsdrv_info = {
@@ -630,6 +630,12 @@ static int nut_libusb_open(usb_dev_handle **udevp,
 				upsdebugx(1, "Eaton device v2.02. Using full report descriptor");
 				rdlens[0] = rdlen1;
 				rdlens[1] = rdlen2;
+			}
+			else if ((curDevice->VendorID == 0x3746) && (curDevice->ProductID == 0xffff)
+				&& (rdlen1 != rdlen2)) {
+				upsdebugx(1, "EcoFlow device. Trying longer report descriptor first");
+				rdlens[0] = rdlen1 > rdlen2 ? rdlen1 : rdlen2;
+				rdlens[1] = rdlen1 > rdlen2 ? rdlen2 : rdlen1;
 			}
 			else {
 				rdlens[0] = rdlen2 >= 0 ? rdlen2 : rdlen1;

--- a/drivers/libusb1.c
+++ b/drivers/libusb1.c
@@ -47,7 +47,7 @@
 #endif
 
 #define USB_DRIVER_NAME		"USB communication driver (libusb 1.0)"
-#define USB_DRIVER_VERSION	"0.54"
+#define USB_DRIVER_VERSION	"0.55"
 
 /* driver description structure */
 upsdrv_info_t comm_upsdrv_info = {
@@ -787,6 +787,12 @@ static int nut_libusb_open(libusb_device_handle **udevp,
 			upsdebugx(1, "Eaton device v2.02. Using full report descriptor");
 			rdlens[0] = rdlen1;
 			rdlens[1] = rdlen2;
+		}
+		else if ((curDevice->VendorID == 0x3746) && (curDevice->ProductID == 0xffff)
+			&& (rdlen1 != rdlen2)) {
+			upsdebugx(1, "EcoFlow device. Trying longer report descriptor first");
+			rdlens[0] = rdlen1 > rdlen2 ? rdlen1 : rdlen2;
+			rdlens[1] = rdlen1 > rdlen2 ? rdlen2 : rdlen1;
 		}
 		else {
 			rdlens[0] = rdlen2 >= 0 ? rdlen2 : rdlen1;


### PR DESCRIPTION
## Summary

- prefer the longer candidate when EcoFlow USB devices using `3746:ffff` report conflicting HID descriptor lengths
- retain the shorter candidate as a fallback if the longer read is rejected
- apply the same behavior to the libusb 0.1 and libusb 1.0 backends
- bump both USB transport versions and document the change in the 2.8.6 release notes

## Root cause

The tested River 3 Plus reports a 403-byte HID report descriptor when it is requested directly, while the HID descriptor embedded in the USB configuration advertises 376 bytes. NUT normally prefers the configuration value because that is correct for several other broken devices.

For this EcoFlow, using 376 bytes truncates the descriptor before the feature form of `ShutdownImminent`, the input and feature forms of `CommunicationLost` and `Overload`, and the closing collection records. The device does return all 403 bytes when asked for them.

The exception is limited to EcoFlow's existing `3746:ffff` VID/PID. Other devices keep the current ordering.

## Validation

- built `usbhid-ups` against libusb 1.0 from current `master`
- `make check -j4`: 6 passed, 0 failed
- compiled `drivers/libusb0.c` with the configured libusb 0.1 headers and `-Werror`
- tested one polling cycle on an EcoFlow River 3 Plus (`3746:ffff`, `bcdDevice 1.00`):
  - method 1: 403 bytes
  - method 2: 376 bytes
  - selected: 403 bytes
  - parsed items: 56, compared with 51 using the packaged driver
  - `CommunicationLost`, `Overload`, and both forms of `ShutdownImminent` were present and mapped
  - the test driver exited successfully and the packaged NUT service was restored in `OL` state

Actual overload and communication-loss conditions were not induced. This test confirms that the previously truncated status fields are now parsed and polled.

Relates to #2735.
