### PR TITLE
common: warn when become_user() leaves root credentials

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -293,6 +293,8 @@ https://github.com/networkupstools/nut/milestone/13
       not do so for single-driver runs -- addressed with this release. [#3302]
 
  - common code:
+    * POSIX daemons now warn if their real or effective UID remains zero after
+      the common credential switch. [issue #3471, PR #3609]
     * Refactored `common::background()` method used by numerous NUT daemons
       to handle parent and child code paths by separately addressable methods.
       This got used in the shared drivers `main` code file to preclude losing

--- a/common/common.c
+++ b/common/common.c
@@ -983,6 +983,8 @@ void become_user(struct passwd *pw)
 	/* if we can't switch users, then don't even try */
 	intmax_t initial_uid = getuid();
 	intmax_t initial_euid = geteuid();
+	intmax_t final_uid;
+	intmax_t final_euid;
 
 	if (!pw) {
 		upsdebugx(1, "Can not become_user(<null>), skipped");
@@ -1019,8 +1021,16 @@ void become_user(struct passwd *pw)
 	if (setuid(pw->pw_uid) == -1)
 		fatal_with_errno(EXIT_FAILURE, "setuid");
 
+	final_uid = getuid();
+	final_euid = geteuid();
+	if ((final_uid == 0) || (final_euid == 0)) {
+		upslogx(LOG_WARNING, "Warning: running as root (UID=%jd EUID=%jd)",
+			final_uid, final_euid);
+		return;
+	}
+
 	upsdebugx(1, "Succeeded to become_user(%s): now UID=%jd GID=%jd",
-		pw->pw_name, (intmax_t)getuid(), (intmax_t)getgid());
+		pw->pw_name, final_uid, (intmax_t)getgid());
 #else	/* WIN32 */
 	/* NUT_WIN32_INCOMPLETE_MAYBE_NOT_APPLICABLE(); */
 	upsdebugx(1, "Can not become_user(%s): not implemented on this platform",

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -54,8 +54,8 @@ $(top_builddir)/clients/libnutclient.la \
 $(top_builddir)/clients/libnutclientstub.la: dummy @dotMAKE@
 	+@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
-$(top_builddir)/clients/upslog: dummy @dotMAKE@
-	+@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
+$(top_builddir)/clients/upslog$(EXEEXT): dummy @dotMAKE@
+	+@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) upslog$(EXEEXT)
 
 # Builds from root dir arrange stuff decently. Make sure parallel builds
 # started from scratch right in this dir get dependencies in proper order
@@ -320,8 +320,8 @@ endif WITH_VALGRIND
 
 check-local: $(CHECK_LOCAL_TARGETS)
 
-become-user-root-warning-test: $(top_builddir)/clients/upslog
-	$(AM_V_at)$(SHELL) $(srcdir)/become-user-root-warning-test.sh
+become-user-root-warning-test: $(top_builddir)/clients/upslog$(EXEEXT)
+	$(AM_V_at)UPSLOG='$(abs_top_builddir)/clients/upslog$(EXEEXT)' $(SHELL) $(srcdir)/become-user-root-warning-test.sh
 
 dummy:
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -15,7 +15,7 @@ SUBDIRS = . NIT
 # handle that properly
 all: $(TESTS) $(check_PROGRAMS) $(check_SCRIPTS)
 
-EXTRA_DIST = nut-driver-enumerator-test.sh nut-driver-enumerator-test--ups.conf
+EXTRA_DIST = become-user-root-warning-test.sh nut-driver-enumerator-test.sh nut-driver-enumerator-test--ups.conf
 EXTRA_DIST += cppunit-warnings.h cppunit-warnings-end.h
 
 TESTS =
@@ -52,6 +52,9 @@ $(top_builddir)/common/libparseconf.la \
 $(top_builddir)/clients/libupsclient.la \
 $(top_builddir)/clients/libnutclient.la \
 $(top_builddir)/clients/libnutclientstub.la: dummy @dotMAKE@
+	+@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
+
+$(top_builddir)/clients/upslog: dummy @dotMAKE@
 	+@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
 # Builds from root dir arrange stuff decently. Make sure parallel builds
@@ -310,9 +313,15 @@ memcheck:
 	@echo "  SKIP	$@ : valgrind was not detected on this system by configure script" >&2
 endif !HAVE_VALGRIND
 
+CHECK_LOCAL_TARGETS = become-user-root-warning-test
 if WITH_VALGRIND
-check-local: memcheck
+CHECK_LOCAL_TARGETS += memcheck
 endif WITH_VALGRIND
+
+check-local: $(CHECK_LOCAL_TARGETS)
+
+become-user-root-warning-test: $(top_builddir)/clients/upslog
+	$(AM_V_at)$(SHELL) $(srcdir)/become-user-root-warning-test.sh
 
 dummy:
 

--- a/tests/become-user-root-warning-test.sh
+++ b/tests/become-user-root-warning-test.sh
@@ -1,17 +1,18 @@
 #!/bin/sh
 
 if test "`id -u`" != 0; then
-	echo "SKIP: root privileges are required to test become_user(root)" >&2
+	echo "SKIP: root privileges are required to test become_user()" >&2
 	exit 0
 fi
 
-testdir="`mktemp -d "${TMPDIR-/tmp}/nut-become-user-root-warning.XXXXXX"`" || exit
+testdir="`mktemp -d "${TMPDIR:-/tmp}/nut-become-user-root-warning.XXXXXX"`" || exit
 trap 'rm -rf "$testdir"' EXIT HUP INT TERM
 
 upslog=${UPSLOG-../clients/upslog}
+root_user="`id -un`" || exit
 warning='Warning: running as root (UID=0 EUID=0)'
 
-if output="`"$upslog" -F -u root -p "$testdir/upslog" -W 1 -d 1 -i 1 \
+if output="`"$upslog" -F -u "$root_user" -p "$testdir/upslog" -W 1 -d 1 -i 1 \
 	-s dummy@127.0.0.1:1 -l - 2>&1`"; then
 	count="`printf '%s\n' "$output" | grep -F "$warning" | wc -l`"
 	if test "$count" -eq 1; then

--- a/tests/become-user-root-warning-test.sh
+++ b/tests/become-user-root-warning-test.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+if test "`id -u`" != 0; then
+	echo "SKIP: root privileges are required to test become_user(root)" >&2
+	exit 0
+fi
+
+testdir="`mktemp -d "${TMPDIR-/tmp}/nut-become-user-root-warning.XXXXXX"`" || exit
+trap 'rm -rf "$testdir"' EXIT HUP INT TERM
+
+upslog=${UPSLOG-../clients/upslog}
+warning='Warning: running as root (UID=0 EUID=0)'
+
+if output="`"$upslog" -F -u root -p "$testdir/upslog" -W 1 -d 1 -i 1 \
+	-s dummy@127.0.0.1:1 -l - 2>&1`"; then
+	count="`printf '%s\n' "$output" | grep -F "$warning" | wc -l`"
+	if test "$count" -eq 1; then
+		exit 0
+	fi
+fi
+
+printf '%s\n' "$output" >&2
+exit 1


### PR DESCRIPTION
Aims to close #3471, pending maintainer review and approval.

This makes the shared POSIX `become_user()` path warn once when a daemon's real or effective UID remains zero after a successful credential transition.

The previous code reported the resulting UID only in a debug-level success message after `initgroups()`, `setgid()` and `setuid()`, and did not warn when the resulting credentials remained root. Checking both resulting UIDs in the shared helper gives daemon callers one consistent invariant without duplicating warnings. Non-root starts retain their existing behaviour, and the intentionally privileged `upsmon -p` path retains its existing warning without receiving another one.

Validation:

- GCC 16.2.1 built `common.o`, `upslog`, `upsmon`, `upsd` and `dummy-ups` successfully. Clang 22.1.8 built the same targets with `-Weverything -Werror`.
- Before the change, a disposable root namespace running `upslog -u root` completed with no root warning. The candidate emitted exactly one `Warning: running as root (UID=0 EUID=0)`.
- The equivalent non-root run emitted no root warning. A bounded `upsmon -p` run retained exactly one existing intentional-root warning and emitted no new shared warning.
- The focused root regression passed, and `make -C tests check` passed all 9 tests.
- `git diff --check`, the shell syntax check and `make stylecheck` passed. A supplementary non-ASCII scan found only an unchanged character outside the diff.
- `distcheck-light` created and built the clean source archive, including the new regression, then failed at the final spellcheck on unchanged `docs/man/apcmicrolink.txt` text.
- The behavioural checks cover the POSIX implementation. The WIN32 branch is unchanged, and no physical UPS hardware was required or tested.

AI assistance: OpenAI Codex gpt-5.6-sol at high reasoning was used for investigation, implementation and validation. The human contributor remains responsible for the change.
