### PR TITLE
drivers/hidparser.c: size the HID usage stack from the descriptor length

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -326,6 +326,11 @@ https://github.com/networkupstools/nut/milestone/13
       more usage items than the fixed stack in the parser could hold. A similar
       problem could lead to "HID path too long" messages and loss of
       readings from the device. [PR #3586]
+    * The `hidparser.c` code was further updated to use not a fixed 50-entry
+      "usage table" buffer for resource descriptor parsing, but one aligned
+      with the actual size detected during device discovery. This should
+      avoid potential truncation introduced by the fix above (and avoid
+      the overflows it addressed) in normal device interactions. [#3588]
 
  - NUT client libraries:
     * Complete support for actions documented in `docs/net-protocol.txt`

--- a/drivers/hidparser.c
+++ b/drivers/hidparser.c
@@ -159,13 +159,30 @@ static int HIDParse(HIDParser_t *pParser, HIDData_t *pData)
 	while ((Found < 0) && (pParser->Pos < pParser->ReportDescSize)) {
 		/* Get new pParser->Item if current pParser->Count is empty */
 		if (pParser->Count == 0) {
+			uint8_t	ItemDataSize;
+
 			pParser->Item = pParser->ReportDesc[pParser->Pos++];
 			pParser->Value = 0;
-			for (i = 0; i < ItemSize[pParser->Item & SIZE_MASK]; i++) {
+			ItemDataSize = ItemSize[pParser->Item & SIZE_MASK];
+
+			/* The item prefix promises ItemDataSize more bytes, and
+			 * nothing so far has checked that the descriptor still
+			 * holds them. A descriptor ending part-way through an
+			 * item would read up to 4 bytes past the end of the
+			 * caller's buffer. Pos is <= ReportDescSize here - the
+			 * loop condition tested it before the increment above -
+			 * so the subtraction cannot wrap. */
+			if ((size_t)ItemDataSize > pParser->ReportDescSize - pParser->Pos) {
+				upsdebugx(1, "%s: truncated HID item, "
+					"aborting report descriptor parsing", __func__);
+				return -1;
+			}
+
+			for (i = 0; i < ItemDataSize; i++) {
 				pParser->Value += (uint32_t)(pParser->ReportDesc[(pParser->Pos)+i]) << (8*i);
 			}
 			/* Pos on next item */
-			pParser->Pos += ItemSize[pParser->Item & SIZE_MASK];
+			pParser->Pos += ItemDataSize;
 		}
 
 		switch (pParser->Item & ITEM_MASK)

--- a/drivers/hidparser.c
+++ b/drivers/hidparser.c
@@ -54,8 +54,9 @@ typedef struct {
 	uint8_t		Count;				/* Store local report count	*/
 
 	uint16_t	UPage;				/* Global UPage			*/
-	HIDNode_t	UsageTab[USAGE_TAB_SIZE];	/* Usage stack			*/
-	uint8_t		UsageSize;			/* Design number of usage used	*/
+	HIDNode_t	*UsageTab;			/* Usage stack			*/
+	size_t		UsageTabSize;			/* Slots allocated in UsageTab	*/
+	size_t		UsageSize;			/* Design number of usage used	*/
 } HIDParser_t;
 
 /* return 1 + the position of the leftmost "1" bit of an int, or 0 if
@@ -89,7 +90,8 @@ static inline unsigned int hibit(unsigned long x)
 static void ResetLocalState(HIDParser_t* pParser)
 {
 	pParser->UsageSize = 0;
-	memset(pParser->UsageTab, 0, sizeof(pParser->UsageTab));
+	memset(pParser->UsageTab, 0,
+		pParser->UsageTabSize * sizeof(*pParser->UsageTab));
 }
 
 /*
@@ -193,14 +195,15 @@ static int HIDParse(HIDParser_t *pParser, HIDData_t *pData)
 			break;
 
 		case ITEM_USAGE:
-			/* The usage stack is a fixed-size array. Refuse to walk past
-			 * it instead of merely complaining about it after the fact
-			 * (see the USAGE_TAB_SIZE report at the end of this loop).
-			 * -1 is the established "no more items" return, and
-			 * Parse_ReportDesc() breaks out of its loop on ret < 0, so
-			 * everything parsed up to here is kept and the remainder of
-			 * the descriptor is dropped. */
-			if (pParser->UsageSize >= USAGE_TAB_SIZE) {
+			/* The usage stack is sized from the descriptor length and
+			 * every Usage item costs at least its one prefix byte, so
+			 * this cannot fire for a descriptor that fits in the length
+			 * we were handed. It stays as a backstop. -1 is the
+			 * established "no more items" return, and Parse_ReportDesc()
+			 * breaks out of its loop on ret < 0, so everything parsed up
+			 * to here is kept and the remainder of the descriptor is
+			 * dropped. */
+			if (pParser->UsageSize >= pParser->UsageTabSize) {
 				upslogx(LOG_ERR, "%s: HID Usage stack overflow, "
 					"aborting report descriptor parsing", __func__);
 				return -1;
@@ -229,14 +232,14 @@ static int HIDParse(HIDParser_t *pParser, HIDData_t *pData)
 
 			/* Unstack UPage/Usage from UsageTab (never remove the last) */
 			if (pParser->UsageSize > 0) {
-				int	j;
+				size_t	j;
 
 				for (j = 0; j < pParser->UsageSize; j++) {
-					/* With UsageSize now allowed to reach
-					 * USAGE_TAB_SIZE, the last slot has no
+					/* With UsageSize allowed to reach
+					 * UsageTabSize, the last slot has no
 					 * successor to shift down. Unused slots
 					 * are zero (see ResetLocalState). */
-					pParser->UsageTab[j] = (j + 1 < USAGE_TAB_SIZE)
+					pParser->UsageTab[j] = (j + 1 < pParser->UsageTabSize)
 						? pParser->UsageTab[j+1] : 0;
 				}
 
@@ -305,14 +308,14 @@ static int HIDParse(HIDParser_t *pParser, HIDData_t *pData)
 
 			/* Unstack UPage/Usage from UsageTab (never remove the last) */
 			if(pParser->UsageSize > 0) {
-				int j;
+				size_t j;
 
 				for (j = 0; j < pParser->UsageSize; j++) {
-					/* With UsageSize now allowed to reach
-					 * USAGE_TAB_SIZE, the last slot has no
+					/* With UsageSize allowed to reach
+					 * UsageTabSize, the last slot has no
 					 * successor to shift down. Unused slots
 					 * are zero (see ResetLocalState). */
-					pParser->UsageTab[j] = (j + 1 < USAGE_TAB_SIZE)
+					pParser->UsageTab[j] = (j + 1 < pParser->UsageTabSize)
 						? pParser->UsageTab[j+1] : 0;
 				}
 
@@ -512,7 +515,7 @@ static int HIDParse(HIDParser_t *pParser, HIDData_t *pData)
 		upslogx(LOG_ERR, "%s: HID path too long", __func__);
 	if(pParser->ReportDescSize >= REPORT_DSC_SIZE)
 		upslogx(LOG_ERR, "%s: Report descriptor too big", __func__);
-	if(pParser->UsageSize >= USAGE_TAB_SIZE)
+	if(pParser->UsageSize >= pParser->UsageTabSize)
 		upslogx(LOG_ERR, "%s: HID Usage too high", __func__);
 
 	/* FIXME: comparison is always false due to limited range of data type [-Werror=type-limits]
@@ -791,6 +794,22 @@ HIDDesc_t *Parse_ReportDesc(const usb_ctrl_charbuf ReportDesc, const usb_ctrl_ch
 	parser->ReportDesc = (const unsigned char *)ReportDesc;
 	parser->ReportDescSize = (const size_t)n;
 
+	/* Size the usage stack from the descriptor itself. Every Usage item
+	 * costs at least its one prefix byte, so n slots can always hold every
+	 * usage an n-byte descriptor is able to push, and a device reporting
+	 * more than USAGE_TAB_SIZE usages is no longer truncated. The old
+	 * fixed size stays as the floor, so small descriptors keep the
+	 * capacity they have always had. */
+	parser->UsageTabSize = ((size_t)n > (size_t)USAGE_TAB_SIZE)
+		? (size_t)n : (size_t)USAGE_TAB_SIZE;
+	parser->UsageTab = (HIDNode_t *)calloc(parser->UsageTabSize,
+		sizeof(*parser->UsageTab));
+	if (!parser->UsageTab) {
+		free(parser);
+		Free_ReportDesc(pDesc_var);
+		return NULL;
+	}
+
 	for (pDesc_var->nitems = 0; pDesc_var->nitems < MAX_REPORT; pDesc_var->nitems += (size_t)ret) {
 		uint8_t	id;
 		size_t	max;
@@ -819,6 +838,7 @@ HIDDesc_t *Parse_ReportDesc(const usb_ctrl_charbuf ReportDesc, const usb_ctrl_ch
 	if ((pDesc_var->nitems == MAX_REPORT) && (parser->Pos < parser->ReportDescSize))
 		upslogx(LOG_ERR, "ERROR in %s: Too many HID objects", __func__);
 
+	free(parser->UsageTab);
 	free(parser);
 
 	if (pDesc_var->nitems == 0) {

--- a/drivers/hidtypes.h
+++ b/drivers/hidtypes.h
@@ -42,7 +42,7 @@ extern "C" {
  * Constants
  * -------------------------------------------------------------------------- */
 #define PATH_SIZE         10   /* Deep max for Path                   */
-#define USAGE_TAB_SIZE    50   /* Size of usage stack                 */
+#define USAGE_TAB_SIZE    50   /* Usage stack floor; grown at parse   */
 #define MAX_REPORT        500  /* Including FEATURE, INPUT and OUTPUT */
 #define REPORT_DSC_SIZE   6144 /* Size max of Report Descriptor       */
 #define MAX_REPORT_TS     3    /* Max time validity of a report       */


### PR DESCRIPTION
Follow-up to #3586, as offered there. This is the dynamic `UsageTab` sizing you agreed could wait for its own PR, plus one bound I tripped over while doing it.

Both commits touch `drivers/hidparser.c`; the second also changes a comment in `drivers/hidtypes.h`. Nothing else in the tree changes.

WHAT THE SECOND COMMIT DOES

This is the one you asked for, so I'll take it first.

The usage stack was `HIDNode_t UsageTab[50]` inside `HIDParser_t`. Your question on #3586 was whether a real device could legitimately report more than that and get truncated. It could. The 50-usage ceiling wasn't new - before #3586 the same descriptor walked off the end of the allocation instead of stopping - but #3586 turned it into a clean truncation, and a truncation is still a device that doesn't work.

`Parse_ReportDesc()` already knows the descriptor length, which is the estimate you suggested using. Every Usage item costs at least the one prefix byte that introduces it, so an n-byte descriptor can push at most n usages, and an n-slot stack always holds all of them. I checked the one path that looked like it might break that: when `ReportCount` is greater than 1 the parser re-enters `HIDParse()` without advancing `Pos`, but `Count` is only ever set inside the `ITEM_FEATURE`/`ITEM_INPUT`/`ITEM_OUTPUT` case, so the replay never reaches `ITEM_USAGE`. Every usage push follows a `Pos++`.

So the ceiling is gone for any descriptor that fits in the length we were handed. `USAGE_TAB_SIZE` stays as the floor, so short descriptors keep the capacity they've always had, and I kept the overflow check as a backstop - it's unreachable now for a descriptor that fits, but it costs one comparison and the invariant seemed worth stating in code rather than only in a commit message.

`UsageSize` goes from `uint8_t` to `size_t` in the same commit. At its old width it wrapped at 256 no matter how big the table was, so growing the table alone wouldn't have raised the real limit.

Cost is one `calloc()` of 4 bytes per descriptor byte, freed before `Parse_ReportDesc()` returns. That's at most 24kB against the 6144-byte `MAX_REPORT_SIZE` the libusb and libshut backends cap at, and at most 8kB against the 2048-byte buffer `apc_modbus` gets from libmodbus. It happens once per device open, not in the data update loop - same reasoning as the logging discussion on #3586.

One second-order cost you'll spot and I'd rather raise myself: `ResetLocalState()` zeroes the whole table, which used to be 200 bytes and can now be 24kB. It fires on every Collection, End Collection and Main item, so a maximum-size descriptor could run it a few thousand times - order of milliseconds once per device open, on my reading, but it is a real change.

I left it zeroing the whole table on purpose, because that's exactly the old semantics. The tighter version is to zero only the first `UsageSize` slots: the two unstack loops already shift a 0 into the last slot, so slots at or above `UsageSize` are always zero and re-zeroing them is redundant. I didn't want to make the reset depend on that invariant without you weighing in, since if it ever broke, the failure would be a stale usage silently reappearing in a later path rather than anything loud. Say which you prefer and I'll push it.

WHAT THE FIRST COMMIT DOES

While sizing the stack from the length I checked what else trusts it, and the item loop doesn't. It tests `Pos < ReportDescSize` before reading an item prefix, but nothing tests that the 1, 2 or 4 payload bytes the prefix promises are actually there. A descriptor whose last byte is a size-bearing prefix reads up to 4 bytes past the buffer the caller gave us.

I traced where that lands, because I didn't want to describe it as worse than it is. In every path today it's a short read just off the end of a fixed buffer:

- `libusb1.c` / `libusb0.c` / `libshut.c` - `rdbuf` is a 6144-byte stack array and `libusb1.c:823` rejects `rdlen > sizeof(rdbuf)`, so the read leaves the array only for `rdlen` in [6141, 6144].
- `apc_modbus.c:1997` - the buffer is libmodbus's 2048-byte stack array in `_modbus_rtu_usb_connect()`, and the length is the actual transfer count from `libusb_control_transfer()`, so the equivalent window is [2045, 2048].

Both windows are device-supplied, so both are reachable, but neither is dramatic and I'm not calling this a vulnerability. It's the parser reading past the length it was given, which it shouldn't do regardless of who owns the buffer.

Reported at debug level rather than `LOG_ERR`. A descriptor ending mid-item is malformed, but a truncated USB transfer is a plausible way for a real device to produce one, so it belongs with the `PATH_SIZE` refusals rather than with the two you kept loud.

HOW IT WAS TESTED

Same harness as #3586, re-baselined against master after ab82520df, extended to 11 phases. All 11 pass. Full output is in the first comment below.

The re-baselining matters and phase 1 exists to enforce it: "unpatched" now already contains your merged fix, so phase 1 asserts the baseline refuses the 200-usage descriptor. If someone runs this against a pre-#3586 clone it fails there instead of quietly comparing against the wrong tree.

Every descriptor is now copied into an exact-sized heap buffer before it reaches the parser. Passing a static array would have hidden the over-read inside the array's own slack, which is exactly the kind of silence that makes a harness worthless.

- 2, negative control. Unpatched, descriptor ending on a `Usage` prefix: `AddressSanitizer: heap-buffer-overflow hidparser.c:165 in HIDParse`, `READ of size 1`, `0 bytes after 7-byte region`, through the real `Parse_ReportDesc()` at `hidparser.c:781`.
- 3. Patched, same input: refused at debug level, no ASAN report.
- 4, negative control. Unpatched, 200 usages plus a Main item: hits the fixed ceiling, `parse=NULL`. The truncation you asked about, reproducing.
- 5. Patched, same input: `parse=OK items=1`. This is the phase the PR is for.
- 6, regression. Patched, the original #3586 overflow input: no ASAN report. Sizing the stack dynamically doesn't reintroduce what you merged the fix for.
- 7 and 8, positive controls. Well-formed descriptor and a full-but-legal 50-usage stack must produce byte-identical output before and after. Both do.
- 9 and 10, regressions. Unbalanced `End Collection` still refused; over-deep path still refused and still at debug level.
- 11. The new allocation must actually be freed. `leaks(1)` on a non-ASAN build: `0 leaks for 0 total leaked bytes`. LeakSanitizer isn't available on macOS, so this is the local substitute rather than the same check your Linux CI would run.

Phases 7 and 8 are the ones that matter for regression risk, same as last time. A patch that "fixed" this by refusing everything would sail through the rest and fail those two.

NOTES

- Both commits are signed off per `LICENSE-DCO`.
- No `NEWS.adoc` entry yet, since those carry PR numbers. Say the word once this has one and I'll push it, or write it yourself if you'd rather - either way I'll run `aspell` against `docs/nut.dict` locally first this time.
- The test harness still isn't in this PR. Same reason as before: wiring it into `tests/Makefile.am` is a bigger change than the fix. The offer stands if you want it as its own PR.
- One thing I noticed and did not touch: `HIDParser_t.Pos` is `uint16_t` while `ReportDescSize` is `size_t`. Nothing today can hand the parser more than 6144 bytes so it can't bite, and if it ever did the outer `MAX_REPORT` bound stops it rather than looping - it would just re-parse from the start and produce nonsense. Left alone to keep this PR to what you asked for. Happy to widen it in a third commit if you want it closed off.
