### PR TITLE
apc: expose NMC3 ambient temperature

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -277,6 +277,8 @@ https://github.com/networkupstools/nut/milestone/13
       `ups.realpower`. [issue #3580, PR #3581]
 
  - `snmp-ups` driver updates:
+    * `apc` subdriver: exposed `ambient.temperature` from universal I/O
+      sensors used with APC Network Management Card 3. [issue #3250]
     * Extended the XPPC-MIB subdriver (enterprise 935) to expose
       `battery.runtime`, `battery.voltage`, `input.frequency`,
       `output.voltage.nominal` and `ups.firmware.aux` from Phoenixtec

--- a/drivers/apc-mib.c
+++ b/drivers/apc-mib.c
@@ -26,7 +26,7 @@
 
 #include "apc-mib.h"
 
-#define APCC_MIB_VERSION	"1.61"
+#define APCC_MIB_VERSION	"1.62"
 
 #define APC_UPS_DEVICE_MODEL	".1.3.6.1.4.1.318.1.1.1.1.1.1.0"
 /* FIXME: Find a better oid_auto_check vs. sysOID for this one? */
@@ -289,6 +289,9 @@ static snmp_info_t apcc_mib[] = {
 	snmp_info_default("output.L2.power.minimum.percent", 0, 1, ".1.3.6.1.4.1.318.1.1.1.9.3.3.1.12.1.1.2", "", SU_FLAG_OK|SU_FLAG_NEGINVALID, NULL),
 	snmp_info_default("output.L3.power.minimum.percent", 0, 1, ".1.3.6.1.4.1.318.1.1.1.9.3.3.1.12.1.1.3", "", SU_FLAG_OK|SU_FLAG_NEGINVALID, NULL),
 	snmp_info_default("output.voltage.nominal", ST_FLAG_STRING | ST_FLAG_RW, 3, ".1.3.6.1.4.1.318.1.1.1.5.2.1.0", "", SU_TYPE_INT | SU_FLAG_OK, NULL),
+
+	/* Universal I/O ambient sensor */
+	snmp_info_default("ambient.temperature", 0, 1, ".1.3.6.1.4.1.318.1.1.25.1.2.1.6.1.1", "", SU_FLAG_OK|SU_FLAG_NEGINVALID, NULL),
 
 	/* Measure-UPS ambient variables */
 	/* Environmental sensors (AP9612TH and others) */


### PR DESCRIPTION
## Summary

Fixes #3250.

APC Network Management Card 3 units expose universal I/O temperature through `uioSensorStatusTemperatureDegC`, but the APC subdriver does not currently map that value to `ambient.temperature`.

This adds the Universal I/O Celsius OID as the first ambient-temperature provider, rejects the MIB-defined `-1` invalid sentinel, bumps `APCC_MIB_VERSION` to `1.62`, and documents the addition in `NEWS.adoc`.

Schneider Electric's official PowerNet MIB v4.6.0, dated 9 July 2026, independently confirms the exact Celsius OID and the `-1` invalid sentinel. Placing the new mapping before the existing Measure-UPS and IEM alternatives lets NMC3 devices use it when legacy OIDs are unavailable while preserving the current later-provider precedence on devices which answer those legacy OIDs.

## Validation

- GCC 16.2.1 hard warnings with `-Werror`: clean complete `snmp-ups` compile and link passed.
- Clang 22 medium warnings with `-Weverything -Werror`: clean complete `snmp-ups` compile and link passed.
- The changed APC object passed Clang hard warnings with `-Weverything -Werror`.
- A compiled lookup-table check confirmed APC MIB version `1.62`, the exact OID, scale `1`, `SU_FLAG_OK | SU_FLAG_NEGINVALID`, and first-provider placement.
- The configured test suite passed 9/9 with loopback sockets available.
- `make stylecheck`, non-ASCII checks and `git diff --check` passed.
- `make SPELLCHECK_ERROR_FATAL=no distcheck-light` passed, including archive, build, check, install and uninstall.
- Spellcheck reported only existing findings in unchanged text; this change introduced none.
- Physical NMC3 confirmation remains pending.
- Upstream CI remains pending.

The whole-driver Clang hard profile stops on nine existing conversion warnings in unchanged `snmp-ups.c`. The changed APC object passes that profile, and the complete driver passes the project's medium Clang profile with `-Werror`.

## General C checklist

- [x] The change is one cohesive update to an existing subdriver.
- [x] `APCC_MIB_VERSION` was bumped.
- [x] The mapping uses the established `ambient.temperature` variable.
- [x] The MIB-defined invalid value is rejected.
- [x] Coding style, ASCII portability and distribution checks passed.
- [x] `NEWS.adoc` was updated.

## AI assistance

OpenAI Codex `gpt-5.6-sol` was used for planning, repository analysis, implementation, review, drafting and validation, including controller and delegated work. The human contributor reviewed the change and remains responsible for it.