### PR TITLE
NUT-Monitor: fix AttributeError (and abort) in automatic reconnection [#3509, #3530]

### DIFF
--- a/scripts/python/app/NUT-Monitor-py2gtk2.in
+++ b/scripts/python/app/NUT-Monitor-py2gtk2.in
@@ -1301,7 +1301,7 @@ class gui_updater( threading.Thread ) :
             ac = PyNUT.AuthConf.getAuthConf(host=host, port=port, user=login)
             if ac:
                 ac = ac.clone()
-                if self.__widgets["ups_authentication_check"].get_active() :
+                if self.__parent_class._interface__widgets["ups_authentication_check"].get_active() :
                     # If the user entered something, honor that.
                     # Otherwise, re-use what we suggested.
                     ac.user = login

--- a/scripts/python/app/NUT-Monitor-py3qt5.in
+++ b/scripts/python/app/NUT-Monitor-py3qt5.in
@@ -1352,7 +1352,7 @@ class gui_updater :
             ac = PyNUT.AuthConf.getAuthConf(host=host, port=port, user=login)
             if ac:
                 ac = ac.clone()
-                if self.__widgets["ups_authentication_check"].isChecked() :
+                if self.__parent_class._interface__widgets["ups_authentication_check"].isChecked() :
                     # If the user entered something, honor that.
                     # Otherwise, re-use what we suggested.
                     ac.user = login

--- a/scripts/python/app/NUT-Monitor-py3qt6.in
+++ b/scripts/python/app/NUT-Monitor-py3qt6.in
@@ -1378,7 +1378,7 @@ class gui_updater :
             ac = PyNUT.AuthConf.getAuthConf(host=host, port=port, user=login)
             if ac:
                 ac = ac.clone()
-                if self.__widgets["ups_authentication_check"].isChecked() :
+                if self.__parent_class._interface__widgets["ups_authentication_check"].isChecked() :
                     # If the user entered something, honor that.
                     # Otherwise, re-use what we suggested.
                     ac.user = login


### PR DESCRIPTION
## Summary

The automatic reconnection added in #3530 crashes instead of reconnecting.
`gui_updater.__attempt_reconnect()` reads `self.__widgets[...]`, but that
attribute belongs to the `interface` class; inside `gui_updater` Python
name-mangles it to `_gui_updater__widgets`, which does not exist. The
surrounding lines already use `self.__parent_class._interface__widgets`,
so this PR does the same on the one remaining line, in the py3qt6, py3qt5
and py2gtk2 variants.

## How to reproduce (master, 59fad7a97)

1. Start `NUT-Monitor-py3qt6` connected to a local `upsd`.
2. `systemctl restart nut-server` (or any way of closing the client socket).
3. The reconnection timer fires and the process aborts:

```
Traceback (most recent call last):
  File ".../NUT-Monitor-py3qt6", line 1381, in __attempt_reconnect
    if self.__widgets["ups_authentication_check"].isChecked() :
AttributeError: 'gui_updater' object has no attribute '_gui_updater__widgets'
```

With PyQt an exception escaping a slot becomes `qFatal()`, so the GUI dies
with SIGABRT (core dump present) rather than showing an error.

With the fix, the same steps reconnect within ~2 s (new client socket on
`upsd`, status icon back to on-line, tooltip refreshing).

## Tested on

Arch Linux, Python 3.14, PyQt6 6.11 / Qt 6.11.2, `nut` 2.8.5 server,
CyberPower-based (Salicru) UPS over `usbhid-ups`. Only the py3qt6 variant
was run; py3qt5 and py2gtk2 carry the identical line and get the identical
change.

## Checklist

- [x] Described the changes in the PR submission
- [x] Single functional commit, no style changes
- [x] AI tooling disclosed: the diagnosis, fix and test were done with
      Claude Code (Anthropic) and verified by me on real hardware
- [x] Commit is Signed-off-by (DCO)
