### PR TITLE
PyNUT: use command identifiers in description requests

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -42,6 +42,10 @@ https://github.com/networkupstools/nut/milestone/13
    to patterns defined in link:docs/nut-names.txt[]
 
  - Fix fallout of development in NUT v2.8.0 through v2.8.5:
+    * PyNUT: `GetUPSCommands()` now requests command descriptions with the
+      advertised identifiers on Python 3 and uses those identifiers when
+      extracting the response. Returned keys and descriptions remain byte
+      sequences. [issue #3621]
     * `nut-scanner` tool updates:
       - Mutexes used in parallelized scans were not properly released on
         failure code paths (impacts likely all 2.8.x until now). [PR #3551]

--- a/configure.ac
+++ b/configure.ac
@@ -3800,6 +3800,7 @@ if test x"${nut_with_nut_monitor}" != xno ; then
     fi
 fi
 
+dnl Options regarding NUT-Monitor GUI app:
 AC_MSG_CHECKING([if we can and should install NUT-Monitor desktop application])
 AS_IF([test x"${nut_enable_configure_debug}" = xyes], [
     AC_MSG_NOTICE([(CONFIGURE-DEVEL-DEBUG) nut_with_nut_monitor-4: ${nut_with_nut_monitor}])
@@ -3937,6 +3938,44 @@ if test "${nut_with_pynut}" = force ; then
     fi
 fi
 
+dnl Check test dependency for scripts handling the PyNUT module itself:
+nut_with_python_unittest_py2="no"
+nut_with_python_unittest_py3="no"
+nut_with_python_unittest_py="no"
+dnl NOTE: Maybe we would remove this "if" layer, if there would appear more
+dnl Pythonic things to `unittest` eventually (hence the abstracted varnames):
+if test "${nut_with_pynut}" = yes ; then
+    if test -n "${PYTHON2_VERSION_INFO_REPORT}" -a -n "${PYTHON2}" ; then
+        AC_MSG_CHECKING([if we have Python2 prerequisites for PyNUT unit testing])
+        if ${PYTHON2} -c "import unittest;" 1>&5 2>&5 ; then
+            nut_with_python_unittest_py2="yes"
+            AC_MSG_RESULT([yes])
+        else
+            AC_MSG_RESULT([no])
+        fi
+    fi
+
+    if test -n "${PYTHON3_VERSION_INFO_REPORT}" -a -n "${PYTHON3}" ; then
+        AC_MSG_CHECKING([if we have Python3 prerequisites for PyNUT unit testing])
+        if ${PYTHON3} -c "import unittest;" 1>&5 2>&5 ; then
+            nut_with_python_unittest_py3="yes"
+            AC_MSG_RESULT([yes])
+        else
+            AC_MSG_RESULT([no])
+        fi
+    fi
+
+    if test -n "${PYTHON_VERSION_INFO_REPORT}" -a -n "${PYTHON}" ; then
+        AC_MSG_CHECKING([if we have Python (default version) prerequisites for PyNUT unit testing])
+        if ${PYTHON} -c "import unittest;" 1>&5 2>&5 ; then
+            nut_with_python_unittest_py="yes"
+            AC_MSG_RESULT([yes])
+        else
+            AC_MSG_RESULT([no])
+        fi
+    fi
+fi
+
 NUT_REPORT_PROGRAM([install NUT-Monitor desktop application], [${nut_with_nut_monitor}], [],
 					[WITH_NUT_MONITOR], [Define to enable NUT-Monitor desktop application installation])
 
@@ -3955,6 +3994,11 @@ AM_CONDITIONAL(WITH_PYNUT_PY,  test "${nut_with_pynut_py}" = "yes"  -a "${nut_wi
 AM_CONDITIONAL(WITH_PYNUT_PY2, test "${nut_with_pynut_py2}" = "yes" -a "${nut_with_pynut}" = yes)
 AM_CONDITIONAL(WITH_PYNUT_PY3, test "${nut_with_pynut_py3}" = "yes" -a "${nut_with_pynut}" = yes)
 AM_CONDITIONAL(WITH_PYNUT_APP, test "${nut_with_pynut}" = "app")
+
+dnl Can and should we test the module here?
+AM_CONDITIONAL(WITH_PYNUT_UNITTEST_PY,  test "${nut_with_python_unittest_py}" = "yes"  -a "${nut_with_pynut}" = yes)
+AM_CONDITIONAL(WITH_PYNUT_UNITTEST_PY2, test "${nut_with_python_unittest_py2}" = "yes" -a "${nut_with_pynut}" = yes)
+AM_CONDITIONAL(WITH_PYNUT_UNITTEST_PY3, test "${nut_with_python_unittest_py3}" = "yes" -a "${nut_with_pynut}" = yes)
 
 AC_SUBST([nut_with_nut_monitor_dir], [${nut_with_nut_monitor_dir}])
 AC_SUBST([nut_with_nut_monitor_py2gtk2], [${nut_with_nut_monitor_py2gtk2}])

--- a/configure.ac
+++ b/configure.ac
@@ -3938,14 +3938,15 @@ if test "${nut_with_pynut}" = force ; then
     fi
 fi
 
-dnl Check test dependency for scripts handling the PyNUT module itself:
+dnl Check test dependency only for interpreters with PyNUT prerequisites.
+dnl A default interpreter shared with Python2 or Python3 is tested there.
 nut_with_python_unittest_py2="no"
 nut_with_python_unittest_py3="no"
 nut_with_python_unittest_py="no"
 dnl NOTE: Maybe we would remove this "if" layer, if there would appear more
 dnl Pythonic things to `unittest` eventually (hence the abstracted varnames):
 if test "${nut_with_pynut}" = yes ; then
-    if test -n "${PYTHON2_VERSION_INFO_REPORT}" -a -n "${PYTHON2}" ; then
+    if test "${nut_with_pynut_py2}" = yes ; then
         AC_MSG_CHECKING([if we have Python2 prerequisites for PyNUT unit testing])
         if ${PYTHON2} -c "import unittest;" 1>&5 2>&5 ; then
             nut_with_python_unittest_py2="yes"
@@ -3955,7 +3956,7 @@ if test "${nut_with_pynut}" = yes ; then
         fi
     fi
 
-    if test -n "${PYTHON3_VERSION_INFO_REPORT}" -a -n "${PYTHON3}" ; then
+    if test "${nut_with_pynut_py3}" = yes ; then
         AC_MSG_CHECKING([if we have Python3 prerequisites for PyNUT unit testing])
         if ${PYTHON3} -c "import unittest;" 1>&5 2>&5 ; then
             nut_with_python_unittest_py3="yes"
@@ -3965,7 +3966,7 @@ if test "${nut_with_pynut}" = yes ; then
         fi
     fi
 
-    if test -n "${PYTHON_VERSION_INFO_REPORT}" -a -n "${PYTHON}" ; then
+    if test "${nut_with_pynut_py}" = yes ; then
         AC_MSG_CHECKING([if we have Python (default version) prerequisites for PyNUT unit testing])
         if ${PYTHON} -c "import unittest;" 1>&5 2>&5 ; then
             nut_with_python_unittest_py="yes"

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3827 utf-8
+personal_ws-1.1 en 3828 utf-8
 AAC
 AAS
 ABI
@@ -3588,6 +3588,7 @@ uninstall
 uninterruptible
 uniq
 unistd
+unittest
 unix
 unmapped
 unmounts

--- a/scripts/python/README.adoc
+++ b/scripts/python/README.adoc
@@ -35,6 +35,12 @@ and protocol support.
 
 For one practical example, you can research `tests/NIT/nit.sh` in NUT sources.
 
+There is a separate `tests/pynut-commands-test.py` whose invocation for any
+currently configured Python version(s) is managed by `tests/Makefile.am`.
+These tests require the `unittest` Python module, which is usually available
+by default (we have seen only one build agent without it, for just one of its
+many Python versions installed).
+
 app
 ~~~
 

--- a/scripts/python/module/PyNUT.py.in
+++ b/scripts/python/module/PyNUT.py.in
@@ -1300,12 +1300,13 @@ of the command as value
 
             # For each var we try to get the available description
             try :
-                self.__send( ("GET CMDDESC %s %s\n" % ( ups, var )).encode('ascii') )
+                command = var.decode('ascii')
+                self.__send( ("GET CMDDESC %s %s\n" % ( ups, command )).encode('ascii') )
                 temp = self.__read_until( b"\n" )
                 if temp[:7] != b"CMDDESC" :
                     raise PyNUTError
                 else :
-                    off  = len( ("CMDDESC %s %s " % ( ups, var )).encode('ascii') )
+                    off  = len( ("CMDDESC %s %s " % ( ups, command )).encode('ascii') )
                     desc = temp[off:-1].split(b'"')[1]
             except :
                 desc = var

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -348,18 +348,42 @@ memcheck:
 endif !HAVE_VALGRIND
 
 CHECK_LOCAL_TARGETS = become-user-root-warning-test
-if HAVE_PYTHON_DEFAULT
-CHECK_LOCAL_TARGETS += pynut-commands-test
+CHECK_LOCAL_TARGETS_PYNUT =
 
-pynut-commands-test:
+if HAVE_PYTHON_DEFAULT
+if WITH_PYNUT_UNITTEST_PY
+CHECK_LOCAL_TARGETS_PYNUT += pynut-commands-test-default
+
+pynut-commands-test-default:
 	$(AM_V_at)PYTHONPATH='$(abs_top_builddir)/scripts/python/module' @PYTHON_DEFAULT@ $(srcdir)/pynut-commands-test.py
+endif WITH_PYNUT_UNITTEST_PY
 endif HAVE_PYTHON_DEFAULT
+
+if HAVE_PYTHON2
+if WITH_PYNUT_UNITTEST_PY2
+CHECK_LOCAL_TARGETS_PYNUT += pynut-commands-test-py2
+
+pynut-commands-test-py2:
+	$(AM_V_at)PYTHONPATH='$(abs_top_builddir)/scripts/python/module' @PYTHON2@ $(srcdir)/pynut-commands-test.py
+endif WITH_PYNUT_UNITTEST_PY2
+endif HAVE_PYTHON2
+
+if HAVE_PYTHON3
+if WITH_PYNUT_UNITTEST_PY3
+CHECK_LOCAL_TARGETS_PYNUT += pynut-commands-test-py3
+
+pynut-commands-test-py3:
+	$(AM_V_at)PYTHONPATH='$(abs_top_builddir)/scripts/python/module' @PYTHON3@ $(srcdir)/pynut-commands-test.py
+endif WITH_PYNUT_UNITTEST_PY3
+endif HAVE_PYTHON3
 
 if WITH_VALGRIND
 CHECK_LOCAL_TARGETS += memcheck
 endif WITH_VALGRIND
 
-check-local: $(CHECK_LOCAL_TARGETS)
+pynut-commands-test: $(CHECK_LOCAL_TARGETS_PYNUT)
+
+check-local: $(CHECK_LOCAL_TARGETS) $(CHECK_LOCAL_TARGETS_PYNUT)
 
 become-user-root-warning-test: $(top_builddir)/clients/upslog$(EXEEXT)
 	$(AM_V_at)UPSLOG='$(abs_top_builddir)/clients/upslog$(EXEEXT)' $(SHELL) $(srcdir)/become-user-root-warning-test.sh

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -17,6 +17,7 @@ all: $(TESTS) $(check_PROGRAMS) $(check_SCRIPTS)
 
 EXTRA_DIST = become-user-root-warning-test.sh nut-driver-enumerator-test.sh nut-driver-enumerator-test--ups.conf
 EXTRA_DIST += cppunit-warnings.h cppunit-warnings-end.h
+EXTRA_DIST += pynut-commands-test.py
 
 TESTS =
 noinst_LTLIBRARIES =
@@ -347,6 +348,13 @@ memcheck:
 endif !HAVE_VALGRIND
 
 CHECK_LOCAL_TARGETS = become-user-root-warning-test
+if HAVE_PYTHON_DEFAULT
+CHECK_LOCAL_TARGETS += pynut-commands-test
+
+pynut-commands-test:
+	$(AM_V_at)PYTHONPATH='$(abs_top_builddir)/scripts/python/module' @PYTHON_DEFAULT@ $(srcdir)/pynut-commands-test.py
+endif HAVE_PYTHON_DEFAULT
+
 if WITH_VALGRIND
 CHECK_LOCAL_TARGETS += memcheck
 endif WITH_VALGRIND

--- a/tests/pynut-commands-test.py
+++ b/tests/pynut-commands-test.py
@@ -1,0 +1,157 @@
+# Regression checks for PyNUT command enumeration (no running server needed).
+# Run with PYTHONPATH pointing to the configured scripts/python/module directory.
+
+import socket
+import unittest
+
+import PyNUT
+
+
+class TranscriptSocket(object):
+    """Only release a response after its exact request has been sent."""
+
+    def __init__(self, exchanges, chunk_size=50):
+        self.exchanges = exchanges
+        self.chunk_size = chunk_size
+        self.sent = []
+        self.pending = b''
+        self.read_error = None
+
+    def sendall(self, request):
+        index = len(self.sent)
+        self.sent.append(request)
+        expected, response = self.exchanges[index]
+        if request != expected:
+            raise AssertionError('Expected %r, received %r' % (expected, request))
+        if isinstance(response, Exception):
+            raise response
+        self.pending += response
+
+    def recv(self, size):
+        if self.read_error is not None and not self.pending:
+            raise self.read_error
+        size = min(size, self.chunk_size)
+        result, self.pending = self.pending[:size], self.pending[size:]
+        return result
+
+
+def command_list(names):
+    return (b'BEGIN LIST CMD dummy\n' +
+            b''.join([b'CMD dummy ' + name + b'\n' for name in names]) +
+            b'END LIST CMD dummy\n')
+
+
+def description_reply(name, description):
+    return b'CMDDESC dummy ' + name + b' "' + description + b'"\n'
+
+
+class CommandTests(unittest.TestCase):
+    def client(self, exchanges, chunk_size=50):
+        transport = TranscriptSocket(exchanges, chunk_size)
+        client = PyNUT.PyNUTClient(connect_now=False)
+        client._PyNUTClient__srv_handler = transport
+        return client, transport
+
+    def assert_requests(self, transport):
+        # GetUPSCommands catches even AssertionError during CMDDESC, so check
+        # the complete transcript outside the client's exception handler too.
+        self.assertEqual(transport.sent, [pair[0] for pair in transport.exchanges])
+        self.assertEqual(transport.pending, b'')
+
+    def test_descriptions(self):
+        pairs = [
+            (b'load.off', b'Turn off the load immediately'),
+            (b'test.panel.start', b'Start testing the UPS panel'),
+            (b'upstream.load.off', b'Turn off the load immediately'),
+            (b'outlet.1.load.off', b'Turn off this outlet'),
+            (b'driver.reload-or-error', b'Reload driver configuration'),
+            (b'test.panel.stop', b''),
+            (b'experimental.example', b'Description unavailable'),
+        ]
+        exchanges = [(b'LIST CMD dummy\n', command_list([p[0] for p in pairs]))]
+        for name, description in pairs:
+            exchanges.append((b'GET CMDDESC dummy ' + name + b'\n',
+                              description_reply(name, description)))
+        for chunk_size in (1, 7, 50):
+            client, transport = self.client(exchanges, chunk_size)
+            commands = client.GetUPSCommands('dummy')
+            self.assert_requests(transport)
+            self.assertEqual(commands, dict(pairs))
+            for name, description in commands.items():
+                self.assertEqual(type(name), bytes)
+                self.assertEqual(type(description), bytes)
+            # NUT-Monitor's Qt variants sort the keys and decode both fields.
+            labels = ['%s\n%s' % (name.decode('ascii'), commands[name].decode('ascii'))
+                      for name in sorted(commands.keys())]
+            self.assertTrue('test.panel.start\nStart testing the UPS panel' in labels)
+
+    def test_description_fallbacks(self):
+        name = b'test.panel.start'
+        for response in (b'ERR CMD-NOT-SUPPORTED\n', b'ERR DATA-STALE\n',
+                         b'WRONG response\n', b'CMDDESC\n',
+                         b'CMDDESC dummy test.panel.start missing-quotes\n'):
+            exchanges = [
+                (b'LIST CMD dummy\n', command_list([name, b'load.off'])),
+                (b'GET CMDDESC dummy test.panel.start\n', response),
+                (b'GET CMDDESC dummy load.off\n',
+                 description_reply(b'load.off', b'Turn off the load immediately')),
+            ]
+            client, transport = self.client(exchanges)
+            self.assertEqual(client.GetUPSCommands('dummy'),
+                             {name: name, b'load.off': b'Turn off the load immediately'})
+            self.assert_requests(transport)
+
+    def test_list_error(self):
+        client, transport = self.client([(b'LIST CMD dummy\n', b'ERR UNKNOWN-UPS\n')])
+        try:
+            client.GetUPSCommands('dummy')
+        except PyNUT.PyNUTError as error:
+            self.assertEqual(str(error), 'ERR UNKNOWN-UPS')
+        else:
+            self.fail('LIST CMD error did not propagate')
+        self.assert_requests(transport)
+
+    def test_list_transport_errors(self):
+        for response in (b'', b'BEGIN LIST CMD dummy\nCMD dummy load.off\n'):
+            client, transport = self.client([(b'LIST CMD dummy\n', response)])
+            self.assertRaises(EOFError, client.GetUPSCommands, 'dummy')
+            self.assert_requests(transport)
+        client, transport = self.client([(b'LIST CMD dummy\n', b'')])
+        transport.read_error = socket.timeout('read timed out')
+        self.assertRaises(socket.timeout, client.GetUPSCommands, 'dummy')
+        self.assert_requests(transport)
+        client, transport = self.client([(b'LIST CMD dummy\n', socket.error('send failed'))])
+        self.assertRaises(socket.error, client.GetUPSCommands, 'dummy')
+        self.assert_requests(transport)
+
+    def test_description_transport_errors(self):
+        name = b'load.off'
+        for response, read_error in ((b'', None), (b'', socket.timeout('read timed out')),
+                                     (socket.error('send failed'), None)):
+            exchanges = [
+                (b'LIST CMD dummy\n', command_list([name])),
+                (b'GET CMDDESC dummy load.off\n', response),
+            ]
+            client, transport = self.client(exchanges)
+            transport.read_error = read_error
+            self.assertEqual(client.GetUPSCommands('dummy'), {name: name})
+            self.assert_requests(transport)
+
+    def test_leftover_response(self):
+        # A coalesced LIST header/body leaves buffered data after the first
+        # line. Repeated calls must consume it without losing response boundaries.
+        name = b'load.off'
+        exchanges = [
+            (b'LIST CMD dummy\n', command_list([name])),
+            (b'GET CMDDESC dummy load.off\n', description_reply(name, b'Load off')),
+        ] * 2 + [(b'LIST UPS\n', b'BEGIN LIST UPS\nUPS dummy "Test device"\nEND LIST UPS\n')]
+        client, transport = self.client(exchanges)
+        for unused in range(2):
+            self.assertEqual(client.GetUPSCommands('dummy'), {name: b'Load off'})
+        self.assertEqual(client.GetUPSList(), {b'dummy': b'Test device'})
+        self.assert_requests(transport)
+        self.assertEqual(client._PyNUTClient__recv_leftover, b'')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/pynut-commands-test.py
+++ b/tests/pynut-commands-test.py
@@ -1,3 +1,6 @@
+# NOTE: No shebang, not marked executable. The Python interpreter setup and
+# execution is driven by NUT tests/Makefile.am goals. Works for Py2 and Py3.
+#
 # Regression checks for PyNUT command enumeration (no running server needed).
 # Run with PYTHONPATH pointing to the configured scripts/python/module directory.
 


### PR DESCRIPTION
Closes: #3621

On Python 3, `GetUPSCommands()` formats command names parsed from `LIST CMD`
as bytes representations, sending requests such as `GET CMDDESC dummy
b'load.off'`. Current `upsd` consequently returns "Description unavailable"
even though `load.off` has a description.

Decode the command identifier as ASCII for both the description request and
the response-prefix length. The returned dictionary retains its bytes keys
and values, and description errors retain the existing identifier fallback.
Add a request-sensitive regression test under `tests`, run it through
`make check`, and record the fix in `NEWS.adoc`.

Validation:

- The regression fails on unmodified Python 3 source and on a request-only
  fix; the complete fix passes on Python 2.6.9, 2.7.18, and 3.4 through 3.14.
- A fresh localhost `upsd` with `dummy-ups` advertises `load.off`. Against the
  same server, baseline returns "Description unavailable" and the patched
  client returns "Turn off the load immediately". Exact request bytes and
  separate unavailable/error controls were checked; no UPS commands ran.
- Generated-module, explicit-path install/uninstall, wheel-install and
  source-distribution-install checks passed. The existing suite passed
  12/12, plus all six new regression tests.
- `make spellcheck`, changed-line ASCII/whitespace checks, and normal
  `make distcheck-light` passed. The latter exercised the extracted archive's
  build, tests, installation, uninstallation and redistribution, using its
  standard placeholder handling for unselected manual pages.

No physical UPS hardware was available for testing. Validation covered
request-sensitive transport tests, Python runtime compatibility checks,
generated and packaged modules, build and distribution checks, and simulated
localhost integration with upsd and dummy-ups. Physical UPS models, firmware
versions, and hardware combinations were not tested.

AI assistance: OpenAI Codex with gpt-6-astra (x-high reasoning).
The human contributor remains responsible for reviewing and submitting
the change.

Relevant contribution checklist:

- [x] Described the concrete behavior, compatibility and testing limitations.
- [x] Disclosed AI use and model.
- [x] Followed affected-file style; added source text is ASCII.
- [x] Registered the new test in distribution metadata; distcheck-light passed.
- [x] Added a NEWS entry and passed spelling checks.
- [x] Human contributor has reviewed and accepted responsibility for the patch.
- [x] DCO sign-off included in each contribution commit.
