### PR TITLE
common: preserve case-only state value updates

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -439,6 +439,10 @@ https://github.com/networkupstools/nut/milestone/13
       not do so for single-driver runs -- addressed with this release. [#3302]
 
  - common code:
+    * The common state store now retains value changes which differ only in
+      letter case, including updates to opaque strings such as `device.contact`.
+      Variable names remain case-insensitive and immutable values remain
+      protected from changes. [issue #3622]
     * POSIX daemons now warn if their real or effective UID remains zero after
       the common credential switch. [issue #3471, PR #3609]
     * Refactored `common::background()` method used by numerous NUT daemons

--- a/common/state.c
+++ b/common/state.c
@@ -301,8 +301,8 @@ int state_setinfo(st_tree_t **nptr, const char *var, const char *val)
 		/* refresh even if "skip-writing" same info value */
 		st_tree_node_refresh_timestamp(node);
 
-		/* updating an existing entry */
-		if (!strcasecmp(node->raw, val)) {
+		/* Compare literal values; only variable names ignore case. */
+		if (!strcmp(node->raw, val)) {
 			return 0;	/* no change */
 		}
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -124,6 +124,10 @@ TESTS += nuttimetest
 nuttimetest_SOURCES = nuttimetest.c
 nuttimetest_LDADD = $(NUT_LIBCOMMON)
 
+TESTS += statetest
+statetest_SOURCES = statetest.c
+statetest_LDADD = $(NUT_LIBCOMMON)
+
 TESTS += ecoflow_cdc_protocol_utest
 ecoflow_cdc_protocol_utest_SOURCES = ecoflow_cdc_protocol_utest.c \
 	$(top_srcdir)/drivers/ecoflow-cdc-protocol.h

--- a/tests/NIT/nit.sh
+++ b/tests/NIT/nit.sh
@@ -2919,8 +2919,10 @@ generatecfg_ups_dummy() {
 
     cat > "$NUT_CONFPATH/dummy.seq" << EOF
 ups.status: OB
+device.contact: Operations
 TIMER 5
 ups.status: OL
+device.contact: operations
 TIMER 5
 EOF
     [ $? = 0 ] || die "Failed to populate temporary FS structure for the NIT: dummy.seq"
@@ -3649,6 +3651,34 @@ testcase_sandbox_upsc_query_model() {
         PASSED="`expr $PASSED + 1`"
         log_info "[testcase_sandbox_upsc_query_model] PASSED: got expected model from dummy device in JSON: $CMDOUT"
     fi
+}
+
+testcase_sandbox_upsc_query_case() {
+    log_info "[testcase_sandbox_upsc_query_case] Check successive case-only contact updates"
+    CASE_PREVIOUS=""
+    CASE_TRANSITIONS=0
+    CASE_TRIES=0
+    while [ "$CASE_TRIES" -lt 30 ]; do
+        runcmd upsc dummy@localhost:$NUT_PORT device.contact || die "[testcase_sandbox_upsc_query_case] upsc failed: $CMDOUT"
+        case "$CMDOUT" in
+            Operations|operations) ;;
+            *) break ;;
+        esac
+        if [ -n "$CASE_PREVIOUS" ] && [ x"$CMDOUT" != x"$CASE_PREVIOUS" ]; then
+            CASE_TRANSITIONS="`expr $CASE_TRANSITIONS + 1`"
+        fi
+        if [ "$CASE_TRANSITIONS" -ge 2 ]; then
+            PASSED="`expr $PASSED + 1`"
+            log_info "[testcase_sandbox_upsc_query_case] PASSED: contact changed case in both directions"
+            return
+        fi
+        CASE_PREVIOUS="$CMDOUT"
+        CASE_TRIES="`expr $CASE_TRIES + 1`"
+        sleep 1
+    done
+    log_error "[testcase_sandbox_upsc_query_case] Error: contact did not change case in both directions"
+    FAILED="`expr $FAILED + 1`"
+    FAILED_FUNCS="$FAILED_FUNCS testcase_sandbox_upsc_query_case"
 }
 
 testcase_sandbox_upsc_query_bogus() {
@@ -4710,6 +4740,7 @@ testgroup_sandbox() {
     testcase_sandbox_upsc_query_model
     testcase_sandbox_upsc_query_bogus
     testcase_sandbox_upsc_query_timer
+    testcase_sandbox_upsc_query_case
     testcases_sandbox_python
     testcases_sandbox_cppnit
     testcases_sandbox_perl

--- a/tests/statetest.c
+++ b/tests/statetest.c
@@ -121,6 +121,9 @@ static void check_strings(size_t numflags, char **flags, int expected_flags)
 	check(!strcmp(state_getinfo(root, "battery.charge"), "100"), "sibling corrupted");
 	check(node_count(root) == 5, "name matching created duplicate nodes");
 	node = state_tree_find(root, "DEVICE.CONTACT");
+	if (!node) {
+		fatalx(EXIT_FAILURE, "device.contact node missing");
+	}
 	check(!strcmp(node->var, "device.contact"), "stored variable name changed");
 
 	/* The internal immutable bit is set by driver override handling;

--- a/tests/statetest.c
+++ b/tests/statetest.c
@@ -1,0 +1,173 @@
+/* statetest.c - test value updates in the common NUT state store
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "config.h"
+#include "common.h"
+#include "state.h"
+
+static int failures;
+
+static void check(int condition, const char *message)
+{
+	if (!condition) {
+		upslogx(LOG_ERR, "%s", message);
+		failures++;
+	}
+}
+
+static size_t node_count(const st_tree_t *node)
+{
+	if (!node) {
+		return 0;
+	}
+	return 1 + node_count(node->left) + node_count(node->right);
+}
+
+static void update(st_tree_t **root, const char *name, const char *value,
+	int changed, const char *raw, const char *escaped)
+{
+	st_tree_t *before = state_tree_find(*root, name), *node;
+	st_tree_timespec_t start, finish;
+	int flags = before ? before->flags : 0;
+	long aux = before ? before->aux : 0;
+	const enum_t *enums = before ? before->enum_list : NULL;
+	const range_t *ranges = before ? before->range_list : NULL;
+	size_t count = node_count(*root);
+	int actual;
+
+	/* A sentinel proves refresh even when consecutive clock reads tie. */
+	if (before) {
+		memset(&before->lastset, 0, sizeof(before->lastset));
+	}
+	if (state_get_timestamp(&start) != 0) {
+		fatal_with_errno(EXIT_FAILURE, "read start time");
+	}
+	actual = state_setinfo(root, name, value);
+	if (state_get_timestamp(&finish) != 0) {
+		fatal_with_errno(EXIT_FAILURE, "read finish time");
+	}
+	node = state_tree_find(*root, name);
+	upslogx(LOG_INFO, "%s: input='%s', changed=%d, stored='%s'",
+		name, value, actual, node ? node->raw : "<missing>");
+	check(actual == changed, "unexpected change result");
+	check(node != NULL, "updated node missing");
+	if (!node) {
+		return;
+	}
+	check(!before || node == before, "existing node replaced");
+	check(node_count(*root) == count + (before ? 0 : 1), "tree size changed");
+	check(!strcmp(node->raw, raw), "raw value differs");
+	check(!strcmp(state_getinfo(*root, name), escaped), "escaped value differs");
+	check(node->rawsize >= strlen(node->raw) + 1, "raw capacity too small");
+	if (!strcmp(raw, escaped)) {
+		check(node->val == node->raw, "plain value does not use raw storage");
+	} else {
+		check(node->val == node->safe, "escaped value does not use safe storage");
+		check(node->safesize >= strlen(node->val) + 1, "escaped capacity too small");
+	}
+	check(node->flags == flags && node->aux == aux, "flags or aux changed");
+	check(node->enum_list == enums && node->range_list == ranges, "metadata lists changed");
+	check(st_tree_node_compare_timestamp(node, &start) >= 0, "timestamp not refreshed");
+	check(st_tree_node_compare_timestamp(node, &finish) <= 0, "timestamp after call");
+}
+
+static void check_strings(size_t numflags, char **flags, int expected_flags)
+{
+	st_tree_t *root = NULL;
+	st_tree_t *node;
+	const enum_t *enums;
+	const range_t *ranges;
+
+	update(&root, "device.contact", "Operations", 1, "Operations", "Operations");
+	state_setflags(root, "device.contact", numflags, flags);
+	check(state_getflags(root, "device.contact") == expected_flags, "set string flags");
+	check(state_setaux(root, "device.contact", "64") == 1, "set aux");
+	update(&root, "battery.type", "Lead", 1, "Lead", "Lead");
+	update(&root, "ups.model", "Model", 1, "Model", "Model");
+	update(&root, "battery.charge", "100", 1, "100", "100");
+	update(&root, "ups.serial", "Serial", 1, "Serial", "Serial");
+
+	update(&root, "DEVICE.CONTACT", "Operations", 0, "Operations", "Operations");
+	update(&root, "device.contact", "operations", 1, "operations", "operations");
+	update(&root, "device.contact", "operations", 0, "operations", "operations");
+	/* An ordinary change makes the reverse case test independent. */
+	update(&root, "device.contact", "Engineering", 1, "Engineering", "Engineering");
+	update(&root, "device.contact", "operations", 1, "operations", "operations");
+	update(&root, "Device.Contact", "Operations", 1, "Operations", "Operations");
+	update(&root, "device.contact", "Operations", 0, "Operations", "Operations");
+	update(&root, "device.contact", "Production", 1, "Production", "Production");
+	update(&root, "device.contact", "Ops", 1, "Ops", "Ops");
+	update(&root, "device.contact", "Operations department", 1,
+		"Operations department", "Operations department");
+	update(&root, "device.contact", "", 1, "", "");
+	update(&root, "device.contact", "", 0, "", "");
+	update(&root, "device.contact", "Ops \"A\"\\Desk", 1,
+		"Ops \"A\"\\Desk", "Ops \\\"A\\\"\\\\Desk");
+	update(&root, "device.contact", "ops \"a\"\\desk", 1,
+		"ops \"a\"\\desk", "ops \\\"a\\\"\\\\desk");
+	update(&root, "device.contact", "A longer \"quoted\"\\value", 1,
+		"A longer \"quoted\"\\value", "A longer \\\"quoted\\\"\\\\value");
+	update(&root, "device.contact", "Plain", 1, "Plain", "Plain");
+
+	update(&root, "BATTERY.TYPE", "lead", 1, "lead", "lead");
+	update(&root, "UPS.MODEL", "model", 1, "model", "model");
+	update(&root, "Ups.Serial", "serial", 1, "serial", "serial");
+	check(!strcmp(state_getinfo(root, "device.contact"), "Plain"), "root corrupted");
+	check(!strcmp(state_getinfo(root, "battery.charge"), "100"), "sibling corrupted");
+	check(node_count(root) == 5, "name matching created duplicate nodes");
+	node = state_tree_find(root, "DEVICE.CONTACT");
+	check(!strcmp(node->var, "device.contact"), "stored variable name changed");
+
+	/* The internal immutable bit is set by driver override handling;
+	 * state_setflags() does not receive this bit over the socket protocol. */
+	node->flags |= ST_FLAG_IMMUTABLE;
+	update(&root, "device.contact", "plain", 0, "Plain", "Plain");
+	update(&root, "DEVICE.CONTACT", "Other", 0, "Plain", "Plain");
+	update(&root, "device.contact", "Plain", 0, "Plain", "Plain");
+	node->flags &= ~ST_FLAG_IMMUTABLE;
+	update(&root, "device.contact", "\"A\"", 1, "\"A\"", "\\\"A\\\"");
+	node->flags |= ST_FLAG_IMMUTABLE;
+	update(&root, "device.contact", "\"a\"", 0, "\"A\"", "\\\"A\\\"");
+	update(&root, "device.contact", "Other", 0, "\"A\"", "\\\"A\\\"");
+
+	update(&root, "input.sensitivity", "Normal", 1, "Normal", "Normal");
+	check(state_addenum(root, "input.sensitivity", "Normal") == 1, "add enum");
+	check(state_addenum(root, "input.sensitivity", "Reduced") == 1, "add second enum");
+	enums = state_getenumlist(root, "input.sensitivity");
+	update(&root, "INPUT.SENSITIVITY", "Reduced", 1, "Reduced", "Reduced");
+	check(enums && !strcmp(enums->val, "Normal") && enums->next
+		&& !strcmp(enums->next->val, "Reduced"), "enum content changed");
+	check(state_addrange(root, "battery.charge", 0, 100) == 1, "add range");
+	ranges = state_getrangelist(root, "battery.charge");
+	update(&root, "BATTERY.CHARGE", "90", 1, "90", "90");
+	check(ranges && ranges->min == 0 && ranges->max == 100, "range content changed");
+	state_infofree(root);
+}
+
+int main(void)
+{
+	char *flags[] = { "STRING", "RW" };
+	char *number[] = { "NUMBER" };
+	st_tree_t *root = NULL;
+
+	check_strings(0, NULL, 0);
+	check_strings(1, flags, ST_FLAG_STRING);
+	check_strings(1, flags + 1, ST_FLAG_RW);
+	check_strings(2, flags, ST_FLAG_STRING | ST_FLAG_RW);
+	update(&root, "input.voltage", "120", 1, "120", "120");
+	state_setflags(root, "input.voltage", 1, number);
+	check(state_getflags(root, "input.voltage") == ST_FLAG_NUMBER, "set number flag");
+	update(&root, "input.voltage", "121", 1, "121", "121");
+	update(&root, "input.voltage", "9", 1, "9", "9");
+	update(&root, "input.voltage", "01200.2", 1, "01200.2", "01200.2");
+	update(&root, "input.voltage", "1200.20", 1, "1200.20", "1200.20");
+	update(&root, "input.voltage", "1200.20", 0, "1200.20", "1200.20");
+	state_infofree(root);
+	upslogx(LOG_INFO, "State update tests: %d failures", failures);
+	return failures ? EXIT_FAILURE : EXIT_SUCCESS;
+}


### PR DESCRIPTION
Changing a mutable `device.contact` from `Operations` to `operations` currently
returns unchanged, keeps the old value and suppresses the driver's SETINFO
publication. The server uses the same comparison when storing received updates.
Compare raw values byte-for-byte so the replacement is stored and published.

Variable-name matching and tree ordering remain case-insensitive. Immutable
values still reject replacements, and timestamps and metadata retain their
existing behavior. Drivers producing case-varying values will now publish those
changes; identical repeats remain suppressed. This is separate from the
IMMUTABLE propagation proposal in #2549.

Adds a regression linked to the actual common state library, an existing NIT
dummy sequence check for both case transitions, and a NEWS entry.

Closes: #3622

Validation:

- The original library regression failed on unmodified upstream `2caa3c875`
  for stale case-only values and passed after the fix. It covers flags, immutable
  values, metadata, timestamps, tree/name behavior, lengths and escaping.
- For the initial fix, GCC 14.2.0 and Clang 19.1.7 Linux builds with project
  warnings and -Werror passed, including real dummy-ups/snmp-ups builds and
  13/13 and 14/14 configured tests respectively. Apple Clang 21.0.0 passed
  9/9 macOS tests; its unrelated
  default-directory warning required a targeted compiler suppression.
- The initial state regression passed in GNU89 and strict C99 modes, against shared
  libraries under ASan/UBSan with leak detection, and under Valgrind with no
  reported errors or leaked blocks.
- Local NIT changes from 7 passing checks and one case-transition failure to
  8 passing checks. A separate real dummy-ups/upsd/upsc run observes timed
  publication, server/client capitalization, authenticated simulated SET VAR
  changes, and suppression of identical repeats on macOS and Linux.
- The test-only null-guard follow-up passes 9/9 macOS tests and 13/13 tests
  in the extracted Linux build. A forced missing-node lookup against the real
  library exits with status 1 and a clear diagnostic before dereferencing.
- Normal `make distcheck-light` passes, including the extracted build, tests,
  install/uninstall and cleanup. All five packaged files match the final patch.
  Full spellcheck, source style, shell syntax and diff whitespace checks pass.
  NEWS renders with one unchanged baseline linkman macro warning.

No physical UPS hardware was available for testing. Validation covered common
state-library regressions, compiler and memory checks, existing configured
tests, and real localhost dummy-ups/upsd/upsc integration with timed updates,
observed publication and simulated SET VAR round trips, plus distribution and
documentation checks. Physical UPS models, firmware versions, hardware write
behavior, and hardware combinations were not tested. The MGE mapping establishes
software applicability; no actual MGE write or publication is claimed.

Relevant checklist:

- [x] Behavior, scope, compatibility and testing described.
- [x] Maintained test sources registered for build and distribution.
- [x] Coding style/portability checked; NEWS updated.
- [x] AI use and model disclosed.
- [x] Human contributor review and acceptance of responsibility completed.
- [x] DCO sign-off authorized and included in the commit.

AI assistance: OpenAI Codex with gpt-6-astra (x-high reasoning).
The human contributor remains responsible for reviewing and submitting
the change.
