### PR TITLE
legrand-hid: fix beeper.disable to disable, not mute

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -58,6 +58,11 @@ https://github.com/networkupstools/nut/milestone/13
    complete descriptor available on affected River 3 Plus firmware while
    retaining the shorter length as a fallback.
 
+ - `usbhid-ups` `legrand-hid` subdriver: `beeper.disable` now sends
+   `AudibleAlarmControl=1` ("disabled") instead of `3` ("muted"), so the
+   buzzer stays off across alarms; added `beeper.mute` and
+   `ups.beeper.status`. [issue #3638]
+
  - Windows serial compatibility: fixed timeout handling to return data
    already received as a successful short read, while safely canceling
    and completing pending overlapped I/O before reusing its state.

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3827 utf-8
+personal_ws-1.1 en 3828 utf-8
 AAC
 AAS
 ABI

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -2540,6 +2540,7 @@ ld
 ldd
 ldflags
 le
+legrand
 len
 leveloffset
 lf

--- a/drivers/legrand-hid.c
+++ b/drivers/legrand-hid.c
@@ -28,7 +28,7 @@
 #include "main.h"
 #include "usb-common.h"
 
-#define LEGRAND_HID_VERSION	"Legrand HID 0.4"
+#define LEGRAND_HID_VERSION	"Legrand HID 0.31"
 
 /* Legrand */
 #define LEGRAND_VENDORID	0x1cb0

--- a/drivers/legrand-hid.c
+++ b/drivers/legrand-hid.c
@@ -28,7 +28,7 @@
 #include "main.h"
 #include "usb-common.h"
 
-#define LEGRAND_HID_VERSION	"Legrand HID 0.3"
+#define LEGRAND_HID_VERSION	"Legrand HID 0.4"
 
 /* Legrand */
 #define LEGRAND_VENDORID	0x1cb0
@@ -180,8 +180,10 @@ static hid_info_t legrand_hid2nut[] = {
 	{ "test.battery.stop", 0, 0, "UPS.Output.Test", NULL, "3", HU_TYPE_CMD, NULL },
 
 	/* Buzzer */
+	{ "ups.beeper.status", 0, 0, "UPS.PowerSummary.AudibleAlarmControl", NULL, "%s", HU_FLAG_SEMI_STATIC, beeper_info },
+	{ "beeper.disable", 0, 0, "UPS.PowerSummary.AudibleAlarmControl", NULL, "1", HU_TYPE_CMD, NULL },
 	{ "beeper.enable", 0, 0, "UPS.PowerSummary.AudibleAlarmControl", NULL, "2", HU_TYPE_CMD, NULL },
-	{ "beeper.disable", 0, 0, "UPS.PowerSummary.AudibleAlarmControl", NULL, "3", HU_TYPE_CMD, NULL },
+	{ "beeper.mute", 0, 0, "UPS.PowerSummary.AudibleAlarmControl", NULL, "3", HU_TYPE_CMD, NULL },
 
 	/* end of structure. */
 	{ NULL, 0, 0, NULL, NULL, NULL, 0, NULL }


### PR DESCRIPTION
Fixes #3638

`beeper.disable` in the Legrand HID subdriver wrote `AudibleAlarmControl = 3`, which NUT defines as `muted` (current alarm only), rather than `1` (`disabled`). The buzzer could re-arm on every alarm.

Changes:

- Map `beeper.disable` to `1`; keep `beeper.enable` at `2`.
- Add `beeper.mute` for `3`.
- Add the `ups.beeper.status` read mapping.
- Bump the Legrand HID subdriver version from `0.3` to `0.4`.
- Document the fix in `NEWS.adoc`.

## Testing

Built successfully in a clean Ubuntu 24.04 Docker container with:

```text
./autogen.sh
./configure --with-usb=yes --with-drivers=usbhid-ups
make -C drivers usbhid-ups
```

Hardware validation was performed on a Legrand KEOR PDU 800 (`1cb0:0038`) with NUT 2.8.1.

## Notes

The same mapping table also serves the Keor SP (`1cb0:0032`), which was not tested.

AI assistance: GitHub Copilot was used during preparation of this contribution. The human contributor reviewed and takes responsibility for the submitted changes.