### PR TITLE
common/snprintf.c: preserve wide integer values

### DIFF
--- a/common/snprintf.c
+++ b/common/snprintf.c
@@ -118,7 +118,8 @@ static void dopr (char *buffer, size_t maxlen, const char *format,
 static void fmtstr (char *buffer, size_t *currlen, size_t maxlen,
                     char *value, int flags, int min, int max);
 static void fmtint (char *buffer, size_t *currlen, size_t maxlen,
-                    LLONG value, int base, int min, int max, int flags);
+                    unsigned LLONG uvalue, int negative,
+                    int base, int min, int max, int flags);
 static void fmtfp (char *buffer, size_t *currlen, size_t maxlen,
                    LDOUBLE fvalue, int min, int max, int flags);
 static void dopr_outch (char *buffer, size_t *currlen, size_t maxlen, char c );
@@ -175,6 +176,7 @@ static void dopr (char *buffer, size_t maxlen, const char *format, va_list args)
 {
   char ch;
   LLONG value;
+  unsigned LLONG uvalue;
   LDOUBLE fvalue;
   char *strvalue;
   int min;
@@ -313,39 +315,40 @@ static void dopr (char *buffer, size_t maxlen, const char *format, va_list args)
           value = va_arg (args, LLONG);
         else
           value = va_arg (args, int);
-        fmtint (buffer, &currlen, maxlen, value, 10, min, max, flags);
+        fmtint (buffer, &currlen, maxlen, (unsigned LLONG)value,
+                (value < 0), 10, min, max, flags);
         break;
       case 'o':
         flags |= DP_F_UNSIGNED;
         if (cflags == DP_C_SHORT)
 #ifdef C89PLUS
-          value = (unsigned short int)va_arg (args, unsigned int);
+          uvalue = (unsigned short int)va_arg (args, unsigned int);
 #else
-          value = va_arg (args, unsigned short int);
+          uvalue = va_arg (args, unsigned short int);
 #endif
         else if (cflags == DP_C_LONG)
-          value = (long)va_arg (args, unsigned long int);
+          uvalue = va_arg (args, unsigned long int);
         else if (cflags == DP_C_LLONG)
-          value = (LLONG)va_arg (args, unsigned LLONG);
+          uvalue = va_arg (args, unsigned LLONG);
         else
-          value = (long)va_arg (args, unsigned int);
-        fmtint (buffer, &currlen, maxlen, value, 8, min, max, flags);
+          uvalue = va_arg (args, unsigned int);
+        fmtint (buffer, &currlen, maxlen, uvalue, 0, 8, min, max, flags);
         break;
       case 'u':
         flags |= DP_F_UNSIGNED;
         if (cflags == DP_C_SHORT)
 #ifdef C89PLUS
-          value = (unsigned short int)va_arg (args, unsigned int);
+          uvalue = (unsigned short int)va_arg (args, unsigned int);
 #else
-          value = va_arg (args, unsigned short int);
+          uvalue = va_arg (args, unsigned short int);
 #endif
         else if (cflags == DP_C_LONG)
-          value = (long)va_arg (args, unsigned long int);
+          uvalue = va_arg (args, unsigned long int);
         else if (cflags == DP_C_LLONG)
-          value = (LLONG)va_arg (args, unsigned LLONG);
+          uvalue = va_arg (args, unsigned LLONG);
         else
-          value = (long)va_arg (args, unsigned int);
-        fmtint (buffer, &currlen, maxlen, value, 10, min, max, flags);
+          uvalue = va_arg (args, unsigned int);
+        fmtint (buffer, &currlen, maxlen, uvalue, 0, 10, min, max, flags);
         break;
       case 'X':
         flags |= DP_F_UP;
@@ -355,17 +358,17 @@ static void dopr (char *buffer, size_t maxlen, const char *format, va_list args)
         flags |= DP_F_UNSIGNED;
         if (cflags == DP_C_SHORT)
 #ifdef C89PLUS
-          value = (unsigned short int)va_arg (args, unsigned int);
+          uvalue = (unsigned short int)va_arg (args, unsigned int);
 #else
-          value = va_arg (args, unsigned short int);
+          uvalue = va_arg (args, unsigned short int);
 #endif
         else if (cflags == DP_C_LONG)
-          value = (long)va_arg (args, unsigned long int);
+          uvalue = va_arg (args, unsigned long int);
         else if (cflags == DP_C_LLONG)
-          value = (LLONG)va_arg (args, unsigned LLONG);
+          uvalue = va_arg (args, unsigned LLONG);
         else
-          value = (long)va_arg (args, unsigned int);
-        fmtint (buffer, &currlen, maxlen, value, 16, min, max, flags);
+          uvalue = va_arg (args, unsigned int);
+        fmtint (buffer, &currlen, maxlen, uvalue, 0, 16, min, max, flags);
         break;
       case 'f':
         if (cflags == DP_C_LDOUBLE)
@@ -407,7 +410,8 @@ static void dopr (char *buffer, size_t maxlen, const char *format, va_list args)
       case 'p':
         strvalue = va_arg (args, void *);
         flags |= DP_F_UNSIGNED;
-        fmtint (buffer, &currlen, maxlen, (LLONG) strvalue, 16, min, max, flags);
+        fmtint (buffer, &currlen, maxlen,
+                (unsigned LLONG)(size_t) strvalue, 0, 16, min, max, flags);
         break;
       case 'n':
         if (cflags == DP_C_SHORT)
@@ -504,11 +508,11 @@ static void fmtstr (char *buffer, size_t *currlen, size_t maxlen,
 /* Have to handle DP_F_NUM (ie 0x and 0 alternates) */
 
 static void fmtint (char *buffer, size_t *currlen, size_t maxlen,
-                    LLONG value, int base, int min, int max, int flags)
+                    unsigned LLONG uvalue, int negative,
+                    int base, int min, int max, int flags)
 {
   int signvalue = 0;
-  unsigned LLONG uvalue;
-  char convert[sizeof(value) * CHAR_BIT + 1];
+  char convert[sizeof(uvalue) * CHAR_BIT + 1];
   int place = 0;
   int spadlen = 0; /* amount to space pad */
   int zpadlen = 0; /* amount to zero pad */
@@ -517,13 +521,13 @@ static void fmtint (char *buffer, size_t *currlen, size_t maxlen,
   if (max < 0)
     max = 0;
 
-  uvalue = value;
-
   if(!(flags & DP_F_UNSIGNED))
   {
-    if( value < 0 ) {
+    if( negative ) {
       signvalue = '-';
-      /* Negate as unsigned to handle LLONG_MIN without overflow. */
+      /* uvalue holds the signed argument converted to unsigned
+       * (defined modulo arithmetic); unsigned negation yields its
+       * magnitude without overflow, even for LLONG_MIN. */
       uvalue = -uvalue;
     }
     else
@@ -946,6 +950,12 @@ static void dopr_outch (char *buffer, size_t *currlen, size_t maxlen, char c)
   static int pointer_num;
 #ifdef HAVE_LONG_LONG_INT
   LLONG llong_nums[] = { ((LLONG)1 << 32) + 1, LLONG_MIN };
+  char *ullong_fmt[] = { "%llu", "%llx", "%llo", NULL };
+  unsigned LLONG ullong_nums[] = {
+    ULLONG_MAX,
+    (unsigned LLONG)1 << (sizeof(unsigned LLONG) * CHAR_BIT - 1),
+    ULLONG_MAX
+  };
 #endif
   char *ptr1;
   char *ptr2;
@@ -983,6 +993,26 @@ static void dopr_outch (char *buffer, size_t *currlen, size_t maxlen, char c)
       num++;
     }
 
+  snprintf (buf1, sizeof (buf1), "%u", UINT_MAX);
+  sprintf (buf2, "%u", UINT_MAX);
+  if (strcmp (buf1, buf2))
+  {
+    printf("snprintf doesn't match Format: %%u\n\tsnprintf = %s\n\tsprintf  = %s\n",
+        buf1, buf2);
+    fail++;
+  }
+  num++;
+
+  snprintf (buf1, sizeof (buf1), "%lu", ULONG_MAX);
+  sprintf (buf2, "%lu", ULONG_MAX);
+  if (strcmp (buf1, buf2))
+  {
+    printf("snprintf doesn't match Format: %%lu\n\tsnprintf = %s\n\tsprintf  = %s\n",
+        buf1, buf2);
+    fail++;
+  }
+  num++;
+
   snprintf (buf1, sizeof (buf1), "%p", (void *)&pointer_num);
   sprintf (buf2, "%p", (void *)&pointer_num);
   ptr1 = buf1;
@@ -1018,6 +1048,19 @@ static void dopr_outch (char *buffer, size_t *currlen, size_t maxlen, char c)
     {
       printf("snprintf doesn't match Format: %%lld\n\tsnprintf = %s\n\tsprintf  = %s\n",
           buf1, buf2);
+      fail++;
+    }
+    num++;
+  }
+
+  for (x = 0; ullong_fmt[x] != NULL; x++)
+  {
+    snprintf (buf1, sizeof (buf1), ullong_fmt[x], ullong_nums[x]);
+    sprintf (buf2, ullong_fmt[x], ullong_nums[x]);
+    if (strcmp (buf1, buf2))
+    {
+      printf("snprintf doesn't match Format: %s\n\tsnprintf = %s\n\tsprintf  = %s\n",
+          ullong_fmt[x], buf1, buf2);
       fail++;
     }
     num++;

--- a/common/snprintf.c
+++ b/common/snprintf.c
@@ -523,6 +523,7 @@ static void fmtint (char *buffer, size_t *currlen, size_t maxlen,
   {
     if( value < 0 ) {
       signvalue = '-';
+      /* Negate as unsigned to handle LLONG_MIN without overflow. */
       uvalue = -uvalue;
     }
     else

--- a/common/snprintf.c
+++ b/common/snprintf.c
@@ -53,9 +53,15 @@
 
 #include "config.h"
 
+#include <limits.h>
 #include <string.h>
 #include <ctype.h>
 #include <sys/types.h>
+
+#ifdef TEST_SNPRINTF
+extern int printf (const char *format, ...);
+extern int sprintf (char *str, const char *format, ...);
+#endif
 
 #if !defined(HAVE_SNPRINTF) || !defined(HAVE_VSNPRINTF)
 
@@ -112,7 +118,7 @@ static void dopr (char *buffer, size_t maxlen, const char *format,
 static void fmtstr (char *buffer, size_t *currlen, size_t maxlen,
                     char *value, int flags, int min, int max);
 static void fmtint (char *buffer, size_t *currlen, size_t maxlen,
-                    long value, int base, int min, int max, int flags);
+                    LLONG value, int base, int min, int max, int flags);
 static void fmtfp (char *buffer, size_t *currlen, size_t maxlen,
                    LDOUBLE fvalue, int min, int max, int flags);
 static void dopr_outch (char *buffer, size_t *currlen, size_t maxlen, char c );
@@ -320,7 +326,7 @@ static void dopr (char *buffer, size_t maxlen, const char *format, va_list args)
         else if (cflags == DP_C_LONG)
           value = (long)va_arg (args, unsigned long int);
         else if (cflags == DP_C_LLONG)
-          value = (long)va_arg (args, unsigned LLONG);
+          value = (LLONG)va_arg (args, unsigned LLONG);
         else
           value = (long)va_arg (args, unsigned int);
         fmtint (buffer, &currlen, maxlen, value, 8, min, max, flags);
@@ -400,13 +406,8 @@ static void dopr (char *buffer, size_t maxlen, const char *format, va_list args)
         break;
       case 'p':
         strvalue = va_arg (args, void *);
-        /* FIXME: in 64-bit (and Windows-targeted) builds this code yields:
-         * warning: cast from pointer to integer of different size
-         * so probably prints a truncated pointer value. Should check
-         * if sizeof(void*) == sizeof(long) and output e.g. two pieces
-         * (lower and upper long for bytes of the pointer).
-         */
-        fmtint (buffer, &currlen, maxlen, (long) strvalue, 16, min, max, flags);
+        flags |= DP_F_UNSIGNED;
+        fmtint (buffer, &currlen, maxlen, (LLONG) strvalue, 16, min, max, flags);
         break;
       case 'n':
         if (cflags == DP_C_SHORT)
@@ -503,11 +504,11 @@ static void fmtstr (char *buffer, size_t *currlen, size_t maxlen,
 /* Have to handle DP_F_NUM (ie 0x and 0 alternates) */
 
 static void fmtint (char *buffer, size_t *currlen, size_t maxlen,
-                    long value, int base, int min, int max, int flags)
+                    LLONG value, int base, int min, int max, int flags)
 {
   int signvalue = 0;
-  unsigned long uvalue;
-  char convert[20];
+  unsigned LLONG uvalue;
+  char convert[sizeof(value) * CHAR_BIT + 1];
   int place = 0;
   int spadlen = 0; /* amount to space pad */
   int zpadlen = 0; /* amount to zero pad */
@@ -522,7 +523,7 @@ static void fmtint (char *buffer, size_t *currlen, size_t maxlen,
   {
     if( value < 0 ) {
       signvalue = '-';
-      uvalue = -value;
+      uvalue = -uvalue;
     }
     else
       if (flags & DP_F_PLUS)  /* Do a sign (+/i) */
@@ -539,8 +540,7 @@ static void fmtint (char *buffer, size_t *currlen, size_t maxlen,
       (caps? "0123456789ABCDEF":"0123456789abcdef")
       [uvalue % (unsigned)base  ];
     uvalue = (uvalue / (unsigned)base );
-  } while(uvalue && (place < 20));
-  if (place == 20) place--;
+  } while(uvalue && (place < (int)(sizeof(convert) - 1)));
   convert[place] = 0;
 
   zpadlen = max - place;
@@ -942,6 +942,12 @@ static void dopr_outch (char *buffer, size_t *currlen, size_t maxlen, char c)
     NULL
   };
   long int_nums[] = { -1, 134, 91340, 341, 0203, 0};
+  static int pointer_num;
+#ifdef HAVE_LONG_LONG_INT
+  LLONG llong_nums[] = { ((LLONG)1 << 32) + 1, LLONG_MIN };
+#endif
+  char *ptr1;
+  char *ptr2;
   int x, y;
   int fail = 0;
   int num = 0;
@@ -975,6 +981,48 @@ static void dopr_outch (char *buffer, size_t *currlen, size_t maxlen, char c)
       }
       num++;
     }
+
+  snprintf (buf1, sizeof (buf1), "%p", (void *)&pointer_num);
+  sprintf (buf2, "%p", (void *)&pointer_num);
+  ptr1 = buf1;
+  ptr2 = buf2;
+  if (ptr1[0] == '0' && (ptr1[1] == 'x' || ptr1[1] == 'X'))
+    ptr1 += 2;
+  if (ptr2[0] == '0' && (ptr2[1] == 'x' || ptr2[1] == 'X'))
+    ptr2 += 2;
+  while (ptr1[0] == '0' && ptr1[1] != '\0')
+    ptr1++;
+  while (ptr2[0] == '0' && ptr2[1] != '\0')
+    ptr2++;
+  while (*ptr1 && *ptr2
+      && tolower ((unsigned char)*ptr1) == tolower ((unsigned char)*ptr2))
+  {
+    ptr1++;
+    ptr2++;
+  }
+  if (*ptr1 || *ptr2)
+  {
+    printf("snprintf doesn't match Format: %%p\n\tsnprintf = %s\n\tsprintf  = %s\n",
+        buf1, buf2);
+    fail++;
+  }
+  num++;
+
+#ifdef HAVE_LONG_LONG_INT
+  for (x = 0; x < 2; x++)
+  {
+    snprintf (buf1, sizeof (buf1), "%lld", llong_nums[x]);
+    sprintf (buf2, "%lld", llong_nums[x]);
+    if (strcmp (buf1, buf2))
+    {
+      printf("snprintf doesn't match Format: %%lld\n\tsnprintf = %s\n\tsprintf  = %s\n",
+          buf1, buf2);
+      fail++;
+    }
+    num++;
+  }
+#endif
   printf ("%d tests failed out of %d.\n", fail, num);
+  return fail;
 }
 #endif /* SNPRINTF_TEST */


### PR DESCRIPTION
## Summary

- Carry integer magnitudes as `unsigned LLONG` through the fallback formatter, with signedness tracked separately.
- Retrieve `%o`, `%u`, `%x` and `%X` arguments directly into unsigned storage instead of passing them through a possibly narrower signed `long`.
- Convert `%p` through `size_t` before widening, avoiding pointer sign extension on conventional 32-bit and LLP64 targets.
- Retain unsigned negation for negative signed values so `LLONG_MIN` is handled without signed overflow.
- Extend `TEST_SNPRINTF` with focused `UINT_MAX`, `ULONG_MAX`, `ULLONG_MAX`, top-bit hexadecimal and full-width octal comparisons.

Fixes #1602

## Review follow-up

Wider ABI testing prompted by review found that the previous PR head regressed the narrow unsigned conversions on systems where `long` is narrower than `long long`. On native Windows LLP64, `%u` with `UINT_MAX` was widened through negative `long` and printed as `18446744073709551615`; the `%o`, `%x`, `%X` and corresponding `unsigned long` cases failed in the same way.

Casting later inside `fmtint()` cannot repair a value already changed by the earlier signed conversion. This revision instead keeps unsigned values unsigned from `va_arg()` through digit conversion. For signed decimal formats, the caller supplies the converted unsigned value and its sign separately; `fmtint()` negates only the unsigned value when producing the magnitude. Plain `-value` is not used because it overflows for `LLONG_MIN`.

## Validation

- Native Windows 11 x64, MSYS2 MinGW64 GCC 16.2.0 Rev3, LLP64:
  - exact PR head failed 8 of 13 focused integer/pointer comparisons;
  - the revised source passed all 13;
  - the expanded built-in comparison passed 196/196;
  - a native forced-fallback configure confirmed `snprintf` and `vsnprintf` unavailable and `HAVE_LONG_LONG_INT=1`;
  - `make -C common V=1 snprintf.lo` passed with GNU99, `-pedantic` and `-Werror`, producing a PE x86-64 object.
- Native Linux ILP32 GCC:
  - exact PR head failed nine focused cases and emitted `-Wpointer-to-int-cast`;
  - the revised source passed 13/13 and the built-in comparison passed 196/196.
- Native Linux LP64:
  - focused and built-in comparisons passed with GCC 16.2.1 and Clang 22.1.8;
  - GNU89 and strict C99/pedantic builds passed with warnings as errors;
  - Clang UBSan passed, including `LLONG_MIN`.
- Forced-fallback project object builds passed with GCC and Clang.
- `make stylecheck`, the non-ASCII source check and `git diff --check` passed.
- `-Wconversion -Wsign-conversion` still reports 11 pre-existing diagnostics in this legacy file; this revision removes the additional signed-to-unsigned diagnostic introduced by the previous PR head and adds none.

No upstream CI result is claimed for this revision until it is published.

## General C checklist

- [x] Integer widths and signedness are carried explicitly without assuming `long` matches pointers or `long long`.
- [x] The change follows the existing fallback implementation and in-file test placement; no new helper, dependency or file is introduced.
- [x] Coding style and whitespace follow `common/snprintf.c` and `docs/developers.txt` precedent.
- [x] No build, distribution or documentation list needs updating.

## AI assistance

OpenAI Codex `gpt-5.6-sol` with xhigh reasoning was used for repository analysis, implementation, review, drafting and local/native validation. Anthropic Claude Fable 5 (`claude-fable-5`) with xhigh reasoning performed an independent adversarial review and produced a prototype used as design evidence. The human contributor reviewed the complete diff and validation evidence and remains responsible for the contribution.
