### PR TITLE
PyNUT: restore socket cleanup in disconnect()

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -22,6 +22,10 @@ PLANNED: Release notes for NUT 2.8.6 - what's new since 2.8.5
 
 https://github.com/networkupstools/nut/milestone/13
 
+ - `PyNUTClient.disconnect()` now attempts to send `LOGOUT`, closes the
+   socket and clears its reference while the client remains alive. Cleanup
+   remains harmless when repeated or when socket operations fail. [issue #3619]
+
  - (expected) Dynamic Mapping Files (DMF) feature supported, to allow
    the driver binaries to be built once and data mappings to be loaded
    and modernized on the fly (porting from 42ITy project)

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -22,10 +22,6 @@ PLANNED: Release notes for NUT 2.8.6 - what's new since 2.8.5
 
 https://github.com/networkupstools/nut/milestone/13
 
- - `PyNUTClient.disconnect()` now attempts to send `LOGOUT`, closes the
-   socket and clears its reference while the client remains alive. Cleanup
-   remains harmless when repeated or when socket operations fail. [issue #3619]
-
  - (expected) Dynamic Mapping Files (DMF) feature supported, to allow
    the driver binaries to be built once and data mappings to be loaded
    and modernized on the fly (porting from 42ITy project)
@@ -509,6 +505,10 @@ https://github.com/networkupstools/nut/milestone/13
       query (for protocol version) to verify that handshake succeeded.
       This change impacted also the classic C `libupsclient` library.
       [issue #3387, PR #3402]
+    * `PyNUTClient.disconnect()` now attempts to send `LOGOUT`, closes the
+      socket and clears its reference while the client remains alive. Such
+      cleanup remains harmless when repeated or when socket operations fail.
+      [issue #3619, PR #3627]
     * Updated OpenSSL code paths in the `libupsclient` C library to support
       features earlier only available with NSS builds, like specifying the
       client certificate+key, optionally with password, and pinning expected

--- a/scripts/python/module/Makefile.am
+++ b/scripts/python/module/Makefile.am
@@ -14,6 +14,11 @@
 all: PyNUTClient
 
 check-local:
+	@if test -n "$(PYTHON_DEFAULT)" && test "$(PYTHON_DEFAULT)" != no; then \
+		$(PYTHON_DEFAULT) "$(builddir)/test_nutclient.py" --disconnect ; \
+	else \
+		echo "Skipping Python disconnect tests: no Python interpreter configured" ; \
+	fi
 	@echo "You may want to set up a NUT data server and run 'make tox' here: `pwd`"
 
 # NOT tying into "make check" because a lot of stars must align for this test:

--- a/scripts/python/module/PyNUT.py.in
+++ b/scripts/python/module/PyNUT.py.in
@@ -815,7 +815,7 @@ certhost    : Optional dict or list of dict/lists: {hostname: [certname, certver
 
     def disconnect(self):
         """ Disconnects from the server cleanly """
-        if hasattr(self, '__srv_handler') and self.__srv_handler:
+        if self.__srv_handler:
             try:
                 self.__send(b"LOGOUT\n")
             except:

--- a/scripts/python/module/test_nutclient.py.in
+++ b/scripts/python/module/test_nutclient.py.in
@@ -7,8 +7,13 @@ import PyNUT
 import sys
 import os
 import socket
-import unittest
 
+HAVE_UNITTEST = False
+try:
+    import unittest
+    HAVE_UNITTEST = True
+except ModuleNotFoundError as ignored:
+    pass
 
 class DisconnectSocket:
     """ Record cleanup attempts, including operations which fail. """
@@ -31,7 +36,8 @@ class DisconnectSocket:
         return b"ERR ACCESS-DENIED\n"
 
 
-class DisconnectTest(unittest.TestCase):
+if HAVE_UNITTEST:
+  class DisconnectTest(unittest.TestCase):
     def check_cleanup(self, send_error=False, close_error=False, destructor=False):
         client = PyNUT.PyNUTClient(connect_now=False)
         sock = DisconnectSocket(send_error, close_error)
@@ -158,9 +164,12 @@ class DisconnectTest(unittest.TestCase):
 
 
 def testsuite_disconnect():
-    suite = unittest.TestLoader().loadTestsFromTestCase(DisconnectTest)
-    return unittest.TextTestRunner(verbosity=2).run(suite).wasSuccessful()
-
+    if HAVE_UNITTEST:
+        suite = unittest.TestLoader().loadTestsFromTestCase(DisconnectTest)
+        return unittest.TextTestRunner(verbosity=2).run(suite).wasSuccessful()
+    else:
+        print("SKIP: testsuite_disconnect(): module unittest is not available")
+        return 1
 
 def test_splitaddr(addr, expected_host, expected_port):
     ac = PyNUT.AuthConf(addr)

--- a/scripts/python/module/test_nutclient.py.in
+++ b/scripts/python/module/test_nutclient.py.in
@@ -6,6 +6,160 @@
 import PyNUT
 import sys
 import os
+import socket
+import unittest
+
+
+class DisconnectSocket:
+    """ Record cleanup attempts, including operations which fail. """
+    def __init__(self, send_error=False, close_error=False):
+        self.events = []
+        self.send_error = send_error
+        self.close_error = close_error
+
+    def sendall(self, data):
+        self.events.append(data)
+        if self.send_error:
+            raise socket.error("send failed")
+
+    def close(self):
+        self.events.append("close")
+        if self.close_error:
+            raise socket.error("close failed")
+
+    def recv(self, size):
+        return b"ERR ACCESS-DENIED\n"
+
+
+class DisconnectTest(unittest.TestCase):
+    def check_cleanup(self, send_error=False, close_error=False, destructor=False):
+        client = PyNUT.PyNUTClient(connect_now=False)
+        sock = DisconnectSocket(send_error, close_error)
+        client._PyNUTClient__srv_handler = sock
+        if destructor:
+            client.__del__()
+        else:
+            client.disconnect()
+        self.assertEqual(sock.events, [b"LOGOUT\n", "close"])
+        self.assertEqual(client._PyNUTClient__srv_handler, None)
+        client.disconnect()
+        client.__del__()
+        self.assertEqual(sock.events, [b"LOGOUT\n", "close"])
+
+    def test_retained_client(self):
+        self.check_cleanup()
+
+    def test_send_failure(self):
+        self.check_cleanup(send_error=True)
+
+    def test_close_failure(self):
+        self.check_cleanup(close_error=True)
+
+    def test_send_and_close_failure(self):
+        self.check_cleanup(send_error=True, close_error=True)
+
+    def test_destructor(self):
+        for send_error in [False, True]:
+            for close_error in [False, True]:
+                self.check_cleanup(send_error, close_error, destructor=True)
+
+    def test_deferred_client(self):
+        client = PyNUT.PyNUTClient(connect_now=False)
+        client.disconnect()
+        client.__del__()
+        self.assertEqual(client._PyNUTClient__srv_handler, None)
+
+    def test_partial_initialization(self):
+        class PartialClient(PyNUT.PyNUTClient):
+            def __init__(self):
+                pass
+        client = PartialClient()
+        # Before an instance socket is assigned, the class default is None.
+        self.assertFalse('_PyNUTClient__srv_handler' in client.__dict__)
+        client.disconnect()
+        client.__del__()
+
+    def test_socket_is_none(self):
+        client = PyNUT.PyNUTClient(connect_now=False)
+        client._PyNUTClient__srv_handler = None
+        client.disconnect()
+        client.__del__()
+        self.assertEqual(client._PyNUTClient__srv_handler, None)
+
+    def test_subclass(self):
+        class Client(PyNUT.PyNUTClient):
+            __srv_handler = None
+        client = Client(connect_now=False)
+        sock = DisconnectSocket()
+        client._PyNUTClient__srv_handler = sock
+        client.disconnect()
+        self.assertEqual(sock.events, [b"LOGOUT\n", "close"])
+        self.assertEqual(client._PyNUTClient__srv_handler, None)
+
+    def test_connection_failure(self):
+        def fail_connect(*args):
+            raise socket.error("connection failed")
+        create_connection = socket.create_connection
+        client = PyNUT.PyNUTClient(connect_now=False)
+        try:
+            socket.create_connection = fail_connect
+            self.assertRaises(socket.error, client.__init__)
+            client.disconnect()
+            client.__del__()
+            self.assertEqual(client._PyNUTClient__srv_handler, None)
+        finally:
+            socket.create_connection = create_connection
+
+    def test_authentication_failure(self):
+        sock = DisconnectSocket()
+        create_connection = socket.create_connection
+        client = PyNUT.PyNUTClient(connect_now=False)
+        try:
+            socket.create_connection = lambda *args: sock
+            self.assertRaises(PyNUT.PyNUTError, client.__init__, login="test")
+            client.__del__()
+            self.assertEqual(sock.events, [b"USERNAME test\n", b"LOGOUT\n", "close"])
+            self.assertEqual(client._PyNUTClient__srv_handler, None)
+        finally:
+            socket.create_connection = create_connection
+
+    def test_local_socket(self):
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        client = None
+        peer = None
+        sock = None
+        try:
+            listener.settimeout(3)
+            listener.bind(('127.0.0.1', 0))
+            listener.listen(1)
+            client = PyNUT.PyNUTClient(host='127.0.0.1',
+                port=listener.getsockname()[1], timeout=3, tracking=None)
+            peer, addr = listener.accept()
+            peer.settimeout(3)
+            sock = client._PyNUTClient__srv_handler
+            client.disconnect()
+            self.assertRaises(socket.error, sock.getpeername)
+            self.assertEqual(client._PyNUTClient__srv_handler, None)
+            data = b''
+            while True:
+                chunk = peer.recv(32)
+                if not chunk:
+                    break
+                data += chunk
+            self.assertEqual(data, b"LOGOUT\n")
+            client.disconnect()
+            client.__del__()
+        finally:
+            if sock is not None:
+                sock.close()
+            if peer is not None:
+                peer.close()
+            listener.close()
+
+
+def testsuite_disconnect():
+    suite = unittest.TestLoader().loadTestsFromTestCase(DisconnectTest)
+    return unittest.TextTestRunner(verbosity=2).run(suite).wasSuccessful()
 
 
 def test_splitaddr(addr, expected_host, expected_port):
@@ -43,6 +197,12 @@ def testsuite_splitaddr():
     return True
 
 if __name__ == "__main__" :
+    if not testsuite_disconnect():
+        sys.exit(1)
+    # Run the self-contained cleanup tests without requiring a NUT server.
+    if '--disconnect' in sys.argv:
+        sys.exit(0)
+
     NUT_HOST = os.getenv('NUT_HOST', '127.0.0.1')
     NUT_PORT = int(os.getenv('NUT_PORT', '3493'))
     NUT_USER = os.getenv('NUT_USER', None)


### PR DESCRIPTION
Calling `disconnect()` on a retained `PyNUTClient` leaves its socket open:
the literal name passed to `hasattr()` does not undergo Python's private
name mangling. Read the existing class attribute directly so the existing
LOGOUT, close and reference cleanup code runs. Its class-level `None`
default covers deferred and partial initialization; send and close errors
remain independently suppressed.

Add 12 regression tests to the existing Python test script and run them
from `make check`, without requiring an external NUT server. They cover
cleanup order, repeat calls, explicit destructor calls, subclasses,
connection/authentication failures, send/close failures, and real loopback
transmission and closure. The same script continues to run the existing
server integration tests. Add a release-note entry; no public API,
dependency, version or hardware-support change is intended.

Closes: #3619

Validation:

- The final regression suite fails 8/12 tests on unmodified upstream
  `ab687a162ad99d2c687c48f02b498845f69c4d91`, including absent LOGOUT/close
  events and the retained open socket. All 12 pass with the fix.
- Linux ARM64: Python 2.6.9, 2.7.18, 3.5.10, 3.6.15, 3.7.17, 3.8.20,
  3.9.25, 3.10.21, 3.11.16, 3.12.14, 3.13.15 and 3.14.7 pass.
  macOS ARM64: Python 3.9.6 and 3.14.7 pass.
- Supplementary IPv6, verified localhost TLS, failed STARTTLS setup and
  cipher-fallback cleanup tests pass on Linux and macOS.
- Locally built `upsd` and `dummy-ups`: retained plain/TLS clients release
  their sockets and logged-in sessions after explicit/destructor cleanup;
  replacement clients reconnect. The existing Python script passes on
  Python 2.6.9 and 3.11.15. The NUT Python integration harness passes
  4 groups with no failures or skips.
- Generated modules, locally installed wheel and source distribution,
  and staged NUT install pass. Source-package installation and its installed
  tests also pass on Python 2.6.9 using setuptools 36.8.0.
- The broad Linux build, `make check` (including 12 Automake tests),
  `make stylecheck`, `make spellcheck` and `make distcheck-light` pass.
  The final distribution check generates real man pages and HTML and
  exercises the extracted archive's build, tests, install/uninstall and
  cleanup. The four changed source files match that archive exactly.

No physical UPS hardware was available for testing. Validation covered
deterministic socket tests, real localhost TCP/TLS connections, and locally
built `upsd` with simulated `dummy-ups` devices.
Physical UPS models, firmware versions, and hardware combinations were
not tested.

Windows was not executed. Python 2.6 uses the plain socket path because
this module disables SSL on runtimes without `ssl.create_default_context`.

Relevant checklist:

- [x] Concrete behavior, compatibility expectations and limitations described.
- [x] Focused change; existing templates and test/distribution infrastructure used.
- [x] New source comments and release-note text use ASCII.
- [x] NEWS entry added; no driver, manual/API or UPGRADING change required.
- [x] Build, tests, package/install, spelling/style and distcheck-light pass.
- [x] AI use and model disclosed.
- [x] Human contributor review and acceptance of responsibility completed.

AI assistance: OpenAI Codex with gpt-6-astra (x-high reasoning).
The human contributor remains responsible for reviewing and submitting
the change.
