### PR TITLE
Perl UPS::Nut: decode NUT tokens and quote authentication arguments

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -494,6 +494,10 @@ https://github.com/networkupstools/nut/milestone/13
       the overflows it addressed) in normal device interactions. [#3588]
 
  - NUT client libraries:
+    * The Perl `UPS::Nut` module now decodes quoted values and backslash
+      escapes in query/list replies and `nutauth.conf` entries, and quotes
+      authentication arguments. Single quotes in configuration are literal.
+      Command descriptions now accept the server's `CMDDESC` response.
     * Complete support for actions documented in `docs/net-protocol.txt`
       was implemented in C++, Python and PERL bindings in-tree, and for Java
       in link:https://github.com/networkupstools/jNut[jNut] nearby. Among

--- a/UPGRADING.adoc
+++ b/UPGRADING.adoc
@@ -31,6 +31,14 @@ command line, in order to quickly pick up any other removed option flags.
 Changes from 2.8.5 to 2.8.6
 ---------------------------
 
+- The Perl `UPS::Nut` module now decodes NUT quoting and backslash escapes
+  in query/list values and `nutauth.conf`, including include paths. Remove
+  manual decoding of these returned values and pass literal credentials
+  to `Authenticate()`. Single quotes in configuration are now literal, as
+  in the C parser; replace single-quoted values with double-quoted values
+  where grouping was intended. The legacy `Set()` argument contract is
+  unchanged.
+
 - PLANNED: Keep track of any further API clean-up?
 
 - Potentially a breaking change for C++ clients that rushed to use the new

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -14,6 +14,7 @@ EXTRA_DIST = \
     misc/osd-notify \
     perl/UPS/Nut.pm.in \
     perl/test_nutclient.pl \
+    perl/test_nut_parser.pl \
     RedHat/halt.patch \
     RedHat/README.adoc \
     RedHat/ups.in \
@@ -60,3 +61,8 @@ CLEANFILES = *-spellchecked RedHat/*-spellchecked usb_resetter/*-spellchecked
 DISTCLEANFILES = misc/nut.bash_completion
 
 MAINTAINERCLEANFILES = Makefile.in .dirstamp
+
+if HAVE_PERL
+check-local:
+	$(PERL) -I$(builddir)/perl $(srcdir)/perl/test_nut_parser.pl
+endif HAVE_PERL

--- a/scripts/perl/UPS/Nut.pm.in
+++ b/scripts/perl/UPS/Nut.pm.in
@@ -9,8 +9,10 @@
 # ### changelog: 1.60: JK 2026-04-08: Added basic STARTTLS, as well as TRACKING support, LIST CLIENT, LIST RANGE, GET UPSDESC and PRIMARY/MASTER aliasing.
 # ### changelog: 1.61: JK 2026-04-08: Make TrackingID a class, similar to C++.
 # ### changelog: 1.62: JK 2026-04-10: Added a testing script nearby; revised API and NUT protocol support, notably TRACKING and STARTTLS.
+# ### changelog: 1.63: Decode NUT protocol and AuthConf tokens once; encode authentication arguments; accept CMDDESC replies.
 
 package UPS::Nut;
+use 5.005;
 use strict;
 # Absent on antique versions like perl-5.005 (Solaris 8)
 eval "use warnings FATAL => 'all';";
@@ -30,7 +32,7 @@ my $_eol = "\n";
 BEGIN {
   use Exporter ();
   use vars qw ($VERSION @ISA @EXPORT @EXPORT_OK %EXPORT_TAGS);
-  $VERSION     = 1.62;
+  $VERSION     = 1.63;
   @ISA         = qw(Exporter IO::Socket::INET);
   @EXPORT      = qw();
   @EXPORT_OK   = qw();
@@ -348,7 +350,7 @@ sub Login { # login to upsd, so that it won't shutdown unless we say we're
 }
 
 sub Authenticate { # Announce to the UPS who we are to set up the proper
-                   # management level.  See upsd.conf man page for details.
+                   # management level.  See upsd.users man page for details.
 
 # Contributor: Wayne Wylupski
   my $self = shift; # myself
@@ -365,10 +367,10 @@ sub Authenticate { # Announce to the UPS who we are to set up the proper
 
   # only attempt authentication if username and password given
   if (defined $user and defined $pass) {
-    $ans = $self->_send("USERNAME $user");
+    $ans = $self->_send("USERNAME " . _encode_arg($user));
     if (defined $ans && $ans =~ /^OK/) { # username OK, send password
 
-      $ans = $self->_send("PASSWORD $pass");
+      $ans = $self->_send("PASSWORD " . _encode_arg($pass));
       if (defined $ans && $ans =~ /^OK/) {
         $self->{authenticated} = 1;
         return 1
@@ -404,6 +406,56 @@ sub Logout { # logout of upsd and close connection
 # internal functions.  These are only used by UPS::Nut internally, so
 # please don't use them otherwise.  If you really think an internal
 # function should be externalized, let me know.
+
+# NUT parseconf grammar, shared with AuthConf. An incomplete quoted word or
+# escape returns undef so a configuration reader can supply the next line.
+# Keep Perl string bytes intact; this is not shell or language escape syntax.
+sub _tokenize {
+  my $line = shift;
+  my @words;
+  my ($word, $started, $quoted, $escaped, $continued) = ('', 0, 0, 0, 0);
+  foreach my $ch (split(//, $line)) {
+    $continued = 0;
+    if ($escaped) {
+      $escaped = 0;
+      $continued = ($ch eq "\n");
+      $word .= $ch unless $continued;
+    } elsif ($ch eq '\\') {
+      $started = 1;
+      $escaped = 1;
+    } elsif ($quoted) {
+      if ($ch eq '"') {
+        push @words, $word;
+        ($word, $started, $quoted) = ('', 0, 0);
+      } else {
+        $word .= $ch unless $ch eq "\n";
+      }
+    } elsif ($ch eq '#') {
+      last;
+    } elsif ($ch eq "\n") {
+      last;
+    } elsif ($ch =~ /[ \t\r\f\x0b=]/) {
+      push @words, $word if $started;
+      ($word, $started) = ('', 0);
+      push @words, '=' if $ch eq '=';
+    } elsif ($ch eq '"' && !$started) {
+      ($started, $quoted) = (1, 1);
+    } else {
+      $word .= $ch;
+      $started = 1;
+    }
+  }
+  return undef if $quoted || $escaped || $continued;
+  push @words, $word if $started;
+  return \@words;
+}
+
+sub _encode_arg {
+  my $value = shift;
+  # Keep escaping # for compatibility with older upsd parsers.
+  $value =~ s/([\\"#])/\\$1/g;
+  return '"' . $value . '"';
+}
 
 sub _initialize {
 # Author: Kit Peters
@@ -629,13 +681,16 @@ sub GetVar { # request a variable from the UPS
   elsif ($ans =~ /^VAR/) {
     my $checkvar; # to make sure the var we asked for is the var we got.
     my $retval; # returned value for requested VAR
-    (undef, undef, $checkvar, $retval) = split(' ', $ans, 4);
-        # get checkvar and retval from the answer
+    my $fields = _tokenize($ans);
+    unless (defined $fields && @$fields >= 4) {
+      $self->_debug($self->{err} = "Unrecognized response from upsd: $ans");
+      return undef;
+    }
+    (undef, undef, $checkvar, $retval) = @$fields;
     if ($checkvar ne $var) { # did not get expected var
       $self->_debug($self->{err} = "Requested $var, received $checkvar");
       return undef;
     }
-    $retval =~ s/^"(.*)"$/$1/;
     return $retval; # return the requested value
   }
   else { # unrecognized response
@@ -875,10 +930,8 @@ sub GetUPSDesc {
     return undef;
   };
   if ($ans =~ /^UPSDESC/) {
-    my @fields = split(' ', $ans, 3);
-    my $desc = $fields[2];
-    $desc =~ s/^"(.*)"$/$1/;
-    return $desc;
+    my $fields = _tokenize($ans);
+    return $fields->[2] if defined $fields && @$fields >= 3;
   }
 
   $self->_debug($self->{err} = "Error: $ans");
@@ -943,8 +996,9 @@ sub ListRange {
     while ($line = $self->_getline) {
       last if $line =~ /^END LIST RANGE/;
       # RANGE <ups> <var> "<min>" "<max>"
-      if ($line =~ /^RANGE \S+ \S+ "([^"]+)" "([^"]+)"/) {
-        push(@$retval, { min => $1, max => $2 });
+      my $fields = _tokenize($line);
+      if (defined $fields && @$fields >= 5 && $fields->[0] eq 'RANGE') {
+        push(@$retval, { min => $fields->[3], max => $fields->[4] });
       }
     }
     return $retval;
@@ -973,10 +1027,14 @@ sub _get_list {
     my $line;
     while ($line = $self->_getline) {
       last if $line =~ /^END LIST/;
-      my @fields = split(' ', $line, $valueidx+1);
-      (my $value = $fields[$valueidx]) =~ s/^"(.*)"$/$1/;
+      my $fields = _tokenize($line);
+      unless (defined $fields && @$fields > $valueidx) {
+        $self->_debug($self->{err} = "Unrecognized response from upsd: $line");
+        return undef;
+      }
+      my $value = $fields->[$valueidx];
       if ($keyidx) {
-        $retval->{$fields[$keyidx]} = $value;
+        $retval->{$fields->[$keyidx]} = $value;
       }
       else {
         push(@$retval, $value);
@@ -1021,9 +1079,12 @@ sub GetDesc {
   }
   elsif ($ans =~ /^DESC/) { # command successful
     $self->_debug("$req command sent successfully.");
-    (undef, undef, undef, $ans) = split(' ', $ans, 4);
-    $ans =~ s/^"(.*)"$/$1/;
-    return $ans;
+    my $fields = _tokenize($ans);
+    unless (defined $fields && @$fields >= 4) {
+      $self->_debug($self->{err} = "Unrecognized response from upsd: $ans");
+      return undef;
+    }
+    return $fields->[3];
   }
   else { # unrecognized response
     $self->_debug($self->{err} = "Can't send $req. Unrecognized response from upsd: $ans");
@@ -1090,11 +1151,14 @@ sub GetCmdDesc {
     $self->_debug($self->{err} = "Error: $ans");
     return undef;
   }
-  elsif ($ans =~ /^DESC/) { # command successful
+  elsif ($ans =~ /^CMDDESC/) { # command successful
     $self->_debug("$req command sent successfully.");
-    (undef, undef, undef, $ans) = split(' ', $ans, 4);
-    $ans =~ s/^"(.*)"$/$1/;
-    return $ans;
+    my $fields = _tokenize($ans);
+    unless (defined $fields && @$fields >= 4) {
+      $self->_debug($self->{err} = "Unrecognized response from upsd: $ans");
+      return undef;
+    }
+    return $fields->[3];
   }
   else { # unrecognized response
     $self->_debug($self->{err} = "Can't send $req. Unrecognized response from upsd: $ans");
@@ -1298,6 +1362,18 @@ the Network UPS Tools package version 1.5 and above
 Note that it only talks to upsd for you in a Perl-ish way.
 It does not monitor the UPS continuously.
 
+Values returned by the query and list methods are decoded once using NUT
+quoting rules. Double quotes delimit a word only at its start; backslash
+quotes the next character, and single quotes are literal. Callers should
+not manually unescape these values. GetType() still returns one scalar
+containing the space-separated type flags.
+
+AuthConf uses the same rules for sections, KEY=VALUE entries and INCLUDE
+paths, including comments outside double quotes and backslash-newline
+continuations. Relative include paths still resolve against the current
+working directory. Single quotes no longer delimit configuration values;
+use double quotes for values containing spaces.
+
 =head1 CONSTRUCTOR
 
 Shown with defaults: new UPS::Nut( NAME => "default",
@@ -1312,7 +1388,7 @@ Shown with defaults: new UPS::Nut( NAME => "default",
 * HOST is the host running upsd
 * PORT is the port that upsd is running on
 * USERNAME and PASSWORD are those that you use to login to upsd.  This
-  gives you the right to do certain things, as specified in upsd.conf.
+  gives you the right to do certain things, as specified in upsd.users.
 * DEBUG turns on debugging output, set to 1 or 0
 * DEBUGOUT is de thing you do when de s*** hits the fan.  Actually, it's
   the filename where you want debugging output to go.  If it's not
@@ -1391,7 +1467,8 @@ constructor.
 
 With NUT certain operations are only available if the user has the
 privilege. The program has to authenticate with one of the accounts
-defined in upsd.conf.
+defined in upsd.users. Pass literal username and password values, without
+adding protocol quotes or escapes; Authenticate() encodes both arguments.
 
 =item Login($username, $password)
 
@@ -1684,8 +1761,8 @@ sub readAuthConfFile {
         return ();
     }
 
-    my $fh;
-    if (!open($fh, '<', $filename)) {
+    my $fh = FileHandle->new($filename, 'r');
+    if (!defined $fh) {
         my $errMsg = "Error opening $filename: $!";
         die $errMsg if $fatal_errors;
         $class->_debug("readAuthConfFile(): " . $errMsg);
@@ -1700,11 +1777,22 @@ sub readAuthConfFile {
     $current_ac = $global_defaults_ref if $global_scope;
 
     while (my $line = <$fh>) {
-        chomp $line;
-        $line =~ s/^\s+|\s+$//g;
-        next if !$line || $line =~ /^#/;
+        my $fields = UPS::Nut::_tokenize($line);
+        while (!defined $fields) {
+            my $next = <$fh>;
+            last unless defined $next;
+            $line .= $next;
+            $fields = UPS::Nut::_tokenize($line);
+        }
+        if (!defined $fields) {
+            my $errMsg = "Incomplete word in $filename";
+            die $errMsg if $fatal_errors;
+            $class->_debug("readAuthConfFile(): " . $errMsg);
+            last;
+        }
+        next unless @$fields;
 
-        if ($line =~ /^\[(.*)\]$/) {
+        if ($fields->[0] =~ /^\[(.*)\]$/) {
             my $sectname = $1;
             if ($class->getDebug()) {
                 if (defined $current_ac) {
@@ -1742,23 +1830,17 @@ sub readAuthConfFile {
         }
 
         # INCLUDE support
-        if ($line =~ /^INCLUDE(?:_REQUIRED)?\s+(.*)$/i) {
-            my $inc_file = $1;
-            $inc_file =~ s/^["']|["']$//g;
-            my $is_required = ($line =~ /^INCLUDE_REQUIRED/i);
+        if ($fields->[0] =~ /^INCLUDE(?:_REQUIRED)?$/i && @$fields >= 2) {
+            my $inc_file = $fields->[1];
+            my $is_required = ($fields->[0] =~ /^INCLUDE_REQUIRED$/i);
             $class->_debug("readAuthConfFile(): INCLUDE '$inc_file'");
             $class->readAuthConfFile($inc_file, $is_required, (!defined $current_ac || $current_ac == $global_defaults_ref));
             next;
         }
 
-        if ($line =~ /^([^=]+)=(.*)$/) {
-            my ($key, $value) = ($1, $2);
-            $key =~ s/^\s+|\s+$//g;
+        if (@$fields >= 3 && $fields->[1] eq '=') {
+            my ($key, $value) = ($fields->[0], $fields->[2]);
             my $keyUC = uc($key);
-
-            # FIXME: NUT parseconf for possibly escaped values is a bit more complicated than this:
-            $value =~ s/^\s+|\s+$//g;
-            $value =~ s/^["']|["']$//g;
 
             if (!defined $current_ac) {
                 if ($global_scope) {

--- a/scripts/perl/test_nut_parser.pl
+++ b/scripts/perl/test_nut_parser.pl
@@ -204,6 +204,9 @@ check(!@missing, 'AuthConf missing optional file');
 my $ok = eval { UPS::Nut::AuthConf->readAuthConfFile('absent.conf', 1); 1; };
 check(!$ok && $@ ne '', 'AuthConf missing required file');
 
+# Load optional TLS support before starting the socket fixture watchdogs.
+eval "require IO::Socket::SSL; 1";
+
 # Exercise the real socket implementation, constructor and buffered getline.
 my $listener = IO::Socket::INET->new(LocalAddr => '127.0.0.1', LocalPort => 0, Listen => 1, Proto => 'tcp', ReuseAddr => 1) or die "listen: $!";
 my $port = $listener->sockport();

--- a/scripts/perl/test_nut_parser.pl
+++ b/scripts/perl/test_nut_parser.pl
@@ -6,7 +6,6 @@ use UPS::Nut;
 use FileHandle;
 use File::Path;
 use Cwd;
-use POSIX ();
 
 my ($checks, $failures) = (0, 0);
 sub check {
@@ -140,8 +139,10 @@ die "mkdir $tmp: $!" unless $created_tmp;
 my $child;
 END {
     if ($child) { kill 'TERM', $child; waitpid($child, 0); }
-    chdir($cwd) if defined $cwd;
-    rmtree($tmp) if $created_tmp && -d $tmp;
+    if ($created_tmp) {
+        chdir($cwd) if defined $cwd;
+        rmtree($tmp) if -d $tmp;
+    }
 }
 sub write_file {
     my ($name, $text) = @_;
@@ -150,13 +151,24 @@ sub write_file {
     close($fh) or die "close $name: $!";
 }
 chdir($tmp) or die "chdir: $!";
+# Check include dispatch without creating a Windows-invalid filename.
+write_file('include-escapes.conf', <<'CONF');
+INCLUDE_REQUIRED "part \"\#\\name.conf"
+CONF
+my $include;
+my $read_authconf = \&UPS::Nut::AuthConf::readAuthConfFile;
+{
+    local *UPS::Nut::AuthConf::readAuthConfFile = sub { $include = $_[1]; return (); };
+    $read_authconf->('UPS::Nut::AuthConf', 'include-escapes.conf', 1);
+}
+equal($include, 'part "#\\name.conf', 'include path quote and backslash decoding');
 # Relative includes have historically resolved against cwd.
-write_file('part "#\\name.conf', "PASSWORD=\"included\\\\n\"\n");
+write_file('part #name.conf', "PASSWORD=\"included\\\\n\"\n");
 write_file('scope.conf', "PASSWORD=ignored\n");
 write_file('auth.conf', <<'CONF');
 USERNAME=global
 PASSWORD=first
-INCLUDE_REQUIRED "part \"\#\\name.conf" # trailing comment
+INCLUDE_REQUIRED "part \#na\me.conf" # trailing comment
 [admin@localhost:12345] # section comment
 PASSWORD = "say \"yes\" \\n # literal"
 INCLUDE scope.conf
@@ -201,9 +213,12 @@ my @dialog = (
     ['LIST UPS', ["BE", "GIN LIST UPS\nUPS test \"a\\", "\"b\\\\c\"\nUPS second \"two words\"\nEND LIST U", "PS\n"]],
     ['LOGOUT', ["OK Goodbye\n"]],
 );
+# Flush TAP before fork; normal child exit also works with Windows pseudofork.
+$| = 1;
 $child = fork();
 die "fork: $!" unless defined $child;
 if (!$child) {
+    $created_tmp = 0; # Only the parent owns temporary-directory cleanup.
     my $status = eval {
         $SIG{ALRM} = sub { die "server timeout\n"; };
         alarm(15);
@@ -221,7 +236,7 @@ if (!$child) {
         1;
     };
     print STDERR $@ unless $status;
-    POSIX::_exit($status ? 0 : 1);
+    exit($status ? 0 : 1);
 }
 close($listener);
 $SIG{ALRM} = sub { die "client timeout\n"; };

--- a/scripts/perl/test_nut_parser.pl
+++ b/scripts/perl/test_nut_parser.pl
@@ -1,0 +1,243 @@
+#!/usr/bin/perl
+# Standalone protocol/configuration regression; core modules only, Perl 5.005+.
+use 5.005;
+use strict;
+use UPS::Nut;
+use FileHandle;
+use File::Path;
+use Cwd;
+use POSIX ();
+
+my ($checks, $failures) = (0, 0);
+sub check {
+    my ($ok, $name) = @_;
+    $checks++;
+    print(($ok ? 'ok' : 'not ok'), " $checks - $name\n");
+    $failures++ unless $ok;
+}
+sub equal {
+    my ($got, $want, $name) = @_;
+    check(defined($got) && $got eq $want, $name);
+}
+
+# Exercise public readers independently of transport scheduling.
+package ParserFixture;
+use vars qw(@ISA);
+@ISA = qw(UPS::Nut);
+sub _send { return shift->{answer}; }
+sub _getline { return shift @{shift->{lines}}; }
+package main;
+sub fixture {
+    my ($answer, @lines) = @_;
+    return bless {name => 'test', answer => $answer, lines => \@lines}, 'ParserFixture';
+}
+
+# Wire strings are explicit, not produced by the encoder being tested.
+my @values = (
+    ['"ordinary"', 'ordinary'], ['""', ''], ['"two words"', 'two words'],
+    ['"say \\"hello\\""', 'say "hello"'],
+    ['"\\"boundary\\""', '"boundary"'],
+    ['"one\\\\two\\\\\\\\three"', 'one\\two\\\\three'],
+    ['"slash\\\\\\"quote"', 'slash\\"quote'],
+    ['"Outlet \\#2"', 'Outlet #2'], ['"Outlet #3"', 'Outlet #3'],
+    ['"it\'s literal"', "it's literal"],
+    ['"literal\\\\n"', 'literal\\n'], ['unquoted\\ value', 'unquoted value'],
+    ['"\200\377"', "\200\377"],
+);
+# Build high bytes explicitly without introducing non-ASCII source text.
+$values[$#values][0] = '"' . "\200\377" . '"';
+foreach my $case (@values) {
+    my ($wire, $value) = @$case;
+    my $tag = unpack('H*', $wire);
+    equal(fixture("VAR test v $wire")->GetVar('v'), $value, "GetVar $tag");
+    equal(fixture("VAR test v $wire")->Request('v'), $value, "Request $tag");
+    equal(fixture("UPSDESC test $wire")->GetUPSDesc(), $value, "GetUPSDesc $tag");
+    equal(fixture("DESC test v $wire")->GetDesc('v'), $value, "GetDesc $tag");
+    equal(fixture("DESC test v $wire")->VarDesc('v'), $value, "VarDesc $tag");
+    equal(fixture("CMDDESC test c $wire")->GetCmdDesc('c'), $value, "GetCmdDesc $tag");
+    equal(fixture("CMDDESC test c $wire")->InstCmdDesc('c'), $value, "InstCmdDesc $tag");
+    my $ups = fixture('BEGIN LIST UPS', "UPS test $wire", 'UPS second "other"', 'END LIST UPS')->ListUPS();
+    check(ref($ups) eq 'HASH' && keys(%$ups) == 2 && $ups->{test} eq $value && $ups->{second} eq 'other', "ListUPS $tag");
+    foreach my $kind ('VAR', 'RW') {
+        my $method = $kind eq 'VAR' ? 'ListVar' : 'ListRW';
+        my $got = fixture("BEGIN LIST $kind test", "$kind test v $wire", "END LIST $kind test")->$method();
+        check(ref($got) eq 'HASH' && $got->{v} eq $value, "$method $tag");
+    }
+    my $enum = fixture('BEGIN LIST ENUM test v', "ENUM test v $wire", 'END LIST ENUM test v')->ListEnum('v');
+    check(ref($enum) eq 'ARRAY' && @$enum == 1 && $enum->[0] eq $value, "ListEnum $tag");
+    my $f = fixture("VAR test v $wire");
+    $f->{vars} = {v => 'cached'};
+    equal($f->FETCH('v'), $value, "tied FETCH consumer $tag");
+}
+# Token boundaries follow parseconf rather than shell concatenation.
+foreach my $case (
+    ['"first"second', 'first'], ['word"quote', 'word"quote'],
+    ["'single'", "'single'"], ['word#comment', 'word'],
+    ['word=other', 'word'], ['"hash#literal" # comment', 'hash#literal'],
+    ['back\\n', 'backn'], ['"back\\n"', 'backn'],
+    ["unquoted\\\ncontinued", 'unquotedcontinued']
+) {
+    equal(fixture('VAR test v ' . $case->[0])->GetVar('v'), $case->[1], 'NUT token boundary ' . unpack('H*', $case->[0]));
+}
+foreach my $case (
+    ['GetVar', 'VAR test v "unterminated'],
+    ['GetUPSDesc', 'UPSDESC test "unterminated'],
+    ['GetDesc', 'DESC test v "unterminated'],
+    ['GetCmdDesc', 'CMDDESC test c "unterminated']
+) {
+    my $f = fixture($case->[1]);
+    my $method = $case->[0];
+    check(!defined($f->$method('v')) && $f->Error() ne 'No error explanation available.', "$method incomplete token");
+}
+my $types = fixture('TYPE test v RW ENUM STRING:20');
+equal($types->GetType('v'), 'RW ENUM STRING:20', 'GetType scalar flags');
+equal($types->VarType('v'), 'RW ENUM STRING:20', 'VarType alias');
+my $commands = fixture('BEGIN LIST CMD test', 'CMD test first', 'CMD test second', 'END LIST CMD test')->ListCmd();
+check(ref($commands) eq 'ARRAY' && join(',', @$commands) eq 'first,second', 'ListCmd array');
+my $clients = fixture('BEGIN LIST CLIENT test', 'CLIENT test 127.0.0.1', 'END LIST CLIENT test')->ListClient();
+check(ref($clients) eq 'HASH' && $clients->{'127.0.0.1'} eq '127.0.0.1', 'ListClient hash');
+my $ranges = fixture('BEGIN LIST RANGE test v', 'RANGE test v "1" "9"', 'RANGE test v 10 20', 'END LIST RANGE test v')->ListRange('v');
+check(ref($ranges) eq 'ARRAY' && @$ranges == 2 && $ranges->[0]{min} eq '1' && $ranges->[1]{max} eq '20', 'ListRange array of min/max hashes');
+my $empty = fixture('BEGIN LIST UPS', 'END LIST UPS')->ListUPS();
+check(ref($empty) eq 'HASH' && !keys(%$empty), 'empty UPS list');
+$empty = fixture('BEGIN LIST ENUM test v', 'END LIST ENUM test v')->ListEnum('v');
+check(ref($empty) eq 'ARRAY' && !@$empty, 'empty enum');
+foreach my $method ('GetVar', 'GetUPSDesc', 'GetDesc', 'GetCmdDesc', 'ListUPS', 'ListVar', 'ListRW', 'ListEnum', 'ListCmd', 'ListRange', 'ListClient') {
+    foreach my $response (undef, 'ERR UNKNOWN-UPS', 'unexpected') {
+        my $f = fixture($response);
+        check(!defined($f->$method('v')) && $f->Error() ne 'No error explanation available.', "$method failure contract");
+    }
+}
+my $mismatch = fixture('VAR test other "x"');
+check(!defined($mismatch->GetVar('v')) && $mismatch->Error() =~ /Requested v, received other/, 'GetVar mismatch');
+my $truncated = fixture('BEGIN LIST UPS', 'UPS test "ordinary"');
+check(!defined($truncated->ListUPS()) && $truncated->Error() =~ /Network error/, 'truncated list failure');
+
+package AuthFixture;
+use vars qw(@ISA);
+@ISA = qw(UPS::Nut);
+sub _send {
+    my ($self, $line) = @_;
+    push @{$self->{sent}}, $line;
+    return shift @{$self->{replies}};
+}
+package main;
+my $auth = bless {sent => [], replies => ['OK', 'OK']}, 'AuthFixture';
+check($auth->Authenticate('user name', 'pass"\\#word'), 'Authenticate success');
+equal(join("\n", @{$auth->{sent}}), 'USERNAME "user name"' . "\n" . 'PASSWORD "pass\\"\\\\\\#word"', 'Authenticate encodes both arguments');
+check($auth->Authenticate('other', 'other') && @{$auth->{sent}} == 2, 'Authenticate already authenticated');
+foreach my $replies ([undef], ['ERR INVALID-ARGUMENT'], ['OK', 'ERR ACCESS-DENIED']) {
+    $auth = bless {sent => [], replies => $replies}, 'AuthFixture';
+    check(!defined($auth->Authenticate('user', 'pass')) && $auth->Error() ne 'No error explanation available.', 'Authenticate failure contract');
+}
+$auth = bless {sent => [], replies => []}, 'AuthFixture';
+check(!defined($auth->Authenticate(undef, 'pass')) && !@{$auth->{sent}}, 'Authenticate missing credentials');
+
+my $cwd = cwd();
+my $tmp = ($ENV{TMPDIR} || '/tmp') . "/nut-perl-parser-$$";
+my $created_tmp = mkdir($tmp, 0700);
+die "mkdir $tmp: $!" unless $created_tmp;
+my $child;
+END {
+    if ($child) { kill 'TERM', $child; waitpid($child, 0); }
+    chdir($cwd) if defined $cwd;
+    rmtree($tmp) if $created_tmp && -d $tmp;
+}
+sub write_file {
+    my ($name, $text) = @_;
+    my $fh = FileHandle->new($name, 'w') or die "open $name: $!";
+    print $fh $text;
+    close($fh) or die "close $name: $!";
+}
+chdir($tmp) or die "chdir: $!";
+# Relative includes have historically resolved against cwd.
+write_file('part "#\\name.conf', "PASSWORD=\"included\\\\n\"\n");
+write_file('scope.conf', "PASSWORD=ignored\n");
+write_file('auth.conf', <<'CONF');
+USERNAME=global
+PASSWORD=first
+INCLUDE_REQUIRED "part \"\#\\name.conf" # trailing comment
+[admin@localhost:12345] # section comment
+PASSWORD = "say \"yes\" \\n # literal"
+INCLUDE scope.conf
+[@localhost:12345]
+USERNAME='literal'
+PASSWORD=unquoted\ value
+[_global_defaults]
+CERTPATH = "two\
+lines"
+CERTFILE = "escaped\#hash" # ignored
+CERTIDENT_NAME = unquoted\
+continuation
+CONF
+UPS::Nut::AuthConf->freeAuthConfList();
+my @conf;
+my $parsed = eval { @conf = UPS::Nut::AuthConf->readAuthConfFile('auth.conf', 1); 1; };
+check($parsed, 'AuthConf escaped required include opens');
+my $ac = UPS::Nut::AuthConf->getAuthConf('admin', 'localhost', 12345, \@conf);
+equal($ac->{pass}, 'say "yes" \\n # literal', 'AuthConf quoted escapes/hash and section comments');
+equal($ac->{user}, 'admin', 'AuthConf section user precedence');
+equal($ac->{certpath}, 'twolines', 'AuthConf logical continuation');
+equal($ac->{certfile}, 'escaped#hash', 'AuthConf escaped hash and trailing comment');
+equal($ac->{certident}, 'unquotedcontinuation', 'AuthConf unquoted continuation');
+my %args = $ac->to_nut_args();
+equal($args{PASSWORD}, $ac->{pass}, 'AuthConf constructor arguments decoded once');
+$ac = UPS::Nut::AuthConf->getAuthConf(undef, 'localhost', 12345, \@conf);
+equal($ac->{user}, "'literal'", 'AuthConf apostrophes literal');
+equal($ac->{pass}, 'unquoted value', 'AuthConf escaped unquoted space');
+$ac = UPS::Nut::AuthConf->getAuthConf(undef, 'elsewhere', 3493, \@conf);
+equal($ac->{pass}, 'included\\n', 'AuthConf escaped include filename decoded once');
+my @missing = UPS::Nut::AuthConf->readAuthConfFile('absent.conf');
+check(!@missing, 'AuthConf missing optional file');
+my $ok = eval { UPS::Nut::AuthConf->readAuthConfFile('absent.conf', 1); 1; };
+check(!$ok && $@ ne '', 'AuthConf missing required file');
+
+# Exercise the real socket implementation, constructor and buffered getline.
+my $listener = IO::Socket::INET->new(LocalAddr => '127.0.0.1', LocalPort => 0, Listen => 1, Proto => 'tcp', ReuseAddr => 1) or die "listen: $!";
+my $port = $listener->sockport();
+my @dialog = (
+    ['LIST VAR test', ["BEGIN LIST VAR test\nVAR test v \"a\\", "\"b\\", "\\c\"\nEND LIST VAR test\n"]],
+    ['GET VAR test v', ["VAR test v \"a\\", "\"b\\\\c\"\n"]],
+    ['LIST UPS', ["BE", "GIN LIST UPS\nUPS test \"a\\", "\"b\\\\c\"\nUPS second \"two words\"\nEND LIST U", "PS\n"]],
+    ['LOGOUT', ["OK Goodbye\n"]],
+);
+$child = fork();
+die "fork: $!" unless defined $child;
+if (!$child) {
+    my $status = eval {
+        $SIG{ALRM} = sub { die "server timeout\n"; };
+        alarm(15);
+        my $sock = $listener->accept() or die "accept: $!";
+        $sock->autoflush(1);
+        foreach my $exchange (@dialog) {
+            my $line = $sock->getline();
+            die "unexpected request\n" unless defined $line && $line eq $exchange->[0] . "\n";
+            foreach my $chunk (@{$exchange->[1]}) {
+                print $sock $chunk;
+                select(undef, undef, undef, 0.01);
+            }
+        }
+        close($sock);
+        1;
+    };
+    print STDERR $@ unless $status;
+    POSIX::_exit($status ? 0 : 1);
+}
+close($listener);
+$SIG{ALRM} = sub { die "client timeout\n"; };
+alarm(15);
+my $nut = UPS::Nut->new(HOST => '127.0.0.1', PORT => $port, NAME => 'test', USESSL => 0, TIMEOUT => 3);
+check(defined($nut), 'localhost constructor');
+if ($nut) {
+    equal($nut->{vars}{v}, 'a"b\\c', 'constructor ListVar decoded');
+    equal($nut->GetVar('v'), 'a"b\\c', 'fragmented GetVar');
+    my $list = $nut->ListUPS();
+    check(ref($list) eq 'HASH' && $list->{test} eq 'a"b\\c' && $list->{second} eq 'two words', 'fragmented and coalesced LIST');
+    $nut->Logout();
+}
+waitpid($child, 0);
+check($? == 0, 'localhost server completed');
+$child = undef;
+alarm(0);
+print "1..$checks\n";
+exit($failures ? 1 : 0);


### PR DESCRIPTION
Reading an UPS description such as `"Main" C:\UPS\\end #1` through
`UPS::Nut` currently leaves wire escapes in returned values. Parse NUT
words once in the shared query/list readers and in `nutauth.conf`, including
escaped include paths, comments and line continuation. Encode literal
username/password arguments in `Authenticate()` so credentials decoded
from configuration can be sent correctly. Keep escaping `#` on output for
older servers. `GetCmdDesc()` now accepts the actual `CMDDESC` reply.

Preserve scalar/hash/array result shapes, the space-separated `GetType()`
scalar, aliases and constructor/tied-read consumers. Keep existing include
resolution, precedence and the separate section-include inheritance FIXME.
`Set()`, `InstCmd()`, tied writes, tracking and TLS are outside this change.
Single quotes in configuration are literal, following the C parser;
UPGRADING and POD explain the change and removal of manual decoding.
Bump the module to 1.63 and add a client-library release note.

Add one core-module regression script to the existing Perl-aware
`make check` and distribution rules. Require the already documented
Perl 5.005 floor explicitly and use the existing FileHandle dependency
for configuration file opening on that runtime.

Related: #3629 (approved separate Perl follow-up).

Validation:

- The 235-check regression fails 120 checks on unmodified upstream
  `2caa3c87501a1aba25a3070ad66757470bd1bf03`. All 235 pass with this change.
- macOS ARM64 Perl 5.34.1 and Linux ARM64 Perl 5.40.1 and 5.005_04
  pass the regression, including the constructor, fragmented/coalesced
  localhost traffic, escaped credentials and temporary include filenames.
  Privately installed generated modules pass the same regression.
- 420 permitted-input records match the separately corrected C parser's
  exact token bytes and boundaries. This does not change the C parser's
  character filter: Perl continues to preserve existing high-byte values.
- Real localhost `upsd`/`dummy-ups` checks cover descriptions, lists,
  variables, actual `CMDDESC`, and AuthConf-to-login credentials containing
  spaces, quotes, backslashes and hashes. Escaped traffic works with the
  unchanged server; raw quoted-hash configuration works with the separately
  corrected C parser. That C change is not part of this patch.
- Existing `NIT_CASE=perl` passes 4 groups with no failures or skips on
  current macOS and Linux, including Linux Perl 5.005_04.
- macOS and Linux builds and `make check` pass, including 12 Automake tests,
  as do staged installs, POD syntax, spelling and style checks.
  Final `make distcheck-light` passes with all 270 real man pages present;
  the extracted archive builds, runs the regression and 12 Automake tests,
  installs/uninstalls and cleans successfully. Its five changed source
  files match this patch exactly.

No physical UPS hardware was available for testing. Validation covered
standalone regressions, deterministic localhost socket fixtures, and locally
built `upsd` with simulated `dummy-ups` devices on macOS and Linux.
Physical UPS models, firmware versions, and hardware combinations were
not tested.

Other operating systems were not executed. Perl 5.005_04 was provisioned
in an isolated Linux prefix with build adjustments for modern GCC, library
paths, shell dependency generation and a removed Linux header; this does
not establish Solaris 8 acceptance. Its supplemental interpreter self-test
run has four failures in preprocessing, Errno generation and an unavailable
DB module; the NUT regression and integration paths above all pass. There is no standard Perl-module install
rule in NUT, so its generated module was also copied to a private Perl
library directory for installed-path checks.

Relevant checklist:

- [x] Concrete behavior, compatibility expectations and limitations described.
- [x] Focused change; maintained templates and test/distribution rules used.
- [x] New source comments and release-note text use ASCII.
- [x] NEWS, UPGRADING and POD updated; no driver changes.
- [x] Build, tests, spelling/style and complete-documentation distcheck-light pass.
- [x] AI use and actual model disclosed.
- [x] Human contributor review and acceptance of responsibility completed.
- [x] Human contributor consciously authorized DCO sign-off for this separate contribution.

AI assistance: OpenAI Codex with gpt-6-astra (high reasoning)
and gpt-daybreak-blue-latest (high reasoning).
The human contributor remains responsible for reviewing and submitting
the change.
