### PR TITLE
tripplite-hid: fix ActivePower mapping and scaling

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -230,7 +230,7 @@ https://github.com/networkupstools/nut/milestone/13
       (`09ae:2012`), which now reports `ups.realpower: 512.0` at `ups.load: 56`
       against its 900 W rating. Note this is a behaviour change for units that
       report a non-zero `ActivePower`: the reading moves from `ups.power` to
-      `ups.realpower`.
+      `ups.realpower`. [issue #3580, PR #3581]
 
  - `snmp-ups` driver updates:
     * Extended the XPPC-MIB subdriver (enterprise 935) to expose

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -212,6 +212,25 @@ https://github.com/networkupstools/nut/milestone/13
       were unaffected. [PR #3555]
     * `mge-hid` subdriver updated to suppress `CHRG` status on constant-charge
       mode devices when battery is fully charged. [issue #3518, PR #3519]
+    * `tripplite-hid` subdriver now recovers the output power reading, which was
+      published as a constant `0.0`. Two defects combined: the HID `ActivePower`
+      usages were mapped to `ups.power`, which `docs/nut-names.txt` defines as
+      apparent power (VA) rather than real power (W); and on the tested
+      SMART1500LCD the firmware declares its `ActivePower` item with the HID PDC
+      unit for watts/VA (`0x0000D121`) while leaving the Unit Exponent at 0, so
+      `get_unit_expo()` applied a factor of 1e-7 and a genuine 520 W reading
+      arrived as 5.2e-05, which the `%.1f` format then rendered as `0.0`.
+      Both `ActivePower` usages now map to `ups.realpower`, matching the
+      `cps-hid` and `mge-hid` subdrivers; `ups.power` is mapped to the
+      corresponding `ApparentPower` usages and `ups.realpower.nominal` to
+      `UPS.Flow.ConfigActivePower`. A new `tripplite_fix_report_desc()` supplies
+      the exponent the firmware omits; it is deliberately limited to the
+      `ActivePower` item, since no Tripp Lite descriptor is known to expose an
+      `ApparentPower` item with the same defect. Verified on a SMART1500LCD
+      (`09ae:2012`), which now reports `ups.realpower: 512.0` at `ups.load: 56`
+      against its 900 W rating. Note this is a behaviour change for units that
+      report a non-zero `ActivePower`: the reading moves from `ups.power` to
+      `ups.realpower`.
 
  - `snmp-ups` driver updates:
     * Extended the XPPC-MIB subdriver (enterprise 935) to expose

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3807 utf-8
+personal_ws-1.1 en 3808 utf-8
 AAC
 AAS
 ABI
@@ -66,6 +66,7 @@ Antonino
 Apodaca
 AppData
 AppVeyor
+ApparentPower
 ArgumentList
 Arjen
 Arkadiusz

--- a/drivers/tripplite-hid.c
+++ b/drivers/tripplite-hid.c
@@ -29,7 +29,12 @@
 #include "tripplite-hid.h"
 #include "usb-common.h"
 
-#define TRIPPLITE_HID_VERSION "TrippLite HID 0.86"
+#define TRIPPLITE_HID_VERSION "TrippLite HID 0.87"
+
+/* HID PDC unit for watts / VA, and the Unit Exponent NUT's HIDUnits table
+ * (drivers/libhid.c) expects it to be declared with. */
+#define TRIPPLITE_HID_POWER_UNIT	0x0000D121L
+#define TRIPPLITE_HID_POWER_UNIT_EXPO	7
 /* FIXME: experimental flag to be put in upsdrv_info */
 
 
@@ -375,8 +380,11 @@ static hid_info_t tripplite_hid2nut[] = {
 	{ "ups.test.result", 0, 0, "UPS.BatterySystem.Test", NULL, "%s", 0, test_read_info },
 	{ "ups.beeper.status", 0, 0, "UPS.PowerSummary.AudibleAlarmControl", NULL, "%s", 0, beeper_info },
 	{ "ups.power.nominal", 0, 0, "UPS.Flow.ConfigApparentPower", NULL, "%.0f", HU_FLAG_STATIC, NULL },
-	{ "ups.power", 0, 0, "UPS.OutletSystem.Outlet.ActivePower", NULL, "%.1f", 0, NULL },
-	{ "ups.power", 0, 0, "UPS.PowerConverter.Output.ActivePower", NULL, "%.1f", 0, NULL },
+	{ "ups.power", 0, 0, "UPS.OutletSystem.Outlet.ApparentPower", NULL, "%.1f", 0, NULL },
+	{ "ups.power", 0, 0, "UPS.PowerConverter.Output.ApparentPower", NULL, "%.1f", 0, NULL },
+	{ "ups.realpower.nominal", 0, 0, "UPS.Flow.ConfigActivePower", NULL, "%.0f", HU_FLAG_STATIC, NULL },
+	{ "ups.realpower", 0, 0, "UPS.OutletSystem.Outlet.ActivePower", NULL, "%.1f", 0, NULL },
+	{ "ups.realpower", 0, 0, "UPS.PowerConverter.Output.ActivePower", NULL, "%.1f", 0, NULL },
 	{ "ups.load", 0, 0, "UPS.OutletSystem.Outlet.PercentLoad", NULL, "%.0f", 0, NULL },
 	/* FIXME: what is the conversion format for this one?
 	 * Example on HP T1500 G3
@@ -556,6 +564,74 @@ static int tripplite_claim(HIDDevice_t *hd) {
 	}
 }
 
+/* The tested Tripp Lite SMART1500LCD (09ae:2012) declares its ActivePower item
+ * with the HID PDC unit for watts / VA (0x0000D121) but leaves the Unit
+ * Exponent at 0, while the report already carries a plain integer expressed in
+ * watts. NUT's HIDUnits table (see get_unit_expo() in drivers/libhid.c)
+ * normalizes that unit against an exponent of 7, so it computes 0 - 7 = -7 and
+ * scales the reading by 1e-7: a genuine 520 W reading arrives as raw 0x0208 and
+ * is published as 5.2e-05, which the "%.1f" format then renders as "0.0".
+ *
+ * Supply the exponent this firmware omits. Items that declare a different unit,
+ * or that already declare UnitExp = 7, are left alone, so this is inert on
+ * descriptors that are correct. */
+static int tripplite_fix_report_desc(HIDDevice_t *pDev, HIDDesc_t *pDesc_arg) {
+	size_t	i;
+	int	retval = 0;
+
+	if (disable_fix_report_desc) {
+		upsdebugx(3,
+			"NOT attempting Report Descriptor fix for UPS: "
+			"Vendor: %04x, Product: %04x "
+			"(got disable_fix_report_desc in config)",
+			(unsigned int)pDev->VendorID,
+			(unsigned int)pDev->ProductID);
+		return 0;
+	}
+
+	for (i = 0; i < pDesc_arg->nitems; i++) {
+		HIDData_t	*pData = &pDesc_arg->item[i];
+		HIDNode_t	usage;
+
+		if (pData->Path.Size == 0)
+			continue;
+
+		usage = pData->Path.Node[pData->Path.Size - 1];
+		if (usage != USAGE_POW_ACTIVE_POWER)
+			continue;
+
+		/* HID PDC 3.2.3: watts and VA use unit 0x0000D121, which NUT
+		 * normalizes against exponent 7. The tested firmware declares
+		 * that unit with UnitExp 0, which is demonstrably wrong on this
+		 * device; match only that combination. */
+		if (pData->Unit != TRIPPLITE_HID_POWER_UNIT
+		 || pData->UnitExp != 0)
+			continue;
+
+		upsdebugx(3, "Fixing Report Descriptor: ActivePower "
+			"(ReportID 0x%02x) declares the PDC power Unit 0x%08lx "
+			"with UnitExp %d, but NUT normalizes that Unit against "
+			"UnitExp %d (see HIDUnits in drivers/libhid.c), so "
+			"readings would be scaled by 1e%d. Setting UnitExp = %d.",
+			pData->ReportID,
+			(unsigned long)pData->Unit,
+			(int)pData->UnitExp,
+			TRIPPLITE_HID_POWER_UNIT_EXPO,
+			(int)pData->UnitExp - TRIPPLITE_HID_POWER_UNIT_EXPO,
+			TRIPPLITE_HID_POWER_UNIT_EXPO);
+
+		pData->UnitExp = TRIPPLITE_HID_POWER_UNIT_EXPO;
+		retval = 1;
+	}
+
+	if (!retval) {
+		upsdebugx(3, "Report Descriptor: no ActivePower item "
+			"needed a Unit Exponent fix");
+	}
+
+	return retval;
+}
+
 subdriver_t tripplite_subdriver = {
 	TRIPPLITE_HID_VERSION,
 	tripplite_claim,
@@ -564,6 +640,6 @@ subdriver_t tripplite_subdriver = {
 	tripplite_format_model,
 	tripplite_format_mfr,
 	tripplite_format_serial,
-	fix_report_desc,
+	tripplite_fix_report_desc,
 	NULL,
 };

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -28,6 +28,9 @@
 /getexponenttest-belkin-hid
 /getexponenttest-belkin-hid.log
 /getexponenttest-belkin-hid.trs
+/fixreportdesctest-tripplite-hid
+/fixreportdesctest-tripplite-hid.log
+/fixreportdesctest-tripplite-hid.trs
 /getvaluetest
 /getvaluetest.log
 /getvaluetest.trs

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -147,7 +147,7 @@ ecoflow-cdc-protocol.c: $(top_srcdir)/drivers/ecoflow-cdc-protocol.c
 	test -s '$@' || ln -s -f "$(top_srcdir)/drivers/ecoflow-cdc-protocol.c" '$@'
 
 if WITH_USB
-TESTS += getvaluetest getexponenttest-belkin-hid
+TESTS += getvaluetest getexponenttest-belkin-hid fixreportdesctest-tripplite-hid
 
 # We only need to call a few methods, not use the whole source - so
 # not linking it as a getvaluetest_SOURCE file (has too many deps):
@@ -160,6 +160,11 @@ getexponenttest-belkin-hid.c: $(top_srcdir)/drivers/belkin-hid.c
 getexponenttest_belkin_hid_SOURCES = getexponenttest-belkin-hid.c
 getexponenttest_belkin_hid_CFLAGS = $(AM_CFLAGS) $(LIBUSB_CFLAGS)
 getexponenttest_belkin_hid_LDADD = $(NUT_LIBCOMMON) libdriverstubusb.la
+
+fixreportdesctest-tripplite-hid.c: $(top_srcdir)/drivers/tripplite-hid.c
+fixreportdesctest_tripplite_hid_SOURCES = fixreportdesctest-tripplite-hid.c
+fixreportdesctest_tripplite_hid_CFLAGS = $(AM_CFLAGS) $(LIBUSB_CFLAGS)
+fixreportdesctest_tripplite_hid_LDADD = $(NUT_LIBCOMMON) libdriverstubusb.la
 
 getvaluetest_SOURCES = getvaluetest.c
 nodist_getvaluetest_SOURCES = hidparser.c

--- a/tests/fixreportdesctest-tripplite-hid.c
+++ b/tests/fixreportdesctest-tripplite-hid.c
@@ -51,7 +51,10 @@ usb_communication_subdriver_t   usb_subdriver = {0};
 #pragma GCC diagnostic pop
 #endif
 
-/* Owned by usbhid-ups.c in a real build; the subdriver honors it */
+/* Owned by usbhid-ups.c in a real build; the subdriver honors it.
+ * Marked extern so the compiler does not bother if it is static or shared by object files.
+ */
+extern int disable_fix_report_desc;
 int disable_fix_report_desc = 0;
 
 #include "tripplite-hid.c"

--- a/tests/fixreportdesctest-tripplite-hid.c
+++ b/tests/fixreportdesctest-tripplite-hid.c
@@ -1,0 +1,235 @@
+/* fixreportdesctest-tripplite-hid - check the Report Descriptor repair which
+ * compensates for Tripp Lite HID firmware that declares the HID PDC power
+ * unit while leaving the Unit Exponent at 0 (as used in the
+ * drivers/tripplite-hid.c subdriver of usbhid-ups).
+ *
+ * Modelled on tests/getexponenttest-belkin-hid.c.
+ *
+ * See also:
+ *  https://github.com/networkupstools/nut/issues/3580
+ *
+ * Copyright (C)
+ *      2026        Kyle Mason <masonkr@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#include "config.h"
+
+#include "nut_stdint.h"
+#include "nut_float.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "common.h"
+
+/* Dummy here */
+#include "nut_libusb.h"
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_BESIDEFUNC) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_MISSING_FIELD_INITIALIZERS_BESIDEFUNC) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_MISSING_BRACES_BESIDEFUNC) )
+#pragma GCC diagnostic push
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_MISSING_FIELD_INITIALIZERS_BESIDEFUNC
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
+#ifdef HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_MISSING_BRACES_BESIDEFUNC
+#pragma GCC diagnostic ignored "-Wmissing-braces"
+#endif
+usb_communication_subdriver_t   usb_subdriver = {0};
+#if (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_PUSH_POP_BESIDEFUNC) && ( (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_MISSING_FIELD_INITIALIZERS_BESIDEFUNC) || (defined HAVE_PRAGMA_GCC_DIAGNOSTIC_IGNORED_MISSING_BRACES_BESIDEFUNC) )
+#pragma GCC diagnostic pop
+#endif
+
+/* Owned by usbhid-ups.c in a real build; the subdriver honors it */
+int disable_fix_report_desc = 0;
+
+#include "tripplite-hid.c"
+/* from drivers/tripplite-hid.c we test:
+static int tripplite_fix_report_desc(HIDDevice_t *pDev, HIDDesc_t *pDesc_arg);
+ */
+
+/* Lookup tables and helpers owned by usbhid-ups.c / libhid.c in a real
+ * build. The repair under test does not consult them; they are referenced
+ * only by the subdriver's mapping table, which must still link. */
+info_lkp_t awaitingpower_info[] = { { 0, NULL, NULL, NULL } };
+info_lkp_t boost_info[] = { { 0, NULL, NULL, NULL } };
+info_lkp_t charging_info[] = { { 0, NULL, NULL, NULL } };
+info_lkp_t commfault_info[] = { { 0, NULL, NULL, NULL } };
+info_lkp_t depleted_info[] = { { 0, NULL, NULL, NULL } };
+info_lkp_t discharging_info[] = { { 0, NULL, NULL, NULL } };
+info_lkp_t fullycharged_info[] = { { 0, NULL, NULL, NULL } };
+info_lkp_t kelvin_celsius_conversion[] = { { 0, NULL, NULL, NULL } };
+info_lkp_t lowbatt_info[] = { { 0, NULL, NULL, NULL } };
+info_lkp_t online_info[] = { { 0, NULL, NULL, NULL } };
+info_lkp_t overheat_info[] = { { 0, NULL, NULL, NULL } };
+info_lkp_t overload_info[] = { { 0, NULL, NULL, NULL } };
+info_lkp_t replacebatt_info[] = { { 0, NULL, NULL, NULL } };
+info_lkp_t shutdownimm_info[] = { { 0, NULL, NULL, NULL } };
+info_lkp_t test_read_info[] = { { 0, NULL, NULL, NULL } };
+info_lkp_t trim_info[] = { { 0, NULL, NULL, NULL } };
+info_lkp_t vrange_info[] = { { 0, NULL, NULL, NULL } };
+
+char *HIDGetIndexString(hid_dev_handle_t arg_udev, const int Index, char *buf, size_t buflen) {
+	NUT_UNUSED_VARIABLE(arg_udev);
+	NUT_UNUSED_VARIABLE(Index);
+	if (buf && buflen) buf[0] = '\0';
+	return buf;
+}
+
+const char *dstate_getinfo(const char *var) {
+	NUT_UNUSED_VARIABLE(var);
+	return NULL;
+}
+
+/* 10^expo without pulling in libm for one call */
+static double scale_by_expo(double v, int expo) {
+	while (expo > 0) { v *= 10.0; expo--; }
+	while (expo < 0) { v /= 10.0; expo++; }
+	return v;
+}
+
+/* NUT's HIDUnits table (drivers/libhid.c) records the exponent that NUT
+ * expects the PDC power unit 0x0000D121 to carry. get_unit_expo() subtracts
+ * it from the device-declared UnitExp. Duplicated here because that table and
+ * get_unit_expo() are both static to libhid.c and cannot be linked from a
+ * unit test without a live USB handle. */
+#define NUT_EXPECTED_POWER_EXPO	7
+
+static int failures = 0;
+
+static void mkitem(HIDData_t *d, HIDNode_t usage, long unit, int8_t unitexp, uint8_t rid)
+{
+	memset((void *)d, 0, sizeof(*d));
+	d->Path.Size = 4;
+	d->Path.Node[0] = 0x00840004;	/* UPS */
+	d->Path.Node[1] = 0x00840016;	/* PowerConverter */
+	d->Path.Node[2] = 0x0084001c;	/* Output */
+	d->Path.Node[3] = usage;
+	d->Unit = unit;
+	d->UnitExp = unitexp;
+	d->ReportID = rid;
+	d->LogMin = 0;
+	d->LogMax = 65535;
+}
+
+static void check(const char *name, int cond)
+{
+	printf("  %-62s %s\n", name, cond ? "PASS" : "FAIL");
+	if (!cond) failures++;
+}
+
+/* Run tripplite_fix_report_desc() over a one-item descriptor */
+static int run_one(HIDData_t *item, int8_t *resulting_exp)
+{
+	HIDDesc_t	desc;
+	HIDDevice_t	dev;
+	int		ret;
+
+	memset((void *)&desc, 0, sizeof(desc));
+	memset((void *)&dev, 0, sizeof(dev));
+	dev.VendorID = 0x09ae;
+	dev.ProductID = 0x2012;
+	desc.nitems = 1;
+	desc.item = item;
+
+	ret = tripplite_fix_report_desc(&dev, &desc);
+	if (resulting_exp) *resulting_exp = item->UnitExp;
+	return ret;
+}
+
+int main(void)
+{
+	HIDData_t	item;
+	int8_t		exp_after;
+	int		fired;
+
+	printf("tripplite-hid: Report Descriptor repair tests\n");
+
+	/* 1. The proven SMART1500LCD (09ae:2012) defect: ActivePower declares
+	 *    the PDC power unit with UnitExp 0, so NUT would apply 10^-7. */
+	printf("\n[1] malformed ActivePower (Unit=0x0000D121, UnitExp=0)\n");
+	mkitem(&item, USAGE_POW_ACTIVE_POWER, 0x0000D121L, 0, 0x47);
+	fired = run_one(&item, &exp_after);
+	check("repair fires", fired == 1);
+	check("UnitExp raised to 7", exp_after == NUT_EXPECTED_POWER_EXPO);
+	check("effective exponent becomes 0",
+		(exp_after - NUT_EXPECTED_POWER_EXPO) == 0);
+	check("raw 520 now interprets as 520 W (was 5.2e-05)",
+		f_equal(scale_by_expo(520.0, exp_after - NUT_EXPECTED_POWER_EXPO), 520.0));
+
+	/* 2. A conformant descriptor must be left alone. */
+	printf("\n[2] correct ActivePower (Unit=0x0000D121, UnitExp=7)\n");
+	mkitem(&item, USAGE_POW_ACTIVE_POWER, 0x0000D121L, NUT_EXPECTED_POWER_EXPO, 0x47);
+	fired = run_one(&item, &exp_after);
+	check("repair does NOT fire", fired == 0);
+	check("UnitExp untouched at 7", exp_after == NUT_EXPECTED_POWER_EXPO);
+
+	/* 3. Right usage, but no PDC power unit declared: our own unit's
+	 *    voltage items look like this and read correctly today. */
+	printf("\n[3] ActivePower with Unit=0x00000000 (no PDC unit)\n");
+	mkitem(&item, USAGE_POW_ACTIVE_POWER, 0x00000000L, 0, 0x47);
+	fired = run_one(&item, &exp_after);
+	check("repair does NOT fire", fired == 0);
+	check("UnitExp untouched at 0", exp_after == 0);
+
+	/* 4. Right unit and exponent, but an unrelated usage. */
+	printf("\n[4] unrelated usage (PercentLoad) with Unit=0x0000D121, UnitExp=0\n");
+	mkitem(&item, 0x00840035L /* PercentLoad */, 0x0000D121L, 0, 0x1e);
+	fired = run_one(&item, &exp_after);
+	check("repair does NOT fire", fired == 0);
+	check("UnitExp untouched at 0", exp_after == 0);
+
+	/* 5. The user's escape hatch must be honored. */
+	printf("\n[5] disable_fix_report_desc=1 on the malformed item\n");
+	disable_fix_report_desc = 1;
+	mkitem(&item, USAGE_POW_ACTIVE_POWER, 0x0000D121L, 0, 0x47);
+	fired = run_one(&item, &exp_after);
+	check("repair does NOT fire", fired == 0);
+	check("UnitExp untouched at 0", exp_after == 0);
+	disable_fix_report_desc = 0;
+
+	/* 6. Scope boundary. ApparentPower shares the same PDC unit, and
+	 *    ApparentPower remains a valid semantic mapping target for
+	 *    ups.power. But no Tripp Lite descriptor is currently known to
+	 *    expose an ApparentPower item at all, so nothing proves the same
+	 *    malformed exponent for that usage. The descriptor repair is
+	 *    deliberately limited to the hardware-proven ActivePower item. */
+	printf("\n[6] scope boundary: ApparentPower (Unit=0x0000D121, UnitExp=0)\n");
+	mkitem(&item, USAGE_POW_APPARENT_POWER, 0x0000D121L, 0, 0x40);
+	fired = run_one(&item, &exp_after);
+	check("repair does NOT fire (ApparentPower is out of scope)", fired == 0);
+	check("UnitExp untouched at 0", exp_after == 0);
+
+	/* 7. Scope boundary. Voltage uses a different PDC unit (0x00F0D121)
+	 *    and issue #1018 implies a different declared exponent (-1) there.
+	 *    We have no device that both exhibits it and can be tested, and
+	 *    output.voltage already passes through the per-product
+	 *    io_voltage_scale conversion function, so a voltage repair could
+	 *    compose with it. This repair must not touch voltage. */
+	printf("\n[7] scope boundary: Output.Voltage (Unit=0x00F0D121, UnitExp=-1)\n");
+	mkitem(&item, 0x00840030L /* Voltage */, 0x00F0D121L, -1, 0x1b);
+	fired = run_one(&item, &exp_after);
+	check("repair does NOT fire (voltage is out of scope)", fired == 0);
+	check("UnitExp untouched at -1", exp_after == -1);
+
+	/* 8. A naive "value looks too small, so rescale it" heuristic would
+	 *    corrupt this: a legitimately tiny reading on a conformant item. */
+	printf("\n[8] anti-heuristic: conformant item carrying a genuinely small value\n");
+	mkitem(&item, USAGE_POW_ACTIVE_POWER, 0x0000D121L, NUT_EXPECTED_POWER_EXPO, 0x47);
+	fired = run_one(&item, &exp_after);
+	check("repair does NOT fire on magnitude alone", fired == 0);
+
+	printf("\n%s: %d check(s) failed\n", failures ? "FAILED" : "OK", failures);
+	return failures ? 1 : 0;
+}


### PR DESCRIPTION
Fixes #3580

## Summary

On the tested Tripp Lite SMART1500LCD, `ups.power` reads a constant `0.0` while
the UPS carries real load. The device is not reporting zero. On the tested SMART1500LCD it
reports 520 W, and the driver scales that by `1e-7` before formatting it.

Two independent defects combine to produce that one symptom.

**1. `ActivePower` is mapped to the apparent-power variable.**
`drivers/tripplite-hid.c:378-379` maps both HID `ActivePower` usages to
`ups.power`. `docs/nut-names.txt` defines `ups.power` as apparent power in VA
(line 262) and `ups.realpower` as real power in W (line 266), so the subdriver
publishes a watts reading under a VA name and never publishes `ups.realpower` at
all. Two sibling subdrivers already follow the contract:
`cps-hid.c:384` and `mge-hid.c:2084`. This half lives in the shared
`tripplite_hid2nut` table and is wrong independently of any firmware quirk.

**2. On at least the tested SMART1500LCD, the Unit Exponent is omitted.**
The firmware declares the power usage with the HID PDC unit for watts/VA
(`0x0000D121`) but leaves `UnitExponent` at 0, while the report already carries a
plain integer in watts. `HIDUnits` in `drivers/libhid.c:391-394` records that this
unit is expected to carry exponent 7, so `get_unit_expo()` (`libhid.c:898`,
`unit_expo -= HIDUnits[i].Expo` at `:908`) resolves `0 - 7`, and `libhid.c:544`
applies it.

## Hardware proof

```
ReportID 0x47, raw bytes 08 02  ->  0x0208 = 520
Unit = 0x0000D121, UnitExp = 0  ->  effective exponent 0 - 7 = -7
520 x 10^-7 = 5.2e-05  ->  "%.1f"  ->  0.0
```

Before, on a SMART1500LCD (`09ae:2012`), NUT 2.8.1 / `TrippLite HID 0.85`:

```
ups.load: 57
ups.power: 0.0
ups.power.nominal: 1500
ups.status: OL
```

`ups.realpower` absent.

After:

```
ups.load: 56
ups.realpower: 512.0
ups.power.nominal: 1500
ups.status: OL
```

`ups.power` absent, because this descriptor exposes no `ApparentPower` usage.

## Fix

- both `ActivePower` usages now map to `ups.realpower`
- `ups.power` now maps to the corresponding `ApparentPower` usages
- added `ups.realpower.nominal` from `UPS.Flow.ConfigActivePower`, matching
  `apc-hid.c:376-377` and `cps-hid.c:385`
- added `tripplite_fix_report_desc()` to supply the omitted exponent on the
  `ActivePower` item, modelled on `cps_fix_report_desc()`. `tripplite_subdriver`
  previously registered the generic no-op `fix_report_desc`
- added `ApparentPower` to `docs/nut.dict`, since the NEWS entry names it
- bumped `TRIPPLITE_HID_VERSION` to 0.87 and added a NEWS entry
- added `tests/fixreportdesctest-tripplite-hid.c`

The repair is gated on the usage being `USAGE_POW_ACTIVE_POWER` **and**
`Unit == 0x0000D121 && UnitExp == 0`. That combination is the one observed on the
tested device, so the repair identifies that firmware defect without a product
allowlist and leaves a conformant descriptor untouched by construction. It
honours `disable_fix_report_desc` and runs before any value is read.

Note the deliberate split between mapping coverage and descriptor-repair
coverage:

| Usage | Mapped to | Descriptor repair |
|---|---|---|
| `ActivePower` | `ups.realpower` | **yes**, hardware-proven |
| `ApparentPower` | `ups.power` | **no** |
| `ConfigActivePower` | `ups.realpower.nominal` | **no** |

`ApparentPower` shares the same PDC unit, but no Tripp Lite descriptor is known
to expose an `ApparentPower` item at all, so repairing it would be speculative.
It remains a mapping target only.

## Testing

- `make -C tests check`: **8/8 pass**, 0 fail, 0 error, 0 skip. That includes the
  new `fixreportdesctest-tripplite-hid` and the pre-existing
  `getexponenttest-belkin-hid`.
- `tests/fixreportdesctest-tripplite-hid`: 17/17 checks. Covers the malformed
  case, a conformant descriptor, the matching usage without the PDC power unit,
  the power unit on an unrelated usage, `disable_fix_report_desc`,
  and three negative cases asserting that `ApparentPower` and voltage usages are
  untouched and that the repair never fires on value magnitude alone.
- `drivers/tripplite-hid.c` and the new test compile with zero warnings under
  `-Wall -Wextra -Wconversion -Wshadow -Wpedantic`.
- Hardware: four runs on a SMART1500LCD (`09ae:2012`) over USB. Raw `ActivePower`
  520 / 494 / 507 / 512 W at `ups.load` 57 / 54 / 55 / 56, each within about a
  point of the device's own `PercentLoad` against its 900 W rating. The repair
  fires exactly once, on ReportID `0x47`; `input.voltage`, `output.voltage`,
  `battery.voltage`, frequencies and every nominal/config field are unchanged.
  Narrowing the gate to `ActivePower` does not alter that proven path.

One limitation on what the standalone test proves: `get_unit_expo()` and
`HIDUnits` are private to `libhid.c`, so the test asserts the repair's decision
and the resulting exponent rather than invoking those internals. The complete
runtime path is covered by the hardware runs.

## Untested mappings

The tested descriptor exposes no `ApparentPower` usage and no
`UPS.Flow.ConfigActivePower`, so the `ups.power <- ApparentPower` and
`ups.realpower.nominal <- ConfigActivePower` rows are **not exercised on this
hardware**. They are kept because they are the semantically correct sources, they
are skipped when the usage is absent (`hid_ups_walk()` never reaches
`dstate_setinfo()` for an unresolved path, and none of these rows carry
`HU_FLAG_ABSENT`), and without them the subdriver would have no correct path to
populate those two variables on a model that does expose them. Happy to drop them
if you would rather the PR carry only mappings this hardware exercises.

## Compatibility

This corrects a public variable. On any Tripp Lite unit that currently exposes a
non-zero `ActivePower` through `ups.power`, that reading moves to
`ups.realpower`, and `ups.power` becomes absent unless the device exposes a real
`ApparentPower` usage. Scripts, dashboards, exporters and alert rules bound to
`ups.power` on these devices will need repointing. That is the intent of the
change, but it is user-visible, hence the NEWS entry.

## Voltage is intentionally out of scope

#1018 reports the same visible scaling class on a SMART3000RM2U, including
`Output.Voltage`. It is not addressed here.

`output.voltage` already passes through `tripplite_iovolt`
(`drivers/tripplite-hid.c:444-445`), which applies the per-product
`io_voltage_scale`, set to `100000.0` for product `0x3016` by
`smart1500lcdt_scale()`. A descriptor-level exponent repair on a voltage item
would compose with a correction some products already receive, so it needs
separate reconciliation. `ActivePower` has no conversion callback, which is why
the power repair composes with nothing.

The #1018 dump is also at debug level 1, which does not print `Unit` / `UnitExp`,
so its voltage failure shares the symptom but is not shown to be the same
descriptor defect. And the unit tested here declares `Unit = 0x00000000` on every
voltage item and reads correctly, so a voltage repair could not be exercised on
this hardware at all. Left as follow-up in #1018 once an affected device can
supply a `-DDDDD` dump and its product ID.
