### PR TITLE
upsd: validate numeric configuration values

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -608,6 +608,11 @@ https://github.com/networkupstools/nut/milestone/13
     * Added a `clean_exit()` handler similar to that in `upsmon`. [PR #3499]
 
  - `upsd` data server updates:
+    * Validate complete numeric values and conversion ranges for `MAXAGE`,
+      `TRACKINGDELAY`, `MAXCONN` and `CERTREQUEST` in `upsd.conf`, retaining
+      the previous setting when conversion fails. Preserve public types
+      and avoid overflow in the `MAXAGE` grace-second calculation at the
+      maximum signed integer value. [issue #676]
     * If we hit "Too many open files" during configuration reload, close
       the oldest client connection and retry. [issue #3365]
     * If the `MAXCONN` requested in the configuration file exceeds the OS

--- a/UPGRADING.adoc
+++ b/UPGRADING.adoc
@@ -33,6 +33,13 @@ Changes from 2.8.5 to 2.8.6
 
 - PLANNED: Keep track of any further API clean-up?
 
+- Correct malformed numeric values in `upsd.conf` when upgrading: `MAXAGE`,
+  `TRACKINGDELAY`, `MAXCONN` and numeric `CERTREQUEST` values are now checked
+  in full and must fit their destination ranges. Values such as `15seconds`
+  were previously read as `15`; these and overflowing values are now logged
+  and ignored, retaining the previous setting. Valid decimal values,
+  leading zeroes and trailing whitespace remain accepted. [issue #676]
+
 - Potentially a breaking change for C++ clients that rushed to use the new
   SSL support options in `libnutclient`: for Mozilla NSS setup, the way to
   provide an expected `CERTHOST` address was missing.  Now the API is fixed

--- a/docs/man/upsd.conf.txt
+++ b/docs/man/upsd.conf.txt
@@ -42,6 +42,13 @@ IMPORTANT NOTES
 CONFIGURATION DIRECTIVES
 ------------------------
 
+The numeric arguments to `MAXAGE`, `TRACKINGDELAY`, `MAXCONN` and
+`CERTREQUEST` must be complete non-negative decimal integers, beginning
+with a digit. Leading zeroes and trailing whitespace are accepted; signs,
+leading whitespace inside quotes, fractions and trailing non-whitespace
+characters are not. Invalid or overflowing conversions are logged and
+ignored, leaving the previous setting unchanged.
+
 *MAXAGE 'seconds'*::
 
 `upsd` usually allows a driver to stop responding for up to 15 seconds
@@ -50,12 +57,16 @@ time to process updates but is otherwise operational, you can use `MAXAGE`
 to make `upsd` wait longer.
 +
 Most users should leave this at the default value.
++
+The value must fit in the platform's signed `int` range. Zero is accepted.
 
 *TRACKINGDELAY 'seconds'*::
 
 When instant commands and variables setting status tracking is enabled, status
 execution information are kept during this amount of time, and then cleaned up.
 This defaults to 3600 (1 hour).
++
+The value must fit in the platform's signed `int` range. Zero is accepted.
 
 *ALLOW_NO_DEVICE 'Boolean'*::
 
@@ -150,6 +161,10 @@ This defaults to maximum number allowed on your system.  Each UPS, each
 `LISTEN` address and each client count as one connection.  If the server
 runs out of connections, it will no longer accept new incoming client
 connections.  Only set this if you know exactly what you're doing.
++
+Zero selects the system default. The value must fit both the platform's
+signed `long` range and its connection-count range. Operating
+system and allocation limits may impose a lower maximum.
 +
 Note that on some platforms there may be a smaller amount of file descriptors
 or handles that can be polled in one operation, the server would then poll

--- a/server/conf.c
+++ b/server/conf.c
@@ -165,9 +165,18 @@ static int parse_boolean(char *arg, int *result)
 /* return 1 if usable, 0 if not */
 static int parse_upsd_conf_args(size_t numargs, char **arg)
 {
+	int n, starts_with_digit;
+	long l;
+
 	/* everything below here uses up through arg[1] */
 	if (numargs < 2)
 		return 0;
+
+	/* Preserve rejection of signs and leading whitespace for numeric options.
+	 * str_to_int/long also check the rest of the value and its range, while
+	 * allowing trailing whitespace as atoi/atol did. Use temporary values
+	 * because the conversion helpers clear their output on failure. */
+	starts_with_digit = (arg[1][0] >= '0' && arg[1][0] <= '9');
 
 	/* DEBUG_MIN (NUM) */
 	/* debug_min (NUM) also acceptable, to be on par with ups.conf */
@@ -183,24 +192,24 @@ static int parse_upsd_conf_args(size_t numargs, char **arg)
 
 	/* MAXAGE <seconds> */
 	if (!strcmp(arg[0], "MAXAGE")) {
-		if (isdigit((size_t)arg[1][0])) {
-			maxage = atoi(arg[1]);
+		if (starts_with_digit && str_to_int(arg[1], &n, 10)) {
+			maxage = n;
 			return 1;
 		}
 		else {
-			upslogx(LOG_ERR, "MAXAGE has non numeric value (%s)!", arg[1]);
+			upslogx(LOG_ERR, "MAXAGE has invalid or out of range numeric value (%s)!", arg[1]);
 			return 0;
 		}
 	}
 
 	/* TRACKINGDELAY <seconds> */
 	if (!strcmp(arg[0], "TRACKINGDELAY")) {
-		if (isdigit((size_t)arg[1][0])) {
-			tracking_delay = atoi(arg[1]);
+		if (starts_with_digit && str_to_int(arg[1], &n, 10)) {
+			tracking_delay = n;
 			return 1;
 		}
 		else {
-			upslogx(LOG_ERR, "TRACKINGDELAY has non numeric value (%s)!", arg[1]);
+			upslogx(LOG_ERR, "TRACKINGDELAY has invalid or out of range numeric value (%s)!", arg[1]);
 			return 0;
 		}
 	}
@@ -233,13 +242,14 @@ static int parse_upsd_conf_args(size_t numargs, char **arg)
 
 	/* MAXCONN <connections> */
 	if (!strcmp(arg[0], "MAXCONN")) {
-		if (isdigit((size_t)arg[1][0])) {
-			/* FIXME: Check for overflows (and int size of nfds_t vs. long) - see get_max_pid_t() for example */
-			maxconn = (nfds_t)atol(arg[1]);
+		if (starts_with_digit && str_to_long(arg[1], &l, 10)
+		&& (uintmax_t)(nfds_t)l == (uintmax_t)l
+		) {
+			maxconn = (nfds_t)l;
 			return 1;
 		}
 		else {
-			upslogx(LOG_ERR, "MAXCONN has non numeric value (%s)!", arg[1]);
+			upslogx(LOG_ERR, "MAXCONN has invalid or out of range numeric value (%s)!", arg[1]);
 			return 0;
 		}
 	}
@@ -307,8 +317,8 @@ static int parse_upsd_conf_args(size_t numargs, char **arg)
 # ifdef WITH_CLIENT_CERTIFICATE_VALIDATION
 	/* CERTREQUEST (0 | 1 | 2) */
 	if (!strcmp(arg[0], "CERTREQUEST")) {
-		if (isdigit((size_t)arg[1][0])) {
-			certrequest = atoi(arg[1]);
+		if (starts_with_digit && str_to_int(arg[1], &n, 10)) {
+			certrequest = n;
 			return 1;
 		}
 		else {
@@ -324,7 +334,7 @@ static int parse_upsd_conf_args(size_t numargs, char **arg)
 				certrequest = NETSSL_CERTREQ_REQUIRE;	/* 2 */
 				return 1;
 			}
-			upslogx(LOG_ERR, "CERTREQUEST has non numeric value (%s)!", arg[1]);
+			upslogx(LOG_ERR, "CERTREQUEST has invalid or out of range value (%s)!", arg[1]);
 			return 0;
 		}
 	}

--- a/server/netssl.c
+++ b/server/netssl.c
@@ -1428,6 +1428,7 @@ void ssl_init(void)
 	) {
 		upslogx(LOG_ERR, "Invalid certificate requirement");
 		fatalx(EXIT_FAILURE, "SSL configuration was specified, but NUT server failed to initialize NSS backend.");
+	}
 
 	if (certrequest == NETSSL_CERTREQ_REQUEST	/* 1 */
 	 || certrequest == NETSSL_CERTREQ_REQUIRE	/* 2 */

--- a/server/sstate.c
+++ b/server/sstate.c
@@ -481,7 +481,7 @@ int sstate_dead(upstype_t *ups, int arg_maxage)
 	if ((elapsed > (arg_maxage / 3)) && (difftime(now, ups->last_ping) > (arg_maxage / 3)))
 		sendping(ups);
 
-	if (elapsed > arg_maxage + 1) {
+	if (elapsed > arg_maxage + 1.0) {
 		upsdebugx(3, "%s: didn't hear from driver for UPS [%s] for %g seconds (max %d)",
 			__func__, ups->name, elapsed, arg_maxage);
 		return 1;	/* dead */

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -18,6 +18,9 @@
 /test_authconf
 /test_authconf.log
 /test_authconf.trs
+/test_upsdconf
+/test_upsdconf.log
+/test_upsdconf.trs
 /selftest-rw/*
 /nutlogtest-nofail.sh
 /nutlogtest

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -99,6 +99,15 @@ nodist_test_cgilib_SOURCES = cgilib.c
 test_cgilib_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/clients
 test_cgilib_LDADD = $(NUT_LIBCOMMON)
 
+TESTS += test_upsdconf
+test_upsdconf_SOURCES = test_upsdconf.c
+test_upsdconf_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/server
+test_upsdconf_LDADD = $(NUT_LIBCOMMON) $(NETLIBS)
+test_upsdconf_DEPENDENCIES = $(NUT_LIBCOMMON) $(top_srcdir)/server/conf.c $(top_srcdir)/server/sstate.c
+if WITH_SSL
+test_upsdconf_CFLAGS += $(LIBSSL_CFLAGS)
+endif WITH_SSL
+
 nutlogtest_SOURCES = nutlogtest.c
 nutlogtest_LDADD = $(NUT_LIBCOMMON)
 

--- a/tests/test_upsdconf.c
+++ b/tests/test_upsdconf.c
@@ -1,0 +1,241 @@
+/* test_upsdconf - numeric configuration parsing and storage for upsd
+ *
+ * Copyright (C) 2026 Network UPS Tools project
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "config.h"
+#include "conf.c"
+#include "sstate.c"
+
+static int failures = 0, checks = 0;
+
+/* Storage normally owned by upsd.c and netssl.c. Keep the public types. */
+int maxage = 15, tracking_delay = 3600;
+int allow_no_device = 0, allow_not_all_listeners = 0;
+nfds_t maxconn = 0;
+char *statepath = NULL, *datapath = NULL;
+upstype_t *firstups = NULL;
+nut_ctype_t *firstclient = NULL;
+char *certfile = NULL, *certpath = NULL, *certname = NULL, *certpasswd = NULL;
+int disable_weak_ssl = 0;
+#ifdef WITH_CLIENT_CERTIFICATE_VALIDATION
+int certrequest = 0;
+#endif
+
+/* These daemon operations must not be reached by the configuration tests. */
+static void unexpected_call(const char *name)
+{
+	upslogx(LOG_ERR, "Unexpected %s", name);
+	failures++;
+}
+
+upstype_t *get_ups_ptr(const char *name)
+{
+	NUT_UNUSED_VARIABLE(name);
+	unexpected_call("get_ups_ptr");
+	return NULL;
+}
+
+void listen_add(const char *addr, const char *port)
+{
+	NUT_UNUSED_VARIABLE(addr);
+	NUT_UNUSED_VARIABLE(port);
+	unexpected_call("listen_add");
+}
+
+void kick_login_clients(const char *name)
+{
+	NUT_UNUSED_VARIABLE(name);
+	unexpected_call("kick_login_clients");
+}
+
+void close_oldest_client(void) { unexpected_call("close_oldest_client"); }
+void user_flush(void) { unexpected_call("user_flush"); }
+void user_load(void) { unexpected_call("user_load"); }
+
+int tracking_set(const char *id, const char *value)
+{
+	NUT_UNUSED_VARIABLE(id);
+	NUT_UNUSED_VARIABLE(value);
+	unexpected_call("tracking_set");
+	return 0;
+}
+
+char *tracking_get(const char *id)
+{
+	NUT_UNUSED_VARIABLE(id);
+	unexpected_call("tracking_get");
+	return NULL;
+}
+
+static char config_dir[128], config_file[160];
+
+static void cleanup(void)
+{
+	unlink(config_file);
+	rmdir(config_dir);
+}
+
+static uintmax_t stored_value(const char *option)
+{
+	if (!strcmp(option, "MAXAGE")) return (uintmax_t)maxage;
+	if (!strcmp(option, "TRACKINGDELAY")) return (uintmax_t)tracking_delay;
+	if (!strcmp(option, "MAXCONN")) return (uintmax_t)maxconn;
+#if defined(WITH_SSL) && defined(WITH_CLIENT_CERTIFICATE_VALIDATION)
+	if (!strcmp(option, "CERTREQUEST")) return (uintmax_t)certrequest;
+#endif
+	unexpected_call(option);
+	return 0;
+}
+
+static void check_value(const char *option, const char *value, int accepted, uintmax_t expected)
+{
+	char *args[2];
+	int result, reloading;
+	FILE *f;
+	uintmax_t actual;
+
+	maxage = tracking_delay = 17;
+	maxconn = 17;
+#ifdef WITH_CLIENT_CERTIFICATE_VALIDATION
+	certrequest = 2;
+#endif
+	args[0] = xstrdup(option);
+	args[1] = xstrdup(value);
+	result = parse_upsd_conf_args(2, args);
+	actual = stored_value(option);
+	checks++;
+	if (result != accepted || actual != expected) {
+		upslogx(LOG_ERR, "FAIL %s '%s': accepted=%d, value=%" PRIuMAX
+			"; expected %d, %" PRIuMAX, option, value, result, actual, accepted, expected);
+		failures++;
+	}
+	free(args[0]);
+	free(args[1]);
+
+	/* parseconf discards control characters even inside quotes. The raw
+	 * argument rejects a leading tab, but the file loader sees just "1". */
+	if (!strcmp(value, "\t1")) expected = 1;
+
+	/* Use the real file loader and tokenizer on startup and reload. A valid
+	 * preceding directive must survive a rejected duplicate. */
+	for (reloading = 0; reloading <= 1; reloading++) {
+		f = fopen(config_file, "w");
+		if (!f) fatal_with_errno(EXIT_FAILURE, "fopen test configuration");
+		fprintf(f, "MAXAGE 17\nTRACKINGDELAY 17\nMAXCONN 17\n");
+#if defined(WITH_SSL) && defined(WITH_CLIENT_CERTIFICATE_VALIDATION)
+		fprintf(f, "CERTREQUEST REQUIRE\n");
+#endif
+		fprintf(f, "%s \"%s\"\n", option, value);
+		if (fclose(f)) fatal_with_errno(EXIT_FAILURE, "fclose test configuration");
+		load_upsdconf(reloading);
+		actual = stored_value(option);
+		checks++;
+		if (actual != expected) {
+			upslogx(LOG_ERR, "FAIL load_upsdconf(%d), %s '%s': value=%" PRIuMAX
+				"; expected %" PRIuMAX, reloading, option, value, actual, expected);
+			failures++;
+		}
+	}
+}
+
+int main(void)
+{
+	static const char *options[] = { "MAXAGE", "TRACKINGDELAY", "MAXCONN",
+#if defined(WITH_SSL) && defined(WITH_CLIENT_CERTIFICATE_VALIDATION)
+		"CERTREQUEST",
+#endif
+	};
+	static const char *invalid[] = { "", " ", "\t", " 1", "\t1", "+1", "-1", "-0",
+		"+", "-", "++1", "--1", "1x", "1.5", "1e2", "0x10", "1 2",
+		"9999999999999999999999999999999999999999",
+		"-9999999999999999999999999999999999999999" };
+	size_t i, j;
+	char number[128];
+	uintmax_t limit, previous;
+	FILE *f;
+#ifndef WIN32
+	upstype_t ups;
+#endif
+
+#ifndef WIN32
+	umask(077);
+#endif
+	snprintf(config_dir, sizeof(config_dir), "test_upsdconf-%ld", (long)getpid());
+#ifdef WIN32
+	if (mkdir(config_dir))
+#else
+	if (mkdir(config_dir, 0700))
+#endif
+		fatal_with_errno(EXIT_FAILURE, "mkdir test configuration");
+	snprintf(config_file, sizeof(config_file), "%s/upsd.conf", config_dir);
+	atexit(cleanup);
+	if (setenv("NUT_CONFPATH", config_dir, 1))
+		fatal_with_errno(EXIT_FAILURE, "setenv NUT_CONFPATH");
+
+	printf("Widths: int=%" PRIuSIZE ", long=%" PRIuSIZE ", nfds_t=%" PRIuSIZE "\n",
+		sizeof(int), sizeof(long), sizeof(nfds_t));
+	for (i = 0; i < sizeof(options) / sizeof(options[0]); i++) {
+		previous = !strcmp(options[i], "CERTREQUEST") ? 2 : 17;
+		check_value(options[i], "0", 1, 0);
+		check_value(options[i], "1", 1, 1);
+		check_value(options[i], "2", 1, 2);
+		check_value(options[i], "00015", 1, 15);
+		check_value(options[i], "32 \t", 1, 32);
+		check_value(options[i], "3600", 1, 3600);
+		for (j = 0; j < sizeof(invalid) / sizeof(invalid[0]); j++)
+			check_value(options[i], invalid[j], 0, previous);
+
+		limit = (uintmax_t)INT_MAX;
+		if (!strcmp(options[i], "MAXCONN")) {
+			limit = (uintmax_t)((nfds_t)-1);
+			if (limit > (uintmax_t)LONG_MAX) limit = (uintmax_t)LONG_MAX;
+		}
+		snprintf(number, sizeof(number), "%" PRIuMAX, limit - 1);
+		check_value(options[i], number, 1, limit - 1);
+		snprintf(number, sizeof(number), "%" PRIuMAX, limit);
+		check_value(options[i], number, 1, limit);
+		snprintf(number, sizeof(number), "%" PRIuMAX, limit + 1);
+		check_value(options[i], number, 0, previous);
+		snprintf(number, sizeof(number), "%" PRIuMAX, (uintmax_t)LONG_MAX + 1);
+		check_value(options[i], number, 0, previous);
+	}
+#if defined(WITH_SSL) && defined(WITH_CLIENT_CERTIFICATE_VALIDATION)
+	check_value("CERTREQUEST", "NO", 1, 0);
+	check_value("CERTREQUEST", "REQUEST", 1, 1);
+	check_value("CERTREQUEST", "REQUIRE", 1, 2);
+	check_value("CERTREQUEST", "require", 0, 2);
+	/* ssl_init still owns the 0..2 domain check and its fatal error policy. */
+	check_value("CERTREQUEST", "3", 1, 3);
+#endif
+
+	f = fopen(config_file, "w");
+	if (!f) fatal_with_errno(EXIT_FAILURE, "fopen whitespace configuration");
+	fprintf(f, "\tMAXAGE\t31 \t# comment\nMAXAGE\n");
+	if (fclose(f)) fatal_with_errno(EXIT_FAILURE, "fclose whitespace configuration");
+	load_upsdconf(0);
+	checks++;
+	if (maxage != 31) failures++;
+
+#ifndef WIN32
+	/* No socket I/O is needed: fresh timestamps suppress the ping path. */
+	memset(&ups, 0, sizeof(ups));
+	ups.sock_fd = 0;
+	ups.name = xstrdup("test");
+	time(&ups.last_heard);
+	ups.last_ping = ups.last_heard;
+	checks++;
+	if (sstate_dead(&ups, INT_MAX)) {
+		upslogx(LOG_ERR, "FAIL MAXAGE INT_MAX: fresh driver data is stale");
+		failures++;
+	}
+	free(ups.name);
+#endif
+	printf("%d checks, %d failures\n", checks, failures);
+	return failures ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/tests/test_upsdconf.c
+++ b/tests/test_upsdconf.c
@@ -68,9 +68,10 @@ int tracking_set(const char *id, const char *value)
 
 char *tracking_get(const char *id)
 {
+	static char result[] = "unexpected tracking_get";
 	NUT_UNUSED_VARIABLE(id);
 	unexpected_call("tracking_get");
-	return NULL;
+	return result;
 }
 
 static char config_dir[128], config_file[160];


### PR DESCRIPTION
`upsd.conf` still converts `MAXAGE`, `TRACKINGDELAY`, `MAXCONN` and numeric
`CERTREQUEST` values after checking only their first character. For example,
`MAXAGE 15seconds` is accepted as 15; overflowing conversions and narrowing
to `nfds_t` are unchecked. Validate the complete conversion with the existing
`str_to_int`/`str_to_long` helpers and check that `MAXCONN` fits `nfds_t`.
Store a converted value only after all checks pass, so a rejected directive
is logged and leaves the previous setting intact.

Keep the current public types, decimal leading zeroes, trailing whitespace,
zero values, and named certificate levels. Signs and leading whitespace in
the numeric argument remain rejected. Keep certificate levels' existing
0..2 domain check and fatal error policy in SSL initialization.

Avoid signed overflow in the `MAXAGE` grace-second calculation at `INT_MAX`.
Also restore one missing closing brace in the existing NSS certificate range
check: the unmodified NSS build with client validation otherwise fails at
end of input. This is a baseline build prerequisite, not a change to the NSS
certificate policy.

Add regression coverage to the existing Automake C tests, including the real
configuration file loader, startup/reload parsing, and failure-state
preservation. Update the maintained `upsd.conf` manual source, the **upsd
data server updates** subsection of NEWS, and UPGRADING for previously
tolerated malformed values. No generated files or public interfaces are added.

This addresses the remaining numeric conversion work discussed in #677;
#690 already fixed the original pointer-to-`isdigit` misuse. #677 remains
open, and this proposal does not presume a maintainer decision to supersede
or close it. Broader C-string/C-bool cleanup and FTY integration are outside
the change.

Closes: #676

## Validation

- The final regression source fails 97 of 365 checks against unmodified
  upstream `2caa3c87501a1aba25a3070ad66757470bd1bf03` on Linux and macOS,
  for malformed values, overflow/narrowing and the MAXAGE boundary. All
  365 checks pass with the patch.
- Reproduced the GCC -O2 warning-as-error failure in the new test's
  `tracking_get()` stub. Returning printable static storage while retaining
  the unexpected-call failure counter clears the diagnostic. The same
  strict GCC configuration and the complete parser regression pass.
- Linux ARM64: GCC 14.2 GNU99 with OpenSSL and NSS client validation,
  GCC GNU89 compatibility, and Clang 19.1.7 C99 with warnings as errors
  and ASan/UBSan pass. GCC C99 builds without SSL and with default OpenSSL
  client validation disabled pass all 263 applicable checks.
- macOS ARM64: Apple Clang 21 C99 passes with 32-bit `nfds_t` and 64-bit
  `long`. Linux ARMHF GCC 14.2 under QEMU passes all 263 applicable checks
  with 32-bit `int`, `long` and `nfds_t`. Bounds come from platform types.
- Locally built `upsd` passes 12 isolated startup/reload and SSL-policy
  checks with GCC/OpenSSL, macOS/OpenSSL and Clang ASan/UBSan; NSS passes
  11 checks (its build has no dummy driver). The 12-check baseline run
  confirms the old behavior. The dummy-ups cases exercise MAXAGE at
  INT_MAX without physical hardware or shutdown commands.
- Valgrind reports zero errors and no leaks. A separate Clang sanitizer
  build retains normal native network capability detection and also
  passes the regression and live checks; an existing `inet_ntop`
  configure probe is invalid under ASan and otherwise selects a fallback.
- The broad Linux build and `make check` pass all 13 Automake tests with
  zero skips. Staged install/uninstall, `make stylecheck`, `make spellcheck`,
  manual checks/generation and release-notes HTML generation pass.
- `make distcheck-light`, full `make distcheck` and
  `make distcheck-completeness` pass. Both final archives contain 269 real
  manual pages with no placeholders; all eight distributed changed source
  files match the reviewed sources. SCM-only `.gitignore` is not distributed.

## Compatibility and limitations

Valid supported configurations retain their behavior. Incomplete or
out-of-range numeric conversions are now rejected instead of being partially
read or overflowing. `MAXCONN 0` still selects the system default, and
OS/allocation limits still apply. A representable numeric `CERTREQUEST`
outside 0..2 still reaches the existing fatal SSL domain check when SSL is
configured; this change does not turn it into a silent fallback.

No physical UPS hardware was available or required for this parsing change.
Software validation covers parsing, storage, boundary consumption, local
simulated-service behavior and packaging. Physical models, firmware versions,
Windows, big-endian systems and other legacy Unix platforms were not tested.
ARMHF execution was emulated.

## Relevant checklist

- [x] Concrete behavior, compatibility expectations and limitations described.
- [x] Existing conversion helpers, logging and public types retained; ranges
  checked without assuming native integer widths.
- [x] Changed source/comments/documentation follow nearby style and use ASCII;
  style and spelling checks pass.
- [x] New test registered in the existing Automake build/distribution recipes;
  full `make distcheck` and `make distcheck-light` pass.
- [x] NEWS placed under upsd; UPGRADING and the maintained manual source updated.
- [x] AI assistance and actual model/reasoning disclosed.
- [x] Human contributor review and acceptance of responsibility completed.
- [x] Human contributor consciously supplies the required DCO sign-off for
  each eventual commit.

AI assistance: OpenAI Codex with gpt-6-astra (x-high reasoning). The human contributor remains responsible for reviewing and submitting the change.
