### PR TITLE
`configure.ac`: revise `NUT_ARG*` methods to remember if the option was "given" by caller or defaulted, address valgrind findings

### DIFF
--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -1004,7 +1004,7 @@ set | sort -n """
                 runAllowedFailure: true,
                 mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs. language standards as centrally defined!
                 excludeCombos: dynacfgPipeline.excludeCombos_DEFAULT_CPPUNIT
-                    + [dynacfgPipeline.axisCombos_STRICT_C] // TODO: revise to match the purpose of this filter
+                    //+ [dynacfgPipeline.axisCombos_STRICT_C] // TODO: revise to match the purpose of this filter
                     + [dynacfgPipeline.axisCombos_COMPILER_NOT_GCC]
                     + [dynacfgPipeline.axisCombos_WINDOWS_CROSS]
                 ], body)

--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -207,22 +207,25 @@ import org.nut.dynamatrix.*;
         dynacfgPipeline.axisCombos_ARCH64x32
         ]
 
-    dynacfgPipeline.excludeCombos_AUTOTOOLS_REQUIRE_TWEAK =
-        [[~/OS_DISTRO=openbsd-6\./, ~/COMPILER=GCC/]] +
-        // Here we picked just OSes and compilers (gcc or clang),
-        // so exclude systems which have e.g. gcc-4.2.1 which claims
-        // type range comparison warnings despite pragma fencing.
-        // gcc-4.8.x on CentOS 7 and Ubuntu 14.04 looks already okay.
-        [[~/OS_DISTRO=macos/]] +
-        // MacOS (at least agents prepared with HomeBrew packages)
-        // requires a few pkg-config and CFLAGS pre-sets which are
-        // done in ci_build.sh and defeat the purpose of this stage.
-        // So it is easier and more honest to just skip it.
-        [[~/OS_DISTRO=netbsd/]]
-        // NetBSD versions on the build agent (9.2, 11.0) have issues
-        // with pkgsrc (lacking -R for some libs, e.g. Shared object
-        // "libssl.so.3" not found), so autotools builds are tricky;
-        // ci_build.sh imposes some fixes - so see notes for macos.
+    dynacfgPipeline.excludeCombos_AUTOTOOLS_REQUIRE_TWEAK = [
+            [~/OS_DISTRO=openbsd-6\./, ~/COMPILER=GCC/],
+            // Here we picked just OSes and compilers (gcc or clang),
+            // so exclude systems which have e.g. gcc-4.2.1 which claims
+            // type range comparison warnings despite pragma fencing.
+            // gcc-4.8.x on CentOS 7 and Ubuntu 14.04 looks already okay.
+
+            [~/OS_DISTRO=macos/],
+            // MacOS (at least agents prepared with HomeBrew packages)
+            // requires a few pkg-config and CFLAGS pre-sets which are
+            // done in ci_build.sh and defeat the purpose of this stage.
+            // So it is easier and more honest to just skip it.
+
+            [~/OS_DISTRO=netbsd/],
+            // NetBSD versions on the build agent (9.2, 11.0) have issues
+            // with pkgsrc (lacking -R for some libs, e.g. Shared object
+            // "libssl.so.3" not found), so autotools builds are tricky;
+            // ci_build.sh imposes some fixes - so see notes for macos.
+        ]
 
     // This combo is used to *run* (with ci_build.sh) only scenarios
     // skipped by excludeCombos_AUTOTOOLS_REQUIRE_TWEAK.

--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -986,7 +986,7 @@ set | sort -n """
                 dynamatrixAxesVirtualLabelsMap: [
                     'BITS': [32, 64],
                     'CSTDVERSION_${KEY}': [ ['c': '89', 'cxx': '98'] ],
-                    'CSTDVARIANT': ['c', 'gnu'],
+                    'CSTDVARIANT': ['c', 'gnu'],    // NOTE: Actual use of Strict-C subject to excludeCombos below
                     ],
                 dynamatrixAxesCommonEnv: [
                     ['LANG=C','LC_ALL=C','TZ=UTC',
@@ -995,11 +995,13 @@ set | sort -n """
                     ]
                     ],
                 allowedFailure: [
+                    dynacfgPipeline.axisCombos_STRICT_C,    // TODO: Disallow failures once it works in some combos
                     dynacfgPipeline.axisCombos_WINDOWS
                     ],
                 runAllowedFailure: true,
                 mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs. language standards as centrally defined!
-                excludeCombos: dynacfgPipeline.excludeCombos_DEFAULT_CPPUNIT_STRICT_C
+                excludeCombos: dynacfgPipeline.excludeCombos_DEFAULT_CPPUNIT
+                    + [dynacfgPipeline.axisCombos_STRICT_C] // TODO: revise to match the purpose of this filter
                     + [dynacfgPipeline.axisCombos_COMPILER_NOT_GCC]
                     + [dynacfgPipeline.axisCombos_WINDOWS_CROSS]
                 ], body)

--- a/Jenkinsfile-dynamatrix
+++ b/Jenkinsfile-dynamatrix
@@ -1005,6 +1005,7 @@ set | sort -n """
                 mergeMode: [ 'excludeCombos': 'merge', 'dynamatrixAxesCommonEnv': 'replace' ], // NOTE: We might want to replace other fields, but excludeCombos must be merged to filter compiler versions vs. language standards as centrally defined!
                 excludeCombos: dynacfgPipeline.excludeCombos_DEFAULT_CPPUNIT
                     //+ [dynacfgPipeline.axisCombos_STRICT_C] // TODO: revise to match the purpose of this filter
+                    + [[~/OS_DISTRO=openbsd-6\./, ~/COMPILER=GCC/, ~/GCCVER=[01234].+/]]	// Does not trust pragmas to quiesce known "infractions" which are not problems
                     + [dynacfgPipeline.axisCombos_COMPILER_NOT_GCC]
                     + [dynacfgPipeline.axisCombos_WINDOWS_CROSS]
                 ], body)

--- a/Makefile.am
+++ b/Makefile.am
@@ -616,7 +616,7 @@ all-recursive/scripts: all/scripts/Windows @dotMAKE@
 DISTCHECK_FLAGS = --with-all --with-ssl --with-doc=auto --enable-docs-man-for-progs-built-only=no --with-pynut=app --with-nut_monitor=force CXXFLAGS='@NUT_CONFIG_CXXFLAGS@' CFLAGS='@NUT_CONFIG_CFLAGS@' CPPFLAGS='@NUT_CONFIG_CPPFLAGS@' LDFLAGS='@NUT_CONFIG_LDFLAGS@'
 DISTCHECK_LIGHT_FLAGS = --with-all=auto --with-ssl=auto --with-doc=auto --enable-docs-man-for-progs-built-only=no --with-pynut=app --with-nut_monitor=force CXXFLAGS='@NUT_CONFIG_CXXFLAGS@' CFLAGS='@NUT_CONFIG_CFLAGS@' CPPFLAGS='@NUT_CONFIG_CPPFLAGS@' LDFLAGS='@NUT_CONFIG_LDFLAGS@'
 DISTCHECK_LIGHT_MAN_FLAGS = --with-all=auto --with-ssl=auto --with-doc=man --enable-docs-man-for-progs-built-only=no --with-pynut=app --with-nut_monitor=force CXXFLAGS='@NUT_CONFIG_CXXFLAGS@' CFLAGS='@NUT_CONFIG_CFLAGS@' CPPFLAGS='@NUT_CONFIG_CPPFLAGS@' LDFLAGS='@NUT_CONFIG_LDFLAGS@'
-DISTCHECK_VALGRIND_FLAGS = --with-all=auto --with-ssl=auto --with-doc=skip --with-valgrind CXXFLAGS='@NUT_CONFIG_CXXFLAGS@ -g' CFLAGS='@NUT_CONFIG_CFLAGS@ -g' CPPFLAGS='@NUT_CONFIG_CPPFLAGS@' LDFLAGS='@NUT_CONFIG_LDFLAGS@' --with-pynut=app --with-nut_monitor=force
+DISTCHECK_VALGRIND_FLAGS = --with-all=auto --with-ssl=auto --with-doc=skip --with-valgrind --with-debuginfo CXXFLAGS='@NUT_CONFIG_CXXFLAGS@' CFLAGS='@NUT_CONFIG_CFLAGS@' CPPFLAGS='@NUT_CONFIG_CPPFLAGS@' LDFLAGS='@NUT_CONFIG_LDFLAGS@' --with-pynut=app --with-nut_monitor=force
 
 # Note: this rule uses envvar DISTCHECK_FLAGS expanded at run-time, which
 # may be passed down from caller and/or one of distcheck-* rules below.

--- a/Makefile.am
+++ b/Makefile.am
@@ -996,6 +996,7 @@ maintainer-asciidocs:
 	  fi; \
 	 )
 
+memcheck-NIT memcheck-NIT-devel memcheck-NIT-sandbox memcheck-NIT-sandbox-devel \
 check-NIT check-NIT-devel check-NIT-sandbox check-NIT-sandbox-devel: @dotMAKE@
 	+cd $(builddir)/tests/NIT && $(MAKE) $(AM_MAKEFLAGS) $@
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -904,6 +904,10 @@ check-quick: @dotMAKE@
 	+@$(SET_PARMAKES_OPT); \
 	  $(MAKE) $(AM_MAKEFLAGS) -k -s $${PARMAKES_OPT} check
 
+memcheck-quick: @dotMAKE@
+	+@$(SET_PARMAKES_OPT); \
+	  $(MAKE) $(AM_MAKEFLAGS) -k -s $${PARMAKES_OPT} memcheck
+
 spellcheck-quick: @dotMAKE@
 	+@$(SET_PARMAKES_OPT); \
 	  $(MAKE) $(AM_MAKEFLAGS) -k -s $${PARMAKES_OPT} spellcheck

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -139,8 +139,7 @@ https://github.com/networkupstools/nut/milestone/13
       DSM 7.3-86009 GPL sources and version 1.02 distributed in the QNAP QTS
       5.2.3 GPL sources. Polling and the direct shutdown commands were verified
       on an unloaded BN150T over USB; other OMRON models and serial connections
-      are untested.
-      [issue #3112]
+      are untested. [issue #3112, PR #3554]
     * In `Voltronic-QS-Hex` subdriver, the format string sanity check added in
       recent NUT releases caught a mismatch in `ups.load` reading. [issue #3532]
     * Modified `voltronic-qs` subdriver to request the QI command, supplying

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -240,6 +240,9 @@ https://github.com/networkupstools/nut/milestone/13
       track of some libusb resources when forking the daemon. [#3437]
     * Revised 'dstate' machinery to track socket connections closed mid-way
       through a call, to avoid access after `free()`. [#3302]
+    * Some operating systems provide in `sys/stdarg.h` definitions that others
+      access through common `stdarg.h` -- code updated to try including both.
+      [PR #3577]
     * Debug logging in `dstate.c` and `upssched.c` reported sent buffers "as
       is", complete with a confusing blank line where `\n` ended the message.
       This is now passed through newly introduced `upsdebug_ascii_compact()`

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -48,6 +48,10 @@ https://github.com/networkupstools/nut/milestone/13
     * USB drivers: fixed an out-of-bounds read of the candidate HID report
       descriptor lengths, which could cause a segmentation fault (regression
       added in NUT v2.8.5 release). [PR #3550]
+    * Refactoring of `configure.ac` for NUT v2.8.5 release led to a problem
+      when explicitly specifying same `--with-user` *OR* `--with-group` name
+      as would be default for current platform (so one was treated as not-set
+      and failed a sanity check). [issue #3513]
 
  - USB drivers now prefer the longer of conflicting HID report descriptor
    lengths for EcoFlow devices using USB ID `3746:ffff`. This makes the

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -2821,6 +2821,8 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-al
                 ) || {
                     RES_ALLERRORS=$?
                     FAILED+=("TESTCOMBO=${TESTCOMBO}[configure]")
+                    # Help find end of build (before cleanup noise) in logs:
+                    echo "=== [Matrix] Error: FAILED 'TESTCOMBO=${TESTCOMBO}' configure"
                     # TOTHINK: Do we want to try clean-up if we likely have no Makefile?
                     if [ "$CI_FAILFAST" = true ]; then
                         echo "===== [Matrix] Error: Aborting because CI_FAILFAST=$CI_FAILFAST" >&2
@@ -2910,6 +2912,8 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-al
                         } || {
                             RES_ALLERRORS=$?
                             FAILED+=("TESTCOMBO=${TESTCOMBO}[dist_clean]")
+                            # Help find end of build (before cleanup noise) in logs:
+                            echo "=== [Matrix] Error: FAILED 'TESTCOMBO=${TESTCOMBO}' dist_clean"
                         }
                     else
                         optional_maintainer_clean_check && {
@@ -2919,6 +2923,8 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-al
                         } || {
                             RES_ALLERRORS=$?
                             FAILED+=("TESTCOMBO=${TESTCOMBO}[maintainer_clean]")
+                            # Help find end of build (before cleanup noise) in logs:
+                            echo "=== [Matrix] Error: FAILED 'TESTCOMBO=${TESTCOMBO}' maintainer_clean"
                         }
                     fi
                     echo "=== Completed sandbox cleanup-check after TESTCOMBO=${TESTCOMBO}, $BUILDSTODO build variants remaining"
@@ -2944,6 +2950,8 @@ default|default-alldrv|default-alldrv:no-distcheck|default-all-errors|default-al
                 } || {
                     RES_ALLERRORS=$?
                     FAILED+=("[final_maintainer_clean]")
+                    # Help find end of build (before cleanup noise) in logs:
+                    echo "=== [Matrix] Error: FAILED 'TESTCOMBO=${TESTCOMBO}' final_maintainer_clean"
                 }
                 echo "=== Completed sandbox maintainer-cleanup-check after all builds"
             fi

--- a/clients/authconf.c
+++ b/clients/authconf.c
@@ -794,7 +794,19 @@ static void handle_authconf_args(size_t numargs, char **arg, int global_scope)
 					current_section->certverify,
 					current_section->forcessl);
 			}
-		}
+
+			free(normalized_sect_name);
+			free(sect_name);
+			free(sect_user);
+			free(sect_host);
+			free(sect_port);
+
+			normalized_sect_name = NULL;
+			sect_name = NULL;
+			sect_user = NULL;
+			sect_host = NULL;
+			sect_port = NULL;
+		}	/* finished handling a section */
 
 		current_section_ignored = 0;
 
@@ -803,19 +815,17 @@ static void handle_authconf_args(size_t numargs, char **arg, int global_scope)
 		/* we would remove the LAST seen bracket (there may be some in text, in case of IPv6 addresses) */
 		end_bracket = strrchr(sect_name, ']');
 		if (!end_bracket || !strcmp(sect_name, "_global_defaults")) {
-			free(sect_name);
-
 			if (global_scope) {
 				/* Subsequent lines will (re-)populate global_defaults */
 				current_section = NULL;
-				return;
+				goto section_header_cleanup_return;
 			}
 
 			current_section_ignored = 1;
 			upslogx(LOG_WARNING, "%s: Invalid nutauth section header format "
 				"in a non-global context, section contents will be ignored: %s",
 				__func__, arg[0]);
-			return;
+			goto section_header_cleanup_return;
 		}
 
 		/* forget trailing ']' and any characters after it (comments etc.)...
@@ -841,7 +851,7 @@ static void handle_authconf_args(size_t numargs, char **arg, int global_scope)
 				"section-scope for [%s], section contents will be ignored",
 				normalized_sect_name, current_section->section);
 			current_section_ignored = 1;
-			return;
+			goto section_header_cleanup_return;
 		}
 
 		/* Find if section already exists */
@@ -876,6 +886,7 @@ static void handle_authconf_args(size_t numargs, char **arg, int global_scope)
 			 */
 		}
 
+section_header_cleanup_return:
 		free(normalized_sect_name);
 		free(sect_name);
 		free(sect_user);

--- a/clients/upsclient.c
+++ b/clients/upsclient.c
@@ -217,7 +217,8 @@ static SSL_CTX	*ssl_ctx = NULL;
 #endif	/* WITH_OPENSSL */
 
 #ifdef WITH_NSS
-static int verify_certificate = 1;
+static int	verify_certificate = 1;
+static int	nss_initialized = 0;
 #endif	/* WITH_NSS */
 
 #if defined(WITH_OPENSSL) || defined(WITH_NSS)
@@ -1260,6 +1261,7 @@ int upscli_init2(int certverify, const char *certpath,
 #elif defined(WITH_NSS) /* WITH_OPENSSL */
 
 	PR_Init(PR_USER_THREAD, PR_PRIORITY_NORMAL, 0);
+	nss_initialized = 1;
 
 	PK11_SetPasswordFunc(nss_password_callback);
 
@@ -1673,17 +1675,22 @@ int upscli_cleanup(void)
 #endif /* WITH_OPENSSL */
 
 #ifdef WITH_NSS
-	/* Called to force cache clearing to prevent NSS shutdown failures.
-	 * http://www.mozilla.org/projects/security/pki/nss/ref/ssl/sslfnc.html#1138601
-	 */
-	SSL_ClearSessionCache();
-	NSS_Shutdown();
-	PR_Cleanup();
-	/* Called to release memory arena used by NSS/NSPR.
-	 * Prevent to show all PL_ArenaAllocate mem alloc as leaks.
-	 * https://developer.mozilla.org/en/NSS_Memory_allocation
-	 */
-	PL_ArenaFinish();
+	/* Avoid first calling NSS to shut it down - this confuses
+	 * the library and leaves allocated memory in its code path */
+	if (nss_initialized) {
+		/* Called to force cache clearing to prevent NSS shutdown failures.
+		 * http://www.mozilla.org/projects/security/pki/nss/ref/ssl/sslfnc.html#1138601
+		 */
+		SSL_ClearSessionCache();
+		NSS_Shutdown();
+		PR_Cleanup();
+		/* Called to release memory arena used by NSS/NSPR.
+		 * Prevent to show all PL_ArenaAllocate mem alloc as leaks.
+		 * https://developer.mozilla.org/en/NSS_Memory_allocation
+		 */
+		PL_ArenaFinish();
+		nss_initialized = 0;
+	}
 #endif /* WITH_NSS */
 
 	upscli_free_host_cert_list();

--- a/clients/upsclient.c
+++ b/clients/upsclient.c
@@ -3362,7 +3362,7 @@ int upscli_is_valid_protocol_version(UPSCONN_t *ups, const char *version_re)
 			);
 	}
 
-	// TODO: Regex
+	/* TODO: Regex */
 	return (!strcmp(version_re, version));
 }
 

--- a/clients/upsclient.c
+++ b/clients/upsclient.c
@@ -1695,6 +1695,15 @@ int upscli_cleanup(void)
 
 	upscli_free_host_cert_list();
 	upscli_free_authconf_list();
+
+#if defined(WITH_OPENSSL) || defined(WITH_NSS)
+	free(sslcertname);
+	sslcertname = NULL;
+
+	free(sslcertpasswd);
+	sslcertpasswd = NULL;
+#endif
+
 	upscli_initialized = 0;
 	return 1;
 }
@@ -3399,7 +3408,7 @@ int upscli_disconnect(UPSCONN_t *ups)
 			ups->openssl_cert_verify_data->hostname = NULL;
 		}
 
-		memset(&(ups->openssl_cert_verify_data), 0, sizeof(ups->openssl_cert_verify_data));
+		memset(ups->openssl_cert_verify_data, 0, sizeof(*(ups->openssl_cert_verify_data)));
 		free(ups->openssl_cert_verify_data);
 		ups->openssl_cert_verify_data = NULL;
 	}

--- a/clients/upslog.c
+++ b/clients/upslog.c
@@ -983,8 +983,12 @@ int main(int argc, char **argv)
 				free(monhost_ups_current->upsname);
 			if (monhost_ups_current->hostname)
 				free(monhost_ups_current->hostname);
-			if (monhost_ups_current->ups)
+
+			/* Should be NULL, but just in case... */
+			if (monhost_ups_current->ups) {
+				upscli_disconnect(monhost_ups_current->ups);
 				free(monhost_ups_current->ups);
+			}
 
 			upsdebugx(2, "%s: detach asterisky monhost_ups_current", __func__);
 			if (monhost_ups_prev) {

--- a/clients/upslog.c
+++ b/clients/upslog.c
@@ -867,8 +867,14 @@ int main(int argc, char **argv)
 	) {
 		upscli_authconf_t	*ac_current;
 
-		if (upscli_splitname(monhost_ups_current->monhost, &(monhost_ups_current->upsname), &(monhost_ups_current->hostname), &(monhost_ups_current->port)) != 0) {
-			fatalx(EXIT_FAILURE, "Error: invalid UPS definition.  Required format: upsname[@hostname[:port]]\n");
+		/* We may be here after rewinding from asterisk-resolved
+		 * devices on a host, parsing to get their authconf etc. */
+		if (!(monhost_ups_current->upsname) || !(monhost_ups_current->hostname)) {
+			free(monhost_ups_current->upsname);
+			free(monhost_ups_current->hostname);
+			if (upscli_splitname(monhost_ups_current->monhost, &(monhost_ups_current->upsname), &(monhost_ups_current->hostname), &(monhost_ups_current->port)) != 0) {
+				fatalx(EXIT_FAILURE, "Error: invalid UPS definition.  Required format: upsname[@hostname[:port]]\n");
+			}
 		}
 
 		upsdebugx(1, "Checking parse of '%s' => '%s' '%s' '%" PRIu16 "'",
@@ -990,6 +996,9 @@ int main(int argc, char **argv)
 				free(monhost_ups_current->ups);
 			}
 
+			/* After detachment, rewind monhost_ups_current to the
+			 * first entry we have resolved in this loop, to gather
+			 * authconf for each such device, etc. */
 			upsdebugx(2, "%s: detach asterisky monhost_ups_current", __func__);
 			if (monhost_ups_prev) {
 				monhost_ups_prev->next = monhost_ups_current->next;

--- a/clients/upslog.c
+++ b/clients/upslog.c
@@ -65,7 +65,7 @@
 
 	static	flist_t	*fhead = NULL;
 
-	/* FIXME: To be valgrind-clean, free these at exit */
+	/* To be valgrind-clean, we free these lists at exit */
 	static	struct	logtarget_t *logfile_anchor = NULL;
 	static	struct	monhost_ups_t *monhost_ups_anchor = NULL;
 	static	struct	monhost_ups_t *monhost_ups_current = NULL;
@@ -1158,8 +1158,10 @@ int main(int argc, char **argv)
 	for (
 		monhost_ups_current = monhost_ups_anchor;
 		monhost_ups_current != NULL;
-		monhost_ups_current = monhost_ups_current->next
+		/* iteration handled below */
 	) {
+		struct monhost_ups_t	*mu = monhost_ups_current;
+
 		upscli_disconnect(monhost_ups_current->ups);
 		free(monhost_ups_current->ups);
 
@@ -1171,6 +1173,9 @@ int main(int argc, char **argv)
 		free(monhost_ups_current->monhost);
 		free(monhost_ups_current->upsname);
 		free(monhost_ups_current->hostname);
+
+		monhost_ups_current = mu->next;
+		free(mu);
 	}
 
 	if (logformat_allocated) {

--- a/clients/upslog.c
+++ b/clients/upslog.c
@@ -142,6 +142,24 @@ static void reopen_log(void)
 	}
 }
 
+static void cleanup_logtarget(void)
+{
+	struct	logtarget_t	*tmp = logfile_anchor, *cur;
+
+	while (tmp) {
+		cur = tmp;
+		tmp = cur->next;
+
+		free((void*)(cur->logfn));
+		/* we might have several systems logged into same file, so
+		 * we close it here once rather than take chances at monhost
+		 * list cleanup; anyway take care to not close stdout */
+		if (cur->logfile && cur->logfile != stdout)
+			fclose(cur->logfile);
+		free(cur);
+	}
+}
+
 #ifndef WIN32
 static void set_reopen_flag(int sig)
 {
@@ -508,6 +526,19 @@ static void run_flist(const struct monhost_ups_t *monhost_ups_print)
 	fflush(monhost_ups_print->logtarget->logfile);
 }
 
+static void cleanup_flist(void)
+{
+	flist_t	*tmp = fhead, *cur;
+
+	while (tmp) {
+		cur = tmp;
+		tmp = tmp->next;
+
+		free((void*)(cur->arg));
+		free(cur);
+	}
+}
+
 	/* -s <monhost>
 	 * -l <log file>
 	 * -m <monhost,logfile>
@@ -813,6 +844,7 @@ int main(int argc, char **argv)
 				if (!logformat)
 					fatalx(EXIT_FAILURE, "Failed re-allocation to prepend UPSHOST to formatting string");
 				memset(logformat, '\0', LARGEBUF);
+				logformat_allocated = 1;
 			}
 			snprintf(logformat, LARGEBUF, "%%UPSHOST%%%%t%s", s);
 			free(s);
@@ -1124,15 +1156,6 @@ int main(int argc, char **argv)
 		monhost_ups_current != NULL;
 		monhost_ups_current = monhost_ups_current->next
 	) {
-		/* we might have several systems logged into same file;
-		 * take care to not close stdout though */
-		if (monhost_ups_current->logtarget->logfile
-		&&  monhost_ups_current->logtarget->logfile != stdout
-		) {
-			fclose(monhost_ups_current->logtarget->logfile);
-			monhost_ups_current->logtarget->logfile = NULL;
-		}
-
 		upscli_disconnect(monhost_ups_current->ups);
 	}
 
@@ -1140,6 +1163,8 @@ int main(int argc, char **argv)
 		free(logformat);
 		logformat = NULL;
 	}
+	cleanup_flist();
+	cleanup_logtarget();
 
 	fflush(stdout);
 	fflush(stderr);

--- a/clients/upslog.c
+++ b/clients/upslog.c
@@ -856,7 +856,7 @@ int main(int argc, char **argv)
 			if (ac_default) {
 				upscli_authconf_update_conn_flags(ac_default, &flags_ssl_default);
 
-				// Do not call on the next loop cycle, if any
+				/* Do not call on the next loop cycle, if any */
 				ac_default = NULL;
 			}
 		}

--- a/clients/upslog.c
+++ b/clients/upslog.c
@@ -1161,6 +1161,16 @@ int main(int argc, char **argv)
 		monhost_ups_current = monhost_ups_current->next
 	) {
 		upscli_disconnect(monhost_ups_current->ups);
+		free(monhost_ups_current->ups);
+
+		upsdebugx(1, "FREEING: [%s] => [%s] @ [%s]",
+			NUT_STRARG(monhost_ups_current->monhost),
+			NUT_STRARG(monhost_ups_current->upsname),
+			NUT_STRARG(monhost_ups_current->hostname)
+			);
+		free(monhost_ups_current->monhost);
+		free(monhost_ups_current->upsname);
+		free(monhost_ups_current->hostname);
 	}
 
 	if (logformat_allocated) {

--- a/clients/upsmon.c
+++ b/clients/upsmon.c
@@ -42,6 +42,9 @@
 #ifdef HAVE_STDARG_H
 # include <stdarg.h>
 #endif
+#ifdef HAVE_SYS_STDARG_H
+# include <sys/stdarg.h>
+#endif
 
 /* name-swap in libupsclient consumer to simplify the look of code base */
 #define builtin_setproctag(x)	setproctag(x)

--- a/clients/upsstats.c
+++ b/clients/upsstats.c
@@ -554,7 +554,7 @@ static void ups_connect(void)
 		if (ac_default) {
 			upscli_authconf_update_conn_flags(ac_default, &flags_ssl_default);
 
-			// Do not call on the next loop cycle, if any
+			/* Do not call on the next loop cycle, if any */
 			ac_default = NULL;
 		}
 	}

--- a/common/parseconf.c
+++ b/common/parseconf.c
@@ -83,7 +83,12 @@
 #include <ctype.h>
 #include <errno.h>
 #include <stdio.h>
-#include <stdarg.h>
+#ifdef HAVE_STDARG_H
+# include <stdarg.h>
+#endif
+#ifdef HAVE_SYS_STDARG_H
+# include <sys/stdarg.h>
+#endif
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>

--- a/common/snprintf.c
+++ b/common/snprintf.c
@@ -67,8 +67,13 @@
 
 /* varargs declarations: */
 
-#if defined(HAVE_STDARG_H)
-# include <stdarg.h>
+#if defined(HAVE_STDARG_H) || defined(HAVE_SYS_STDARG_H)
+# ifdef HAVE_STDARG_H
+#  include <stdarg.h>
+# endif
+# ifdef HAVE_SYS_STDARG_H
+#  include <sys/stdarg.h>
+# endif
 # define HAVE_STDARGS    /* let's hope that works everywhere (mj) */
 # define VA_LOCAL_DECL   va_list ap
 # define VA_START(f)     va_start(ap, f)

--- a/common/state.c
+++ b/common/state.c
@@ -24,7 +24,12 @@
 #include "config.h"	/* must be first */
 
 #include <stdio.h>
-#include <stdarg.h>
+#ifdef HAVE_STDARG_H
+# include <stdarg.h>
+#endif
+#ifdef HAVE_SYS_STDARG_H
+# include <sys/stdarg.h>
+#endif
 #include <sys/stat.h>
 #include <sys/types.h>
 #ifndef WIN32

--- a/common/str.c
+++ b/common/str.c
@@ -34,7 +34,13 @@
 #include <strings.h>	/* for strncasecmp() and strcasecmp() */
 #endif
 
-#include <stdarg.h>	/* get the va_* routines */
+/* get the va_* routines */
+#ifdef HAVE_STDARG_H
+# include <stdarg.h>
+#endif
+#ifdef HAVE_SYS_STDARG_H
+# include <sys/stdarg.h>
+#endif
 
 #include "nut_stdint.h"
 #include "str.h"

--- a/common/timegm_fallback.c
+++ b/common/timegm_fallback.c
@@ -18,17 +18,17 @@ static int days_from_epoch_1970(int y, int m, int d)
 {
     y -= m <= 2;
     int era = y / 400;
-    int yoe = y - era * 400;                                   // [0, 399]
-    int doy = (153 * (m + (m > 2 ? -3 : 9)) + 2) / 5 + d - 1;  // [0, 365]
-    int doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;           // [0, 146096]
+    int yoe = y - era * 400;                                   /* [0, 399]    */
+    int doy = (153 * (m + (m > 2 ? -3 : 9)) + 2) / 5 + d - 1;  /* [0, 365]    */
+    int doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;           /* [0, 146096] */
     return era * 146097 + doe - 719468;
 }
 
 /* It does not modify broken-down time */
-time_t timegm_fallback(struct tm const* t)     
+time_t timegm_fallback(struct tm const* t)
 {
     int year = t->tm_year + 1900;
-    int month = t->tm_mon;          // 0-11
+    int month = t->tm_mon;          /* 0-11 */
     int days_since_epoch_1970;
 
     if (month > 11)

--- a/configure.ac
+++ b/configure.ac
@@ -1718,12 +1718,25 @@ AS_IF([test x"${ac_cv_printfmt_zu}" = xyes],
     [AC_MSG_WARN([Desired C library support for printf("%zu", size_t) not found; try adding -D_POSIX_C_SOURCE=200112L])]
     )
 
+AC_CHECK_HEADER([stdarg.h],
+    [AC_DEFINE([HAVE_STDARG_H], [1],
+        [Define to 1 if you have <stdarg.h>.])])
+
+AC_CHECK_HEADER([sys/stdarg.h],
+    [AC_DEFINE([HAVE_SYS_STDARG_H], [1],
+        [Define to 1 if you have <sys/stdarg.h>.])])
+
 AC_CACHE_CHECK([for va_copy(dest,src)],
   [ac_cv_have_va_copy],
   [
     AX_RUN_OR_LINK_IFELSE(
       [AC_LANG_PROGRAM(
-        [[#include <stdarg.h>
+        [[#ifdef HAVE_STDARG_H
+          # include <stdarg.h>
+          #endif
+          #ifdef HAVE_SYS_STDARG_H
+          # include <sys/stdarg.h>
+          #endif
           void check_va_copy(const char *fmt, ...) {
             va_list ap1, ap2;
             va_start(ap1, fmt);
@@ -1744,7 +1757,12 @@ AC_CACHE_CHECK([for __va_copy(dest,src)],
   [
     AX_RUN_OR_LINK_IFELSE(
       [AC_LANG_PROGRAM(
-        [[#include <stdarg.h>
+        [[#ifdef HAVE_STDARG_H
+          # include <stdarg.h>
+          #endif
+          #ifdef HAVE_SYS_STDARG_H
+          # include <sys/stdarg.h>
+          #endif
           void check___va_copy(const char *fmt, ...) {
             va_list ap1, ap2;
             va_start(ap1, fmt);
@@ -2024,7 +2042,7 @@ dnl Solaris compatibility - check for -lnsl and -lsocket
 AC_SEARCH_LIBS(gethostbyname, nsl)
 AC_SEARCH_LIBS(connect, socket)
 
-AC_CHECK_HEADERS(sys/modem.h stdarg.h varargs.h, [], [], [AC_INCLUDES_DEFAULT])
+AC_CHECK_HEADERS(sys/modem.h varargs.h, [], [], [AC_INCLUDES_DEFAULT])
 
 
 dnl pthread related checks

--- a/configure.ac
+++ b/configure.ac
@@ -6368,16 +6368,16 @@ NUT_ARG_WITH_CUSTOM_DEFAULT_HELP([user], [USERNAME], [(Unprivileged) user for pr
 AS_CASE([${nut_with_user}],
 	[yes|no], [AC_MSG_ERROR(invalid option --with(out)-user - see docs/configure.txt)],
 	["${RUN_AS_USER}"], [
-		 nut_user_given=no
-		 AC_MSG_RESULT([default])
+		 AS_IF([test x"${nut_withGiven_user}" = xyes],
+			[AC_MSG_RESULT([specified])],	dnl Just happens to be same as default
+			[AC_MSG_RESULT([default])])
 		],
 		[RUN_AS_USER="${nut_with_user}"
-		 nut_user_given=yes
 		 AC_MSG_RESULT([specified])
 		]
 )
 NUT_REPORT_SETTING([User to run as],
-    RUN_AS_USER, "${RUN_AS_USER}", [User to switch to if started as root])
+	RUN_AS_USER, "${RUN_AS_USER}", [User to switch to if started as root])
 
 dnl Note: Technically daemons "run as" the primary GID of the user they de-levate into;
 dnl but in simpler setups (stipulated by common packaging) this one is the "run as" GID too
@@ -6387,21 +6387,21 @@ NUT_ARG_WITH_CUSTOM_DEFAULT_HELP([group], [GROUPNAME], [(Unprivileged) group mem
 AS_CASE([${nut_with_group}],
 	[yes|no], [AC_MSG_ERROR(invalid option --with(out)-group - see docs/configure.txt)],
 	["${RUN_AS_GROUP}"], [
-		 nut_group_given=no
-		 AC_MSG_RESULT([default])
+		 AS_IF([test x"${nut_withGiven_group}" = xyes],
+			[AC_MSG_RESULT([specified])],	dnl Just happens to be same as default
+			[AC_MSG_RESULT([default])])
 		],
 		[RUN_AS_GROUP="${nut_with_group}"
-		 nut_group_given=yes
 		 AC_MSG_RESULT([specified])
 		]
 )
 NUT_REPORT_SETTING([Group of user to own state files],
-    RUN_AS_GROUP, "${RUN_AS_GROUP}", [Group membership for state files of drivers normally started as root])
+	RUN_AS_GROUP, "${RUN_AS_GROUP}", [Group membership for state files of drivers normally started as root])
 
 dnl check that --with-user is given if --with-group is given.
-if test "${nut_user_given}" = "yes" -a "${nut_group_given}" = "no"; then
+if test "${nut_withGiven_user}" = "yes" -a "${nut_withGiven_group}" = "no"; then
 	AC_MSG_ERROR([If you specify --with-user, you also must specify --with-group])
-elif test "${nut_user_given}" = "no" -a "${nut_group_given}" = "yes"; then
+elif test "${nut_withGiven_user}" = "no" -a "${nut_withGiven_group}" = "yes"; then
 	AC_MSG_ERROR([If you specify --with-group, you also must specify --with-user])
 fi
 

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -13,7 +13,8 @@ As many other projects relying on GNU autotools for build recipe automation,
 NUT sources deliver a `configure` script which is used to set up numerous
 nuances relevant for your build of the project.  Most of the configuration
 requirements are passed by `--with-something` or `--enable-something` options
-(allegedly, not always used consistently with autotools naming recommendations),
+(allegedly, not always used consistently with autotools naming recommendations
+for `--with-DEPENDENCY_PACKAGE` and `--enable-PROJECT_FEATURE` semantics),
 and with environment variables like `CFLAGS` typically also passed as command
 line options.
 

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3807 utf-8
+personal_ws-1.1 en 3808 utf-8
 AAC
 AAS
 ABI
@@ -1039,6 +1039,7 @@ Potrans
 Poush
 PowerAlert
 PowerCOM
+PowerChute
 PowerCom
 PowerES
 PowerGuide
@@ -1054,7 +1055,6 @@ PowerPC
 PowerPS
 PowerPal
 PowerPanel
-PowerChute
 PowerShare
 PowerShell
 PowerShield
@@ -3358,6 +3358,7 @@ startdelay
 startup
 statepath
 stayoff
+stdarg
 stderr
 stdint
 stdlib

--- a/drivers/dstate.c
+++ b/drivers/dstate.c
@@ -26,7 +26,12 @@
 
 #include <stdio.h>
 #ifndef WIN32
-# include <stdarg.h>
+# ifdef HAVE_STDARG_H
+#  include <stdarg.h>
+# endif
+# ifdef HAVE_SYS_STDARG_H
+#  include <sys/stdarg.h>
+# endif
 # include <sys/stat.h>
 # include <pwd.h>
 # include <sys/types.h>

--- a/drivers/dummy-ups.c
+++ b/drivers/dummy-ups.c
@@ -48,7 +48,7 @@
 #include "dummy-ups.h"
 
 #define DRIVER_NAME	"Device simulation and repeater driver"
-#define DRIVER_VERSION	"0.26"
+#define DRIVER_VERSION	"0.27"
 
 /* driver description structure */
 upsdrv_info_t upsdrv_info =
@@ -444,7 +444,7 @@ static void dummy_setproctag_callback(const char *tag) {
 	const void	*cookie = nut_common_cookie();
 
 	if (cookie != upscli_upslog_cookie())
-		upscli_upslog_setproctag(xstrdup(tag), cookie);
+		upscli_upslog_setproctag(tag, cookie);
 }
 
 /* optionally tweak prognames[] entries */
@@ -463,7 +463,7 @@ void upsdrv_tweak_prognames(void)
 	if (cookie != upscli_upslog_cookie()) {
 		/* Send over a copy */
 		upscli_upslog_setprocname(xstrdup(getmyprocname()), cookie);
-		upscli_upslog_setproctag(xstrdup(getproctag()), cookie);
+		upscli_upslog_setproctag(getproctag(), cookie);
 
 		upsdrv_callback_setproctag = dummy_setproctag_callback;
 	}

--- a/drivers/generic_gpio_libgpiod.c
+++ b/drivers/generic_gpio_libgpiod.c
@@ -311,7 +311,7 @@ void gpio_get_lines_states(struct gpioups_t *gpioupsfdlocal) {
 			}
 		}
 #else	/* #if WITH_LIBGPIO_VERSION >= 0x00020000 */
-		int64_t poll_timeout = 1000000000;	//	in nanoseconds
+		int64_t poll_timeout = 1000000000;	/* in nanoseconds */
 		if(gpioupsfdlocal->initial) {
 			poll_timeout = 35000000000;
 		} else {

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -3534,6 +3534,8 @@ sockname_ownership_finished:
 				update_count++;
 		}
 		else {
+			/* NOTE: this doubles as (up to) poll_interval sleep
+			 * between update loop cycles */
 			while (!dstate_poll_fds(timeout, extrafd) && !exit_flag) {
 				/* repeat until time is up or extrafd has data */
 				handle_reload_flag();

--- a/drivers/nutdrv_qx_voltronic-axpert.c
+++ b/drivers/nutdrv_qx_voltronic-axpert.c
@@ -68,7 +68,7 @@
 #define TESTING_AXPERT_INSTCMD		TESTING_AXPERT_UNMAPPED_MAPPINGS_DEFAULT
 
 /* Warning: unlocks a method not used in any code path: */
-#define TESTING_AXPERT_FUNC_PROCESS_SIGN	0 // TESTING_AXPERT_UNMAPPED_MAPPINGS_DEFAULT
+#define TESTING_AXPERT_FUNC_PROCESS_SIGN	0	/* TESTING_AXPERT_UNMAPPED_MAPPINGS_DEFAULT */
 
 /* Support functions */
 static int	voltronic_sunny_claim(void);

--- a/include/common.h
+++ b/include/common.h
@@ -45,7 +45,12 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <stdarg.h>
+#ifdef HAVE_STDARG_H
+# include <stdarg.h>
+#endif
+#ifdef HAVE_SYS_STDARG_H
+# include <sys/stdarg.h>
+#endif
 #include <sys/types.h>	/* suseconds_t among other things */
 #include <sys/stat.h>
 

--- a/include/proto.h
+++ b/include/proto.h
@@ -50,8 +50,13 @@ extern "C" {
 
 /* varargs declarations: */
 
-#if defined(HAVE_STDARG_H)
-# include <stdarg.h>
+#if defined(HAVE_STDARG_H) || defined(HAVE_SYS_STDARG_H)
+# ifdef HAVE_STDARG_H
+#  include <stdarg.h>
+# endif
+# ifdef HAVE_SYS_STDARG_H
+#  include <sys/stdarg.h>
+# endif
 # define HAVE_STDARGS    /* let's hope that works everywhere (mj) */
 # define VA_LOCAL_DECL   va_list ap
 # define VA_START(f)     va_start(ap, f)

--- a/m4/nut_arg_with.m4
+++ b/m4/nut_arg_with.m4
@@ -47,8 +47,12 @@ AC_DEFUN([NUT_ARG_WITH_CUSTOM_DEFAULT_HELP],
             [m4_ifval([$5],
                 [AS_HELP_STRING([--with-$1], [$3 (default: $5)])],
                 [AS_HELP_STRING([--with-$1], [$3 (default: $4)])])]),
-        [[nut_with_]m4_translit([$1], [-], [_])="${withval}"],
-        [[nut_with_]m4_translit([$1], [-], [_])="$4"]
+        [[nut_with_]m4_translit([$1], [-], [_])="${withval}"
+         [nut_withGiven_]m4_translit([$1], [-], [_])="yes"
+        ],
+        [[nut_with_]m4_translit([$1], [-], [_])="$4"
+         [nut_withGiven_]m4_translit([$1], [-], [_])="no"
+        ]
     )
 ])
 
@@ -85,8 +89,12 @@ AC_DEFUN([NUT_ARG_WITH_LIBOPTS],
 [
     AC_ARG_WITH([$1],
         [AS_HELP_STRING([@<:@--with-$1=$2@:>@], [$3 (default: $4)])],
-        [[nut_with_]m4_translit([$1], [-], [_])="${withval}"],
-        [[nut_with_]m4_translit([$1], [-], [_])="$4"]
+        [[nut_with_]m4_translit([$1], [-], [_])="${withval}"
+         [nut_withGiven_]m4_translit([$1], [-], [_])="yes"
+        ],
+        [[nut_with_]m4_translit([$1], [-], [_])="$4"
+         [nut_withGiven_]m4_translit([$1], [-], [_])="no"
+        ]
     )
 ])
 
@@ -96,9 +104,13 @@ AC_DEFUN([NUT_ARG_WITH_LIBOPTS_INVALID_YESNO],
         [AS_HELP_STRING([@<:@--with-$1=$2@:>@], [$3 (default: $4)])],
         [AS_CASE([${withval}],
             [yes|no], [AC_MSG_ERROR([invalid option --with(out)-$1 - see docs/configure.txt])],
-                [[nut_with_]m4_translit([$1], [-], [_])="${withval}"]
+                [[nut_with_]m4_translit([$1], [-], [_])="${withval}"
+                 [nut_withGiven_]m4_translit([$1], [-], [_])="yes"
+                ]
         )],
-        [[nut_with_]m4_translit([$1], [-], [_])="$4"]
+        [[nut_with_]m4_translit([$1], [-], [_])="$4"
+         [nut_withGiven_]m4_translit([$1], [-], [_])="no"
+        ]
     )
 ])
 
@@ -197,8 +209,12 @@ AC_DEFUN([NUT_ARG_ENABLE_CUSTOM_DEFAULT_HELP],
             [m4_ifval([$5],
                 [AS_HELP_STRING([--enable-$1], [$3 (default: $5)])],
                 [AS_HELP_STRING([--enable-$1], [$3 (default: $4)])])]),
-        [[nut_enable_]m4_translit([$1], [-], [_])="${enableval}"],
-        [[nut_enable_]m4_translit([$1], [-], [_])="$4"]
+        [[nut_enable_]m4_translit([$1], [-], [_])="${enableval}"
+         [nut_enableGiven_]m4_translit([$1], [-], [_])="yes"
+        ],
+        [[nut_enable_]m4_translit([$1], [-], [_])="$4"
+         [nut_enableGiven_]m4_translit([$1], [-], [_])="no"
+        ]
     )
 ])
 

--- a/scripts/valgrind/.valgrind.supp.in
+++ b/scripts/valgrind/.valgrind.supp.in
@@ -60,6 +60,15 @@
    ...
 }
 {
+   <libssl_asn1_decoder>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   ...
+   fun:ossl_algorithm_do_all
+   ...
+   fun:asn1_item_embed_d2i
+}
+{
    <libssl_init_SSL_CTX>
    Memcheck:Leak
    ...

--- a/scripts/valgrind/valgrind.sh.in
+++ b/scripts/valgrind/valgrind.sh.in
@@ -19,6 +19,8 @@ LTEXEC=""
 
 # TODO: Also wrap tool=callgrind e.g. via $0 symlink name?
 
+# Avoid going to the internet just to run tests:
+DEBUGINFOD_URLS=: DEBUGINFOD_TIMEOUT=1 DEBUGINFOD_MAXTIME=1 \
 exec ${LTEXEC} \
 ${VALGRIND} \
 	--tool=memcheck --verbose \

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -1247,6 +1247,10 @@ static void upsd_cleanup(void)
 	free(certname);
 	free(certpasswd);
 
+#if defined(WITH_SSL)
+	free(certpath);
+#endif
+
 	free(fds);
 	free(handler);
 

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -614,6 +614,9 @@ static void client_disconnect(nut_ctype_t *client)
 	shutdown(client->sock_fd, 2);
 	close(client->sock_fd);
 
+	/* Avoid re-closing twice in ssl_finish() below: */
+	client->sock_fd = ERROR_FD_SOCK;
+
 #ifdef WIN32
 	CloseHandle(client->Event);
 #endif	/* WIN32 */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -34,7 +34,7 @@ check_PROGRAMS = $(TESTS)
 check_SCRIPTS =
 
 # NUT Integration Testing suite
-check-NIT check-NIT-devel: @dotMAKE@
+check-NIT check-NIT-devel check-NIT-sandbox check-NIT-sandbox-devel: @dotMAKE@
 	+cd "$(builddir)/NIT" && $(MAKE) $(AM_MAKEFLAGS) $@
 
 # Make sure out-of-dir dependencies exist (especially when dev-building

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -34,6 +34,7 @@ check_PROGRAMS = $(TESTS)
 check_SCRIPTS =
 
 # NUT Integration Testing suite
+memcheck-NIT memcheck-NIT-devel memcheck-NIT-sandbox memcheck-NIT-sandbox-devel \
 check-NIT check-NIT-devel check-NIT-sandbox check-NIT-sandbox-devel: @dotMAKE@
 	+cd "$(builddir)/NIT" && $(MAKE) $(AM_MAKEFLAGS) $@
 

--- a/tests/NIT/Makefile.am
+++ b/tests/NIT/Makefile.am
@@ -96,6 +96,28 @@ check-NIT-sandbox-devel: $(abs_srcdir)/nit.sh @dotMAKE@
 	BUILTIN_RUN_AS_USER='$(RUN_AS_USER)' BUILTIN_RUN_AS_GROUP='$(RUN_AS_GROUP)' \
 	$(MAKE) $(AM_MAKEFLAGS) check-NIT-devel
 
+if HAVE_VALGRIND
+memcheck_warn = true
+else !HAVE_VALGRIND
+memcheck_warn = echo "  WARNING	$@: valgrind was not detected on this system by configure script, test may fail" >&2
+endif !HAVE_VALGRIND
+
+memcheck-NIT:
+	@$(memcheck_warn)
+	+DO_MEMCHECK=true $(MAKE) $(AM_MAKEFLAGS) check-NIT
+
+memcheck-NIT-devel:
+	@$(memcheck_warn)
+	+DO_MEMCHECK=true $(MAKE) $(AM_MAKEFLAGS) check-NIT-devel
+
+memcheck-NIT-sandbox:
+	@$(memcheck_warn)
+	+DO_MEMCHECK=true $(MAKE) $(AM_MAKEFLAGS) check-NIT-sandbox
+
+memcheck-NIT-sandbox-devel:
+	@$(memcheck_warn)
+	+DO_MEMCHECK=true $(MAKE) $(AM_MAKEFLAGS) check-NIT-sandbox-devel
+
 SPELLCHECK_SRC = README.adoc
 
 # NOTE: Due to portability, we do not use a GNU percent-wildcard extension.

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -3031,7 +3031,7 @@ testcase_upsd_no_configs_at_all() {
     fi
     (execcmd upsd ${ARG_FG} ${ARG_USER})
     if [ "$?" = 0 ]; then
-        log_error "[testcase_upsd_no_configs_at_all] upsd should fail without configs"
+        log_error "[testcase_upsd_no_configs_at_all] Error: upsd should fail without configs"
         FAILED="`expr $FAILED + 1`"
         FAILED_FUNCS="$FAILED_FUNCS testcase_upsd_no_configs_at_all"
     else
@@ -3050,7 +3050,7 @@ testcase_upsd_no_configs_driver_file() {
     fi
     (execcmd upsd ${ARG_FG} ${ARG_USER})
     if [ "$?" = 0 ]; then
-        log_error "[testcase_upsd_no_configs_driver_file] upsd should fail without driver config file"
+        log_error "[testcase_upsd_no_configs_driver_file] Error: upsd should fail without driver config file"
         FAILED="`expr $FAILED + 1`"
         FAILED_FUNCS="$FAILED_FUNCS testcase_upsd_no_configs_driver_file"
     else
@@ -3070,7 +3070,7 @@ testcase_upsd_no_configs_in_driver_file() {
     fi
     (execcmd upsd ${ARG_FG} ${ARG_USER})
     if [ "$?" = 0 ]; then
-        log_error "[testcase_upsd_no_configs_in_driver_file] upsd should fail without drivers defined in config file"
+        log_error "[testcase_upsd_no_configs_in_driver_file] Error: upsd should fail without drivers defined in config file"
         FAILED="`expr $FAILED + 1`"
         FAILED_FUNCS="$FAILED_FUNCS testcase_upsd_no_configs_in_driver_file"
     else
@@ -3142,7 +3142,7 @@ upsd_start_loop() {
         return
     fi
 
-    log_error "[${TESTCASE}] Port ${NUT_PORT} is not listening and/or UPSD PID $PID_UPSD is not alive"
+    log_error "[${TESTCASE}] Error: Port ${NUT_PORT} is not listening and/or UPSD PID $PID_UPSD is not alive"
     return 1
 }
 
@@ -3185,7 +3185,7 @@ testcase_upsd_allow_no_device() {
             [ "$CMDRES" = 0 ] || die "[testcase_upsd_allow_no_device] upsd does not respond on port ${NUT_PORT} ($?): $CMDOUT"
         fi
         if [ -n "$CMDOUT" ] ; then
-            log_error "[testcase_upsd_allow_no_device] got reply for upsc listing when none was expected: $CMDOUT"
+            log_error "[testcase_upsd_allow_no_device] Error: got reply for upsc listing when none was expected: $CMDOUT"
             FAILED="`expr $FAILED + 1`"
             FAILED_FUNCS="$FAILED_FUNCS testcase_upsd_allow_no_device"
             res_testcase_upsd_allow_no_device=1
@@ -3203,20 +3203,20 @@ testcase_upsd_allow_no_device() {
                 log_info "[testcase_upsd_allow_no_device] OK, empty-list JSON response as expected"
                 PASSED="`expr $PASSED + 1`"
             else
-                log_error "[testcase_upsd_allow_no_device] got a reply for upsc JSON listing for empty but running server, but it was not expected (not an empty list):" "$CMDOUT" "$CMDERR"
+                log_error "[testcase_upsd_allow_no_device] Error: got a reply for upsc JSON listing for empty but running server, but it was not expected (not an empty list):" "$CMDOUT" "$CMDERR"
                 FAILED="`expr $FAILED + 1`"
                 FAILED_FUNCS="$FAILED_FUNCS testcase_upsd_allow_no_device"
                 res_testcase_upsd_allow_no_device=1
             fi
         else
-            log_error "[testcase_upsd_allow_no_device] did not get a reply for upsc JSON listing for empty but running server:" "$CMDOUT" "$CMDERR"
+            log_error "[testcase_upsd_allow_no_device] Error: did not get a reply for upsc JSON listing for empty but running server:" "$CMDOUT" "$CMDERR"
             FAILED="`expr $FAILED + 1`"
             FAILED_FUNCS="$FAILED_FUNCS testcase_upsd_allow_no_device"
             res_testcase_upsd_allow_no_device=1
         fi
         log_separator
     else
-        log_error "[testcase_upsd_allow_no_device] upsd was expected to be running although no devices are defined; is ups.conf populated?"
+        log_error "[testcase_upsd_allow_no_device] Error: upsd was expected to be running although no devices are defined; is ups.conf populated?"
         ls -la "$NUT_CONFPATH/" || true
         FAILED="`expr $FAILED + 1`"
         FAILED_FUNCS="$FAILED_FUNCS testcase_upsd_allow_no_device"
@@ -3231,7 +3231,7 @@ testcase_upsd_allow_no_device() {
     if [ "$res_testcase_upsd_allow_no_device" = 0 ] ; then
         log_info "[testcase_upsd_allow_no_device] upsd exit-code was: $UPSD_RES"
     else
-        log_error "[testcase_upsd_allow_no_device] upsd exit-code was: $UPSD_RES"
+        log_error "[testcase_upsd_allow_no_device] Error: upsd exit-code was: $UPSD_RES"
     fi
     if [ "$UPSD_RES" != 0 ]; then
         return $UPSD_RES
@@ -3402,7 +3402,7 @@ UPSwarm$N"
         CMDOUT="`echo \"$CMDOUT\" | tr -d '\r'`"
     fi
     if [ x"$CMDOUT" != x"$EXPECTED_UPSLIST" ] ; then
-        log_error "[testcase_sandbox_start_upsd_alone] got this reply for upsc listing when '$EXPECTED_UPSLIST' was expected: '$CMDOUT'"
+        log_error "[testcase_sandbox_start_upsd_alone] Error: got this reply for upsc listing when '$EXPECTED_UPSLIST' was expected: '$CMDOUT'"
         FAILED="`expr $FAILED + 1`"
         FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_start_upsd_alone"
         res_testcase_sandbox_start_upsd_alone=1
@@ -3415,7 +3415,7 @@ UPSwarm$N"
         CMDOUT="`echo \"$CMDOUT\" | tr -d '\r'`"
     fi
     if [ x"$CMDOUT" != x"$EXPECTED_UPSLIST_JSON" ] ; then
-        log_error "[testcase_sandbox_start_upsd_alone] got this reply for upsc JSON listing when '$EXPECTED_UPSLIST' was expected: '$CMDOUT'"
+        log_error "[testcase_sandbox_start_upsd_alone] Error: got this reply for upsc JSON listing when '$EXPECTED_UPSLIST' was expected: '$CMDOUT'"
         FAILED="`expr $FAILED + 1`"
         FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_start_upsd_alone"
         res_testcase_sandbox_start_upsd_alone=1
@@ -3434,7 +3434,7 @@ UPSwarm$N"
     if echo "$CMDERR" | ${GREP} 'Error: Driver not connected' >/dev/null ; then
         PASSED="`expr $PASSED + 1`"
     else
-        log_error "[testcase_sandbox_start_upsd_alone] got some other reply for upsc query when 'Error: Driver not connected' was expected on stderr: '$CMDOUT'"
+        log_error "[testcase_sandbox_start_upsd_alone] Error: got some other reply for upsc query when 'Error: Driver not connected' was expected on stderr: '$CMDOUT'"
         FAILED="`expr $FAILED + 1`"
         FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_start_upsd_alone"
         res_testcase_sandbox_start_upsd_alone=1
@@ -3458,7 +3458,7 @@ UPSwarm$N"
     if echo "$CMDERR" | ${GREP} 'Error: Driver not connected' >/dev/null && test x"${CMDOUT}" = x"${EXPECTED_UPSDATA_JSON}"; then
         PASSED="`expr $PASSED + 1`"
     else
-        log_error "[testcase_sandbox_start_upsd_alone] got some other reply for upsc JSON query when 'Error: Driver not connected' was expected on stderr and similar in JSON object: '$CMDOUT'"
+        log_error "[testcase_sandbox_start_upsd_alone] Error: got some other reply for upsc JSON query when 'Error: Driver not connected' was expected on stderr and similar in JSON object: '$CMDOUT'"
         FAILED="`expr $FAILED + 1`"
         FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_start_upsd_alone"
         res_testcase_sandbox_start_upsd_alone=1
@@ -3467,7 +3467,7 @@ UPSwarm$N"
     if [ "$res_testcase_sandbox_start_upsd_alone" = 0 ]; then
         log_info "[testcase_sandbox_start_upsd_alone] PASSED: got just the failures expected for data server alone (driver not running yet)"
     else
-        log_error "[testcase_sandbox_start_upsd_alone] got some unexpected failures, see above"
+        log_error "[testcase_sandbox_start_upsd_alone] Error: got some unexpected failures, see above"
     fi
 
     return $res_testcase_sandbox_start_upsd_alone
@@ -3582,7 +3582,7 @@ testcase_sandbox_start_drivers_after_upsd() {
 
     if [ "$COUNTDOWN" -le 1 ] ; then
         # Should not get to this, except on very laggy systems maybe
-        log_error "[testcase_sandbox_start_drivers_after_upsd] Query failed, retrying with UPSD started after drivers"
+        log_error "[testcase_sandbox_start_drivers_after_upsd] Error: Query failed, retrying with UPSD started after drivers"
         testcase_sandbox_start_upsd_after_drivers
     fi
 
@@ -3626,7 +3626,7 @@ testcase_sandbox_upsc_query_model() {
     log_info "[testcase_sandbox_upsc_query_model] Query model from dummy device"
     runcmd upsc dummy@localhost:$NUT_PORT device.model || die "[testcase_sandbox_upsc_query_model] upsd does not respond on port ${NUT_PORT} ($?): $CMDOUT"
     if [ x"$CMDOUT" != x"Dummy UPS" ] ; then
-        log_error "[testcase_sandbox_upsc_query_model] got this reply for upsc query when 'Dummy UPS' was expected: $CMDOUT"
+        log_error "[testcase_sandbox_upsc_query_model] Error: got this reply for upsc query when 'Dummy UPS' was expected: $CMDOUT"
         FAILED="`expr $FAILED + 1`"
         FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_upsc_query_model"
     else
@@ -3642,7 +3642,7 @@ testcase_sandbox_upsc_query_model() {
     EXPECTED_UPSDATA_JSON="`echo \"$EXPECTED_UPSDATA_JSON\" | tr -d '\r'`"
     CMDOUT="`echo \"$CMDOUT\" | tr -d '\r'`"
     if [ x"$CMDOUT" != x"${EXPECTED_UPSDATA_JSON}" ] ; then
-        log_error "[testcase_sandbox_upsc_query_model] got this reply for upsc JSON query when 'device.model: Dummy UPS' was expected: $CMDOUT"
+        log_error "[testcase_sandbox_upsc_query_model] Error: got this reply for upsc JSON query when 'device.model: Dummy UPS' was expected: $CMDOUT"
         FAILED="`expr $FAILED + 1`"
         FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_upsc_query_model"
     else
@@ -3654,7 +3654,7 @@ testcase_sandbox_upsc_query_model() {
 testcase_sandbox_upsc_query_bogus() {
     log_info "[testcase_sandbox_upsc_query_bogus] Query driver state from UPSD by UPSC for bogus info"
     runcmd upsc dummy@localhost:$NUT_PORT ups.bogus.value && {
-        log_error "[testcase_sandbox_upsc_query_bogus] upsc was supposed to answer with error exit code: $CMDOUT"
+        log_error "[testcase_sandbox_upsc_query_bogus] Error: upsc was supposed to answer with error exit code: $CMDOUT"
         FAILED="`expr $FAILED + 1`"
         FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_upsc_query_bogus"
     }
@@ -3663,14 +3663,14 @@ testcase_sandbox_upsc_query_bogus() {
         PASSED="`expr $PASSED + 1`"
         log_info "[testcase_sandbox_upsc_query_bogus] PASSED: got expected reply to bogus query"
     else
-        log_error "[testcase_sandbox_upsc_query_bogus] got some other reply for upsc query when 'Error: Variable not supported by UPS' was expected on stderr: stderr:'$CMDERR' / stdout:'$CMDOUT'"
+        log_error "[testcase_sandbox_upsc_query_bogus] Error: got some other reply for upsc query when 'Error: Variable not supported by UPS' was expected on stderr: stderr:'$CMDERR' / stdout:'$CMDOUT'"
         FAILED="`expr $FAILED + 1`"
         FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_upsc_query_bogus"
     fi
 
     log_info "[testcase_sandbox_upsc_query_bogus] Query driver state from UPSD by UPSC for bogus info in JSON"
     runcmd upsc -j dummy@localhost:$NUT_PORT ups.bogus.value && {
-        log_error "[testcase_sandbox_upsc_query_bogus] upsc was supposed to answer with error exit code: $CMDOUT"
+        log_error "[testcase_sandbox_upsc_query_bogus] Error: upsc was supposed to answer with error exit code: $CMDOUT"
         FAILED="`expr $FAILED + 1`"
         FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_upsc_query_bogus"
     }
@@ -3688,7 +3688,7 @@ testcase_sandbox_upsc_query_bogus() {
         PASSED="`expr $PASSED + 1`"
         log_info "[testcase_sandbox_upsc_query_bogus] PASSED: got expected reply to bogus query in JSON"
     else
-        log_error "[testcase_sandbox_upsc_query_bogus] got some other reply for upsc JSON query when 'Error: Variable not supported by UPS' was expected on stderr: stderr:'$CMDERR' / stdout:'$CMDOUT'"
+        log_error "[testcase_sandbox_upsc_query_bogus] Error: got some other reply for upsc JSON query when 'Error: Variable not supported by UPS' was expected on stderr: stderr:'$CMDERR' / stdout:'$CMDOUT'"
         FAILED="`expr $FAILED + 1`"
         FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_upsc_query_bogus"
     fi
@@ -3755,7 +3755,7 @@ testcase_sandbox_upsc_query_timer() {
         log_info "[testcase_sandbox_upsc_query_timer] PASSED: ups.status flips over time"
         PASSED="`expr $PASSED + 1`"
     else
-        log_error "[testcase_sandbox_upsc_query_timer] ups.status did not flip over time"
+        log_error "[testcase_sandbox_upsc_query_timer] Error: ups.status did not flip over time"
         FAILED="`expr $FAILED + 1`"
         FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_upsc_query_timer"
     fi
@@ -3804,7 +3804,7 @@ isTestablePython() {
         log_debug "=======\nDetected python shebang: '${PY_SHEBANG}' (result=${PY_RES})"
         PYTHON="`echo \"${PY_SHEBANG}\" | sed 's,^#!,,'`"
     else
-        log_error "[isTestablePython] Detected python shebang: '${PY_SHEBANG}' (result=${PY_RES})"
+        log_error "[isTestablePython] Error: Detected python shebang: '${PY_SHEBANG}' (result=${PY_RES})"
     fi
     return $PY_RES
 }
@@ -4030,7 +4030,7 @@ testcase_sandbox_python_without_credentials() {
         log_info "[testcase_sandbox_python_without_credentials] PASSED: PyNUT did not complain"
         PASSED="`expr $PASSED + 1`"
     else
-        log_error "[testcase_sandbox_python_without_credentials] PyNUT complained, check above"
+        log_error "[testcase_sandbox_python_without_credentials] Error: PyNUT complained, check above"
         FAILED="`expr $FAILED + 1`"
         FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_python_without_credentials"
     fi
@@ -4061,7 +4061,7 @@ testcase_sandbox_python_with_credentials() {
         log_info "[testcase_sandbox_python_with_credentials] PASSED: PyNUT did not complain"
         PASSED="`expr $PASSED + 1`"
     else
-        log_error "[testcase_sandbox_python_with_credentials] PyNUT complained, check above"
+        log_error "[testcase_sandbox_python_with_credentials] Error: PyNUT complained, check above"
         FAILED="`expr $FAILED + 1`"
         FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_python_with_credentials"
     fi
@@ -4089,7 +4089,7 @@ testcase_sandbox_python_with_upsmon_credentials() {
         log_info "[testcase_sandbox_python_with_upsmon_credentials] PASSED: PyNUT did not complain"
         PASSED="`expr $PASSED + 1`"
     else
-        log_error "[testcase_sandbox_python_with_upsmon_credentials] PyNUT complained, check above"
+        log_error "[testcase_sandbox_python_with_upsmon_credentials] Error: PyNUT complained, check above"
         FAILED="`expr $FAILED + 1`"
         FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_python_with_upsmon_credentials"
     fi
@@ -4273,7 +4273,7 @@ isTestablePerl() {
         if [ -x "$PERL" ] ; then : ; else PERL="`command -v perl`" ; fi
         if [ -n "$PERL" ] && [ -x "$PERL" ] ; then : ; else PL_RES=3 ; fi
     else
-        log_error "[isTestablePerl] Detected perl shebang: '${PL_SHEBANG}' (result=${PL_RES})"
+        log_error "[isTestablePerl] Error: Detected perl shebang: '${PL_SHEBANG}' (result=${PL_RES})"
     fi
 
     PERL_OPTS_INC="-I${TOP_BUILDDIR}/scripts/perl"
@@ -4311,7 +4311,7 @@ testcase_sandbox_perl_without_credentials() {
         log_info "[testcase_sandbox_perl_without_credentials] PASSED: UPS::Nut did not complain"
         PASSED="`expr $PASSED + 1`"
     else
-        log_error "[testcase_sandbox_perl_without_credentials] UPS::Nut complained, check above"
+        log_error "[testcase_sandbox_perl_without_credentials] Error: UPS::Nut complained, check above"
         FAILED="`expr $FAILED + 1`"
         FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_perl_without_credentials"
     fi
@@ -4342,7 +4342,7 @@ testcase_sandbox_perl_with_credentials() {
         log_info "[testcase_sandbox_perl_with_credentials] PASSED: UPS::Nut did not complain"
         PASSED="`expr $PASSED + 1`"
     else
-        log_error "[testcase_sandbox_perl_with_credentials] UPS::Nut complained, check above"
+        log_error "[testcase_sandbox_perl_with_credentials] Error: UPS::Nut complained, check above"
         FAILED="`expr $FAILED + 1`"
         FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_perl_with_credentials"
     fi
@@ -4370,7 +4370,7 @@ testcase_sandbox_perl_with_upsmon_credentials() {
         log_info "[testcase_sandbox_perl_with_upsmon_credentials] PASSED: UPS::Nut did not complain"
         PASSED="`expr $PASSED + 1`"
     else
-        log_error "[testcase_sandbox_perl_with_upsmon_credentials] UPS::Nut complained, check above"
+        log_error "[testcase_sandbox_perl_with_upsmon_credentials] Error: UPS::Nut complained, check above"
         FAILED="`expr $FAILED + 1`"
         FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_perl_with_upsmon_credentials"
     fi
@@ -4421,7 +4421,7 @@ testcase_sandbox_cppnit_without_creds() {
         log_info "[testcase_sandbox_cppnit_without_creds] PASSED: cppnit did not complain"
         PASSED="`expr $PASSED + 1`"
     else
-        log_error "[testcase_sandbox_cppnit_without_creds] cppnit complained, check above"
+        log_error "[testcase_sandbox_cppnit_without_creds] Error: cppnit complained, check above"
         FAILED="`expr $FAILED + 1`"
         FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_cppnit_without_creds"
     fi
@@ -4457,7 +4457,7 @@ testcase_sandbox_cppnit_simple_admin() {
         log_info "[testcase_sandbox_cppnit_simple_admin] PASSED: cppnit did not complain"
         PASSED="`expr $PASSED + 1`"
     else
-        log_error "[testcase_sandbox_cppnit_simple_admin] cppnit complained, check above"
+        log_error "[testcase_sandbox_cppnit_simple_admin] Error: cppnit complained, check above"
         FAILED="`expr $FAILED + 1`"
         FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_cppnit_simple_admin"
     fi
@@ -4487,7 +4487,7 @@ testcase_sandbox_cppnit_upsmon_primary() {
         log_info "[testcase_sandbox_cppnit_upsmon_primary] PASSED: cppnit did not complain"
         PASSED="`expr $PASSED + 1`"
     else
-        log_error "[testcase_sandbox_cppnit_upsmon_primary] cppnit complained, check above"
+        log_error "[testcase_sandbox_cppnit_upsmon_primary] Error: cppnit complained, check above"
         FAILED="`expr $FAILED + 1`"
         FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_cppnit_upsmon_primary"
     fi
@@ -4517,7 +4517,7 @@ testcase_sandbox_cppnit_upsmon_master() {
         log_info "[testcase_sandbox_cppnit_upsmon_master] PASSED: cppnit did not complain"
         PASSED="`expr $PASSED + 1`"
     else
-        log_error "[testcase_sandbox_cppnit_upsmon_master] cppnit complained, check above"
+        log_error "[testcase_sandbox_cppnit_upsmon_master] Error: cppnit complained, check above"
         FAILED="`expr $FAILED + 1`"
         FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_cppnit_upsmon_master"
     fi
@@ -4598,7 +4598,7 @@ testcase_sandbox_nutscanner_list() {
         else
             echo "$CMDOUT" | ${EGREP} 'dummy@.*'":${NUT_PORT}" \
             || {
-                log_error "[testcase_sandbox_nutscanner_list] dummy@... not found" >&2
+                log_error "[testcase_sandbox_nutscanner_list] Error: dummy@... not found" >&2
                 return 1
             }
         fi
@@ -4611,7 +4611,7 @@ testcase_sandbox_nutscanner_list() {
             && echo "$CMDOUT" | ${EGREP} '^\[nutdev-nut3\]$' \
             && echo "$CMDOUT" | ${GREP} 'port = "UPS2@' \
             || {
-                log_error "[testcase_sandbox_nutscanner_list] something about UPS1/UPS2 not found" >&2
+                log_error "[testcase_sandbox_nutscanner_list] Error: something about UPS1/UPS2 not found" >&2
                 return 1
             }
         fi
@@ -4624,7 +4624,7 @@ testcase_sandbox_nutscanner_list() {
         PORTS_SEEN="`echo \"$CMDOUT\" | ${EGREP} -c 'port *='`"
 
         if [ "$PORTS_WANT" != "$PORTS_SEEN" ]; then
-            log_error "[testcase_sandbox_nutscanner_list] Too many 'port=' lines: want $PORTS_WANT != seen $PORTS_SEEN" >&2
+            log_error "[testcase_sandbox_nutscanner_list] Error: Too many 'port=' lines: want $PORTS_WANT != seen $PORTS_SEEN" >&2
             return 1
         fi
     ) >/dev/null ; then
@@ -4634,7 +4634,7 @@ testcase_sandbox_nutscanner_list() {
         if ( echo "$CMDERR" | ${EGREP} "Cannot load NUT library.*libupsclient.*found.*NUT search disabled" ) ; then
             log_warn "[testcase_sandbox_nutscanner_list] SKIP: ${TOP_BUILDDIR}/tools/nut-scanner/nut-scanner: $CMDERR"
         else
-            log_error "[testcase_sandbox_nutscanner_list] nut-scanner complained or did not return all expected data, check above"
+            log_error "[testcase_sandbox_nutscanner_list] Error: nut-scanner complained or did not return all expected data, check above"
             FAILED="`expr $FAILED + 1`"
             FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_nutscanner_list"
         fi
@@ -4683,7 +4683,7 @@ upsmon_start_loop() {
         return
     fi
 
-    log_error "[${TESTCASE}] UPSMON PID $PID_UPSMON is not alive after a short while"
+    log_error "[${TESTCASE}] Error: UPSMON PID $PID_UPSMON is not alive after a short while"
     return 1
 }
 

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -298,8 +298,20 @@ execcmd() {
     esac
     shift
 
-    log_debug "execcmd: running:   ${CMDPROG} $@"
-    exec "${CMDPROG}" "$@"
+    # NOTE: Ability to use valgrind depends on the platform!
+    #  NUT CI farm build agent labels and ci_build.sh allow
+    #  us to know where it is safe to call this script. YMMV!
+    # NOTE: Process initialization can take half a minute or
+    #  so under valgrind, impacting our many `upsc` calls!
+    EXECWRAP=""
+    if [ x"${DO_MEMCHECK}" = xtrue ]; then
+        if [ -x "${TOP_BUILDDIR}/scripts/valgrind/valgrind.sh" ] ; then
+            EXECWRAP="${TOP_BUILDDIR}/scripts/valgrind/valgrind.sh"
+        fi
+    fi
+
+    log_debug "execcmd: running:   ${EXECWRAP} ${CMDPROG} $@"
+    exec $EXECWRAP "${CMDPROG}" "$@"
 }
 
 runcmd() {

--- a/tests/test_authconf.c
+++ b/tests/test_authconf.c
@@ -18,7 +18,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdarg.h>
+#ifdef HAVE_STDARG_H
+# include <stdarg.h>
+#endif
+#ifdef HAVE_SYS_STDARG_H
+# include <sys/stdarg.h>
+#endif
 
 static void exit_cleanup(void) {
 	if (!upscli_cleanup()) {

--- a/tests/test_authconf.c
+++ b/tests/test_authconf.c
@@ -12,12 +12,19 @@
 
 #include "common.h"
 #include "authconf.h"
+#include "upsclient.h"	/* For upscli_cleanup() */
 
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
+
+static void exit_cleanup(void) {
+	if (!upscli_cleanup()) {
+		fprintf(stderr, "FAILED upscli_cleanup() during exit");
+	}
+}
 
 int main(int argc, char **argv)
 {
@@ -46,6 +53,8 @@ int main(int argc, char **argv)
 		perror("fopen test_nutauth.conf");
 		return 1;
 	}
+
+	atexit(exit_cleanup);
 
 	expected_sections++;
 	fprintf(f, "USER = globaluser\n");

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -31,7 +31,12 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
+#ifdef HAVE_STDARG_H
+# include <stdarg.h>
+#endif
+#ifdef HAVE_SYS_STDARG_H
+# include <sys/stdarg.h>
+#endif
 #include <unistd.h>
 #include <string.h>
 


### PR DESCRIPTION
…and fix passing one default and one custom user/name value

Closes: #3513

Follow-up to #3567 in refining the CI recipes.

Fallout of #3140 (NUT v2.8.5): In that PR, the logic was changed to track if the caller gave us the user and group values - and then should have specified both. That check was flawed in case that (exactly) one of those specified values was same as the default that the `configure` script would apply, then it got treated as not-set and rejected the build configuration.