### PR TITLE
apc_modbus: three fixes for the #3414 read-retry loop

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -70,6 +70,11 @@ https://github.com/networkupstools/nut/milestone/13
     * Added `modbus_retries` option to configure the number of read retry
       attempts on timeout errors, simplifying error recovery. [PR #3414]
     * Increased default TCP response timeout to 2000 ms. [PR #3418]
+    * Three fixes for the read-retry loop added in PR #3414:
+      the loop ignored `exit_flag`, causing `upsdrvctl` to kill the driver
+      and wedge the device if it was killed mid-exchange; now we retry on more
+      failure causes than just a timeout; quieter retry logging to avoid
+      severe syslog/journal thrashing. [PR #3571, #3414]
 
  - `dummy-ups` driver updates:
     * Added `authconf` driver parameter for repeater mode to control

--- a/drivers/apc_modbus.c
+++ b/drivers/apc_modbus.c
@@ -1044,7 +1044,18 @@ static int _apc_modbus_read_registers(modbus_t *ctx, int addr, int nb, uint16_t 
 
 		upslogx(LOG_ERR, "%s: Read of %d:%d failed: %s (%s)", __func__, addr, addr + nb, modbus_strerror(saved_errno), device_path);
 
-		if (saved_errno != ETIMEDOUT) {
+		/* ETIMEDOUT means no reply arrived (yet). EMBBADSLAVE, EMBBADCRC and
+		 * EMBBADDATA mean one did arrive but does not belong to this request:
+		 * typically a deferred reply to an earlier exchange that was abandoned,
+		 * which on a serial line would have been discarded but on a packetised
+		 * transport is still queued. Both are transient states of the wire, and
+		 * reading the stale frame has already consumed it, so the next attempt
+		 * can succeed. Anything else is the device answering us properly -- a
+		 * Modbus exception, say -- and will not improve on a retry. */
+		if (saved_errno != ETIMEDOUT
+		    && saved_errno != EMBBADSLAVE
+		    && saved_errno != EMBBADCRC
+		    && saved_errno != EMBBADDATA) {
 			break;
 		}
 	}

--- a/drivers/apc_modbus.c
+++ b/drivers/apc_modbus.c
@@ -1057,7 +1057,9 @@ static int _apc_modbus_read_registers(modbus_t *ctx, int addr, int nb, uint16_t 
 		 * can succeed. Anything else is the device answering us properly -- a
 		 * Modbus exception, say -- and will not improve on a retry. */
 		if (saved_errno != ETIMEDOUT
+#ifdef EMBBADSLAVE
 		&&  saved_errno != EMBBADSLAVE
+#endif
 		&&  saved_errno != EMBBADCRC
 		&&  saved_errno != EMBBADDATA
 		) {

--- a/drivers/apc_modbus.c
+++ b/drivers/apc_modbus.c
@@ -1020,7 +1020,8 @@ static int _apc_modbus_read_registers(modbus_t *ctx, int addr, int nb, uint16_t 
 {
 	int res;
 	int retries = modbus_retries;
-	int saved_errno;
+	int saved_errno = 0;
+	int attempt = 0;
 
 	while (retries-- > 0) {
 		/* Stop retrying if the driver has been asked to exit. upsdrvctl gives
@@ -1035,6 +1036,7 @@ static int _apc_modbus_read_registers(modbus_t *ctx, int addr, int nb, uint16_t 
 
 		_apc_modbus_interframe_delay();
 
+		attempt++;
 		res = modbus_read_registers(ctx, addr, nb, dest);
 		saved_errno = errno;
 		_apc_modbus_interframe_delay_reset();
@@ -1042,7 +1044,7 @@ static int _apc_modbus_read_registers(modbus_t *ctx, int addr, int nb, uint16_t 
 			return 1;
 		}
 
-		upslogx(LOG_ERR, "%s: Read of %d:%d failed: %s (%s)", __func__, addr, addr + nb, modbus_strerror(saved_errno), device_path);
+		upsdebugx(1, "%s: Read of %d:%d failed on attempt %d: %s (%s)", __func__, addr, addr + nb, attempt, modbus_strerror(saved_errno), device_path);
 
 		/* ETIMEDOUT means no reply arrived (yet). EMBBADSLAVE, EMBBADCRC and
 		 * EMBBADDATA mean one did arrive but does not belong to this request:
@@ -1058,6 +1060,20 @@ static int _apc_modbus_read_registers(modbus_t *ctx, int addr, int nb, uint16_t 
 		    && saved_errno != EMBBADDATA) {
 			break;
 		}
+	}
+
+	/* Only now is this a failure: the retries are gone, or the error was one
+	 * they cannot help, and the connection is about to be closed. Individual
+	 * attempts are logged at debug level instead, because the retry loop
+	 * exists precisely so that a recovered attempt is not an error. Logging
+	 * each one at LOG_ERR misreports a working driver, and on a device that
+	 * needs retries routinely it buries every other message in the system log.
+	 *
+	 * Nothing is logged when exit_flag broke the loop: the driver is stopping,
+	 * not failing, and saved_errno may not have been set at all. */
+	if (!exit_flag) {
+		upslogx(LOG_ERR, "%s: Read of %d:%d failed after %d attempt(s): %s (%s)",
+			__func__, addr, addr + nb, attempt, modbus_strerror(saved_errno), device_path);
 	}
 
 	_apc_modbus_close(0);

--- a/drivers/apc_modbus.c
+++ b/drivers/apc_modbus.c
@@ -43,7 +43,7 @@
 #endif
 
 #define DRIVER_NAME	"NUT APC Modbus driver " DRIVER_NAME_NUT_MODBUS_HAS_USB_WITH_STR " USB support (libmodbus link type: " NUT_MODBUS_LINKTYPE_STR ")"
-#define DRIVER_VERSION	"0.21"
+#define DRIVER_VERSION	"0.22"
 
 #if defined NUT_MODBUS_HAS_USB
 
@@ -1044,7 +1044,9 @@ static int _apc_modbus_read_registers(modbus_t *ctx, int addr, int nb, uint16_t 
 			return 1;
 		}
 
-		upsdebugx(1, "%s: Read of %d:%d failed on attempt %d: %s (%s)", __func__, addr, addr + nb, attempt, modbus_strerror(saved_errno), device_path);
+		upsdebugx(1, "%s: Read of %d:%d failed on attempt %d: %s (%s)",
+			__func__, addr, addr + nb, attempt,
+			modbus_strerror(saved_errno), device_path);
 
 		/* ETIMEDOUT means no reply arrived (yet). EMBBADSLAVE, EMBBADCRC and
 		 * EMBBADDATA mean one did arrive but does not belong to this request:
@@ -1055,9 +1057,10 @@ static int _apc_modbus_read_registers(modbus_t *ctx, int addr, int nb, uint16_t 
 		 * can succeed. Anything else is the device answering us properly -- a
 		 * Modbus exception, say -- and will not improve on a retry. */
 		if (saved_errno != ETIMEDOUT
-		    && saved_errno != EMBBADSLAVE
-		    && saved_errno != EMBBADCRC
-		    && saved_errno != EMBBADDATA) {
+		&&  saved_errno != EMBBADSLAVE
+		&&  saved_errno != EMBBADCRC
+		&&  saved_errno != EMBBADDATA
+		) {
 			break;
 		}
 	}
@@ -1073,7 +1076,8 @@ static int _apc_modbus_read_registers(modbus_t *ctx, int addr, int nb, uint16_t 
 	 * not failing, and saved_errno may not have been set at all. */
 	if (!exit_flag) {
 		upslogx(LOG_ERR, "%s: Read of %d:%d failed after %d attempt(s): %s (%s)",
-			__func__, addr, addr + nb, attempt, modbus_strerror(saved_errno), device_path);
+			__func__, addr, addr + nb, attempt,
+			modbus_strerror(saved_errno), device_path);
 	}
 
 	_apc_modbus_close(0);

--- a/drivers/apc_modbus.c
+++ b/drivers/apc_modbus.c
@@ -1023,6 +1023,16 @@ static int _apc_modbus_read_registers(modbus_t *ctx, int addr, int nb, uint16_t 
 	int saved_errno;
 
 	while (retries-- > 0) {
+		/* Stop retrying if the driver has been asked to exit. upsdrvctl gives
+		 * a driver 5 seconds to honour SIGTERM before sending SIGKILL, and
+		 * retries * response_timeout can exceed that comfortably. On some UPS
+		 * hardware a SIGKILL mid-exchange leaves the device unable to serve
+		 * Modbus until its USB cable is physically reseated, so being slow to
+		 * exit is not merely untidy. */
+		if (exit_flag) {
+			break;
+		}
+
 		_apc_modbus_interframe_delay();
 
 		res = modbus_read_registers(ctx, addr, nb, dest);


### PR DESCRIPTION
Three defects in the register-read retry loop added by #3414, found while
getting `apc_modbus` running reliably on an APC Smart-UPS X1500 (051d:0003,
FW "UPS 16.0") over USB. Each is device-independent; the X1500 is just the
hardware that makes all three visible at once. Compile-tested on master and
running in production (backported) on 2.8.4.

### 1. The loop ignores `exit_flag`

A driver asked to stop keeps working through its remaining retries — up to
`retries × response_timeout`, which with non-default settings comfortably
exceeds the 5 s upsdrvctl allows for SIGTERM before escalating to SIGKILL.
On the X1500 a SIGKILL mid-exchange leaves the device unable to serve Modbus
until its USB cable is physically reseated, so every clean shutdown wedged
the UPS. Journal signature before the fix:

```
Stopping /run/nut/apc_modbus-smx.pid failed, retrying harder: Success
Main process exited, code=killed, status=9/KILL
```

### 2. The loop retries only ETIMEDOUT

It gives up on `EMBBADSLAVE`/`EMBBADCRC`/`EMBBADDATA` — the one case where a
retry is most obviously right, because a reply arrived that belongs to an
*earlier* request, and reading it has already consumed it. On packetised
transports (rtu_usb) a deferred reply stays queued on the endpoint rather
than ageing off the wire, so this is routine: the first driver start after a
host reboot collects a reply queued before the reboot (the self-powered UPS
keeps its state), fails, and systemd restart-loops the driver, degrading the
device further with every failed start.

### 3. Every attempt is logged at LOG_ERR

The pre-#3414 error log was left inside the new loop, so attempts the next
retry recovers are still reported as errors — the exact case the loop was
added for. Measured here in a degraded state: ~310 LOG_ERR/min while the
connection was never closed once and every read succeeded; ~890k lines/day,
42% of the journal (doubled by upsdrvctl forwarding driver stderr alongside
the syslog write). Attempts now log at `upsdebugx(1)`; the error logs once,
after the loop, with the attempt count.

### Context

The wider investigation (the X1500's post-reset behaviour, its reply
queueing, and the transport-level fixes in networkupstools/libmodbus#12) is
written up separately; these three fixes stand on their own and are the
device-independent part. Related: #2609, #3414.

### Note on authorship

Developed with assistance from Claude (Anthropic); commits carry a
Co-Authored-By trailer to that effect. All findings were verified on real
hardware.
