### PR TITLE
drivers/hidparser.c: bound the HID usage and path stacks [GHSA-f444-v6f2-2vcj]

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -321,6 +321,10 @@ https://github.com/networkupstools/nut/milestone/13
       exiting right away or remaining in data stale mode indefinitely, also
       using `reconnect_trying()` for consistent reporting. They now track
       serial port file descriptor validity a bit more diligently. [PR #3541]
+    * The `hidparser.c` code (used primarily in USB drivers) risked a heap
+      out-of-bounds write if the device would report too many descriptors.
+      A similar problem could lead to "HID path too long" messages and loss
+      of readings from the device. [PR #3586]
 
  - NUT client libraries:
     * Complete support for actions documented in `docs/net-protocol.txt`

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -323,7 +323,7 @@ https://github.com/networkupstools/nut/milestone/13
       serial port file descriptor validity a bit more diligently. [PR #3541]
     * The `hidparser.c` code (used primarily in USB drivers) risked a heap
       out-of-bounds write if a device reported a HID report descriptor with
-      more usage items than the parser's fixed stack could hold. A similar
+      more usage items than the fixed stack in the parser could hold. A similar
       problem could lead to "HID path too long" messages and loss of
       readings from the device. [PR #3586]
 

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -322,9 +322,10 @@ https://github.com/networkupstools/nut/milestone/13
       using `reconnect_trying()` for consistent reporting. They now track
       serial port file descriptor validity a bit more diligently. [PR #3541]
     * The `hidparser.c` code (used primarily in USB drivers) risked a heap
-      out-of-bounds write if the device would report too many descriptors.
-      A similar problem could lead to "HID path too long" messages and loss
-      of readings from the device. [PR #3586]
+      out-of-bounds write if a device reported a HID report descriptor with
+      more usage items than the parser's fixed stack could hold. A similar
+      problem could lead to "HID path too long" messages and loss of
+      readings from the device. [PR #3586]
 
  - NUT client libraries:
     * Complete support for actions documented in `docs/net-protocol.txt`

--- a/drivers/hidparser.c
+++ b/drivers/hidparser.c
@@ -176,6 +176,19 @@ static int HIDParse(HIDParser_t *pParser, HIDData_t *pData)
 			break;
 
 		case ITEM_USAGE:
+			/* The usage stack is a fixed-size array. Refuse to walk past
+			 * it instead of merely complaining about it after the fact
+			 * (see the USAGE_TAB_SIZE report at the end of this loop).
+			 * -1 is the established "no more items" return, and
+			 * Parse_ReportDesc() breaks out of its loop on ret < 0, so
+			 * everything parsed up to here is kept and the remainder of
+			 * the descriptor is dropped. */
+			if (pParser->UsageSize >= USAGE_TAB_SIZE) {
+				upslogx(LOG_ERR, "%s: HID Usage stack overflow, "
+					"aborting report descriptor parsing", __func__);
+				return -1;
+			}
+
 			/* Copy global or local UPage if any, in Usage stack */
 			if ((pParser->Item & SIZE_MASK) > 2) {
 				pParser->UsageTab[pParser->UsageSize] = pParser->Value;
@@ -197,7 +210,12 @@ static int HIDParse(HIDParser_t *pParser, HIDData_t *pData)
 				int	j;
 
 				for (j = 0; j < pParser->UsageSize; j++) {
-					pParser->UsageTab[j] = pParser->UsageTab[j+1];
+					/* With UsageSize now allowed to reach
+					 * USAGE_TAB_SIZE, the last slot has no
+					 * successor to shift down. Unused slots
+					 * are zero (see ResetLocalState). */
+					pParser->UsageTab[j] = (j + 1 < USAGE_TAB_SIZE)
+						? pParser->UsageTab[j+1] : 0;
 				}
 
 				/* Remove Usage */
@@ -249,7 +267,12 @@ static int HIDParse(HIDParser_t *pParser, HIDData_t *pData)
 				int j;
 
 				for (j = 0; j < pParser->UsageSize; j++) {
-					pParser->UsageTab[j] = pParser->UsageTab[j+1];
+					/* With UsageSize now allowed to reach
+					 * USAGE_TAB_SIZE, the last slot has no
+					 * successor to shift down. Unused slots
+					 * are zero (see ResetLocalState). */
+					pParser->UsageTab[j] = (j + 1 < USAGE_TAB_SIZE)
+						? pParser->UsageTab[j+1] : 0;
 				}
 
 				/* Remove Usage */

--- a/drivers/hidparser.c
+++ b/drivers/hidparser.c
@@ -202,6 +202,11 @@ static int HIDParse(HIDParser_t *pParser, HIDData_t *pData)
 
 		case ITEM_COLLECTION:
 			/* Get UPage/Usage from UsageTab and store them in pParser->Data.Path */
+			if (pParser->Data.Path.Size >= PATH_SIZE) {
+				upslogx(LOG_ERR, "%s: HID path too long, "
+					"aborting report descriptor parsing", __func__);
+				return -1;
+			}
 			pParser->Data.Path.Node[pParser->Data.Path.Size] = pParser->UsageTab[0];
 			pParser->Data.Path.Size++;
 
@@ -224,6 +229,11 @@ static int HIDParse(HIDParser_t *pParser, HIDData_t *pData)
 
 			/* Get Index if any */
 			if (pParser->Value >= 0x80) {
+				if (pParser->Data.Path.Size >= PATH_SIZE) {
+					upslogx(LOG_ERR, "%s: HID path too long, "
+						"aborting report descriptor parsing", __func__);
+					return -1;
+				}
 				pParser->Data.Path.Node[pParser->Data.Path.Size] = 0x00ff0000 | (pParser->Value & 0x7F);
 				pParser->Data.Path.Size++;
 			}
@@ -232,10 +242,19 @@ static int HIDParse(HIDParser_t *pParser, HIDData_t *pData)
 			break;
 
 		case ITEM_END_COLLECTION :
+			/* An End Collection with no matching Collection would wrap
+			 * the unsigned Path.Size around to 255 and index far past
+			 * Path.Node[PATH_SIZE] on the next line. */
+			if (pParser->Data.Path.Size == 0) {
+				upslogx(LOG_ERR, "%s: unbalanced HID End Collection, "
+					"aborting report descriptor parsing", __func__);
+				return -1;
+			}
 			pParser->Data.Path.Size--;
 
 			/* Remove Index if any */
-			if((pParser->Data.Path.Node[pParser->Data.Path.Size] & 0xffff0000) == 0x00ff0000) {
+			if((pParser->Data.Path.Size > 0)
+			&& ((pParser->Data.Path.Node[pParser->Data.Path.Size] & 0xffff0000) == 0x00ff0000)) {
 				pParser->Data.Path.Size--;
 			}
 
@@ -259,6 +278,11 @@ static int HIDParse(HIDParser_t *pParser, HIDData_t *pData)
 			}
 
 			/* Get UPage/Usage from UsageTab and store them in pParser->Data.Path */
+			if (pParser->Data.Path.Size >= PATH_SIZE) {
+				upslogx(LOG_ERR, "%s: HID path too long, "
+					"aborting report descriptor parsing", __func__);
+				return -1;
+			}
 			pParser->Data.Path.Node[pParser->Data.Path.Size] = pParser->UsageTab[0];
 			pParser->Data.Path.Size++;
 

--- a/drivers/hidparser.c
+++ b/drivers/hidparser.c
@@ -203,7 +203,7 @@ static int HIDParse(HIDParser_t *pParser, HIDData_t *pData)
 		case ITEM_COLLECTION:
 			/* Get UPage/Usage from UsageTab and store them in pParser->Data.Path */
 			if (pParser->Data.Path.Size >= PATH_SIZE) {
-				upslogx(LOG_ERR, "%s: HID path too long, "
+				upsdebugx(1, "%s: HID path too long, "
 					"aborting report descriptor parsing", __func__);
 				return -1;
 			}
@@ -230,7 +230,7 @@ static int HIDParse(HIDParser_t *pParser, HIDData_t *pData)
 			/* Get Index if any */
 			if (pParser->Value >= 0x80) {
 				if (pParser->Data.Path.Size >= PATH_SIZE) {
-					upslogx(LOG_ERR, "%s: HID path too long, "
+					upsdebugx(1, "%s: HID path too long, "
 						"aborting report descriptor parsing", __func__);
 					return -1;
 				}
@@ -279,7 +279,7 @@ static int HIDParse(HIDParser_t *pParser, HIDData_t *pData)
 
 			/* Get UPage/Usage from UsageTab and store them in pParser->Data.Path */
 			if (pParser->Data.Path.Size >= PATH_SIZE) {
-				upslogx(LOG_ERR, "%s: HID path too long, "
+				upsdebugx(1, "%s: HID path too long, "
 					"aborting report descriptor parsing", __func__);
 				return -1;
 			}


### PR DESCRIPTION
Fixes the heap out-of-bounds write reported privately as GHSA-f444-v6f2-2vcj, plus the same-class problem in the path stack that I flagged in the same report. Opening this in the open at @jimklimov's direction on the advisory thread.

Both commits touch only `drivers/hidparser.c`. Nothing else in the tree changes.

WHAT THE FIRST COMMIT FIXES

`ITEM_USAGE` stored into `pParser->UsageTab[pParser->UsageSize]` with no check against `USAGE_TAB_SIZE`. The one `USAGE_TAB_SIZE` test in the file sits after the parsing loop and only calls `upslogx()`, so it reports the problem after the writes have already landed. `UsageTab` is `HIDNode_t[50]` and it's the last member of the heap-allocated `HIDParser_t`, so a report descriptor with more than 50 usage items writes 32-bit values from the descriptor past the end of the allocation. About 820 bytes of it, linearly, with the values under the descriptor's control.

The fix checks before the store and returns -1, which is the parser's existing "stop here" return. `Parse_ReportDesc()` already breaks out of its loop on `ret < 0`, so whatever parsed before the bad item is kept and the rest of the descriptor is dropped. That seemed better than clamping, which would silently mis-associate usages with the following main item.

Allowing `UsageSize` to reach `USAGE_TAB_SIZE` exposes a one-past-the-end read in the two unstack loops, which shifted `UsageTab[j+1]` down for every `j < UsageSize`. The last slot has no successor, so it now shifts in 0. `ResetLocalState()` zeroes unused slots anyway, so this matches what was already there.

WHAT THE SECOND COMMIT FIXES

The `Path` handling has the same shape - `upslogx()` after the loop instead of a test at the store - in the three places that append to `Data.Path.Node[]`. And `ITEM_END_COLLECTION` decremented `Path.Size` unconditionally, so an `End Collection` with no matching `Collection` wrapped the unsigned counter to 255 and the "remove index if any" test on the very next line read far past `Path.Node[PATH_SIZE]`.

This one stays inside the `HIDParser_t` allocation, so a sanitizer won't flag it. That's why it's folded in here rather than reported as its own vulnerability. It isn't only an overread though: on an unbalanced `End Collection` the current parser returns success with wrong paths - first node of every path missing, `pathsize` 2 where it should be 3 - after logging "HID path too long". A device quietly reporting wrong values is harder to catch than a crash, so it seemed worth fixing at the same time.

HOW IT WAS TESTED

There's a harness in my tree that builds the real `drivers/hidparser.c` twice under ASAN, pristine and patched, and runs five phases against both. I ran it against `0d949e373` this morning, all five pass:

1. Negative control. Unpatched build on the malicious descriptor: `AddressSanitizer: heap-buffer-overflow hidparser.c:181 in HIDParse`, `WRITE of size 4`, reached through the real `Parse_ReportDesc()` at `hidparser.c:734`. Exit 134. This phase runs first on purpose - a harness that has never been shown to fire proves nothing when it stays quiet.
2. Patched build, same descriptor: refused cleanly, no ASAN report.
3. Patched build, unbalanced `End Collection`: refused cleanly.
4. Positive control. A well-formed descriptor must parse to byte-identical output before and after. It does: same 3 items, same offsets, same `pathsize` 3 paths.
5. Positive control at the boundary. Exactly `USAGE_TAB_SIZE` usages must still be accepted, not rejected off by one. It is.

Phases 4 and 5 are the ones that matter for regression risk. A patch that "fixed" this by refusing every descriptor would pass 1 through 3 and fail these two.

I've left the harness out of this PR because wiring it into `tests/` properly is a bigger change than the fix and I didn't want to put that in front of a security fix, especially right after you spent weeks getting the build farm green. Happy to send it as a follow-up in whatever form suits `tests/Makefile.am` if you want it.

REACHABILITY

The descriptor comes off the wire in `nut_libusb_open()` in `drivers/libusb0.c` / `libusb1.c` and the SHUT equivalent in `libshut.c`, and goes straight into `Parse_ReportDesc()`. So the trigger is a malicious USB device, or a UPS running firmware someone else controls. Physical vector, not remote. I've scored and described it that way throughout and I'm not claiming code execution.

NOTES

- Both commits are signed off per `LICENSE-DCO`.
- No `NEWS.adoc` entry yet, since the entries in that file carry PR numbers. Say the word and I'll push one referencing this PR, or leave it to you if you'd rather write it in your own words.
- `drivers/hidparser.c` and `drivers/hidparser.h` are byte-identical between `26177060b`, where I originally found this on 4 August, and today's master, so nothing about the analysis has drifted.
