### PR TITLE
DMF: employ conversion methods from common dmfstdlib that can be used by "static" and DMF builds alike

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -23,6 +23,16 @@ CLEANFILES =
 noinst_LTLIBRARIES = libparseconf.la libcommon.la libcommonclient.la
 lib_LTLIBRARIES =
 
+# Shared "standard library" of DMF-related data-conversion helpers
+# (numeric scaling, temperature, dates, phase naming). Built for every
+# configuration (does not depend on WITH_DMF/WITH_NEON/WITH_SNMP etc.)
+# so that both classically-compiled mapping-table drivers (e.g. plain
+# snmp-ups, usbhid-ups subdrivers) and DMF-enabled binaries can link
+# against the very same implementation instead of duplicating it.
+noinst_LTLIBRARIES += libnutdmfstdlib.la
+libnutdmfstdlib_la_SOURCES = dmf_stdlib.c
+libnutdmfstdlib_la_CFLAGS = $(AM_CFLAGS)
+
 if ENABLE_SHARED_PRIVATE_LIBS
 ### Hopefully we can bundle this code together and
 ### install this somewhat away from the public eye?..
@@ -37,6 +47,10 @@ if ENABLE_SHARED_PRIVATE_LIBS
   libnutprivate_@NUT_SOURCE_GITREV_SEMVER_UNDERSCORES@_common_client_la_SOURCES =
   libnutprivate_@NUT_SOURCE_GITREV_SEMVER_UNDERSCORES@_common_client_la_LIBADD = libcommonclient.la libcommonversion-private.la
 
+  lib_LTLIBRARIES += libnutprivate-@NUT_SOURCE_GITREV_SEMVER_UNDERSCORES@-drivers-dmfstdlib.la
+  libnutprivate_@NUT_SOURCE_GITREV_SEMVER_UNDERSCORES@_drivers_dmfstdlib_la_SOURCES =
+  libnutprivate_@NUT_SOURCE_GITREV_SEMVER_UNDERSCORES@_drivers_dmfstdlib_la_LIBADD = libnutdmfstdlib.la
+
 ### Avoid unexpected linking across NUT generations
 ### far apart (e.g. custom rebuilds of new programs
 ### tucked into an existing deployment); see libtool
@@ -45,11 +59,13 @@ if ENABLE_SHARED_PRIVATE_LIBS
 ### especially when bumping "age" into loss of compatibility with old releases!
   libnutprivate_@NUT_SOURCE_GITREV_SEMVER_UNDERSCORES@_common_all_la_LDFLAGS = -version-info 1:0:0
   libnutprivate_@NUT_SOURCE_GITREV_SEMVER_UNDERSCORES@_common_client_la_LDFLAGS = -version-info 1:0:0
+  libnutprivate_@NUT_SOURCE_GITREV_SEMVER_UNDERSCORES@_drivers_dmfstdlib_la_LDFLAGS = -version-info 1:0:0
 
 if HAVE_WINDOWS
   # Many versions of MingW seem to fail to build non-static DLL without this
   libnutprivate_@NUT_SOURCE_GITREV_SEMVER_UNDERSCORES@_common_all_la_LDFLAGS += -no-undefined
   libnutprivate_@NUT_SOURCE_GITREV_SEMVER_UNDERSCORES@_common_client_la_LDFLAGS += -no-undefined
+  libnutprivate_@NUT_SOURCE_GITREV_SEMVER_UNDERSCORES@_drivers_dmfstdlib_la_LDFLAGS += -no-undefined
 endif HAVE_WINDOWS
 endif ENABLE_SHARED_PRIVATE_LIBS
 
@@ -280,7 +296,7 @@ if WITH_DMF
   libnutdmfsnmp_la_LDFLAGS =
 # Note: no LTLIBOBJS here, so we do not conflict when linked along with
 # other libraries we build (typically consumed with libcommonstr.la)
-  libnutdmfsnmp_la_LIBADD = $(LIBNETSNMP_LIBS)
+  libnutdmfsnmp_la_LIBADD = $(LIBNETSNMP_LIBS) libnutdmfstdlib.la
 
 if WITH_LIBLTDL
 # NOTE: the C macro WITH_LIBLTDL=1 will probably be defined by config.h

--- a/common/dmf_stdlib.c
+++ b/common/dmf_stdlib.c
@@ -29,6 +29,24 @@
 #include <string.h>
 #include <stdlib.h>
 
+/* Sticky flag for "reject whole file" support under the strict policy;
+ * intentionally process-global (not thread-local) like several other
+ * bits of DMF parser state (e.g. 'functions_aux', 'temperature_unit') -
+ * DMF parsing is not currently re-entrant/threaded. */
+static int dmf_stdlib_unsupported_function_seen = 0;
+
+void
+dmf_stdlib_reset_unsupported_function_flag(void)
+{
+	dmf_stdlib_unsupported_function_seen = 0;
+}
+
+int
+dmf_stdlib_had_unsupported_function(void)
+{
+	return dmf_stdlib_unsupported_function_seen;
+}
+
 dmf_function_policy_t
 dmf_stdlib_get_function_policy(void)
 {
@@ -48,27 +66,29 @@ dmf_stdlib_get_function_policy(void)
 }
 
 dmf_function_policy_t
-dmf_stdlib_log_unsupported_function(const char *context, const char *language)
+dmf_stdlib_log_unsupported_function(const char *context, const char *capability)
 {
 	dmf_function_policy_t policy = dmf_stdlib_get_function_policy();
+
+	dmf_stdlib_unsupported_function_seen = 1;
 
 	switch (policy) {
 	case DMF_FUNCTION_POLICY_DROP:
 		upslogx(LOG_WARNING,
-			"DMF: dropping mapping entry for '%s' - dynamic-language "
-			"function in '%s' is not supported by this build "
+			"DMF: dropping mapping entry for '%s' - requested capability '%s' "
+			"is not supported/recognized by this build "
 			"(NUT_DMF_FUNCTION_POLICY=drop)",
 			context ? context : "<unknown>",
-			language ? language : "<unknown>");
+			capability ? capability : "<unknown>");
 		break;
 	case DMF_FUNCTION_POLICY_STRICT:
 	default:
 		upslogx(LOG_ERR,
-			"DMF: rejecting mapping table - entry '%s' uses dynamic-language "
-			"function in '%s' which is not supported by this build "
+			"DMF: rejecting mapping table - entry '%s' requires capability '%s' "
+			"which is not supported/recognized by this build "
 			"(set NUT_DMF_FUNCTION_POLICY=drop to only skip this entry)",
 			context ? context : "<unknown>",
-			language ? language : "<unknown>");
+			capability ? capability : "<unknown>");
 		break;
 	}
 

--- a/common/dmf_stdlib.c
+++ b/common/dmf_stdlib.c
@@ -1,0 +1,207 @@
+/* dmf_stdlib.c - Shared library of "standard" data-conversion helpers,
+ * reusable from statically compiled mapping tables, DMF XML mappings,
+ * and DMF dynamic-language glue (LUA) alike. See dmf_stdlib.h for the
+ * public API and rationale.
+ *
+ * Copyright (C) 2016 - 2017 Jim Klimov <EvgenyKlimov@eaton.com>
+ * Copyright (C) 2024-2026 Jim Klimov <jimklimov+nut@gmail.com>
+ * Copyright (C) by NUT Community
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#include "common.h"	/* includes "config.h" which must be the first header */
+#include "timehead.h"	/* time.h => strptime()/strftime() */
+#include "dmf_stdlib.h"
+
+#include <string.h>
+#include <stdlib.h>
+
+dmf_function_policy_t
+dmf_stdlib_get_function_policy(void)
+{
+	const char *s = getenv("NUT_DMF_FUNCTION_POLICY");
+
+	if (s) {
+		if (!strcasecmp(s, "drop"))
+			return DMF_FUNCTION_POLICY_DROP;
+		if (!strcasecmp(s, "strict"))
+			return DMF_FUNCTION_POLICY_STRICT;
+		upslogx(LOG_WARNING,
+			"dmf_stdlib_get_function_policy(): unrecognized "
+			"NUT_DMF_FUNCTION_POLICY='%s', defaulting to 'strict'", s);
+	}
+
+	return DMF_FUNCTION_POLICY_STRICT;
+}
+
+dmf_function_policy_t
+dmf_stdlib_log_unsupported_function(const char *context, const char *language)
+{
+	dmf_function_policy_t policy = dmf_stdlib_get_function_policy();
+
+	switch (policy) {
+	case DMF_FUNCTION_POLICY_DROP:
+		upslogx(LOG_WARNING,
+			"DMF: dropping mapping entry for '%s' - dynamic-language "
+			"function in '%s' is not supported by this build "
+			"(NUT_DMF_FUNCTION_POLICY=drop)",
+			context ? context : "<unknown>",
+			language ? language : "<unknown>");
+		break;
+	case DMF_FUNCTION_POLICY_STRICT:
+	default:
+		upslogx(LOG_ERR,
+			"DMF: rejecting mapping table - entry '%s' uses dynamic-language "
+			"function in '%s' which is not supported by this build "
+			"(set NUT_DMF_FUNCTION_POLICY=drop to only skip this entry)",
+			context ? context : "<unknown>",
+			language ? language : "<unknown>");
+		break;
+	}
+
+	return policy;
+}
+
+const char *
+nut_scale_format_static(double value, double factor, const char *fmt)
+{
+	static char buf[32];
+
+	if (!fmt || !*fmt)
+		fmt = "%0.1f";
+
+	/* NOTE: caller-provided fmt is expected to be a single numeric
+	 * conversion (as used throughout the codebase for this pattern);
+	 * we do not validate it further here. */
+	snprintf(buf, sizeof(buf), fmt, value * factor);
+	return buf;
+}
+
+const char *
+nut_temperature_deci_to_celsius_static(long value_deci, int unit)
+{
+	static char buf[32];
+	long celsius_value = value_deci;
+
+	memset(buf, 0, sizeof(buf));
+
+	switch (unit) {
+		case NUT_STDLIB_TEMP_KELVIN:
+			celsius_value = (value_deci / 10) - 273.15;
+			snprintf(buf, sizeof(buf), "%.1ld", celsius_value);
+			break;
+		case NUT_STDLIB_TEMP_CELSIUS:
+			snprintf(buf, sizeof(buf), "%.1ld", (value_deci / 10));
+			break;
+		case NUT_STDLIB_TEMP_FAHRENHEIT:
+			celsius_value = (((value_deci / 10) - 32) * 5) / 9;
+			snprintf(buf, sizeof(buf), "%.1ld", celsius_value);
+			break;
+		case NUT_STDLIB_TEMP_UNKNOWN:
+		default:
+			upsdebugx(1, "%s: not a known temperature unit for conversion!", __func__);
+			return NULL;
+	}
+
+	return buf;
+}
+
+const char *
+nut_usdate_to_isodate_static(const char *usdate)
+{
+	static char buf[32];
+	struct tm tm;
+
+	if (!usdate)
+		return NULL;
+
+	memset(&tm, 0, sizeof(tm));
+	memset(buf, 0, sizeof(buf));
+
+	upsdebugx(3, "%s: US date = %s", __func__, usdate);
+
+	/* Note strptime() returns NULL upon failure, and a ptr to the last
+	 * NUL char of the string upon success. Just try blindly the
+	 * conversion, same as the legacy snmp-ups-helpers.c code did. */
+	strptime(usdate, "%m/%d/%Y", &tm);
+	if (strftime(buf, sizeof(buf) - 1, "%F", &tm) != 0) {
+		upsdebugx(3, "%s: successfully reformatted: %s", __func__, buf);
+		return buf;
+	}
+
+	return NULL;
+}
+
+const char *
+nut_phase_name_static(int index, int total_phases)
+{
+	static char buf[8];
+
+	if (index < 1)
+		return NULL;
+
+	if (total_phases <= 1) {
+		/* Single-phase devices: everything maps to L1 */
+		snprintf(buf, sizeof(buf), "L1");
+		return buf;
+	}
+
+	/* 3ph assumed (2ph PDUs do not exist in practice); wrap index into
+	 * the [1..3] range the same way the historical per-driver helpers
+	 * did (see e.g. the commented-out marlin_outlet_group_phase_fun()
+	 * in eaton-pdu-marlin-mib.c). */
+	if (index > 3) {
+		index = ((index - 1) % 3) + 1;
+	}
+
+	if (index < 1 || index > 3)
+		return NULL;
+
+	snprintf(buf, sizeof(buf), "L%d", index);
+	return buf;
+}
+
+const char *
+nut_phase_pair_name_static(int n1, int n2)
+{
+	static char buf[16];
+
+	if (n1 < 1 || n1 > 3 || n2 < 0 || n2 > 3)
+		return NULL;
+
+	if (n2 == 0) {
+		snprintf(buf, sizeof(buf), "L%d-N", n1);
+	} else {
+		snprintf(buf, sizeof(buf), "L%d-L%d", n1, n2);
+	}
+
+	return buf;
+}
+
+#define DMF_STDLIB_METHOD_ENTRY(cname, dname, desc, args, ret) \
+	{ #cname, dname, desc, args, ret },
+
+static const dmf_stdlib_method_t dmf_stdlib_methods[] = {
+	DMF_STDLIB_METHODS(DMF_STDLIB_METHOD_ENTRY)
+};
+
+const dmf_stdlib_method_t *
+dmf_stdlib_list_methods(size_t *count)
+{
+	if (count)
+		*count = sizeof(dmf_stdlib_methods) / sizeof(dmf_stdlib_methods[0]);
+	return dmf_stdlib_methods;
+}

--- a/common/dmf_stdlib.c
+++ b/common/dmf_stdlib.c
@@ -211,6 +211,67 @@ nut_phase_pair_name_static(int n1, int n2)
 	return buf;
 }
 
+const char *
+nut_dmf_apply_conversion(const char *dmf_name, const char *args,
+	double raw_number, const char *raw_string, const char *context)
+{
+	char argbuf[128];
+	char *save = NULL;
+	char *tok1 = NULL, *tok2 = NULL;
+
+	if (!dmf_name)
+		return NULL;
+
+	if (args) {
+		snprintf(argbuf, sizeof(argbuf), "%s", args);
+		tok1 = strtok_r(argbuf, ",", &save);
+		if (tok1)
+			tok2 = strtok_r(NULL, ",", &save);
+	}
+
+	if (!strcmp(dmf_name, "scale_format")) {
+		double factor = tok1 ? atof(tok1) : 1.0;
+		const char *fmt = tok2 ? tok2 : "%0.1f";
+		return nut_scale_format_static(raw_number, factor, fmt);
+	}
+
+	if (!strcmp(dmf_name, "temperature_deci_to_celsius")) {
+		int unit = NUT_STDLIB_TEMP_CELSIUS;
+		if (tok1) {
+			if (!strcasecmp(tok1, "kelvin"))
+				unit = NUT_STDLIB_TEMP_KELVIN;
+			else if (!strcasecmp(tok1, "fahrenheit"))
+				unit = NUT_STDLIB_TEMP_FAHRENHEIT;
+			else if (!strcasecmp(tok1, "celsius"))
+				unit = NUT_STDLIB_TEMP_CELSIUS;
+			else
+				unit = NUT_STDLIB_TEMP_UNKNOWN;
+		}
+		return nut_temperature_deci_to_celsius_static((long) raw_number, unit);
+	}
+
+	if (!strcmp(dmf_name, "usdate_to_isodate")) {
+		return nut_usdate_to_isodate_static(raw_string);
+	}
+
+	if (!strcmp(dmf_name, "phase_name")) {
+		int total_phases = tok1 ? atoi(tok1) : 1;
+		return nut_phase_name_static((int) raw_number, total_phases);
+	}
+
+	if (!strcmp(dmf_name, "phase_pair_name")) {
+		int n2 = tok1 ? atoi(tok1) : 0;
+		return nut_phase_pair_name_static((int) raw_number, n2);
+	}
+
+	/* Unknown conversion name: log via the same policy machinery used
+	 * for an unsupported dynamic-language function - this also sets the
+	 * sticky flag so the strict policy can reject the whole DMF source,
+	 * catching typos in 'conversion="..."' the same way. */
+	dmf_stdlib_log_unsupported_function(context, dmf_name);
+	return NULL;
+}
+
 #define DMF_STDLIB_METHOD_ENTRY(cname, dname, desc, args, ret) \
 	{ #cname, dname, desc, args, ret },
 

--- a/common/dmfsnmp.c
+++ b/common/dmfsnmp.c
@@ -303,6 +303,7 @@ info_snmp_new (const char *name, int info_flags, double multiplier,
 #if WITH_DMF_FUNCTIONS
 	, char **function_language, char **function_code
 #endif
+	, const char *conversion, const char *conversion_args
 )
 {
 	snmp_info_t *self = (snmp_info_t*) calloc (1, sizeof (snmp_info_t));
@@ -317,6 +318,10 @@ info_snmp_new (const char *name, int info_flags, double multiplier,
 	self->info_flags = info_flags;
 	self->flags = flags;
 	self->oid2info = lookup;
+	if(conversion)
+		self->conversion = xstrdup (conversion);
+	if(conversion_args)
+		self->conversion_args = xstrdup (conversion_args);
 #if WITH_DMF_SETVAR
 	self->setvar = setvar;
 #endif	/* WITH_DMF_SETVAR */
@@ -1034,6 +1039,8 @@ snmp_info_node_handler(alist_t *list, const char **attrs)
 #if WITH_DMF_SETVAR
 	arg[5] = get_param_by_name(SNMP_SETVAR, attrs);
 #endif	/* WITH_DMF_SETVAR */
+	arg[7] = get_param_by_name(SNMP_CONVERSION, attrs);
+	arg[8] = get_param_by_name(SNMP_CONVERSION_ARGS, attrs);
 
 #if WITH_DMF_FUNCTIONS
 	arg[6] = get_param_by_name(TYPE_FUNCTIONSET, attrs);

--- a/common/dmfsnmp.c
+++ b/common/dmfsnmp.c
@@ -33,6 +33,7 @@
 
 #include "dmfsnmp.h"
 #include "dmfcore.h"
+#include "dmf_stdlib.h"
 
 /*
  *
@@ -344,13 +345,12 @@ info_snmp_new (const char *name, int info_flags, double multiplier,
 			}else
 				lua_pcall(self->luaContext,0,0,0);
 # else
-			upsdebugx(5, "SNMP_INFO entry backed by dynamic code in '%s' was skipped because support for this language is not compiled in",
+			dmf_stdlib_log_unsupported_function(self->info_type,
 				self->function_language ? self->function_language : "LUA");
 # endif /* WITH_DMF_LUA */
 		} /* if function_language resolved to "lua*" */
 		else {
-			upsdebugx(5, "SNMP_INFO entry backed by dynamic code in '%s' was skipped because support for this language is not compiled in",
-				self->function_language);
+			dmf_stdlib_log_unsupported_function(self->info_type, self->function_language);
 		} /* if language is recognized */
 	} /* if code is present */
 	else { /* No code - clean up */
@@ -362,13 +362,12 @@ info_snmp_new (const char *name, int info_flags, double multiplier,
 # if WITH_DMF_LUA
 			self->luaContext = NULL;
 # else
-			upsdebugx(5, "SNMP_INFO entry backed by dynamic code in '%s' was skipped because support for this language is not compiled in",
+			dmf_stdlib_log_unsupported_function(self->info_type,
 				self->function_language ? self->function_language : "LUA");
 # endif /* WITH_DMF_LUA */
 		} /* if function_language resolved to "lua*" */
 		else {
-			upsdebugx(5, "SNMP_INFO entry backed by dynamic code in '%s' was skipped because support for this language is not compiled in",
-				self->function_language);
+			dmf_stdlib_log_unsupported_function(self->info_type, self->function_language);
 		} /* if language is recognized */
 	} /* no code is present */
 #endif /* WITH_DMF_FUNCTIONS */

--- a/common/dmfsnmp.c
+++ b/common/dmfsnmp.c
@@ -1543,6 +1543,9 @@ mibdmf_parse_begin_cb(void *parsed_data)
 		upslogx(LOG_ERR, "mibdmf_parse_begin_cb() was called with parsed_data==NULL");
 		return ERR;
 	}
+	/* Reset the "saw an unsupported dynamic-language function" flag for
+	 * this source (file/string); see mibdmf_parse_finish_cb() below. */
+	dmf_stdlib_reset_unsupported_function_flag();
 	mibdmf_parser_new_list(dmp);
 	assert (mibdmf_get_aux_list(dmp)!=NULL);
 	if (mibdmf_get_aux_list(dmp)==NULL) {
@@ -1561,6 +1564,21 @@ mibdmf_parse_finish_cb(void *parsed_data, int result)
 	if (dmp==NULL) {
 		upslogx(LOG_ERR, "mibdmf_parse_finish_cb() was called with parsed_data==NULL");
 		return ECANCELED;
+	}
+
+	/* Strict policy: if any mapping entry in this source referenced a
+	 * dynamic-language function this build can not honor, reject the
+	 * whole file/string instead of silently keeping the static-table
+	 * entries that did parse (the 'drop' policy just skips the entry
+	 * and lets the rest of the file load normally). */
+	if (result == 0 && dmf_stdlib_had_unsupported_function()
+	&& dmf_stdlib_get_function_policy() == DMF_FUNCTION_POLICY_STRICT
+	) {
+		upslogx(LOG_ERR, "mibdmf_parse_finish_cb(): rejecting this DMF source: "
+			"at least one mapping entry referenced a dynamic-language function "
+			"not supported by this build (set NUT_DMF_FUNCTION_POLICY=drop to "
+			"only skip such entries instead)");
+		result = ECANCELED;
 	}
 
 	/* Extend or truncate the tables to the current amount of known entries

--- a/common/dmfsnmp.c
+++ b/common/dmfsnmp.c
@@ -204,7 +204,7 @@ snmp_info_type_to_main_function_name(const char * info_type)
 	int j = 0;
 
 	assert(info_type);
-	result = (char *) calloc(strlen(info_type), sizeof(char));
+	result = (char *) calloc(strlen(info_type) + 1, sizeof(char));
 	while(info_type[i]){
 		if(info_type[i] != '.'){
 			result[j] = info_type[i];

--- a/common/dmfsnmp.c
+++ b/common/dmfsnmp.c
@@ -225,7 +225,7 @@ get_param_by_name (const char *name, const char **items)
 	iname = 0;
 	while (items[iname]) {
 		if (strcmp (items[iname],name) == 0) {
-			return strdup(items[iname+1]);
+			return xstrdup(items[iname+1]);
 		}
 		iname += 2;
 	}
@@ -247,7 +247,7 @@ info_lkp_new (int oid, const char *value
 	assert (self);
 	self->oid_value = oid;
 	if (value)
-		self->info_value = strdup (value);
+		self->info_value = xstrdup (value);
 #if WITH_SNMP_LKP_FUN
 	/* TOTHINK: consider WITH_DMF_FUNCTIONS too? */
 	if (fun_vp2s || nuf_s2l || fun_s2l || nuf_vp2s) {
@@ -285,11 +285,11 @@ info_alarm_new (const char *oid, const char *status, const char *alarm)
 	alarms_info_t *self = (alarms_info_t*) calloc(1, sizeof (alarms_info_t));
 	assert (self);
 	if(oid)
-		self->OID = strdup (oid);
+		self->OID = xstrdup (oid);
 	if(status)
-		self->status_value = strdup (status);
+		self->status_value = xstrdup (status);
 	if(alarm)
-		self->alarm_value = strdup (alarm);
+		self->alarm_value = xstrdup (alarm);
 	return self;
 }
 
@@ -308,12 +308,12 @@ info_snmp_new (const char *name, int info_flags, double multiplier,
 	snmp_info_t *self = (snmp_info_t*) calloc (1, sizeof (snmp_info_t));
 	assert (self);
 	if(name)
-		self->info_type = strdup (name);
+		self->info_type = xstrdup (name);
 	self->info_len = multiplier;
 	if(oid)
-		self->OID = strdup (oid);
+		self->OID = xstrdup (oid);
 	if(dfl)
-		self->dfl = strdup (dfl);
+		self->dfl = xstrdup (dfl);
 	self->info_flags = info_flags;
 	self->flags = flags;
 	self->oid2info = lookup;
@@ -382,15 +382,15 @@ info_mib2nut_new (const char *name, const char *version,
 	mib2nut_info_t *self = (mib2nut_info_t*) calloc(1, sizeof(mib2nut_info_t));
 	assert (self);
 	if(name)
-		self->mib_name = strdup (name);
+		self->mib_name = xstrdup (name);
 	if(version)
-		self->mib_version = strdup (version);
+		self->mib_version = xstrdup (version);
 	if(oid_power_status)
-		self->oid_pwr_status = strdup (oid_power_status);
+		self->oid_pwr_status = xstrdup (oid_power_status);
 	if(oid_auto_check)
-		self->oid_auto_check = strdup (oid_auto_check);
+		self->oid_auto_check = xstrdup (oid_auto_check);
 	if(sysOID)
-		self->sysOID = strdup (sysOID);
+		self->sysOID = xstrdup (sysOID);
 	self->snmp_info = snmp;
 	self->alarms_info = alarms;
 
@@ -401,12 +401,12 @@ info_mib2nut_new (const char *name, const char *version,
 dmf_function_t *
 function_new (const char *name, const char *language){
 	dmf_function_t *self = (dmf_function_t*) calloc(1, sizeof(dmf_function_t));
-	self->name = strdup (name);
+	self->name = xstrdup (name);
 	if (language == NULL) {
-		self->language = strdup ("lua-5.1");
+		self->language = xstrdup ("lua-5.1");
 		upsdebugx(1, "Language not specified for DMF function %s, assuming %s by default", self->name, self->language);
 	} else {
-		self->language = strdup (language);
+		self->language = xstrdup (language);
 		upsdebugx(1, "Language was specified for DMF function %s : %s", self->name, self->language);
 	}
 	return self;
@@ -1482,7 +1482,7 @@ mibdmf_xml_end_cb(void *userdata, int state, const char *nspace, const char *nam
 	{
 		alist_t *sub_element = alist_get_last_element(list);
 		dmf_function_t *func =(dmf_function_t *) alist_get_last_element(sub_element);
-		func->code = strdup(function_text);
+		func->code = xstrdup(function_text);
 		free(function_text);
 		function_text = NULL;
 	}

--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -16,6 +16,7 @@ $(top_builddir)/common/libcommonclient.la \
 $(top_builddir)/common/libcommonversion.la \
 $(top_builddir)/common/libparseconf.la \
 $(top_builddir)/common/libnutdmfsnmp.la \
+$(top_builddir)/common/libnutdmfstdlib.la \
 $(top_builddir)/clients/libupsclient.la: dummy @dotMAKE@
 	+@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
@@ -30,6 +31,7 @@ $(top_builddir)/common/libcommonversion.la: $(top_builddir)/include/nut_version.
 if ENABLE_SHARED_PRIVATE_LIBS
 $(top_builddir)/common/libcommonversion-private.la \
 $(top_builddir)/common/libnutprivate-@NUT_SOURCE_GITREV_SEMVER_UNDERSCORES@-common-all.la \
+$(top_builddir)/common/libnutprivate-@NUT_SOURCE_GITREV_SEMVER_UNDERSCORES@-drivers-dmfstdlib.la \
 $(top_builddir)/common/libnutprivate-@NUT_SOURCE_GITREV_SEMVER_UNDERSCORES@-common-client.la: dummy @dotMAKE@
 	+@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
@@ -86,6 +88,9 @@ endif WITH_USB
 # Note: unlike SERLIBS that are usually part of the system one way or another, LIBUSB_LIBS are typically shared:
   LDADD_DRIVERS_LIBUSB = libnutprivate-@NUT_SOURCE_GITREV_SEMVER_UNDERSCORES@-drivers-libusb.la $(LDADD_DRIVERS) $(LIBUSB_LIBS) -lm
 
+# Shared "standard library" of DMF-related data-conversion helpers (see common/dmf_stdlib.c)
+  LDADD_DMFSTDLIB = $(top_builddir)/common/libnutprivate-@NUT_SOURCE_GITREV_SEMVER_UNDERSCORES@-drivers-dmfstdlib.la
+
 if HAVE_WINDOWS
   # Many versions of MingW seem to fail to build non-static DLL without this
   libnutprivate_@NUT_SOURCE_GITREV_SEMVER_UNDERSCORES@_drivers_common_la_LDFLAGS += -no-undefined
@@ -103,6 +108,9 @@ else !ENABLE_SHARED_PRIVATE_LIBS
   LDADD_DRIVERS = libdummy_main.la libdummy_upsdrvquery.la $(LDADD_COMMON)
   LDADD_DRIVERS_SERIAL = libdummy_serial.la $(LDADD_DRIVERS) $(SERLIBS)
   LDADD_DRIVERS_LIBUSB = libdummy_libusb.la $(LDADD_DRIVERS) $(LIBUSB_LIBS) -lm
+
+# Shared "standard library" of DMF-related data-conversion helpers (see common/dmf_stdlib.c)
+  LDADD_DMFSTDLIB = $(top_builddir)/common/libnutdmfstdlib.la
 endif !ENABLE_SHARED_PRIVATE_LIBS
 
 if WITH_SERIAL
@@ -361,9 +369,9 @@ USBHID_UPS_SUBDRIVERS = apc-hid.c arduino-hid.c belkin-hid.c cps-hid.c explore-h
  legrand-hid.c salicru-hid.c
 usbhid_ups_SOURCES = usbhid-ups.c libhid.c hidparser.c ecoflow-hid-aux-cdc.c ecoflow-cdc-protocol.c $(USBHID_UPS_SUBDRIVERS)
 if WITH_SERIAL
-usbhid_ups_LDADD = libdummy_serial.la $(LDADD_DRIVERS_LIBUSB) $(SERLIBS)
+usbhid_ups_LDADD = libdummy_serial.la $(LDADD_DRIVERS_LIBUSB) $(SERLIBS) $(LDADD_DMFSTDLIB)
 else
-usbhid_ups_LDADD = $(LDADD_DRIVERS_LIBUSB)
+usbhid_ups_LDADD = $(LDADD_DRIVERS_LIBUSB) $(LDADD_DMFSTDLIB)
 endif
 
 powervar_cx_usb_SOURCES = powervar_cx_usb.c powervar_cx.c
@@ -427,13 +435,13 @@ snmp_ups_SOURCES = snmp-ups.c snmp-ups-helpers.c \
 snmp_ups_CFLAGS = $(AM_CFLAGS)
 snmp_ups_CFLAGS += $(LIBNETSNMP_CFLAGS)
 snmp_ups_CFLAGS += -DWITH_DMFMIB=0 -DWITH_DMF_LUA=0 -DWITH_DMF_FUNCTIONS=0
-snmp_ups_LDADD = $(LDADD_DRIVERS) $(LIBNETSNMP_LIBS) -lm
+snmp_ups_LDADD = $(LDADD_DRIVERS) $(LIBNETSNMP_LIBS) $(LDADD_DMFSTDLIB) -lm
 snmp_ups_LDFLAGS = $(AM_LDFLAGS)
 
 # DMF SNMP - ok to define this in the open, it is only built if enabled above
 snmp_ups_dmf_SOURCES = snmp-ups.c
 snmp_ups_dmf_LDADD = $(LDADD_DRIVERS) $(LIBNETSNMP_LIBS) \
- $(top_builddir)/common/libnutdmfsnmp.la $(LIBNEON_LIBS) -lm
+ $(top_builddir)/common/libnutdmfsnmp.la $(LIBNEON_LIBS) $(LDADD_DMFSTDLIB) -lm
 if ENABLE_SHARED_PRIVATE_LIBS
 snmp_ups_dmf_LDADD += $(top_builddir)/common/libnutprivate-@NUT_SOURCE_GITREV_SEMVER_UNDERSCORES@-common-all.la
 else !ENABLE_SHARED_PRIVATE_LIBS

--- a/drivers/legrand-hid.c
+++ b/drivers/legrand-hid.c
@@ -27,6 +27,7 @@
 #include "legrand-hid.h"
 #include "main.h"
 #include "usb-common.h"
+#include "dmf_stdlib.h"
 
 #define LEGRAND_HID_VERSION	"Legrand HID 0.3"
 
@@ -74,9 +75,8 @@ static usage_tables_t legrand_utab[] = {
 
 static const char *legrand_times10(double value)
 {
-	static char buf[20];
-	snprintf(buf, sizeof(buf), "%0.1f", value * 10);
-	return buf;
+	/* Deduplicated: delegates to the shared dmf_stdlib scale/format helper */
+	return nut_scale_format_static(value, 10, "%0.1f");
 }
 
 static info_lkp_t legrand_times10_info[] = {
@@ -86,9 +86,7 @@ static info_lkp_t legrand_times10_info[] = {
 
 static const char *legrand_times100k(double value)
 {
-	static char buf[20];
-	snprintf(buf, sizeof(buf), "%0.1f", value * 100000);
-	return buf;
+	return nut_scale_format_static(value, 100000, "%0.1f");
 }
 
 static info_lkp_t legrand_times100k_info[] = {
@@ -98,9 +96,7 @@ static info_lkp_t legrand_times100k_info[] = {
 
 static const char *legrand_times1M(double value)
 {
-	static char buf[20];
-	snprintf(buf, sizeof(buf), "%0.1f", value * 1000000);
-	return buf;
+	return nut_scale_format_static(value, 1000000, "%0.1f");
 }
 
 static info_lkp_t legrand_times1M_info[] = {
@@ -110,9 +106,7 @@ static info_lkp_t legrand_times1M_info[] = {
 
 static const char *legrand_times10M(double value)
 {
-	static char buf[20];
-	snprintf(buf, sizeof(buf), "%0.1f", value * 10000000);
-	return buf;
+	return nut_scale_format_static(value, 10000000, "%0.1f");
 }
 
 static info_lkp_t legrand_times10M_info[] = {

--- a/drivers/snmp-ups-helpers.c
+++ b/drivers/snmp-ups-helpers.c
@@ -26,6 +26,7 @@
 
 /* NUT SNMP common functions */
 #include "common.h"	/* includes "config.h" which must be the first header */
+#include "dmf_stdlib.h"
 /*
 #include "config.h"
 #include "main.h"
@@ -52,31 +53,15 @@
  * of other compilation units, so separated into a stand-alone file
  **********************************************************************/
 
-static char su_scratch_buf[255];
-
 /* Temperature handling, to convert back to Celsius */
 int temperature_unit = TEMPERATURE_UNKNOWN;
 
 /* Convert a US formated date (mm/dd/yyyy) to an ISO 8601 Calendar date (yyyy-mm-dd) */
 const char *su_usdate_to_isodate_info_fun(void *raw_date)
 {
-	const char *usdate = (char *)raw_date;
-	struct tm tm;
-	memset(&tm, 0, sizeof(struct tm));
-	memset(&su_scratch_buf, 0, sizeof(su_scratch_buf));
-
-	upsdebugx(3, "%s: US date = %s", __func__, usdate);
-
-	/* Try to convert from US date string to time */
-	/* Note strptime returns NULL upon failure, and a ptr to the last
-	 * null char of the string upon success. Just try blindly the conversion! */
-	strptime(usdate, "%m/%d/%Y", &tm);
-	if (strftime(su_scratch_buf, 254, "%F", &tm) != 0) {
-		upsdebugx(3, "%s: successfully reformated: %s", __func__, su_scratch_buf);
-		return su_scratch_buf;
-	}
-
-	return NULL;
+	/* Delegate to the shared dmf_stdlib implementation, reused verbatim
+	 * by DMF XML mappings and (where enabled) LUA glue code. */
+	return nut_usdate_to_isodate_static((const char *)raw_date);
 }
 
 info_lkp_t su_convert_to_iso_date_info[] = {
@@ -90,28 +75,17 @@ info_lkp_t su_convert_to_iso_date_info[] = {
 const char *su_temperature_read_fun(void *raw_snmp_value)
 {
 	const long snmp_value = *((long*)raw_snmp_value);
-	long celsius_value = snmp_value;
 
-	memset(su_scratch_buf, 0, sizeof(su_scratch_buf));
+	/* Delegate to the shared dmf_stdlib implementation; NUT_STDLIB_TEMP_*
+	 * values are numerically identical to the historical TEMPERATURE_*
+	 * macros used by 'temperature_unit' (see snmp-ups.h). */
+	const char *result = nut_temperature_deci_to_celsius_static(snmp_value, temperature_unit);
 
-	switch (temperature_unit) {
-		case TEMPERATURE_KELVIN:
-			celsius_value = (snmp_value / 10) - 273.15;
-			snprintf(su_scratch_buf, sizeof(su_scratch_buf), "%.1ld", celsius_value);
-			break;
-		case TEMPERATURE_CELSIUS:
-			snprintf(su_scratch_buf, sizeof(su_scratch_buf), "%.1ld", (snmp_value / 10));
-			break;
-		case TEMPERATURE_FAHRENHEIT:
-			celsius_value = (((snmp_value / 10) - 32) * 5) / 9;
-			snprintf(su_scratch_buf, sizeof(su_scratch_buf), "%.1ld", celsius_value);
-			break;
-		case TEMPERATURE_UNKNOWN:
-		default:
-			upsdebugx(1, "%s: not a known temperature unit for conversion!", __func__);
-			break;
-	}
-	upsdebugx(2, "%s: %.1ld => %s", __func__, (snmp_value / 10), su_scratch_buf);
-	return su_scratch_buf;
+	if (!result)
+		upsdebugx(1, "%s: not a known temperature unit for conversion!", __func__);
+	else
+		upsdebugx(2, "%s: %.1ld => %s", __func__, (snmp_value / 10), result);
+
+	return result;
 }
 #endif	/* WITH_SNMP_LKP_FUN_DUMMY */

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -3497,9 +3497,19 @@ int lua_C_gateway(lua_State *L) {
 	const char	*lua_info_type = lua_tostring(L, 1);
 	int	lua_current_device_number = lua_tointeger(L, 2);
 	const char	*value = NULL;
-	size_t	bufsz = (strlen(lua_info_type) + 12) * sizeof(char);
-	char	*buf = (char *) malloc(bufsz);
+	size_t	bufsz = 0;
+	char	*buf = NULL;
 
+	if (!lua_info_type) {
+		upsdebugx(1, "%s: missing info_type argument", __func__);
+		return -1;
+	}
+
+	/* FIXME: This allocation is a bit fragile: it sizes a buffer
+	 *  from the variable name length, but the function does not
+	 *  validate the Lua argument list before using it. */
+	bufsz = (strlen(lua_info_type) + 12) * sizeof(char);
+	buf = (char *) malloc(bufsz);
 	if (!buf) {
 		upsdebugx(1, "%s: failed to allocate a buffer", __func__);
 		return -1;

--- a/drivers/snmp-ups.h
+++ b/drivers/snmp-ups.h
@@ -316,6 +316,13 @@ typedef struct {
 	lua_State *luaContext;
 # endif /* WITH_DMF_LUA  */
 #endif /* WITH_DMF_FUNCTIONS */
+	/* DMF "conversion" attribute: names a dmf_stdlib.h method (and its
+	 * comma-separated parameters) to apply to the raw SNMP value in
+	 * place of the oid2info lookup/multiplier logic. Always present
+	 * (not gated by WITH_DMF_FUNCTIONS): unlike LUA/'functionset', this
+	 * only dispatches to a fixed, pre-registered C function by name. */
+	const char *conversion;
+	const char *conversion_args;
 } snmp_info_t;
 
 #if WITH_DMF_FUNCTIONS

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -14,7 +14,7 @@ dist_noinst_HEADERS = \
     attribute.h common.h extstate.h proto.h			\
     state.h str.h strjson.h timehead.h upsconf.h		\
     nut_bool.h nut_float.h nut_stdint.h nut_platform.h		\
-    dmf.h alist.h dmfsnmp.h dmfcore.h				\
+    dmf.h alist.h dmfsnmp.h dmfcore.h dmf_stdlib.h		\
     strcasestr-static.h wincompat.h
 
 # Optionally deliverable as part of NUT public API:

--- a/include/dmf_stdlib.h
+++ b/include/dmf_stdlib.h
@@ -65,13 +65,25 @@ typedef enum {
 dmf_function_policy_t dmf_stdlib_get_function_policy(void);
 
 /* Log (at LOG_ERR for strict policy, LOG_WARNING for drop policy) that
- * a DMF mapping entry referencing "language" could not be honored in
- * "context" (e.g. a mapping name or file name). Returns the policy that
- * was in effect at the time of the call, so the caller can decide
- * whether to abort processing of the current file/mapping or just
- * skip the one entry. */
+ * a DMF mapping entry could not be honored in "context" (e.g. a mapping
+ * name or file name) because it requires "capability" (a dynamic-language
+ * name such as "lua", or an unrecognized 'conversion=' method name) that
+ * this build does not support/recognize. Returns the policy that was in
+ * effect at the time of the call, so the caller can decide whether to
+ * abort processing of the current file/mapping or just skip the one
+ * entry. */
 dmf_function_policy_t dmf_stdlib_log_unsupported_function(
-	const char *context, const char *language);
+	const char *context, const char *capability);
+
+/* Reset the sticky "an unsupported function was encountered" flag; call
+ * this once at the start of parsing a DMF source (file/string/dir entry).
+ * Used together with dmf_stdlib_had_unsupported_function() to implement
+ * "reject the whole file" behavior for the strict policy. */
+void dmf_stdlib_reset_unsupported_function_flag(void);
+
+/* Returns non-zero if dmf_stdlib_log_unsupported_function() was called at
+ * least once since the last dmf_stdlib_reset_unsupported_function_flag(). */
+int dmf_stdlib_had_unsupported_function(void);
 
 /* --- Generic numeric scale/format helper ---
  * Multiply "value" by "factor" and format the result with the given

--- a/include/dmf_stdlib.h
+++ b/include/dmf_stdlib.h
@@ -122,6 +122,24 @@ const char *nut_phase_name_static(int index, int total_phases);
  * out-of-range input. */
 const char *nut_phase_pair_name_static(int n1, int n2);
 
+/* --- DMF XML "conversion" attribute dispatcher ---
+ * Apply the named stdlib conversion (one of the DMF_STDLIB_METHODS()
+ * "dmf_name" entries below, e.g. "scale_format") to a raw value coming
+ * from a DMF mapping entry, given its (optional) comma-separated
+ * "args" as found in the DMF XML "conversion_args" attribute:
+ *   scale_format:                  args = "factor[,fmt]"
+ *   temperature_deci_to_celsius:   args = "unit" (celsius|kelvin|fahrenheit)
+ *   usdate_to_isodate:             args ignored, uses raw_string
+ *   phase_name:                    args = "total_phases"
+ *   phase_pair_name:               args = "n2" (raw_number is n1)
+ * "context" is used only for logging (e.g. the mapping's info_type).
+ * Returns a pointer to an internal static buffer, or NULL if dmf_name
+ * is not a recognized method (in which case this also logs via
+ * dmf_stdlib_log_unsupported_function() and applies the current
+ * dmf_function_policy_t, same as an unsupported LUA language would). */
+const char *nut_dmf_apply_conversion(const char *dmf_name, const char *args,
+	double raw_number, const char *raw_string, const char *context);
+
 /* --- Introspection / self-documentation ---
  * A read-only description of each of the methods above, primarily so
  * that:

--- a/include/dmf_stdlib.h
+++ b/include/dmf_stdlib.h
@@ -1,0 +1,161 @@
+/* dmf_stdlib.h - Shared library of "standard" data-conversion helpers
+ * usable from three call sites: statically compiled mapping tables
+ * (SNMP MIB files and similar), DMF XML definitions (via a named
+ * lookup once wired into the parser), and DMF dynamic-language glue
+ * (e.g. LUA) where enabled.
+ *
+ * The intent is to stop each driver/MIB file from privately
+ * re-implementing the same handful of numeric/date/phase-naming
+ * conversions (see e.g. legrand-hid.c, mge-hid.c, belkin-hid.c,
+ * snmp-ups-helpers.c before this file existed).
+ *
+ * Copyright (C) 2026 Jim Klimov <jimklimov+nut@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#ifndef NUT_DMF_STDLIB_H
+#define NUT_DMF_STDLIB_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stddef.h>
+
+/* Temperature unit values; numerically compatible with the historical
+ * TEMPERATURE_UNKNOWN/CELSIUS/KELVIN/FAHRENHEIT macros in snmp-ups.h
+ * (0/1/2/3) so callers may pass either interchangeably. Kept as a
+ * separate definition here to avoid a common/ -> drivers/ header
+ * dependency. */
+#define NUT_STDLIB_TEMP_UNKNOWN    0
+#define NUT_STDLIB_TEMP_CELSIUS    1
+#define NUT_STDLIB_TEMP_KELVIN     2
+#define NUT_STDLIB_TEMP_FAHRENHEIT 3
+
+/* Runtime policy for handling DMF mapping entries that reference a
+ * dynamic-language function (e.g. LUA) which this build cannot execute
+ * (interpreter not compiled in), or any other "unsupported function"
+ * situation flagged by a DMF consumer.
+ *   STRICT (default): treat as a hard error for the affected mapping/file.
+ *   DROP:             skip just the affected mapping entry, keep going.
+ * Either way, the event is logged loudly (LOG_ERR/LOG_WARNING), not just
+ * at a buried debug verbosity, so operators are not left guessing about
+ * silently missing data points. */
+typedef enum {
+	DMF_FUNCTION_POLICY_STRICT = 0,
+	DMF_FUNCTION_POLICY_DROP = 1
+} dmf_function_policy_t;
+
+/* Reads NUT_DMF_FUNCTION_POLICY=strict|drop from the environment
+ * (case-insensitive); defaults to DMF_FUNCTION_POLICY_STRICT if unset
+ * or unrecognized. */
+dmf_function_policy_t dmf_stdlib_get_function_policy(void);
+
+/* Log (at LOG_ERR for strict policy, LOG_WARNING for drop policy) that
+ * a DMF mapping entry referencing "language" could not be honored in
+ * "context" (e.g. a mapping name or file name). Returns the policy that
+ * was in effect at the time of the call, so the caller can decide
+ * whether to abort processing of the current file/mapping or just
+ * skip the one entry. */
+dmf_function_policy_t dmf_stdlib_log_unsupported_function(
+	const char *context, const char *language);
+
+/* --- Generic numeric scale/format helper ---
+ * Multiply "value" by "factor" and format the result with the given
+ * printf-style "fmt" (e.g. "%0.1f", "%.2f"). Returns a pointer to an
+ * internal static buffer (like the rest of this codebase's similar
+ * helpers) - NOT thread-safe, do not hold the pointer across another
+ * call from the same thread. Covers the very common "timesN"/"/N"
+ * driver-local helpers (legrand_times10, mge_powerfactor_conversion,
+ * mge_battery_capacity_fun, etc). */
+const char *nut_scale_format_static(double value, double factor, const char *fmt);
+
+/* --- Temperature conversion ---
+ * Convert a raw "deci-value" reading (i.e. already-scaled by 10, as
+ * commonly seen straight off SNMP/HID) expressed in the given unit
+ * (NUT_STDLIB_TEMP_*) into a Celsius value formatted as "%.1f" text.
+ * Returns a pointer to an internal static buffer; NULL if unit is
+ * unknown/unrecognized. */
+const char *nut_temperature_deci_to_celsius_static(long value_deci, int unit);
+
+/* --- Date conversion ---
+ * Convert a US-formatted date string "mm/dd/yyyy" into an ISO-8601
+ * calendar date "yyyy-mm-dd". Returns a pointer to an internal static
+ * buffer, or NULL if the input could not be parsed. */
+const char *nut_usdate_to_isodate_static(const char *usdate);
+
+/* --- Multi-phase naming helpers ---
+ * Compute the "L<N>" phase label for a 1-based outlet/group index,
+ * given the total number of phases the device reports (1 or 3).
+ * Returns a pointer to an internal static buffer, or NULL on
+ * out-of-range input. */
+const char *nut_phase_name_static(int index, int total_phases);
+
+/* Compute the "L<N1>-L<N2>" (or "L<N1>-N" when n2==0) phase-pair label
+ * for two 1-based phase numbers (e.g. 1,2 -> "L1-L2"; 1,0 -> "L1-N").
+ * Returns a pointer to an internal static buffer, or NULL on
+ * out-of-range input. */
+const char *nut_phase_pair_name_static(int n1, int n2);
+
+/* --- Introspection / self-documentation ---
+ * A read-only description of each of the methods above, primarily so
+ * that:
+ *  - a generator script (see scripts/DMF/gen-dmf-stdlib-methods.py)
+ *    can emit an XML listing of method names/args/return types for
+ *    schema validation or documentation purposes;
+ *  - LUA glue code (where enabled) can enumerate what is available
+ *    without hardcoding a duplicate list;
+ *  - developers can grep this header, which is also authoritative.
+ * NOTE: keep the DMF_STDLIB_METHODS(X) list below in sync with the
+ * public functions declared above - the generator and the runtime
+ * registry both derive from it.
+ */
+typedef struct {
+	const char *c_name;      /* C function name, e.g. "nut_scale_format_static" */
+	const char *dmf_name;    /* short name for DMF XML / LUA reference */
+	const char *description;
+	const char *args;        /* human-readable arg list, e.g. "double value, double factor, string fmt" */
+	const char *retval;      /* human-readable return type, e.g. "string" */
+} dmf_stdlib_method_t;
+
+/* X-Macro listing of registered methods: X(c_name, dmf_name, description, args, retval) */
+#define DMF_STDLIB_METHODS(X) \
+	X(nut_scale_format_static, "scale_format", \
+		"Multiply value by factor and format with a printf-style spec", \
+		"double value, double factor, string fmt", "string") \
+	X(nut_temperature_deci_to_celsius_static, "temperature_deci_to_celsius", \
+		"Convert a raw deci-value temperature reading in a given unit to a Celsius string", \
+		"double value_deci, int unit", "string") \
+	X(nut_usdate_to_isodate_static, "usdate_to_isodate", \
+		"Convert a US date mm/dd/yyyy to ISO 8601 yyyy-mm-dd", \
+		"string usdate", "string") \
+	X(nut_phase_name_static, "phase_name", \
+		"Compute the phase label (L1/L2/L3) for a 1-based index given the total phase count", \
+		"int index, int total_phases", "string") \
+	X(nut_phase_pair_name_static, "phase_pair_name", \
+		"Compute the phase-pair label (e.g. L1-L2, or L1-N) for two 1-based phase numbers", \
+		"int n1, int n2", "string")
+
+/* Returns a pointer to a static array of method descriptors and sets
+ * *count to its length. The array and its contents are owned by this
+ * library and must not be freed or modified by the caller. */
+const dmf_stdlib_method_t *dmf_stdlib_list_methods(size_t *count);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NUT_DMF_STDLIB_H */

--- a/include/dmfsnmp.h
+++ b/include/dmfsnmp.h
@@ -198,6 +198,13 @@
 #define SNMP_DEFAULT "default"
 #define SNMP_LOOKUP "lookup"
 #define SNMP_SETVAR "setvar"
+/* Names a dmf_stdlib.h conversion method (e.g. "scale_format") plus its
+ * comma-separated parameters, applied to the raw SNMP value. Unlike
+ * 'functionset'/LUA, this only dispatches to a fixed, pre-registered C
+ * function by name - no dynamic code execution is involved, so it is
+ * always available (not gated by WITH_DMF_FUNCTIONS). */
+#define SNMP_CONVERSION "conversion"
+#define SNMP_CONVERSION_ARGS "conversion_args"
 /* Info_flags */
 #define SNMP_INFOFLAG_WRITABLE "writable"
 #define SNMP_INFOFLAG_STRING "string"
@@ -437,6 +444,7 @@ snmp_info_t *
 #if WITH_DMF_FUNCTIONS
 		,char **function_language, char **function_code
 #endif	/* WITH_DMF_FUNCTIONS */
+		, const char *conversion, const char *conversion_args
 );
 
 void

--- a/scripts/DMF/Makefile.am
+++ b/scripts/DMF/Makefile.am
@@ -50,17 +50,30 @@ $(abs_top_builddir)/common/libcommon.la: $(top_builddir)/common/libcommon.la
 
 $(abs_top_builddir)/drivers/dstate.o: $(top_builddir)/drivers/dstate.o
 
-# TODO: Support for libnutprivate* / ENABLE_SHARED_PRIVATE_LIBS
+# TODO: Support for libnutprivate* / ENABLE_SHARED_PRIVATE_LIBS for the
+# other libs referenced above (libcommon.la, libcommonstr.la, dstate.o,
+# libnutwincompat.la, libnutdmfsnmp.la) - only libnutdmfstdlib.la (below)
+# currently follows the same pattern as tests/Makefile.am.
 $(top_builddir)/common/libcommon.la \
 $(top_builddir)/common/libcommonstr.la \
 $(top_builddir)/drivers/dstate.o \
 $(top_builddir)/common/libnutwincompat.la \
-$(top_builddir)/common/libnutdmfstdlib.la \
 $(top_builddir)/common/libnutdmfsnmp.la: @dotMAKE@
+	+cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
+
+if ENABLE_SHARED_PRIVATE_LIBS
+$(top_builddir)/common/libnutprivate-@NUT_SOURCE_GITREV_SEMVER_UNDERSCORES@-drivers-dmfstdlib.la: @dotMAKE@
+	+cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
+
+# Shared "standard library" of DMF-related data-conversion helpers (see common/dmf_stdlib.c)
+LDADD_DMFSTDLIB = $(top_builddir)/common/libnutprivate-@NUT_SOURCE_GITREV_SEMVER_UNDERSCORES@-drivers-dmfstdlib.la
+else !ENABLE_SHARED_PRIVATE_LIBS
+$(top_builddir)/common/libnutdmfstdlib.la: @dotMAKE@
 	+cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
 # Shared "standard library" of DMF-related data-conversion helpers (see common/dmf_stdlib.c)
 LDADD_DMFSTDLIB = $(top_builddir)/common/libnutdmfstdlib.la
+endif !ENABLE_SHARED_PRIVATE_LIBS
 
 # A way to to relative symlinks, or hardlinks, or copies... depends on OS.
 LN_S_R = @LN_S_R@ -f

--- a/scripts/DMF/Makefile.am
+++ b/scripts/DMF/Makefile.am
@@ -50,12 +50,17 @@ $(abs_top_builddir)/common/libcommon.la: $(top_builddir)/common/libcommon.la
 
 $(abs_top_builddir)/drivers/dstate.o: $(top_builddir)/drivers/dstate.o
 
+# TODO: Support for libnutprivate* / ENABLE_SHARED_PRIVATE_LIBS
 $(top_builddir)/common/libcommon.la \
 $(top_builddir)/common/libcommonstr.la \
 $(top_builddir)/drivers/dstate.o \
 $(top_builddir)/common/libnutwincompat.la \
+$(top_builddir)/common/libnutdmfstdlib.la \
 $(top_builddir)/common/libnutdmfsnmp.la: @dotMAKE@
 	+cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
+
+# Shared "standard library" of DMF-related data-conversion helpers (see common/dmf_stdlib.c)
+LDADD_DMFSTDLIB = $(top_builddir)/common/libnutdmfstdlib.la
 
 # A way to to relative symlinks, or hardlinks, or copies... depends on OS.
 LN_S_R = @LN_S_R@ -f
@@ -609,7 +614,8 @@ noinst_PROGRAMS += dmf-test
 dmf_test_SOURCES = $(DMFTEST_SRC)
 nodist_dmf_test_SOURCES = $(DMFTEST_SRC_ADD)
 dmf_test_LDADD = $(LIBS_dmfsnmp_ltdlXneon) \
-	$(top_builddir)/common/libcommonstr.la
+	$(top_builddir)/common/libcommonstr.la \
+	$(LDADD_DMFSTDLIB)
 # $(top_builddir)/common/libnutdmfsnmp.la
 # $(top_builddir)/common/libcommon.la $(top_builddir)/drivers/dstate.o
 dmf_test_CFLAGS = $(DMFTESTS_COMMON_CFLAGS) $(CFLAGS_DMF_LUA)
@@ -683,7 +689,8 @@ noinst_PROGRAMS += dmf-lua-test
 dmf_lua_test_SOURCES = $(DMFTEST_SRC)
 nodist_dmf_lua_test_SOURCES = $(DMFTEST_SRC_ADD)
 dmf_lua_test_LDADD = $(LIBS_dmfsnmp_ltdlXneon) \
-	$(top_builddir)/common/libcommonstr.la
+	$(top_builddir)/common/libcommonstr.la \
+	$(LDADD_DMFSTDLIB)
 # $(top_builddir)/common/libnutdmfsnmp.la
 # $(top_builddir)/common/libcommon.la $(top_builddir)/drivers/dstate.o
 dmf_lua_test_CFLAGS = $(DMFTESTS_COMMON_CFLAGS) $(CFLAGS_DMF_LUA) \
@@ -701,7 +708,8 @@ noinst_PROGRAMS += dmf-fun-test
 dmf_fun_test_SOURCES = $(DMFTEST_SRC)
 nodist_dmf_fun_test_SOURCES = $(DMFTEST_SRC_ADD)
 dmf_fun_test_LDADD = $(LIBS_dmfsnmp_ltdlXneon) \
-	$(top_builddir)/common/libcommonstr.la
+	$(top_builddir)/common/libcommonstr.la \
+	$(LDADD_DMFSTDLIB)
 # $(top_builddir)/common/libnutdmfsnmp.la
 # $(top_builddir)/common/libcommon.la $(top_builddir)/drivers/dstate.o
 dmf_fun_test_CFLAGS = $(DMFTESTS_COMMON_CFLAGS) $(CFLAGS_DMF_LUA) $(DMFSNMP_LKP_FUN_FLAGS) \

--- a/scripts/DMF/gen-dmf-stdlib-methods.py
+++ b/scripts/DMF/gen-dmf-stdlib-methods.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# gen-dmf-stdlib-methods.py
+#
+# Generates an XML listing of the "standard library" conversion methods
+# exposed by common/dmf_stdlib.c (see include/dmf_stdlib.h), by parsing
+# the single-source-of-truth DMF_STDLIB_METHODS(X) X-Macro list in that
+# header. Intended uses:
+#  - documentation (method names, arguments, return types);
+#  - a basis for a future XML Schema addition so DMF XML files could
+#    validate references to "conversion=" methods by name;
+#  - a reference list that LUA glue code (where enabled) could load or
+#    be checked against, so scripts do not call into unregistered names.
+#
+# This script has no dependencies beyond the Python 3 standard library.
+#
+# Copyright (C) 2026 Jim Klimov <jimklimov+nut@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+import argparse
+import re
+import sys
+import xml.etree.ElementTree as ET
+import xml.dom.minidom as MINIDOM
+
+
+MACRO_NAME = "DMF_STDLIB_METHODS"
+
+# Matches one X(...) entry once continuation backslashes and newlines
+# have been collapsed into a single line of text.
+ENTRY_RE = re.compile(
+    r'X\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*,\s*'
+    r'"((?:[^"\\]|\\.)*)"\s*,\s*'
+    r'"((?:[^"\\]|\\.)*)"\s*,\s*'
+    r'"((?:[^"\\]|\\.)*)"\s*,\s*'
+    r'"((?:[^"\\]|\\.)*)"\s*\)'
+)
+
+
+def extract_macro_block(header_text, macro_name):
+    """Return the raw text of the '#define macro_name(X) \\\n ... ' block,
+    with backslash-newline continuations joined into a single string."""
+    lines = header_text.splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        if line.strip().startswith("#define %s(" % macro_name):
+            start = i
+            break
+    if start is None:
+        raise ValueError("Could not find '#define %s(...)' in header" % macro_name)
+
+    block_lines = []
+    i = start
+    while i < len(lines):
+        line = lines[i]
+        block_lines.append(line)
+        if not line.rstrip().endswith("\\"):
+            break
+        i += 1
+
+    # Strip line-continuation backslashes and join
+    joined = " ".join(l.rstrip().rstrip("\\").strip() for l in block_lines)
+    return joined
+
+
+def parse_methods(header_path):
+    with open(header_path, "r", encoding="utf-8") as f:
+        text = f.read()
+
+    block = extract_macro_block(text, MACRO_NAME)
+
+    methods = []
+    for m in ENTRY_RE.finditer(block):
+        c_name, dmf_name, description, args, retval = m.groups()
+        methods.append({
+            "c_name": c_name,
+            "dmf_name": dmf_name,
+            "description": description,
+            "args": args,
+            "retval": retval,
+        })
+    return methods
+
+
+def build_xml(methods):
+    root = ET.Element("dmf-stdlib-methods")
+    for method in methods:
+        method_el = ET.SubElement(root, "method",
+                                   {"name": method["dmf_name"],
+                                    "c_name": method["c_name"]})
+        ET.SubElement(method_el, "description").text = method["description"]
+        ET.SubElement(method_el, "args").text = method["args"]
+        ET.SubElement(method_el, "retval").text = method["retval"]
+    return root
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate an XML listing of dmf_stdlib methods "
+                    "from include/dmf_stdlib.h")
+    parser.add_argument(
+        "--header", default="include/dmf_stdlib.h",
+        help="Path to dmf_stdlib.h (default: %(default)s)")
+    parser.add_argument(
+        "--output", default="-",
+        help="Output file path, or '-' for stdout (default: %(default)s)")
+    args = parser.parse_args()
+
+    try:
+        methods = parse_methods(args.header)
+    except (OSError, ValueError) as e:
+        sys.stderr.write("ERROR: %s\n" % e)
+        return 1
+
+    if not methods:
+        sys.stderr.write("WARNING: no methods parsed from %s\n" % args.header)
+
+    root = build_xml(methods)
+    rough = ET.tostring(root, encoding="unicode")
+    pretty = MINIDOM.parseString(rough).toprettyxml(indent="  ")
+
+    if args.output == "-":
+        sys.stdout.write(pretty)
+    else:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(pretty)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -45,6 +45,7 @@ $(top_builddir)/include/nut_version.h \
 $(top_builddir)/common/libcommonversion.la \
 $(top_builddir)/drivers/libdummy_mockdrv.la \
 $(top_builddir)/common/libnutconf.la \
+$(top_builddir)/common/libnutdmfstdlib.la \
 $(top_builddir)/common/libcommonclient.la \
 $(top_builddir)/common/libcommon.la \
 $(top_builddir)/common/libparseconf.la \
@@ -64,6 +65,7 @@ if ENABLE_SHARED_PRIVATE_LIBS
 
 $(top_builddir)/common/libcommonversion-private.la \
 $(top_builddir)/common/libnutprivate-@NUT_SOURCE_GITREV_SEMVER_UNDERSCORES@-common-all.la \
+$(top_builddir)/common/libnutprivate-@NUT_SOURCE_GITREV_SEMVER_UNDERSCORES@-drivers-dmfstdlib.la \
 $(top_builddir)/common/libnutprivate-@NUT_SOURCE_GITREV_SEMVER_UNDERSCORES@-common-client.la: dummy @dotMAKE@
 	+@cd $(@D) && $(MAKE) $(AM_MAKEFLAGS) $(@F)
 
@@ -78,6 +80,9 @@ $(top_builddir)/clients/libupsclient.la: $(top_builddir)/common/libnutprivate-@N
 
 NUT_LIBCOMMON = $(top_builddir)/common/libnutprivate-@NUT_SOURCE_GITREV_SEMVER_UNDERSCORES@-common-all.la
 
+# Shared "standard library" of DMF-related data-conversion helpers (see common/dmf_stdlib.c)
+LDADD_DMFSTDLIB = $(top_builddir)/common/libnutprivate-@NUT_SOURCE_GITREV_SEMVER_UNDERSCORES@-drivers-dmfstdlib.la
+
 else !ENABLE_SHARED_PRIVATE_LIBS
 
 $(top_builddir)/drivers/libdummy_mockdrv.la: $(top_builddir)/common/libcommon.la $(top_builddir)/common/libcommonversion.la $(top_builddir)/common/libparseconf.la
@@ -86,6 +91,9 @@ $(top_builddir)/clients/libnutclient.la: $(top_builddir)/common/libcommonclient.
 $(top_builddir)/clients/libupsclient.la: $(top_builddir)/common/libcommonclient.la $(top_builddir)/include/nut_version.h
 
 NUT_LIBCOMMON = $(top_builddir)/common/libcommon.la
+
+# Shared "standard library" of DMF-related data-conversion helpers (see common/dmf_stdlib.c)
+LDADD_DMFSTDLIB = $(top_builddir)/common/libnutdmfstdlib.la
 
 endif !ENABLE_SHARED_PRIVATE_LIBS
 


### PR DESCRIPTION
After some analysis, a lot of active data manipulations can be done by relatively few methods predefined in C and used in classic mappings same as in DMF variants -- to the point that many use-cases would not employ LUA at all.

This PR reshuffles related code and recipes to aid in this effort (there would be more work to actually benefit from this in XML DMF handling). Burned through a month's allowance in CoPilot already in the first couple of days, and another in the last day of August, so maybe will follow up much later or find another provider to pick up the torch. Still, thanks to GitHub for sponsoring maintainers to have an allowance at all.
* To this effect, this would build upon #3615 with attempts at making use of the baseline changes and code de-duplication made there.

This PR also fixes a couple of potential memory errors in older DMF code, found while CoPilot read through the feature code.