### PR TITLE
xppc: map inverter standby to OL

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -281,6 +281,9 @@ https://github.com/networkupstools/nut/milestone/13
       `battery.runtime`, `battery.voltage`, `input.frequency`,
       `output.voltage.nominal` and `ups.firmware.aux` from Phoenixtec
       based UPS cards that already answer the rest of the subtree. [#2608]
+    * Mapped `standby(8)` from XPPC output status to `OL` rather than `OFF`,
+      because line-interactive devices use it for inverter standby while their
+      UPS output remains online on utility power. [issue #3512]
     * Introduced `voltronic` subdriver for Voltronic enterprise 43943 UPSes,
       developed and tested against a PowerShield Centurion RT 1000VA
       (PSCERT1000) with a PSSNMPV4 card running firmware 1.1.8.C. [issue #3478,

--- a/drivers/xppc-mib.c
+++ b/drivers/xppc-mib.c
@@ -24,7 +24,7 @@
 
 #include "xppc-mib.h"
 
-#define XPPC_MIB_VERSION  "0.41"
+#define XPPC_MIB_VERSION  "0.42"
 
 #define XPPC_SYSOID       ".1.3.6.1.4.1.935"
 
@@ -66,7 +66,7 @@ static info_lkp_t xpcc_power_info[] = {
 	info_lkp_default(5, "OFF"),	/* sleeping */
 	info_lkp_default(6, "BYPASS"),	/* onBypass */
 	info_lkp_default(7, ""),	/* rebooting */
-	info_lkp_default(8, "OFF"),	/* standBy */
+	info_lkp_default(8, "OL"),	/* line-interactive inverter standby, not UPS/output standby */
 	info_lkp_default(9, "OL TRIM"),	/* onBuck */
 	info_lkp_sentinel
 };


### PR DESCRIPTION
## Summary

Fixes #3512.

Line-interactive XPPC devices can report `standBy(8)` while utility
power continues to supply the load and only the inverter is idle. The
existing `OFF` mapping therefore makes `upsmon` treat a healthy online
UPS as not supplying power.

This changes the mapping to `OL`, clarifies the distinction between
inverter standby and UPS/output standby, bumps `XPPC_MIB_VERSION` to
`0.42`, and documents the correction in `NEWS.adoc`.

Issue #3512 reports that this mapping produces `OL` on utility power
and retains the expected `OB`/`LB` transitions on a Vertiv/Liebert PSI
PS1500RT3-230. This exact candidate has not been re-tested on that
hardware, so reporter confirmation remains the runtime acceptance
boundary.

## Validation

- GCC 16.2.1 hard warnings with `-Werror`: complete `snmp-ups` and
  top-level builds passed.
- Clang 22.1.8 CI-style warnings with `-Werror`: complete `snmp-ups`
  build passed.
- The changed XPPC object passed Clang `-Weverything -Werror`.
- `make stylecheck` passed.
- The compiled lookup table reports value `8` as `OL` and XPPC MIB
  version `0.42`.
- The configured test suite passed 9/9 with loopback sockets available.
- `make -j8 SPELLCHECK_ERROR_FATAL=no check` passed.
- `make SPELLCHECK_ERROR_FATAL=no distcheck-light` passed, including
  archive, build, check, install, uninstall and distclean.
- The candidate introduces no new spellcheck finding.
- Physical Liebert PSI confirmation remains pending.
- Upstream CI remains pending.

The full-driver Clang `-Weverything -Werror` probe encountered nine
existing float-conversion diagnostics in unchanged `snmp-ups.c`. The
changed XPPC object passed that stricter probe, and the project’s
CI-style Clang build passed.

## General C checklist

- The change is one cohesive existing-subdriver correction.
- The XPPC MIB version was bumped.
- The mapping follows NUT’s established `OL` meaning.
- Coding style, ASCII portability and distribution checks passed.
- `NEWS.adoc` was updated.

## AI assistance

OpenAI Codex `gpt-5.6-sol` was used for planning, repository analysis,
implementation, review, drafting and validation, including controller
and delegated work. The human contributor reviewed the change and
remains responsible for it.
