### PR TITLE
mge-hid: add Eaton 5P Gen2 models to mge_model_names

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -248,6 +248,11 @@ https://github.com/networkupstools/nut/milestone/13
       were unaffected. [PR #3555]
     * `mge-hid` subdriver updated to suppress `CHRG` status on constant-charge
       mode devices when battery is fully charged. [issue #3518, PR #3519]
+    * `mge-hid` subdriver: extended the `mge_model_names[]` list for the
+      Eaton 5P Gen2 series (largely guessing, feedback and PRs for
+      adaptation to actual string values reported by devices via USB are
+      welcome), so these devices would now report `battery.voltage` and
+      `battery.voltage.nominal`. [#2380]
     * `cps-hid` subdriver: widened under-declared Logical Maximums for
       `UPS.Input.Voltage`, `UPS.Input.ConfigVoltage`, `UPS.PowerSummary.Voltage`
       and `UPS.PowerSummary.ConfigVoltage` on CyberPower HID devices (e.g.

--- a/drivers/mge-hid.c
+++ b/drivers/mge-hid.c
@@ -52,7 +52,7 @@
 # endif
 #endif	/* WIN32 */
 
-#define MGE_HID_VERSION		"MGE HID 1.60"
+#define MGE_HID_VERSION		"MGE HID 1.61"
 
 /* (prev. MGE Office Protection Systems, prev. MGE UPS SYSTEMS) */
 /* Eaton */
@@ -1830,6 +1830,20 @@ static models_name_t mge_model_names [] =
 	{ "Eaton 5P", "850", EATON_5P, "5P 850" },
 	{ "Eaton 5P", "1150", EATON_5P, "5P 1150" },
 	{ "Eaton 5P", "1550", EATON_5P, "5P 1550" },
+
+	/* Eaton 5P Gen2, names assumed per VA numbers and form factors
+	 * ("iR" rack, "i" tower) of the Gen2 range; see also
+	 * https://github.com/networkupstools/nut/issues/2380
+	 * Fixes for actual product/model names reported via USB are welcome
+	 */
+	{ "Eaton 5P", "650iR G2", EATON_5P, NULL },
+	{ "Eaton 5P", "850iR G2", EATON_5P, NULL },
+	{ "Eaton 5P", "1150iR G2", EATON_5P, NULL },
+	{ "Eaton 5P", "1550iR G2", EATON_5P, NULL },
+	{ "Eaton 5P", "650i G2", EATON_5P, NULL },
+	{ "Eaton 5P", "850i G2", EATON_5P, NULL },
+	{ "Eaton 5P", "1150i G2", EATON_5P, NULL },
+	{ "Eaton 5P", "1550i G2", EATON_5P, NULL },
 
 	/* Eaton 5PX, names assumed per VA numbers in
 	 * https://www.eaton.com/gb/en-gb/catalog/backup-power-ups-surge-it-power-distribution/eaton-5px-ups-emea.html#tab-2


### PR DESCRIPTION
Adds the Eaton 5P Gen2 model strings to `mge_model_names[]`.

The Gen2 units report `iModel` strings like "650iR G2", which match no entry in the table, so `mge_type` stays `MGE_DEFAULT`. Both `mge_battery_voltage_fun()` and `mge_battery_voltage_nominal_fun()` return NULL for unknown types, so `battery.voltage` and `battery.voltage.nominal` are dropped although `UPS.PowerSummary.Voltage` and `.ConfigVoltage` are parsed fine. Same mechanism as #2380, different models.

Tested against an Eaton 5P 650iR G2 (`0463:ffff`, iProduct "Eaton 5P", firmware 00.04.0015). Before the change:

    get_model_name(Eaton 5P, 650iR G2)
    [D2] Path: UPS.PowerSummary.Voltage, Type: Feature, ReportID: 0x07,
         Offset: 40, Size: 16, Value: 13.7
    [D5] Lookup [13.7] failed for [battery.voltage]

so `upsc` showed `device.model: Eaton 5P 650iR G2` (the concatenation fallback, i.e. nothing matched) and no `battery.voltage`. After the change both `battery.voltage` and `battery.voltage.nominal` are reported.

Only "650iR G2" is confirmed from hardware. The other entries are guesses at the VA ratings and the rack ("iR") / tower ("i") form factors of the Gen2 range, similarly as the existing 5PX and 5SC blocks. Corrections from anyone with other Gen2 units are welcome. Names are left NULL so `ups.model` keeps the `iProduct` + `iModel` concatenation.

Checklist notes:

* `MGE_HID_VERSION` bumped to "MGE HID 1.61".
* `NEWS.adoc` bullet added; `make spellcheck` clean, no `docs/nut.dict` change.
* `data/driver.list.in` untouched: Eaton "5P" / "USB port" / `usbhid-ups` is already listed at series level.
* `scripts/upower/95-upower-hid.hwdb` untouched: `usb:v0463pFFFF*` is already covered.

Happy to post a NUT DDL dump for this unit if that is useful.

AI disclosure per the template: the initial debug (why the voltage isn't showing) also as the initial draft of the patch was done using Claude Code (Claude Opus 5) and reviewed and tuned manually. The hardware evidence above is from my own unit.